### PR TITLE
Adopt more smart pointers in SVG

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3088,7 +3088,7 @@ void RenderLayer::setupClipPath(GraphicsContext& context, GraphicsContextStateSa
     if (RefPtr referenceClipPathOperation = dynamicDowncast<ReferencePathOperation>(style.clipPath())) {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
         if (auto* svgClipper = renderer().svgClipperResourceFromStyle()) {
-            auto* graphicsElement = svgClipper->shouldApplyPathClipping();
+            RefPtr graphicsElement = svgClipper->shouldApplyPathClipping();
             if (!graphicsElement) {
                 paintFlags.add(PaintLayerFlag::PaintingSVGClippingMask);
                 return;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -78,7 +78,7 @@ static Path& sharedClipAllPath()
     return clipAllPath.get();
 }
 
-SVGGraphicsElement* RenderSVGResourceClipper::shouldApplyPathClipping() const
+RefPtr<SVGGraphicsElement> RenderSVGResourceClipper::shouldApplyPathClipping() const
 {
     if (currentClippingMode() == ClippingMode::MaskClipping)
         return nullptr;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -39,7 +39,7 @@ public:
 
     inline SVGClipPathElement& clipPathElement() const;
 
-    SVGGraphicsElement* shouldApplyPathClipping() const;
+    RefPtr<SVGGraphicsElement> shouldApplyPathClipping() const;
     void applyPathClipping(GraphicsContext&, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox, SVGGraphicsElement&);
     void applyMaskClipping(PaintInfo&, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox);
 

--- a/Source/WebCore/svg/PatternAttributes.h
+++ b/Source/WebCore/svg/PatternAttributes.h
@@ -22,34 +22,14 @@
 #include "SVGLengthValue.h"
 #include "SVGPreserveAspectRatioValue.h"
 #include "SVGUnitTypes.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class SVGPatternElement;
 
 struct PatternAttributes {
-    PatternAttributes()
-        : m_x()
-        , m_y()
-        , m_width()
-        , m_height()
-        , m_viewBox()
-        , m_preserveAspectRatio()
-        , m_patternUnits(SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX)
-        , m_patternContentUnits(SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE)
-        , m_patternContentElement(nullptr)
-        , m_xSet(false)
-        , m_ySet(false)
-        , m_widthSet(false)
-        , m_heightSet(false)
-        , m_viewBoxSet(false)
-        , m_preserveAspectRatioSet(false)
-        , m_patternUnitsSet(false)
-        , m_patternContentUnitsSet(false)
-        , m_patternTransformSet(false)
-        , m_patternContentElementSet(false)
-    {
-    }
+    PatternAttributes() = default;
 
     SVGLengthValue x() const { return m_x; }
     SVGLengthValue y() const { return m_y; }
@@ -60,7 +40,7 @@ struct PatternAttributes {
     SVGUnitTypes::SVGUnitType patternUnits() const { return m_patternUnits; }
     SVGUnitTypes::SVGUnitType patternContentUnits() const { return m_patternContentUnits; }
     AffineTransform patternTransform() const { return m_patternTransform; }
-    const SVGPatternElement* patternContentElement() const { return m_patternContentElement; }
+    const SVGPatternElement* patternContentElement() const { return m_patternContentElement.get(); }
 
     void setX(SVGLengthValue value)
     {
@@ -141,22 +121,22 @@ private:
     SVGLengthValue m_height;
     FloatRect m_viewBox;
     SVGPreserveAspectRatioValue m_preserveAspectRatio;
-    SVGUnitTypes::SVGUnitType m_patternUnits;
-    SVGUnitTypes::SVGUnitType m_patternContentUnits;
+    SVGUnitTypes::SVGUnitType m_patternUnits { SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX };
+    SVGUnitTypes::SVGUnitType m_patternContentUnits { SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE };
     AffineTransform m_patternTransform;
-    const SVGPatternElement* m_patternContentElement;
+    WeakPtr<const SVGPatternElement, WeakPtrImplWithEventTargetData> m_patternContentElement;
 
     // Property states
-    bool m_xSet : 1;
-    bool m_ySet : 1;
-    bool m_widthSet : 1;
-    bool m_heightSet : 1;
-    bool m_viewBoxSet : 1;
-    bool m_preserveAspectRatioSet : 1;
-    bool m_patternUnitsSet : 1;
-    bool m_patternContentUnitsSet : 1;
-    bool m_patternTransformSet : 1;
-    bool m_patternContentElementSet : 1;
+    bool m_xSet : 1 { false };
+    bool m_ySet : 1 { false };
+    bool m_widthSet : 1 { false };
+    bool m_heightSet : 1 { false };
+    bool m_viewBoxSet : 1 { false };
+    bool m_preserveAspectRatioSet : 1 { false };
+    bool m_patternUnitsSet : 1 { false };
+    bool m_patternContentUnitsSet : 1 { false };
+    bool m_patternTransformSet : 1 { false };
+    bool m_patternContentElementSet : 1 { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -81,7 +81,7 @@ String SVGAElement::title() const
 void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::targetAttr) {
-        m_target->setBaseValInternal(newValue);
+        Ref { m_target }->setBaseValInternal(newValue);
         return;
     } else if (name == SVGNames::relAttr) {
         if (m_relList)
@@ -105,7 +105,7 @@ void SVGAElement::svgAttributeChanged(const QualifiedName& attrName)
 
 RenderPtr<RenderElement> SVGAElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    auto* svgParent = dynamicDowncast<SVGElement>(parentNode());
+    RefPtr svgParent = dynamicDowncast<SVGElement>(parentNode());
     if (svgParent && svgParent->isTextContent())
         return createRenderer<RenderSVGInline>(RenderObject::Type::SVGInline, *this, WTFMove(style));
 
@@ -141,10 +141,8 @@ void SVGAElement::defaultEventHandler(Event& event)
                 target = blankTargetFrameName();
             event.setDefaultHandled();
 
-            RefPtr frame = document().frame();
-            if (!frame)
-                return;
-            frame->loader().changeLocation(document().completeURL(url), target, &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
+            if (RefPtr frame = document().frame())
+                frame->checkedLoader()->changeLocation(protectedDocument()->completeURL(url), target, &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
             return;
         }
     }

--- a/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
@@ -91,12 +91,12 @@ bool SVGAltGlyphDefElement::hasValidGlyphElements(Vector<String>& glyphNames) co
     bool fountFirstGlyphRef = false;
     bool foundFirstAltGlyphItem = false;
 
-    for (auto& child : childrenOfType<SVGElement>(*this)) {
+    for (Ref child : childrenOfType<SVGElement>(*this)) {
         if (!foundFirstAltGlyphItem && is<SVGGlyphRefElement>(child)) {
             fountFirstGlyphRef = true;
             String referredGlyphName;
 
-            if (downcast<SVGGlyphRefElement>(child).hasValidGlyphElement(referredGlyphName))
+            if (downcast<SVGGlyphRefElement>(child.get()).hasValidGlyphElement(referredGlyphName))
                 glyphNames.append(referredGlyphName);
             else {
                 // As the spec says "If any of the referenced glyphs are unavailable,
@@ -107,7 +107,7 @@ bool SVGAltGlyphDefElement::hasValidGlyphElements(Vector<String>& glyphNames) co
                 return false;
             }
         } else if (!fountFirstGlyphRef) {
-            if (auto* altGlyphItem = dynamicDowncast<SVGAltGlyphItemElement>(child)) {
+            if (RefPtr altGlyphItem = dynamicDowncast<SVGAltGlyphItemElement>(WTFMove(child))) {
                 foundFirstAltGlyphItem = true;
 
                 // As the spec says "The first 'altGlyphItem' in which all referenced glyphs

--- a/Source/WebCore/svg/SVGAltGlyphElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphElement.cpp
@@ -89,7 +89,7 @@ bool SVGAltGlyphElement::hasValidGlyphElements(Vector<String>& glyphNames) const
         return true;
     }
     
-    auto* altGlyphDefElement = downcast<SVGAltGlyphDefElement>(target.element.get());
+    RefPtr altGlyphDefElement = downcast<SVGAltGlyphDefElement>(target.element.get());
     return altGlyphDefElement && altGlyphDefElement->hasValidGlyphElements(glyphNames);
 }
 

--- a/Source/WebCore/svg/SVGAltGlyphItemElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphItemElement.cpp
@@ -53,9 +53,9 @@ bool SVGAltGlyphItemElement::hasValidGlyphElements(Vector<String>& glyphNames) c
     // Here we fill glyphNames and return true only if all referenced glyphs are valid and
     // there is at least one glyph.
 
-    for (auto& glyphRef : childrenOfType<SVGGlyphRefElement>(*this)) {
+    for (Ref glyphRef : childrenOfType<SVGGlyphRefElement>(*this)) {
         String referredGlyphName;
-        if (glyphRef.hasValidGlyphElement(referredGlyphName))
+        if (glyphRef->hasValidGlyphElement(referredGlyphName))
             glyphNames.append(referredGlyphName);
         else {
             glyphNames.clear();

--- a/Source/WebCore/svg/SVGAnimateElementBase.cpp
+++ b/Source/WebCore/svg/SVGAnimateElementBase.cpp
@@ -49,7 +49,7 @@ SVGAttributeAnimator* SVGAnimateElementBase::animator() const
     ASSERT(!hasInvalidCSSAttributeType());
 
     if (!m_animator)
-        m_animator = targetElement()->createAnimator(attributeName(), animationMode(), calcMode(), isAccumulated(), isAdditive());
+        m_animator = protectedTargetElement()->createAnimator(attributeName(), animationMode(), calcMode(), isAccumulated(), isAdditive());
 
     return m_animator.get();
 }
@@ -59,7 +59,7 @@ bool SVGAnimateElementBase::hasValidAttributeType() const
     if (!targetElement() || hasInvalidCSSAttributeType())
         return false;
 
-    return targetElement()->isAnimatedAttribute(attributeName());
+    return protectedTargetElement()->isAnimatedAttribute(attributeName());
 }
 
 bool SVGAnimateElementBase::hasInvalidCSSAttributeType() const
@@ -106,8 +106,8 @@ bool SVGAnimateElementBase::setFromAndToValues(const String& fromString, const S
     if (!targetElement())
         return false;
 
-    if (auto* animator = this->animator()) {
-        animator->setFromAndToValues(*targetElement(), animateRangeString(fromString), animateRangeString(toString));
+    if (RefPtr animator = this->animator()) {
+        animator->setFromAndToValues(*protectedTargetElement(), animateRangeString(fromString), animateRangeString(toString));
         return true;
     }
     return false;
@@ -124,8 +124,8 @@ bool SVGAnimateElementBase::setFromAndByValues(const String& fromString, const S
     if (animationMode() == AnimationMode::FromBy && isDiscreteAnimator())
         return false;
 
-    if (auto* animator = this->animator()) {
-        animator->setFromAndByValues(*targetElement(), animateRangeString(fromString), animateRangeString(byString));
+    if (RefPtr animator = this->animator()) {
+        animator->setFromAndByValues(*protectedTargetElement(), animateRangeString(fromString), animateRangeString(byString));
         return true;
     }
     return false;
@@ -139,7 +139,7 @@ bool SVGAnimateElementBase::setToAtEndOfDurationValue(const String& toAtEndOfDur
     if (isDiscreteAnimator())
         return true;
 
-    if (auto* animator = this->animator()) {
+    if (RefPtr animator = this->animator()) {
         animator->setToAtEndOfDurationValue(animateRangeString(toAtEndOfDurationString));
         return true;
     }
@@ -152,7 +152,7 @@ void SVGAnimateElementBase::startAnimation()
         return;
 
     if (RefPtr protectedAnimator = this->animator())
-        protectedAnimator->start(*targetElement());
+        protectedAnimator->start(*protectedTargetElement());
 }
 
 void SVGAnimateElementBase::calculateAnimatedValue(float progress, unsigned repeatCount)
@@ -167,8 +167,8 @@ void SVGAnimateElementBase::calculateAnimatedValue(float progress, unsigned repe
     if (calcMode() == CalcMode::Discrete)
         progress = progress < 0.5 ? 0 : 1;
 
-    if (RefPtr protectedAnimator = this->animator())
-        protectedAnimator->animate(*targetElement(), progress, repeatCount);
+    if (RefPtr animator = this->animator())
+        animator->animate(*protectedTargetElement(), progress, repeatCount);
 }
 
 void SVGAnimateElementBase::applyResultsToTarget()
@@ -176,7 +176,7 @@ void SVGAnimateElementBase::applyResultsToTarget()
     if (!targetElement())
         return;
 
-    if (auto* animator = this->animator())
+    if (RefPtr animator = this->animator())
         animator->apply(*targetElement());
 }
 
@@ -185,7 +185,7 @@ void SVGAnimateElementBase::stopAnimation(SVGElement* targetElement)
     if (!targetElement)
         return;
 
-    if (auto* animator = this->animatorIfExists())
+    if (RefPtr animator = this->animatorIfExists())
         animator->stop(*targetElement);
 }
 
@@ -195,7 +195,7 @@ std::optional<float> SVGAnimateElementBase::calculateDistance(const String& from
     if (!targetElement())
         return { };
 
-    if (auto* animator = this->animator())
+    if (RefPtr animator = this->animator())
         return animator->calculateDistance(*targetElement(), fromString, toString);
 
     return { };

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -126,8 +126,7 @@ void SVGAnimateMotionElement::updateAnimationPath()
     bool foundMPath = false;
 
     for (auto& mPath : childrenOfType<SVGMPathElement>(*this)) {
-        auto pathElement = mPath.pathElement();
-        if (pathElement) {
+        if (RefPtr pathElement = mPath.pathElement()) {
             m_animationPath = pathFromGraphicsElement(*pathElement);
             foundMPath = true;
             break;
@@ -256,14 +255,14 @@ void SVGAnimateMotionElement::applyResultsToTarget()
     auto updateTargetElement = [](SVGElement& element) {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
         if (element.document().settings().layerBasedSVGEngineEnabled()) {
-            if (auto* layerRenderer = dynamicDowncast<RenderLayerModelObject>(element.renderer()))
+            if (CheckedPtr layerRenderer = dynamicDowncast<RenderLayerModelObject>(element.renderer()))
                 layerRenderer->updateHasSVGTransformFlags();
             // TODO: [LBSE] Avoid relayout upon transform changes (not possible in legacy, but should be in LBSE).
             element.updateSVGRendererForElementChange();
             return;
         }
 #endif
-        if (auto* renderer = element.renderer())
+        if (CheckedPtr renderer = element.renderer())
             renderer->setNeedsTransformUpdate();
         element.updateSVGRendererForElementChange();
     };

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -116,7 +116,7 @@ RenderPtr<RenderElement> SVGClipPathElement::createElementRenderer(RenderStyle&&
     return createRenderer<LegacyRenderSVGResourceClipper>(*this, WTFMove(style));
 }
 
-SVGGraphicsElement* SVGClipPathElement::shouldApplyPathClipping() const
+RefPtr<SVGGraphicsElement> SVGClipPathElement::shouldApplyPathClipping() const
 {
     // If the current clip-path gets clipped itself, we have to fall back to masking.
     if (renderer() && renderer()->style().clipPath())
@@ -133,7 +133,7 @@ SVGGraphicsElement* SVGClipPathElement::shouldApplyPathClipping() const
         return style.clipPath();
     };
 
-    SVGGraphicsElement* useGraphicsElement = nullptr;
+    RefPtr<SVGGraphicsElement> useGraphicsElement;
 
     // If clip-path only contains one visible shape or path, we can use path-based clipping. Invisible
     // shapes don't affect the clipping and can be ignored. If clip-path contains more than one
@@ -141,10 +141,10 @@ SVGGraphicsElement* SVGClipPathElement::shouldApplyPathClipping() const
     // as well as NonZero can cause self-clipping of the elements.
     // See also http://www.w3.org/TR/SVG/painting.html#FillRuleProperty
     for (auto* childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
-        auto* graphicsElement = dynamicDowncast<SVGGraphicsElement>(*childNode);
+        RefPtr graphicsElement = dynamicDowncast<SVGGraphicsElement>(*childNode);
         if (!graphicsElement)
             continue;
-        auto* renderer = graphicsElement->renderer();
+        CheckedPtr renderer = graphicsElement->renderer();
         if (!renderer)
             continue;
         if (rendererRequiresMaskClipping(*renderer))
@@ -154,13 +154,13 @@ SVGGraphicsElement* SVGClipPathElement::shouldApplyPathClipping() const
             return nullptr;
 
         // For <use> elements, delegate the decision whether to use mask clipping or not to the referenced element.
-        if (auto* useElement = dynamicDowncast<SVGUseElement>(graphicsElement)) {
-            auto* clipChildRenderer = useElement->rendererClipChild();
+        if (auto* useElement = dynamicDowncast<SVGUseElement>(*graphicsElement)) {
+            CheckedPtr clipChildRenderer = useElement->rendererClipChild();
             if (clipChildRenderer && rendererRequiresMaskClipping(*clipChildRenderer))
                 return nullptr;
         }
 
-        useGraphicsElement = graphicsElement;
+        useGraphicsElement = WTFMove(graphicsElement);
     }
 
     return useGraphicsElement;
@@ -186,7 +186,7 @@ FloatRect SVGClipPathElement::calculateClipContentRepaintRect(RepaintRectCalcula
     FloatRect clipContentRepaintRect;
     // This is a rough heuristic to appraise the clip size and doesn't consider clip on clip.
     for (auto* childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
-        auto* renderer = childNode->renderer();
+        CheckedPtr renderer = childNode->renderer();
         if (!childNode->isSVGElement() || !renderer)
             continue;
         if (!renderer->isRenderSVGShape() && !renderer->isRenderSVGText() && !childNode->hasTagName(SVGNames::useTag))

--- a/Source/WebCore/svg/SVGClipPathElement.h
+++ b/Source/WebCore/svg/SVGClipPathElement.h
@@ -38,7 +38,7 @@ public:
     SVGUnitTypes::SVGUnitType clipPathUnits() const { return m_clipPathUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     SVGAnimatedEnumeration& clipPathUnitsAnimated() { return m_clipPathUnits; }
 
-    SVGGraphicsElement* shouldApplyPathClipping() const;
+    RefPtr<SVGGraphicsElement> shouldApplyPathClipping() const;
 
     FloatRect calculateClipContentRepaintRect(RepaintRectCalculation);
 

--- a/Source/WebCore/svg/SVGCursorElement.cpp
+++ b/Source/WebCore/svg/SVGCursorElement.cpp
@@ -63,9 +63,9 @@ void SVGCursorElement::attributeChanged(const QualifiedName& name, const AtomStr
     SVGParsingError parseError = NoError;
 
     if (name == SVGNames::xAttr)
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
     else if (name == SVGNames::yAttr)
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
 
     reportAttributeParsingError(parseError, name, newValue);
 

--- a/Source/WebCore/svg/SVGDocument.cpp
+++ b/Source/WebCore/svg/SVGDocument.cpp
@@ -38,7 +38,7 @@ SVGDocument::SVGDocument(LocalFrame* frame, const Settings& settings, const URL&
 
 bool SVGDocument::zoomAndPanEnabled() const
 {
-    auto element = DocumentSVG::rootElement(*this);
+    RefPtr element = DocumentSVG::rootElement(*this);
     if (!element)
         return false;
     return (element->useCurrentView() ? element->currentView().zoomAndPan() : element->zoomAndPan()) == SVGZoomAndPanMagnify;
@@ -46,7 +46,7 @@ bool SVGDocument::zoomAndPanEnabled() const
 
 void SVGDocument::startPan(const FloatPoint& start)
 {
-    auto element = DocumentSVG::rootElement(*this);
+    RefPtr element = DocumentSVG::rootElement(*this);
     if (!element)
         return;
     m_panningOffset = start - element->currentTranslateValue();
@@ -54,7 +54,7 @@ void SVGDocument::startPan(const FloatPoint& start)
 
 void SVGDocument::updatePan(const FloatPoint& position) const
 {
-    auto element = DocumentSVG::rootElement(*this);
+    RefPtr element = DocumentSVG::rootElement(*this);
     if (!element)
         return;
     element->setCurrentTranslate(position - m_panningOffset);
@@ -62,7 +62,7 @@ void SVGDocument::updatePan(const FloatPoint& position) const
 
 Ref<Document> SVGDocument::cloneDocumentWithoutChildren() const
 {
-    return create(nullptr, settings(), url());
+    return create(nullptr, protectedSettings(), url());
 }
 
 }

--- a/Source/WebCore/svg/SVGDocument.h
+++ b/Source/WebCore/svg/SVGDocument.h
@@ -46,7 +46,7 @@ private:
 
 inline Ref<SVGDocument> SVGDocument::create(LocalFrame* frame, const Settings& settings, const URL& url)
 {
-    auto document = adoptRef(*new SVGDocument(frame, settings, url));
+    Ref document = adoptRef(*new SVGDocument(frame, settings, url));
     document->addToContextsMap();
     return document;
 }

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -70,7 +70,9 @@ public:
     void unregisterSVGFontFaceElement(SVGFontFaceElement&);
 
 private:
-    Document& m_document;
+    Ref<Document> protectedDocument() const;
+
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_timeContainers; // For SVG 1.2 support this will need to be made more general.
     WeakHashSet<SVGFontFaceElement, WeakPtrImplWithEventTargetData> m_svgFontFaceElements;
     std::unique_ptr<SVGResourcesCache> m_resourcesCache;

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -225,7 +225,7 @@ public:
     InstanceInvalidationGuard(SVGElement&);
     ~InstanceInvalidationGuard();
 private:
-    SVGElement& m_element;
+    WeakRef<SVGElement, WeakPtrImplWithEventTargetData> m_element;
 };
 
 class SVGElement::InstanceUpdateBlocker {
@@ -233,7 +233,7 @@ public:
     InstanceUpdateBlocker(SVGElement&);
     ~InstanceUpdateBlocker();
 private:
-    SVGElement& m_element;
+    WeakRef<SVGElement, WeakPtrImplWithEventTargetData> m_element;
 };
 
 inline SVGElement::InstanceInvalidationGuard::InstanceInvalidationGuard(SVGElement& element)
@@ -243,18 +243,18 @@ inline SVGElement::InstanceInvalidationGuard::InstanceInvalidationGuard(SVGEleme
 
 inline SVGElement::InstanceInvalidationGuard::~InstanceInvalidationGuard()
 {
-    m_element.invalidateInstances();
+    m_element->invalidateInstances();
 }
 
 inline SVGElement::InstanceUpdateBlocker::InstanceUpdateBlocker(SVGElement& element)
     : m_element(element)
 {
-    m_element.setInstanceUpdatesBlocked(true);
+    m_element->setInstanceUpdatesBlocked(true);
 }
 
 inline SVGElement::InstanceUpdateBlocker::~InstanceUpdateBlocker()
 {
-    m_element.setInstanceUpdatesBlocked(false);
+    m_element->setInstanceUpdatesBlocked(false);
 }
 
 

--- a/Source/WebCore/svg/SVGEllipseElement.cpp
+++ b/Source/WebCore/svg/SVGEllipseElement.cpp
@@ -58,16 +58,16 @@ void SVGEllipseElement::attributeChanged(const QualifiedName& name, const AtomSt
 
     switch (name.nodeName()) {
     case AttributeNames::cxAttr:
-        m_cx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_cx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::cyAttr:
-        m_cy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_cy }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::rxAttr:
-        m_rx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_rx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::ryAttr:
-        m_ry->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_ry }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEBlendElement.cpp
+++ b/Source/WebCore/svg/SVGFEBlendElement.cpp
@@ -56,14 +56,14 @@ void SVGFEBlendElement::attributeChanged(const QualifiedName& name, const AtomSt
     case AttributeNames::modeAttr: {
         BlendMode mode = BlendMode::Normal;
         if (parseBlendMode(newValue, mode))
-            m_mode->setBaseValInternal<BlendMode>(mode);
+        Ref { m_mode }->setBaseValInternal<BlendMode>(mode);
         break;
     }
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::in2Attr:
-        m_in2->setBaseValInternal(newValue);
+        Ref { m_in2 }->setBaseValInternal(newValue);
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -65,14 +65,14 @@ void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const 
     case AttributeNames::typeAttr: {
         auto propertyValue = SVGPropertyTraits<ColorMatrixType>::fromString(newValue);
         if (enumToUnderlyingType(propertyValue))
-            m_type->setBaseValInternal<ColorMatrixType>(propertyValue);
+            Ref { m_type }->setBaseValInternal<ColorMatrixType>(propertyValue);
         break;
     }
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::valuesAttr:
-        m_values->baseVal()->parse(newValue);
+        Ref { m_values }->baseVal()->parse(newValue);
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -54,7 +54,7 @@ Ref<SVGFEComponentTransferElement> SVGFEComponentTransferElement::create(const Q
 void SVGFEComponentTransferElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::inAttr)
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
 
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -59,26 +59,26 @@ void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const At
     case AttributeNames::operatorAttr: {
         CompositeOperationType propertyValue = SVGPropertyTraits<CompositeOperationType>::fromString(newValue);
         if (enumToUnderlyingType(propertyValue))
-            m_svgOperator->setBaseValInternal<CompositeOperationType>(propertyValue);
+            Ref { m_svgOperator }->setBaseValInternal<CompositeOperationType>(propertyValue);
         break;
     }
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::in2Attr:
-        m_in2->setBaseValInternal(newValue);
+        Ref { m_in2 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::k1Attr:
-        m_k1->setBaseValInternal(newValue.toFloat());
+        Ref { m_k1 }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::k2Attr:
-        m_k2->setBaseValInternal(newValue.toFloat());
+        Ref { m_k2 }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::k3Attr:
-        m_k3->setBaseValInternal(newValue.toFloat());
+        Ref { m_k3 }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::k4Attr:
-        m_k4->setBaseValInternal(newValue.toFloat());
+        Ref { m_k4 }->setBaseValInternal(newValue.toFloat());
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -62,13 +62,13 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
 {
     switch (name.nodeName()) {
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::orderAttr: {
         auto result = parseNumberOptionalNumber(newValue);
         if (result && result->first >= 1 && result->second >= 1) {
-            m_orderX->setBaseValInternal(result->first);
-            m_orderY->setBaseValInternal(result->second);
+            Ref { m_orderX }->setBaseValInternal(result->first);
+            Ref { m_orderY }->setBaseValInternal(result->second);
         } else
             protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing order=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
@@ -76,43 +76,43 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
     case AttributeNames::edgeModeAttr: {
         EdgeModeType propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(newValue);
         if (propertyValue != EdgeModeType::Unknown)
-            m_edgeMode->setBaseValInternal<EdgeModeType>(propertyValue);
+            Ref { m_edgeMode }->setBaseValInternal<EdgeModeType>(propertyValue);
         else
             protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing edgeMode=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     }
     case AttributeNames::kernelMatrixAttr:
-        m_kernelMatrix->baseVal()->parse(newValue);
+        Ref { m_kernelMatrix }->baseVal()->parse(newValue);
         break;
     case AttributeNames::divisorAttr:
         if (float divisor = newValue.toFloat())
-            m_divisor->setBaseValInternal(divisor);
+            Ref { m_divisor }->setBaseValInternal(divisor);
         else
             protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing divisor=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     case AttributeNames::biasAttr:
-        m_bias->setBaseValInternal(newValue.toFloat());
+        Ref { m_bias }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::targetXAttr:
-        m_targetX->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
+        Ref { m_targetX }->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
         break;
     case AttributeNames::targetYAttr:
-        m_targetY->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
+        Ref { m_targetY }->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
         break;
     case AttributeNames::kernelUnitLengthAttr: {
         auto result = parseNumberOptionalNumber(newValue);
         if (result && result->first > 0 && result->second > 0) {
-            m_kernelUnitLengthX->setBaseValInternal(result->first);
-            m_kernelUnitLengthY->setBaseValInternal(result->second);
+            Ref { m_kernelUnitLengthX }->setBaseValInternal(result->first);
+            Ref { m_kernelUnitLengthY }->setBaseValInternal(result->second);
         } else
             protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing kernelUnitLength=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     }
     case AttributeNames::preserveAlphaAttr:
         if (newValue == trueAtom())
-            m_preserveAlpha->setBaseValInternal(true);
+            Ref { m_preserveAlpha }->setBaseValInternal(true);
         else if (newValue == falseAtom())
-            m_preserveAlpha->setBaseValInternal(false);
+            Ref { m_preserveAlpha }->setBaseValInternal(false);
         else
             protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing preserveAlphaAttr=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
@@ -149,15 +149,15 @@ bool SVGFEConvolveMatrixElement::setFilterEffectAttribute(FilterEffect& filterEf
 
 void SVGFEConvolveMatrixElement::setOrder(float x, float y)
 {
-    m_orderX->setBaseValInternal(x);
-    m_orderY->setBaseValInternal(y);
+    Ref { m_orderX }->setBaseValInternal(x);
+    Ref { m_orderY }->setBaseValInternal(y);
     updateSVGRendererForElementChange();
 }
 
 void SVGFEConvolveMatrixElement::setKernelUnitLength(float x, float y)
 {
-    m_kernelUnitLengthX->setBaseValInternal(x);
-    m_kernelUnitLengthY->setBaseValInternal(y);
+    Ref { m_kernelUnitLengthX }->setBaseValInternal(x);
+    Ref { m_kernelUnitLengthY }->setBaseValInternal(y);
     updateSVGRendererForElementChange();
 }
 

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -57,18 +57,18 @@ void SVGFEDiffuseLightingElement::attributeChanged(const QualifiedName& name, co
 {
     switch (name.nodeName()) {
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::surfaceScaleAttr:
-        m_surfaceScale->setBaseValInternal(newValue.toFloat());
+        Ref { m_surfaceScale }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::diffuseConstantAttr:
-        m_diffuseConstant->setBaseValInternal(newValue.toFloat());
+        Ref { m_diffuseConstant }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::kernelUnitLengthAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
-            m_kernelUnitLengthX->setBaseValInternal(result->first);
-            m_kernelUnitLengthY->setBaseValInternal(result->second);
+            Ref { m_kernelUnitLengthX }->setBaseValInternal(result->first);
+            Ref { m_kernelUnitLengthY }->setBaseValInternal(result->second);
         }
         break;
     default:
@@ -158,11 +158,11 @@ RefPtr<FilterEffect> SVGFEDiffuseLightingElement::createFilterEffect(const Filte
     if (!lightElement)
         return nullptr;
 
-    auto* renderer = this->renderer();
+    CheckedPtr renderer = this->renderer();
     if (!renderer)
         return nullptr;
 
-    auto lightSource = lightElement->lightSource();
+    Ref lightSource = lightElement->lightSource();
     auto& style = renderer->style();
 
     Color color = style.colorWithColorFilter(style.svgStyle().lightingColor());

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -781,6 +781,11 @@ bool SVGSVGElement::scrollToFragment(StringView fragmentIdentifier)
     return false;
 }
 
+Ref<SMILTimeContainer> SVGSVGElement::protectedTimeContainer()
+{
+    return m_timeContainer;
+}
+
 void SVGSVGElement::resetScrollAnchor()
 {
     if (!m_useCurrentView && m_currentViewFragmentIdentifier.isEmpty())

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -92,6 +92,7 @@ public:
     using SVGGraphicsElement::deref;
 
     SMILTimeContainer& timeContainer() { return m_timeContainer.get(); }
+    Ref<SMILTimeContainer> protectedTimeContainer();
 
     void setCurrentTranslate(const FloatPoint&); // Used to pan.
     void updateCurrentTranslate();

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -59,6 +59,7 @@ public:
     SMILTimeContainer* timeContainer() { return m_timeContainer.get(); }
 
     SVGElement* targetElement() const { return m_targetElement.get(); }
+    RefPtr<SVGElement> protectedTargetElement() const { return m_targetElement.get(); }
     const QualifiedName& attributeName() const { return m_attributeName; }
 
     void beginByLinkActivation();


### PR DESCRIPTION
#### 6c750407870d5a24dc93bfb2c7c1b900dfb39530
<pre>
Adopt more smart pointers in SVG
<a href="https://bugs.webkit.org/show_bug.cgi?id=269043">https://bugs.webkit.org/show_bug.cgi?id=269043</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupClipPath):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::shouldApplyPathClipping const):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
* Source/WebCore/svg/PatternAttributes.h:
(WebCore::PatternAttributes::patternContentElement const):
(WebCore::PatternAttributes::PatternAttributes): Deleted.
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::attributeChanged):
(WebCore::SVGAElement::createElementRenderer):
(WebCore::SVGAElement::defaultEventHandler):
* Source/WebCore/svg/SVGAltGlyphDefElement.cpp:
(WebCore::SVGAltGlyphDefElement::hasValidGlyphElements const):
* Source/WebCore/svg/SVGAltGlyphElement.cpp:
(WebCore::SVGAltGlyphElement::hasValidGlyphElements const):
* Source/WebCore/svg/SVGAltGlyphItemElement.cpp:
(WebCore::SVGAltGlyphItemElement::hasValidGlyphElements const):
* Source/WebCore/svg/SVGAnimateElementBase.cpp:
(WebCore::SVGAnimateElementBase::animator const):
(WebCore::SVGAnimateElementBase::hasValidAttributeType const):
(WebCore::SVGAnimateElementBase::setFromAndToValues):
(WebCore::SVGAnimateElementBase::setFromAndByValues):
(WebCore::SVGAnimateElementBase::setToAtEndOfDurationValue):
(WebCore::SVGAnimateElementBase::startAnimation):
(WebCore::SVGAnimateElementBase::calculateAnimatedValue):
(WebCore::SVGAnimateElementBase::applyResultsToTarget):
(WebCore::SVGAnimateElementBase::stopAnimation):
(WebCore::SVGAnimateElementBase::calculateDistance):
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::updateAnimationPath):
(WebCore::SVGAnimateMotionElement::applyResultsToTarget):
* Source/WebCore/svg/SVGClipPathElement.cpp:
(WebCore::SVGClipPathElement::shouldApplyPathClipping const):
(WebCore::SVGClipPathElement::calculateClipContentRepaintRect):
* Source/WebCore/svg/SVGClipPathElement.h:
* Source/WebCore/svg/SVGCursorElement.cpp:
(WebCore::SVGCursorElement::attributeChanged):
* Source/WebCore/svg/SVGDocument.cpp:
(WebCore::SVGDocument::zoomAndPanEnabled const):
(WebCore::SVGDocument::startPan):
(WebCore::SVGDocument::updatePan const):
(WebCore::SVGDocument::cloneDocumentWithoutChildren const):
* Source/WebCore/svg/SVGDocument.h:
(WebCore::SVGDocument::create):
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::startAnimations):
(WebCore::SVGDocumentExtensions::pauseAnimations):
(WebCore::SVGDocumentExtensions::protectedDocument const):
(WebCore::SVGDocumentExtensions::unpauseAnimations):
(WebCore::SVGDocumentExtensions::reportWarning):
(WebCore::SVGDocumentExtensions::reportError):
(WebCore::SVGDocumentExtensions::clearTargetDependencies):
(WebCore::SVGDocumentExtensions::rebuildAllElementReferencesForTarget):
* Source/WebCore/svg/SVGDocumentExtensions.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::removeEventListener):
(WebCore::SVGElement::createAnimator):
(WebCore::SVGElement::animatedSMILStyleProperties const):
(WebCore::SVGElement::title const):
(WebCore::SVGElement::updateSVGRendererForElementChange):
(WebCore::SVGElement::svgAttributeChanged):
(WebCore::SVGElement::buildPendingResourcesIfNeeded):
(WebCore::SVGElement::invalidateInstances):
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::InstanceInvalidationGuard::~InstanceInvalidationGuard):
(WebCore::SVGElement::InstanceUpdateBlocker::InstanceUpdateBlocker):
(WebCore::SVGElement::InstanceUpdateBlocker::~InstanceUpdateBlocker):
* Source/WebCore/svg/SVGEllipseElement.cpp:
(WebCore::SVGEllipseElement::attributeChanged):
* Source/WebCore/svg/SVGFEBlendElement.cpp:
(WebCore::SVGFEBlendElement::attributeChanged):
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::attributeChanged):
* Source/WebCore/svg/SVGFEComponentTransferElement.cpp:
(WebCore::SVGFEComponentTransferElement::attributeChanged):
* Source/WebCore/svg/SVGFECompositeElement.cpp:
(WebCore::SVGFECompositeElement::attributeChanged):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
(WebCore::SVGFEConvolveMatrixElement::setOrder):
(WebCore::SVGFEConvolveMatrixElement::setKernelUnitLength):
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::attributeChanged):
(WebCore::SVGFEDiffuseLightingElement::createFilterEffect const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::protectedTimeContainer):
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/animation/SVGSMILElement.h:
(WebCore::SVGSMILElement::protectedTargetElement const):

Canonical link: <a href="https://commits.webkit.org/274362@main">https://commits.webkit.org/274362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b649086d6160e98e08efbcdbc93b5aba7f729fb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41330 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32535 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42606 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38759 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36974 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14889 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5067 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->