### PR TITLE
[JSC] Do not invalidate DFG / FTL code when it is not executed currently

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2229,11 +2229,33 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
             }
             jitData->invalidate();
         }
+
         if (!jitCode()->isUnlinked()) {
-            if (!jitCode()->dfgCommon()->invalidateLinkedCode()) {
-                // We've already been invalidated.
-                RELEASE_ASSERT(this != replacement() || (vm.heap.currentThreadIsDoingGCWork() && !vm.heap.isMarked(ownerExecutable())));
-                return;
+            // Invalidate CodeBlock only when we are currently executing this CodeBlock. Otherwise, we don't care.
+            auto isCurrentlyExecuting = [&](CodeBlock* codeBlock) -> bool {
+                // Now we are in the OSR exit ramp. This means we do not need to invalidate CodeBlock if the current frame is executing this CodeBlock.
+                // Still, if CodeBlock exists in upper callstack, we need to invalidate code. This means, we can skip the first frame safely here.
+                bool skipFirstFrame = false;
+                if (reason == Profiler::JettisonDueToOSRExit)
+                    skipFirstFrame = true;
+
+                bool result = false;
+                StackVisitor::visit(vm.topCallFrame, vm, [&](StackVisitor& visitor) {
+                    if (visitor->codeBlock() == codeBlock) {
+                        result = true;
+                        return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                }, skipFirstFrame);
+                return result;
+            };
+
+            if (isCurrentlyExecuting(this)) {
+                if (!jitCode()->dfgCommon()->invalidateLinkedCode()) {
+                    // We've already been invalidated.
+                    RELEASE_ASSERT(this != replacement() || (vm.heap.currentThreadIsDoingGCWork() && !vm.heap.isMarked(ownerExecutable())));
+                    return;
+                }
             }
         }
     }
@@ -2290,46 +2312,6 @@ JSGlobalObject* CodeBlock::globalObjectFor(CodeOrigin codeOrigin)
         return nullptr;
     return inlineCallFrame->baselineCodeBlock->globalObject();
 }
-
-class RecursionCheckFunctor {
-public:
-    RecursionCheckFunctor(CallFrame* startCallFrame, CodeBlock* codeBlock, unsigned depthToCheck)
-        : m_startCallFrame(startCallFrame)
-        , m_codeBlock(codeBlock)
-        , m_depthToCheck(depthToCheck)
-        , m_foundStartCallFrame(false)
-        , m_didRecurse(false)
-    { }
-
-    IterationStatus operator()(StackVisitor& visitor) const
-    {
-        CallFrame* currentCallFrame = visitor->callFrame();
-
-        if (currentCallFrame == m_startCallFrame)
-            m_foundStartCallFrame = true;
-
-        if (m_foundStartCallFrame) {
-            if (visitor->codeBlock() == m_codeBlock) {
-                m_didRecurse = true;
-                return IterationStatus::Done;
-            }
-
-            if (!m_depthToCheck--)
-                return IterationStatus::Done;
-        }
-
-        return IterationStatus::Continue;
-    }
-
-    bool didRecurse() const { return m_didRecurse; }
-
-private:
-    CallFrame* const m_startCallFrame;
-    CodeBlock* const m_codeBlock;
-    mutable unsigned m_depthToCheck;
-    mutable bool m_foundStartCallFrame;
-    mutable bool m_didRecurse;
-};
 
 void CodeBlock::noticeIncomingCall(JSCell* caller)
 {

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4308,9 +4308,13 @@ JSC_DEFINE_JIT_OPERATION(operationLinkDirectCall, void, (DirectCallLinkInfo* cal
 
 JSC_DEFINE_JIT_OPERATION(operationTriggerReoptimizationNow, void, (CodeBlock* codeBlock, CodeBlock* optimizedCodeBlock, OSRExitBase* exit))
 {
+    VM& vm = codeBlock->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
     // It's sort of preferable that we don't GC while in here. Anyways, doing so wouldn't
     // really be profitable.
-    DeferGCForAWhile deferGC(codeBlock->vm());
+    DeferGCForAWhile deferGC(vm);
     
     sanitizeStackForVM(codeBlock->vm());
 


### PR DESCRIPTION
#### 8cfb410af0aeb8da8615a688ae976f476b22c36c
<pre>
[JSC] Do not invalidate DFG / FTL code when it is not executed currently
<a href="https://bugs.webkit.org/show_bug.cgi?id=269053">https://bugs.webkit.org/show_bug.cgi?id=269053</a>
<a href="https://rdar.apple.com/122610326">rdar://122610326</a>

Reviewed by NOBODY (OOPS!).

Invalidation jump repatching is done because we may execute the jettisoned code currently. This means,
if we are not executing it right now, there is no need to invalidate it at all. Once jettison gets done,
we no longer allow new execution of this CodeBlock. So, what we need to care is whether we are running it right now.
Repatching is super costly and if we can, we would like to avoid. This patch checks whether this CodeBlock exists
in the call stack. And if it is not, then we will not invalidate it.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::jettison):
(JSC::RecursionCheckFunctor::RecursionCheckFunctor): Deleted.
(JSC::RecursionCheckFunctor::operator() const): Deleted.
(JSC::RecursionCheckFunctor::didRecurse const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cfb410af0aeb8da8615a688ae976f476b22c36c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34511 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15138 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32556 "Found 3 new test failures: http/wpt/service-workers/service-worker-spinning-message.https.html, http/wpt/service-workers/service-worker-spinning-push.https.html, http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13002 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42666 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/32345 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35260 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34957 "Found 5 new test failures: http/wpt/service-workers/service-worker-spinning-activate.https.html, http/wpt/service-workers/service-worker-spinning-fetch.https.html, http/wpt/service-workers/service-worker-spinning-install.https.html, http/wpt/service-workers/service-worker-spinning-push.https.html, http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38789 "Found 3 new test failures: http/wpt/service-workers/service-worker-spinning-message.https.html, http/wpt/service-workers/service-worker-spinning-push.https.html, http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html (failure)") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38535 "Found 1 new JSC binary failure: testapi, Found 54 new JSC stress test failures: stress/call-varargs-inlining-should-not-clobber-previous-to-free-register.js.default, stress/dont-osr-enter-into-jettisoned-ftl-code-block.js.default, stress/ftl-ai-filter-phantoms-should-clear-clear-value.js.bytecode-cache, stress/ftl-ai-filter-phantoms-should-clear-clear-value.js.default, stress/ftl-ai-filter-phantoms-should-clear-clear-value.js.ftl-eager, stress/ftl-ai-filter-phantoms-should-clear-clear-value.js.ftl-eager-no-cjit-b3o1, stress/ftl-ai-filter-phantoms-should-clear-clear-value.js.ftl-no-cjit-b3o0, stress/ftl-ai-filter-phantoms-should-clear-clear-value.js.ftl-no-cjit-no-inline-validate, stress/ftl-ai-filter-phantoms-should-clear-clear-value.js.ftl-no-cjit-no-put-stack-validate, stress/ftl-ai-filter-phantoms-should-clear-clear-value.js.ftl-no-cjit-small-pool ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13668 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11266 "Found 6 new test failures: http/wpt/service-workers/service-worker-spinning-activate.https.html, http/wpt/service-workers/service-worker-spinning-fetch.https.html, http/wpt/service-workers/service-worker-spinning-install.https.html, http/wpt/service-workers/service-worker-spinning-push.https.html, http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html, inspector/cpu-profiler/tracking.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37010 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15280 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45490 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14941 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9275 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->