### PR TITLE
Adopt more smart pointers in WebCore/page

### DIFF
--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -60,6 +60,10 @@ public:
     void releaseCapture();
     void removeSpinButtonOwner() { m_spinButtonOwner = nullptr; }
 
+    using HTMLDivElement::weakPtrFactory;
+    using HTMLDivElement::WeakValueType;
+    using HTMLDivElement::WeakPtrImplType;
+
     void step(int amount);
     
     bool willRespondToMouseMoveEvents() const override;

--- a/Source/WebCore/page/BarProp.cpp
+++ b/Source/WebCore/page/BarProp.cpp
@@ -54,7 +54,7 @@ bool BarProp::visible() const
     auto* frame = this->frame();
     if (!frame)
         return false;
-    auto* page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return false;
 

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -104,7 +104,7 @@ void CaptionUserPreferences::setCaptionDisplayMode(CaptionUserPreferences::Capti
 
 Page* CaptionUserPreferences::currentPage() const
 {
-    for (auto& page : m_pageGroup.pages())
+    for (auto& page : m_pageGroup->pages())
         return &page;
     return nullptr;
 }
@@ -120,7 +120,7 @@ bool CaptionUserPreferences::userPrefersCaptions() const
 
 void CaptionUserPreferences::setUserPrefersCaptions(bool preference)
 {
-    auto* page = currentPage();
+    RefPtr page = currentPage();
     if (!page)
         return;
 
@@ -130,7 +130,7 @@ void CaptionUserPreferences::setUserPrefersCaptions(bool preference)
 
 bool CaptionUserPreferences::userPrefersSubtitles() const
 {
-    auto* page = currentPage();
+    RefPtr page = currentPage();
     if (!page)
         return false;
 
@@ -139,7 +139,7 @@ bool CaptionUserPreferences::userPrefersSubtitles() const
 
 void CaptionUserPreferences::setUserPrefersSubtitles(bool preference)
 {
-    auto* page = currentPage();
+    RefPtr page = currentPage();
     if (!page)
         return;
 
@@ -149,7 +149,7 @@ void CaptionUserPreferences::setUserPrefersSubtitles(bool preference)
 
 bool CaptionUserPreferences::userPrefersTextDescriptions() const
 {
-    auto* page = currentPage();
+    RefPtr page = currentPage();
     if (!page)
         return false;
 
@@ -159,7 +159,7 @@ bool CaptionUserPreferences::userPrefersTextDescriptions() const
 
 void CaptionUserPreferences::setUserPrefersTextDescriptions(bool preference)
 {
-    auto* page = currentPage();
+    RefPtr page = currentPage();
     if (!page)
         return;
     
@@ -169,7 +169,7 @@ void CaptionUserPreferences::setUserPrefersTextDescriptions(bool preference)
 
 void CaptionUserPreferences::captionPreferencesChanged()
 {
-    m_pageGroup.captionPreferencesChanged();
+    m_pageGroup->captionPreferencesChanged();
 }
 
 Vector<String> CaptionUserPreferences::preferredLanguages() const
@@ -437,8 +437,8 @@ void CaptionUserPreferences::setCaptionsStyleSheetOverride(const String& overrid
 void CaptionUserPreferences::updateCaptionStyleSheetOverride()
 {
     String captionsOverrideStyleSheet = captionsStyleSheetOverride();
-    for (auto& page : m_pageGroup.pages())
-        page.setCaptionUserPreferencesStyleSheet(captionsOverrideStyleSheet);
+    for (Ref page : m_pageGroup->pages())
+        page->setCaptionUserPreferencesStyleSheet(captionsOverrideStyleSheet);
 }
 
 String CaptionUserPreferences::primaryAudioTrackLanguageOverride() const
@@ -447,7 +447,12 @@ String CaptionUserPreferences::primaryAudioTrackLanguageOverride() const
         return m_primaryAudioTrackLanguageOverride;
     return defaultLanguage(ShouldMinimizeLanguages::No);
 }
-    
+
+PageGroup& CaptionUserPreferences::pageGroup() const
+{
+    return m_pageGroup.get();
 }
+
+} // namespace WebCore
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -106,7 +106,7 @@ public:
     friend class CaptionUserPreferencesTestingModeToken;
     UniqueRef<CaptionUserPreferencesTestingModeToken> createTestingModeToken() { return makeUniqueRef<CaptionUserPreferencesTestingModeToken>(*this); }
     
-    PageGroup& pageGroup() const { return m_pageGroup; }
+    PageGroup& pageGroup() const;
 
 protected:
     explicit CaptionUserPreferences(PageGroup&);
@@ -128,7 +128,7 @@ private:
     void notify();
     Page* currentPage() const;
 
-    PageGroup& m_pageGroup;
+    WeakRef<PageGroup> m_pageGroup;
     mutable CaptionDisplayMode m_displayMode;
     Timer m_timer;
     String m_userPreferredLanguage;

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -109,7 +109,7 @@ private:
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK) && PLATFORM(COCOA)
     static RetainPtr<WebCaptionUserPreferencesMediaAFWeakObserver> createWeakObserver(CaptionUserPreferencesMediaAF*);
 
-    RetainPtr<WebCaptionUserPreferencesMediaAFWeakObserver> m_weakObserver;
+    RetainPtr<WebCaptionUserPreferencesMediaAFWeakObserver> m_observer;
 #endif
 
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -28,6 +28,7 @@
 #include "ContactInfo.h"
 #include "ContactsRequestData.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "DocumentType.h"
 #include "FaceDetectorInterface.h"
 #include "FileList.h"
@@ -86,6 +87,11 @@ Chrome::~Chrome()
     m_client->chromeDestroyed();
 }
 
+Ref<Page> Chrome::protectedPage() const
+{
+    return m_page.get();
+}
+
 void Chrome::invalidateRootView(const IntRect& updateRect)
 {
     m_client->invalidateRootView(updateRect);
@@ -104,7 +110,7 @@ void Chrome::invalidateContentsForSlowScroll(const IntRect& updateRect)
 void Chrome::scroll(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect)
 {
     m_client->scroll(scrollDelta, rectToScroll, clipRect);
-    InspectorInstrumentation::didScroll(m_page);
+    InspectorInstrumentation::didScroll(protectedPage());
 }
 
 IntPoint Chrome::screenToRootView(const IntPoint& point) const
@@ -199,14 +205,16 @@ void Chrome::focusedFrameChanged(Frame* frame)
     m_client->focusedFrameChanged(frame);
 }
 
-Page* Chrome::createWindow(LocalFrame& frame, const WindowFeatures& features, const NavigationAction& action)
+RefPtr<Page> Chrome::createWindow(LocalFrame& frame, const WindowFeatures& features, const NavigationAction& action)
 {
-    Page* newPage = m_client->createWindow(frame, features, action);
+    RefPtr newPage = m_client->createWindow(frame, features, action);
     if (!newPage)
         return nullptr;
 
-    if (!features.wantsNoOpener())
-        m_page.storageNamespaceProvider().copySessionStorageNamespace(m_page, *newPage);
+    if (!features.wantsNoOpener()) {
+        Ref page = m_page.get();
+        page->protectedStorageNamespaceProvider()->copySessionStorageNamespace(page, *newPage);
+    }
 
     return newPage;
 }
@@ -230,7 +238,7 @@ void Chrome::runModal()
     // JavaScript that runs within the nested event loop must not be run in the context of the
     // script that called showModalDialog. Null out entryScope to break the connection.
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)
         return;
 
@@ -320,7 +328,7 @@ bool Chrome::runJavaScriptConfirm(LocalFrame& frame, const String& message)
 {
     // Defer loads in case the client method runs a new event loop that would
     // otherwise cause the load to continue while we're in the middle of executing JavaScript.
-    PageGroupLoadDeferrer deferrer(m_page, true);
+    PageGroupLoadDeferrer deferrer(protectedPage(), true);
 
     notifyPopupOpeningObservers();
     return m_client->runJavaScriptConfirm(frame, frame.displayStringModifiedByEncoding(message));
@@ -330,7 +338,7 @@ bool Chrome::runJavaScriptPrompt(LocalFrame& frame, const String& prompt, const 
 {
     // Defer loads in case the client method runs a new event loop that would
     // otherwise cause the load to continue while we're in the middle of executing JavaScript.
-    PageGroupLoadDeferrer deferrer(m_page, true);
+    PageGroupLoadDeferrer deferrer(protectedPage(), true);
 
     notifyPopupOpeningObservers();
     String displayPrompt = frame.displayStringModifiedByEncoding(prompt);
@@ -349,19 +357,19 @@ void Chrome::setStatusbarText(LocalFrame& frame, const String& status)
 
 void Chrome::mouseDidMoveOverElement(const HitTestResult& result, OptionSet<PlatformEventModifier> modifiers)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)
         return;
 
     if (result.innerNode() && result.innerNode()->document().isDNSPrefetchEnabled())
-        localMainFrame->loader().client().prefetchDNS(result.absoluteLinkURL().host().toString());
+        localMainFrame->checkedLoader()->client().prefetchDNS(result.absoluteLinkURL().host().toString());
 
     String toolTip;
     TextDirection toolTipDirection;
     getToolTip(result, toolTip, toolTipDirection);
     m_client->mouseDidMoveOverElement(result, modifiers, toolTip, toolTipDirection);
 
-    InspectorInstrumentation::mouseDidMoveOverElement(m_page, result, modifiers);
+    InspectorInstrumentation::mouseDidMoveOverElement(protectedPage(), result, modifiers);
 }
 
 void Chrome::getToolTip(const HitTestResult& result, String& toolTip, TextDirection& toolTipDirection)
@@ -370,7 +378,7 @@ void Chrome::getToolTip(const HitTestResult& result, String& toolTip, TextDirect
     toolTip = result.spellingToolTip(toolTipDirection);
 
     // Next priority is a toolTip from a URL beneath the mouse (if preference is set to show those).
-    if (toolTip.isEmpty() && m_page.settings().showsURLsInToolTips()) {
+    if (toolTip.isEmpty() && m_page->settings().showsURLsInToolTips()) {
         if (RefPtr element = result.innerNonSharedElement()) {
             // Get tooltip representing form action, if relevant
             if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element)) {
@@ -399,7 +407,7 @@ void Chrome::getToolTip(const HitTestResult& result, String& toolTip, TextDirect
     if (toolTip.isEmpty())
         toolTip = result.title(toolTipDirection);
 
-    if (toolTip.isEmpty() && m_page.settings().showsToolTipOverTruncatedText())
+    if (toolTip.isEmpty() && m_page->settings().showsToolTipOverTruncatedText())
         toolTip = result.innerTextIfTruncated(toolTipDirection);
 
     // Lastly, for <input type="file"> that allow multiple files, we'll consider a tooltip for the selected filenames
@@ -424,7 +432,7 @@ bool Chrome::print(LocalFrame& frame)
     // FIXME: This should have PageGroupLoadDeferrer, like runModal() or runJavaScriptAlert(), because it's no different from those.
 
     if (frame.document()->isSandboxed(SandboxModals)) {
-        frame.document()->domWindow()->printErrorMessage("Use of window.print is not allowed in a sandboxed frame when the allow-modals flag is not set."_s);
+        frame.document()->protectedWindow()->printErrorMessage("Use of window.print is not allowed in a sandboxed frame when the allow-modals flag is not set."_s);
         return false;
     }
 
@@ -600,12 +608,12 @@ RefPtr<ShapeDetection::TextDetector> Chrome::createTextDetector() const
 
 PlatformDisplayID Chrome::displayID() const
 {
-    return m_page.displayID();
+    return m_page->displayID();
 }
 
 void Chrome::windowScreenDidChange(PlatformDisplayID displayID, std::optional<FramesPerSecond> nominalFrameInterval)
 {
-    m_page.windowScreenDidChange(displayID, nominalFrameInterval);
+    protectedPage()->windowScreenDidChange(displayID, nominalFrameInterval);
 }
 
 bool Chrome::selectItemWritingDirectionIsNatural()
@@ -650,18 +658,18 @@ void Chrome::didReceiveDocType(LocalFrame& frame)
 
 void Chrome::registerPopupOpeningObserver(PopupOpeningObserver& observer)
 {
-    m_popupOpeningObservers.append(&observer);
+    m_popupOpeningObservers.append(observer);
 }
 
 void Chrome::unregisterPopupOpeningObserver(PopupOpeningObserver& observer)
 {
-    bool removed = m_popupOpeningObservers.removeFirst(&observer);
+    bool removed = m_popupOpeningObservers.removeFirst(WeakPtr { observer });
     ASSERT_UNUSED(removed, removed);
 }
 
 void Chrome::notifyPopupOpeningObservers() const
 {
-    const Vector<PopupOpeningObserver*> observers(m_popupOpeningObservers);
+    auto observers = m_popupOpeningObservers;
     for (auto& observer : observers)
         observer->willOpenPopup();
 }

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -152,7 +152,7 @@ public:
     void focusedElementChanged(Element*);
     void focusedFrameChanged(Frame*);
 
-    WEBCORE_EXPORT Page* createWindow(LocalFrame&, const WindowFeatures&, const NavigationAction&);
+    WEBCORE_EXPORT RefPtr<Page> createWindow(LocalFrame&, const WindowFeatures&, const NavigationAction&);
     WEBCORE_EXPORT void show();
 
     bool canRunModal() const;
@@ -240,11 +240,11 @@ public:
 
 private:
     void notifyPopupOpeningObservers() const;
+    Ref<Page> protectedPage() const;
 
-    Page& m_page;
+    SingleThreadWeakRef<Page> m_page;
     UniqueRef<ChromeClient> m_client;
-    // FIXME: This should be WeakPtr<PopupOpeningObserver>.
-    Vector<PopupOpeningObserver*> m_popupOpeningObservers;
+    Vector<WeakPtr<PopupOpeningObserver>> m_popupOpeningObservers;
 #if PLATFORM(IOS_FAMILY)
     bool m_isDispatchViewportDataDidChangeSuppressed { false };
 #endif

--- a/Source/WebCore/page/ContextMenuContext.cpp
+++ b/Source/WebCore/page/ContextMenuContext.cpp
@@ -38,10 +38,10 @@ ContextMenuContext::~ContextMenuContext() = default;
 
 ContextMenuContext& ContextMenuContext::operator=(const ContextMenuContext&) = default;
 
-ContextMenuContext::ContextMenuContext(Type type, const HitTestResult& hitTestResult, Event* event)
+ContextMenuContext::ContextMenuContext(Type type, const HitTestResult& hitTestResult, RefPtr<Event>&& event)
     : m_type(type)
     , m_hitTestResult(hitTestResult)
-    , m_event(event)
+    , m_event(WTFMove(event))
     , m_hasEntireImage(hitTestResult.hasEntireImage())
 {
 }

--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -50,7 +50,7 @@ public:
     using Type = ContextMenuContextType;
 
     ContextMenuContext();
-    ContextMenuContext(Type, const HitTestResult&, Event*);
+    ContextMenuContext(Type, const HitTestResult&, RefPtr<Event>&&);
 
     ~ContextMenuContext();
 

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -32,6 +32,7 @@
 #include "HitTestRequest.h"
 #include <wtf/OptionSet.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -47,7 +48,7 @@ public:
     ContextMenuController(Page&, UniqueRef<ContextMenuClient>&&);
     ~ContextMenuController();
 
-    Page& page() { return m_page; }
+    Page& page();
     ContextMenuClient& client() { return m_client.get(); }
 
     ContextMenu* contextMenu() const { return m_contextMenu.get(); }
@@ -97,7 +98,7 @@ private:
     void performPDFJSAction(LocalFrame&, const String& action);
 #endif
 
-    Page& m_page;
+    SingleThreadWeakRef<Page> m_page;
     UniqueRef<ContextMenuClient> m_client;
     std::unique_ptr<ContextMenu> m_contextMenu;
     RefPtr<ContextMenuProvider> m_menuProvider;

--- a/Source/WebCore/page/PopupOpeningObserver.h
+++ b/Source/WebCore/page/PopupOpeningObserver.h
@@ -25,9 +25,11 @@
 
 #pragma once
 
+#include <wtf/WeakPtr.h>
+
 namespace WebCore {
 
-class PopupOpeningObserver {
+class PopupOpeningObserver : public CanMakeWeakPtr<PopupOpeningObserver> {
 public:
     virtual void willOpenPopup() = 0;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -876,15 +876,11 @@ LocalFrame* WebLocalFrameLoaderClient::dispatchCreatePage(const NavigationAction
     // Just call through to the chrome client.
     WindowFeatures windowFeatures;
     windowFeatures.noopener = newFrameOpenerPolicy == NewFrameOpenerPolicy::Suppress;
-    Page* newPage = webPage->corePage()->chrome().createWindow(*m_frame->coreLocalFrame(), windowFeatures, navigationAction);
+    RefPtr newPage = webPage->corePage()->chrome().createWindow(*m_frame->coreLocalFrame(), windowFeatures, navigationAction);
     if (!newPage)
         return nullptr;
     
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(newPage->mainFrame());
-    if (!localMainFrame)
-        return nullptr;
-
-    return localMainFrame;
+    return dynamicDowncast<LocalFrame>(newPage->mainFrame());
 }
 
 void WebLocalFrameLoaderClient::dispatchShow()


### PR DESCRIPTION
#### c66e393c17cab05d2b5b7b0f4fc928b1808b144d
<pre>
Adopt more smart pointers in WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=269048">https://bugs.webkit.org/show_bug.cgi?id=269048</a>

Reviewed by Darin Adler.

* Source/WebCore/html/shadow/SpinButtonElement.h:
* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::stopAutoscrollTimer):
(WebCore::AutoscrollController::updateAutoscrollRenderer):
(WebCore::AutoscrollController::updateDragAndDrop):
(WebCore::AutoscrollController::startPanScrolling):
(WebCore::AutoscrollController::autoscrollTimerFired):
* Source/WebCore/page/BarProp.cpp:
(WebCore::BarProp::visible const):
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::currentPage const):
(WebCore::CaptionUserPreferences::setUserPrefersCaptions):
(WebCore::CaptionUserPreferences::userPrefersSubtitles const):
(WebCore::CaptionUserPreferences::setUserPrefersSubtitles):
(WebCore::CaptionUserPreferences::userPrefersTextDescriptions const):
(WebCore::CaptionUserPreferences::setUserPrefersTextDescriptions):
(WebCore::CaptionUserPreferences::captionPreferencesChanged):
(WebCore::CaptionUserPreferences::updateCaptionStyleSheetOverride):
(WebCore::CaptionUserPreferences::pageGroup const):
* Source/WebCore/page/CaptionUserPreferences.h:
(WebCore::CaptionUserPreferences::pageGroup const): Deleted.
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::~CaptionUserPreferencesMediaAF):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersCaptions const):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersSubtitles const):
(WebCore::CaptionUserPreferencesMediaAF::userPrefersTextDescriptions const):
(WebCore::CaptionUserPreferencesMediaAF::setInterestedInCaptionPreferenceChanges):
(WebCore::CaptionUserPreferencesMediaAF::captionsWindowCSS const):
(WebCore::CaptionUserPreferencesMediaAF::captionsBackgroundCSS const):
(WebCore::CaptionUserPreferencesMediaAF::captionsTextColor const):
(WebCore::CaptionUserPreferencesMediaAF::captionStrokeWidthForFont const):
(WebCore::CaptionUserPreferencesMediaAF::captionsDefaultFontCSS const):
(WebCore::CaptionUserPreferencesMediaAF::platformPreferredLanguages):
(WebCore::CaptionUserPreferencesMediaAF::preferredAudioCharacteristics const):
(WebCore::trackDisplayName):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::protectedPage const):
(WebCore::Chrome::scroll):
(WebCore::Chrome::createWindow):
(WebCore::Chrome::runModal):
(WebCore::Chrome::runJavaScriptConfirm):
(WebCore::Chrome::runJavaScriptPrompt):
(WebCore::Chrome::mouseDidMoveOverElement):
(WebCore::Chrome::getToolTip):
(WebCore::Chrome::print):
(WebCore::Chrome::displayID const):
(WebCore::Chrome::windowScreenDidChange):
(WebCore::Chrome::registerPopupOpeningObserver):
(WebCore::Chrome::unregisterPopupOpeningObserver):
(WebCore::Chrome::notifyPopupOpeningObservers const):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ContextMenuContext.cpp:
(WebCore::ContextMenuContext::ContextMenuContext):
* Source/WebCore/page/ContextMenuContext.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::page):
(WebCore::ContextMenuController::clearContextMenu):
(WebCore::prepareContextForQRCode):
(WebCore::ContextMenuController::maybeCreateContextMenu):
(WebCore::ContextMenuController::showContextMenu):
(WebCore::ContextMenuController::didDismissContextMenu):
(WebCore::openNewWindow):
(WebCore::insertUnicodeCharacter):
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::addDebuggingItems):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
(WebCore::ContextMenuController::showContextMenuAt):
(WebCore::ContextMenuController::performPDFJSAction):
* Source/WebCore/page/ContextMenuController.h:
(WebCore::ContextMenuController::page): Deleted.
* Source/WebCore/page/PopupOpeningObserver.h:

Canonical link: <a href="https://commits.webkit.org/274374@main">https://commits.webkit.org/274374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45909cf3c63fdad1d9c00bd3b3ea9c9e7a645bfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41453 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15201 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15022 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13055 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42730 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35321 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13732 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/14998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5074 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->