### PR TITLE
Messages sent to a Web Extension port should not be delivered to itself.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
@@ -129,7 +129,7 @@ void WebExtensionMessagePort::sendMessage(id message, CompletionHandler<void(Err
 
     THROW_UNLESS(isValidJSONObject(message, { JSONOptions::FragmentsAllowed }), @"Message object is not JSON-serializable");
 
-    m_extensionContext->portPostMessage(WebExtensionContentWorldType::Main, m_channelIdentifier, encodeJSONString(message, { JSONOptions::FragmentsAllowed }) );
+    m_extensionContext->portPostMessage(WebExtensionContentWorldType::Main, std::nullopt, m_channelIdentifier, encodeJSONString(message, { JSONOptions::FragmentsAllowed }) );
 
     completionHandler(std::nullopt);
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -168,8 +168,9 @@ public:
     using WebProcessProxySet = HashSet<Ref<WebProcessProxy>>;
 
     using PortWorldPair = std::pair<WebExtensionContentWorldType, WebExtensionPortChannelIdentifier>;
+    using MessagePageProxyIdentifierPair = std::pair<String, std::optional<WebPageProxyIdentifier>>;
     using PortCountedSet = HashCountedSet<PortWorldPair>;
-    using PortQueuedMessageMap = HashMap<PortWorldPair, Vector<String>>;
+    using PortQueuedMessageMap = HashMap<PortWorldPair, Vector<MessagePageProxyIdentifierPair>>;
     using NativePortMap = HashMap<WebExtensionPortChannelIdentifier, Ref<WebExtensionMessagePort>>;
 
     using PageIdentifierTuple = std::tuple<WebCore::PageIdentifier, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>>;
@@ -619,7 +620,7 @@ private:
     void firePermissionsEventListenerIfNecessary(WebExtensionEventListenerType, const PermissionsSet&, const MatchPatternSet&);
 
     // Port APIs
-    void portPostMessage(WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier, const String& messageJSON);
+    void portPostMessage(WebExtensionContentWorldType targetContentWorldType, std::optional<WebKit::WebPageProxyIdentifier>, WebExtensionPortChannelIdentifier, const String& messageJSON);
     void portDisconnect(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier);
     void addPorts(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, size_t totalPortObjects);
     void removePort(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -86,7 +86,7 @@ messages -> WebExtensionContext {
     PermissionsRemove(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
 
     // Port APIs
-    PortPostMessage(WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON);
+    PortPostMessage(WebKit::WebExtensionContentWorldType targetContentWorldType, std::optional<WebKit::WebPageProxyIdentifier> sendingPageProxyIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON);
     PortDisconnect(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier);
 
     // Runtime APIs

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -51,6 +51,8 @@ public:
 
     WebExtensionContentWorldType targetContentWorldType() const { return m_targetContentWorldType; }
     WebExtensionPortChannelIdentifier channelIdentifier() const { return m_channelIdentifier; }
+    WebPageProxyIdentifier owningPageProxyIdentifier() const { return m_owningPageProxyIdentifier; }
+    const std::optional<WebExtensionMessageSenderParameters>& senderParameters() const { return m_senderParameters; }
 
     void postMessage(WebFrame&, NSString *, NSString **outExceptionString);
     void disconnect();
@@ -78,18 +80,20 @@ public:
 private:
     friend class WebExtensionContextProxy;
 
-    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionContentWorldType targetContentWorldType, const String& name)
+    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name)
         : WebExtensionAPIObject(forMainWorld, runtime, context)
         , m_targetContentWorldType(targetContentWorldType)
+        , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
         , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
         , m_name(name)
     {
         add();
     }
 
-    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionContentWorldType targetContentWorldType, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
+    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
         : WebExtensionAPIObject(forMainWorld, runtime, context)
         , m_targetContentWorldType(targetContentWorldType)
+        , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
         , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
         , m_name(name)
         , m_senderParameters(senderParameters)
@@ -97,9 +101,10 @@ private:
         add();
     }
 
-    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
+    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPage& page, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
         : WebExtensionAPIObject(forMainWorld, runtime, context)
         , m_targetContentWorldType(targetContentWorldType)
+        , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
         , m_channelIdentifier(channelIdentifier)
         , m_name(name)
         , m_senderParameters(senderParameters)
@@ -114,6 +119,7 @@ private:
     void fireDisconnectEventIfNeeded();
 
     WebExtensionContentWorldType m_targetContentWorldType;
+    WebPageProxyIdentifier m_owningPageProxyIdentifier;
     WebExtensionPortChannelIdentifier m_channelIdentifier;
     bool m_disconnected { false };
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -148,7 +148,7 @@ private:
     void dispatchPermissionsEvent(WebExtensionEventListenerType, HashSet<String> permissions, HashSet<String> origins);
 
     // Port
-    void dispatchPortMessageEvent(WebExtensionPortChannelIdentifier, const String& messageJSON);
+    void dispatchPortMessageEvent(std::optional<WebKit::WebPageProxyIdentifier>, WebExtensionPortChannelIdentifier, const String& messageJSON);
     void dispatchPortDisconnectEvent(WebExtensionPortChannelIdentifier);
 
     // Runtime

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -51,7 +51,7 @@ messages -> WebExtensionContextProxy {
     DispatchPermissionsEvent(WebKit::WebExtensionEventListenerType type, HashSet<String> permissions, HashSet<String> origins)
 
     // Ports
-    DispatchPortMessageEvent(WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON)
+    DispatchPortMessageEvent(std::optional<WebKit::WebPageProxyIdentifier> sendingPageProxyIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON)
     DispatchPortDisconnectEvent(WebKit::WebExtensionPortChannelIdentifier channelIdentifier)
 
     // Runtime

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -672,36 +672,40 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.runtime.onConnect.addListener((port) => {",
-        @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
-        @"  browser.test.assertEq(port.error, null, 'Port error should be null')",
+        @"browser.runtime?.onConnect.addListener((port) => {",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"  browser.test.assertEq(port?.error, null, 'Port error should be null')",
 
-        @"  browser.test.assertEq(typeof port.sender, 'object', 'sender should be an object')",
-        @"  browser.test.assertEq(typeof port.sender.url, 'string', 'sender.url should be a string')",
-        @"  browser.test.assertEq(typeof port.sender.origin, 'string', 'sender.origin should be a string')",
-        @"  browser.test.assertTrue(port.sender.url.startsWith('http'), 'sender.url should start with http')",
-        @"  browser.test.assertTrue(port.sender.origin.startsWith('http'), 'sender.origin should start with http')",
-        @"  browser.test.assertEq(typeof port.sender.tab, 'object', 'sender.tab should be an object')",
-        @"  browser.test.assertEq(port.sender.frameId, 0, 'sender.frameId should be 0')",
+        @"  browser.test.assertEq(typeof port?.sender, 'object', 'sender should be an object')",
+        @"  browser.test.assertEq(typeof port?.sender?.url, 'string', 'sender.url should be a string')",
+        @"  browser.test.assertEq(typeof port?.sender?.origin, 'string', 'sender.origin should be a string')",
+        @"  browser.test.assertTrue(port?.sender?.url?.startsWith('http'), 'sender.url should start with http')",
+        @"  browser.test.assertTrue(port?.sender?.origin?.startsWith('http'), 'sender.origin should start with http')",
+        @"  browser.test.assertEq(typeof port?.sender?.tab, 'object', 'sender.tab should be an object')",
+        @"  browser.test.assertEq(port?.sender?.frameId, 0, 'sender.frameId should be 0')",
 
-        @"  port.onMessage.addListener((message) => {",
+        @"  port?.onMessage.addListener((message) => {",
         @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content')",
-        @"    port.postMessage('Received')",
+        @"    port?.postMessage('Received')",
         @"  })",
         @"})"
     ]);
 
     auto *contentScript = Util::constructScript(@[
         @"setTimeout(() => {",
-        @"  const port = browser.runtime.connect({ name: 'testPort' })",
-        @"  port.postMessage('Hello')",
+        @"  const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
-        @"  port.onMessage.addListener((response) => {",
+        @"  port?.postMessage('Hello')",
+
+        @"  port?.onMessage.addListener((response) => {",
         @"    browser.test.assertEq(response, 'Received', 'Should get the response from the background script')",
 
         @"    browser.test.notifyPass()",
         @"  })",
-        @"}, 1000);"
+        @"}, 1000)"
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:runtimeContentScriptManifest resources:@{ @"background.js": backgroundScript, @"content.js": contentScript }]);
@@ -721,56 +725,60 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.runtime.onConnect.addListener((port) => {",
-        @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort in first listener')",
-        @"  browser.test.assertEq(port.error, null, 'Port error should be null in first listener')",
+        @"browser.runtime?.onConnect.addListener((port) => {",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort in first listener')",
+        @"  browser.test.assertEq(port?.error, null, 'Port error should be null in first listener')",
 
-        @"  browser.test.assertEq(typeof port.sender, 'object', 'sender should be an object')",
-        @"  browser.test.assertEq(typeof port.sender.url, 'string', 'sender.url should be a string')",
-        @"  browser.test.assertEq(typeof port.sender.origin, 'string', 'sender.origin should be a string')",
-        @"  browser.test.assertTrue(port.sender.url.startsWith('http'), 'sender.url should start with http')",
-        @"  browser.test.assertTrue(port.sender.origin.startsWith('http'), 'sender.origin should start with http')",
-        @"  browser.test.assertEq(typeof port.sender.tab, 'object', 'sender.tab should be an object')",
-        @"  browser.test.assertEq(port.sender.frameId, 0, 'sender.frameId should be 0')",
+        @"  browser.test.assertEq(typeof port?.sender, 'object', 'sender should be an object')",
+        @"  browser.test.assertEq(typeof port?.sender?.url, 'string', 'sender.url should be a string')",
+        @"  browser.test.assertEq(typeof port?.sender?.origin, 'string', 'sender.origin should be a string')",
+        @"  browser.test.assertTrue(port?.sender?.url?.startsWith('http'), 'sender.url should start with http')",
+        @"  browser.test.assertTrue(port?.sender?.origin?.startsWith('http'), 'sender.origin should start with http')",
+        @"  browser.test.assertEq(typeof port?.sender?.tab, 'object', 'sender.tab should be an object')",
+        @"  browser.test.assertEq(port?.sender?.frameId, 0, 'sender.frameId should be 0')",
 
-        @"  port.onMessage.addListener((message) => {",
+        @"  port?.onMessage.addListener((message) => {",
         @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content in first listener')",
-        @"    port.postMessage('Received')",
+        @"    port?.postMessage('Received')",
         @"  })",
         @"})",
 
-        @"browser.runtime.onConnect.addListener((port) => {",
-        @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort in second listener')",
-        @"  browser.test.assertEq(port.error, null, 'Port error should be null in second listener')",
+        @"browser.runtime?.onConnect.addListener((port) => {",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort in second listener')",
+        @"  browser.test.assertEq(port?.error, null, 'Port error should be null in second listener')",
 
-        @"  browser.test.assertEq(typeof port.sender, 'object', 'sender should be an object')",
-        @"  browser.test.assertEq(typeof port.sender.url, 'string', 'sender.url should be a string')",
-        @"  browser.test.assertEq(typeof port.sender.origin, 'string', 'sender.origin should be a string')",
-        @"  browser.test.assertTrue(port.sender.url.startsWith('http'), 'sender.url should start with http')",
-        @"  browser.test.assertTrue(port.sender.origin.startsWith('http'), 'sender.origin should start with http')",
-        @"  browser.test.assertEq(typeof port.sender.tab, 'object', 'sender.tab should be an object')",
-        @"  browser.test.assertEq(port.sender.frameId, 0, 'sender.frameId should be 0')",
+        @"  browser.test.assertEq(typeof port?.sender, 'object', 'sender should be an object')",
+        @"  browser.test.assertEq(typeof port?.sender?.url, 'string', 'sender.url should be a string')",
+        @"  browser.test.assertEq(typeof port?.sender?.origin, 'string', 'sender.origin should be a string')",
+        @"  browser.test.assertTrue(port?.sender?.url?.startsWith('http'), 'sender.url should start with http')",
+        @"  browser.test.assertTrue(port?.sender?.origin?.startsWith('http'), 'sender.origin should start with http')",
+        @"  browser.test.assertEq(typeof port?.sender?.tab, 'object', 'sender.tab should be an object')",
+        @"  browser.test.assertEq(port?.sender?.frameId, 0, 'sender.frameId should be 0')",
 
-        @"  port.onMessage.addListener((message) => {",
+        @"  port?.onMessage.addListener((message) => {",
         @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content in second listener')",
-        @"    port.postMessage('Received')",
+        @"    port?.postMessage('Received')",
         @"  })",
         @"})"
     ]);
 
     auto *contentScript = Util::constructScript(@[
         @"setTimeout(() => {",
-        @"  const port = browser.runtime.connect({ name: 'testPort' })",
-        @"  port.postMessage('Hello')",
+        @"  const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+
+        @"  port?.postMessage('Hello')",
 
         @"  let receivedMessages = 0",
-        @"  port.onMessage.addListener((response) => {",
+        @"  port?.onMessage.addListener((response) => {",
         @"    browser.test.assertEq(response, 'Received', 'Should get the response from the background script')",
 
         @"    if (++receivedMessages === 2)",
         @"      browser.test.notifyPass()",
         @"  })",
-        @"}, 1000);"
+        @"}, 1000)"
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:runtimeContentScriptManifest resources:@{ @"background.js": backgroundScript, @"content.js": contentScript }]);
@@ -790,14 +798,14 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.runtime.onConnect.addListener((port) => {",
-        @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
+        @"browser.runtime?.onConnect.addListener((port) => {",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
 
-        @"  port.onMessage.addListener((message) => {",
-        @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content')",
+        @"  port?.onMessage.addListener((message) => {",
+        @"    browser.test.assertEq(message, 'Message from content script to background', 'Should receive the correct message content from the content script')",
         @"  })",
 
-        @"  port.onDisconnect.addListener(() => {",
+        @"  port?.onDisconnect.addListener(() => {",
         @"    browser.test.assertTrue(true, 'Should trigger the onDisconnect event in the background script')",
 
         @"    browser.test.notifyPass()",
@@ -807,15 +815,19 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)
 
     auto *contentScript = Util::constructScript(@[
         @"setTimeout(() => {",
-        @"  const port = browser.runtime.connect({ name: 'testPort' })",
-        @"  port.postMessage('Hello')",
+        @"  const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
-        @"  port.onDisconnect.addListener(() => {",
+        @"  port?.postMessage('Message from content script to background')",
+
+        @"  port?.onDisconnect.addListener(() => {",
         @"    browser.test.assertTrue(true, 'Should trigger the onDisconnect event in the content script')",
         @"  })",
 
-        @"  port.disconnect()",
-        @"}, 1000);"
+        @"  port?.disconnect()",
+        @"}, 1000)"
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:runtimeContentScriptManifest resources:@{ @"background.js": backgroundScript, @"content.js": contentScript }]);
@@ -835,20 +847,24 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListen
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.runtime.onConnect.addListener((port) => {",
-        @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
-        @"  port.onMessage.addListener((message) => {",
-        @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content')",
-        @"    port.postMessage('Hello')",
-        @"    port.disconnect()",
+        @"browser.runtime?.onConnect.addListener((port) => {",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+
+        @"  port?.onMessage.addListener((message) => {",
+        @"    browser.test.assertEq(message, 'Message from content script', 'Should receive the correct message content from content script')",
+
+        @"    port?.postMessage('Response from background script 1')",
+        @"    port?.disconnect()",
         @"  })",
         @"})",
 
-        @"browser.runtime.onConnect.addListener((port) => {",
-        @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
-        @"  port.onMessage.addListener((message) => {",
-        @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content')",
-        @"    port.postMessage('Hello')",
+        @"browser.runtime?.onConnect.addListener((port) => {",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+
+        @"  port?.onMessage.addListener((message) => {",
+        @"    browser.test.assertEq(message, 'Message from content script', 'Should receive the correct message content from content script')",
+
+        @"    port?.postMessage('Response from background script 2')",
         @"  })",
         @"})"
     ]);
@@ -857,16 +873,20 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListen
         @"let messagesReceived = 0",
 
         @"setTimeout(() => {",
-        @"  const port = browser.runtime.connect({ name: 'testPort' })",
-        @"  port.postMessage('Hello')",
+        @"  const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
-        @"  port.onMessage.addListener((message) => {",
-        @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content')",
+        @"  port?.postMessage('Message from content script')",
+
+        @"  port?.onMessage.addListener((message) => {",
+        @"    browser.test.assertTrue(message?.startsWith('Response from background script '), 'Should receive the correct message content')",
 
         @"    if (++messagesReceived === 2)",
         @"      browser.test.notifyPass()",
         @"  })",
-        @"}, 1000);"
+        @"}, 1000)"
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:runtimeContentScriptManifest resources:@{ @"background.js": backgroundScript, @"content.js": contentScript }]);
@@ -875,6 +895,51 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListen
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
     [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIRuntime, ConnectFromPopup)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.runtime?.onConnect.addListener((port) => {",
+        @"  port?.onMessage.addListener((message) => {",
+        @"    browser.test.assertEq(message, 'Hello from popup', 'Should receive the correct message content')",
+
+        @"    port?.postMessage('Received by background')",
+        @"  })",
+        @"})",
+
+        @"browser.action?.openPopup()"
+    ]);
+
+    auto *popupScript = Util::constructScript(@[
+        @"const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+
+        @"port?.onMessage.addListener((response) => {",
+        @"  browser.test.assertEq(response, 'Received by background', 'Should get the response from the background script')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"port?.postMessage('Hello from popup')",
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": @"<script type='module' src='popup.js'></script>",
+        @"popup.js": popupScript
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:runtimeManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
+        // Do nothing so the popup web view will stay loaded.
+    };
 
     [manager loadAndRun];
 }
@@ -908,22 +973,26 @@ TEST(WKWebExtensionAPIRuntime, SendNativeMessage)
 TEST(WKWebExtensionAPIRuntime, ConnectNative)
 {
     auto *backgroundScript = Util::constructScript(@[
-        @"const port = browser.runtime.connectNative('test')",
+        @"const port = browser.runtime?.connectNative('test')",
+        @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"browser.test.assertEq(port?.name, 'test', 'Port name should be test')",
+        @"browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
         @"let messagesReceived = 0",
-        @"port.onMessage.addListener((response) => {",
-        @"  browser.test.assertTrue(response.startsWith('Received '), 'Should get the response from the native code')",
+        @"port?.onMessage.addListener((response) => {",
+        @"  browser.test.assertTrue(response?.startsWith('Received '), 'Should get the response from the native code')",
+
         @"  ++messagesReceived",
         @"})",
 
-        @"port.onDisconnect.addListener(() => {",
+        @"port?.onDisconnect.addListener(() => {",
         @"  if (messagesReceived === 2)",
         @"    browser.test.notifyPass()",
         @"  else",
         @"    browser.test.notifyFail('Not all messages were received')",
         @"})",
 
-        @"port.postMessage('Hello')"
+        @"port?.postMessage('Hello')"
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:runtimeManifest resources:@{ @"background.js": backgroundScript }]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -1518,6 +1518,10 @@ TEST(WKWebExtensionAPITabs, Connect)
         @"  const tabId = tabs[0].id",
 
         @"  const port = browser.tabs.connect(tabId, { name: 'testPort' })",
+        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+
         @"  port.postMessage('Hello')",
 
         @"  port.onMessage.addListener((response) => {",
@@ -1576,6 +1580,10 @@ TEST(WKWebExtensionAPITabs, PortDisconnect)
         @"  const tabId = tabs[0].id",
 
         @"  const port = browser.tabs.connect(tabId)",
+        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"  browser.test.assertEq(port?.name, '', 'Port name should be empty')",
+        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+
         @"  port.postMessage('Hello')",
 
         @"  port.onDisconnect.addListener(() => {",
@@ -1627,6 +1635,10 @@ TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
         @"  const tabId = tabs[0].id",
 
         @"  const port = browser.tabs.connect(tabId)",
+        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"  browser.test.assertEq(port?.name, '', 'Port name should be empty')",
+        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+
         @"  port.postMessage('Hello')",
 
         @"  let receivedMessages = 0",
@@ -1692,6 +1704,10 @@ TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
         @"  const tabId = tabs[0].id",
 
         @"  const port = browser.tabs.connect(tabId)",
+        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"  browser.test.assertEq(port?.name, '', 'Port name should be empty')",
+        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+
         @"  port.postMessage('Hello')",
 
         @"  let receivedMessages = 0",


### PR DESCRIPTION
#### a3e8427b4707498583267f2f0b9f42f82ec0f30a
<pre>
Messages sent to a Web Extension port should not be delivered to itself.
<a href="https://webkit.org/b/269049">https://webkit.org/b/269049</a>
<a href="https://rdar.apple.com/122583434">rdar://122583434</a>

Reviewed by Brian Weinstein.

Track the port&apos;s owning page proxy identifier, to identify the sending page, and
then prevent ports from delivering a message to its own page. This was causing a
loop because the ports array in the same extension web process had both the sender
and receiver port. Also make sure the port&apos;s sender is null when it is the port
returned by calling tabs.connect() or runtime.connect().

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::portPostMessage):
(WebKit::WebExtensionContext::fireQueuedPortMessageEventsIfNeeded):
(WebKit::WebExtensionContext::sendQueuedNativePortMessagesIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm:
(WebKit::WebExtensionMessagePort::sendMessage):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::postMessage):
(WebKit::WebExtensionContextProxy::dispatchPortMessageEvent):
(WebKit::WebExtensionContextProxy::dispatchPortDisconnectEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::connectNative):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeConnectEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::sendMessage):
(WebKit::WebExtensionAPITabs::connect):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
(WebKit::WebExtensionAPIPort::owningPageProxyIdentifier const): Added.
(WebKit::WebExtensionAPIPort::senderParameters const): Added.
(WebKit::WebExtensionAPIPort::WebExtensionAPIPort):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TEST(WKWebExtensionAPIRuntime, ConnectFromPopup)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST): Added sender checks.

Canonical link: <a href="https://commits.webkit.org/274403@main">https://commits.webkit.org/274403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/941792faa678d34ab8e958140eec959dc1b3aa1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41493 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15240 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13087 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42770 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38883 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11371 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37107 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15377 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15038 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5091 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->