### PR TITLE
Connect body to the document before invoking tryFastParsingHTMLFragment

### DIFF
--- a/LayoutTests/fast/dom/dom-parser-head-body-order-expected.txt
+++ b/LayoutTests/fast/dom/dom-parser-head-body-order-expected.txt
@@ -1,0 +1,11 @@
+This tests that head appears before body in the result of (new DOMParser).parseFromString
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS doc.documentElement.children[0] is doc.head
+PASS doc.documentElement.children[1] is doc.body
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/dom-parser-head-body-order.html
+++ b/LayoutTests/fast/dom/dom-parser-head-body-order.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description('This tests that head appears before body in the result of (new DOMParser).parseFromString');
+doc = (new DOMParser).parseFromString('', 'text/html');
+shouldBe('doc.documentElement.children[0]', 'doc.head');
+shouldBe('doc.documentElement.children[1]', 'doc.body');
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -687,8 +687,12 @@ private:
             if (parsingFailed())
                 return;
 
-            if (!text.isNull())
-                parent.parserAppendChildIntoIsolatedTree(Text::create(m_document.get(), WTFMove(text)));
+            if (!text.isNull()) {
+                if (!parent.isConnected())
+                    parent.parserAppendChildIntoIsolatedTree(Text::create(m_document.get(), WTFMove(text)));
+                else
+                    parent.parserAppendChild(Text::create(m_document.get(), WTFMove(text)));
+            }
 
             if (m_parsingBuffer.atEnd())
                 return;
@@ -839,7 +843,10 @@ private:
         parseAttributes(element);
         if (parsingFailed())
             return WTFMove(element);
-        parent.parserAppendChildIntoIsolatedTree(element);
+        if (!parent.isConnected())
+            parent.parserAppendChildIntoIsolatedTree(element);
+        else
+            parent.parserAppendChild(element);
         element->beginParsingChildren();
         parseChildren<Tag>(element);
         if (parsingFailed() || m_parsingBuffer.atEnd())
@@ -868,7 +875,10 @@ private:
         parseAttributes(element);
         if (parsingFailed())
             return WTFMove(element);
-        parent.parserAppendChildIntoIsolatedTree(element);
+        if (!parent.isConnected())
+            parent.parserAppendChildIntoIsolatedTree(element);
+        else
+            parent.parserAppendChild(element);
         element->beginParsingChildren();
         element->finishParsingChildren();
         return WTFMove(element);


### PR DESCRIPTION
#### 2652615cd5bdb8e30000c71c384336f0250bbc39
<pre>
Connect body to the document before invoking tryFastParsingHTMLFragment
<a href="https://bugs.webkit.org/show_bug.cgi?id=269047">https://bugs.webkit.org/show_bug.cgi?id=269047</a>

Reviewed by Anne van Kesteren and Yusuke Suzuki.

Connect the body element to the document before invoking tryFastParsingHTMLFragment
in Document::setMarkupUnsafe to avoid the secondary insertedIntoAncestor call.

We need to disable coalescing of childrenChanged in this case because we need to call
didFinishInsertingNode on some of the newly connected nodes.

Also added a regression test for a bug that was not caught during the development.

* LayoutTests/fast/dom/dom-parser-head-body-order-expected.txt: Added.
* LayoutTests/fast/dom/dom-parser-head-body-order.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setMarkupUnsafe):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseChildren):
(WebCore::HTMLFastPathParser::parseContainerElement):
(WebCore::HTMLFastPathParser::parseVoidElement):

Canonical link: <a href="https://commits.webkit.org/274429@main">https://commits.webkit.org/274429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9063377127725ef61ef709c09d9d0c7a34dbe3cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32675 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35452 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38943 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37171 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34059 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15125 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5106 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->