### PR TITLE
Try to avoid conflicts between ObjC's Protocol and Inspector::Protocol namespace

### DIFF
--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -95,7 +95,7 @@ void CommandLineAPIHost::inspect(JSC::JSGlobalObject& lexicalGlobalObject, JSC::
     if (!hintsObject)
         return;
 
-    auto remoteObject = Protocol::BindingTraits<Protocol::Runtime::RemoteObject>::runtimeCast(objectValue.releaseNonNull());
+    auto remoteObject = Inspector::Protocol::BindingTraits<Inspector::Protocol::Runtime::RemoteObject>::runtimeCast(objectValue.releaseNonNull());
     inspectorAgent->inspect(WTFMove(remoteObject), hintsObject.releaseNonNull());
 }
 

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -105,7 +105,7 @@ ExceptionOr<InspectorAuditResourcesObject::ResourceContent> InspectorAuditResour
     if (!cachedResource)
         return Exception { ExceptionCode::NotFoundError, makeString("Unknown identifier "_s, id) };
 
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
     ResourceContent resourceContent;
     InspectorPageAgent::resourceContent(errorString, frame, cachedResource->url(), &resourceContent.data, &resourceContent.base64Encoded);
     if (!errorString.isEmpty())

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -194,19 +194,19 @@ static bool isValidRuleHeaderText(const String& headerText, StyleRuleType styleR
     }
 }
 
-static std::optional<Protocol::CSS::Grouping::Type> protocolGroupingTypeForStyleRuleType(StyleRuleType styleRuleType)
+static std::optional<Inspector::Protocol::CSS::Grouping::Type> protocolGroupingTypeForStyleRuleType(StyleRuleType styleRuleType)
 {
     switch (styleRuleType) {
     case StyleRuleType::Style:
-        return Protocol::CSS::Grouping::Type::StyleRule;
+        return Inspector::Protocol::CSS::Grouping::Type::StyleRule;
     case StyleRuleType::Media:
-        return Protocol::CSS::Grouping::Type::MediaRule;
+        return Inspector::Protocol::CSS::Grouping::Type::MediaRule;
     case StyleRuleType::Supports:
-        return Protocol::CSS::Grouping::Type::SupportsRule;
+        return Inspector::Protocol::CSS::Grouping::Type::SupportsRule;
     case StyleRuleType::LayerBlock:
-        return Protocol::CSS::Grouping::Type::LayerRule;
+        return Inspector::Protocol::CSS::Grouping::Type::LayerRule;
     case StyleRuleType::Container:
-        return Protocol::CSS::Grouping::Type::ContainerRule;
+        return Inspector::Protocol::CSS::Grouping::Type::ContainerRule;
     default:
         return std::nullopt;
     }
@@ -539,7 +539,7 @@ void StyleSheetHandler::observeComment(unsigned startOffset, unsigned endOffset)
     m_currentRuleDataStack.last()->styleSourceData->propertyData.append(CSSPropertySourceData(propertyData.name, propertyData.value, false, true, true, SourceRange(startOffset - topRuleBodyRange.start, endOffset - topRuleBodyRange.start)));
 }
 
-static RefPtr<Protocol::CSS::SourceRange> buildSourceRangeObject(const SourceRange& range, const Vector<size_t>& lineEndings, int* endingLine = nullptr)
+static RefPtr<Inspector::Protocol::CSS::SourceRange> buildSourceRangeObject(const SourceRange& range, const Vector<size_t>& lineEndings, int* endingLine = nullptr)
 {
     if (lineEndings.isEmpty())
         return nullptr;
@@ -550,7 +550,7 @@ static RefPtr<Protocol::CSS::SourceRange> buildSourceRangeObject(const SourceRan
     if (endingLine)
         *endingLine = end.m_line.zeroBasedInt();
 
-    return Protocol::CSS::SourceRange::create()
+    return Inspector::Protocol::CSS::SourceRange::create()
         .setStartLine(start.m_line.zeroBasedInt())
         .setStartColumn(start.m_column.zeroBasedInt())
         .setEndLine(end.m_line.zeroBasedInt())
@@ -618,11 +618,11 @@ RefPtr<Inspector::Protocol::CSS::Grouping> InspectorStyleSheet::buildObjectForGr
     if (!groupingRuleProtocolType)
         return nullptr;
 
-    auto payload = Protocol::CSS::Grouping::create()
+    auto payload = Inspector::Protocol::CSS::Grouping::create()
         .setType(*groupingRuleProtocolType)
         .release();
 
-    if (auto ruleId = this->ruleOrStyleId(groupingRule).asProtocolValue<Protocol::CSS::CSSRuleId>())
+    if (auto ruleId = this->ruleOrStyleId(groupingRule).asProtocolValue<Inspector::Protocol::CSS::CSSRuleId>())
         payload->setRuleId(ruleId.releaseNonNull());
 
     if (RefPtr<CSSRuleSourceData> sourceData = ensureParsedDataReady() ? ruleSourceDataFor(groupingRule) : nullptr) {
@@ -655,8 +655,8 @@ Ref<JSON::ArrayOf<Inspector::Protocol::CSS::Grouping>> InspectorStyleSheet::buil
                 // FIXME: <webkit.org/b/246958> Show import rule as a single rule, instead of two rules for media and layer.
                 auto sourceURL = sourceURLForCSSRule(*importRule);
                 if (auto layerName = importRule->layerName(); !layerName.isNull()) {
-                    auto layerRulePayload = Protocol::CSS::Grouping::create()
-                        .setType(Protocol::CSS::Grouping::Type::LayerImportRule)
+                    auto layerRulePayload = Inspector::Protocol::CSS::Grouping::create()
+                        .setType(Inspector::Protocol::CSS::Grouping::Type::LayerImportRule)
                         .release();
                     layerRulePayload->setText(layerName);
                     if (!sourceURL.isEmpty())
@@ -665,8 +665,8 @@ Ref<JSON::ArrayOf<Inspector::Protocol::CSS::Grouping>> InspectorStyleSheet::buil
                 }
 
                 if (auto& media = importRule->media(); media.length() && media.mediaText() != "all"_s) {
-                    auto mediaRulePayload = Protocol::CSS::Grouping::create()
-                        .setType(Protocol::CSS::Grouping::Type::MediaImportRule)
+                    auto mediaRulePayload = Inspector::Protocol::CSS::Grouping::create()
+                        .setType(Inspector::Protocol::CSS::Grouping::Type::MediaImportRule)
                         .release();
                     mediaRulePayload->setText(media.mediaText());
                     if (!sourceURL.isEmpty())
@@ -686,8 +686,8 @@ Ref<JSON::ArrayOf<Inspector::Protocol::CSS::Grouping>> InspectorStyleSheet::buil
             auto* media = styleSheet->media();
             // FIXME: <webkit.org/b/246959> Support editing `style` and `link` node media queries.
             if (media && media->length() && media->mediaText() != "all"_s) {
-                auto sheetGroupingPayload = Protocol::CSS::Grouping::create()
-                    .setType(is<HTMLStyleElement>(styleSheet->ownerNode()) ? Protocol::CSS::Grouping::Type::MediaStyleNode: Protocol::CSS::Grouping::Type::MediaLinkNode)
+                auto sheetGroupingPayload = Inspector::Protocol::CSS::Grouping::create()
+                    .setType(is<HTMLStyleElement>(styleSheet->ownerNode()) ? Inspector::Protocol::CSS::Grouping::Type::MediaStyleNode: Inspector::Protocol::CSS::Grouping::Type::MediaLinkNode)
                     .release();
                 sheetGroupingPayload->setText(media->mediaText());
 
@@ -727,10 +727,10 @@ InspectorStyle::InspectorStyle(const InspectorCSSId& styleId, Ref<CSSStyleDeclar
 
 InspectorStyle::~InspectorStyle() = default;
 
-Ref<Protocol::CSS::CSSStyle> InspectorStyle::buildObjectForStyle() const
+Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyle::buildObjectForStyle() const
 {
     auto result = styleWithProperties();
-    if (auto styleId = m_styleId.asProtocolValue<Protocol::CSS::CSSStyleId>())
+    if (auto styleId = m_styleId.asProtocolValue<Inspector::Protocol::CSS::CSSStyleId>())
         result->setStyleId(styleId.releaseNonNull());
 
     result->setWidth(m_style->getPropertyValue("width"_s));
@@ -744,12 +744,12 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyle::buildObjectForStyle() const
     return result;
 }
 
-Ref<JSON::ArrayOf<Protocol::CSS::CSSComputedStyleProperty>> InspectorStyle::buildArrayForComputedStyle() const
+Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>> InspectorStyle::buildArrayForComputedStyle() const
 {
-    auto result = JSON::ArrayOf<Protocol::CSS::CSSComputedStyleProperty>::create();
+    auto result = JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>::create();
     for (auto& property : collectProperties(true)) {
         const CSSPropertySourceData& propertyEntry = property.sourceData;
-        auto entry = Protocol::CSS::CSSComputedStyleProperty::create()
+        auto entry = Inspector::Protocol::CSS::CSSComputedStyleProperty::create()
             .setName(propertyEntry.name)
             .setValue(propertyEntry.value)
             .release();
@@ -826,13 +826,13 @@ Vector<InspectorStyleProperty> InspectorStyle::collectProperties(bool includeAll
     return result;
 }
 
-Ref<Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
+Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
 {
     auto properties = collectProperties(false);
 
-    auto propertiesObject = JSON::ArrayOf<Protocol::CSS::CSSProperty>::create();
-    auto shorthandEntries = ArrayOf<Protocol::CSS::ShorthandEntry>::create();
-    HashMap<String, RefPtr<Protocol::CSS::CSSProperty>> propertyNameToPreviousActiveProperty;
+    auto propertiesObject = JSON::ArrayOf<Inspector::Protocol::CSS::CSSProperty>::create();
+    auto shorthandEntries = ArrayOf<Inspector::Protocol::CSS::ShorthandEntry>::create();
+    HashMap<String, RefPtr<Inspector::Protocol::CSS::CSSProperty>> propertyNameToPreviousActiveProperty;
     HashSet<String> foundShorthands;
     String previousPriority;
     String previousStatus;
@@ -844,9 +844,9 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
         const CSSPropertySourceData& propertyEntry = it->sourceData;
         const String& name = propertyEntry.name;
 
-        auto status = it->disabled ? Protocol::CSS::CSSPropertyStatus::Disabled : Protocol::CSS::CSSPropertyStatus::Active;
+        auto status = it->disabled ? Inspector::Protocol::CSS::CSSPropertyStatus::Disabled : Inspector::Protocol::CSS::CSSPropertyStatus::Active;
 
-        auto property = Protocol::CSS::CSSProperty::create()
+        auto property = Inspector::Protocol::CSS::CSSProperty::create()
             .setName(lowercasePropertyName(name))
             .setValue(propertyEntry.value)
             .release();
@@ -890,27 +890,27 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
 
                 // Canonicalize property names to treat non-prefixed and vendor-prefixed property names the same (opacity vs. -webkit-opacity).
                 String canonicalPropertyName = propertyId != CSSPropertyID::CSSPropertyInvalid && propertyId != CSSPropertyID::CSSPropertyCustom ? nameString(propertyId) : name;
-                HashMap<String, RefPtr<Protocol::CSS::CSSProperty>>::iterator activeIt = propertyNameToPreviousActiveProperty.find(canonicalPropertyName);
+                HashMap<String, RefPtr<Inspector::Protocol::CSS::CSSProperty>>::iterator activeIt = propertyNameToPreviousActiveProperty.find(canonicalPropertyName);
                 if (activeIt != propertyNameToPreviousActiveProperty.end()) {
                     if (propertyEntry.parsedOk) {
-                        auto newPriority = activeIt->value->getString(Protocol::CSS::CSSProperty::priorityKey);
+                        auto newPriority = activeIt->value->getString(Inspector::Protocol::CSS::CSSProperty::priorityKey);
                         if (!!newPriority)
                             previousPriority = newPriority;
 
-                        auto newStatus = activeIt->value->getString(Protocol::CSS::CSSProperty::statusKey);
+                        auto newStatus = activeIt->value->getString(Inspector::Protocol::CSS::CSSProperty::statusKey);
                         if (!!newStatus) {
                             previousStatus = newStatus;
-                            if (previousStatus != Protocol::Helpers::getEnumConstantValue(Protocol::CSS::CSSPropertyStatus::Inactive)) {
+                            if (previousStatus != Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::CSSPropertyStatus::Inactive)) {
                                 if (propertyEntry.important || !newPriority) // Priority not set == "not important".
                                     shouldInactivate = true;
-                                else if (status == Protocol::CSS::CSSPropertyStatus::Active) {
+                                else if (status == Inspector::Protocol::CSS::CSSPropertyStatus::Active) {
                                     // Inactivate a non-important property following the same-named important property.
-                                    status = Protocol::CSS::CSSPropertyStatus::Inactive;
+                                    status = Inspector::Protocol::CSS::CSSPropertyStatus::Inactive;
                                 }
                             }
                         }
                     } else {
-                        auto previousParsedOk = activeIt->value->getBoolean(Protocol::CSS::CSSProperty::parsedOkKey);
+                        auto previousParsedOk = activeIt->value->getBoolean(Inspector::Protocol::CSS::CSSProperty::parsedOkKey);
                         if (previousParsedOk && !previousParsedOk)
                             shouldInactivate = true;
                     }
@@ -918,7 +918,7 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
                     propertyNameToPreviousActiveProperty.set(canonicalPropertyName, property.copyRef());
 
                 if (shouldInactivate) {
-                    activeIt->value->setStatus(Protocol::CSS::CSSPropertyStatus::Inactive);
+                    activeIt->value->setStatus(Inspector::Protocol::CSS::CSSPropertyStatus::Inactive);
                     propertyNameToPreviousActiveProperty.set(canonicalPropertyName, property.copyRef());
                 }
             } else {
@@ -926,13 +926,13 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
                 // Default "implicit" == false.
                 if (implicit)
                     property->setImplicit(true);
-                status = Protocol::CSS::CSSPropertyStatus::Style;
+                status = Inspector::Protocol::CSS::CSSPropertyStatus::Style;
 
                 String shorthand = m_style->getPropertyShorthand(name);
                 if (!shorthand.isEmpty()) {
                     if (!foundShorthands.contains(shorthand)) {
                         foundShorthands.add(shorthand);
-                        auto entry = Protocol::CSS::ShorthandEntry::create()
+                        auto entry = Inspector::Protocol::CSS::ShorthandEntry::create()
                             .setName(shorthand)
                             .setValue(shorthandValue(shorthand))
                             .release();
@@ -943,11 +943,11 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
         }
 
         // Default "status" == "style".
-        if (status != Protocol::CSS::CSSPropertyStatus::Style)
+        if (status != Inspector::Protocol::CSS::CSSPropertyStatus::Style)
             property->setStatus(status);
     }
 
-    return Protocol::CSS::CSSStyle::create()
+    return Inspector::Protocol::CSS::CSSStyle::create()
         .setCssProperties(WTFMove(propertiesObject))
         .setShorthandEntries(WTFMove(shorthandEntries))
         .release();
@@ -1012,7 +1012,7 @@ Vector<String> InspectorStyle::longhandProperties(const String& shorthandPropert
     return properties;
 }
 
-Ref<InspectorStyleSheet> InspectorStyleSheet::create(InspectorPageAgent* pageAgent, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Protocol::CSS::StyleSheetOrigin origin, const String& documentURL, Listener* listener)
+Ref<InspectorStyleSheet> InspectorStyleSheet::create(InspectorPageAgent* pageAgent, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin origin, const String& documentURL, Listener* listener)
 {
     return adoptRef(*new InspectorStyleSheet(pageAgent, id, WTFMove(pageStyleSheet), origin, documentURL, listener));
 }
@@ -1024,7 +1024,7 @@ String InspectorStyleSheet::styleSheetURL(CSSStyleSheet* pageStyleSheet)
     return emptyString();
 }
 
-InspectorStyleSheet::InspectorStyleSheet(InspectorPageAgent* pageAgent, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Protocol::CSS::StyleSheetOrigin origin, const String& documentURL, Listener* listener)
+InspectorStyleSheet::InspectorStyleSheet(InspectorPageAgent* pageAgent, const String& id, RefPtr<CSSStyleSheet>&& pageStyleSheet, Inspector::Protocol::CSS::StyleSheetOrigin origin, const String& documentURL, Listener* listener)
     : m_pageAgent(pageAgent)
     , m_id(id)
     , m_pageStyleSheet(WTFMove(pageStyleSheet))
@@ -1186,7 +1186,7 @@ ExceptionOr<CSSStyleRule*> InspectorStyleSheet::addRule(const String& selector)
     setText(styleSheetText.toString());
 
     // Inspector Style Sheets are always treated as though their parsed data is ready.
-    if (m_origin == Protocol::CSS::StyleSheetOrigin::Inspector)
+    if (m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::Inspector)
         fireStyleSheetChanged();
     else
         reparseStyleSheet(styleSheetText.toString());
@@ -1245,7 +1245,7 @@ CSSRule* InspectorStyleSheet::ruleForId(const InspectorCSSId& id) const
     return id.ordinal() >= m_flatRules.size() ? nullptr : m_flatRules.at(id.ordinal()).get();
 }
 
-RefPtr<Protocol::CSS::CSSStyleSheetBody> InspectorStyleSheet::buildObjectForStyleSheet()
+RefPtr<Inspector::Protocol::CSS::CSSStyleSheetBody> InspectorStyleSheet::buildObjectForStyleSheet()
 {
     CSSStyleSheet* styleSheet = pageStyleSheet();
     if (!styleSheet)
@@ -1253,7 +1253,7 @@ RefPtr<Protocol::CSS::CSSStyleSheetBody> InspectorStyleSheet::buildObjectForStyl
 
     RefPtr<CSSRuleList> cssRuleList = asCSSRuleList(styleSheet);
 
-    auto result = Protocol::CSS::CSSStyleSheetBody::create()
+    auto result = Inspector::Protocol::CSS::CSSStyleSheetBody::create()
         .setStyleSheetId(id())
         .setRules(buildArrayForRuleList(cssRuleList.get()))
         .release();
@@ -1265,7 +1265,7 @@ RefPtr<Protocol::CSS::CSSStyleSheetBody> InspectorStyleSheet::buildObjectForStyl
     return result;
 }
 
-RefPtr<Protocol::CSS::CSSStyleSheetHeader> InspectorStyleSheet::buildObjectForStyleSheetInfo()
+RefPtr<Inspector::Protocol::CSS::CSSStyleSheetHeader> InspectorStyleSheet::buildObjectForStyleSheetInfo()
 {
     auto* styleSheet = pageStyleSheet();
     if (!styleSheet)
@@ -1273,7 +1273,7 @@ RefPtr<Protocol::CSS::CSSStyleSheetHeader> InspectorStyleSheet::buildObjectForSt
 
     auto* document = styleSheet->ownerDocument();
     auto* frame = document ? document->frame() : nullptr;
-    return Protocol::CSS::CSSStyleSheetHeader::create()
+    return Inspector::Protocol::CSS::CSSStyleSheetHeader::create()
         .setStyleSheetId(id())
         .setOrigin(m_origin)
         .setDisabled(styleSheet->disabled())
@@ -1286,9 +1286,9 @@ RefPtr<Protocol::CSS::CSSStyleSheetHeader> InspectorStyleSheet::buildObjectForSt
         .release();
 }
 
-static Ref<Protocol::CSS::CSSSelector> buildObjectForSelectorHelper(const String& selectorText, const CSSSelector& selector)
+static Ref<Inspector::Protocol::CSS::CSSSelector> buildObjectForSelectorHelper(const String& selectorText, const CSSSelector& selector)
 {
-    auto inspectorSelector = Protocol::CSS::CSSSelector::create()
+    auto inspectorSelector = Inspector::Protocol::CSS::CSSSelector::create()
         .setText(selectorText)
         .release();
 
@@ -1307,11 +1307,11 @@ static Ref<Protocol::CSS::CSSSelector> buildObjectForSelectorHelper(const String
     return inspectorSelector;
 }
 
-static Ref<JSON::ArrayOf<Protocol::CSS::CSSSelector>> selectorsFromSource(const CSSRuleSourceData* sourceData, const String& sheetText, const Vector<const CSSSelector*> selectors)
+static Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSSelector>> selectorsFromSource(const CSSRuleSourceData* sourceData, const String& sheetText, const Vector<const CSSSelector*> selectors)
 {
     static NeverDestroyed<JSC::Yarr::RegularExpression> comment("/\\*[^]*?\\*/"_s, OptionSet<JSC::Yarr::Flags> { JSC::Yarr::Flags::Multiline });
 
-    auto result = JSON::ArrayOf<Protocol::CSS::CSSSelector>::create();
+    auto result = JSON::ArrayOf<Inspector::Protocol::CSS::CSSSelector>::create();
     unsigned selectorIndex = 0;
     for (auto& range : sourceData->selectorRanges) {
         // If we don't have a selector, that means the SourceData for this CSSStyleSheet
@@ -1381,17 +1381,17 @@ Vector<const CSSSelector*> InspectorStyleSheet::selectorsForCSSStyleRule(CSSStyl
     return selectors;
 }
 
-Ref<Protocol::CSS::CSSSelector> InspectorStyleSheet::buildObjectForSelector(const CSSSelector* selector)
+Ref<Inspector::Protocol::CSS::CSSSelector> InspectorStyleSheet::buildObjectForSelector(const CSSSelector* selector)
 {
     return buildObjectForSelectorHelper(selector->selectorText(), *selector);
 }
 
-Ref<Protocol::CSS::SelectorList> InspectorStyleSheet::buildObjectForSelectorList(CSSStyleRule* rule, int& endingLine)
+Ref<Inspector::Protocol::CSS::SelectorList> InspectorStyleSheet::buildObjectForSelectorList(CSSStyleRule* rule, int& endingLine)
 {
     RefPtr<CSSRuleSourceData> sourceData;
     if (ensureParsedDataReady())
         sourceData = ruleSourceDataFor(rule);
-    RefPtr<JSON::ArrayOf<Protocol::CSS::CSSSelector>> selectors;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::CSSSelector>> selectors;
 
     // This intentionally does not rely on the source data to avoid catching the trailing comments (before the declaration starting '{').
     String selectorText = rule->selectorText();
@@ -1399,11 +1399,11 @@ Ref<Protocol::CSS::SelectorList> InspectorStyleSheet::buildObjectForSelectorList
     if (sourceData)
         selectors = selectorsFromSource(sourceData.get(), m_parsedStyleSheet->text(), selectorsForCSSStyleRule(*rule));
     else {
-        selectors = JSON::ArrayOf<Protocol::CSS::CSSSelector>::create();
+        selectors = JSON::ArrayOf<Inspector::Protocol::CSS::CSSSelector>::create();
         for (const CSSSelector* selector : selectorsForCSSStyleRule(*rule))
             selectors->addItem(buildObjectForSelector(selector));
     }
-    auto result = Protocol::CSS::SelectorList::create()
+    auto result = Inspector::Protocol::CSS::SelectorList::create()
         .setSelectors(selectors.releaseNonNull())
         .setText(selectorText)
         .release();
@@ -1414,25 +1414,25 @@ Ref<Protocol::CSS::SelectorList> InspectorStyleSheet::buildObjectForSelectorList
     return result;
 }
 
-RefPtr<Protocol::CSS::CSSRule> InspectorStyleSheet::buildObjectForRule(CSSStyleRule* rule)
+RefPtr<Inspector::Protocol::CSS::CSSRule> InspectorStyleSheet::buildObjectForRule(CSSStyleRule* rule)
 {
     CSSStyleSheet* styleSheet = pageStyleSheet();
     if (!styleSheet)
         return nullptr;
 
     int endingLine = 0;
-    auto result = Protocol::CSS::CSSRule::create()
+    auto result = Inspector::Protocol::CSS::CSSRule::create()
         .setSelectorList(buildObjectForSelectorList(rule, endingLine))
         .setSourceLine(endingLine)
         .setOrigin(m_origin)
         .setStyle(buildObjectForStyle(&rule->style()))
         .release();
 
-    if (m_origin == Protocol::CSS::StyleSheetOrigin::Author || m_origin == Protocol::CSS::StyleSheetOrigin::User)
+    if (m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::Author || m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::User)
         result->setSourceURL(finalURL());
 
     if (canBind()) {
-        if (auto ruleId = this->ruleOrStyleId(rule).asProtocolValue<Protocol::CSS::CSSRuleId>())
+        if (auto ruleId = this->ruleOrStyleId(rule).asProtocolValue<Inspector::Protocol::CSS::CSSRuleId>())
             result->setRuleId(ruleId.releaseNonNull());
     }
 
@@ -1446,7 +1446,7 @@ RefPtr<Protocol::CSS::CSSRule> InspectorStyleSheet::buildObjectForRule(CSSStyleR
     return result;
 }
 
-Ref<Protocol::CSS::CSSStyle> InspectorStyleSheet::buildObjectForStyle(CSSStyleDeclaration* style)
+Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyleSheet::buildObjectForStyle(CSSStyleDeclaration* style)
 {
     RefPtr<CSSRuleSourceData> sourceData;
     if (ensureParsedDataReady())
@@ -1454,9 +1454,9 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyleSheet::buildObjectForStyle(CSSStyleDe
 
     InspectorCSSId id = ruleOrStyleId(style);
     if (id.isEmpty()) {
-        return Protocol::CSS::CSSStyle::create()
-            .setCssProperties(ArrayOf<Protocol::CSS::CSSProperty>::create())
-            .setShorthandEntries(ArrayOf<Protocol::CSS::ShorthandEntry>::create())
+        return Inspector::Protocol::CSS::CSSStyle::create()
+            .setCssProperties(ArrayOf<Inspector::Protocol::CSS::CSSProperty>::create())
+            .setShorthandEntries(ArrayOf<Inspector::Protocol::CSS::ShorthandEntry>::create())
             .release();
     }
 
@@ -1659,7 +1659,7 @@ bool InspectorStyleSheet::styleSheetMutated() const
 
 bool InspectorStyleSheet::ensureParsedDataReady()
 {
-    bool allowParsedData = m_origin == Protocol::CSS::StyleSheetOrigin::Inspector || !styleSheetMutated();
+    bool allowParsedData = m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::Inspector || !styleSheetMutated();
     return allowParsedData && ensureText() && ensureSourceData();
 }
 
@@ -1732,7 +1732,7 @@ bool InspectorStyleSheet::styleSheetTextWithChangedStyle(CSSStyleDeclaration* st
 
 bool InspectorStyleSheet::originalStyleSheetText(String* result) const
 {
-    if (!m_pageStyleSheet || m_origin == Protocol::CSS::StyleSheetOrigin::UserAgent)
+    if (!m_pageStyleSheet || m_origin == Inspector::Protocol::CSS::StyleSheetOrigin::UserAgent)
         return false;
     return inlineStyleSheetText(result) || resourceStyleSheetText(result) || extensionStyleSheetText(result);
 }
@@ -1775,9 +1775,9 @@ bool InspectorStyleSheet::extensionStyleSheetText(String* result) const
     return true;
 }
 
-Ref<JSON::ArrayOf<Protocol::CSS::CSSRule>> InspectorStyleSheet::buildArrayForRuleList(CSSRuleList* ruleList)
+Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSRule>> InspectorStyleSheet::buildArrayForRuleList(CSSRuleList* ruleList)
 {
-    auto result = JSON::ArrayOf<Protocol::CSS::CSSRule>::create();
+    auto result = JSON::ArrayOf<Inspector::Protocol::CSS::CSSRule>::create();
     if (!ruleList)
         return result;
 
@@ -1821,12 +1821,12 @@ void InspectorStyleSheet::collectFlatRules(RefPtr<CSSRuleList>&& ruleList, Vecto
     }
 }
 
-Ref<InspectorStyleSheetForInlineStyle> InspectorStyleSheetForInlineStyle::create(InspectorPageAgent* pageAgent, const String& id, Ref<StyledElement>&& element, Protocol::CSS::StyleSheetOrigin origin, Listener* listener)
+Ref<InspectorStyleSheetForInlineStyle> InspectorStyleSheetForInlineStyle::create(InspectorPageAgent* pageAgent, const String& id, Ref<StyledElement>&& element, Inspector::Protocol::CSS::StyleSheetOrigin origin, Listener* listener)
 {
     return adoptRef(*new InspectorStyleSheetForInlineStyle(pageAgent, id, WTFMove(element), origin, listener));
 }
 
-InspectorStyleSheetForInlineStyle::InspectorStyleSheetForInlineStyle(InspectorPageAgent* pageAgent, const String& id, Ref<StyledElement>&& element, Protocol::CSS::StyleSheetOrigin origin, Listener* listener)
+InspectorStyleSheetForInlineStyle::InspectorStyleSheetForInlineStyle(InspectorPageAgent* pageAgent, const String& id, Ref<StyledElement>&& element, Inspector::Protocol::CSS::StyleSheetOrigin origin, Listener* listener)
     : InspectorStyleSheet(pageAgent, id, nullptr, origin, String(), listener)
     , m_element(WTFMove(element))
     , m_ruleSourceData(nullptr)

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -75,45 +75,45 @@ static std::optional<double> protocolValueForSeconds(const Seconds& seconds)
     return seconds.milliseconds();
 }
 
-static std::optional<Protocol::Animation::PlaybackDirection> protocolValueForPlaybackDirection(PlaybackDirection playbackDirection)
+static std::optional<Inspector::Protocol::Animation::PlaybackDirection> protocolValueForPlaybackDirection(PlaybackDirection playbackDirection)
 {
     switch (playbackDirection) {
     case PlaybackDirection::Normal:
-        return Protocol::Animation::PlaybackDirection::Normal;
+        return Inspector::Protocol::Animation::PlaybackDirection::Normal;
     case PlaybackDirection::Reverse:
-        return Protocol::Animation::PlaybackDirection::Reverse;
+        return Inspector::Protocol::Animation::PlaybackDirection::Reverse;
     case PlaybackDirection::Alternate:
-        return Protocol::Animation::PlaybackDirection::Alternate;
+        return Inspector::Protocol::Animation::PlaybackDirection::Alternate;
     case PlaybackDirection::AlternateReverse:
-        return Protocol::Animation::PlaybackDirection::AlternateReverse;
+        return Inspector::Protocol::Animation::PlaybackDirection::AlternateReverse;
     }
 
     ASSERT_NOT_REACHED();
     return std::nullopt;
 }
 
-static std::optional<Protocol::Animation::FillMode> protocolValueForFillMode(FillMode fillMode)
+static std::optional<Inspector::Protocol::Animation::FillMode> protocolValueForFillMode(FillMode fillMode)
 {
     switch (fillMode) {
     case FillMode::None:
-        return Protocol::Animation::FillMode::None;
+        return Inspector::Protocol::Animation::FillMode::None;
     case FillMode::Forwards:
-        return Protocol::Animation::FillMode::Forwards;
+        return Inspector::Protocol::Animation::FillMode::Forwards;
     case FillMode::Backwards:
-        return Protocol::Animation::FillMode::Backwards;
+        return Inspector::Protocol::Animation::FillMode::Backwards;
     case FillMode::Both:
-        return Protocol::Animation::FillMode::Both;
+        return Inspector::Protocol::Animation::FillMode::Both;
     case FillMode::Auto:
-        return Protocol::Animation::FillMode::Auto;
+        return Inspector::Protocol::Animation::FillMode::Auto;
     }
 
     ASSERT_NOT_REACHED();
     return std::nullopt;
 }
 
-static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes(KeyframeEffect& keyframeEffect)
+static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectForKeyframes(KeyframeEffect& keyframeEffect)
 {
-    auto keyframesPayload = JSON::ArrayOf<Protocol::Animation::Keyframe>::create();
+    auto keyframesPayload = JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>::create();
 
     const auto& blendingKeyframes = keyframeEffect.blendingKeyframes();
     const auto& parsedKeyframes = keyframeEffect.parsedKeyframes();
@@ -133,7 +133,7 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
             ASSERT(blendingKeyframe.style());
             auto& style = *blendingKeyframe.style();
 
-            auto keyframePayload = Protocol::Animation::Keyframe::create()
+            auto keyframePayload = Inspector::Protocol::Animation::Keyframe::create()
                 .setOffset(blendingKeyframe.offset())
                 .release();
 
@@ -175,7 +175,7 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
         }
     } else {
         for (const auto& parsedKeyframe : parsedKeyframes) {
-            auto keyframePayload = Protocol::Animation::Keyframe::create()
+            auto keyframePayload = Inspector::Protocol::Animation::Keyframe::create()
                 .setOffset(parsedKeyframe.computedOffset)
                 .release();
 
@@ -194,9 +194,9 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
     return keyframesPayload;
 }
 
-static Ref<Protocol::Animation::Effect> buildObjectForEffect(AnimationEffect& effect)
+static Ref<Inspector::Protocol::Animation::Effect> buildObjectForEffect(AnimationEffect& effect)
 {
-    auto effectPayload = Protocol::Animation::Effect::create()
+    auto effectPayload = Inspector::Protocol::Animation::Effect::create()
         .release();
 
     if (auto startDelay = protocolValueForSeconds(effect.delay()))
@@ -254,7 +254,7 @@ void InspectorAnimationAgent::willDestroyFrontendAndBackend(DisconnectReason)
     m_instrumentingAgents.setPersistentAnimationAgent(nullptr);
 }
 
-Protocol::ErrorStringOr<void> InspectorAnimationAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::enable()
 {
     if (m_instrumentingAgents.enabledAnimationAgent() == this)
         return makeUnexpected("Animation domain already enabled"_s);
@@ -277,7 +277,7 @@ Protocol::ErrorStringOr<void> InspectorAnimationAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorAnimationAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::disable()
 {
     m_instrumentingAgents.setEnabledAnimationAgent(nullptr);
 
@@ -286,9 +286,9 @@ Protocol::ErrorStringOr<void> InspectorAnimationAgent::disable()
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::DOM::Styleable>> InspectorAnimationAgent::requestEffectTarget(const Protocol::Animation::AnimationId& animationId)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Styleable>> InspectorAnimationAgent::requestEffectTarget(const Inspector::Protocol::Animation::AnimationId& animationId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* animation = assertAnimation(errorString, animationId);
     if (!animation)
@@ -309,9 +309,9 @@ Protocol::ErrorStringOr<Ref<Protocol::DOM::Styleable>> InspectorAnimationAgent::
     return domAgent->pushStyleablePathToFrontend(errorString, *target);
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorAnimationAgent::resolveAnimation(const Protocol::Animation::AnimationId& animationId, const String& objectGroup)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> InspectorAnimationAgent::resolveAnimation(const Inspector::Protocol::Animation::AnimationId& animationId, const String& objectGroup)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* animation = assertAnimation(errorString, animationId);
     if (!animation)
@@ -341,7 +341,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorAnimation
     return object.releaseNonNull();
 }
 
-Protocol::ErrorStringOr<void> InspectorAnimationAgent::startTracking()
+Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::startTracking()
 {
     if (m_instrumentingAgents.trackingAnimationAgent() == this)
         return { };
@@ -355,7 +355,7 @@ Protocol::ErrorStringOr<void> InspectorAnimationAgent::startTracking()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorAnimationAgent::stopTracking()
+Inspector::Protocol::ErrorStringOr<void> InspectorAnimationAgent::stopTracking()
 {
     if (m_instrumentingAgents.trackingAnimationAgent() != this)
         return { };
@@ -388,31 +388,31 @@ void InspectorAnimationAgent::willApplyKeyframeEffect(const Styleable& target, K
     });
     auto& trackingData = ensureResult.iterator->value.get();
 
-    std::optional<Protocol::Animation::AnimationState> animationAnimationState;
+    std::optional<Inspector::Protocol::Animation::AnimationState> animationAnimationState;
 
     if ((ensureResult.isNewEntry || !isDelayed(trackingData.lastComputedTiming)) && isDelayed(computedTiming))
-        animationAnimationState = Protocol::Animation::AnimationState::Delayed;
+        animationAnimationState = Inspector::Protocol::Animation::AnimationState::Delayed;
     else if (ensureResult.isNewEntry || trackingData.lastComputedTiming.phase != computedTiming.phase) {
         switch (computedTiming.phase) {
         case AnimationEffectPhase::Before:
-            animationAnimationState = Protocol::Animation::AnimationState::Ready;
+            animationAnimationState = Inspector::Protocol::Animation::AnimationState::Ready;
             break;
 
         case AnimationEffectPhase::Active:
-            animationAnimationState = Protocol::Animation::AnimationState::Active;
+            animationAnimationState = Inspector::Protocol::Animation::AnimationState::Active;
             break;
 
         case AnimationEffectPhase::After:
-            animationAnimationState = Protocol::Animation::AnimationState::Done;
+            animationAnimationState = Inspector::Protocol::Animation::AnimationState::Done;
             break;
 
         case AnimationEffectPhase::Idle:
-            animationAnimationState = Protocol::Animation::AnimationState::Canceled;
+            animationAnimationState = Inspector::Protocol::Animation::AnimationState::Canceled;
             break;
         }
     } else if (trackingData.lastComputedTiming.currentIteration != computedTiming.currentIteration) {
         // Iterations are represented by sequential "active" state events.
-        animationAnimationState = Protocol::Animation::AnimationState::Active;
+        animationAnimationState = Inspector::Protocol::Animation::AnimationState::Active;
     }
 
     trackingData.lastComputedTiming = computedTiming;
@@ -420,7 +420,7 @@ void InspectorAnimationAgent::willApplyKeyframeEffect(const Styleable& target, K
     if (!animationAnimationState)
         return;
 
-    auto event = Protocol::Animation::TrackingUpdate::create()
+    auto event = Inspector::Protocol::Animation::TrackingUpdate::create()
         .setTrackingAnimationId(trackingData.trackingAnimationId)
         .setAnimationState(animationAnimationState.value())
         .release();
@@ -540,7 +540,7 @@ String InspectorAnimationAgent::findAnimationId(WebAnimation& animation)
     return nullString();
 }
 
-WebAnimation* InspectorAnimationAgent::assertAnimation(Protocol::ErrorString& errorString, const String& animationId)
+WebAnimation* InspectorAnimationAgent::assertAnimation(Inspector::Protocol::ErrorString& errorString, const String& animationId)
 {
     auto* animation = m_animationIdMap.get(animationId);
     if (!animation)
@@ -548,12 +548,12 @@ WebAnimation* InspectorAnimationAgent::assertAnimation(Protocol::ErrorString& er
     return animation;
 }
 
-void InspectorAnimationAgent::bindAnimation(WebAnimation& animation, RefPtr<Protocol::Console::StackTrace> backtrace)
+void InspectorAnimationAgent::bindAnimation(WebAnimation& animation, RefPtr<Inspector::Protocol::Console::StackTrace> backtrace)
 {
     auto animationId = makeString("animation:" + IdentifiersFactory::createIdentifier());
     m_animationIdMap.set(animationId, &animation);
 
-    auto animationPayload = Protocol::Animation::Animation::create()
+    auto animationPayload = Inspector::Protocol::Animation::Animation::create()
         .setAnimationId(animationId)
         .release();
 
@@ -619,9 +619,9 @@ void InspectorAnimationAgent::stopTrackingStyleOriginatedAnimation(StyleOriginat
         return;
 
     if (data->lastComputedTiming.phase != AnimationEffectPhase::After && data->lastComputedTiming.phase != AnimationEffectPhase::Idle) {
-        auto event = Protocol::Animation::TrackingUpdate::create()
+        auto event = Inspector::Protocol::Animation::TrackingUpdate::create()
             .setTrackingAnimationId(data->trackingAnimationId)
-            .setAnimationState(Protocol::Animation::AnimationState::Canceled)
+            .setAnimationState(Inspector::Protocol::Animation::AnimationState::Canceled)
             .release();
         m_frontendDispatcher->trackingUpdate(m_environment.executionStopwatch().elapsedTime().seconds(), WTFMove(event));
     }

--- a/Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.cpp
@@ -59,7 +59,7 @@ void InspectorApplicationCacheAgent::willDestroyFrontendAndBackend(Inspector::Di
     disable();
 }
 
-Protocol::ErrorStringOr<void> InspectorApplicationCacheAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorApplicationCacheAgent::enable()
 {
     if (m_instrumentingAgents.enabledApplicationCacheAgent() == this)
         return makeUnexpected("ApplicationCache domain already enabled"_s);
@@ -72,7 +72,7 @@ Protocol::ErrorStringOr<void> InspectorApplicationCacheAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorApplicationCacheAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorApplicationCacheAgent::disable()
 {
     if (m_instrumentingAgents.enabledApplicationCacheAgent() != this)
         return makeUnexpected("ApplicationCache domain already disabled"_s);
@@ -107,13 +107,13 @@ void InspectorApplicationCacheAgent::networkStateChanged()
     m_frontendDispatcher->networkStateUpdated(platformStrategies()->loaderStrategy()->isOnLine());
 }
 
-Expected<Ref<JSON::ArrayOf<Protocol::ApplicationCache::FrameWithManifest>>, Protocol::ErrorString> InspectorApplicationCacheAgent::getFramesWithManifests()
+Expected<Ref<JSON::ArrayOf<Inspector::Protocol::ApplicationCache::FrameWithManifest>>, Inspector::Protocol::ErrorString> InspectorApplicationCacheAgent::getFramesWithManifests()
 {
     auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
     if (!pageAgent)
         return makeUnexpected("Page domain must be enabled"_s);
 
-    auto result = JSON::ArrayOf<Protocol::ApplicationCache::FrameWithManifest>::create();
+    auto result = JSON::ArrayOf<Inspector::Protocol::ApplicationCache::FrameWithManifest>::create();
     m_inspectedPage.forEachLocalFrame([&](LocalFrame& frame) {
         auto* documentLoader = frame.loader().documentLoader();
         if (!documentLoader)
@@ -122,7 +122,7 @@ Expected<Ref<JSON::ArrayOf<Protocol::ApplicationCache::FrameWithManifest>>, Prot
         auto& host = documentLoader->applicationCacheHost();
         String manifestURL = host.applicationCacheInfo().manifest.string();
         if (!manifestURL.isEmpty()) {
-            result->addItem(Protocol::ApplicationCache::FrameWithManifest::create()
+            result->addItem(Inspector::Protocol::ApplicationCache::FrameWithManifest::create()
                 .setFrameId(pageAgent->frameId(&frame))
                 .setManifestURL(manifestURL)
                 .setStatus(static_cast<int>(host.status()))
@@ -132,7 +132,7 @@ Expected<Ref<JSON::ArrayOf<Protocol::ApplicationCache::FrameWithManifest>>, Prot
     return result;
 }
 
-DocumentLoader* InspectorApplicationCacheAgent::assertFrameWithDocumentLoader(Protocol::ErrorString& errorString, const Inspector::Protocol::Network::FrameId& frameId)
+DocumentLoader* InspectorApplicationCacheAgent::assertFrameWithDocumentLoader(Inspector::Protocol::ErrorString& errorString, const Inspector::Protocol::Network::FrameId& frameId)
 {
     auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
     if (!pageAgent) {
@@ -147,9 +147,9 @@ DocumentLoader* InspectorApplicationCacheAgent::assertFrameWithDocumentLoader(Pr
     return InspectorPageAgent::assertDocumentLoader(errorString, frame);
 }
 
-Expected<String, Protocol::ErrorString> InspectorApplicationCacheAgent::getManifestForFrame(const Inspector::Protocol::Network::FrameId& frameId)
+Expected<String, Inspector::Protocol::ErrorString> InspectorApplicationCacheAgent::getManifestForFrame(const Inspector::Protocol::Network::FrameId& frameId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     DocumentLoader* documentLoader = assertFrameWithDocumentLoader(errorString, frameId);
     if (!documentLoader)
@@ -158,9 +158,9 @@ Expected<String, Protocol::ErrorString> InspectorApplicationCacheAgent::getManif
     return documentLoader->applicationCacheHost().applicationCacheInfo().manifest.string();
 }
 
-Expected<Ref<Protocol::ApplicationCache::ApplicationCache>, Protocol::ErrorString> InspectorApplicationCacheAgent::getApplicationCacheForFrame(const Inspector::Protocol::Network::FrameId& frameId)
+Expected<Ref<Inspector::Protocol::ApplicationCache::ApplicationCache>, Inspector::Protocol::ErrorString> InspectorApplicationCacheAgent::getApplicationCacheForFrame(const Inspector::Protocol::Network::FrameId& frameId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* documentLoader = assertFrameWithDocumentLoader(errorString, frameId);
     if (!documentLoader)
@@ -170,9 +170,9 @@ Expected<Ref<Protocol::ApplicationCache::ApplicationCache>, Protocol::ErrorStrin
     return buildObjectForApplicationCache(host.resourceList(), host.applicationCacheInfo());
 }
 
-Ref<Protocol::ApplicationCache::ApplicationCache> InspectorApplicationCacheAgent::buildObjectForApplicationCache(const Vector<ApplicationCacheHost::ResourceInfo>& applicationCacheResources, const ApplicationCacheHost::CacheInfo& applicationCacheInfo)
+Ref<Inspector::Protocol::ApplicationCache::ApplicationCache> InspectorApplicationCacheAgent::buildObjectForApplicationCache(const Vector<ApplicationCacheHost::ResourceInfo>& applicationCacheResources, const ApplicationCacheHost::CacheInfo& applicationCacheInfo)
 {
-    return Protocol::ApplicationCache::ApplicationCache::create()
+    return Inspector::Protocol::ApplicationCache::ApplicationCache::create()
         .setManifestURL(applicationCacheInfo.manifest.string())
         .setSize(applicationCacheInfo.size)
         .setCreationTime(applicationCacheInfo.creationTime)
@@ -181,22 +181,22 @@ Ref<Protocol::ApplicationCache::ApplicationCache> InspectorApplicationCacheAgent
         .release();
 }
 
-Ref<JSON::ArrayOf<Protocol::ApplicationCache::ApplicationCacheResource>> InspectorApplicationCacheAgent::buildArrayForApplicationCacheResources(const Vector<ApplicationCacheHost::ResourceInfo>& applicationCacheResources)
+Ref<JSON::ArrayOf<Inspector::Protocol::ApplicationCache::ApplicationCacheResource>> InspectorApplicationCacheAgent::buildArrayForApplicationCacheResources(const Vector<ApplicationCacheHost::ResourceInfo>& applicationCacheResources)
 {
-    auto result = JSON::ArrayOf<Protocol::ApplicationCache::ApplicationCacheResource>::create();
+    auto result = JSON::ArrayOf<Inspector::Protocol::ApplicationCache::ApplicationCacheResource>::create();
     for (auto& info : applicationCacheResources)
         result->addItem(buildObjectForApplicationCacheResource(info));
     return result;
 }
 
-Ref<Protocol::ApplicationCache::ApplicationCacheResource> InspectorApplicationCacheAgent::buildObjectForApplicationCacheResource(const ApplicationCacheHost::ResourceInfo& resourceInfo)
+Ref<Inspector::Protocol::ApplicationCache::ApplicationCacheResource> InspectorApplicationCacheAgent::buildObjectForApplicationCacheResource(const ApplicationCacheHost::ResourceInfo& resourceInfo)
 {
     auto types = makeString(resourceInfo.isMaster ? "Master " : "",
         resourceInfo.isManifest ? "Manifest " : "",
         resourceInfo.isFallback ? "Fallback " : "",
         resourceInfo.isForeign ? "Foreign " : "",
         resourceInfo.isExplicit ? "Explicit " : "");
-    return Protocol::ApplicationCache::ApplicationCacheResource::create()
+    return Inspector::Protocol::ApplicationCache::ApplicationCacheResource::create()
         .setUrl(resourceInfo.resource.string())
         .setSize(static_cast<int>(resourceInfo.size))
         .setType(types)

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
@@ -58,7 +58,7 @@ void InspectorCPUProfilerAgent::willDestroyFrontendAndBackend(DisconnectReason)
     m_instrumentingAgents.setPersistentCPUProfilerAgent(nullptr);
 }
 
-Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::startTracking()
+Inspector::Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::startTracking()
 {
     if (m_tracking)
         return { };
@@ -74,7 +74,7 @@ Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::startTracking()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::stopTracking()
+Inspector::Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::stopTracking()
 {
     if (!m_tracking)
         return { };
@@ -88,19 +88,19 @@ Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::stopTracking()
     return { };
 }
 
-static Ref<Protocol::CPUProfiler::ThreadInfo> buildThreadInfo(const ThreadCPUInfo& thread)
+static Ref<Inspector::Protocol::CPUProfiler::ThreadInfo> buildThreadInfo(const ThreadCPUInfo& thread)
 {
     ASSERT(thread.cpu <= 100);
 
-    auto threadInfo = Protocol::CPUProfiler::ThreadInfo::create()
+    auto threadInfo = Inspector::Protocol::CPUProfiler::ThreadInfo::create()
         .setName(thread.name)
         .setUsage(thread.cpu)
         .release();
 
     if (thread.type == ThreadCPUInfo::Type::Main)
-        threadInfo->setType(Protocol::CPUProfiler::ThreadInfo::Type::Main);
+        threadInfo->setType(Inspector::Protocol::CPUProfiler::ThreadInfo::Type::Main);
     else if (thread.type == ThreadCPUInfo::Type::WebKit)
-        threadInfo->setType(Protocol::CPUProfiler::ThreadInfo::Type::WebKit);
+        threadInfo->setType(Inspector::Protocol::CPUProfiler::ThreadInfo::Type::WebKit);
 
     if (!thread.identifier.isEmpty())
         threadInfo->setTargetId(thread.identifier);
@@ -110,13 +110,13 @@ static Ref<Protocol::CPUProfiler::ThreadInfo> buildThreadInfo(const ThreadCPUInf
 
 void InspectorCPUProfilerAgent::collectSample(const ResourceUsageData& data)
 {
-    auto event = Protocol::CPUProfiler::Event::create()
+    auto event = Inspector::Protocol::CPUProfiler::Event::create()
         .setTimestamp(m_environment.executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
         .setUsage(data.cpuExcludingDebuggerThreads)
         .release();
 
     if (!data.cpuThreads.isEmpty()) {
-        auto threads = JSON::ArrayOf<Protocol::CPUProfiler::ThreadInfo>::create();
+        auto threads = JSON::ArrayOf<Inspector::Protocol::CPUProfiler::ThreadInfo>::create();
         for (auto& threadInfo : data.cpuThreads)
             threads->addItem(buildThreadInfo(threadInfo));
         event->setThreads(WTFMove(threads));

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -296,11 +296,11 @@ void InspectorCSSAgent::reset()
     m_nodesWithPendingLayoutFlagsChange.clear();
     if (m_nodesWithPendingLayoutFlagsChangeDispatchTimer.isActive())
         m_nodesWithPendingLayoutFlagsChangeDispatchTimer.stop();
-    m_layoutContextTypeChangedMode = Protocol::CSS::LayoutContextTypeChangedMode::Observed;
+    m_layoutContextTypeChangedMode = Inspector::Protocol::CSS::LayoutContextTypeChangedMode::Observed;
     resetPseudoStates();
 }
 
-Protocol::ErrorStringOr<void> InspectorCSSAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::enable()
 {
     if (m_instrumentingAgents.enabledCSSAgent() == this)
         return { };
@@ -315,7 +315,7 @@ Protocol::ErrorStringOr<void> InspectorCSSAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorCSSAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::disable()
 {
     m_instrumentingAgents.setEnabledCSSAgent(nullptr);
 
@@ -395,53 +395,53 @@ bool InspectorCSSAgent::forcePseudoState(const Element& element, CSSSelector::Ps
     return m_nodeIdToForcedPseudoState.get(nodeId).contains(pseudoClass);
 }
 
-std::optional<Protocol::CSS::PseudoId> InspectorCSSAgent::protocolValueForPseudoId(PseudoId pseudoId)
+std::optional<Inspector::Protocol::CSS::PseudoId> InspectorCSSAgent::protocolValueForPseudoId(PseudoId pseudoId)
 {
     switch (pseudoId) {
     case PseudoId::FirstLine:
-        return Protocol::CSS::PseudoId::FirstLine;
+        return Inspector::Protocol::CSS::PseudoId::FirstLine;
     case PseudoId::FirstLetter:
-        return Protocol::CSS::PseudoId::FirstLetter;
+        return Inspector::Protocol::CSS::PseudoId::FirstLetter;
     case PseudoId::GrammarError:
-        return Protocol::CSS::PseudoId::GrammarError;
+        return Inspector::Protocol::CSS::PseudoId::GrammarError;
     case PseudoId::Marker:
-        return Protocol::CSS::PseudoId::Marker;
+        return Inspector::Protocol::CSS::PseudoId::Marker;
     case PseudoId::Backdrop:
-        return Protocol::CSS::PseudoId::Backdrop;
+        return Inspector::Protocol::CSS::PseudoId::Backdrop;
     case PseudoId::Before:
-        return Protocol::CSS::PseudoId::Before;
+        return Inspector::Protocol::CSS::PseudoId::Before;
     case PseudoId::After:
-        return Protocol::CSS::PseudoId::After;
+        return Inspector::Protocol::CSS::PseudoId::After;
     case PseudoId::Selection:
-        return Protocol::CSS::PseudoId::Selection;
+        return Inspector::Protocol::CSS::PseudoId::Selection;
     case PseudoId::Highlight:
-        return Protocol::CSS::PseudoId::Highlight;
+        return Inspector::Protocol::CSS::PseudoId::Highlight;
     case PseudoId::SpellingError:
-        return Protocol::CSS::PseudoId::SpellingError;
+        return Inspector::Protocol::CSS::PseudoId::SpellingError;
     case PseudoId::ViewTransition:
-        return Protocol::CSS::PseudoId::ViewTransition;
+        return Inspector::Protocol::CSS::PseudoId::ViewTransition;
     case PseudoId::ViewTransitionGroup:
-        return Protocol::CSS::PseudoId::ViewTransitionGroup;
+        return Inspector::Protocol::CSS::PseudoId::ViewTransitionGroup;
     case PseudoId::ViewTransitionImagePair:
-        return Protocol::CSS::PseudoId::ViewTransitionImagePair;
+        return Inspector::Protocol::CSS::PseudoId::ViewTransitionImagePair;
     case PseudoId::ViewTransitionOld:
-        return Protocol::CSS::PseudoId::ViewTransitionOld;
+        return Inspector::Protocol::CSS::PseudoId::ViewTransitionOld;
     case PseudoId::ViewTransitionNew:
-        return Protocol::CSS::PseudoId::ViewTransitionNew;
+        return Inspector::Protocol::CSS::PseudoId::ViewTransitionNew;
     case PseudoId::WebKitResizer:
-        return Protocol::CSS::PseudoId::WebKitResizer;
+        return Inspector::Protocol::CSS::PseudoId::WebKitResizer;
     case PseudoId::WebKitScrollbar:
-        return Protocol::CSS::PseudoId::WebKitScrollbar;
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbar;
     case PseudoId::WebKitScrollbarThumb:
-        return Protocol::CSS::PseudoId::WebKitScrollbarThumb;
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarThumb;
     case PseudoId::WebKitScrollbarButton:
-        return Protocol::CSS::PseudoId::WebKitScrollbarButton;
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarButton;
     case PseudoId::WebKitScrollbarTrack:
-        return Protocol::CSS::PseudoId::WebKitScrollbarTrack;
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarTrack;
     case PseudoId::WebKitScrollbarTrackPiece:
-        return Protocol::CSS::PseudoId::WebKitScrollbarTrackPiece;
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarTrackPiece;
     case PseudoId::WebKitScrollbarCorner:
-        return Protocol::CSS::PseudoId::WebKitScrollbarCorner;
+        return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarCorner;
 
     default:
         ASSERT_NOT_REACHED();
@@ -449,9 +449,9 @@ std::optional<Protocol::CSS::PseudoId> InspectorCSSAgent::protocolValueForPseudo
     }
 }
 
-Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Protocol::CSS::RuleMatch>>, RefPtr<JSON::ArrayOf<Protocol::CSS::PseudoIdMatches>>, RefPtr<JSON::ArrayOf<Protocol::CSS::InheritedStyleEntry>>>> InspectorCSSAgent::getMatchedStylesForNode(Protocol::DOM::NodeId nodeId, std::optional<bool>&& includePseudo, std::optional<bool>&& includeInherited)
+Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>>>> InspectorCSSAgent::getMatchedStylesForNode(Inspector::Protocol::DOM::NodeId nodeId, std::optional<bool>&& includePseudo, std::optional<bool>&& includeInherited)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Element* element = elementForId(errorString, nodeId);
     if (!element)
@@ -472,12 +472,12 @@ Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Protocol::CSS::RuleMatch
     auto& styleResolver = element->styleResolver();
     auto matchedRules = styleResolver.pseudoStyleRulesForElement(element, elementPseudoId, Style::Resolver::AllCSSRules);
     auto matchedCSSRules = buildArrayForMatchedRuleList(matchedRules, styleResolver, *element, elementPseudoId);
-    RefPtr<JSON::ArrayOf<Protocol::CSS::PseudoIdMatches>> pseudoElements;
-    RefPtr<JSON::ArrayOf<Protocol::CSS::InheritedStyleEntry>> inherited;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>> pseudoElements;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>> inherited;
 
     if (!originalElement->isPseudoElement()) {
         if (!includePseudo || *includePseudo) {
-            pseudoElements = JSON::ArrayOf<Protocol::CSS::PseudoIdMatches>::create();
+            pseudoElements = JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>::create();
             for (PseudoId pseudoId = PseudoId::FirstPublicPseudoId; pseudoId < PseudoId::AfterLastInternalPseudoId; pseudoId = static_cast<PseudoId>(static_cast<unsigned>(pseudoId) + 1)) {
                 // `*::marker` selectors are only applicable to elements with `display: list-item`.
                 if (pseudoId == PseudoId::Marker && element->computedStyle()->display() != DisplayType::ListItem)
@@ -489,7 +489,7 @@ Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Protocol::CSS::RuleMatch
                 if (auto protocolPseudoId = protocolValueForPseudoId(pseudoId)) {
                     auto matchedRules = styleResolver.pseudoStyleRulesForElement(element, pseudoId, Style::Resolver::AllCSSRules);
                     if (!matchedRules.isEmpty()) {
-                        auto matches = Protocol::CSS::PseudoIdMatches::create()
+                        auto matches = Inspector::Protocol::CSS::PseudoIdMatches::create()
                             .setPseudoId(protocolPseudoId.value())
                             .setMatches(buildArrayForMatchedRuleList(matchedRules, styleResolver, *element, pseudoId))
                             .release();
@@ -500,11 +500,11 @@ Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Protocol::CSS::RuleMatch
         }
 
         if (!includeInherited || *includeInherited) {
-            inherited = JSON::ArrayOf<Protocol::CSS::InheritedStyleEntry>::create();
+            inherited = JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>::create();
             for (auto& ancestor : ancestorsOfType<Element>(*element)) {
                 auto& parentStyleResolver = ancestor.styleResolver();
                 auto parentMatchedRules = parentStyleResolver.styleRulesForElement(&ancestor, Style::Resolver::AllCSSRules);
-                auto entry = Protocol::CSS::InheritedStyleEntry::create()
+                auto entry = Inspector::Protocol::CSS::InheritedStyleEntry::create()
                     .setMatchedCSSRules(buildArrayForMatchedRuleList(parentMatchedRules, styleResolver, ancestor, PseudoId::None))
                     .release();
                 if (RefPtr styledElement = dynamicDowncast<StyledElement>(ancestor); styledElement && styledElement->cssomStyle().length()) {
@@ -519,9 +519,9 @@ Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Protocol::CSS::RuleMatch
     return { { WTFMove(matchedCSSRules), WTFMove(pseudoElements), WTFMove(inherited) } };
 }
 
-Protocol::ErrorStringOr<std::tuple<RefPtr<Protocol::CSS::CSSStyle> /* inlineStyle */, RefPtr<Protocol::CSS::CSSStyle> /* attributesStyle */>> InspectorCSSAgent::getInlineStylesForNode(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<Inspector::Protocol::CSS::CSSStyle> /* inlineStyle */, RefPtr<Inspector::Protocol::CSS::CSSStyle> /* attributesStyle */>> InspectorCSSAgent::getInlineStylesForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* element = elementForId(errorString, nodeId);
     if (!element)
@@ -535,9 +535,9 @@ Protocol::ErrorStringOr<std::tuple<RefPtr<Protocol::CSS::CSSStyle> /* inlineStyl
     return { { styleSheet.buildObjectForStyle(&styledElement->cssomStyle()), buildObjectForAttributesStyle(*styledElement) } };
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::CSS::CSSComputedStyleProperty>>> InspectorCSSAgent::getComputedStyleForNode(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>>> InspectorCSSAgent::getComputedStyleForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* element = elementForId(errorString, nodeId);
     if (!element)
@@ -551,13 +551,13 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::CSS::CSSComputedStylePropert
     return inspectorStyle->buildArrayForComputedStyle();
 }
 
-static Ref<Protocol::CSS::Font> buildObjectForFont(const Font& font)
+static Ref<Inspector::Protocol::CSS::Font> buildObjectForFont(const Font& font)
 {
     auto& fontPlatformData = font.platformData();
     
-    auto resultVariationAxes = JSON::ArrayOf<Protocol::CSS::FontVariationAxis>::create();
+    auto resultVariationAxes = JSON::ArrayOf<Inspector::Protocol::CSS::FontVariationAxis>::create();
     for (auto& variationAxis : fontPlatformData.variationAxes(ShouldLocalizeAxisNames::Yes)) {
-        auto axis = Protocol::CSS::FontVariationAxis::create()
+        auto axis = Inspector::Protocol::CSS::FontVariationAxis::create()
             .setTag(variationAxis.tag())
             .setMinimumValue(variationAxis.minimumValue())
             .setMaximumValue(variationAxis.maximumValue())
@@ -570,7 +570,7 @@ static Ref<Protocol::CSS::Font> buildObjectForFont(const Font& font)
         resultVariationAxes->addItem(WTFMove(axis));
     }
 
-    auto protocolFont = Protocol::CSS::Font::create()
+    auto protocolFont = Inspector::Protocol::CSS::Font::create()
         .setDisplayName(font.platformData().familyName())
         .setVariationAxes(WTFMove(resultVariationAxes))
         .release();
@@ -581,9 +581,9 @@ static Ref<Protocol::CSS::Font> buildObjectForFont(const Font& font)
     return protocolFont;
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::CSS::Font>> InspectorCSSAgent::getFontDataForNode(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::Font>> InspectorCSSAgent::getFontDataForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
     auto* node = nodeForId(errorString, nodeId);
     if (!node)
         return makeUnexpected(errorString);
@@ -595,9 +595,9 @@ Protocol::ErrorStringOr<Ref<Protocol::CSS::Font>> InspectorCSSAgent::getFontData
     return buildObjectForFont(computedStyle->fontCascade().primaryFont());
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::CSS::CSSStyleSheetHeader>>> InspectorCSSAgent::getAllStyleSheets()
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>>> InspectorCSSAgent::getAllStyleSheets()
 {
-    auto headers = JSON::ArrayOf<Protocol::CSS::CSSStyleSheetHeader>::create();
+    auto headers = JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>::create();
 
     Vector<InspectorStyleSheet*> inspectorStyleSheets;
     collectAllStyleSheets(inspectorStyleSheets);
@@ -640,9 +640,9 @@ void InspectorCSSAgent::collectStyleSheets(CSSStyleSheet* styleSheet, Vector<CSS
     }
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::CSS::CSSStyleSheetBody>> InspectorCSSAgent::getStyleSheet(const Protocol::CSS::StyleSheetId& styleSheetId)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSStyleSheetBody>> InspectorCSSAgent::getStyleSheet(const Inspector::Protocol::CSS::StyleSheetId& styleSheetId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     InspectorStyleSheet* inspectorStyleSheet = assertStyleSheetForId(errorString, styleSheetId);
     if (!inspectorStyleSheet)
@@ -655,9 +655,9 @@ Protocol::ErrorStringOr<Ref<Protocol::CSS::CSSStyleSheetBody>> InspectorCSSAgent
     return styleSheet.releaseNonNull();
 }
 
-Protocol::ErrorStringOr<String> InspectorCSSAgent::getStyleSheetText(const Protocol::CSS::StyleSheetId& styleSheetId)
+Inspector::Protocol::ErrorStringOr<String> InspectorCSSAgent::getStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId& styleSheetId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     InspectorStyleSheet* inspectorStyleSheet = assertStyleSheetForId(errorString, styleSheetId);
     if (!inspectorStyleSheet)
@@ -670,9 +670,9 @@ Protocol::ErrorStringOr<String> InspectorCSSAgent::getStyleSheetText(const Proto
     return text.releaseReturnValue();
 }
 
-Protocol::ErrorStringOr<void> InspectorCSSAgent::setStyleSheetText(const Protocol::CSS::StyleSheetId& styleSheetId, const String& text)
+Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::setStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId& styleSheetId, const String& text)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     InspectorStyleSheet* inspectorStyleSheet = assertStyleSheetForId(errorString, styleSheetId);
     if (!inspectorStyleSheet)
@@ -689,9 +689,9 @@ Protocol::ErrorStringOr<void> InspectorCSSAgent::setStyleSheetText(const Protoco
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::CSS::CSSStyle>> InspectorCSSAgent::setStyleText(Ref<JSON::Object>&& styleId, const String& text)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSStyle>> InspectorCSSAgent::setStyleText(Ref<JSON::Object>&& styleId, const String& text)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     InspectorCSSId compoundId(styleId);
     ASSERT(!compoundId.isEmpty());
@@ -711,9 +711,9 @@ Protocol::ErrorStringOr<Ref<Protocol::CSS::CSSStyle>> InspectorCSSAgent::setStyl
     return inspectorStyleSheet->buildObjectForStyle(inspectorStyleSheet->styleForId(compoundId));
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::CSS::CSSRule>> InspectorCSSAgent::setRuleSelector(Ref<JSON::Object>&& ruleId, const String& selector)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSRule>> InspectorCSSAgent::setRuleSelector(Ref<JSON::Object>&& ruleId, const String& selector)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     InspectorCSSId compoundId(ruleId);
     ASSERT(!compoundId.isEmpty());
@@ -737,9 +737,9 @@ Protocol::ErrorStringOr<Ref<Protocol::CSS::CSSRule>> InspectorCSSAgent::setRuleS
     return rule.releaseNonNull();
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::CSS::Grouping>> InspectorCSSAgent::setGroupingHeaderText(Ref<JSON::Object>&& ruleId, const String& headerText)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::Grouping>> InspectorCSSAgent::setGroupingHeaderText(Ref<JSON::Object>&& ruleId, const String& headerText)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     InspectorCSSId compoundId(WTFMove(ruleId));
     ASSERT(!compoundId.isEmpty());
@@ -764,9 +764,9 @@ Protocol::ErrorStringOr<Ref<Protocol::CSS::Grouping>> InspectorCSSAgent::setGrou
 }
 
 
-Protocol::ErrorStringOr<Protocol::CSS::StyleSheetId> InspectorCSSAgent::createStyleSheet(const Protocol::Network::FrameId& frameId)
+Inspector::Protocol::ErrorStringOr<Inspector::Protocol::CSS::StyleSheetId> InspectorCSSAgent::createStyleSheet(const Inspector::Protocol::Network::FrameId& frameId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
     if (!pageAgent)
@@ -828,9 +828,9 @@ InspectorStyleSheet* InspectorCSSAgent::createInspectorStyleSheetForDocument(Doc
     return inspectorStyleSheetsForDocument.last().get();
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::CSS::CSSRule>> InspectorCSSAgent::addRule(const Protocol::CSS::StyleSheetId& styleSheetId, const String& selector)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSRule>> InspectorCSSAgent::addRule(const Inspector::Protocol::CSS::StyleSheetId& styleSheetId, const String& selector)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     InspectorStyleSheet* inspectorStyleSheet = assertStyleSheetForId(errorString, styleSheetId);
     if (!inspectorStyleSheet)
@@ -853,15 +853,15 @@ Protocol::ErrorStringOr<Ref<Protocol::CSS::CSSRule>> InspectorCSSAgent::addRule(
     return rule.releaseNonNull();
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::CSS::CSSPropertyInfo>>> InspectorCSSAgent::getSupportedCSSProperties()
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>>> InspectorCSSAgent::getSupportedCSSProperties()
 {
-    auto cssProperties = JSON::ArrayOf<Protocol::CSS::CSSPropertyInfo>::create();
+    auto cssProperties = JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>::create();
 
     for (auto propertyID : allCSSProperties()) {
         if (!isExposed(propertyID, &m_inspectedPage.settings()))
             continue;
 
-        auto property = Protocol::CSS::CSSPropertyInfo::create()
+        auto property = Inspector::Protocol::CSS::CSSPropertyInfo::create()
             .setName(nameString(propertyID))
             .release();
 
@@ -903,7 +903,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::CSS::CSSPropertyInfo>>> Insp
     return cssProperties;
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorCSSAgent::getSupportedSystemFontFamilyNames()
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorCSSAgent::getSupportedSystemFontFamilyNames()
 {
     auto fontFamilyNames = JSON::ArrayOf<String>::create();
 
@@ -914,9 +914,9 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorCSSAgent::getSuppor
     return fontFamilyNames;
 }
 
-Protocol::ErrorStringOr<void> InspectorCSSAgent::forcePseudoState(Protocol::DOM::NodeId nodeId, Ref<JSON::Array>&& forcedPseudoClasses)
+Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::forcePseudoState(Inspector::Protocol::DOM::NodeId nodeId, Ref<JSON::Array>&& forcedPseudoClasses)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
     if (!domAgent)
@@ -932,36 +932,36 @@ Protocol::ErrorStringOr<void> InspectorCSSAgent::forcePseudoState(Protocol::DOM:
         if (!pseudoClassString)
             return makeUnexpected("Unexpected non-string value in given forcedPseudoClasses"_s);
 
-        auto pseudoClass = Protocol::Helpers::parseEnumValueFromString<Protocol::CSS::ForceablePseudoClass>(pseudoClassString);
+        auto pseudoClass = Inspector::Protocol::Helpers::parseEnumValueFromString<Inspector::Protocol::CSS::ForceablePseudoClass>(pseudoClassString);
         if (!pseudoClass)
             return makeUnexpected(makeString("Unknown forcedPseudoClass: ", pseudoClassString));
 
         switch (*pseudoClass) {
-        case Protocol::CSS::ForceablePseudoClass::Active:
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Active:
             forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Active);
             break;
 
-        case Protocol::CSS::ForceablePseudoClass::Hover:
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Hover:
             forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Hover);
             break;
 
-        case Protocol::CSS::ForceablePseudoClass::Focus:
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Focus:
             forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Focus);
             break;
 
-        case Protocol::CSS::ForceablePseudoClass::FocusVisible:
+        case Inspector::Protocol::CSS::ForceablePseudoClass::FocusVisible:
             forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::FocusVisible);
             break;
 
-        case Protocol::CSS::ForceablePseudoClass::FocusWithin:
+        case Inspector::Protocol::CSS::ForceablePseudoClass::FocusWithin:
             forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::FocusWithin);
             break;
 
-        case Protocol::CSS::ForceablePseudoClass::Target:
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Target:
             forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Target);
             break;
 
-        case Protocol::CSS::ForceablePseudoClass::Visited:
+        case Inspector::Protocol::CSS::ForceablePseudoClass::Visited:
             forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Visited);
             break;
         }
@@ -1049,26 +1049,26 @@ OptionSet<InspectorCSSAgent::LayoutFlag> InspectorCSSAgent::layoutFlagsForNode(N
     return layoutFlags;
 }
 
-static RefPtr<JSON::ArrayOf<String /* Protocol::CSS::LayoutFlag */>> toProtocol(OptionSet<InspectorCSSAgent::LayoutFlag> layoutFlags)
+static RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> toProtocol(OptionSet<InspectorCSSAgent::LayoutFlag> layoutFlags)
 {
     if (layoutFlags.isEmpty())
         return nullptr;
 
-    auto protocolLayoutFlags = JSON::ArrayOf<String /* Protocol::CSS::LayoutFlag */>::create();
+    auto protocolLayoutFlags = JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>::create();
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Rendered))
-        protocolLayoutFlags->addItem(Protocol::Helpers::getEnumConstantValue(Protocol::CSS::LayoutFlag::Rendered));
+        protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Rendered));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Scrollable))
-        protocolLayoutFlags->addItem(Protocol::Helpers::getEnumConstantValue(Protocol::CSS::LayoutFlag::Scrollable));
+        protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Scrollable));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Flex))
-        protocolLayoutFlags->addItem(Protocol::Helpers::getEnumConstantValue(Protocol::CSS::LayoutFlag::Flex));
+        protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Flex));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Grid))
-        protocolLayoutFlags->addItem(Protocol::Helpers::getEnumConstantValue(Protocol::CSS::LayoutFlag::Grid));
+        protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Grid));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Event))
-        protocolLayoutFlags->addItem(Protocol::Helpers::getEnumConstantValue(Protocol::CSS::LayoutFlag::Event));
+        protocolLayoutFlags->addItem(Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::LayoutFlag::Event));
     return protocolLayoutFlags;
 }
 
-RefPtr<JSON::ArrayOf<String /* Protocol::CSS::LayoutFlag */>> InspectorCSSAgent::protocolLayoutFlagsForNode(Node& node)
+RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> InspectorCSSAgent::protocolLayoutFlagsForNode(Node& node)
 {
     auto layoutFlags = layoutFlagsForNode(node);
     if (!layoutFlags.isEmpty())
@@ -1085,14 +1085,14 @@ static void pushChildrenNodesToFrontendIfLayoutFlagIsRelevant(InspectorDOMAgent&
         domAgent.pushNodeToFrontend(&node);
 }
 
-Protocol::ErrorStringOr<void> InspectorCSSAgent::setLayoutContextTypeChangedMode(Protocol::CSS::LayoutContextTypeChangedMode mode)
+Inspector::Protocol::ErrorStringOr<void> InspectorCSSAgent::setLayoutContextTypeChangedMode(Inspector::Protocol::CSS::LayoutContextTypeChangedMode mode)
 {
     if (m_layoutContextTypeChangedMode == mode)
         return { };
     
     m_layoutContextTypeChangedMode = mode;
     
-    if (mode == Protocol::CSS::LayoutContextTypeChangedMode::All) {
+    if (mode == Inspector::Protocol::CSS::LayoutContextTypeChangedMode::All) {
         auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
         if (!domAgent)
             return makeUnexpected("DOM domain must be enabled"_s);
@@ -1141,7 +1141,7 @@ void InspectorCSSAgent::nodesWithPendingLayoutFlagsChangeDispatchTimerFired()
 
         auto nodeId = domAgent->boundNodeId(&node);
         auto nodeWasPushedToFrontend = false;
-        if (!nodeId && m_layoutContextTypeChangedMode == Protocol::CSS::LayoutContextTypeChangedMode::All && layoutFlagsContainLayoutContextType(layoutFlags)) {
+        if (!nodeId && m_layoutContextTypeChangedMode == Inspector::Protocol::CSS::LayoutContextTypeChangedMode::All && layoutFlagsContainLayoutContextType(layoutFlags)) {
             // FIXME: <https://webkit.org/b/189687> Preserve DOM.NodeId if a node is removed and re-added
             nodeId = domAgent->identifierForNode(node);
             nodeWasPushedToFrontend = nodeId;
@@ -1159,13 +1159,13 @@ InspectorStyleSheetForInlineStyle& InspectorCSSAgent::asInspectorStyleSheet(Styl
 {
     return m_nodeToInspectorStyleSheet.ensure(&element, [this, &element] {
         String newStyleSheetId = String::number(m_lastStyleSheetId++);
-        auto inspectorStyleSheet = InspectorStyleSheetForInlineStyle::create(m_instrumentingAgents.enabledPageAgent(), newStyleSheetId, element, Protocol::CSS::StyleSheetOrigin::Author, this);
+        auto inspectorStyleSheet = InspectorStyleSheetForInlineStyle::create(m_instrumentingAgents.enabledPageAgent(), newStyleSheetId, element, Inspector::Protocol::CSS::StyleSheetOrigin::Author, this);
         m_idToInspectorStyleSheet.set(newStyleSheetId, inspectorStyleSheet.copyRef());
         return inspectorStyleSheet;
     }).iterator->value;
 }
 
-Element* InspectorCSSAgent::elementForId(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
+Element* InspectorCSSAgent::elementForId(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
     auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
     if (!domAgent) {
@@ -1176,7 +1176,7 @@ Element* InspectorCSSAgent::elementForId(Protocol::ErrorString& errorString, Pro
     return domAgent->assertElement(errorString, nodeId);
 }
 
-Node* InspectorCSSAgent::nodeForId(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
+Node* InspectorCSSAgent::nodeForId(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
     auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
     if (!domAgent) {
@@ -1213,7 +1213,7 @@ InspectorStyleSheet* InspectorCSSAgent::bindStyleSheet(CSSStyleSheet* styleSheet
     return inspectorStyleSheet.get();
 }
 
-InspectorStyleSheet* InspectorCSSAgent::assertStyleSheetForId(Protocol::ErrorString& errorString, const String& styleSheetId)
+InspectorStyleSheet* InspectorCSSAgent::assertStyleSheetForId(Inspector::Protocol::ErrorString& errorString, const String& styleSheetId)
 {
     IdToInspectorStyleSheet::iterator it = m_idToInspectorStyleSheet.find(styleSheetId);
     if (it == m_idToInspectorStyleSheet.end()) {
@@ -1223,29 +1223,29 @@ InspectorStyleSheet* InspectorCSSAgent::assertStyleSheetForId(Protocol::ErrorStr
     return it->value.get();
 }
 
-Protocol::CSS::StyleSheetOrigin InspectorCSSAgent::detectOrigin(CSSStyleSheet* pageStyleSheet, Document* ownerDocument)
+Inspector::Protocol::CSS::StyleSheetOrigin InspectorCSSAgent::detectOrigin(CSSStyleSheet* pageStyleSheet, Document* ownerDocument)
 {
     if (m_creatingViaInspectorStyleSheet)
-        return Protocol::CSS::StyleSheetOrigin::Inspector;
+        return Inspector::Protocol::CSS::StyleSheetOrigin::Inspector;
 
     if (pageStyleSheet && !pageStyleSheet->ownerNode() && pageStyleSheet->href().isEmpty())
-        return Protocol::CSS::StyleSheetOrigin::UserAgent;
+        return Inspector::Protocol::CSS::StyleSheetOrigin::UserAgent;
 
     if (pageStyleSheet && pageStyleSheet->contents().isUserStyleSheet())
-        return Protocol::CSS::StyleSheetOrigin::User;
+        return Inspector::Protocol::CSS::StyleSheetOrigin::User;
 
     auto iterator = m_documentToInspectorStyleSheet.find(ownerDocument);
     if (iterator != m_documentToInspectorStyleSheet.end()) {
         for (auto& inspectorStyleSheet : iterator->value) {
             if (pageStyleSheet == inspectorStyleSheet->pageStyleSheet())
-                return Protocol::CSS::StyleSheetOrigin::Inspector;
+                return Inspector::Protocol::CSS::StyleSheetOrigin::Inspector;
         }
     }
 
-    return Protocol::CSS::StyleSheetOrigin::Author;
+    return Inspector::Protocol::CSS::StyleSheetOrigin::Author;
 }
 
-RefPtr<Protocol::CSS::CSSRule> InspectorCSSAgent::buildObjectForRule(const StyleRule* styleRule, Style::Resolver& styleResolver, Element& element)
+RefPtr<Inspector::Protocol::CSS::CSSRule> InspectorCSSAgent::buildObjectForRule(const StyleRule* styleRule, Style::Resolver& styleResolver, Element& element)
 {
     ASSERT(element.isConnected());
 
@@ -1266,7 +1266,7 @@ RefPtr<Protocol::CSS::CSSRule> InspectorCSSAgent::buildObjectForRule(const Style
     return buildObjectForRule(cssomWrapper);
 }
 
-RefPtr<Protocol::CSS::CSSRule> InspectorCSSAgent::buildObjectForRule(CSSStyleRule* rule)
+RefPtr<Inspector::Protocol::CSS::CSSRule> InspectorCSSAgent::buildObjectForRule(CSSStyleRule* rule)
 {
     if (!rule)
         return nullptr;
@@ -1276,16 +1276,16 @@ RefPtr<Protocol::CSS::CSSRule> InspectorCSSAgent::buildObjectForRule(CSSStyleRul
     return inspectorStyleSheet ? inspectorStyleSheet->buildObjectForRule(rule) : nullptr;
 }
 
-Ref<JSON::ArrayOf<Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMatchedRuleList(const Vector<RefPtr<const StyleRule>>& matchedRules, Style::Resolver& styleResolver, Element& element, PseudoId pseudoId)
+Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMatchedRuleList(const Vector<RefPtr<const StyleRule>>& matchedRules, Style::Resolver& styleResolver, Element& element, PseudoId pseudoId)
 {
-    auto result = JSON::ArrayOf<Protocol::CSS::RuleMatch>::create();
+    auto result = JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>::create();
 
     SelectorChecker::CheckingContext context(SelectorChecker::Mode::CollectingRules);
     context.pseudoId = pseudoId != PseudoId::None ? pseudoId : element.pseudoId();
     SelectorChecker selectorChecker(element.document());
 
     for (auto& matchedRule : matchedRules) {
-        RefPtr<Protocol::CSS::CSSRule> ruleObject = buildObjectForRule(matchedRule.get(), styleResolver, element);
+        RefPtr<Inspector::Protocol::CSS::CSSRule> ruleObject = buildObjectForRule(matchedRule.get(), styleResolver, element);
         if (!ruleObject)
             continue;
 
@@ -1299,7 +1299,7 @@ Ref<JSON::ArrayOf<Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMat
             ++index;
         }
 
-        auto match = Protocol::CSS::RuleMatch::create()
+        auto match = Inspector::Protocol::CSS::RuleMatch::create()
             .setRule(ruleObject.releaseNonNull())
             .setMatchingSelectors(WTFMove(matchingSelectors))
             .release();
@@ -1309,7 +1309,7 @@ Ref<JSON::ArrayOf<Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMat
     return result;
 }
 
-RefPtr<Protocol::CSS::CSSStyle> InspectorCSSAgent::buildObjectForAttributesStyle(StyledElement& element)
+RefPtr<Inspector::Protocol::CSS::CSSStyle> InspectorCSSAgent::buildObjectForAttributesStyle(StyledElement& element)
 {
     auto* presentationalHintStyle = element.presentationalHintStyle();
     if (!presentationalHintStyle)
@@ -1321,7 +1321,7 @@ RefPtr<Protocol::CSS::CSSStyle> InspectorCSSAgent::buildObjectForAttributesStyle
     return inspectorStyle->buildObjectForStyle();
 }
 
-void InspectorCSSAgent::didRemoveDOMNode(Node& node, Protocol::DOM::NodeId nodeId)
+void InspectorCSSAgent::didRemoveDOMNode(Node& node, Inspector::Protocol::DOM::NodeId nodeId)
 {
     // This can be called in response to GC.
     m_nodeIdToForcedPseudoState.remove(nodeId);

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -116,7 +116,7 @@ void InspectorCanvasAgent::discardAgent()
     reset();
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::enable()
 {
     if (enabled())
         return makeUnexpected("Canvas domain already enabled"_s);
@@ -126,7 +126,7 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::disable()
 {
     internalDisable();
 
@@ -184,18 +184,18 @@ void InspectorCanvasAgent::internalDisable()
     m_recordingAutoCaptureFrameCount = std::nullopt;
 }
 
-Protocol::ErrorStringOr<String> InspectorCanvasAgent::requestContent(const Protocol::Canvas::CanvasId& canvasId)
+Inspector::Protocol::ErrorStringOr<String> InspectorCanvasAgent::requestContent(const Inspector::Protocol::Canvas::CanvasId& canvasId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
     auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
     if (!inspectorCanvas)
         return makeUnexpected(errorString);
     return inspectorCanvas->getContentAsDataURL();
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorCanvasAgent::resolveContext(const Protocol::Canvas::CanvasId& canvasId, const String& objectGroup)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> InspectorCanvasAgent::resolveContext(const Inspector::Protocol::Canvas::CanvasId& canvasId, const String& objectGroup)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
     if (!inspectorCanvas)
@@ -219,7 +219,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorCanvasAge
     return result.releaseNonNull();
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::setRecordingAutoCaptureFrameCount(int count)
+Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::setRecordingAutoCaptureFrameCount(int count)
 {
     if (count > 0)
         m_recordingAutoCaptureFrameCount = count;
@@ -228,9 +228,9 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::setRecordingAutoCaptureFrame
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::startRecording(const Protocol::Canvas::CanvasId& canvasId, std::optional<int>&& frameCount, std::optional<int>&& memoryLimit)
+Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::startRecording(const Inspector::Protocol::Canvas::CanvasId& canvasId, std::optional<int>&& frameCount, std::optional<int>&& memoryLimit)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
     if (!inspectorCanvas)
@@ -248,14 +248,14 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::startRecording(const Protoco
         recordingOptions.frameCount = *frameCount;
     if (memoryLimit)
         recordingOptions.memoryLimit = *memoryLimit;
-    startRecording(*inspectorCanvas, Protocol::Recording::Initiator::Frontend, WTFMove(recordingOptions));
+    startRecording(*inspectorCanvas, Inspector::Protocol::Recording::Initiator::Frontend, WTFMove(recordingOptions));
 
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::stopRecording(const Protocol::Canvas::CanvasId& canvasId)
+Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::stopRecording(const Inspector::Protocol::Canvas::CanvasId& canvasId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
     if (!inspectorCanvas)
@@ -275,9 +275,9 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::stopRecording(const Protocol
 
 #if ENABLE(WEBGL)
 
-Protocol::ErrorStringOr<String> InspectorCanvasAgent::requestShaderSource(const Protocol::Canvas::ProgramId& programId, Protocol::Canvas::ShaderType shaderType)
+Inspector::Protocol::ErrorStringOr<String> InspectorCanvasAgent::requestShaderSource(const Inspector::Protocol::Canvas::ProgramId& programId, Inspector::Protocol::Canvas::ShaderType shaderType)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto inspectorProgram = assertInspectorProgram(errorString, programId);
     if (!inspectorProgram)
@@ -290,9 +290,9 @@ Protocol::ErrorStringOr<String> InspectorCanvasAgent::requestShaderSource(const 
     return source;
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::updateShader(const Protocol::Canvas::ProgramId& programId, Protocol::Canvas::ShaderType shaderType, const String& source)
+Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::updateShader(const Inspector::Protocol::Canvas::ProgramId& programId, Inspector::Protocol::Canvas::ShaderType shaderType, const String& source)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto inspectorProgram = assertInspectorProgram(errorString, programId);
     if (!inspectorProgram)
@@ -304,9 +304,9 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::updateShader(const Protocol:
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramDisabled(const Protocol::Canvas::ProgramId& programId, bool disabled)
+Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramDisabled(const Inspector::Protocol::Canvas::ProgramId& programId, bool disabled)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto inspectorProgram = assertInspectorProgram(errorString, programId);
     if (!inspectorProgram)
@@ -317,9 +317,9 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramDisabled(con
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramHighlighted(const Protocol::Canvas::ProgramId& programId, bool highlighted)
+Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramHighlighted(const Inspector::Protocol::Canvas::ProgramId& programId, bool highlighted)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto inspectorProgram = assertInspectorProgram(errorString, programId);
     if (!inspectorProgram)
@@ -344,7 +344,7 @@ void InspectorCanvasAgent::didCreateCanvasRenderingContext(CanvasRenderingContex
     if (m_recordingAutoCaptureFrameCount) {
         RecordingOptions recordingOptions;
         recordingOptions.frameCount = m_recordingAutoCaptureFrameCount.value();
-        startRecording(inspectorCanvas, Protocol::Recording::Initiator::AutoCapture, WTFMove(recordingOptions));
+        startRecording(inspectorCanvas, Inspector::Protocol::Recording::Initiator::AutoCapture, WTFMove(recordingOptions));
     }
 }
 
@@ -458,7 +458,7 @@ void InspectorCanvasAgent::consoleStartRecordingCanvas(CanvasRenderingContext& c
         if (JSC::JSValue optionName = options->get(&exec, JSC::Identifier::fromString(vm, "name"_s)))
             recordingOptions.name = optionName.toWTFString(&exec);
     }
-    startRecording(*inspectorCanvas, Protocol::Recording::Initiator::Console, WTFMove(recordingOptions));
+    startRecording(*inspectorCanvas, Inspector::Protocol::Recording::Initiator::Console, WTFMove(recordingOptions));
 }
 
 void InspectorCanvasAgent::consoleStopRecordingCanvas(CanvasRenderingContext& context)
@@ -575,7 +575,7 @@ void InspectorCanvasAgent::recordAction(CanvasRenderingContext& canvasRenderingC
         didFinishRecordingCanvasFrame(canvasRenderingContext, true);
 }
 
-void InspectorCanvasAgent::startRecording(InspectorCanvas& inspectorCanvas, Protocol::Recording::Initiator initiator, RecordingOptions&& recordingOptions)
+void InspectorCanvasAgent::startRecording(InspectorCanvas& inspectorCanvas, Inspector::Protocol::Recording::Initiator initiator, RecordingOptions&& recordingOptions)
 {
     auto& context = inspectorCanvas.canvasContext();
     // FIXME: <https://webkit.org/b/201651> Web Inspector: Canvas: support canvas recordings for WebGPUDevice
@@ -705,7 +705,7 @@ void InspectorCanvasAgent::unbindCanvas(InspectorCanvas& inspectorCanvas)
         m_canvasDestroyedTimer.startOneShot(0_s);
 }
 
-RefPtr<InspectorCanvas> InspectorCanvasAgent::assertInspectorCanvas(Protocol::ErrorString& errorString, const String& canvasId)
+RefPtr<InspectorCanvas> InspectorCanvasAgent::assertInspectorCanvas(Inspector::Protocol::ErrorString& errorString, const String& canvasId)
 {
     auto inspectorCanvas = m_identifierToInspectorCanvas.get(canvasId);
     if (!inspectorCanvas) {
@@ -740,7 +740,7 @@ void InspectorCanvasAgent::unbindProgram(InspectorShaderProgram& inspectorProgra
         m_programDestroyedTimer.startOneShot(0_s);
 }
 
-RefPtr<InspectorShaderProgram> InspectorCanvasAgent::assertInspectorProgram(Protocol::ErrorString& errorString, const String& programId)
+RefPtr<InspectorShaderProgram> InspectorCanvasAgent::assertInspectorProgram(Inspector::Protocol::ErrorString& errorString, const String& programId)
 {
     auto inspectorProgram = m_identifierToInspectorProgram.get(programId);
     if (!inspectorProgram) {

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -150,13 +150,13 @@ static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
     if (!colorObject)
         return std::nullopt;
 
-    auto r = colorObject->getInteger(Protocol::DOM::RGBAColor::rKey);
-    auto g = colorObject->getInteger(Protocol::DOM::RGBAColor::gKey);
-    auto b = colorObject->getInteger(Protocol::DOM::RGBAColor::bKey);
+    auto r = colorObject->getInteger(Inspector::Protocol::DOM::RGBAColor::rKey);
+    auto g = colorObject->getInteger(Inspector::Protocol::DOM::RGBAColor::gKey);
+    auto b = colorObject->getInteger(Inspector::Protocol::DOM::RGBAColor::bKey);
     if (!r || !g || !b)
         return std::nullopt;
 
-    auto a = colorObject->getDouble(Protocol::DOM::RGBAColor::aKey);
+    auto a = colorObject->getDouble(Inspector::Protocol::DOM::RGBAColor::aKey);
     if (!a)
         return { makeFromComponentsClamping<SRGBA<uint8_t>>(*r, *g, *b) };
     return { makeFromComponentsClampingExceptAlpha<SRGBA<uint8_t>>(*r, *g, *b, convertFloatAlphaTo<uint8_t>(*a)) };
@@ -342,7 +342,7 @@ void InspectorDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReaso
     m_mousedOverNode = nullptr;
     m_inspectedNode = nullptr;
 
-    Protocol::ErrorString ignored;
+    Inspector::Protocol::ErrorString ignored;
     setSearchingForNode(ignored, false, nullptr, nullptr, nullptr, false);
     hideHighlight();
 
@@ -415,7 +415,7 @@ void InspectorDOMAgent::relayoutDocument()
     m_document->updateLayout();
 }
 
-Protocol::DOM::NodeId InspectorDOMAgent::bind(Node& node)
+Inspector::Protocol::DOM::NodeId InspectorDOMAgent::bind(Node& node)
 {
     return m_nodeToId.ensure(node, [&] {
         auto id = m_lastNodeId++;
@@ -456,7 +456,7 @@ void InspectorDOMAgent::unbind(Node& node)
     }
 }
 
-Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
+Node* InspectorDOMAgent::assertNode(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
     RefPtr node = nodeForId(nodeId);
     if (!node) {
@@ -466,7 +466,7 @@ Node* InspectorDOMAgent::assertNode(Protocol::ErrorString& errorString, Protocol
     return node.get();
 }
 
-Document* InspectorDOMAgent::assertDocument(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
+Document* InspectorDOMAgent::assertDocument(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
     RefPtr node = assertNode(errorString, nodeId);
     if (!node)
@@ -477,7 +477,7 @@ Document* InspectorDOMAgent::assertDocument(Protocol::ErrorString& errorString, 
     return document.get();
 }
 
-Element* InspectorDOMAgent::assertElement(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
+Element* InspectorDOMAgent::assertElement(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
     RefPtr node = assertNode(errorString, nodeId);
     if (!node)
@@ -488,7 +488,7 @@ Element* InspectorDOMAgent::assertElement(Protocol::ErrorString& errorString, Pr
     return element.get();
 }
 
-Node* InspectorDOMAgent::assertEditableNode(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
+Node* InspectorDOMAgent::assertEditableNode(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
     RefPtr node = assertNode(errorString, nodeId);
     if (!node)
@@ -504,7 +504,7 @@ Node* InspectorDOMAgent::assertEditableNode(Protocol::ErrorString& errorString, 
     return node.get();
 }
 
-Element* InspectorDOMAgent::assertEditableElement(Protocol::ErrorString& errorString, Protocol::DOM::NodeId nodeId)
+Element* InspectorDOMAgent::assertEditableElement(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
 {
     RefPtr node = assertEditableNode(errorString, nodeId);
     if (!node)
@@ -515,7 +515,7 @@ Element* InspectorDOMAgent::assertEditableElement(Protocol::ErrorString& errorSt
     return element.get();
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::DOM::Node>> InspectorDOMAgent::getDocument()
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Node>> InspectorDOMAgent::getDocument()
 {
     m_documentRequested = true;
 
@@ -535,7 +535,7 @@ Protocol::ErrorStringOr<Ref<Protocol::DOM::Node>> InspectorDOMAgent::getDocument
     return root;
 }
 
-void InspectorDOMAgent::pushChildNodesToFrontend(Protocol::DOM::NodeId nodeId, int depth)
+void InspectorDOMAgent::pushChildNodesToFrontend(Inspector::Protocol::DOM::NodeId nodeId, int depth)
 {
     Node* node = nodeForId(nodeId);
     if (!node || (node->nodeType() != Node::ELEMENT_NODE && node->nodeType() != Node::DOCUMENT_NODE && node->nodeType() != Node::DOCUMENT_FRAGMENT_NODE))
@@ -582,24 +582,24 @@ static Element* elementToPushForStyleable(const Styleable& styleable)
     return element;
 }
 
-Protocol::DOM::NodeId InspectorDOMAgent::pushStyleableElementToFrontend(const Styleable& styleable)
+Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushStyleableElementToFrontend(const Styleable& styleable)
 {
     auto* element = elementToPushForStyleable(styleable);
     return pushNodeToFrontend(element ? element : &styleable.element);
 }
 
-Protocol::DOM::NodeId InspectorDOMAgent::pushNodeToFrontend(Node* nodeToPush)
+Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushNodeToFrontend(Node* nodeToPush)
 {
     if (!nodeToPush)
         return 0;
 
     // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
 
-    Protocol::ErrorString ignored;
+    Inspector::Protocol::ErrorString ignored;
     return pushNodeToFrontend(ignored, boundNodeId(&nodeToPush->document()), nodeToPush);
 }
 
-Protocol::DOM::NodeId InspectorDOMAgent::pushNodeToFrontend(Protocol::ErrorString& errorString, Protocol::DOM::NodeId documentNodeId, Node* nodeToPush)
+Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushNodeToFrontend(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId documentNodeId, Node* nodeToPush)
 {
     Document* document = assertDocument(errorString, documentNodeId);
     if (!document)
@@ -612,7 +612,7 @@ Protocol::DOM::NodeId InspectorDOMAgent::pushNodeToFrontend(Protocol::ErrorStrin
     return pushNodePathToFrontend(errorString, nodeToPush);
 }
 
-Node* InspectorDOMAgent::nodeForId(Protocol::DOM::NodeId id)
+Node* InspectorDOMAgent::nodeForId(Inspector::Protocol::DOM::NodeId id)
 {
     if (!m_idToNode.isValidKey(id))
         return nullptr;
@@ -620,7 +620,7 @@ Node* InspectorDOMAgent::nodeForId(Protocol::DOM::NodeId id)
     return m_idToNode.get(id).get();
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::requestChildNodes(Protocol::DOM::NodeId nodeId, std::optional<int>&& depth)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::requestChildNodes(Inspector::Protocol::DOM::NodeId nodeId, std::optional<int>&& depth)
 {
     int sanitizedDepth;
 
@@ -638,9 +638,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::requestChildNodes(Protocol::DOM
     return { };
 }
 
-Protocol::ErrorStringOr<std::optional<Protocol::DOM::NodeId>> InspectorDOMAgent::querySelector(Protocol::DOM::NodeId nodeId, const String& selector)
+Inspector::Protocol::ErrorStringOr<std::optional<Inspector::Protocol::DOM::NodeId>> InspectorDOMAgent::querySelector(Inspector::Protocol::DOM::NodeId nodeId, const String& selector)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     RefPtr node = assertNode(errorString, nodeId);
     if (!node)
@@ -664,9 +664,9 @@ Protocol::ErrorStringOr<std::optional<Protocol::DOM::NodeId>> InspectorDOMAgent:
     return { resultNodeId };
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> InspectorDOMAgent::querySelectorAll(Protocol::DOM::NodeId nodeId, const String& selector)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> InspectorDOMAgent::querySelectorAll(Inspector::Protocol::DOM::NodeId nodeId, const String& selector)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     RefPtr node = assertNode(errorString, nodeId);
     if (!node)
@@ -681,24 +681,24 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> InspectorDOMA
 
     auto nodes = queryResult.releaseReturnValue();
 
-    auto nodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+    auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
     for (unsigned i = 0; i < nodes->length(); ++i)
         nodeIds->addItem(pushNodePathToFrontend(nodes->item(i)));
     return nodeIds;
 }
 
-Protocol::DOM::NodeId InspectorDOMAgent::pushNodePathToFrontend(Node* nodeToPush)
+Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushNodePathToFrontend(Node* nodeToPush)
 {
-    Protocol::ErrorString ignored;
+    Inspector::Protocol::ErrorString ignored;
     return pushNodePathToFrontend(ignored, nodeToPush);
 }
 
-Ref<Protocol::DOM::Styleable> InspectorDOMAgent::pushStyleablePathToFrontend(Protocol::ErrorString errorString, const Styleable& styleable)
+Ref<Inspector::Protocol::DOM::Styleable> InspectorDOMAgent::pushStyleablePathToFrontend(Inspector::Protocol::ErrorString errorString, const Styleable& styleable)
 {
     auto* element = elementToPushForStyleable(styleable);
     auto nodeId = pushNodePathToFrontend(errorString, element ? element : &styleable.element);
 
-    auto protocolStyleable = Protocol::DOM::Styleable::create()
+    auto protocolStyleable = Inspector::Protocol::DOM::Styleable::create()
         .setNodeId(nodeId)
         .release();
 
@@ -710,7 +710,7 @@ Ref<Protocol::DOM::Styleable> InspectorDOMAgent::pushStyleablePathToFrontend(Pro
     return protocolStyleable;
 }
 
-Protocol::DOM::NodeId InspectorDOMAgent::pushNodePathToFrontend(Protocol::ErrorString errorString, Node* nodeToPush)
+Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushNodePathToFrontend(Inspector::Protocol::ErrorString errorString, Node* nodeToPush)
 {
     ASSERT(nodeToPush);  // Invalid input
 
@@ -736,7 +736,7 @@ Protocol::DOM::NodeId InspectorDOMAgent::pushNodePathToFrontend(Protocol::ErrorS
         Node* parent = innerParentNode(node);
         if (!parent) {
             // Node being pushed is detached -> push subtree root.
-            auto children = JSON::ArrayOf<Protocol::DOM::Node>::create();
+            auto children = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
             children->addItem(buildObjectForNode(node, 0));
             m_frontendDispatcher->setChildNodes(0, WTFMove(children));
             break;
@@ -756,7 +756,7 @@ Protocol::DOM::NodeId InspectorDOMAgent::pushNodePathToFrontend(Protocol::ErrorS
     return boundNodeId(nodeToPush);
 }
 
-Protocol::DOM::NodeId InspectorDOMAgent::boundNodeId(const Node* node)
+Inspector::Protocol::DOM::NodeId InspectorDOMAgent::boundNodeId(const Node* node)
 {
     if (!node)
         return 0;
@@ -764,9 +764,9 @@ Protocol::DOM::NodeId InspectorDOMAgent::boundNodeId(const Node* node)
     return m_nodeToId.get(*node);
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setAttributeValue(Protocol::DOM::NodeId nodeId, const String& name, const String& value)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAttributeValue(Inspector::Protocol::DOM::NodeId nodeId, const String& name, const String& value)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Element* element = assertEditableElement(errorString, nodeId);
     if (!element)
@@ -778,9 +778,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAttributeValue(Protocol::DOM
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setAttributesAsText(Protocol::DOM::NodeId nodeId, const String& text, const String& name)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAttributesAsText(Inspector::Protocol::DOM::NodeId nodeId, const String& text, const String& name)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Element* element = assertEditableElement(errorString, nodeId);
     if (!element)
@@ -819,9 +819,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setAttributesAsText(Protocol::D
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::removeAttribute(Protocol::DOM::NodeId nodeId, const String& name)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::removeAttribute(Inspector::Protocol::DOM::NodeId nodeId, const String& name)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Element* element = assertEditableElement(errorString, nodeId);
     if (!element)
@@ -833,9 +833,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::removeAttribute(Protocol::DOM::
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::removeNode(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::removeNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     RefPtr node = assertEditableNode(errorString, nodeId);
     if (!node)
@@ -851,9 +851,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::removeNode(Protocol::DOM::NodeI
     return { };
 }
 
-Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::setNodeName(Protocol::DOM::NodeId nodeId, const String& tagName)
+Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> InspectorDOMAgent::setNodeName(Inspector::Protocol::DOM::NodeId nodeId, const String& tagName)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto oldNode = assertElement(errorString, nodeId);
     if (!oldNode)
@@ -889,9 +889,9 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::setNodeName(Pr
     return resultNodeId;
 }
 
-Protocol::ErrorStringOr<String> InspectorDOMAgent::getOuterHTML(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<String> InspectorDOMAgent::getOuterHTML(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Node* node = assertNode(errorString, nodeId);
     if (!node)
@@ -900,9 +900,9 @@ Protocol::ErrorStringOr<String> InspectorDOMAgent::getOuterHTML(Protocol::DOM::N
     return serializeFragment(*node, SerializedNodes::SubtreeIncludingNode);
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setOuterHTML(Protocol::DOM::NodeId nodeId, const String& outerHTML)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setOuterHTML(Inspector::Protocol::DOM::NodeId nodeId, const String& outerHTML)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     if (!nodeId) {
         DOMPatchSupport { *m_domEditor, *m_document }.patchDocument(outerHTML);
@@ -935,9 +935,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setOuterHTML(Protocol::DOM::Nod
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::insertAdjacentHTML(Protocol::DOM::NodeId nodeId, const String& position, const String& html)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::insertAdjacentHTML(Inspector::Protocol::DOM::NodeId nodeId, const String& position, const String& html)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     RefPtr node = assertEditableNode(errorString, nodeId);
     if (!node)
@@ -953,9 +953,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::insertAdjacentHTML(Protocol::DO
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setNodeValue(Protocol::DOM::NodeId nodeId, const String& value)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setNodeValue(Inspector::Protocol::DOM::NodeId nodeId, const String& value)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     RefPtr node = assertEditableNode(errorString, nodeId);
     if (!node)
@@ -971,7 +971,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setNodeValue(Protocol::DOM::Nod
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDOMAgent::getSupportedEventNames()
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDOMAgent::getSupportedEventNames()
 {
     auto list = JSON::ArrayOf<String>::create();
 
@@ -982,20 +982,20 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDOMAgent::getSuppor
 }
 
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::DataBinding>>> InspectorDOMAgent::getDataBindingsForNode(Protocol::DOM::NodeId)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::DataBinding>>> InspectorDOMAgent::getDataBindingsForNode(Inspector::Protocol::DOM::NodeId)
 {
     return makeUnexpected("Not supported"_s);
 }
 
-Protocol::ErrorStringOr<String> InspectorDOMAgent::getAssociatedDataForNode(Protocol::DOM::NodeId)
+Inspector::Protocol::ErrorStringOr<String> InspectorDOMAgent::getAssociatedDataForNode(Inspector::Protocol::DOM::NodeId)
 {
     return makeUnexpected("Not supported"_s);
 }
 #endif
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::EventListener>>> InspectorDOMAgent::getEventListenersForNode(Protocol::DOM::NodeId nodeId, std::optional<bool>&& includeAncestors)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>>> InspectorDOMAgent::getEventListenersForNode(Inspector::Protocol::DOM::NodeId nodeId, std::optional<bool>&& includeAncestors)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     RefPtr node = assertNode(errorString, nodeId);
     if (!node)
@@ -1030,10 +1030,10 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::EventListener>>> Inspec
         }
     }
 
-    auto listeners = JSON::ArrayOf<Protocol::DOM::EventListener>::create();
+    auto listeners = JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>::create();
 
     auto addListener = [&] (RegisteredEventListener& listener, const EventListenerInfo& info) {
-        Protocol::DOM::EventListenerId identifier = 0;
+        Inspector::Protocol::DOM::EventListenerId identifier = 0;
         bool disabled = false;
         RefPtr<JSC::Breakpoint> breakpoint;
 
@@ -1083,7 +1083,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::EventListener>>> Inspec
     return listeners;
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setEventListenerDisabled(Protocol::DOM::EventListenerId eventListenerId, bool disabled)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setEventListenerDisabled(Inspector::Protocol::DOM::EventListenerId eventListenerId, bool disabled)
 {
     auto it = m_eventListenerEntries.find(eventListenerId);
     if (it == m_eventListenerEntries.end())
@@ -1094,9 +1094,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setEventListenerDisabled(Protoc
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setBreakpointForEventListener(Protocol::DOM::EventListenerId eventListenerId, RefPtr<JSON::Object>&& options)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setBreakpointForEventListener(Inspector::Protocol::DOM::EventListenerId eventListenerId, RefPtr<JSON::Object>&& options)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto it = m_eventListenerEntries.find(eventListenerId);
     if (it == m_eventListenerEntries.end())
@@ -1112,7 +1112,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setBreakpointForEventListener(P
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::removeBreakpointForEventListener(Protocol::DOM::EventListenerId eventListenerId)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::removeBreakpointForEventListener(Inspector::Protocol::DOM::EventListenerId eventListenerId)
 {
     auto it = m_eventListenerEntries.find(eventListenerId);
     if (it == m_eventListenerEntries.end())
@@ -1126,9 +1126,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::removeBreakpointForEventListene
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::DOM::AccessibilityProperties>> InspectorDOMAgent::getAccessibilityPropertiesForNode(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::AccessibilityProperties>> InspectorDOMAgent::getAccessibilityPropertiesForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Node* node = assertNode(errorString, nodeId);
     if (!node)
@@ -1137,9 +1137,9 @@ Protocol::ErrorStringOr<Ref<Protocol::DOM::AccessibilityProperties>> InspectorDO
     return buildObjectForAccessibilityProperties(*node);
 }
 
-Protocol::ErrorStringOr<std::tuple<String /* searchId */, int /* resultCount */>> InspectorDOMAgent::performSearch(const String& query, RefPtr<JSON::Array>&& nodeIds, std::optional<bool>&& caseSensitive)
+Inspector::Protocol::ErrorStringOr<std::tuple<String /* searchId */, int /* resultCount */>> InspectorDOMAgent::performSearch(const String& query, RefPtr<JSON::Array>&& nodeIds, std::optional<bool>&& caseSensitive)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     // FIXME: Search works with node granularity - number of matches within node is not calculated.
     InspectorNodeFinder finder(query, caseSensitive && *caseSensitive);
@@ -1171,7 +1171,7 @@ Protocol::ErrorStringOr<std::tuple<String /* searchId */, int /* resultCount */>
     return { { searchId, resultsVector.size() } };
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> InspectorDOMAgent::getSearchResults(const String& searchId, int fromIndex, int toIndex)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> InspectorDOMAgent::getSearchResults(const String& searchId, int fromIndex, int toIndex)
 {
     SearchResults::iterator it = m_searchResults.find(searchId);
     if (it == m_searchResults.end())
@@ -1181,13 +1181,13 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> InspectorDOMA
     if (fromIndex < 0 || toIndex > size || fromIndex >= toIndex)
         return makeUnexpected("Invalid search result range for given fromIndex and toIndex"_s);
 
-    auto nodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+    auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
     for (int i = fromIndex; i < toIndex; ++i)
         nodeIds->addItem(pushNodePathToFrontend((it->value)[i].get()));
     return nodeIds;
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::discardSearchResults(const String& searchId)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::discardSearchResults(const String& searchId)
 {
     m_searchResults.remove(searchId);
 
@@ -1222,7 +1222,7 @@ bool InspectorDOMAgent::handleTouchEvent(Node& node)
 
 void InspectorDOMAgent::inspect(Node* inspectedNode)
 {
-    Protocol::ErrorString ignored;
+    Inspector::Protocol::ErrorString ignored;
     RefPtr<Node> node = inspectedNode;
     setSearchingForNode(ignored, false, nullptr, nullptr, nullptr, false);
 
@@ -1278,7 +1278,7 @@ void InspectorDOMAgent::highlightMousedOverNode()
         m_overlay->highlightNode(node, *m_inspectModeHighlightConfig, m_inspectModeGridOverlayConfig, m_inspectModeFlexOverlayConfig, m_inspectModeShowRulers);
 }
 
-void InspectorDOMAgent::setSearchingForNode(Protocol::ErrorString& errorString, bool enabled, RefPtr<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, bool showRulers)
+void InspectorDOMAgent::setSearchingForNode(Inspector::Protocol::ErrorString& errorString, bool enabled, RefPtr<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, bool showRulers)
 {
     if (m_searchingForNode == enabled)
         return;
@@ -1312,7 +1312,7 @@ void InspectorDOMAgent::setSearchingForNode(Protocol::ErrorString& errorString, 
         client->elementSelectionChanged(m_searchingForNode);
 }
 
-std::unique_ptr<InspectorOverlay::Highlight::Config> InspectorDOMAgent::highlightConfigFromInspectorObject(Protocol::ErrorString& errorString, RefPtr<JSON::Object>&& highlightInspectorObject)
+std::unique_ptr<InspectorOverlay::Highlight::Config> InspectorDOMAgent::highlightConfigFromInspectorObject(Inspector::Protocol::ErrorString& errorString, RefPtr<JSON::Object>&& highlightInspectorObject)
 {
     if (!highlightInspectorObject) {
         errorString = "Internal error: highlight configuration parameter is missing"_s;
@@ -1320,11 +1320,11 @@ std::unique_ptr<InspectorOverlay::Highlight::Config> InspectorDOMAgent::highligh
     }
 
     auto highlightConfig = makeUnique<InspectorOverlay::Highlight::Config>();
-    highlightConfig->showInfo = highlightInspectorObject->getBoolean(Protocol::DOM::HighlightConfig::showInfoKey).value_or(false);
-    highlightConfig->content = parseOptionalConfigColor(Protocol::DOM::HighlightConfig::contentColorKey, *highlightInspectorObject);
-    highlightConfig->padding = parseOptionalConfigColor(Protocol::DOM::HighlightConfig::paddingColorKey, *highlightInspectorObject);
-    highlightConfig->border = parseOptionalConfigColor(Protocol::DOM::HighlightConfig::borderColorKey, *highlightInspectorObject);
-    highlightConfig->margin = parseOptionalConfigColor(Protocol::DOM::HighlightConfig::marginColorKey, *highlightInspectorObject);
+    highlightConfig->showInfo = highlightInspectorObject->getBoolean(Inspector::Protocol::DOM::HighlightConfig::showInfoKey).value_or(false);
+    highlightConfig->content = parseOptionalConfigColor(Inspector::Protocol::DOM::HighlightConfig::contentColorKey, *highlightInspectorObject);
+    highlightConfig->padding = parseOptionalConfigColor(Inspector::Protocol::DOM::HighlightConfig::paddingColorKey, *highlightInspectorObject);
+    highlightConfig->border = parseOptionalConfigColor(Inspector::Protocol::DOM::HighlightConfig::borderColorKey, *highlightInspectorObject);
+    highlightConfig->margin = parseOptionalConfigColor(Inspector::Protocol::DOM::HighlightConfig::marginColorKey, *highlightInspectorObject);
     return highlightConfig;
 }
 
@@ -1333,7 +1333,7 @@ std::optional<InspectorOverlay::Grid::Config> InspectorDOMAgent::gridOverlayConf
     if (!gridOverlayInspectorObject)
         return std::nullopt;
 
-    auto gridColor = parseRequiredConfigColor(Protocol::DOM::GridOverlayConfig::gridColorKey, *gridOverlayInspectorObject);
+    auto gridColor = parseRequiredConfigColor(Inspector::Protocol::DOM::GridOverlayConfig::gridColorKey, *gridOverlayInspectorObject);
     if (!gridColor) {
         errorString = "Internal error: grid color property of grid overlay configuration parameter is missing"_s;
         return std::nullopt;
@@ -1341,11 +1341,11 @@ std::optional<InspectorOverlay::Grid::Config> InspectorDOMAgent::gridOverlayConf
 
     InspectorOverlay::Grid::Config gridOverlayConfig;
     gridOverlayConfig.gridColor = *gridColor;
-    gridOverlayConfig.showLineNames = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showLineNamesKey).value_or(false);
-    gridOverlayConfig.showLineNumbers = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showLineNumbersKey).value_or(false);
-    gridOverlayConfig.showExtendedGridLines = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showExtendedGridLinesKey).value_or(false);
-    gridOverlayConfig.showTrackSizes = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showTrackSizesKey).value_or(false);
-    gridOverlayConfig.showAreaNames = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showAreaNamesKey).value_or(false);
+    gridOverlayConfig.showLineNames = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showLineNamesKey).value_or(false);
+    gridOverlayConfig.showLineNumbers = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showLineNumbersKey).value_or(false);
+    gridOverlayConfig.showExtendedGridLines = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showExtendedGridLinesKey).value_or(false);
+    gridOverlayConfig.showTrackSizes = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showTrackSizesKey).value_or(false);
+    gridOverlayConfig.showAreaNames = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showAreaNamesKey).value_or(false);
     return gridOverlayConfig;
 }
 
@@ -1354,7 +1354,7 @@ std::optional<InspectorOverlay::Flex::Config> InspectorDOMAgent::flexOverlayConf
     if (!flexOverlayInspectorObject)
         return std::nullopt;
 
-    auto flexColor = parseRequiredConfigColor(Protocol::DOM::FlexOverlayConfig::flexColorKey, *flexOverlayInspectorObject);
+    auto flexColor = parseRequiredConfigColor(Inspector::Protocol::DOM::FlexOverlayConfig::flexColorKey, *flexOverlayInspectorObject);
     if (!flexColor) {
         errorString = "Internal error: flex color property of flex overlay configuration parameter is missing"_s;
         return std::nullopt;
@@ -1362,14 +1362,14 @@ std::optional<InspectorOverlay::Flex::Config> InspectorDOMAgent::flexOverlayConf
 
     InspectorOverlay::Flex::Config flexOverlayConfig;
     flexOverlayConfig.flexColor = *flexColor;
-    flexOverlayConfig.showOrderNumbers = flexOverlayInspectorObject->getBoolean(Protocol::DOM::FlexOverlayConfig::showOrderNumbersKey).value_or(false);
+    flexOverlayConfig.showOrderNumbers = flexOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::FlexOverlayConfig::showOrderNumbersKey).value_or(false);
     return flexOverlayConfig;
 }
 
 #if PLATFORM(IOS_FAMILY)
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     setSearchingForNode(errorString, enabled, WTFMove(highlightConfig), WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), false);
 
@@ -1379,9 +1379,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enab
     return { };
 }
 #else
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     setSearchingForNode(errorString, enabled, WTFMove(highlightConfig), WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), showRulers && *showRulers);
 
@@ -1392,7 +1392,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enab
 }
 #endif
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightRect(int x, int y, int width, int height, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightRect(int x, int y, int width, int height, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
 {
     auto quad = makeUnique<FloatQuad>(FloatRect(x, y, width, height));
     innerHighlightQuad(WTFMove(quad), WTFMove(color), WTFMove(outlineColor), WTFMove(usePageCoordinates));
@@ -1400,7 +1400,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightRect(int x, int y, int
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightQuad(Ref<JSON::Array>&& quadObject, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightQuad(Ref<JSON::Array>&& quadObject, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates)
 {
     auto quad = makeUnique<FloatQuad>();
     if (!parseQuad(WTFMove(quadObject), quad.get()))
@@ -1422,16 +1422,16 @@ void InspectorDOMAgent::innerHighlightQuad(std::unique_ptr<FloatQuad> quad, RefP
 
 #if PLATFORM(IOS_FAMILY)
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(const String& selectorString, const Protocol::Network::FrameId& frameId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(const String& selectorString, const Inspector::Protocol::Network::FrameId& frameId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
 {
     return highlightSelector(selectorString, frameId, WTFMove(highlightInspectorObject), WTFMove(gridOverlayInspectorObject), WTFMove(flexOverlayInspectorObject), std::nullopt);
 }
 
 #endif // PLATFORM(IOS_FAMILY)
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(const String& selectorString, const Protocol::Network::FrameId& frameId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(const String& selectorString, const Inspector::Protocol::Network::FrameId& frameId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto highlightConfig = highlightConfigFromInspectorObject(errorString, WTFMove(highlightInspectorObject));
     if (!highlightConfig)
@@ -1529,16 +1529,16 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(const String&
 
 #if PLATFORM(IOS_FAMILY)
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(std::optional<Protocol::DOM::NodeId>&& nodeId, const Protocol::Runtime::RemoteObjectId& objectId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(std::optional<Inspector::Protocol::DOM::NodeId>&& nodeId, const Inspector::Protocol::Runtime::RemoteObjectId& objectId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
 {
     return highlightNode(WTFMove(nodeId), objectId, WTFMove(highlightInspectorObject), WTFMove(gridOverlayInspectorObject), WTFMove(flexOverlayInspectorObject), std::nullopt);
 }
 
 #endif // PLATFORM(IOS_FAMILY)
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(std::optional<Protocol::DOM::NodeId>&& nodeId, const Protocol::Runtime::RemoteObjectId& objectId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(std::optional<Inspector::Protocol::DOM::NodeId>&& nodeId, const Inspector::Protocol::Runtime::RemoteObjectId& objectId, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Node* node = nullptr;
     if (nodeId)
@@ -1573,16 +1573,16 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(std::optional<Pro
 
 #if PLATFORM(IOS_FAMILY)
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject)
 {
     return highlightNodeList(WTFMove(nodeIds), WTFMove(highlightInspectorObject), WTFMove(gridOverlayInspectorObject), WTFMove(flexOverlayInspectorObject), std::nullopt);
 }
 
 #endif // PLATFORM(IOS_FAMILY)
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, std::optional<bool>&& showRulers)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Vector<Ref<Node>> nodes;
     for (auto& nodeIdValue : nodeIds.get()) {
@@ -1594,7 +1594,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNodeList(Ref<JSON::Arr
         // by the frontend and it is executed by the backend, we should still attempt to highlight
         // as many nodes as possible. As such, we should ignore any errors generated when attempting
         // to get a Node from a given nodeId. 
-        Protocol::ErrorString ignored;
+        Inspector::Protocol::ErrorString ignored;
         Node* node = assertNode(ignored, *nodeId);
         if (!node)
             continue;
@@ -1621,9 +1621,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNodeList(Ref<JSON::Arr
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const Protocol::Network::FrameId& frameId, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const Inspector::Protocol::Network::FrameId& frameId, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
     if (!pageAgent)
@@ -1644,7 +1644,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const Protocol::
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::hideHighlight()
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideHighlight()
 {
     m_overlay->hideHighlight();
 
@@ -1653,7 +1653,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::hideHighlight()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showGridOverlay(Inspector::Protocol::DOM::NodeId nodeId,  Ref<JSON::Object>&& gridOverlayInspectorObject)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
     Node* node = assertNode(errorString, nodeId);
     if (!node)
         return makeUnexpected(errorString);
@@ -1667,10 +1667,10 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showGridOverlay(Insp
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideGridOverlay(std::optional<Protocol::DOM::NodeId>&& nodeId)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideGridOverlay(std::optional<Inspector::Protocol::DOM::NodeId>&& nodeId)
 {
     if (nodeId) {
-        Protocol::ErrorString errorString;
+        Inspector::Protocol::ErrorString errorString;
         auto node = assertNode(errorString, *nodeId);
         if (!node)
             return makeUnexpected(errorString);
@@ -1685,7 +1685,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideGridOverlay(std:
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showFlexOverlay(Inspector::Protocol::DOM::NodeId nodeId, Ref<JSON::Object>&& flexOverlayInspectorObject)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
     Node* node = assertNode(errorString, nodeId);
     if (!node)
         return makeUnexpected(errorString);
@@ -1699,10 +1699,10 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showFlexOverlay(Insp
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideFlexOverlay(std::optional<Protocol::DOM::NodeId>&& nodeId)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideFlexOverlay(std::optional<Inspector::Protocol::DOM::NodeId>&& nodeId)
 {
     if (nodeId) {
-        Protocol::ErrorString errorString;
+        Inspector::Protocol::ErrorString errorString;
         auto node = assertNode(errorString, *nodeId);
         if (!node)
             return makeUnexpected(errorString);
@@ -1715,9 +1715,9 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideFlexOverlay(std:
     return { };
 }
 
-Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::moveTo(Protocol::DOM::NodeId nodeId, Protocol::DOM::NodeId targetNodeId, std::optional<Protocol::DOM::NodeId>&& insertBeforeNodeId)
+Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> InspectorDOMAgent::moveTo(Inspector::Protocol::DOM::NodeId nodeId, Inspector::Protocol::DOM::NodeId targetNodeId, std::optional<Inspector::Protocol::DOM::NodeId>&& insertBeforeNodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Node* node = assertEditableNode(errorString, nodeId);
     if (!node)
@@ -1742,7 +1742,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::moveTo(Protoco
     return pushNodePathToFrontend(errorString, node);
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::undo()
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::undo()
 {
     auto result = m_history->undo();
     if (result.hasException())
@@ -1751,7 +1751,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::undo()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::redo()
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::redo()
 {
     auto result = m_history->redo();
     if (result.hasException())
@@ -1760,16 +1760,16 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::redo()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::markUndoableState()
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::markUndoableState()
 {
     m_history->markUndoableState();
 
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::focus(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::focus(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Element* element = assertElement(errorString, nodeId);
     if (!element)
@@ -1782,9 +1782,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::focus(Protocol::DOM::NodeId nod
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Node* node = assertNode(errorString, nodeId);
     if (!node)
@@ -1803,9 +1803,9 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectedNode(Protocol::DOM:
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorDOMAgent::resolveNode(Protocol::DOM::NodeId nodeId, const String& objectGroup)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> InspectorDOMAgent::resolveNode(Inspector::Protocol::DOM::NodeId nodeId, const String& objectGroup)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Node* node = assertNode(errorString, nodeId);
     if (!node)
@@ -1818,9 +1818,9 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorDOMAgent:
     return object.releaseNonNull();
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDOMAgent::getAttributes(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDOMAgent::getAttributes(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Element* element = assertElement(errorString, nodeId);
     if (!element)
@@ -1829,9 +1829,9 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDOMAgent::getAttrib
     return buildArrayForElementAttributes(element);
 }
 
-Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::requestNode(const Protocol::Runtime::RemoteObjectId& objectId)
+Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> InspectorDOMAgent::requestNode(const Inspector::Protocol::Runtime::RemoteObjectId& objectId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     Node* node = nodeForObjectId(objectId);
     if (!node)
@@ -1856,44 +1856,44 @@ static String documentBaseURLString(Document* document)
     return document->completeURL(emptyString()).string();
 }
 
-static bool pseudoElementType(PseudoId pseudoId, Protocol::DOM::PseudoType* type)
+static bool pseudoElementType(PseudoId pseudoId, Inspector::Protocol::DOM::PseudoType* type)
 {
     switch (pseudoId) {
     case PseudoId::Before:
-        *type = Protocol::DOM::PseudoType::Before;
+        *type = Inspector::Protocol::DOM::PseudoType::Before;
         return true;
     case PseudoId::After:
-        *type = Protocol::DOM::PseudoType::After;
+        *type = Inspector::Protocol::DOM::PseudoType::After;
         return true;
     default:
         return false;
     }
 }
 
-static Protocol::DOM::ShadowRootType shadowRootType(ShadowRootMode mode)
+static Inspector::Protocol::DOM::ShadowRootType shadowRootType(ShadowRootMode mode)
 {
     switch (mode) {
     case ShadowRootMode::UserAgent:
-        return Protocol::DOM::ShadowRootType::UserAgent;
+        return Inspector::Protocol::DOM::ShadowRootType::UserAgent;
     case ShadowRootMode::Closed:
-        return Protocol::DOM::ShadowRootType::Closed;
+        return Inspector::Protocol::DOM::ShadowRootType::Closed;
     case ShadowRootMode::Open:
-        return Protocol::DOM::ShadowRootType::Open;
+        return Inspector::Protocol::DOM::ShadowRootType::Open;
     }
 
     ASSERT_NOT_REACHED();
-    return Protocol::DOM::ShadowRootType::UserAgent;
+    return Inspector::Protocol::DOM::ShadowRootType::UserAgent;
 }
 
-static Protocol::DOM::CustomElementState customElementState(const Element& element)
+static Inspector::Protocol::DOM::CustomElementState customElementState(const Element& element)
 {
     if (element.isDefinedCustomElement())
-        return Protocol::DOM::CustomElementState::Custom;
+        return Inspector::Protocol::DOM::CustomElementState::Custom;
     if (element.isFailedOrPrecustomizedCustomElement())
-        return Protocol::DOM::CustomElementState::Failed;
+        return Inspector::Protocol::DOM::CustomElementState::Failed;
     if (element.isCustomElementUpgradeCandidate())
-        return Protocol::DOM::CustomElementState::Waiting;
-    return Protocol::DOM::CustomElementState::Builtin;
+        return Inspector::Protocol::DOM::CustomElementState::Waiting;
+    return Inspector::Protocol::DOM::CustomElementState::Builtin;
 }
 
 static String computeContentSecurityPolicySHA256Hash(const Element& element)
@@ -1909,7 +1909,7 @@ static String computeContentSecurityPolicySHA256Hash(const Element& element)
     return makeString("sha256-", base64Encoded(digest.data(), digest.size()));
 }
 
-Ref<Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int depth)
+Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int depth)
 {
     auto id = bind(*node);
     String nodeName;
@@ -1940,7 +1940,7 @@ Ref<Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int d
         break;
     }
 
-    auto value = Protocol::DOM::Node::create()
+    auto value = Inspector::Protocol::DOM::Node::create()
         .setNodeId(id)
         .setNodeType(enumToUnderlyingType(node->nodeType()))
         .setNodeName(nodeName)
@@ -1975,7 +1975,7 @@ Ref<Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int d
         }
 
         if (RefPtr root = element->shadowRoot()) {
-            auto shadowRoots = JSON::ArrayOf<Protocol::DOM::Node>::create();
+            auto shadowRoots = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
             shadowRoots->addItem(buildObjectForNode(root.get(), 0));
             value->setShadowRoots(WTFMove(shadowRoots));
         }
@@ -1987,11 +1987,11 @@ Ref<Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int d
             value->setContentSecurityPolicyHash(computeContentSecurityPolicySHA256Hash(*element));
 
         auto state = customElementState(*element);
-        if (state != Protocol::DOM::CustomElementState::Builtin)
+        if (state != Inspector::Protocol::DOM::CustomElementState::Builtin)
             value->setCustomElementState(state);
 
         if (element->pseudoId() != PseudoId::None) {
-            Protocol::DOM::PseudoType pseudoType;
+            Inspector::Protocol::DOM::PseudoType pseudoType;
             if (pseudoElementType(element->pseudoId(), &pseudoType))
                 value->setPseudoType(pseudoType);
         } else {
@@ -2030,9 +2030,9 @@ Ref<JSON::ArrayOf<String>> InspectorDOMAgent::buildArrayForElementAttributes(Ele
     return attributesValue;
 }
 
-Ref<JSON::ArrayOf<Protocol::DOM::Node>> InspectorDOMAgent::buildArrayForContainerChildren(Node* container, int depth)
+Ref<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> InspectorDOMAgent::buildArrayForContainerChildren(Node* container, int depth)
 {
-    auto children = JSON::ArrayOf<Protocol::DOM::Node>::create();
+    auto children = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
     if (depth == 0) {
         // Special-case the only text child - pretend that container's children have been requested.
         Node* firstChild = container->firstChild();
@@ -2054,14 +2054,14 @@ Ref<JSON::ArrayOf<Protocol::DOM::Node>> InspectorDOMAgent::buildArrayForContaine
     return children;
 }
 
-RefPtr<JSON::ArrayOf<Protocol::DOM::Node>> InspectorDOMAgent::buildArrayForPseudoElements(const Element& element)
+RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> InspectorDOMAgent::buildArrayForPseudoElements(const Element& element)
 {
     RefPtr beforeElement = element.beforePseudoElement();
     RefPtr afterElement = element.afterPseudoElement();
     if (!beforeElement && !afterElement)
         return nullptr;
 
-    auto pseudoElements = JSON::ArrayOf<Protocol::DOM::Node>::create();
+    auto pseudoElements = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
     if (beforeElement)
         pseudoElements->addItem(buildObjectForNode(beforeElement.get(), 0));
     if (afterElement)
@@ -2069,7 +2069,7 @@ RefPtr<JSON::ArrayOf<Protocol::DOM::Node>> InspectorDOMAgent::buildArrayForPseud
     return pseudoElements;
 }
 
-Ref<Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEventListener(const RegisteredEventListener& registeredEventListener, Protocol::DOM::EventListenerId identifier, EventTarget& eventTarget, const AtomString& eventType, bool disabled, const RefPtr<JSC::Breakpoint>& breakpoint)
+Ref<Inspector::Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEventListener(const RegisteredEventListener& registeredEventListener, Inspector::Protocol::DOM::EventListenerId identifier, EventTarget& eventTarget, const AtomString& eventType, bool disabled, const RefPtr<JSC::Breakpoint>& breakpoint)
 {
     Ref<EventListener> eventListener = registeredEventListener.callback();
 
@@ -2132,7 +2132,7 @@ Ref<Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEventListener
         }
     }
 
-    auto value = Protocol::DOM::EventListener::create()
+    auto value = Inspector::Protocol::DOM::EventListener::create()
         .setEventListenerId(identifier)
         .setType(eventType)
         .setUseCapture(registeredEventListener.useCapture())
@@ -2143,7 +2143,7 @@ Ref<Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEventListener
     else if (is<LocalDOMWindow>(eventTarget))
         value->setOnWindow(true);
     if (!scriptID.isNull()) {
-        auto location = Protocol::Debugger::Location::create()
+        auto location = Inspector::Protocol::Debugger::Location::create()
             .setScriptId(scriptID)
             .setLineNumber(lineNumber)
             .release();
@@ -2163,7 +2163,7 @@ Ref<Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEventListener
     return value;
 }
 
-void InspectorDOMAgent::processAccessibilityChildren(AXCoreObject& axObject, JSON::ArrayOf<Protocol::DOM::NodeId>& childNodeIds)
+void InspectorDOMAgent::processAccessibilityChildren(AXCoreObject& axObject, JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>& childNodeIds)
 {
     const auto& children = axObject.children();
     if (!children.size())
@@ -2177,39 +2177,39 @@ void InspectorDOMAgent::processAccessibilityChildren(AXCoreObject& axObject, JSO
     }
 }
     
-Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAccessibilityProperties(Node& node)
+Ref<Inspector::Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAccessibilityProperties(Node& node)
 {
     if (!WebCore::AXObjectCache::accessibilityEnabled())
         WebCore::AXObjectCache::enableAccessibility();
 
     Node* activeDescendantNode = nullptr;
     bool busy = false;
-    auto checked = Protocol::DOM::AccessibilityProperties::Checked::False;
-    RefPtr<JSON::ArrayOf<Protocol::DOM::NodeId>> childNodeIds;
-    RefPtr<JSON::ArrayOf<Protocol::DOM::NodeId>> controlledNodeIds;
-    auto currentState = Protocol::DOM::AccessibilityProperties::Current::False;
+    auto checked = Inspector::Protocol::DOM::AccessibilityProperties::Checked::False;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> childNodeIds;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> controlledNodeIds;
+    auto currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::False;
     bool exists = false;
     bool expanded = false;
     bool disabled = false;
-    RefPtr<JSON::ArrayOf<Protocol::DOM::NodeId>> flowedNodeIds;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> flowedNodeIds;
     bool focused = false;
     bool ignored = true;
     bool ignoredByDefault = false;
-    auto invalid = Protocol::DOM::AccessibilityProperties::Invalid::False;
+    auto invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::False;
     bool hidden = false;
     String label;
     bool liveRegionAtomic = false;
     RefPtr<JSON::ArrayOf<String>> liveRegionRelevant;
-    auto liveRegionStatus = Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Off;
+    auto liveRegionStatus = Inspector::Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Off;
     Node* mouseEventNode = nullptr;
-    RefPtr<JSON::ArrayOf<Protocol::DOM::NodeId>> ownedNodeIds;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> ownedNodeIds;
     Node* parentNode = nullptr;
     bool pressed = false;
     bool readonly = false;
     bool required = false;
     String role;
     bool selected = false;
-    RefPtr<JSON::ArrayOf<Protocol::DOM::NodeId>> selectedChildNodeIds;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>> selectedChildNodeIds;
     bool supportsChecked = false;
     bool supportsExpanded = false;
     bool supportsLiveRegion = false;
@@ -2238,21 +2238,21 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
             if (supportsChecked) {
                 AccessibilityButtonState checkValue = axObject->checkboxOrRadioValue(); // Element using aria-checked.
                 if (checkValue == AccessibilityButtonState::On)
-                    checked = Protocol::DOM::AccessibilityProperties::Checked::True;
+                    checked = Inspector::Protocol::DOM::AccessibilityProperties::Checked::True;
                 else if (checkValue == AccessibilityButtonState::Mixed)
-                    checked = Protocol::DOM::AccessibilityProperties::Checked::Mixed;
+                    checked = Inspector::Protocol::DOM::AccessibilityProperties::Checked::Mixed;
                 else if (axObject->isChecked()) // Native checkbox.
-                    checked = Protocol::DOM::AccessibilityProperties::Checked::True;
+                    checked = Inspector::Protocol::DOM::AccessibilityProperties::Checked::True;
             }
             
             if (!axObject->children().isEmpty()) {
-                childNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+                childNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
                 processAccessibilityChildren(*axObject, *childNodeIds);
             }
 
             auto controlledElements = axObject->elementsFromAttribute(aria_controlsAttr);
             if (controlledElements.size()) {
-                controlledNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+                controlledNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
                 for (auto& controlledElement : controlledElements) {
                     if (auto controlledElementId = pushNodePathToFrontend(controlledElement.ptr()))
                         controlledNodeIds->addItem(controlledElementId);
@@ -2261,25 +2261,25 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
             
             switch (axObject->currentState()) {
             case AccessibilityCurrentState::False:
-                currentState = Protocol::DOM::AccessibilityProperties::Current::False;
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::False;
                 break;
             case AccessibilityCurrentState::Page:
-                currentState = Protocol::DOM::AccessibilityProperties::Current::Page;
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Page;
                 break;
             case AccessibilityCurrentState::Step:
-                currentState = Protocol::DOM::AccessibilityProperties::Current::Step;
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Step;
                 break;
             case AccessibilityCurrentState::Location:
-                currentState = Protocol::DOM::AccessibilityProperties::Current::Location;
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Location;
                 break;
             case AccessibilityCurrentState::Date:
-                currentState = Protocol::DOM::AccessibilityProperties::Current::Date;
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Date;
                 break;
             case AccessibilityCurrentState::Time:
-                currentState = Protocol::DOM::AccessibilityProperties::Current::Time;
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::Time;
                 break;
             case AccessibilityCurrentState::True:
-                currentState = Protocol::DOM::AccessibilityProperties::Current::True;
+                currentState = Inspector::Protocol::DOM::AccessibilityProperties::Current::True;
                 break;
             }
 
@@ -2292,7 +2292,7 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
 
             auto flowedElements = axObject->elementsFromAttribute(aria_flowtoAttr);
             if (flowedElements.size()) {
-                flowedNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+                flowedNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
                 for (auto& flowedElement : flowedElements) {
                     if (auto flowedElementId = pushNodePathToFrontend(flowedElement.ptr()))
                         flowedNodeIds->addItem(flowedElementId);
@@ -2310,13 +2310,13 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
             
             String invalidValue = axObject->invalidStatus();
             if (invalidValue == "false"_s)
-                invalid = Protocol::DOM::AccessibilityProperties::Invalid::False;
+                invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::False;
             else if (invalidValue == "grammar"_s)
-                invalid = Protocol::DOM::AccessibilityProperties::Invalid::Grammar;
+                invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::Grammar;
             else if (invalidValue == "spelling"_s)
-                invalid = Protocol::DOM::AccessibilityProperties::Invalid::Spelling;
+                invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::Spelling;
             else // Future versions of ARIA may allow additional truthy values. Ex. format, order, or size.
-                invalid = Protocol::DOM::AccessibilityProperties::Invalid::True;
+                invalid = Inspector::Protocol::DOM::AccessibilityProperties::Invalid::True;
             
             if (axObject->isHidden())
                 hidden = true;
@@ -2330,9 +2330,9 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
                 auto ariaRelevantAttrValue = axObject->liveRegionRelevant();
                 if (!ariaRelevantAttrValue.isEmpty()) {
                     // FIXME: Pass enum values rather than strings once unblocked. http://webkit.org/b/133711
-                    String ariaRelevantAdditions = Protocol::Helpers::getEnumConstantValue(Protocol::DOM::LiveRegionRelevant::Additions);
-                    String ariaRelevantRemovals = Protocol::Helpers::getEnumConstantValue(Protocol::DOM::LiveRegionRelevant::Removals);
-                    String ariaRelevantText = Protocol::Helpers::getEnumConstantValue(Protocol::DOM::LiveRegionRelevant::Text);
+                    String ariaRelevantAdditions = Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::DOM::LiveRegionRelevant::Additions);
+                    String ariaRelevantRemovals = Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::DOM::LiveRegionRelevant::Removals);
+                    String ariaRelevantText = Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::DOM::LiveRegionRelevant::Text);
                     liveRegionRelevant = JSON::ArrayOf<String>::create();
                     SpaceSplitString values(AtomString { ariaRelevantAttrValue }, SpaceSplitString::ShouldFoldCase::Yes);
                     // @aria-relevant="all" is exposed as ["additions","removals","text"], in order.
@@ -2353,9 +2353,9 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
 
                 String ariaLive = axObject->liveRegionStatus();
                 if (ariaLive == "assertive"_s)
-                    liveRegionStatus = Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Assertive;
+                    liveRegionStatus = Inspector::Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Assertive;
                 else if (ariaLive == "polite"_s)
-                    liveRegionStatus = Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Polite;
+                    liveRegionStatus = Inspector::Protocol::DOM::AccessibilityProperties::LiveRegionStatus::Polite;
             }
 
             if (auto* accessibilityNodeObject = dynamicDowncast<AccessibilityNodeObject>(*axObject))
@@ -2364,7 +2364,7 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
             if (axObject->supportsARIAOwns()) {
                 auto ownedElements = axObject->elementsFromAttribute(aria_ownsAttr);
                 if (ownedElements.size()) {
-                    ownedNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+                    ownedNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
                     for (auto& ownedElement : ownedElements) {
                         if (auto ownedElementId = pushNodePathToFrontend(ownedElement.ptr()))
                             ownedNodeIds->addItem(ownedElementId);
@@ -2391,7 +2391,7 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
 
             auto selectedChildren = axObject->selectedChildren();
             if (selectedChildren.size()) {
-                selectedChildNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+                selectedChildNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
                 for (auto& selectedChildObject : selectedChildren) {
                     if (Node* selectedChildNode = selectedChildObject->node()) {
                         if (auto selectedChildNodeId = pushNodePathToFrontend(selectedChildNode))
@@ -2408,7 +2408,7 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
         }
     }
     
-    auto value = Protocol::DOM::AccessibilityProperties::create()
+    auto value = Inspector::Protocol::DOM::AccessibilityProperties::create()
         .setExists(exists)
         .setLabel(label)
         .setRole(role)
@@ -2428,7 +2428,7 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
             value->setChildNodeIds(childNodeIds.releaseNonNull());
         if (controlledNodeIds)
             value->setControlledNodeIds(controlledNodeIds.releaseNonNull());
-        if (currentState != Protocol::DOM::AccessibilityProperties::Current::False)
+        if (currentState != Inspector::Protocol::DOM::AccessibilityProperties::Current::False)
             value->setCurrent(currentState);
         if (disabled)
             value->setDisabled(disabled);
@@ -2442,7 +2442,7 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
             value->setIgnored(ignored);
         if (ignoredByDefault)
             value->setIgnoredByDefault(ignoredByDefault);
-        if (invalid != Protocol::DOM::AccessibilityProperties::Invalid::False)
+        if (invalid != Inspector::Protocol::DOM::AccessibilityProperties::Invalid::False)
             value->setInvalid(invalid);
         if (hidden)
             value->setHidden(hidden);
@@ -2568,7 +2568,7 @@ void InspectorDOMAgent::didCommitLoad(Document* document)
     m_frontendDispatcher->childNodeInserted(parentId, prevId, WTFMove(value));
 }
 
-Protocol::DOM::NodeId InspectorDOMAgent::identifierForNode(Node& node)
+Inspector::Protocol::DOM::NodeId InspectorDOMAgent::identifierForNode(Node& node)
 {
     return pushNodePathToFrontend(&node);
 }
@@ -2742,7 +2742,7 @@ void InspectorDOMAgent::didRemoveDOMAttr(Element& element, const AtomString& nam
 
 void InspectorDOMAgent::styleAttributeInvalidated(const Vector<Element*>& elements)
 {
-    auto nodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+    auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
     for (auto& element : elements) {
         auto id = boundNodeId(element);
         if (!id)
@@ -2943,7 +2943,7 @@ RefPtr<JSC::Breakpoint> InspectorDOMAgent::breakpointForEventListener(EventTarge
     return nullptr;
 }
 
-Protocol::DOM::EventListenerId InspectorDOMAgent::idForEventListener(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
+Inspector::Protocol::DOM::EventListenerId InspectorDOMAgent::idForEventListener(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
 {
     for (auto& inspectorEventListener : m_eventListenerEntries.values()) {
         if (inspectorEventListener.matches(target, eventType, listener, capture))
@@ -3037,7 +3037,7 @@ Node* InspectorDOMAgent::nodeForPath(const String& path)
     return node;
 }
 
-Node* InspectorDOMAgent::nodeForObjectId(const Protocol::Runtime::RemoteObjectId& objectId)
+Node* InspectorDOMAgent::nodeForObjectId(const Inspector::Protocol::Runtime::RemoteObjectId& objectId)
 {
     InjectedScript injectedScript = m_injectedScriptManager.injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue())
@@ -3046,9 +3046,9 @@ Node* InspectorDOMAgent::nodeForObjectId(const Protocol::Runtime::RemoteObjectId
     return scriptValueAsNode(injectedScript.findObjectById(objectId));
 }
 
-Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPathToFrontend(const String& path)
+Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPathToFrontend(const String& path)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     if (Node* node = nodeForPath(path)) {
         if (auto nodeId = pushNodePathToFrontend(errorString, node))
@@ -3059,7 +3059,7 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorDOMAgent::pushNodeByPath
     return makeUnexpected("Missing node for given path"_s);
 }
 
-RefPtr<Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* node, const String& objectGroup)
+RefPtr<Inspector::Protocol::Runtime::RemoteObject> InspectorDOMAgent::resolveNode(Node* node, const String& objectGroup)
 {
     Document* document = &node->document();
     if (auto* templateHost = document->templateDocumentHost())
@@ -3089,16 +3089,16 @@ JSC::JSValue InspectorDOMAgent::nodeAsScriptValue(JSC::JSGlobalObject& state, No
     return toJS(&state, deprecatedGlobalObjectForPrototype(&state), BindingSecurity::checkSecurityForNode(state, node));
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowTrees(bool allow)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowTrees(bool allow)
 {
     m_allowEditingUserAgentShadowTrees = allow;
 
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::DOM::MediaStats>> InspectorDOMAgent::getMediaStats(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> InspectorDOMAgent::getMediaStats(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* element = assertElement(errorString, nodeId);
     if (!element)

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -130,16 +130,16 @@ void InspectorDOMDebuggerAgent::mainFrameNavigated()
         m_pauseOnAllTimeoutsBreakpoint->resetHitCount();
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::setEventBreakpoint(Protocol::DOMDebugger::EventBreakpointType breakpointType, const String& eventName, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, RefPtr<JSON::Object>&& options)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::setEventBreakpoint(Inspector::Protocol::DOMDebugger::EventBreakpointType breakpointType, const String& eventName, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, RefPtr<JSON::Object>&& options)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto breakpoint = InspectorDebuggerAgent::debuggerBreakpointFromPayload(errorString, WTFMove(options));
     if (!breakpoint)
         return makeUnexpected(errorString);
 
     if (!eventName.isEmpty()) {
-        if (breakpointType == Protocol::DOMDebugger::EventBreakpointType::Listener) {
+        if (breakpointType == Inspector::Protocol::DOMDebugger::EventBreakpointType::Listener) {
             EventBreakpoint eventBreakpoint;
             eventBreakpoint.eventName = eventName;
             if (caseSensitive)
@@ -163,24 +163,24 @@ Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::setEventBreakpoint(Prot
         return makeUnexpected("Unexpected isRegex"_s);
 
     switch (breakpointType) {
-    case Protocol::DOMDebugger::EventBreakpointType::AnimationFrame:
+    case Inspector::Protocol::DOMDebugger::EventBreakpointType::AnimationFrame:
         if (!setAnimationFrameBreakpoint(errorString, WTFMove(breakpoint)))
             return makeUnexpected(errorString);
         return { };
 
-    case Protocol::DOMDebugger::EventBreakpointType::Interval:
+    case Inspector::Protocol::DOMDebugger::EventBreakpointType::Interval:
         if (m_pauseOnAllIntervalsBreakpoint)
             return makeUnexpected("Breakpoint for Interval already exists"_s);
         m_pauseOnAllIntervalsBreakpoint = WTFMove(breakpoint);
         return { };
 
-    case Protocol::DOMDebugger::EventBreakpointType::Listener:
+    case Inspector::Protocol::DOMDebugger::EventBreakpointType::Listener:
         if (m_pauseOnAllListenersBreakpoint)
             return makeUnexpected("Breakpoint for Listener already exists"_s);
         m_pauseOnAllListenersBreakpoint = WTFMove(breakpoint);
         return { };
 
-    case Protocol::DOMDebugger::EventBreakpointType::Timeout:
+    case Inspector::Protocol::DOMDebugger::EventBreakpointType::Timeout:
         if (m_pauseOnAllTimeoutsBreakpoint)
             return makeUnexpected("Breakpoint for Timeout already exists"_s);
         m_pauseOnAllTimeoutsBreakpoint = WTFMove(breakpoint);
@@ -191,12 +191,12 @@ Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::setEventBreakpoint(Prot
     return makeUnexpected("Not supported"_s);
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::removeEventBreakpoint(Protocol::DOMDebugger::EventBreakpointType breakpointType, const String& eventName, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::removeEventBreakpoint(Inspector::Protocol::DOMDebugger::EventBreakpointType breakpointType, const String& eventName, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     if (!eventName.isEmpty()) {
-        if (breakpointType == Protocol::DOMDebugger::EventBreakpointType::Listener) {
+        if (breakpointType == Inspector::Protocol::DOMDebugger::EventBreakpointType::Listener) {
             EventBreakpoint eventBreakpoint;
             eventBreakpoint.eventName = eventName;
             if (caseSensitive)
@@ -219,24 +219,24 @@ Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::removeEventBreakpoint(P
         return makeUnexpected("Unexpected isRegex"_s);
 
     switch (breakpointType) {
-    case Protocol::DOMDebugger::EventBreakpointType::AnimationFrame:
+    case Inspector::Protocol::DOMDebugger::EventBreakpointType::AnimationFrame:
         if (!setAnimationFrameBreakpoint(errorString, nullptr))
             return makeUnexpected(errorString);
         return { };
 
-    case Protocol::DOMDebugger::EventBreakpointType::Interval:
+    case Inspector::Protocol::DOMDebugger::EventBreakpointType::Interval:
         if (!m_pauseOnAllIntervalsBreakpoint)
             return makeUnexpected("Breakpoint for Intervals missing"_s);
         m_pauseOnAllIntervalsBreakpoint = nullptr;
         return { };
 
-    case Protocol::DOMDebugger::EventBreakpointType::Listener:
+    case Inspector::Protocol::DOMDebugger::EventBreakpointType::Listener:
         if (!m_pauseOnAllListenersBreakpoint)
             return makeUnexpected("Breakpoint for Listeners missing"_s);
         m_pauseOnAllListenersBreakpoint = nullptr;
         return { };
 
-    case Protocol::DOMDebugger::EventBreakpointType::Timeout:
+    case Inspector::Protocol::DOMDebugger::EventBreakpointType::Timeout:
         if (!m_pauseOnAllTimeoutsBreakpoint)
             return makeUnexpected("Breakpoint for Timeouts missing"_s);
         m_pauseOnAllTimeoutsBreakpoint = nullptr;
@@ -373,9 +373,9 @@ void InspectorDOMDebuggerAgent::willSendRequestOfType(ResourceRequest& request)
     willSendRequest(request);
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::setURLBreakpoint(const String& url, std::optional<bool>&& isRegex, RefPtr<JSON::Object>&& options)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::setURLBreakpoint(const String& url, std::optional<bool>&& isRegex, RefPtr<JSON::Object>&& options)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto breakpoint = InspectorDebuggerAgent::debuggerBreakpointFromPayload(errorString, WTFMove(options));
     if (!breakpoint)
@@ -399,7 +399,7 @@ Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::setURLBreakpoint(const 
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::removeURLBreakpoint(const String& url, std::optional<bool>&& isRegex)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMDebuggerAgent::removeURLBreakpoint(const String& url, std::optional<bool>&& isRegex)
 {
     if (url.isEmpty()) {
         if (!m_pauseOnAllURLsBreakpoint)

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -73,7 +73,7 @@ void InspectorDOMStorageAgent::willDestroyFrontendAndBackend(Inspector::Disconne
     disable();
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::enable()
 {
     if (m_instrumentingAgents.enabledDOMStorageAgent() == this)
         return makeUnexpected("DOMStorage domain already enabled"_s);
@@ -83,7 +83,7 @@ Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::disable()
 {
     if (m_instrumentingAgents.enabledDOMStorageAgent() != this)
         return makeUnexpected("DOMStorage domain already disabled"_s);
@@ -93,9 +93,9 @@ Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::disable()
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOMStorage::Item>>> InspectorDOMStorageAgent::getDOMStorageItems(Ref<JSON::Object>&& storageId)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOMStorage::Item>>> InspectorDOMStorageAgent::getDOMStorageItems(Ref<JSON::Object>&& storageId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     LocalFrame* frame;
     RefPtr<StorageArea> storageArea = findStorageArea(errorString, WTFMove(storageId), frame);
@@ -115,9 +115,9 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOMStorage::Item>>> Inspecto
     return storageItems;
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::setDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key, const String& value)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::setDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key, const String& value)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     LocalFrame* frame;
     RefPtr<StorageArea> storageArea = findStorageArea(errorString, WTFMove(storageId), frame);
@@ -132,9 +132,9 @@ Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::setDOMStorageItem(Ref<JS
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::removeDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::removeDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     LocalFrame* frame;
     RefPtr<StorageArea> storageArea = findStorageArea(errorString, WTFMove(storageId), frame);
@@ -146,9 +146,9 @@ Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::removeDOMStorageItem(Ref
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::clearDOMStorageItems(Ref<JSON::Object>&& storageId)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::clearDOMStorageItems(Ref<JSON::Object>&& storageId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     LocalFrame* frame;
     auto storageArea = findStorageArea(errorString, WTFMove(storageId), frame);
@@ -171,9 +171,9 @@ String InspectorDOMStorageAgent::storageId(Storage& storage)
     return InspectorDOMStorageAgent::storageId(securityOrigin, isLocalStorage)->toJSONString();
 }
 
-Ref<Protocol::DOMStorage::StorageId> InspectorDOMStorageAgent::storageId(const SecurityOrigin& securityOrigin, bool isLocalStorage)
+Ref<Inspector::Protocol::DOMStorage::StorageId> InspectorDOMStorageAgent::storageId(const SecurityOrigin& securityOrigin, bool isLocalStorage)
 {
-    return Protocol::DOMStorage::StorageId::create()
+    return Inspector::Protocol::DOMStorage::StorageId::create()
         .setSecurityOrigin(securityOrigin.toRawString())
         .setIsLocalStorage(isLocalStorage)
         .release();
@@ -193,15 +193,15 @@ void InspectorDOMStorageAgent::didDispatchDOMStorageEvent(const String& key, con
         m_frontendDispatcher->domStorageItemUpdated(WTFMove(id), key, oldValue, newValue);
 }
 
-RefPtr<StorageArea> InspectorDOMStorageAgent::findStorageArea(Protocol::ErrorString& errorString, Ref<JSON::Object>&& storageId, LocalFrame*& targetFrame)
+RefPtr<StorageArea> InspectorDOMStorageAgent::findStorageArea(Inspector::Protocol::ErrorString& errorString, Ref<JSON::Object>&& storageId, LocalFrame*& targetFrame)
 {
-    auto securityOrigin = storageId->getString(Protocol::DOMStorage::StorageId::securityOriginKey);
+    auto securityOrigin = storageId->getString(Inspector::Protocol::DOMStorage::StorageId::securityOriginKey);
     if (!securityOrigin) {
         errorString = "Missing securityOrigin in given storageId"_s;
         return nullptr;
     }
 
-    auto isLocalStorage = storageId->getBoolean(Protocol::DOMStorage::StorageId::isLocalStorageKey);
+    auto isLocalStorage = storageId->getBoolean(Inspector::Protocol::DOMStorage::StorageId::isLocalStorageKey);
     if (!isLocalStorage) {
         errorString = "Missing isLocalStorage in given storageId"_s;
         return nullptr;

--- a/Source/WebCore/inspector/agents/InspectorDatabaseAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDatabaseAgent.cpp
@@ -59,7 +59,7 @@ namespace {
 
 void reportTransactionFailed(ExecuteSQLCallback& requestCallback, SQLError& error)
 {
-    auto errorObject = Protocol::Database::Error::create()
+    auto errorObject = Inspector::Protocol::Database::Error::create()
         .setMessage(error.messageIsolatedCopy())
         .setCode(error.code())
         .release();
@@ -233,7 +233,7 @@ void InspectorDatabaseAgent::willDestroyFrontendAndBackend(Inspector::Disconnect
     disable();
 }
 
-Protocol::ErrorStringOr<void> InspectorDatabaseAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorDatabaseAgent::enable()
 {
     if (m_instrumentingAgents.enabledDatabaseAgent() == this)
         return makeUnexpected("Database domain already enabled"_s);
@@ -246,7 +246,7 @@ Protocol::ErrorStringOr<void> InspectorDatabaseAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorDatabaseAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorDatabaseAgent::disable()
 {
     if (m_instrumentingAgents.enabledDatabaseAgent() != this)
         return makeUnexpected("Database domain already disabled"_s);
@@ -258,7 +258,7 @@ Protocol::ErrorStringOr<void> InspectorDatabaseAgent::disable()
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDatabaseAgent::getDatabaseTableNames(const Protocol::Database::DatabaseId& databaseId)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDatabaseAgent::getDatabaseTableNames(const Inspector::Protocol::Database::DatabaseId& databaseId)
 {
     if (m_instrumentingAgents.enabledDatabaseAgent() != this)
         return makeUnexpected("Database domain must be enabled"_s);
@@ -271,7 +271,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorDatabaseAgent::getD
     return names;
 }
 
-void InspectorDatabaseAgent::executeSQL(const Protocol::Database::DatabaseId& databaseId, const String& query, Ref<ExecuteSQLCallback>&& requestCallback)
+void InspectorDatabaseAgent::executeSQL(const Inspector::Protocol::Database::DatabaseId& databaseId, const String& query, Ref<ExecuteSQLCallback>&& requestCallback)
 {
     if (m_instrumentingAgents.enabledDatabaseAgent() != this) {
         requestCallback->sendFailure("Database domain must be enabled"_s);

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
@@ -59,7 +59,7 @@ void InspectorMemoryAgent::willDestroyFrontendAndBackend(DisconnectReason)
     m_instrumentingAgents.setPersistentMemoryAgent(nullptr);
 }
 
-Protocol::ErrorStringOr<void> InspectorMemoryAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::enable()
 {
     if (m_instrumentingAgents.enabledMemoryAgent() == this)
         return makeUnexpected("Memory domain already enabled"_s);
@@ -69,7 +69,7 @@ Protocol::ErrorStringOr<void> InspectorMemoryAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorMemoryAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::disable()
 {
     if (m_instrumentingAgents.enabledMemoryAgent() != this)
         return makeUnexpected("Memory domain already disabled"_s);
@@ -83,7 +83,7 @@ Protocol::ErrorStringOr<void> InspectorMemoryAgent::disable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorMemoryAgent::startTracking()
+Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::startTracking()
 {
     if (m_tracking)
         return { };
@@ -99,7 +99,7 @@ Protocol::ErrorStringOr<void> InspectorMemoryAgent::startTracking()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorMemoryAgent::stopTracking()
+Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::stopTracking()
 {
     if (!m_tracking)
         return { };
@@ -116,42 +116,42 @@ Protocol::ErrorStringOr<void> InspectorMemoryAgent::stopTracking()
 void InspectorMemoryAgent::didHandleMemoryPressure(Critical critical)
 {
     MemoryFrontendDispatcher::Severity severity = critical == Critical::Yes ? MemoryFrontendDispatcher::Severity::Critical : MemoryFrontendDispatcher::Severity::NonCritical;
-    m_frontendDispatcher->memoryPressure(m_environment.executionStopwatch().elapsedTime().seconds(), Protocol::Helpers::getEnumConstantValue(severity));
+    m_frontendDispatcher->memoryPressure(m_environment.executionStopwatch().elapsedTime().seconds(), Inspector::Protocol::Helpers::getEnumConstantValue(severity));
 }
 
 void InspectorMemoryAgent::collectSample(const ResourceUsageData& data)
 {
-    auto javascriptCategory = Protocol::Memory::CategoryData::create()
-        .setType(Protocol::Memory::CategoryData::Type::JavaScript)
+    auto javascriptCategory = Inspector::Protocol::Memory::CategoryData::create()
+        .setType(Inspector::Protocol::Memory::CategoryData::Type::JavaScript)
         .setSize(data.categories[MemoryCategory::GCHeap].totalSize() + data.categories[MemoryCategory::GCOwned].totalSize())
         .release();
 
-    auto jitCategory = Protocol::Memory::CategoryData::create()
-        .setType(Protocol::Memory::CategoryData::Type::JIT)
+    auto jitCategory = Inspector::Protocol::Memory::CategoryData::create()
+        .setType(Inspector::Protocol::Memory::CategoryData::Type::JIT)
         .setSize(data.categories[MemoryCategory::JSJIT].totalSize())
         .release();
 
-    auto imagesCategory = Protocol::Memory::CategoryData::create()
-        .setType(Protocol::Memory::CategoryData::Type::Images)
+    auto imagesCategory = Inspector::Protocol::Memory::CategoryData::create()
+        .setType(Inspector::Protocol::Memory::CategoryData::Type::Images)
         .setSize(data.categories[MemoryCategory::Images].totalSize())
         .release();
 
-    auto layersCategory = Protocol::Memory::CategoryData::create()
-        .setType(Protocol::Memory::CategoryData::Type::Layers)
+    auto layersCategory = Inspector::Protocol::Memory::CategoryData::create()
+        .setType(Inspector::Protocol::Memory::CategoryData::Type::Layers)
         .setSize(data.categories[MemoryCategory::Layers].totalSize())
         .release();
 
-    auto pageCategory = Protocol::Memory::CategoryData::create()
-        .setType(Protocol::Memory::CategoryData::Type::Page)
+    auto pageCategory = Inspector::Protocol::Memory::CategoryData::create()
+        .setType(Inspector::Protocol::Memory::CategoryData::Type::Page)
         .setSize(data.categories[MemoryCategory::bmalloc].totalSize() + data.categories[MemoryCategory::LibcMalloc].totalSize())
         .release();
 
-    auto otherCategory = Protocol::Memory::CategoryData::create()
-        .setType(Protocol::Memory::CategoryData::Type::Other)
+    auto otherCategory = Inspector::Protocol::Memory::CategoryData::create()
+        .setType(Inspector::Protocol::Memory::CategoryData::Type::Other)
         .setSize(data.categories[MemoryCategory::Other].totalSize())
         .release();
 
-    auto categories = JSON::ArrayOf<Protocol::Memory::CategoryData>::create();
+    auto categories = JSON::ArrayOf<Inspector::Protocol::Memory::CategoryData>::create();
     categories->addItem(WTFMove(javascriptCategory));
     categories->addItem(WTFMove(jitCategory));
     categories->addItem(WTFMove(imagesCategory));
@@ -159,7 +159,7 @@ void InspectorMemoryAgent::collectSample(const ResourceUsageData& data)
     categories->addItem(WTFMove(pageCategory));
     categories->addItem(WTFMove(otherCategory));
 
-    auto event = Protocol::Memory::Event::create()
+    auto event = Inspector::Protocol::Memory::Event::create()
         .setTimestamp(m_environment.executionStopwatch().elapsedTimeSince(data.timestamp).seconds())
         .setCategories(WTFMove(categories))
         .release();

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -170,9 +170,9 @@ private:
     int m_statusCode;
 };
 
-Ref<Protocol::Network::WebSocketFrame> buildWebSocketMessage(const WebSocketFrame& frame)
+Ref<Inspector::Protocol::Network::WebSocketFrame> buildWebSocketMessage(const WebSocketFrame& frame)
 {
-    return Protocol::Network::WebSocketFrame::create()
+    return Inspector::Protocol::Network::WebSocketFrame::create()
         .setOpcode(frame.opCode)
         .setMask(frame.masked)
         .setPayloadData(frame.opCode == 1 ? String::fromUTF8WithLatin1Fallback(frame.payload, frame.payloadLength) : base64EncodeToString(frame.payload, frame.payloadLength))
@@ -202,9 +202,9 @@ void InspectorNetworkAgent::willDestroyFrontendAndBackend(Inspector::DisconnectR
     disable();
 }
 
-static Ref<Protocol::Network::Headers> buildObjectForHeaders(const HTTPHeaderMap& headers)
+static Ref<Inspector::Protocol::Network::Headers> buildObjectForHeaders(const HTTPHeaderMap& headers)
 {
-    auto headersValue = Protocol::Network::Headers::create().release();
+    auto headersValue = Inspector::Protocol::Network::Headers::create().release();
 
     auto headersObject = headersValue->asObject();
     for (const auto& header : headers)
@@ -213,7 +213,7 @@ static Ref<Protocol::Network::Headers> buildObjectForHeaders(const HTTPHeaderMap
     return headersValue;
 }
 
-Ref<Protocol::Network::ResourceTiming> InspectorNetworkAgent::buildObjectForTiming(const NetworkLoadMetrics& timing, ResourceLoader& resourceLoader)
+Ref<Inspector::Protocol::Network::ResourceTiming> InspectorNetworkAgent::buildObjectForTiming(const NetworkLoadMetrics& timing, ResourceLoader& resourceLoader)
 {
     auto elapsedTimeSince = [&] (const MonotonicTime& time) {
         return m_environment.executionStopwatch().elapsedTimeSince(time).seconds();
@@ -224,7 +224,7 @@ Ref<Protocol::Network::ResourceTiming> InspectorNetworkAgent::buildObjectForTimi
         return (time - timing.fetchStart).milliseconds();
     };
 
-    return Protocol::Network::ResourceTiming::create()
+    return Inspector::Protocol::Network::ResourceTiming::create()
         .setStartTime(elapsedTimeSince(resourceLoader.loadTiming().startTime()))
         .setRedirectStart(elapsedTimeSince(timing.redirectStart))
         .setRedirectEnd(elapsedTimeSince(timing.fetchStart))
@@ -240,26 +240,26 @@ Ref<Protocol::Network::ResourceTiming> InspectorNetworkAgent::buildObjectForTimi
         .release();
 }
 
-static Protocol::Network::Metrics::Priority toProtocol(NetworkLoadPriority priority)
+static Inspector::Protocol::Network::Metrics::Priority toProtocol(NetworkLoadPriority priority)
 {
     switch (priority) {
     case NetworkLoadPriority::Low:
-        return Protocol::Network::Metrics::Priority::Low;
+        return Inspector::Protocol::Network::Metrics::Priority::Low;
     case NetworkLoadPriority::Medium:
-        return Protocol::Network::Metrics::Priority::Medium;
+        return Inspector::Protocol::Network::Metrics::Priority::Medium;
     case NetworkLoadPriority::High:
-        return Protocol::Network::Metrics::Priority::High;
+        return Inspector::Protocol::Network::Metrics::Priority::High;
     case NetworkLoadPriority::Unknown:
         break;
     }
 
     ASSERT_NOT_REACHED();
-    return Protocol::Network::Metrics::Priority::Medium;
+    return Inspector::Protocol::Network::Metrics::Priority::Medium;
 }
 
-Ref<Protocol::Network::Metrics> InspectorNetworkAgent::buildObjectForMetrics(const NetworkLoadMetrics& networkLoadMetrics)
+Ref<Inspector::Protocol::Network::Metrics> InspectorNetworkAgent::buildObjectForMetrics(const NetworkLoadMetrics& networkLoadMetrics)
 {
-    auto metrics = Protocol::Network::Metrics::create().release();
+    auto metrics = Inspector::Protocol::Network::Metrics::create().release();
 
     if (!networkLoadMetrics.protocol.isNull())
         metrics->setProtocol(networkLoadMetrics.protocol);
@@ -286,7 +286,7 @@ Ref<Protocol::Network::Metrics> InspectorNetworkAgent::buildObjectForMetrics(con
     if (networkLoadMetrics.responseBodyDecodedSize != std::numeric_limits<uint64_t>::max())
         metrics->setResponseBodyDecodedSize(networkLoadMetrics.responseBodyDecodedSize);
 
-    auto connectionPayload = Protocol::Security::Connection::create()
+    auto connectionPayload = Inspector::Protocol::Security::Connection::create()
         .release();
 
     if (auto* additionalMetrics = networkLoadMetrics.additionalNetworkLoadMetricsForWebInspector.get()) {
@@ -301,36 +301,36 @@ Ref<Protocol::Network::Metrics> InspectorNetworkAgent::buildObjectForMetrics(con
     return metrics;
 }
 
-static Protocol::Network::ReferrerPolicy toProtocol(ReferrerPolicy referrerPolicy)
+static Inspector::Protocol::Network::ReferrerPolicy toProtocol(ReferrerPolicy referrerPolicy)
 {
     switch (referrerPolicy) {
     case ReferrerPolicy::EmptyString:
-        return Protocol::Network::ReferrerPolicy::EmptyString;
+        return Inspector::Protocol::Network::ReferrerPolicy::EmptyString;
     case ReferrerPolicy::NoReferrer:
-        return Protocol::Network::ReferrerPolicy::NoReferrer;
+        return Inspector::Protocol::Network::ReferrerPolicy::NoReferrer;
     case ReferrerPolicy::NoReferrerWhenDowngrade:
-        return Protocol::Network::ReferrerPolicy::NoReferrerWhenDowngrade;
+        return Inspector::Protocol::Network::ReferrerPolicy::NoReferrerWhenDowngrade;
     case ReferrerPolicy::SameOrigin:
-        return Protocol::Network::ReferrerPolicy::SameOrigin;
+        return Inspector::Protocol::Network::ReferrerPolicy::SameOrigin;
     case ReferrerPolicy::Origin:
-        return Protocol::Network::ReferrerPolicy::Origin;
+        return Inspector::Protocol::Network::ReferrerPolicy::Origin;
     case ReferrerPolicy::StrictOrigin:
-        return Protocol::Network::ReferrerPolicy::StrictOrigin;
+        return Inspector::Protocol::Network::ReferrerPolicy::StrictOrigin;
     case ReferrerPolicy::OriginWhenCrossOrigin:
-        return Protocol::Network::ReferrerPolicy::OriginWhenCrossOrigin;
+        return Inspector::Protocol::Network::ReferrerPolicy::OriginWhenCrossOrigin;
     case ReferrerPolicy::StrictOriginWhenCrossOrigin:
-        return Protocol::Network::ReferrerPolicy::StrictOriginWhenCrossOrigin;
+        return Inspector::Protocol::Network::ReferrerPolicy::StrictOriginWhenCrossOrigin;
     case ReferrerPolicy::UnsafeUrl:
-        return Protocol::Network::ReferrerPolicy::UnsafeUrl;
+        return Inspector::Protocol::Network::ReferrerPolicy::UnsafeUrl;
     }
 
     ASSERT_NOT_REACHED();
-    return Protocol::Network::ReferrerPolicy::EmptyString;
+    return Inspector::Protocol::Network::ReferrerPolicy::EmptyString;
 }
 
-static Ref<Protocol::Network::Request> buildObjectForResourceRequest(const ResourceRequest& request, ResourceLoader* resourceLoader)
+static Ref<Inspector::Protocol::Network::Request> buildObjectForResourceRequest(const ResourceRequest& request, ResourceLoader* resourceLoader)
 {
-    auto requestObject = Protocol::Network::Request::create()
+    auto requestObject = Inspector::Protocol::Network::Request::create()
         .setUrl(request.url().string())
         .setMethod(request.httpMethod())
         .setHeaders(buildObjectForHeaders(request.httpHeaderFields()))
@@ -351,38 +351,38 @@ static Ref<Protocol::Network::Request> buildObjectForResourceRequest(const Resou
     return requestObject;
 }
 
-static Protocol::Network::Response::Source responseSource(ResourceResponse::Source source)
+static Inspector::Protocol::Network::Response::Source responseSource(ResourceResponse::Source source)
 {
     switch (source) {
     case ResourceResponse::Source::DOMCache:
     case ResourceResponse::Source::ApplicationCache:
         // FIXME: Add support for ApplicationCache in inspector.
     case ResourceResponse::Source::Unknown:
-        return Protocol::Network::Response::Source::Unknown;
+        return Inspector::Protocol::Network::Response::Source::Unknown;
     case ResourceResponse::Source::Network:
-        return Protocol::Network::Response::Source::Network;
+        return Inspector::Protocol::Network::Response::Source::Network;
     case ResourceResponse::Source::MemoryCache:
     case ResourceResponse::Source::MemoryCacheAfterValidation:
-        return Protocol::Network::Response::Source::MemoryCache;
+        return Inspector::Protocol::Network::Response::Source::MemoryCache;
     case ResourceResponse::Source::DiskCache:
     case ResourceResponse::Source::DiskCacheAfterValidation:
-        return Protocol::Network::Response::Source::DiskCache;
+        return Inspector::Protocol::Network::Response::Source::DiskCache;
     case ResourceResponse::Source::ServiceWorker:
-        return Protocol::Network::Response::Source::ServiceWorker;
+        return Inspector::Protocol::Network::Response::Source::ServiceWorker;
     case ResourceResponse::Source::InspectorOverride:
-        return Protocol::Network::Response::Source::InspectorOverride;
+        return Inspector::Protocol::Network::Response::Source::InspectorOverride;
     }
 
     ASSERT_NOT_REACHED();
-    return Protocol::Network::Response::Source::Unknown;
+    return Inspector::Protocol::Network::Response::Source::Unknown;
 }
 
-RefPtr<Protocol::Network::Response> InspectorNetworkAgent::buildObjectForResourceResponse(const ResourceResponse& response, ResourceLoader* resourceLoader)
+RefPtr<Inspector::Protocol::Network::Response> InspectorNetworkAgent::buildObjectForResourceResponse(const ResourceResponse& response, ResourceLoader* resourceLoader)
 {
     if (response.isNull())
         return nullptr;
 
-    auto responseObject = Protocol::Network::Response::create()
+    auto responseObject = Inspector::Protocol::Network::Response::create()
         .setUrl(response.url().string())
         .setStatus(response.httpStatusCode())
         .setStatusText(response.httpStatusText())
@@ -397,11 +397,11 @@ RefPtr<Protocol::Network::Response> InspectorNetworkAgent::buildObjectForResourc
     }
 
     if (auto& certificateInfo = response.certificateInfo()) {
-        auto securityPayload = Protocol::Security::Security::create()
+        auto securityPayload = Inspector::Protocol::Security::Security::create()
             .release();
 
         if (auto certificateSummaryInfo = certificateInfo.value().summary()) {
-            auto certificatePayload = Protocol::Security::Certificate::create()
+            auto certificatePayload = Inspector::Protocol::Security::Certificate::create()
                 .release();
 
             certificatePayload->setSubject(certificateSummaryInfo.value().subject);
@@ -433,9 +433,9 @@ RefPtr<Protocol::Network::Response> InspectorNetworkAgent::buildObjectForResourc
     return responseObject;
 }
 
-Ref<Protocol::Network::CachedResource> InspectorNetworkAgent::buildObjectForCachedResource(CachedResource* cachedResource)
+Ref<Inspector::Protocol::Network::CachedResource> InspectorNetworkAgent::buildObjectForCachedResource(CachedResource* cachedResource)
 {
-    auto resourceObject = Protocol::Network::CachedResource::create()
+    auto resourceObject = Inspector::Protocol::Network::CachedResource::create()
         .setUrl(cachedResource->url().string())
         .setType(InspectorPageAgent::cachedResourceTypeJSON(*cachedResource))
         .setBodySize(cachedResource->encodedSize())
@@ -483,7 +483,7 @@ void InspectorNetworkAgent::willSendRequest(ResourceLoaderIdentifier identifier,
     auto initiatorObject = buildInitiatorObject(document, &request);
 
     String url = loader ? loader->url().string() : request.url().string();
-    std::optional<Protocol::Page::ResourceType> typePayload;
+    std::optional<Inspector::Protocol::Page::ResourceType> typePayload;
     if (type != InspectorPageAgent::OtherResource)
         typePayload = protocolResourceType;
     m_frontendDispatcher->requestWillBeSent(requestId, frameId, loaderId, url, buildObjectForResourceRequest(request, resourceLoader), sendTimestamp, walltime.secondsSinceEpoch().seconds(), WTFMove(initiatorObject), buildObjectForResourceResponse(redirectResponse, nullptr), WTFMove(typePayload), targetId);
@@ -571,7 +571,7 @@ void InspectorNetworkAgent::didReceiveResponse(ResourceLoaderIdentifier identifi
     if (cachedResource) {
         // Use mime type from cached resource in case the one in response is empty.
         if (resourceResponse && response.mimeType().isEmpty())
-            resourceResponse->setString(Protocol::Network::Response::mimeTypeKey, cachedResource->response().mimeType());
+            resourceResponse->setString(Inspector::Protocol::Network::Response::mimeTypeKey, cachedResource->response().mimeType());
         m_resourcesData->addCachedResource(requestId, cachedResource);
     }
 
@@ -594,17 +594,17 @@ void InspectorNetworkAgent::didReceiveResponse(ResourceLoaderIdentifier identifi
                 });
             }
             
-            resourceResponse->setString(Protocol::Network::Response::mimeTypeKey, previousResourceData->mimeType());
+            resourceResponse->setString(Inspector::Protocol::Network::Response::mimeTypeKey, previousResourceData->mimeType());
             
-            resourceResponse->setInteger(Protocol::Network::Response::statusKey, previousResourceData->httpStatusCode());
-            resourceResponse->setString(Protocol::Network::Response::statusTextKey, previousResourceData->httpStatusText());
+            resourceResponse->setInteger(Inspector::Protocol::Network::Response::statusKey, previousResourceData->httpStatusCode());
+            resourceResponse->setString(Inspector::Protocol::Network::Response::statusTextKey, previousResourceData->httpStatusText());
             
-            resourceResponse->setString(Protocol::Network::Response::sourceKey, Protocol::Helpers::getEnumConstantValue(Protocol::Network::Response::Source::DiskCache));
+            resourceResponse->setString(Inspector::Protocol::Network::Response::sourceKey, Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::Network::Response::Source::DiskCache));
         }
     }
 
-    Protocol::Network::FrameId frameId = frameIdentifier(loader);
-    Protocol::Network::LoaderId loaderId = loaderIdentifier(loader);
+    Inspector::Protocol::Network::FrameId frameId = frameIdentifier(loader);
+    Inspector::Protocol::Network::LoaderId loaderId = loaderIdentifier(loader);
 
     m_resourcesData->responseReceived(requestId, frameId, response, type, shouldForceBufferingNetworkResourceData());
 
@@ -696,8 +696,8 @@ void InspectorNetworkAgent::didLoadResourceFromMemoryCache(DocumentLoader* loade
 
     auto identifier = ResourceLoaderIdentifier::generate();
     String requestId = IdentifiersFactory::requestId(identifier.toUInt64());
-    Protocol::Network::LoaderId loaderId = loaderIdentifier(loader);
-    Protocol::Network::FrameId frameId = frameIdentifier(loader);
+    Inspector::Protocol::Network::LoaderId loaderId = loaderIdentifier(loader);
+    Inspector::Protocol::Network::FrameId frameId = frameIdentifier(loader);
 
     m_resourcesData->resourceCreated(requestId, loaderId, resource);
 
@@ -771,26 +771,26 @@ void InspectorNetworkAgent::didScheduleStyleRecalculation(Document& document)
         m_styleRecalculationInitiator = buildInitiatorObject(&document);
 }
 
-Ref<Protocol::Network::Initiator> InspectorNetworkAgent::buildInitiatorObject(Document* document, const ResourceRequest* resourceRequest)
+Ref<Inspector::Protocol::Network::Initiator> InspectorNetworkAgent::buildInitiatorObject(Document* document, const ResourceRequest* resourceRequest)
 {
     // FIXME: Worker support.
     if (!isMainThread()) {
-        return Protocol::Network::Initiator::create()
-            .setType(Protocol::Network::Initiator::Type::Other)
+        return Inspector::Protocol::Network::Initiator::create()
+            .setType(Inspector::Protocol::Network::Initiator::Type::Other)
             .release();
     }
 
-    RefPtr<Protocol::Network::Initiator> initiatorObject;
+    RefPtr<Inspector::Protocol::Network::Initiator> initiatorObject;
 
     Ref<ScriptCallStack> stackTrace = createScriptCallStack(JSExecState::currentState());
     if (stackTrace->size() > 0) {
-        initiatorObject = Protocol::Network::Initiator::create()
-            .setType(Protocol::Network::Initiator::Type::Script)
+        initiatorObject = Inspector::Protocol::Network::Initiator::create()
+            .setType(Inspector::Protocol::Network::Initiator::Type::Script)
             .release();
         initiatorObject->setStackTrace(stackTrace->buildInspectorObject());
     } else if (document && document->scriptableDocumentParser()) {
-        initiatorObject = Protocol::Network::Initiator::create()
-            .setType(Protocol::Network::Initiator::Type::Parser)
+        initiatorObject = Inspector::Protocol::Network::Initiator::create()
+            .setType(Inspector::Protocol::Network::Initiator::Type::Parser)
             .release();
         initiatorObject->setUrl(document->url().string());
         initiatorObject->setLineNumber(document->scriptableDocumentParser()->textPosition().m_line.oneBasedInt());
@@ -800,8 +800,8 @@ Ref<Protocol::Network::Initiator> InspectorNetworkAgent::buildInitiatorObject(Do
     if (domAgent && resourceRequest) {
         if (auto inspectorInitiatorNodeIdentifier = resourceRequest->inspectorInitiatorNodeIdentifier()) {
             if (!initiatorObject) {
-                initiatorObject = Protocol::Network::Initiator::create()
-                    .setType(Protocol::Network::Initiator::Type::Other)
+                initiatorObject = Inspector::Protocol::Network::Initiator::create()
+                    .setType(Inspector::Protocol::Network::Initiator::Type::Other)
                     .release();
             }
 
@@ -815,8 +815,8 @@ Ref<Protocol::Network::Initiator> InspectorNetworkAgent::buildInitiatorObject(Do
     if (m_isRecalculatingStyle && m_styleRecalculationInitiator)
         return *m_styleRecalculationInitiator;
 
-    return Protocol::Network::Initiator::create()
-        .setType(Protocol::Network::Initiator::Type::Other)
+    return Inspector::Protocol::Network::Initiator::create()
+        .setType(Inspector::Protocol::Network::Initiator::Type::Other)
         .release();
 }
 
@@ -827,7 +827,7 @@ void InspectorNetworkAgent::didCreateWebSocket(WebSocketChannelIdentifier identi
 
 void InspectorNetworkAgent::willSendWebSocketHandshakeRequest(WebSocketChannelIdentifier identifier, const ResourceRequest& request)
 {
-    auto requestObject = Protocol::Network::WebSocketRequest::create()
+    auto requestObject = Inspector::Protocol::Network::WebSocketRequest::create()
         .setHeaders(buildObjectForHeaders(request.httpHeaderFields()))
         .release();
     m_frontendDispatcher->webSocketWillSendHandshakeRequest(IdentifiersFactory::requestId(identifier.toUInt64()), timestamp(), WallTime::now().secondsSinceEpoch().seconds(), WTFMove(requestObject));
@@ -835,7 +835,7 @@ void InspectorNetworkAgent::willSendWebSocketHandshakeRequest(WebSocketChannelId
 
 void InspectorNetworkAgent::didReceiveWebSocketHandshakeResponse(WebSocketChannelIdentifier identifier, const ResourceResponse& response)
 {
-    auto responseObject = Protocol::Network::WebSocketResponse::create()
+    auto responseObject = Inspector::Protocol::Network::WebSocketResponse::create()
         .setStatus(response.httpStatusCode())
         .setStatusText(response.httpStatusText())
         .setHeaders(buildObjectForHeaders(response.httpHeaderFields()))
@@ -862,7 +862,7 @@ void InspectorNetworkAgent::didReceiveWebSocketFrameError(WebSocketChannelIdenti
     m_frontendDispatcher->webSocketFrameError(IdentifiersFactory::requestId(identifier.toUInt64()), timestamp(), errorMessage);
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::enable()
 {
     m_enabled = true;
     m_instrumentingAgents.setEnabledNetworkAgent(this);
@@ -898,7 +898,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::disable()
 {
     m_enabled = false;
     m_interceptionEnabled = false;
@@ -919,7 +919,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::disable()
     return { };
 }
 
-bool InspectorNetworkAgent::shouldIntercept(URL url, Protocol::Network::NetworkStage networkStage)
+bool InspectorNetworkAgent::shouldIntercept(URL url, Inspector::Protocol::Network::NetworkStage networkStage)
 {
     url.removeFragmentIdentifier();
 
@@ -956,7 +956,7 @@ void InspectorNetworkAgent::continuePendingResponses()
     m_pendingInterceptResponses.clear();
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::setExtraHTTPHeaders(Ref<JSON::Object>&& headers)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::setExtraHTTPHeaders(Ref<JSON::Object>&& headers)
 {
     for (auto& entry : headers.get()) {
         auto stringValue = entry.value->asString();
@@ -967,7 +967,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::setExtraHTTPHeaders(Ref<JSO
     return { };
 }
 
-Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorNetworkAgent::getResponseBody(const Protocol::Network::RequestId& requestId)
+Inspector::Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorNetworkAgent::getResponseBody(const Inspector::Protocol::Network::RequestId& requestId)
 {
     NetworkResourcesData::ResourceData const* resourceData = m_resourcesData->data(requestId);
     if (!resourceData)
@@ -995,16 +995,16 @@ Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorN
     return makeUnexpected("Missing content of resource for given requestId"_s);
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::setResourceCachingDisabled(bool disabled)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::setResourceCachingDisabled(bool disabled)
 {
     setResourceCachingDisabledInternal(disabled);
 
     return { };
 }
 
-void InspectorNetworkAgent::loadResource(const Protocol::Network::FrameId& frameId, const String& urlString, Ref<LoadResourceCallback>&& callback)
+void InspectorNetworkAgent::loadResource(const Inspector::Protocol::Network::FrameId& frameId, const String& urlString, Ref<LoadResourceCallback>&& callback)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
     auto* context = scriptExecutionContext(errorString, frameId);
     if (!context) {
         callback->sendFailure(errorString);
@@ -1038,7 +1038,7 @@ void InspectorNetworkAgent::loadResource(const Protocol::Network::FrameId& frame
     inspectorThreadableLoaderClient->setLoader(WTFMove(loader));
 }
 
-Protocol::ErrorStringOr<String> InspectorNetworkAgent::getSerializedCertificate(const Protocol::Network::RequestId& requestId)
+Inspector::Protocol::ErrorStringOr<String> InspectorNetworkAgent::getSerializedCertificate(const Inspector::Protocol::Network::RequestId& requestId)
 {
     auto* resourceData = m_resourcesData->data(requestId);
     if (!resourceData)
@@ -1053,7 +1053,7 @@ Protocol::ErrorStringOr<String> InspectorNetworkAgent::getSerializedCertificate(
     return base64EncodeToString(encoder.buffer(), encoder.bufferSize());
 }
 
-WebSocket* InspectorNetworkAgent::webSocketForRequestId(const Protocol::Network::RequestId& requestId)
+WebSocket* InspectorNetworkAgent::webSocketForRequestId(const Inspector::Protocol::Network::RequestId& requestId)
 {
     Locker locker { WebSocket::allActiveWebSocketsLock() };
 
@@ -1071,7 +1071,7 @@ static JSC::JSValue webSocketAsScriptValue(JSC::JSGlobalObject& state, WebSocket
     return toJS(&state, deprecatedGlobalObjectForPrototype(&state), webSocket);
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorNetworkAgent::resolveWebSocket(const Protocol::Network::RequestId& requestId, const String& objectGroup)
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> InspectorNetworkAgent::resolveWebSocket(const Inspector::Protocol::Network::RequestId& requestId, const String& objectGroup)
 {
     WebSocket* webSocket = webSocketForRequestId(requestId);
     if (!webSocket)
@@ -1097,7 +1097,7 @@ Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorNetworkAg
     return object.releaseNonNull();
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::setInterceptionEnabled(bool enabled)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::setInterceptionEnabled(bool enabled)
 {
     if (m_interceptionEnabled == enabled)
         return makeUnexpected(m_interceptionEnabled ? "Interception already enabled"_s : "Interception already disabled"_s);
@@ -1112,7 +1112,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::setInterceptionEnabled(bool
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::addInterception(const String& url, Protocol::Network::NetworkStage networkStage, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::addInterception(const String& url, Inspector::Protocol::Network::NetworkStage networkStage, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex)
 {
     Intercept intercept;
     intercept.url = url;
@@ -1128,7 +1128,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::addInterception(const Strin
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::removeInterception(const String& url, Protocol::Network::NetworkStage networkStage, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::removeInterception(const String& url, Inspector::Protocol::Network::NetworkStage networkStage, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex)
 {
     Intercept intercept;
     intercept.url = url;
@@ -1149,8 +1149,8 @@ bool InspectorNetworkAgent::willIntercept(const ResourceRequest& request)
     if (!m_interceptionEnabled)
         return false;
 
-    return shouldIntercept(request.url(), Protocol::Network::NetworkStage::Request)
-        || shouldIntercept(request.url(), Protocol::Network::NetworkStage::Response);
+    return shouldIntercept(request.url(), Inspector::Protocol::Network::NetworkStage::Request)
+        || shouldIntercept(request.url(), Inspector::Protocol::Network::NetworkStage::Response);
 }
 
 bool InspectorNetworkAgent::shouldInterceptRequest(const ResourceLoader& loader)
@@ -1161,7 +1161,7 @@ bool InspectorNetworkAgent::shouldInterceptRequest(const ResourceLoader& loader)
     if (loader.options().serviceWorkerRegistrationIdentifier)
         return false;
 
-    return shouldIntercept(loader.url(), Protocol::Network::NetworkStage::Request);
+    return shouldIntercept(loader.url(), Inspector::Protocol::Network::NetworkStage::Request);
 }
 
 bool InspectorNetworkAgent::shouldInterceptResponse(const ResourceResponse& response)
@@ -1169,7 +1169,7 @@ bool InspectorNetworkAgent::shouldInterceptResponse(const ResourceResponse& resp
     if (!m_interceptionEnabled)
         return false;
 
-    return shouldIntercept(response.url(), Protocol::Network::NetworkStage::Response);
+    return shouldIntercept(response.url(), Inspector::Protocol::Network::NetworkStage::Response);
 }
 
 void InspectorNetworkAgent::interceptRequest(ResourceLoader& loader, Function<void(const ResourceRequest&)>&& handler)
@@ -1207,17 +1207,17 @@ void InspectorNetworkAgent::interceptResponse(const ResourceResponse& response, 
     m_frontendDispatcher->responseIntercepted(requestId, resourceResponse.releaseNonNull());
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptContinue(const Protocol::Network::RequestId& requestId, Protocol::Network::NetworkStage networkStage)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptContinue(const Inspector::Protocol::Network::RequestId& requestId, Inspector::Protocol::Network::NetworkStage networkStage)
 {
     switch (networkStage) {
-    case Protocol::Network::NetworkStage::Request:
+    case Inspector::Protocol::Network::NetworkStage::Request:
         if (auto pendingInterceptRequest = m_pendingInterceptRequests.take(requestId)) {
             pendingInterceptRequest->continueWithOriginalRequest();
             return { };
         }
         return makeUnexpected("Missing pending intercept request for given requestId"_s);
 
-    case Protocol::Network::NetworkStage::Response:
+    case Inspector::Protocol::Network::NetworkStage::Response:
         if (auto pendingInterceptResponse = m_pendingInterceptResponses.take(requestId)) {
             pendingInterceptResponse->respondWithOriginalResponse();
             return { };
@@ -1229,7 +1229,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptContinue(const Pro
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithRequest(const Protocol::Network::RequestId& requestId, const String& url, const String& method, RefPtr<JSON::Object>&& headers, const String& postData)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithRequest(const Inspector::Protocol::Network::RequestId& requestId, const String& url, const String& method, RefPtr<JSON::Object>&& headers, const String& postData)
 {
     auto pendingRequest = m_pendingInterceptRequests.take(requestId);
     if (!pendingRequest)
@@ -1263,7 +1263,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithRequest(const 
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithResponse(const Protocol::Network::RequestId& requestId, const String& content, bool base64Encoded, const String& mimeType, std::optional<int>&& status, const String& statusText, RefPtr<JSON::Object>&& headers)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithResponse(const Inspector::Protocol::Network::RequestId& requestId, const String& content, bool base64Encoded, const String& mimeType, std::optional<int>&& status, const String& statusText, RefPtr<JSON::Object>&& headers)
 {
     auto pendingInterceptResponse = m_pendingInterceptResponses.take(requestId);
     if (!pendingInterceptResponse)
@@ -1306,7 +1306,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithResponse(const
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithResponse(const Protocol::Network::RequestId& requestId, const String& content, bool base64Encoded, const String& mimeType, int status, const String& statusText, Ref<JSON::Object>&& headers)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithResponse(const Inspector::Protocol::Network::RequestId& requestId, const String& content, bool base64Encoded, const String& mimeType, int status, const String& statusText, Ref<JSON::Object>&& headers)
 {
     auto pendingRequest = m_pendingInterceptRequests.take(requestId);
     if (!pendingRequest)
@@ -1354,19 +1354,19 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithRespons
     return { };
 }
 
-static ResourceError::Type toResourceErrorType(Protocol::Network::ResourceErrorType protocolResourceErrorType)
+static ResourceError::Type toResourceErrorType(Inspector::Protocol::Network::ResourceErrorType protocolResourceErrorType)
 {
     switch (protocolResourceErrorType) {
-    case Protocol::Network::ResourceErrorType::General:
+    case Inspector::Protocol::Network::ResourceErrorType::General:
         return ResourceError::Type::General;
 
-    case Protocol::Network::ResourceErrorType::AccessControl:
+    case Inspector::Protocol::Network::ResourceErrorType::AccessControl:
         return ResourceError::Type::AccessControl;
 
-    case Protocol::Network::ResourceErrorType::Cancellation:
+    case Inspector::Protocol::Network::ResourceErrorType::Cancellation:
         return ResourceError::Type::Cancellation;
 
-    case Protocol::Network::ResourceErrorType::Timeout:
+    case Inspector::Protocol::Network::ResourceErrorType::Timeout:
         return ResourceError::Type::Timeout;
     }
 
@@ -1374,7 +1374,7 @@ static ResourceError::Type toResourceErrorType(Protocol::Network::ResourceErrorT
     return ResourceError::Type::Null;
 }
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithError(const Protocol::Network::RequestId& requestId, Protocol::Network::ResourceErrorType errorType)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithError(const Inspector::Protocol::Network::RequestId& requestId, Inspector::Protocol::Network::ResourceErrorType errorType)
 {
     auto pendingRequest = m_pendingInterceptRequests.take(requestId);
     if (!pendingRequest)
@@ -1392,7 +1392,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithError(c
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-Protocol::ErrorStringOr<void> InspectorNetworkAgent::setEmulatedConditions(std::optional<int>&& bytesPerSecondLimit)
+Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::setEmulatedConditions(std::optional<int>&& bytesPerSecondLimit)
 {
     if (bytesPerSecondLimit && *bytesPerSecondLimit < 0)
         return makeUnexpected("bytesPerSecond cannot be negative"_s);
@@ -1485,9 +1485,9 @@ bool InspectorNetworkAgent::cachedResourceContent(CachedResource& resource, Stri
     }
 }
 
-static Ref<Protocol::Page::SearchResult> buildObjectForSearchResult(const Protocol::Network::RequestId& requestId, const Protocol::Network::FrameId& frameId, const String& url, int matchesCount)
+static Ref<Inspector::Protocol::Page::SearchResult> buildObjectForSearchResult(const Inspector::Protocol::Network::RequestId& requestId, const Inspector::Protocol::Network::FrameId& frameId, const String& url, int matchesCount)
 {
-    auto searchResult = Protocol::Page::SearchResult::create()
+    auto searchResult = Inspector::Protocol::Page::SearchResult::create()
         .setUrl(url)
         .setFrameId(frameId)
         .setMatchesCount(matchesCount)
@@ -1507,7 +1507,7 @@ static std::optional<String> textContentForResourceData(const NetworkResourcesDa
     return std::nullopt;
 }
 
-void InspectorNetworkAgent::searchOtherRequests(const JSC::Yarr::RegularExpression& regex, Ref<JSON::ArrayOf<Protocol::Page::SearchResult>>& result)
+void InspectorNetworkAgent::searchOtherRequests(const JSC::Yarr::RegularExpression& regex, Ref<JSON::ArrayOf<Inspector::Protocol::Page::SearchResult>>& result)
 {
     Vector<NetworkResourcesData::ResourceData*> resources = m_resourcesData->resources();
     for (auto* resourceData : resources) {
@@ -1519,7 +1519,7 @@ void InspectorNetworkAgent::searchOtherRequests(const JSC::Yarr::RegularExpressi
     }
 }
 
-void InspectorNetworkAgent::searchInRequest(Protocol::ErrorString& errorString, const Protocol::Network::RequestId& requestId, const String& query, bool caseSensitive, bool isRegex, RefPtr<JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>>& results)
+void InspectorNetworkAgent::searchInRequest(Inspector::Protocol::ErrorString& errorString, const Inspector::Protocol::Network::RequestId& requestId, const String& query, bool caseSensitive, bool isRegex, RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>>& results)
 {
     NetworkResourcesData::ResourceData const* resourceData = m_resourcesData->data(requestId);
     if (!resourceData) {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -152,7 +152,7 @@ Vector<CachedResource*> InspectorPageAgent::cachedResourcesForFrame(LocalFrame* 
     return result;
 }
 
-void InspectorPageAgent::resourceContent(Protocol::ErrorString& errorString, LocalFrame* frame, const URL& url, String* result, bool* base64Encoded)
+void InspectorPageAgent::resourceContent(Inspector::Protocol::ErrorString& errorString, LocalFrame* frame, const URL& url, String* result, bool* base64Encoded)
 {
     DocumentLoader* loader = assertDocumentLoader(errorString, frame);
     if (!loader)
@@ -214,39 +214,39 @@ CachedResource* InspectorPageAgent::cachedResource(const LocalFrame* frame, cons
     return cachedResource;
 }
 
-Protocol::Page::ResourceType InspectorPageAgent::resourceTypeJSON(InspectorPageAgent::ResourceType resourceType)
+Inspector::Protocol::Page::ResourceType InspectorPageAgent::resourceTypeJSON(InspectorPageAgent::ResourceType resourceType)
 {
     switch (resourceType) {
     case DocumentResource:
-        return Protocol::Page::ResourceType::Document;
+        return Inspector::Protocol::Page::ResourceType::Document;
     case ImageResource:
-        return Protocol::Page::ResourceType::Image;
+        return Inspector::Protocol::Page::ResourceType::Image;
     case FontResource:
-        return Protocol::Page::ResourceType::Font;
+        return Inspector::Protocol::Page::ResourceType::Font;
     case StyleSheetResource:
-        return Protocol::Page::ResourceType::StyleSheet;
+        return Inspector::Protocol::Page::ResourceType::StyleSheet;
     case ScriptResource:
-        return Protocol::Page::ResourceType::Script;
+        return Inspector::Protocol::Page::ResourceType::Script;
     case XHRResource:
-        return Protocol::Page::ResourceType::XHR;
+        return Inspector::Protocol::Page::ResourceType::XHR;
     case FetchResource:
-        return Protocol::Page::ResourceType::Fetch;
+        return Inspector::Protocol::Page::ResourceType::Fetch;
     case PingResource:
-        return Protocol::Page::ResourceType::Ping;
+        return Inspector::Protocol::Page::ResourceType::Ping;
     case BeaconResource:
-        return Protocol::Page::ResourceType::Beacon;
+        return Inspector::Protocol::Page::ResourceType::Beacon;
     case WebSocketResource:
-        return Protocol::Page::ResourceType::WebSocket;
+        return Inspector::Protocol::Page::ResourceType::WebSocket;
     case EventSourceResource:
-        return Protocol::Page::ResourceType::EventSource;
+        return Inspector::Protocol::Page::ResourceType::EventSource;
     case OtherResource:
-        return Protocol::Page::ResourceType::Other;
+        return Inspector::Protocol::Page::ResourceType::Other;
 #if ENABLE(APPLICATION_MANIFEST)
     case ApplicationManifestResource:
         break;
 #endif
     }
-    return Protocol::Page::ResourceType::Other;
+    return Inspector::Protocol::Page::ResourceType::Other;
 }
 
 InspectorPageAgent::ResourceType InspectorPageAgent::inspectorResourceType(CachedResource::Type type)
@@ -303,7 +303,7 @@ InspectorPageAgent::ResourceType InspectorPageAgent::inspectorResourceType(const
     return inspectorResourceType(cachedResource.type());
 }
 
-Protocol::Page::ResourceType InspectorPageAgent::cachedResourceTypeJSON(const CachedResource& cachedResource)
+Inspector::Protocol::Page::ResourceType InspectorPageAgent::cachedResourceTypeJSON(const CachedResource& cachedResource)
 {
     return resourceTypeJSON(inspectorResourceType(cachedResource));
 }
@@ -320,7 +320,7 @@ LocalFrame* InspectorPageAgent::findFrameWithSecurityOrigin(Page& page, const St
     return nullptr;
 }
 
-DocumentLoader* InspectorPageAgent::assertDocumentLoader(Protocol::ErrorString& errorString, LocalFrame* frame)
+DocumentLoader* InspectorPageAgent::assertDocumentLoader(Inspector::Protocol::ErrorString& errorString, LocalFrame* frame)
 {
     FrameLoader& frameLoader = frame->loader();
     DocumentLoader* documentLoader = frameLoader.documentLoader();
@@ -350,7 +350,7 @@ void InspectorPageAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReas
     disable();
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
 {
     if (m_instrumentingAgents.enabledPageAgent() == this)
         return makeUnexpected("Page domain already enabled"_s);
@@ -366,7 +366,7 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
 {
     m_instrumentingAgents.setEnabledPageAgent(nullptr);
 
@@ -404,7 +404,7 @@ double InspectorPageAgent::timestamp()
     return m_environment.executionStopwatch().elapsedTime().seconds();
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::reload(std::optional<bool>&& ignoreCache, std::optional<bool>&& revalidateAllResources)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::reload(std::optional<bool>&& ignoreCache, std::optional<bool>&& revalidateAllResources)
 {
     OptionSet<ReloadOption> reloadOptions;
     if (ignoreCache && *ignoreCache)
@@ -420,7 +420,7 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::reload(std::optional<bool>&& i
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::navigate(const String& url)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::navigate(const String& url)
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
     if (!localMainFrame)
@@ -436,64 +436,64 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::navigate(const String& url)
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserAgent(const String& value)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserAgent(const String& value)
 {
     m_userAgentOverride = value;
 
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page::Setting setting, std::optional<bool>&& value)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Inspector::Protocol::Page::Setting setting, std::optional<bool>&& value)
 {
     auto& inspectedPageSettings = m_inspectedPage.settings();
 
     switch (setting) {
-    case Protocol::Page::Setting::PrivateClickMeasurementDebugModeEnabled:
+    case Inspector::Protocol::Page::Setting::PrivateClickMeasurementDebugModeEnabled:
         m_client->setDeveloperPreferenceOverride(InspectorClient::DeveloperPreference::PrivateClickMeasurementDebugModeEnabled, value);
         return { };
 
-    case Protocol::Page::Setting::AuthorAndUserStylesEnabled:
+    case Inspector::Protocol::Page::Setting::AuthorAndUserStylesEnabled:
         inspectedPageSettings.setAuthorAndUserStylesEnabledInspectorOverride(value);
         return { };
 
-    case Protocol::Page::Setting::ICECandidateFilteringEnabled:
+    case Inspector::Protocol::Page::Setting::ICECandidateFilteringEnabled:
         inspectedPageSettings.setICECandidateFilteringEnabledInspectorOverride(value);
         return { };
 
-    case Protocol::Page::Setting::ITPDebugModeEnabled:
+    case Inspector::Protocol::Page::Setting::ITPDebugModeEnabled:
         m_client->setDeveloperPreferenceOverride(InspectorClient::DeveloperPreference::ITPDebugModeEnabled, value);
         return { };
 
-    case Protocol::Page::Setting::ImagesEnabled:
+    case Inspector::Protocol::Page::Setting::ImagesEnabled:
         inspectedPageSettings.setImagesEnabledInspectorOverride(value);
         return { };
 
-    case Protocol::Page::Setting::MediaCaptureRequiresSecureConnection:
+    case Inspector::Protocol::Page::Setting::MediaCaptureRequiresSecureConnection:
         inspectedPageSettings.setMediaCaptureRequiresSecureConnectionInspectorOverride(value);
         return { };
 
-    case Protocol::Page::Setting::MockCaptureDevicesEnabled:
+    case Inspector::Protocol::Page::Setting::MockCaptureDevicesEnabled:
         inspectedPageSettings.setMockCaptureDevicesEnabledInspectorOverride(value);
         m_client->setDeveloperPreferenceOverride(InspectorClient::DeveloperPreference::MockCaptureDevicesEnabled, value);
         return { };
 
-    case Protocol::Page::Setting::NeedsSiteSpecificQuirks:
+    case Inspector::Protocol::Page::Setting::NeedsSiteSpecificQuirks:
         inspectedPageSettings.setNeedsSiteSpecificQuirksInspectorOverride(value);
         return { };
 
-    case Protocol::Page::Setting::ScriptEnabled:
+    case Inspector::Protocol::Page::Setting::ScriptEnabled:
         inspectedPageSettings.setScriptEnabledInspectorOverride(value);
         return { };
 
-    case Protocol::Page::Setting::ShowDebugBorders:
+    case Inspector::Protocol::Page::Setting::ShowDebugBorders:
         inspectedPageSettings.setShowDebugBordersInspectorOverride(value);
         return { };
 
-    case Protocol::Page::Setting::ShowRepaintCounter:
+    case Inspector::Protocol::Page::Setting::ShowRepaintCounter:
         inspectedPageSettings.setShowRepaintCounterInspectorOverride(value);
         return { };
 
-    case Protocol::Page::Setting::WebSecurityEnabled:
+    case Inspector::Protocol::Page::Setting::WebSecurityEnabled:
         inspectedPageSettings.setWebSecurityEnabledInspectorOverride(value);
         return { };
     }
@@ -502,18 +502,18 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideSetting(Protocol::Page
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserPreference(Protocol::Page::UserPreferenceName preference, std::optional<Protocol::Page::UserPreferenceValue>&& value)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserPreference(Inspector::Protocol::Page::UserPreferenceName preference, std::optional<Inspector::Protocol::Page::UserPreferenceValue>&& value)
 {
     switch (preference) {
-    case Protocol::Page::UserPreferenceName::PrefersReducedMotion:
+    case Inspector::Protocol::Page::UserPreferenceName::PrefersReducedMotion:
         overridePrefersReducedMotion(WTFMove(value));
         return { };
 
-    case Protocol::Page::UserPreferenceName::PrefersContrast:
+    case Inspector::Protocol::Page::UserPreferenceName::PrefersContrast:
         overridePrefersContrast(WTFMove(value));
         return { };
 
-    case Protocol::Page::UserPreferenceName::PrefersColorScheme:
+    case Inspector::Protocol::Page::UserPreferenceName::PrefersColorScheme:
         overridePrefersColorScheme(WTFMove(value));
         return { };
     }
@@ -522,63 +522,63 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::overrideUserPreference(Protoco
     return { };
 }
 
-void InspectorPageAgent::overridePrefersReducedMotion(std::optional<Protocol::Page::UserPreferenceValue>&& value)
+void InspectorPageAgent::overridePrefersReducedMotion(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&& value)
 {
     ForcedAccessibilityValue forcedValue = ForcedAccessibilityValue::System;
 
-    if (value == Protocol::Page::UserPreferenceValue::Reduce)
+    if (value == Inspector::Protocol::Page::UserPreferenceValue::Reduce)
         forcedValue = ForcedAccessibilityValue::On;
-    else if (value == Protocol::Page::UserPreferenceValue::NoPreference)
+    else if (value == Inspector::Protocol::Page::UserPreferenceValue::NoPreference)
         forcedValue = ForcedAccessibilityValue::Off;
 
     m_inspectedPage.settings().setForcedPrefersReducedMotionAccessibilityValue(forcedValue);
     m_inspectedPage.accessibilitySettingsDidChange();
 }
 
-void InspectorPageAgent::overridePrefersContrast(std::optional<Protocol::Page::UserPreferenceValue>&& value)
+void InspectorPageAgent::overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&& value)
 {
     ForcedAccessibilityValue forcedValue = ForcedAccessibilityValue::System;
 
-    if (value == Protocol::Page::UserPreferenceValue::More)
+    if (value == Inspector::Protocol::Page::UserPreferenceValue::More)
         forcedValue = ForcedAccessibilityValue::On;
-    else if (value == Protocol::Page::UserPreferenceValue::NoPreference)
+    else if (value == Inspector::Protocol::Page::UserPreferenceValue::NoPreference)
         forcedValue = ForcedAccessibilityValue::Off;
 
     m_inspectedPage.settings().setForcedPrefersContrastAccessibilityValue(forcedValue);
     m_inspectedPage.accessibilitySettingsDidChange();
 }
 
-void InspectorPageAgent::overridePrefersColorScheme(std::optional<Protocol::Page::UserPreferenceValue>&& value)
+void InspectorPageAgent::overridePrefersColorScheme(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&& value)
 {
 #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
     if (!value)
         m_inspectedPage.setUseDarkAppearanceOverride(std::nullopt);
-    else if (value == Protocol::Page::UserPreferenceValue::Light)
+    else if (value == Inspector::Protocol::Page::UserPreferenceValue::Light)
         m_inspectedPage.setUseDarkAppearanceOverride(false);
-    else if (value == Protocol::Page::UserPreferenceValue::Dark)
+    else if (value == Inspector::Protocol::Page::UserPreferenceValue::Dark)
         m_inspectedPage.setUseDarkAppearanceOverride(true);
 #else
     UNUSED_PARAM(value);
 #endif
 }
 
-static Protocol::Page::CookieSameSitePolicy cookieSameSitePolicyJSON(Cookie::SameSitePolicy policy)
+static Inspector::Protocol::Page::CookieSameSitePolicy cookieSameSitePolicyJSON(Cookie::SameSitePolicy policy)
 {
     switch (policy) {
     case Cookie::SameSitePolicy::None:
-        return Protocol::Page::CookieSameSitePolicy::None;
+        return Inspector::Protocol::Page::CookieSameSitePolicy::None;
     case Cookie::SameSitePolicy::Lax:
-        return Protocol::Page::CookieSameSitePolicy::Lax;
+        return Inspector::Protocol::Page::CookieSameSitePolicy::Lax;
     case Cookie::SameSitePolicy::Strict:
-        return Protocol::Page::CookieSameSitePolicy::Strict;
+        return Inspector::Protocol::Page::CookieSameSitePolicy::Strict;
     }
     ASSERT_NOT_REACHED();
-    return Protocol::Page::CookieSameSitePolicy::None;
+    return Inspector::Protocol::Page::CookieSameSitePolicy::None;
 }
 
-static Ref<Protocol::Page::Cookie> buildObjectForCookie(const Cookie& cookie)
+static Ref<Inspector::Protocol::Page::Cookie> buildObjectForCookie(const Cookie& cookie)
 {
-    return Protocol::Page::Cookie::create()
+    return Inspector::Protocol::Page::Cookie::create()
         .setName(cookie.name)
         .setValue(cookie.value)
         .setDomain(cookie.domain)
@@ -591,9 +591,9 @@ static Ref<Protocol::Page::Cookie> buildObjectForCookie(const Cookie& cookie)
         .release();
 }
 
-static Ref<JSON::ArrayOf<Protocol::Page::Cookie>> buildArrayForCookies(ListHashSet<Cookie>& cookiesList)
+static Ref<JSON::ArrayOf<Inspector::Protocol::Page::Cookie>> buildArrayForCookies(ListHashSet<Cookie>& cookiesList)
 {
-    auto cookies = JSON::ArrayOf<Protocol::Page::Cookie>::create();
+    auto cookies = JSON::ArrayOf<Inspector::Protocol::Page::Cookie>::create();
 
     for (const auto& cookie : cookiesList)
         cookies->addItem(buildObjectForCookie(cookie));
@@ -613,7 +613,7 @@ static Vector<URL> allResourcesURLsForFrame(LocalFrame* frame)
     return result;
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Page::Cookie>>> InspectorPageAgent::getCookies()
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Page::Cookie>>> InspectorPageAgent::getCookies()
 {
     ListHashSet<Cookie> allRawCookies;
 
@@ -638,35 +638,35 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Page::Cookie>>> InspectorPag
     return buildArrayForCookies(allRawCookies);
 }
 
-static std::optional<Cookie> parseCookieObject(Protocol::ErrorString& errorString, Ref<JSON::Object>&& cookieObject)
+static std::optional<Cookie> parseCookieObject(Inspector::Protocol::ErrorString& errorString, Ref<JSON::Object>&& cookieObject)
 {
     Cookie cookie;
 
-    cookie.name = cookieObject->getString(Protocol::Page::Cookie::nameKey);
+    cookie.name = cookieObject->getString(Inspector::Protocol::Page::Cookie::nameKey);
     if (!cookie.name) {
         errorString = "Invalid value for key name in given cookie"_s;
         return std::nullopt;
     }
 
-    cookie.value = cookieObject->getString(Protocol::Page::Cookie::valueKey);
+    cookie.value = cookieObject->getString(Inspector::Protocol::Page::Cookie::valueKey);
     if (!cookie.value) {
         errorString = "Invalid value for key value in given cookie"_s;
         return std::nullopt;
     }
 
-    cookie.domain = cookieObject->getString(Protocol::Page::Cookie::domainKey);
+    cookie.domain = cookieObject->getString(Inspector::Protocol::Page::Cookie::domainKey);
     if (!cookie.domain) {
         errorString = "Invalid value for key domain in given cookie"_s;
         return std::nullopt;
     }
 
-    cookie.path = cookieObject->getString(Protocol::Page::Cookie::pathKey);
+    cookie.path = cookieObject->getString(Inspector::Protocol::Page::Cookie::pathKey);
     if (!cookie.path) {
         errorString = "Invalid value for key path in given cookie"_s;
         return std::nullopt;
     }
 
-    auto httpOnly = cookieObject->getBoolean(Protocol::Page::Cookie::httpOnlyKey);
+    auto httpOnly = cookieObject->getBoolean(Inspector::Protocol::Page::Cookie::httpOnlyKey);
     if (!httpOnly) {
         errorString = "Invalid value for key httpOnly in given cookie"_s;
         return std::nullopt;
@@ -674,7 +674,7 @@ static std::optional<Cookie> parseCookieObject(Protocol::ErrorString& errorStrin
 
     cookie.httpOnly = *httpOnly;
 
-    auto secure = cookieObject->getBoolean(Protocol::Page::Cookie::secureKey);
+    auto secure = cookieObject->getBoolean(Inspector::Protocol::Page::Cookie::secureKey);
     if (!secure) {
         errorString = "Invalid value for key secure in given cookie"_s;
         return std::nullopt;
@@ -682,8 +682,8 @@ static std::optional<Cookie> parseCookieObject(Protocol::ErrorString& errorStrin
 
     cookie.secure = *secure;
 
-    auto session = cookieObject->getBoolean(Protocol::Page::Cookie::sessionKey);
-    cookie.expires = cookieObject->getDouble(Protocol::Page::Cookie::expiresKey);
+    auto session = cookieObject->getBoolean(Inspector::Protocol::Page::Cookie::sessionKey);
+    cookie.expires = cookieObject->getDouble(Inspector::Protocol::Page::Cookie::expiresKey);
     if (!session && !cookie.expires) {
         errorString = "Invalid value for key expires in given cookie"_s;
         return std::nullopt;
@@ -691,28 +691,28 @@ static std::optional<Cookie> parseCookieObject(Protocol::ErrorString& errorStrin
 
     cookie.session = *session;
 
-    auto sameSiteString = cookieObject->getString(Protocol::Page::Cookie::sameSiteKey);
+    auto sameSiteString = cookieObject->getString(Inspector::Protocol::Page::Cookie::sameSiteKey);
     if (!sameSiteString) {
         errorString = "Invalid value for key sameSite in given cookie"_s;
         return std::nullopt;
     }
 
-    auto sameSite = Protocol::Helpers::parseEnumValueFromString<Protocol::Page::CookieSameSitePolicy>(sameSiteString);
+    auto sameSite = Inspector::Protocol::Helpers::parseEnumValueFromString<Inspector::Protocol::Page::CookieSameSitePolicy>(sameSiteString);
     if (!sameSite) {
         errorString = "Invalid value for key sameSite in given cookie"_s;
         return std::nullopt;
     }
 
     switch (sameSite.value()) {
-    case Protocol::Page::CookieSameSitePolicy::None:
+    case Inspector::Protocol::Page::CookieSameSitePolicy::None:
         cookie.sameSite = Cookie::SameSitePolicy::None;
         break;
 
-    case Protocol::Page::CookieSameSitePolicy::Lax:
+    case Inspector::Protocol::Page::CookieSameSitePolicy::Lax:
         cookie.sameSite = Cookie::SameSitePolicy::Lax;
         break;
 
-    case Protocol::Page::CookieSameSitePolicy::Strict:
+    case Inspector::Protocol::Page::CookieSameSitePolicy::Strict:
         cookie.sameSite = Cookie::SameSitePolicy::Strict;
         break;
     }
@@ -720,9 +720,9 @@ static std::optional<Cookie> parseCookieObject(Protocol::ErrorString& errorStrin
     return cookie;
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::setCookie(Ref<JSON::Object>&& cookieObject)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setCookie(Ref<JSON::Object>&& cookieObject)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto cookie = parseCookieObject(errorString, WTFMove(cookieObject));
     if (!cookie)
@@ -744,7 +744,7 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::setCookie(Ref<JSON::Object>&& 
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::deleteCookie(const String& cookieName, const String& url)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::deleteCookie(const String& cookieName, const String& url)
 {
     URL parsedURL({ }, url);
     for (Frame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
@@ -763,15 +763,15 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::deleteCookie(const String& coo
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::Page::FrameResourceTree>> InspectorPageAgent::getResourceTree()
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Page::FrameResourceTree>> InspectorPageAgent::getResourceTree()
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
     return buildObjectForFrameTree(localMainFrame);
 }
 
-Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorPageAgent::getResourceContent(const Protocol::Network::FrameId& frameId, const String& url)
+Inspector::Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorPageAgent::getResourceContent(const Inspector::Protocol::Network::FrameId& frameId, const String& url)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* frame = assertFrame(errorString, frameId);
     if (!frame)
@@ -785,20 +785,20 @@ Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorP
     return { { content, base64Encoded } };
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::setBootstrapScript(const String& source)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setBootstrapScript(const String& source)
 {
     m_bootstrapScript = source;
 
     return { };
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>>> InspectorPageAgent::searchInResource(const Protocol::Network::FrameId& frameId, const String& url, const String& query, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, const Protocol::Network::RequestId& requestId)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>>> InspectorPageAgent::searchInResource(const Inspector::Protocol::Network::FrameId& frameId, const String& url, const String& query, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex, const Inspector::Protocol::Network::RequestId& requestId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     if (!!requestId) {
         if (auto* networkAgent = m_instrumentingAgents.enabledNetworkAgent()) {
-            RefPtr<JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>> result;
+            RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>> result;
             networkAgent->searchInRequest(errorString, requestId, query, caseSensitive && *caseSensitive, isRegex && *isRegex, result);
             if (!result)
                 return makeUnexpected(errorString);
@@ -831,23 +831,23 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>>>
     }
 
     if (!success)
-        return JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>::create();
+        return JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>::create();
 
     return ContentSearchUtilities::searchInTextByLines(content, query, caseSensitive && *caseSensitive, isRegex && *isRegex);
 }
 
-static Ref<Protocol::Page::SearchResult> buildObjectForSearchResult(const Protocol::Network::FrameId& frameId, const String& url, int matchesCount)
+static Ref<Inspector::Protocol::Page::SearchResult> buildObjectForSearchResult(const Inspector::Protocol::Network::FrameId& frameId, const String& url, int matchesCount)
 {
-    return Protocol::Page::SearchResult::create()
+    return Inspector::Protocol::Page::SearchResult::create()
         .setUrl(url)
         .setFrameId(frameId)
         .setMatchesCount(matchesCount)
         .release();
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Page::SearchResult>>> InspectorPageAgent::searchInResources(const String& text, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Page::SearchResult>>> InspectorPageAgent::searchInResources(const String& text, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex)
 {
-    auto result = JSON::ArrayOf<Protocol::Page::SearchResult>::create();
+    auto result = JSON::ArrayOf<Inspector::Protocol::Page::SearchResult>::create();
 
     auto searchStringType = (isRegex && *isRegex) ? ContentSearchUtilities::SearchStringType::Regex : ContentSearchUtilities::SearchStringType::ContainsString;
     auto regex = ContentSearchUtilities::createRegularExpressionForSearchString(text, caseSensitive && *caseSensitive, searchStringType);
@@ -872,7 +872,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Page::SearchResult>>> Inspec
 }
 
 #if !PLATFORM(IOS_FAMILY)
-Protocol::ErrorStringOr<void> InspectorPageAgent::setShowRulers(bool showRulers)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setShowRulers(bool showRulers)
 {
     m_overlay->setShowRulers(showRulers);
 
@@ -880,7 +880,7 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::setShowRulers(bool showRulers)
 }
 #endif
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::setShowPaintRects(bool show)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setShowPaintRects(bool show)
 {
     m_showPaintRects = show;
     m_client->setShowPaintRects(show);
@@ -918,7 +918,7 @@ void InspectorPageAgent::frameDetached(LocalFrame& frame)
     m_identifierToFrame.remove(identifier);
 }
 
-Frame* InspectorPageAgent::frameForId(const Protocol::Network::FrameId& frameId)
+Frame* InspectorPageAgent::frameForId(const Inspector::Protocol::Network::FrameId& frameId)
 {
     return frameId.isEmpty() ? nullptr : m_identifierToFrame.get(frameId).get();
 }
@@ -943,7 +943,7 @@ String InspectorPageAgent::loaderId(DocumentLoader* loader)
     }).iterator->value;
 }
 
-LocalFrame* InspectorPageAgent::assertFrame(Protocol::ErrorString& errorString, const Protocol::Network::FrameId& frameId)
+LocalFrame* InspectorPageAgent::assertFrame(Inspector::Protocol::ErrorString& errorString, const Inspector::Protocol::Network::FrameId& frameId)
 {
     auto* frame = dynamicDowncast<LocalFrame>(frameForId(frameId));
     if (!frame)
@@ -983,30 +983,30 @@ void InspectorPageAgent::accessibilitySettingsDidChange()
 
 void InspectorPageAgent::defaultUserPreferencesDidChange()
 {
-    auto defaultUserPreferences = JSON::ArrayOf<Protocol::Page::UserPreference>::create();
+    auto defaultUserPreferences = JSON::ArrayOf<Inspector::Protocol::Page::UserPreference>::create();
 
     bool prefersReducedMotion = Theme::singleton().userPrefersReducedMotion();
 
-    auto prefersReducedMotionUserPreference = Protocol::Page::UserPreference::create()
-        .setName(Protocol::Page::UserPreferenceName::PrefersReducedMotion)
-        .setValue(prefersReducedMotion ? Protocol::Page::UserPreferenceValue::Reduce : Protocol::Page::UserPreferenceValue::NoPreference)
+    auto prefersReducedMotionUserPreference = Inspector::Protocol::Page::UserPreference::create()
+        .setName(Inspector::Protocol::Page::UserPreferenceName::PrefersReducedMotion)
+        .setValue(prefersReducedMotion ? Inspector::Protocol::Page::UserPreferenceValue::Reduce : Inspector::Protocol::Page::UserPreferenceValue::NoPreference)
         .release();
 
     defaultUserPreferences->addItem(WTFMove(prefersReducedMotionUserPreference));
 
     bool prefersContrast = Theme::singleton().userPrefersContrast();
 
-    auto prefersContrastUserPreference = Protocol::Page::UserPreference::create()
-        .setName(Protocol::Page::UserPreferenceName::PrefersContrast)
-        .setValue(prefersContrast ? Protocol::Page::UserPreferenceValue::More : Protocol::Page::UserPreferenceValue::NoPreference)
+    auto prefersContrastUserPreference = Inspector::Protocol::Page::UserPreference::create()
+        .setName(Inspector::Protocol::Page::UserPreferenceName::PrefersContrast)
+        .setValue(prefersContrast ? Inspector::Protocol::Page::UserPreferenceValue::More : Inspector::Protocol::Page::UserPreferenceValue::NoPreference)
         .release();
 
     defaultUserPreferences->addItem(WTFMove(prefersContrastUserPreference));
 
 #if ENABLE(DARK_MODE_CSS) || HAVE(OS_DARK_MODE_SUPPORT)
-    auto prefersColorSchemeUserPreference = Protocol::Page::UserPreference::create()
-        .setName(Protocol::Page::UserPreferenceName::PrefersColorScheme)
-        .setValue(m_inspectedPage.defaultUseDarkAppearance() ? Protocol::Page::UserPreferenceValue::Dark : Protocol::Page::UserPreferenceValue::Light)
+    auto prefersColorSchemeUserPreference = Inspector::Protocol::Page::UserPreference::create()
+        .setName(Inspector::Protocol::Page::UserPreferenceName::PrefersColorScheme)
+        .setValue(m_inspectedPage.defaultUseDarkAppearance() ? Inspector::Protocol::Page::UserPreferenceValue::Dark : Inspector::Protocol::Page::UserPreferenceValue::Light)
         .release();
 
     defaultUserPreferences->addItem(WTFMove(prefersColorSchemeUserPreference));
@@ -1075,11 +1075,11 @@ void InspectorPageAgent::didRecalculateStyle()
     m_overlay->update();
 }
 
-Ref<Protocol::Page::Frame> InspectorPageAgent::buildObjectForFrame(LocalFrame* frame)
+Ref<Inspector::Protocol::Page::Frame> InspectorPageAgent::buildObjectForFrame(LocalFrame* frame)
 {
     ASSERT_ARG(frame, frame);
 
-    auto frameObject = Protocol::Page::Frame::create()
+    auto frameObject = Inspector::Protocol::Page::Frame::create()
         .setId(frameId(frame))
         .setLoaderId(loaderId(frame->loader().documentLoader()))
         .setUrl(frame->document()->url().string())
@@ -1098,19 +1098,19 @@ Ref<Protocol::Page::Frame> InspectorPageAgent::buildObjectForFrame(LocalFrame* f
     return frameObject;
 }
 
-Ref<Protocol::Page::FrameResourceTree> InspectorPageAgent::buildObjectForFrameTree(LocalFrame* frame)
+Ref<Inspector::Protocol::Page::FrameResourceTree> InspectorPageAgent::buildObjectForFrameTree(LocalFrame* frame)
 {
     ASSERT_ARG(frame, frame);
 
     auto frameObject = buildObjectForFrame(frame);
-    auto subresources = JSON::ArrayOf<Protocol::Page::FrameResource>::create();
-    auto result = Protocol::Page::FrameResourceTree::create()
+    auto subresources = JSON::ArrayOf<Inspector::Protocol::Page::FrameResource>::create();
+    auto result = Inspector::Protocol::Page::FrameResourceTree::create()
         .setFrame(WTFMove(frameObject))
         .setResources(subresources.copyRef())
         .release();
 
     for (auto* cachedResource : cachedResourcesForFrame(frame)) {
-        auto resourceObject = Protocol::Page::FrameResource::create()
+        auto resourceObject = Inspector::Protocol::Page::FrameResource::create()
             .setUrl(cachedResource->url().string())
             .setType(cachedResourceTypeJSON(*cachedResource))
             .setMimeType(cachedResource->response().mimeType())
@@ -1128,10 +1128,10 @@ Ref<Protocol::Page::FrameResourceTree> InspectorPageAgent::buildObjectForFrameTr
         subresources->addItem(WTFMove(resourceObject));
     }
 
-    RefPtr<JSON::ArrayOf<Protocol::Page::FrameResourceTree>> childrenArray;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::Page::FrameResourceTree>> childrenArray;
     for (Frame* child = frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
         if (!childrenArray) {
-            childrenArray = JSON::ArrayOf<Protocol::Page::FrameResourceTree>::create();
+            childrenArray = JSON::ArrayOf<Inspector::Protocol::Page::FrameResourceTree>::create();
             result->setChildFrames(*childrenArray);
         }
         auto* localChild = dynamicDowncast<LocalFrame>(child);
@@ -1142,7 +1142,7 @@ Ref<Protocol::Page::FrameResourceTree> InspectorPageAgent::buildObjectForFrameTr
     return result;
 }
 
-Protocol::ErrorStringOr<void> InspectorPageAgent::setEmulatedMedia(const String& media)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setEmulatedMedia(const String& media)
 {
     if (media == m_emulatedMedia)
         return { };
@@ -1178,9 +1178,9 @@ void InspectorPageAgent::applyEmulatedMedia(AtomString& media)
         media = m_emulatedMedia;
 }
 
-Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotNode(Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     InspectorDOMAgent* domAgent = m_instrumentingAgents.persistentDOMAgent();
     ASSERT(domAgent);
@@ -1199,10 +1199,10 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotNode(Protocol::DOM::
     return snapshot->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
 }
 
-Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotRect(int x, int y, int width, int height, Protocol::Page::CoordinateSystem coordinateSystem)
+Inspector::Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotRect(int x, int y, int width, int height, Inspector::Protocol::Page::CoordinateSystem coordinateSystem)
 {
     SnapshotOptions options { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() };
-    if (coordinateSystem == Protocol::Page::CoordinateSystem::Viewport)
+    if (coordinateSystem == Inspector::Protocol::Page::CoordinateSystem::Viewport)
         options.flags.add(SnapshotFlags::InViewCoordinates);
 
     IntRect rectangle(x, y, width, height);
@@ -1218,7 +1218,7 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotRect(int x, int y, i
 }
 
 #if ENABLE(WEB_ARCHIVE) && USE(CF)
-Protocol::ErrorStringOr<String> InspectorPageAgent::archive()
+Inspector::Protocol::ErrorStringOr<String> InspectorPageAgent::archive()
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
     if (!localMainFrame)
@@ -1234,7 +1234,7 @@ Protocol::ErrorStringOr<String> InspectorPageAgent::archive()
 #endif
 
 #if !PLATFORM(COCOA)
-Protocol::ErrorStringOr<void> InspectorPageAgent::setScreenSizeOverride(std::optional<int>&& width, std::optional<int>&& height)
+Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setScreenSizeOverride(std::optional<int>&& width, std::optional<int>&& height)
 {
     if (width.has_value() != height.has_value())
         return makeUnexpected("Screen width and height override should be both specified or omitted"_s);

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -107,7 +107,7 @@ void InspectorTimelineAgent::willDestroyFrontendAndBackend(Inspector::Disconnect
     disable();
 }
 
-Protocol::ErrorStringOr<void> InspectorTimelineAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::enable()
 {
     if (m_instrumentingAgents.enabledTimelineAgent() == this)
         return makeUnexpected("Timeline domain already enabled"_s);
@@ -117,7 +117,7 @@ Protocol::ErrorStringOr<void> InspectorTimelineAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorTimelineAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::disable()
 {
     if (m_instrumentingAgents.enabledTimelineAgent() != this)
         return makeUnexpected("Timeline domain already disabled"_s);
@@ -132,7 +132,7 @@ Protocol::ErrorStringOr<void> InspectorTimelineAgent::disable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorTimelineAgent::start(std::optional<int>&& maxCallStackDepth)
+Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::start(std::optional<int>&& maxCallStackDepth)
 {
     m_trackingFromFrontend = true;
 
@@ -141,7 +141,7 @@ Protocol::ErrorStringOr<void> InspectorTimelineAgent::start(std::optional<int>&&
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorTimelineAgent::stop()
+Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::stop()
 {
     internalStop();
 
@@ -150,16 +150,16 @@ Protocol::ErrorStringOr<void> InspectorTimelineAgent::stop()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorTimelineAgent::setAutoCaptureEnabled(bool enabled)
+Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::setAutoCaptureEnabled(bool enabled)
 {
     m_autoCaptureEnabled = enabled;
 
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorTimelineAgent::setInstruments(Ref<JSON::Array>&& instruments)
+Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::setInstruments(Ref<JSON::Array>&& instruments)
 {
-    Vector<Protocol::Timeline::Instrument> newInstruments;
+    Vector<Inspector::Protocol::Timeline::Instrument> newInstruments;
     newInstruments.reserveCapacity(instruments->length());
 
     for (const auto& instrumentValue : instruments.get()) {
@@ -167,7 +167,7 @@ Protocol::ErrorStringOr<void> InspectorTimelineAgent::setInstruments(Ref<JSON::A
         if (!instrumentString)
             return makeUnexpected("Unexpected non-string value in given instruments"_s);
 
-        auto instrument = Protocol::Helpers::parseEnumValueFromString<Protocol::Timeline::Instrument>(instrumentString);
+        auto instrument = Inspector::Protocol::Helpers::parseEnumValueFromString<Inspector::Protocol::Timeline::Instrument>(instrumentString);
         if (!instrument)
             return makeUnexpected(makeString("Unknown instrument: ", instrumentString));
 
@@ -417,7 +417,7 @@ void InspectorTimelineAgent::didComposite()
         didCompleteCurrentRecord(TimelineRecordType::Composite);
     m_startedComposite = false;
 
-    if (m_instruments.contains(Protocol::Timeline::Instrument::Screenshot))
+    if (m_instruments.contains(Inspector::Protocol::Timeline::Instrument::Screenshot))
         captureScreenshot();
 }
 
@@ -569,29 +569,29 @@ void InspectorTimelineAgent::toggleInstruments(InstrumentState state)
 {
     for (auto instrumentType : m_instruments) {
         switch (instrumentType) {
-        case Protocol::Timeline::Instrument::ScriptProfiler: {
+        case Inspector::Protocol::Timeline::Instrument::ScriptProfiler: {
             toggleScriptProfilerInstrument(state);
             break;
         }
-        case Protocol::Timeline::Instrument::Heap: {
+        case Inspector::Protocol::Timeline::Instrument::Heap: {
             toggleHeapInstrument(state);
             break;
         }
-        case Protocol::Timeline::Instrument::CPU: {
+        case Inspector::Protocol::Timeline::Instrument::CPU: {
             toggleCPUInstrument(state);
             break;
         }
-        case Protocol::Timeline::Instrument::Memory: {
+        case Inspector::Protocol::Timeline::Instrument::Memory: {
             toggleMemoryInstrument(state);
             break;
         }
-        case Protocol::Timeline::Instrument::Timeline:
+        case Inspector::Protocol::Timeline::Instrument::Timeline:
             toggleTimelineInstrument(state);
             break;
-        case Protocol::Timeline::Instrument::Animation:
+        case Inspector::Protocol::Timeline::Instrument::Animation:
             toggleAnimationInstrument(state);
             break;
-        case Protocol::Timeline::Instrument::Screenshot: {
+        case Inspector::Protocol::Timeline::Instrument::Screenshot: {
             break;
         }
         }
@@ -717,74 +717,74 @@ void InspectorTimelineAgent::breakpointActionProbe(JSC::JSGlobalObject* lexicalG
     appendRecord(TimelineRecordFactory::createProbeSampleData(actionID, sampleId), TimelineRecordType::ProbeSample, false, frame(lexicalGlobalObject));
 }
 
-static Protocol::Timeline::EventType toProtocol(TimelineRecordType type)
+static Inspector::Protocol::Timeline::EventType toProtocol(TimelineRecordType type)
 {
     switch (type) {
     case TimelineRecordType::EventDispatch:
-        return Protocol::Timeline::EventType::EventDispatch;
+        return Inspector::Protocol::Timeline::EventType::EventDispatch;
     case TimelineRecordType::ScheduleStyleRecalculation:
-        return Protocol::Timeline::EventType::ScheduleStyleRecalculation;
+        return Inspector::Protocol::Timeline::EventType::ScheduleStyleRecalculation;
     case TimelineRecordType::RecalculateStyles:
-        return Protocol::Timeline::EventType::RecalculateStyles;
+        return Inspector::Protocol::Timeline::EventType::RecalculateStyles;
     case TimelineRecordType::InvalidateLayout:
-        return Protocol::Timeline::EventType::InvalidateLayout;
+        return Inspector::Protocol::Timeline::EventType::InvalidateLayout;
     case TimelineRecordType::Layout:
-        return Protocol::Timeline::EventType::Layout;
+        return Inspector::Protocol::Timeline::EventType::Layout;
     case TimelineRecordType::Paint:
-        return Protocol::Timeline::EventType::Paint;
+        return Inspector::Protocol::Timeline::EventType::Paint;
     case TimelineRecordType::Composite:
-        return Protocol::Timeline::EventType::Composite;
+        return Inspector::Protocol::Timeline::EventType::Composite;
     case TimelineRecordType::RenderingFrame:
-        return Protocol::Timeline::EventType::RenderingFrame;
+        return Inspector::Protocol::Timeline::EventType::RenderingFrame;
 
     case TimelineRecordType::TimerInstall:
-        return Protocol::Timeline::EventType::TimerInstall;
+        return Inspector::Protocol::Timeline::EventType::TimerInstall;
     case TimelineRecordType::TimerRemove:
-        return Protocol::Timeline::EventType::TimerRemove;
+        return Inspector::Protocol::Timeline::EventType::TimerRemove;
     case TimelineRecordType::TimerFire:
-        return Protocol::Timeline::EventType::TimerFire;
+        return Inspector::Protocol::Timeline::EventType::TimerFire;
 
     case TimelineRecordType::EvaluateScript:
-        return Protocol::Timeline::EventType::EvaluateScript;
+        return Inspector::Protocol::Timeline::EventType::EvaluateScript;
 
     case TimelineRecordType::TimeStamp:
-        return Protocol::Timeline::EventType::TimeStamp;
+        return Inspector::Protocol::Timeline::EventType::TimeStamp;
     case TimelineRecordType::Time:
-        return Protocol::Timeline::EventType::Time;
+        return Inspector::Protocol::Timeline::EventType::Time;
     case TimelineRecordType::TimeEnd:
-        return Protocol::Timeline::EventType::TimeEnd;
+        return Inspector::Protocol::Timeline::EventType::TimeEnd;
 
     case TimelineRecordType::FunctionCall:
-        return Protocol::Timeline::EventType::FunctionCall;
+        return Inspector::Protocol::Timeline::EventType::FunctionCall;
     case TimelineRecordType::ProbeSample:
-        return Protocol::Timeline::EventType::ProbeSample;
+        return Inspector::Protocol::Timeline::EventType::ProbeSample;
     case TimelineRecordType::ConsoleProfile:
-        return Protocol::Timeline::EventType::ConsoleProfile;
+        return Inspector::Protocol::Timeline::EventType::ConsoleProfile;
 
     case TimelineRecordType::RequestAnimationFrame:
-        return Protocol::Timeline::EventType::RequestAnimationFrame;
+        return Inspector::Protocol::Timeline::EventType::RequestAnimationFrame;
     case TimelineRecordType::CancelAnimationFrame:
-        return Protocol::Timeline::EventType::CancelAnimationFrame;
+        return Inspector::Protocol::Timeline::EventType::CancelAnimationFrame;
     case TimelineRecordType::FireAnimationFrame:
-        return Protocol::Timeline::EventType::FireAnimationFrame;
+        return Inspector::Protocol::Timeline::EventType::FireAnimationFrame;
 
     case TimelineRecordType::ObserverCallback:
-        return Protocol::Timeline::EventType::ObserverCallback;
+        return Inspector::Protocol::Timeline::EventType::ObserverCallback;
 
     case TimelineRecordType::Screenshot:
-        return Protocol::Timeline::EventType::Screenshot;
+        return Inspector::Protocol::Timeline::EventType::Screenshot;
     }
 
-    return Protocol::Timeline::EventType::TimeStamp;
+    return Inspector::Protocol::Timeline::EventType::TimeStamp;
 }
 
 void InspectorTimelineAgent::addRecordToTimeline(Ref<JSON::Object>&& record, TimelineRecordType type)
 {
-    record->setString(Protocol::Timeline::TimelineEvent::typeKey, Protocol::Helpers::getEnumConstantValue(toProtocol(type)));
+    record->setString(Inspector::Protocol::Timeline::TimelineEvent::typeKey, Inspector::Protocol::Helpers::getEnumConstantValue(toProtocol(type)));
 
     if (m_recordStack.isEmpty()) {
         // FIXME: runtimeCast is a hack. We do it because we can't build TimelineEvent directly now.
-        auto recordObject = Protocol::BindingTraits<Protocol::Timeline::TimelineEvent>::runtimeCast(WTFMove(record));
+        auto recordObject = Inspector::Protocol::BindingTraits<Inspector::Protocol::Timeline::TimelineEvent>::runtimeCast(WTFMove(record));
         sendEvent(WTFMove(recordObject));
     } else {
         const TimelineRecordEntry& parent = m_recordStack.last();
@@ -810,9 +810,9 @@ void InspectorTimelineAgent::setFrameIdentifier(JSON::Object* record, LocalFrame
 
 void InspectorTimelineAgent::didCompleteRecordEntry(const TimelineRecordEntry& entry)
 {
-    entry.record->setObject(Protocol::Timeline::TimelineEvent::dataKey, entry.data.copyRef());
+    entry.record->setObject(Inspector::Protocol::Timeline::TimelineEvent::dataKey, entry.data.copyRef());
     if (entry.children)
-        entry.record->setArray(Protocol::Timeline::TimelineEvent::childrenKey, *entry.children);
+        entry.record->setArray(Inspector::Protocol::Timeline::TimelineEvent::childrenKey, *entry.children);
     entry.record->setDouble("endTime"_s, timestamp());
     addRecordToTimeline(entry.record.copyRef(), entry.type);
 }
@@ -837,7 +837,7 @@ void InspectorTimelineAgent::didCompleteCurrentRecord(TimelineRecordType type)
 void InspectorTimelineAgent::appendRecord(Ref<JSON::Object>&& data, TimelineRecordType type, bool captureCallStack, LocalFrame* frame, std::optional<double> startTime)
 {
     Ref<JSON::Object> record = TimelineRecordFactory::createGenericRecord(startTime.value_or(timestamp()), captureCallStack ? m_maxCallStackDepth : 0);
-    record->setObject(Protocol::Timeline::TimelineEvent::dataKey, WTFMove(data));
+    record->setObject(Inspector::Protocol::Timeline::TimelineEvent::dataKey, WTFMove(data));
     setFrameIdentifier(&record.get(), frame);
     addRecordToTimeline(WTFMove(record), type);
 }
@@ -845,7 +845,7 @@ void InspectorTimelineAgent::appendRecord(Ref<JSON::Object>&& data, TimelineReco
 void InspectorTimelineAgent::sendEvent(Ref<JSON::Object>&& event)
 {
     // FIXME: runtimeCast is a hack. We do it because we can't build TimelineEvent directly now.
-    auto recordChecked = Protocol::BindingTraits<Protocol::Timeline::TimelineEvent>::runtimeCast(WTFMove(event));
+    auto recordChecked = Inspector::Protocol::BindingTraits<Inspector::Protocol::Timeline::TimelineEvent>::runtimeCast(WTFMove(event));
     m_frontendDispatcher->eventRecorded(WTFMove(recordChecked));
 }
 

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
@@ -58,7 +58,7 @@ void InspectorWorkerAgent::willDestroyFrontendAndBackend(DisconnectReason)
     disable();
 }
 
-Protocol::ErrorStringOr<void> InspectorWorkerAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> InspectorWorkerAgent::enable()
 {
     if (m_enabled)
         return { };
@@ -70,7 +70,7 @@ Protocol::ErrorStringOr<void> InspectorWorkerAgent::enable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorWorkerAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> InspectorWorkerAgent::disable()
 {
     if (!m_enabled)
         return { };
@@ -82,7 +82,7 @@ Protocol::ErrorStringOr<void> InspectorWorkerAgent::disable()
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorWorkerAgent::initialized(const String& workerId)
+Inspector::Protocol::ErrorStringOr<void> InspectorWorkerAgent::initialized(const String& workerId)
 {
     RefPtr proxy = m_connectedProxies.get(workerId).get();
     if (!proxy)
@@ -93,7 +93,7 @@ Protocol::ErrorStringOr<void> InspectorWorkerAgent::initialized(const String& wo
     return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorWorkerAgent::sendMessageToWorker(const String& workerId, const String& message)
+Inspector::Protocol::ErrorStringOr<void> InspectorWorkerAgent::sendMessageToWorker(const String& workerId, const String& message)
 {
     if (!m_enabled)
         return makeUnexpected("Worker domain must be enabled"_s);

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 using namespace Inspector;
 
 struct GarbageCollectionData {
-    Protocol::Heap::GarbageCollection::Type type;
+    Inspector::Protocol::Heap::GarbageCollection::Type type;
     Seconds startTime;
     Seconds endTime;
 };
@@ -105,7 +105,7 @@ WebHeapAgent::WebHeapAgent(WebAgentContext& context)
 
 WebHeapAgent::~WebHeapAgent() = default;
 
-Protocol::ErrorStringOr<void> WebHeapAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::enable()
 {
     auto result = InspectorHeapAgent::enable();
 
@@ -115,7 +115,7 @@ Protocol::ErrorStringOr<void> WebHeapAgent::enable()
     return result;
 }
 
-Protocol::ErrorStringOr<void> WebHeapAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::disable()
 {
     m_sendGarbageCollectionEventsTask->reset();
 
@@ -125,7 +125,7 @@ Protocol::ErrorStringOr<void> WebHeapAgent::disable()
     return InspectorHeapAgent::disable();
 }
 
-void WebHeapAgent::dispatchGarbageCollectedEvent(Protocol::Heap::GarbageCollection::Type type, Seconds startTime, Seconds endTime)
+void WebHeapAgent::dispatchGarbageCollectedEvent(Inspector::Protocol::Heap::GarbageCollection::Type type, Seconds startTime, Seconds endTime)
 {
     // Dispatch the event asynchronously because this method may be
     // called between collection and sweeping and we don't want to

--- a/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
@@ -56,7 +56,7 @@ PageAuditAgent::PageAuditAgent(PageAgentContext& context)
 
 PageAuditAgent::~PageAuditAgent() = default;
 
-InjectedScript PageAuditAgent::injectedScriptForEval(std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InjectedScript PageAuditAgent::injectedScriptForEval(std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId)
         return injectedScriptManager().injectedScriptForId(*executionContextId);
@@ -65,7 +65,7 @@ InjectedScript PageAuditAgent::injectedScriptForEval(std::optional<Protocol::Run
     return InjectedScript();
 }
 
-InjectedScript PageAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InjectedScript PageAuditAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     InjectedScript injectedScript = injectedScriptForEval(WTFMove(executionContextId));
     if (injectedScript.hasNoValue()) {

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -80,9 +80,9 @@ void PageCanvasAgent::internalDisable()
     InspectorCanvasAgent::internalDisable();
 }
 
-Protocol::ErrorStringOr<Protocol::DOM::NodeId> PageCanvasAgent::requestNode(const Protocol::Canvas::CanvasId& canvasId)
+Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> PageCanvasAgent::requestNode(const Inspector::Protocol::Canvas::CanvasId& canvasId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
     if (!inspectorCanvas)
@@ -100,9 +100,9 @@ Protocol::ErrorStringOr<Protocol::DOM::NodeId> PageCanvasAgent::requestNode(cons
     return m_instrumentingAgents.persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> PageCanvasAgent::requestClientNodes(const Protocol::Canvas::CanvasId& canvasId)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> PageCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId& canvasId)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
     if (!domAgent)
@@ -112,7 +112,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> PageCanvasAge
     if (!inspectorCanvas)
         return makeUnexpected(errorString);
 
-    auto clientNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+    auto clientNodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
     for (auto& clientNode : inspectorCanvas->clientNodes()) {
         // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
         if (auto documentNodeId = domAgent->boundNodeId(&clientNode->document()))

--- a/Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp
@@ -54,71 +54,71 @@ PageConsoleAgent::PageConsoleAgent(PageAgentContext& context)
 
 PageConsoleAgent::~PageConsoleAgent() = default;
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Console::Channel>>> PageConsoleAgent::getLoggingChannels()
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Console::Channel>>> PageConsoleAgent::getLoggingChannels()
 {
-    auto channels = JSON::ArrayOf<Protocol::Console::Channel>::create();
+    auto channels = JSON::ArrayOf<Inspector::Protocol::Console::Channel>::create();
 
-    auto addLogChannel = [&] (Protocol::Console::ChannelSource source) {
-        auto* logChannel = getLogChannel(Protocol::Helpers::getEnumConstantValue(source));
+    auto addLogChannel = [&] (Inspector::Protocol::Console::ChannelSource source) {
+        auto* logChannel = getLogChannel(Inspector::Protocol::Helpers::getEnumConstantValue(source));
         if (!logChannel)
             return;
 
-        auto level = Protocol::Console::ChannelLevel::Off;
+        auto level = Inspector::Protocol::Console::ChannelLevel::Off;
         if (logChannel->state != WTFLogChannelState::Off) {
             switch (logChannel->level) {
             case WTFLogLevel::Always:
             case WTFLogLevel::Error:
             case WTFLogLevel::Warning:
             case WTFLogLevel::Info:
-                level = Protocol::Console::ChannelLevel::Basic;
+                level = Inspector::Protocol::Console::ChannelLevel::Basic;
                 break;
 
             case WTFLogLevel::Debug:
-                level = Protocol::Console::ChannelLevel::Verbose;
+                level = Inspector::Protocol::Console::ChannelLevel::Verbose;
                 break;
             }
         }
 
-        auto channel = Protocol::Console::Channel::create()
+        auto channel = Inspector::Protocol::Console::Channel::create()
             .setSource(source)
             .setLevel(level)
             .release();
         channels->addItem(WTFMove(channel));
     };
-    addLogChannel(Protocol::Console::ChannelSource::XML);
-    addLogChannel(Protocol::Console::ChannelSource::JavaScript);
-    addLogChannel(Protocol::Console::ChannelSource::Network);
-    addLogChannel(Protocol::Console::ChannelSource::ConsoleAPI);
-    addLogChannel(Protocol::Console::ChannelSource::Storage);
-    addLogChannel(Protocol::Console::ChannelSource::Appcache);
-    addLogChannel(Protocol::Console::ChannelSource::Rendering);
-    addLogChannel(Protocol::Console::ChannelSource::CSS);
-    addLogChannel(Protocol::Console::ChannelSource::Security);
-    addLogChannel(Protocol::Console::ChannelSource::ContentBlocker);
-    addLogChannel(Protocol::Console::ChannelSource::Media);
-    addLogChannel(Protocol::Console::ChannelSource::MediaSource);
-    addLogChannel(Protocol::Console::ChannelSource::WebRTC);
-    addLogChannel(Protocol::Console::ChannelSource::ITPDebug);
-    addLogChannel(Protocol::Console::ChannelSource::PrivateClickMeasurement);
-    addLogChannel(Protocol::Console::ChannelSource::PaymentRequest);
-    addLogChannel(Protocol::Console::ChannelSource::Other);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::XML);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::JavaScript);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::Network);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::ConsoleAPI);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::Storage);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::Appcache);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::Rendering);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::CSS);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::Security);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::ContentBlocker);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::Media);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::MediaSource);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::WebRTC);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::ITPDebug);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::PrivateClickMeasurement);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::PaymentRequest);
+    addLogChannel(Inspector::Protocol::Console::ChannelSource::Other);
 
     return channels;
 }
 
-Protocol::ErrorStringOr<void> PageConsoleAgent::setLoggingChannelLevel(Protocol::Console::ChannelSource source, Protocol::Console::ChannelLevel level)
+Inspector::Protocol::ErrorStringOr<void> PageConsoleAgent::setLoggingChannelLevel(Inspector::Protocol::Console::ChannelSource source, Inspector::Protocol::Console::ChannelLevel level)
 {
     switch (level) {
-    case Protocol::Console::ChannelLevel::Off:
-        m_inspectedPage.configureLoggingChannel(Protocol::Helpers::getEnumConstantValue(source), WTFLogChannelState::Off, WTFLogLevel::Error);
+    case Inspector::Protocol::Console::ChannelLevel::Off:
+        m_inspectedPage.configureLoggingChannel(Inspector::Protocol::Helpers::getEnumConstantValue(source), WTFLogChannelState::Off, WTFLogLevel::Error);
         return { };
 
-    case Protocol::Console::ChannelLevel::Basic:
-        m_inspectedPage.configureLoggingChannel(Protocol::Helpers::getEnumConstantValue(source), WTFLogChannelState::On, WTFLogLevel::Info);
+    case Inspector::Protocol::Console::ChannelLevel::Basic:
+        m_inspectedPage.configureLoggingChannel(Inspector::Protocol::Helpers::getEnumConstantValue(source), WTFLogChannelState::On, WTFLogLevel::Info);
         return { };
 
-    case Protocol::Console::ChannelLevel::Verbose:
-        m_inspectedPage.configureLoggingChannel(Protocol::Helpers::getEnumConstantValue(source), WTFLogChannelState::On, WTFLogLevel::Debug);
+    case Inspector::Protocol::Console::ChannelLevel::Verbose:
+        m_inspectedPage.configureLoggingChannel(Inspector::Protocol::Helpers::getEnumConstantValue(source), WTFLogChannelState::On, WTFLogLevel::Debug);
         return { };
     }
 

--- a/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
@@ -68,9 +68,9 @@ void PageDOMDebuggerAgent::disable()
     InspectorDOMDebuggerAgent::disable();
 }
 
-Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::setDOMBreakpoint(Protocol::DOM::NodeId nodeId, Protocol::DOMDebugger::DOMBreakpointType type, RefPtr<JSON::Object>&& options)
+Inspector::Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::setDOMBreakpoint(Inspector::Protocol::DOM::NodeId nodeId, Inspector::Protocol::DOMDebugger::DOMBreakpointType type, RefPtr<JSON::Object>&& options)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
     if (!domAgent)
@@ -85,17 +85,17 @@ Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::setDOMBreakpoint(Protocol::D
         return makeUnexpected(errorString);
 
     switch (type) {
-    case Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified:
+    case Inspector::Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified:
         if (!m_domSubtreeModifiedBreakpoints.add(node, breakpoint.releaseNonNull()))
             return makeUnexpected("Breakpoint for given node and given type already exists"_s);
         return { };
 
-    case Protocol::DOMDebugger::DOMBreakpointType::AttributeModified:
+    case Inspector::Protocol::DOMDebugger::DOMBreakpointType::AttributeModified:
         if (!m_domAttributeModifiedBreakpoints.add(node, breakpoint.releaseNonNull()))
             return makeUnexpected("Breakpoint for given node and given type already exists"_s);
         return { };
 
-    case Protocol::DOMDebugger::DOMBreakpointType::NodeRemoved:
+    case Inspector::Protocol::DOMDebugger::DOMBreakpointType::NodeRemoved:
         if (!m_domNodeRemovedBreakpoints.add(node, breakpoint.releaseNonNull()))
             return makeUnexpected("Breakpoint for given node and given type already exists"_s);
         return { };
@@ -105,9 +105,9 @@ Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::setDOMBreakpoint(Protocol::D
     return makeUnexpected("Not supported"_s);
 }
 
-Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::removeDOMBreakpoint(Protocol::DOM::NodeId nodeId, Protocol::DOMDebugger::DOMBreakpointType type)
+Inspector::Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::removeDOMBreakpoint(Inspector::Protocol::DOM::NodeId nodeId, Inspector::Protocol::DOMDebugger::DOMBreakpointType type)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
     if (!domAgent)
@@ -118,17 +118,17 @@ Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::removeDOMBreakpoint(Protocol
         return makeUnexpected(errorString);
 
     switch (type) {
-    case Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified:
+    case Inspector::Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified:
         if (!m_domSubtreeModifiedBreakpoints.remove(node))
             return makeUnexpected("Breakpoint for given node and given type missing"_s);
         return { };
 
-    case Protocol::DOMDebugger::DOMBreakpointType::AttributeModified:
+    case Inspector::Protocol::DOMDebugger::DOMBreakpointType::AttributeModified:
         if (!m_domAttributeModifiedBreakpoints.remove(node))
             return makeUnexpected("Breakpoint for given node and given type missing"_s);
         return { };
 
-    case Protocol::DOMDebugger::DOMBreakpointType::NodeRemoved:
+    case Inspector::Protocol::DOMDebugger::DOMBreakpointType::NodeRemoved:
         if (!m_domNodeRemovedBreakpoints.remove(node))
             return makeUnexpected("Breakpoint for given node and given type missing"_s);
         return { };
@@ -202,7 +202,7 @@ void PageDOMDebuggerAgent::willInsertDOMNode(Node& parent)
 
     ASSERT(closestBreakpointOwner);
 
-    auto pauseData = buildPauseDataForDOMBreakpoint(Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified, *closestBreakpointOwner);
+    auto pauseData = buildPauseDataForDOMBreakpoint(Inspector::Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified, *closestBreakpointOwner);
     pauseData->setBoolean("insertion"_s, true);
     // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
     // Include the new child node ID so the frontend can show the node that's about to be inserted.
@@ -219,7 +219,7 @@ void PageDOMDebuggerAgent::willRemoveDOMNode(Node& node)
 
     std::optional<size_t> closestDistance;
     RefPtr<JSC::Breakpoint> closestBreakpoint;
-    std::optional<Protocol::DOMDebugger::DOMBreakpointType> closestBreakpointType;
+    std::optional<Inspector::Protocol::DOMDebugger::DOMBreakpointType> closestBreakpointType;
     Node* closestBreakpointOwner = nullptr;
 
     for (auto [breakpointOwner, breakpoint] : m_domNodeRemovedBreakpoints) {
@@ -230,7 +230,7 @@ void PageDOMDebuggerAgent::willRemoveDOMNode(Node& node)
         if (!closestDistance || distance < closestDistance) {
             closestDistance = distance;
             closestBreakpoint = breakpoint.copyRef();
-            closestBreakpointType = Protocol::DOMDebugger::DOMBreakpointType::NodeRemoved;
+            closestBreakpointType = Inspector::Protocol::DOMDebugger::DOMBreakpointType::NodeRemoved;
             closestBreakpointOwner = breakpointOwner;
         }
     }
@@ -244,7 +244,7 @@ void PageDOMDebuggerAgent::willRemoveDOMNode(Node& node)
             if (!closestDistance || distance < closestDistance) {
                 closestDistance = distance;
                 closestBreakpoint = breakpoint.copyRef();
-                closestBreakpointType = Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified;
+                closestBreakpointType = Inspector::Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified;
                 closestBreakpointOwner = breakpointOwner;
             }
         }
@@ -292,7 +292,7 @@ void PageDOMDebuggerAgent::willModifyDOMAttr(Element& element)
     if (it == m_domAttributeModifiedBreakpoints.end())
         return;
 
-    auto pauseData = buildPauseDataForDOMBreakpoint(Protocol::DOMDebugger::DOMBreakpointType::AttributeModified, element);
+    auto pauseData = buildPauseDataForDOMBreakpoint(Inspector::Protocol::DOMDebugger::DOMBreakpointType::AttributeModified, element);
     m_debuggerAgent->breakProgram(Inspector::DebuggerFrontendDispatcher::Reason::DOM, WTFMove(pauseData), it->value.copyRef());
 }
 
@@ -329,11 +329,11 @@ void PageDOMDebuggerAgent::willInvalidateStyleAttr(Element& element)
     if (it == m_domAttributeModifiedBreakpoints.end())
         return;
 
-    auto pauseData = buildPauseDataForDOMBreakpoint(Protocol::DOMDebugger::DOMBreakpointType::AttributeModified, element);
+    auto pauseData = buildPauseDataForDOMBreakpoint(Inspector::Protocol::DOMDebugger::DOMBreakpointType::AttributeModified, element);
     m_debuggerAgent->breakProgram(Inspector::DebuggerFrontendDispatcher::Reason::DOM, WTFMove(pauseData), it->value.copyRef());
 }
 
-bool PageDOMDebuggerAgent::setAnimationFrameBreakpoint(Protocol::ErrorString& errorString, RefPtr<JSC::Breakpoint>&& breakpoint)
+bool PageDOMDebuggerAgent::setAnimationFrameBreakpoint(Inspector::Protocol::ErrorString& errorString, RefPtr<JSC::Breakpoint>&& breakpoint)
 {
     if (!m_pauseOnAllAnimationFramesBreakpoint == !breakpoint) {
         errorString = m_pauseOnAllAnimationFramesBreakpoint ? "Breakpoint for AnimationFrame already exists"_s : "Breakpoint for AnimationFrame missing"_s;
@@ -344,13 +344,13 @@ bool PageDOMDebuggerAgent::setAnimationFrameBreakpoint(Protocol::ErrorString& er
     return true;
 }
 
-Ref<JSON::Object> PageDOMDebuggerAgent::buildPauseDataForDOMBreakpoint(Protocol::DOMDebugger::DOMBreakpointType breakpointType, Node& breakpointOwner)
+Ref<JSON::Object> PageDOMDebuggerAgent::buildPauseDataForDOMBreakpoint(Inspector::Protocol::DOMDebugger::DOMBreakpointType breakpointType, Node& breakpointOwner)
 {
     ASSERT(m_debuggerAgent->breakpointsActive());
     ASSERT(m_domSubtreeModifiedBreakpoints.contains(&breakpointOwner) || m_domAttributeModifiedBreakpoints.contains(&breakpointOwner) || m_domNodeRemovedBreakpoints.contains(&breakpointOwner));
 
     auto pauseData = JSON::Object::create();
-    pauseData->setString("type"_s, Protocol::Helpers::getEnumConstantValue(breakpointType));
+    pauseData->setString("type"_s, Inspector::Protocol::Helpers::getEnumConstantValue(breakpointType));
     if (auto* domAgent = m_instrumentingAgents.persistentDOMAgent()) {
         if (auto breakpointOwnerNodeId = domAgent->pushNodeToFrontend(&breakpointOwner))
             pauseData->setInteger("nodeId"_s, breakpointOwnerNodeId);

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -68,7 +68,7 @@ bool PageDebuggerAgent::enabled() const
     return m_instrumentingAgents.enabledPageDebuggerAgent() == this && WebDebuggerAgent::enabled();
 }
 
-Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> PageDebuggerAgent::evaluateOnCallFrame(const Protocol::Debugger::CallFrameId& callFrameId, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
+Inspector::Protocol::ErrorStringOr<std::tuple<Ref<Inspector::Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> PageDebuggerAgent::evaluateOnCallFrame(const Inspector::Protocol::Debugger::CallFrameId& callFrameId, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
 {
     auto injectedScript = injectedScriptManager().injectedScriptForObjectId(callFrameId);
     if (injectedScript.hasNoValue())
@@ -142,7 +142,7 @@ void PageDebuggerAgent::breakpointActionLog(JSC::JSGlobalObject* lexicalGlobalOb
     m_inspectedPage.console().addMessage(MessageSource::JS, MessageLevel::Log, message, createScriptCallStack(lexicalGlobalObject));
 }
 
-InjectedScript PageDebuggerAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InjectedScript PageDebuggerAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
     if (!localMainFrame)

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
@@ -39,7 +39,7 @@ PageHeapAgent::PageHeapAgent(PageAgentContext& context)
 
 PageHeapAgent::~PageHeapAgent() = default;
 
-Protocol::ErrorStringOr<void> PageHeapAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> PageHeapAgent::enable()
 {
     auto result = WebHeapAgent::enable();
 
@@ -48,7 +48,7 @@ Protocol::ErrorStringOr<void> PageHeapAgent::enable()
     return result;
 }
 
-Protocol::ErrorStringOr<void> PageHeapAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> PageHeapAgent::disable()
 {
     m_instrumentingAgents.setEnabledPageHeapAgent(nullptr);
 

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -55,7 +55,7 @@ PageNetworkAgent::PageNetworkAgent(PageAgentContext& context, InspectorClient* c
 
 PageNetworkAgent::~PageNetworkAgent() = default;
 
-Protocol::Network::LoaderId PageNetworkAgent::loaderIdentifier(DocumentLoader* loader)
+Inspector::Protocol::Network::LoaderId PageNetworkAgent::loaderIdentifier(DocumentLoader* loader)
 {
     if (loader) {
         if (auto* pageAgent = m_instrumentingAgents.enabledPageAgent())
@@ -64,7 +64,7 @@ Protocol::Network::LoaderId PageNetworkAgent::loaderIdentifier(DocumentLoader* l
     return { };
 }
 
-Protocol::Network::FrameId PageNetworkAgent::frameIdentifier(DocumentLoader* loader)
+Inspector::Protocol::Network::FrameId PageNetworkAgent::frameIdentifier(DocumentLoader* loader)
 {
     if (loader) {
         if (auto* pageAgent = m_instrumentingAgents.enabledPageAgent())
@@ -113,7 +113,7 @@ bool PageNetworkAgent::setEmulatedConditionsInternal(std::optional<int>&& bytesP
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-ScriptExecutionContext* PageNetworkAgent::scriptExecutionContext(Protocol::ErrorString& errorString, const Protocol::Network::FrameId& frameId)
+ScriptExecutionContext* PageNetworkAgent::scriptExecutionContext(Inspector::Protocol::ErrorString& errorString, const Inspector::Protocol::Network::FrameId& frameId)
 {
     auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
     if (!pageAgent) {

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -63,7 +63,7 @@ PageRuntimeAgent::PageRuntimeAgent(PageAgentContext& context)
 
 PageRuntimeAgent::~PageRuntimeAgent() = default;
 
-Protocol::ErrorStringOr<void> PageRuntimeAgent::enable()
+Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::enable()
 {
     if (m_instrumentingAgents.enabledPageRuntimeAgent() == this)
         return { };
@@ -81,7 +81,7 @@ Protocol::ErrorStringOr<void> PageRuntimeAgent::enable()
     return result;
 }
 
-Protocol::ErrorStringOr<void> PageRuntimeAgent::disable()
+Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::disable()
 {
     m_instrumentingAgents.setEnabledPageRuntimeAgent(nullptr);
 
@@ -103,7 +103,7 @@ void PageRuntimeAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapper
     notifyContextCreated(pageAgent->frameId(&frame), frame.script().globalObject(world), world);
 }
 
-InjectedScript PageRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InjectedScript PageRuntimeAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (!executionContextId) {
         auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
@@ -159,22 +159,22 @@ void PageRuntimeAgent::reportExecutionContextCreation()
     });
 }
 
-static Protocol::Runtime::ExecutionContextType toProtocol(DOMWrapperWorld::Type type)
+static Inspector::Protocol::Runtime::ExecutionContextType toProtocol(DOMWrapperWorld::Type type)
 {
     switch (type) {
     case DOMWrapperWorld::Type::Normal:
-        return Protocol::Runtime::ExecutionContextType::Normal;
+        return Inspector::Protocol::Runtime::ExecutionContextType::Normal;
     case DOMWrapperWorld::Type::User:
-        return Protocol::Runtime::ExecutionContextType::User;
+        return Inspector::Protocol::Runtime::ExecutionContextType::User;
     case DOMWrapperWorld::Type::Internal:
-        return Protocol::Runtime::ExecutionContextType::Internal;
+        return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
     }
 
     ASSERT_NOT_REACHED();
-    return Protocol::Runtime::ExecutionContextType::Internal;
+    return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
 }
 
-void PageRuntimeAgent::notifyContextCreated(const Protocol::Network::FrameId& frameId, JSC::JSGlobalObject* globalObject, const DOMWrapperWorld& world, SecurityOrigin* securityOrigin)
+void PageRuntimeAgent::notifyContextCreated(const Inspector::Protocol::Network::FrameId& frameId, JSC::JSGlobalObject* globalObject, const DOMWrapperWorld& world, SecurityOrigin* securityOrigin)
 {
     auto injectedScript = injectedScriptManager().injectedScriptFor(globalObject);
     if (injectedScript.hasNoValue())
@@ -184,7 +184,7 @@ void PageRuntimeAgent::notifyContextCreated(const Protocol::Network::FrameId& fr
     if (name.isEmpty() && securityOrigin)
         name = securityOrigin->toRawString();
 
-    m_frontendDispatcher->executionContextCreated(Protocol::Runtime::ExecutionContextDescription::create()
+    m_frontendDispatcher->executionContextCreated(Inspector::Protocol::Runtime::ExecutionContextDescription::create()
         .setId(injectedScriptManager().injectedScriptIdFor(globalObject))
         .setType(toProtocol(world.type()))
         .setName(name)
@@ -192,9 +192,9 @@ void PageRuntimeAgent::notifyContextCreated(const Protocol::Network::FrameId& fr
         .release());
 }
 
-Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> PageRuntimeAgent::evaluate(const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
+Inspector::Protocol::ErrorStringOr<std::tuple<Ref<Inspector::Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> PageRuntimeAgent::evaluate(const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
 {
-    Protocol::ErrorString errorString;
+    Inspector::Protocol::ErrorString errorString;
 
     auto injectedScript = injectedScriptForEval(errorString, WTFMove(executionContextId));
     if (injectedScript.hasNoValue())
@@ -204,7 +204,7 @@ Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::op
     return InspectorRuntimeAgent::evaluate(injectedScript, expression, objectGroup, WTFMove(includeCommandLineAPI), WTFMove(doNotPauseOnExceptionsAndMuteConsole), WTFMove(returnByValue), WTFMove(generatePreview), WTFMove(saveResult), WTFMove(emulateUserGesture));
 }
 
-void PageRuntimeAgent::callFunctionOn(const Protocol::Runtime::RemoteObjectId& objectId, const String& expression, RefPtr<JSON::Array>&& optionalArguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture, std::optional<bool>&& awaitPromise, Ref<CallFunctionOnCallback>&& callback)
+void PageRuntimeAgent::callFunctionOn(const Inspector::Protocol::Runtime::RemoteObjectId& objectId, const String& expression, RefPtr<JSON::Array>&& optionalArguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture, std::optional<bool>&& awaitPromise, Ref<CallFunctionOnCallback>&& callback)
 {
     auto injectedScript = injectedScriptManager().injectedScriptForObjectId(objectId);
     if (injectedScript.hasNoValue()) {

--- a/Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.cpp
@@ -52,9 +52,9 @@ void ServiceWorkerAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReas
 {
 }
 
-Protocol::ErrorStringOr<Ref<Protocol::ServiceWorker::Configuration>> ServiceWorkerAgent::getInitializationInfo()
+Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::ServiceWorker::Configuration>> ServiceWorkerAgent::getInitializationInfo()
 {
-    return Protocol::ServiceWorker::Configuration::create()
+    return Inspector::Protocol::ServiceWorker::Configuration::create()
         .setTargetId(m_serviceWorkerGlobalScope.inspectorIdentifier())
         .setSecurityOrigin(m_serviceWorkerGlobalScope.securityOrigin()->toRawString())
         .setUrl(m_serviceWorkerGlobalScope.contextData().scriptURL.string())

--- a/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp
@@ -46,7 +46,7 @@ WorkerAuditAgent::WorkerAuditAgent(WorkerAgentContext& context)
 
 WorkerAuditAgent::~WorkerAuditAgent() = default;
 
-InjectedScript WorkerAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InjectedScript WorkerAuditAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for workers as there is only one execution context"_s;

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
@@ -41,12 +41,12 @@ WorkerCanvasAgent::WorkerCanvasAgent(WorkerAgentContext& context)
 
 WorkerCanvasAgent::~WorkerCanvasAgent() = default;
 
-Protocol::ErrorStringOr<Protocol::DOM::NodeId> WorkerCanvasAgent::requestNode(const Protocol::Canvas::CanvasId&)
+Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> WorkerCanvasAgent::requestNode(const Inspector::Protocol::Canvas::CanvasId&)
 {
     return makeUnexpected("Not supported"_s);
 }
 
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> WorkerCanvasAgent::requestClientNodes(const Protocol::Canvas::CanvasId&)
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> WorkerCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&)
 {
     return makeUnexpected("Not supported"_s);
 }

--- a/Source/WebCore/inspector/agents/worker/WorkerDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerDOMDebuggerAgent.cpp
@@ -37,17 +37,17 @@ WorkerDOMDebuggerAgent::WorkerDOMDebuggerAgent(WorkerAgentContext& context, Insp
 
 WorkerDOMDebuggerAgent::~WorkerDOMDebuggerAgent() = default;
 
-Protocol::ErrorStringOr<void> WorkerDOMDebuggerAgent::setDOMBreakpoint(Protocol::DOM::NodeId, Protocol::DOMDebugger::DOMBreakpointType, RefPtr<JSON::Object>&& /* options */)
+Inspector::Protocol::ErrorStringOr<void> WorkerDOMDebuggerAgent::setDOMBreakpoint(Inspector::Protocol::DOM::NodeId, Inspector::Protocol::DOMDebugger::DOMBreakpointType, RefPtr<JSON::Object>&& /* options */)
 {
     return makeUnexpected("Not supported"_s);
 }
 
-Protocol::ErrorStringOr<void> WorkerDOMDebuggerAgent::removeDOMBreakpoint(Protocol::DOM::NodeId, Protocol::DOMDebugger::DOMBreakpointType)
+Inspector::Protocol::ErrorStringOr<void> WorkerDOMDebuggerAgent::removeDOMBreakpoint(Inspector::Protocol::DOM::NodeId, Inspector::Protocol::DOMDebugger::DOMBreakpointType)
 {
     return makeUnexpected("Not supported"_s);
 }
 
-bool WorkerDOMDebuggerAgent::setAnimationFrameBreakpoint(Protocol::ErrorString& errorString, RefPtr<JSC::Breakpoint>&&)
+bool WorkerDOMDebuggerAgent::setAnimationFrameBreakpoint(Inspector::Protocol::ErrorString& errorString, RefPtr<JSC::Breakpoint>&&)
 {
     errorString = "Not supported"_s;
     return false;

--- a/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
@@ -54,7 +54,7 @@ void WorkerDebuggerAgent::breakpointActionLog(JSGlobalObject* lexicalGlobalObjec
     m_globalScope.addConsoleMessage(makeUnique<ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Log, message, createScriptCallStack(lexicalGlobalObject)));
 }
 
-InjectedScript WorkerDebuggerAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InjectedScript WorkerDebuggerAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for workers as there is only one execution context"_s;

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
@@ -44,12 +44,12 @@ WorkerNetworkAgent::WorkerNetworkAgent(WorkerAgentContext& context)
 
 WorkerNetworkAgent::~WorkerNetworkAgent() = default;
 
-Protocol::Network::LoaderId WorkerNetworkAgent::loaderIdentifier(DocumentLoader*)
+Inspector::Protocol::Network::LoaderId WorkerNetworkAgent::loaderIdentifier(DocumentLoader*)
 {
     return { };
 }
 
-Protocol::Network::FrameId WorkerNetworkAgent::frameIdentifier(DocumentLoader*)
+Inspector::Protocol::Network::FrameId WorkerNetworkAgent::frameIdentifier(DocumentLoader*)
 {
     return { };
 }
@@ -75,7 +75,7 @@ bool WorkerNetworkAgent::setEmulatedConditionsInternal(std::optional<int>&& /* b
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-ScriptExecutionContext* WorkerNetworkAgent::scriptExecutionContext(Protocol::ErrorString&, const Protocol::Network::FrameId&)
+ScriptExecutionContext* WorkerNetworkAgent::scriptExecutionContext(Inspector::Protocol::ErrorString&, const Inspector::Protocol::Network::FrameId&)
 {
     return &m_globalScope;
 }

--- a/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp
@@ -52,7 +52,7 @@ WorkerRuntimeAgent::WorkerRuntimeAgent(WorkerAgentContext& context)
 
 WorkerRuntimeAgent::~WorkerRuntimeAgent() = default;
 
-InjectedScript WorkerRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
+InjectedScript WorkerRuntimeAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (executionContextId) {
         errorString = "executionContextId is not supported for workers as there is only one execution context"_s;

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -31,7 +31,6 @@
 #include "IntSize.h"
 #include "ProcessIdentity.h"
 #include <CoreGraphics/CoreGraphics.h>
-#include <objc/objc.h>
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST) && !PLATFORM(IOS_FAMILY_SIMULATOR)


### PR DESCRIPTION
#### a23acff183dd2d16c27644f1e4d4ef10b9cf1a6f
<pre>
Try to avoid conflicts between ObjC&apos;s Protocol and Inspector::Protocol namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=269040">https://bugs.webkit.org/show_bug.cgi?id=269040</a>

Reviewed by Wenson Hsieh and Patrick Angle.

ObjC has a Protocol type; sometimes with various Unified Sources shuffling we
end up getting that included in an Inspector file, which also has Inspector::Protocol,
which it often uses without the Inspector:: namespace being mentioned explicitly,
via `using namespace Inspector`.

* Source/WebCore/inspector/CommandLineAPIHost.cpp:
* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
* Source/WebCore/inspector/InspectorCanvas.cpp:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
* Source/WebCore/inspector/agents/InspectorApplicationCacheAgent.cpp:
* Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDatabaseAgent.cpp:
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
* Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
* Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp:
* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
* Source/WebCore/inspector/agents/page/PageAuditAgent.cpp:
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp:
* Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp:
* Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/page/PageHeapAgent.cpp:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
* Source/WebCore/inspector/agents/worker/ServiceWorkerAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerAuditAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerDOMDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp:
Avoid this conflict by specifying Inspector:: in all cases.

* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
Also remove one common cause of objc/objc.h getting included places,
by removing it from IOSurface.h (the build still succeeds...).

Canonical link: <a href="https://commits.webkit.org/274340@main">https://commits.webkit.org/274340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2984c9d992ddb770b1221475d3b30e141e556aeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41320 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15069 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14910 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12952 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35208 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8686 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/14882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->