### PR TITLE
Update m_valueIfDirty when parser initializes InputType

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2549,15 +2549,14 @@ void Element::parserSetAttributes(std::span<const Attribute> attributes)
 
     }
 
-    parserDidSetAttributes();
+    parserDidSetAttributes(attributes);
+}
 
+void Element::parserDidSetAttributes(std::span<const Attribute> attributes)
+{
     // Use attributes instead of m_elementData because attributeChanged might modify m_elementData.
     for (const auto& attribute : attributes)
         notifyAttributeChanged(attribute.name(), nullAtom(), attribute.value(), AttributeModificationReason::Directly);
-}
-
-void Element::parserDidSetAttributes()
-{
 }
 
 void Element::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -776,7 +776,7 @@ protected:
     void removedFromAncestor(RemovalType, ContainerNode&) override;
     void childrenChanged(const ChildChange&) override;
     void removeAllEventListeners() override;
-    virtual void parserDidSetAttributes();
+    virtual void parserDidSetAttributes(std::span<const Attribute>);
 
     void setTabIndexExplicitly(std::optional<int>);
 
@@ -796,6 +796,8 @@ protected:
     void ensureFormAssociatedCustomElement();
 
     static AtomString makeTargetBlankIfHasDanglingMarkup(const AtomString& target);
+
+    void notifyAttributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly);
 
 private:
     LocalFrame* documentFrameWithNonNullView() const;
@@ -841,7 +843,6 @@ private:
 
     bool childTypeAllowed(NodeType) const final;
 
-    void notifyAttributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly);
     enum class InSynchronizationOfLazyAttribute : bool { No, Yes };
     void setAttributeInternal(unsigned index, const QualifiedName&, const AtomString& value, InSynchronizationOfLazyAttribute);
     void addAttributeInternal(const QualifiedName&, const AtomString& value, InSynchronizationOfLazyAttribute);

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -389,7 +389,7 @@ private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
-    void parserDidSetAttributes() final;
+    void parserDidSetAttributes(std::span<const Attribute>) final;
 
     void copyNonAttributePropertiesFromElement(const Element&) final;
 


### PR DESCRIPTION
#### f1b70f3bfb9d3c48179d88e147aecc45d8253374
<pre>
Update m_valueIfDirty when parser initializes InputType
<a href="https://bugs.webkit.org/show_bug.cgi?id=269045">https://bugs.webkit.org/show_bug.cgi?id=269045</a>
<a href="https://rdar.apple.com/122602737">rdar://122602737</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::parserSetAttributes):
(WebCore::Element::parserDidSetAttributes):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::initializeInputType):
(WebCore::HTMLInputElement::parserDidSetAttributes):
* Source/WebCore/html/HTMLInputElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1b70f3bfb9d3c48179d88e147aecc45d8253374

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15096 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32540 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-value-interactions.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12936 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34576 "Found 5 new test failures: fast/forms/fieldset-pseudo-valid-style.html, fast/forms/form-pseudo-valid-style.html, fast/forms/input-text-maxlength.html, fast/forms/input-value.html, imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-value-interactions.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42623 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35229 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34937 "Found 5 new test failures: fast/forms/fieldset-pseudo-valid-style.html, fast/forms/form-pseudo-valid-style.html, fast/forms/input-text-maxlength.html, fast/forms/input-value.html, imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-value-interactions.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38771 "Found 5 new test failures: fast/forms/fieldset-pseudo-valid-style.html, fast/forms/form-pseudo-valid-style.html, fast/forms/input-text-maxlength.html, fast/forms/input-value.html, imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-value-interactions.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13626 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11240 "Found 5 new test failures: fast/forms/fieldset-pseudo-valid-style.html, fast/forms/form-pseudo-valid-style.html, fast/forms/input-text-maxlength.html, fast/forms/input-value.html, imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection-value-interactions.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36989 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14902 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->