### PR TITLE
Some dynamicDowncast<> adoption in WebCore code

### DIFF
--- a/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
@@ -92,11 +92,11 @@ bool SVGAltGlyphDefElement::hasValidGlyphElements(Vector<String>& glyphNames) co
     bool foundFirstAltGlyphItem = false;
 
     for (Ref child : childrenOfType<SVGElement>(*this)) {
-        if (!foundFirstAltGlyphItem && is<SVGGlyphRefElement>(child)) {
+        if (RefPtr glyphRef = dynamicDowncast<SVGGlyphRefElement>(child); glyphRef && !foundFirstAltGlyphItem) {
             fountFirstGlyphRef = true;
             String referredGlyphName;
 
-            if (downcast<SVGGlyphRefElement>(child.get()).hasValidGlyphElement(referredGlyphName))
+            if (glyphRef->hasValidGlyphElement(referredGlyphName))
                 glyphNames.append(referredGlyphName);
             else {
                 // As the spec says "If any of the referenced glyphs are unavailable,

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -98,29 +98,28 @@ bool SVGFEComponentTransferElement::setFilterEffectAttributeFromChild(FilterEffe
 {
     ASSERT(isRelevantTransferFunctionElement(childElement));
 
-    if (!is<SVGComponentTransferFunctionElement>(childElement)) {
-        ASSERT_NOT_REACHED();
+    auto* child = dynamicDowncast<SVGComponentTransferFunctionElement>(childElement);
+    ASSERT(child);
+    if (!child)
         return false;
-    }
 
     auto& effect = downcast<FEComponentTransfer>(filterEffect);
-    auto& child = downcast<SVGComponentTransferFunctionElement>(childElement);
 
     switch (attrName.nodeName()) {
     case AttributeNames::typeAttr:
-        return effect.setType(child.channel(), child.type());
+        return effect.setType(child->channel(), child->type());
     case AttributeNames::slopeAttr:
-        return effect.setSlope(child.channel(), child.slope());
+        return effect.setSlope(child->channel(), child->slope());
     case AttributeNames::interceptAttr:
-        return effect.setIntercept(child.channel(), child.intercept());
+        return effect.setIntercept(child->channel(), child->intercept());
     case AttributeNames::amplitudeAttr:
-        return effect.setAmplitude(child.channel(), child.amplitude());
+        return effect.setAmplitude(child->channel(), child->amplitude());
     case AttributeNames::exponentAttr:
-        return effect.setExponent(child.channel(), child.exponent());
+        return effect.setExponent(child->channel(), child->exponent());
     case AttributeNames::offsetAttr:
-        return effect.setOffset(child.channel(), child.offset());
+        return effect.setOffset(child->channel(), child->offset());
     case AttributeNames::tableValuesAttr:
-        return effect.setTableValues(child.channel(), child.tableValues());
+        return effect.setTableValues(child->channel(), child->tableValues());
     default:
         break;
     }

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -113,6 +113,10 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DedicatedWorkerGlobalScope)
-    static bool isType(const WebCore::ScriptExecutionContext& context) { return is<WebCore::WorkerGlobalScope>(context) && downcast<WebCore::WorkerGlobalScope>(context).type() == WebCore::WorkerGlobalScope::Type::DedicatedWorker; }
+    static bool isType(const WebCore::ScriptExecutionContext& context)
+    {
+        auto* global = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
+        return global && global->type() == WebCore::WorkerGlobalScope::Type::DedicatedWorker;
+    }
     static bool isType(const WebCore::WorkerGlobalScope& context) { return context.type() == WebCore::WorkerGlobalScope::Type::DedicatedWorker; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -234,10 +234,8 @@ void Worker::dispatchEvent(Event& event)
         return;
 
     AbstractWorker::dispatchEvent(event);
-    if (is<ErrorEvent>(event) && !event.defaultPrevented() && event.isTrusted() && scriptExecutionContext()) {
-        auto& errorEvent = downcast<ErrorEvent>(event);
-        scriptExecutionContext()->reportException(errorEvent.message(), errorEvent.lineno(), errorEvent.colno(), errorEvent.filename(), nullptr, nullptr);
-    }
+    if (auto* errorEvent = dynamicDowncast<ErrorEvent>(event); errorEvent && !event.defaultPrevented() && event.isTrusted() && scriptExecutionContext())
+        protectedScriptExecutionContext()->reportException(errorEvent->message(), errorEvent->lineno(), errorEvent->colno(), errorEvent->filename(), nullptr, nullptr);
 }
 
 void Worker::reportError(const String& errorMessage)

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.h
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.h
@@ -106,7 +106,11 @@ inline auto PaintWorkletGlobalScope::paintDefinitionMap() -> HashMap<String, std
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::PaintWorkletGlobalScope)
-static bool isType(const WebCore::ScriptExecutionContext& context) { return is<WebCore::WorkletGlobalScope>(context) && downcast<WebCore::WorkletGlobalScope>(context).isPaintWorkletGlobalScope(); }
+static bool isType(const WebCore::ScriptExecutionContext& context)
+{
+    auto* global = dynamicDowncast<WebCore::WorkletGlobalScope>(context);
+    return global && global->isPaintWorkletGlobalScope();
+}
 static bool isType(const WebCore::WorkletGlobalScope& context) { return context.isPaintWorkletGlobalScope(); }
 SPECIALIZE_TYPE_TRAITS_END()
 


### PR DESCRIPTION
#### 47f4ac4c5cb7b4607726db184163fe5346908b0e
<pre>
Some dynamicDowncast&lt;&gt; adoption in WebCore code
<a href="https://bugs.webkit.org/show_bug.cgi?id=269059">https://bugs.webkit.org/show_bug.cgi?id=269059</a>

Reviewed by Chris Dumez.

* Source/WebCore/svg/SVGAltGlyphDefElement.cpp:
(WebCore::SVGAltGlyphDefElement::hasValidGlyphElements const):
* Source/WebCore/svg/SVGFEComponentTransferElement.cpp:
(WebCore::SVGFEComponentTransferElement::setFilterEffectAttributeFromChild):
* Source/WebCore/workers/DedicatedWorkerGlobalScope.h:
(isType):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::dispatchEvent):
* Source/WebCore/worklets/PaintWorkletGlobalScope.h:
(isType):

Canonical link: <a href="https://commits.webkit.org/274419@main">https://commits.webkit.org/274419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d3d95bc1d51beff3fe22f414d95c4705011e2ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32680 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13158 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42860 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38945 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37174 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15467 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8737 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14953 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->