### PR TITLE
[WebGPU] Resource usage compatibliity does not consider the texture aspect

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.h
+++ b/Source/WebGPU/WebGPU/BindGroup.h
@@ -76,6 +76,7 @@ public:
 
     Device& device() const { return m_device; }
     static bool allowedUsage(const OptionSet<BindGroupEntryUsage>&);
+    static NSString* usageName(const OptionSet<BindGroupEntryUsage>&);
     static uint64_t makeEntryMapKey(uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect);
 
     const BindGroupLayout* bindGroupLayout() const;

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1185,9 +1185,37 @@ bool BindGroup::allowedUsage(const OptionSet<BindGroupEntryUsage>& allowedUsage)
     return true;
 }
 
-uint64_t BindGroup::makeEntryMapKey(uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect)
+NSString* BindGroup::usageName(const OptionSet<BindGroupEntryUsage>& allowedUsage)
 {
-    return static_cast<uint64_t>(baseMipLevel) | (32 << static_cast<uint64_t>(baseArrayLayer));
+    NSString* result = @"";
+    if (allowedUsage & BindGroupEntryUsage::Input)
+        result = [result stringByAppendingString:@"Input "];
+    if (allowedUsage & BindGroupEntryUsage::Constant)
+        result = [result stringByAppendingString:@"Constant "];
+    if (allowedUsage & BindGroupEntryUsage::Storage)
+        result = [result stringByAppendingString:@"Storage "];
+    if (allowedUsage & BindGroupEntryUsage::StorageRead)
+        result = [result stringByAppendingString:@"StorageRead "];
+    if (allowedUsage & BindGroupEntryUsage::Attachment)
+        result = [result stringByAppendingString:@"Attachment "];
+    if (allowedUsage & BindGroupEntryUsage::AttachmentRead)
+        result = [result stringByAppendingString:@"AttachmentRead "];
+    if (allowedUsage & BindGroupEntryUsage::ConstantTexture)
+        result = [result stringByAppendingString:@"ConstantTexture "];
+    if (allowedUsage & BindGroupEntryUsage::StorageTextureWriteOnly)
+        result = [result stringByAppendingString:@"StorageTextureWriteOnly "];
+    if (allowedUsage & BindGroupEntryUsage::StorageTextureRead)
+        result = [result stringByAppendingString:@"StorageTextureRead "];
+    if (allowedUsage & BindGroupEntryUsage::StorageTextureReadWrite)
+        result = [result stringByAppendingString:@"StorageTextureReadWrite "];
+
+    return result;
+}
+
+uint64_t BindGroup::makeEntryMapKey(uint32_t baseMipLevel, uint32_t baseArrayLayer, WGPUTextureAspect aspect)
+{
+    RELEASE_ASSERT(aspect);
+    return (static_cast<uint64_t>(aspect) - 1) | (static_cast<uint64_t>(baseMipLevel) << 1) | (static_cast<uint64_t>(baseArrayLayer) << 32);
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -514,9 +514,9 @@ NSString* BindGroupLayout::errorValidatingBindGroupCompatibility(const BindGroup
     auto& entries = m_sortedEntries;
     auto& otherEntries = otherLayout.sortedEntries();
     if (entries.size() != otherEntries.size())
-        return @"entries size mismatch";
+        return [NSString stringWithFormat:@"entries.size()(%zu) > otherEntries.size()(%zu)", entries.size(), otherEntries.size()];
 
-    auto entryCount = otherEntries.size();
+    auto entryCount = entries.size();
     for (size_t i = 0; i < entryCount; ++i) {
         const auto* entry = entries[i];
         const auto* otherEntry = otherEntries[i];

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -255,10 +255,10 @@ const Vector<uint32_t>* PipelineLayout::computeOffsets(uint32_t bindGroupIndex, 
 
 NSString* PipelineLayout::errorValidatingBindGroupCompatibility(const PipelineLayout::BindGroupHashMap& bindGroups, size_t vertexStageInBufferCount) const
 {
-    auto setBindGroupsSize = bindGroups.size();
     if (!m_bindGroupLayouts)
-        return (!setBindGroupsSize && !vertexStageInBufferCount) ? nil : @"bind groups were set but layout has no bind groups";
+        return nil;
 
+    auto setBindGroupsSize = bindGroups.size();
     auto& bindGroupLayouts = *m_bindGroupLayouts;
     auto numberOfBindGroupsInPipeline = bindGroupLayouts.size();
     if (setBindGroupsSize + vertexStageInBufferCount < numberOfBindGroupsInPipeline) {

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -223,7 +223,7 @@ void RenderBundleEncoder::addResource(RenderBundle::ResourcesContainer* resource
         if (resource.renderStages && mtlResource)
             [m_renderPassEncoder->renderCommandEncoder() useResource:mtlResource usage:resource.usage stages:resource.renderStages];
         ASSERT(resource.entryUsage.hasExactlyOneBitSet());
-        m_renderPassEncoder->addResourceToActiveResources(mtlResource, *resource.entryUsage.toSingleValue());
+        m_renderPassEncoder->addResourceToActiveResources(resource.resource, mtlResource, resource.entryUsage);
         m_renderPassEncoder->setCommandEncoder(resource.resource);
         return;
     }
@@ -233,7 +233,6 @@ void RenderBundleEncoder::addResource(RenderBundle::ResourcesContainer* resource
         existingResource.renderStages |= resource.renderStages;
         existingResource.entryUsage |= resource.entryUsage;
         existingResource.binding = resource.binding;
-        // !! assert resource is the same
     } else
         [resources setObject:resource forKey:mtlResource];
 }

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -95,9 +95,9 @@ public:
     bool colorDepthStencilTargetsMatch(const RenderPipeline&) const;
     id<MTLRenderCommandEncoder> renderCommandEncoder() const;
     void makeInvalid(NSString* = nil);
-    void addResourceToActiveResources(id<MTLResource>, OptionSet<BindGroupEntryUsage>, uint32_t baseMipLevel = 0, uint32_t baseArrayLayer = 0, WGPUTextureAspect = WGPUTextureAspect_All);
     CommandEncoder& parentEncoder();
     void setCommandEncoder(const BindGroupEntryUsageData::Resource&);
+    void addResourceToActiveResources(const BindGroupEntryUsageData::Resource&, id<MTLResource>, OptionSet<BindGroupEntryUsage>);
 
 private:
     RenderPassEncoder(id<MTLRenderCommandEncoder>, const WGPURenderPassDescriptor&, NSUInteger, bool depthReadOnly, bool stencilReadOnly, CommandEncoder&, id<MTLBuffer>, uint64_t maxDrawCount, Device&);
@@ -107,7 +107,10 @@ private:
     bool executePreDrawCommands(id<MTLBuffer> = nil);
     bool runIndexBufferValidation(uint32_t firstInstance, uint32_t instanceCount);
     void runVertexBufferValidation(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
-    void addResourceToActiveResources(const TextureView&, BindGroupEntryUsage);
+    void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>);
+    void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>, WGPUTextureAspect);
+    void addResourceToActiveResources(id<MTLResource>, OptionSet<BindGroupEntryUsage>, uint32_t baseMipLevel = 0, uint32_t baseArrayLayer = 0, WGPUTextureAspect = WGPUTextureAspect_DepthOnly);
+
     NSString* errorValidatingAndBindingBuffers();
     NSString* errorValidatingDrawIndexed() const;
     uint32_t maxVertexBufferIndex() const;
@@ -143,7 +146,7 @@ private:
     Ref<CommandEncoder> m_parentEncoder;
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
     using EntryUsage = OptionSet<BindGroupEntryUsage>;
-    using EntryMap = HashMap<uint64_t, EntryUsage>;
+    using EntryMap = HashMap<uint64_t, EntryUsage, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
     HashMap<void*, EntryMap> m_usagesForResource;
     float m_minDepth { 0.f };
     float m_maxDepth { 1.f };

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -775,7 +775,7 @@ static WGPUTextureFormat convertFormat(WGSL::TexelFormat format)
 
 NSString* Device::addPipelineLayouts(Vector<Vector<WGPUBindGroupLayoutEntry>>& pipelineEntries, const std::optional<WGSL::PipelineLayout>& optionalPipelineLayout)
 {
-    if (!optionalPipelineLayout)
+    if (!optionalPipelineLayout || !optionalPipelineLayout->bindGroupLayouts.size())
         return nil;
 
     auto &pipelineLayout = *optionalPipelineLayout;


### PR DESCRIPTION
#### 5bd85931929484b4b380d78cd318f9b589c7abf9
<pre>
[WebGPU] Resource usage compatibliity does not consider the texture aspect
<a href="https://bugs.webkit.org/show_bug.cgi?id=269044">https://bugs.webkit.org/show_bug.cgi?id=269044</a>
&lt;radar://122602154&gt;

Reviewed by Tadeu Zagallo.

When computing a &quot;compatible usage list&quot; per
<a href="https://www.w3.org/TR/webgpu/#compatible-usage-list">https://www.w3.org/TR/webgpu/#compatible-usage-list</a>
we must consider the texture aspect per
<a href="https://www.w3.org/TR/webgpu/#texture-subresources">https://www.w3.org/TR/webgpu/#texture-subresources</a>
and not only consider the array layer and mip level.

* Source/WebGPU/WebGPU/BindGroup.h:
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::BindGroup::usageName):
(WebGPU::BindGroup::makeEntryMapKey):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::BindGroupLayout::errorValidatingBindGroupCompatibility const):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::addResourceToActiveResources):
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::errorValidatingBindGroupCompatibility const):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::addResource):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::RenderPassEncoder::addResourceToActiveResources):
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::addPipelineLayouts):

Canonical link: <a href="https://commits.webkit.org/274518@main">https://commits.webkit.org/274518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94ccf0c79a783cf227e7c6478d6fb8b5bc5e7f29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41875 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15649 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15410 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13392 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35349 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37402 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8795 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->