### PR TITLE
[CSS Container Queries][Style queries] Basic evaluation support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL style(--my-prop: foo) assert_equals: expected "true" but got ""
-FAIL style(--my-prop: foo - bar ()) assert_equals: expected "true" but got ""
-FAIL style(not ((--foo: calc(10px + 2em)) and ((--foo: url(x))))) assert_equals: expected "true" but got ""
-FAIL style((--foo: bar) or (--bar: 10px)) assert_equals: expected "true" but got ""
-FAIL style(--my-prop:) assert_equals: expected "true" but got ""
-FAIL style(--my-prop: ) assert_equals: expected "true" but got ""
-FAIL style(--foo: bar !important) assert_equals: expected "true" but got ""
-FAIL style(--foo) assert_equals: expected "true" but got ""
-PASS style(--foo: bar;)
+PASS style(--my-prop: foo)
+PASS style(--my-prop: foo - bar ())
+PASS style(not ((--foo: calc(10px + 2em)) and ((--foo: url(x)))))
+PASS style((--foo: bar) or (--bar: 10px))
+PASS style(--my-prop:)
+PASS style(--my-prop: )
+PASS style(--foo: bar !important)
+PASS style(--foo)
+FAIL style(--foo: bar;) assert_equals: expected "" but got "true"
 PASS style(style(--foo: bar))
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt
@@ -6,5 +6,5 @@ PASS No declaration value
 PASS Unknown CSS property after 'or'
 PASS Not a style function with space before '('
 FAIL Spaces preserved in custom property value assert_equals: expected "style(--foo: bar   baz)" but got "style(--foo: bar baz)"
-FAIL Original string number in custom property value assert_equals: expected "style(--foo: 2.100)" but got "style(--foo: 2.1 )"
+FAIL Original string number in custom property value assert_equals: expected "style(--foo: 2.100)" but got "style(--foo: 2.1)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
@@ -1,16 +1,16 @@
 
-FAIL style(--inner: true) assert_equals: expected "true" but got ""
-FAIL style(--inner:true) assert_equals: expected "true" but got ""
-FAIL style(--inner:true ) assert_equals: expected "true" but got ""
-FAIL style(--inner: true ) assert_equals: expected "true" but got ""
-FAIL style(--inner-no-space: true) assert_equals: expected "true" but got ""
-FAIL style(--inner-no-space:true) assert_equals: expected "true" but got ""
-FAIL style(--inner-no-space:true ) assert_equals: expected "true" but got ""
-FAIL style(--inner-no-space: true ) assert_equals: expected "true" but got ""
-FAIL style(--inner-space-after: true) assert_equals: expected "true" but got ""
-FAIL style(--inner-space-after:true) assert_equals: expected "true" but got ""
-FAIL style(--inner-space-after:true ) assert_equals: expected "true" but got ""
-FAIL style(--inner-space-after: true ) assert_equals: expected "true" but got ""
+PASS style(--inner: true)
+PASS style(--inner:true)
+PASS style(--inner:true )
+PASS style(--inner: true )
+PASS style(--inner-no-space: true)
+PASS style(--inner-no-space:true)
+PASS style(--inner-no-space:true )
+PASS style(--inner-no-space: true )
+PASS style(--inner-space-after: true)
+PASS style(--inner-space-after:true)
+PASS style(--inner-space-after:true )
+PASS style(--inner-space-after: true )
 PASS style(--outer: true)
 PASS style(--outer:true)
 PASS style(--outer:true )
@@ -35,34 +35,34 @@ PASS outer style(--inner-space-after: true)
 PASS outer style(--inner-space-after:true)
 PASS outer style(--inner-space-after:true )
 PASS outer style(--inner-space-after: true )
-FAIL outer style(--outer: true) assert_equals: expected "true" but got ""
-FAIL outer style(--outer:true) assert_equals: expected "true" but got ""
-FAIL outer style(--outer:true ) assert_equals: expected "true" but got ""
-FAIL outer style(--outer: true ) assert_equals: expected "true" but got ""
-FAIL outer style(--outer-no-space: true) assert_equals: expected "true" but got ""
-FAIL outer style(--outer-no-space:true) assert_equals: expected "true" but got ""
-FAIL outer style(--outer-no-space:true ) assert_equals: expected "true" but got ""
-FAIL outer style(--outer-no-space: true ) assert_equals: expected "true" but got ""
-FAIL outer style(--outer-space-after: true) assert_equals: expected "true" but got ""
-FAIL outer style(--outer-space-after:true) assert_equals: expected "true" but got ""
-FAIL outer style(--outer-space-after:true ) assert_equals: expected "true" but got ""
-FAIL outer style(--outer-space-after: true ) assert_equals: expected "true" but got ""
+PASS outer style(--outer: true)
+PASS outer style(--outer:true)
+PASS outer style(--outer:true )
+PASS outer style(--outer: true )
+PASS outer style(--outer-no-space: true)
+PASS outer style(--outer-no-space:true)
+PASS outer style(--outer-no-space:true )
+PASS outer style(--outer-no-space: true )
+PASS outer style(--outer-space-after: true)
+PASS outer style(--outer-space-after:true)
+PASS outer style(--outer-space-after:true )
+PASS outer style(--outer-space-after: true )
 FAIL Query custom property with !important declaration assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Query custom property using var() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Query custom property including unknown var() reference assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Query custom property including unknown var() reference with non-matching fallback assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Query custom property including unknown var() reference
+PASS Query custom property including unknown var() reference with non-matching fallback
 FAIL Query custom property including unknown var() reference with matching fallback assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Query custom property matching guaranteed-invalid values assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Style query with revert keyword is false
 PASS Style query with revert-layer keyword is false
 FAIL Style query 'initial' matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Style query matching negated value-less query against initial value assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Style query 'initial' not matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Style query matching value-less query against non-initial value assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Style query matching negated value-less query against initial value
+PASS Style query 'initial' not matching
+PASS Style query matching value-less query against non-initial value
 FAIL Style query 'inherit' matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Style query 'inherit' not matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Style query 'inherit' not matching
 FAIL Style query 'unset' matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Style query 'unset' not matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Style query 'unset' not matching
 FAIL Match registered <length> custom property with px. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match registered <length> custom property with px via initial keyword. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match registered <length> custom property with em in query. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
@@ -70,6 +70,6 @@ FAIL Match registered <length> custom property with em in computed value. assert
 FAIL Match registered <length> custom property with cqi unit. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match registered <length> custom property with initial value. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match registered <length> custom property with initial value via initial keyword. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Should only match exact string for numbers in non-registered custom properties assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Spaces should not collapse in non-registered custom properties assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Should only match exact string for numbers in non-registered custom properties assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Spaces should not collapse in non-registered custom properties
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-query-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-query-change-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Initially no queries match.
-FAIL Target child assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL Target grandchild assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Target child
+PASS Target grandchild
 PASS Initially no queries for registered property match.
 FAIL Registered property query child assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL Registered property query grandchild assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/display-contents-dynamic-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/display-contents-dynamic-style-queries-expected.txt
@@ -1,5 +1,5 @@
 This should be green
 
 PASS Initially the color is red
-FAIL After display and --foo changes, style() query causes the color to be green assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS After display and --foo changes, style() query causes the color to be green
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-size-style-container-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-size-style-container-invalidation-expected.txt
@@ -1,5 +1,5 @@
 Green?
 
 PASS Initially red
-FAIL Green after reducing width assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Green after reducing width
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-005-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL ::before pseudo element querying style() of originating element assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS ::before pseudo element querying style() of originating element
 PASS ::before pseudo element not matching style()
 FAIL ::before pseudo element matching style() query after class change assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL style((--foo: bar)) assert_equals: expected "true" but got "false"
+PASS style((--foo: bar))
 PASS style((--baz: qux))
 PASS style((unknown))
 PASS unknown((--foo: bar))
 PASS style(not (--foo: bar))
-FAIL style(not (--baz: qux)) assert_equals: expected "true" but got "false"
+PASS style(not (--baz: qux))
 PASS style(not (unknown))
-FAIL style((--foo: bar) and (--foo: bar)) assert_equals: expected "true" but got "false"
-FAIL style((--foo: bar) and (--foo: bar) and (--foo: bar)) assert_equals: expected "true" but got "false"
+PASS style((--foo: bar) and (--foo: bar))
+PASS style((--foo: bar) and (--foo: bar) and (--foo: bar))
 PASS style((--baz: qux) and (--baz: qux))
 PASS style((--baz: qux) and (--foo: bar) and (--foo: bar))
 PASS style((--foo: bar) and (--baz: qux) and (--foo: bar))
@@ -15,19 +15,19 @@ PASS style((--foo: bar) and (--foo: bar) and (--baz: qux))
 PASS style((unknown) and (--foo: bar) and (--foo: bar))
 PASS style((--foo: bar) and (unknown) and (--foo: bar))
 PASS style((--foo: bar) and (--foo: bar) and (unknown))
-FAIL style((--foo: bar) or (--foo: bar)) assert_equals: expected "true" but got "false"
-FAIL style((--foo: bar) or (--foo: bar) or (--foo: bar)) assert_equals: expected "true" but got "false"
+PASS style((--foo: bar) or (--foo: bar))
+PASS style((--foo: bar) or (--foo: bar) or (--foo: bar))
 PASS style((--baz: qux) or (--baz: qux))
-FAIL style((--baz: qux) or (--foo: bar) or (--foo: bar)) assert_equals: expected "true" but got "false"
-FAIL style((--foo: bar) or (--baz: qux) or (--foo: bar)) assert_equals: expected "true" but got "false"
-FAIL style((--foo: bar) or (--foo: bar) or (--baz: qux)) assert_equals: expected "true" but got "false"
+PASS style((--baz: qux) or (--foo: bar) or (--foo: bar))
+PASS style((--foo: bar) or (--baz: qux) or (--foo: bar))
+PASS style((--foo: bar) or (--foo: bar) or (--baz: qux))
 PASS style((unknown) or (--foo: bar) or (--foo: bar))
 PASS style((--foo: bar) or (unknown) or (--foo: bar))
 PASS style((--foo: bar) or (--foo: bar) or (unknown))
 PASS style((unknown) or (--baz: qux) or (--foo: bar))
 PASS style(not ((--foo: bar) and (--foo: bar)))
-FAIL style(not ((--foo: bar) and (--baz: qux))) assert_equals: expected "true" but got "false"
+PASS style(not ((--foo: bar) and (--baz: qux)))
 PASS style((--foo: bar) and (not ((--baz: qux) or (--foo: bar))))
-FAIL style((--baz: qux) or (not ((--baz: qux) and (--foo: bar)))) assert_equals: expected "true" but got "false"
+PASS style((--baz: qux) or (not ((--baz: qux) and (--foo: bar))))
 PASS style((--baz: qux) or ((--baz: qux) and (--foo: bar)))
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-container-for-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-container-for-shadow-dom-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Match container in outer tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container in same tree, not walking flat tree ancestors assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container in ::slotted selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container in outer tree for :host assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container in ::part selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container for ::before in ::slotted selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container in outer tree for :host::before assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container for ::before in ::part selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container for ::part selector's originating element tree for exportparts assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container for slot light tree child fallback assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match container in outer tree
+PASS Match container in same tree, not walking flat tree ancestors
+PASS Match container in ::slotted selector's originating element tree
+PASS Match container in outer tree for :host
+PASS Match container in ::part selector's originating element tree
+PASS Match container for ::before in ::slotted selector's originating element tree
+PASS Match container in outer tree for :host::before
+PASS Match container for ::before in ::part selector's originating element tree
+PASS Match container for ::part selector's originating element tree for exportparts
+PASS Match container for slot light tree child fallback
 PASS Should not match container inside shadow tree for ::part()
-FAIL A :host::part rule should match containers in the originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS A :host::part rule should match containers in the originating element tree
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-container-invalidation-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-container-invalidation-inheritance-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Pre-conditions
-FAIL Changed --match inherits down descendants and affects container query assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Changed --match inherits down descendants and affects container query
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-query-with-unknown-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-query-with-unknown-width-expected.txt
@@ -1,4 +1,4 @@
 Should be green
 
-FAIL width query should evaluate to unknown and style query to true assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS width query should evaluate to unknown and style query to true
 

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -105,6 +105,16 @@ void CSSParserTokenRange::consumeComponentValue()
     } while (nestingLevel && m_first < m_last);
 }
 
+CSSParserTokenRange CSSParserTokenRange::consumeAllExcludingTrailingWhitespace()
+{
+    auto* last = m_last;
+    for (; last > m_first; --last) {
+        if ((last - 1)->type() != WhitespaceToken)
+            break;
+    }
+    return { std::exchange(m_first, last), last };
+}
+
 String CSSParserTokenRange::serialize() const
 {
     StringBuilder builder;

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -92,6 +92,7 @@ public:
     }
 
     CSSParserTokenRange consumeAll() { return { std::exchange(m_first, m_last), m_last }; }
+    CSSParserTokenRange consumeAllExcludingTrailingWhitespace();
 
     String serialize() const;
 

--- a/Source/WebCore/css/query/ContainerQuery.h
+++ b/Source/WebCore/css/query/ContainerQuery.h
@@ -66,6 +66,4 @@ void serialize(StringBuilder&, const ContainerQuery&);
 
 }
 
-using CachedQueryContainers = Vector<Ref<const Element>>;
-
 }

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -166,10 +166,18 @@ struct StyleFeatureSchema : public FeatureSchema {
         : FeatureSchema("style"_s, FeatureSchema::Type::Discrete, FeatureSchema::ValueType::CustomProperty)
     { }
 
-    EvaluationResult evaluate(const MQ::Feature&, const FeatureEvaluationContext&) const override
+    EvaluationResult evaluate(const MQ::Feature& feature, const FeatureEvaluationContext& context) const override
     {
-        // FIXME: Implement.
-        return EvaluationResult::Unknown;
+        if (!context.conversionData.style())
+            return EvaluationResult::False;
+
+        auto& style = *context.conversionData.style();
+        auto* customProperty = style.customPropertyValue(feature.name);
+        if (!feature.rightComparison)
+            return toEvaluationResult(!!customProperty);
+
+        ASSERT(feature.rightComparison->op == ComparisonOperator::Equal);
+        return toEvaluationResult(customProperty && *customProperty == *feature.rightComparison->value);
     }
 };
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -40,11 +40,11 @@
 
 namespace WebCore::Style {
 
-ContainerQueryEvaluator::ContainerQueryEvaluator(const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, SelectorMatchingState* selectorMatchingState)
+ContainerQueryEvaluator::ContainerQueryEvaluator(const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, ContainerQueryEvaluationState* evaluationState)
     : m_element(element)
     , m_selectionMode(selectionMode)
     , m_scopeOrdinal(scopeOrdinal)
-    , m_selectorMatchingState(selectorMatchingState)
+    , m_evaluationState(evaluationState)
 {
 }
 
@@ -55,6 +55,16 @@ bool ContainerQueryEvaluator::evaluate(const CQ::ContainerQuery& containerQuery)
         return false;
 
     return evaluateCondition(containerQuery.condition, *context) == MQ::EvaluationResult::True;
+}
+
+static const RenderStyle* styleForContainer(const Element& container, OptionSet<CQ::Axis> requiredAxes, const ContainerQueryEvaluationState* evaluationState)
+{
+    // Any element can be a style container and we haven't necessarily committed the style to render tree yet.
+    // Look it up from the currently computed style update instead.
+    if (requiredAxes.isEmpty() && evaluationState)
+        return evaluationState->styleUpdate->elementStyle(container);
+
+    return container.existingComputedStyle();
 }
 
 auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::ContainerQuery& containerQuery) const -> std::optional<MQ::FeatureEvaluationContext>
@@ -69,25 +79,24 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
     if (containerQuery.containsUnknownFeature == CQ::ContainsUnknownFeature::Yes)
         return { };
 
-    auto* cachedQueryContainers = m_selectorMatchingState ? &m_selectorMatchingState->queryContainers : nullptr;
-
-    auto* container = selectContainer(containerQuery.requiredAxes, containerQuery.name, m_element.get(), m_selectionMode, m_scopeOrdinal, cachedQueryContainers);
+    auto* container = selectContainer(containerQuery.requiredAxes, containerQuery.name, m_element.get(), m_selectionMode, m_scopeOrdinal, m_evaluationState);
     if (!container)
         return { };
 
-    if (!container->renderer())
-        return MQ::FeatureEvaluationContext { m_element->document() };
+    auto* containerStyle = styleForContainer(*container, containerQuery.requiredAxes, m_evaluationState);
+    if (!containerStyle)
+        return { };
 
-    auto& renderer = *container->renderer();
+    auto* rootStyle = m_element->document().documentElement()->renderStyle();
 
     return MQ::FeatureEvaluationContext {
         m_element->document(),
-        CSSToLengthConversionData { renderer.style(), m_element->document().documentElement()->renderStyle(), nullptr, &renderer.view(), container },
-        &renderer
+        CSSToLengthConversionData { *containerStyle, rootStyle, nullptr, m_element->document().renderView(), container },
+        container->renderer()
     };
 }
 
-const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> axes, const String& name, const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, const CachedQueryContainers* cachedQueryContainers)
+const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requiredAxes, const String& name, const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, const ContainerQueryEvaluationState* evaluationState)
 {
     // "For each element, the query container to be queried is selected from among the element’s
     // ancestor query containers that have a valid container-type for all the container features
@@ -96,6 +105,10 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> axes
     // https://drafts.csswg.org/css-contain-3/#container-rule
 
     auto isValidContainerForRequiredAxes = [&](ContainerType containerType, const RenderElement* principalBox) {
+        // Any container is valid for style queries.
+        if (requiredAxes.isEmpty())
+            return true;
+
         switch (containerType) {
         case ContainerType::Size:
             return true;
@@ -103,23 +116,24 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> axes
             // Without a principal box the container matches but the query against it will evaluate to Unknown.
             if (!principalBox)
                 return true;
-            if (axes.contains(CQ::Axis::Block))
+            if (requiredAxes.contains(CQ::Axis::Block))
                 return false;
-            return !axes.contains(principalBox->isHorizontalWritingMode() ? CQ::Axis::Height : CQ::Axis::Width);
+            return !requiredAxes.contains(principalBox->isHorizontalWritingMode() ? CQ::Axis::Height : CQ::Axis::Width);
         case ContainerType::Normal:
-            return axes.isEmpty();
+            return false;
         }
         RELEASE_ASSERT_NOT_REACHED();
     };
 
     auto isContainerForQuery = [&](const Element& candidateElement, const Element* originatingElement = nullptr) {
-        auto* style = candidateElement.existingComputedStyle();
+        auto* style = styleForContainer(candidateElement, requiredAxes, evaluationState);
         if (!style)
             return false;
         if (!isValidContainerForRequiredAxes(style->containerType(), candidateElement.renderer()))
             return false;
         if (name.isEmpty())
             return true;
+
         return style->containerNames().containsIf([&](auto& scopedName) {
             auto isNameFromAllowedScope = [&](auto& scopedName) {
                 // Names from :host rules are allowed when the candidate is the host element.
@@ -162,8 +176,8 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> axes
             return &element;
     }
 
-    if (cachedQueryContainers) {
-        for (auto& container : makeReversedRange(*cachedQueryContainers)) {
+    if (evaluationState && !requiredAxes.isEmpty()) {
+        for (auto& container : makeReversedRange(evaluationState->sizeQueryContainers)) {
             if (isContainerForQuery(container))
                 return container.ptr();
         }

--- a/Source/WebCore/style/ContainerQueryEvaluator.h
+++ b/Source/WebCore/style/ContainerQueryEvaluator.h
@@ -26,8 +26,8 @@
 
 #include "ContainerQuery.h"
 #include "GenericMediaQueryEvaluator.h"
-#include "SelectorMatchingState.h"
 #include "StyleScopeOrdinal.h"
+#include "StyleUpdate.h"
 #include <wtf/Ref.h>
 
 namespace WebCore {
@@ -36,14 +36,19 @@ class Element;
 
 namespace Style {
 
+struct ContainerQueryEvaluationState {
+    Vector<Ref<const Element>> sizeQueryContainers;
+    CheckedPtr<Style::Update> styleUpdate;
+};
+
 class ContainerQueryEvaluator : public MQ::GenericMediaQueryEvaluator<ContainerQueryEvaluator> {
 public:
     enum class SelectionMode : uint8_t { Element, PseudoElement, PartPseudoElement };
-    ContainerQueryEvaluator(const Element&, SelectionMode, ScopeOrdinal, SelectorMatchingState*);
+    ContainerQueryEvaluator(const Element&, SelectionMode, ScopeOrdinal, ContainerQueryEvaluationState*);
 
     bool evaluate(const CQ::ContainerQuery&) const;
 
-    static const Element* selectContainer(OptionSet<CQ::Axis>, const String& name, const Element&, SelectionMode = SelectionMode::Element, ScopeOrdinal = ScopeOrdinal::Element, const CachedQueryContainers* = nullptr);
+    static const Element* selectContainer(OptionSet<CQ::Axis>, const String& name, const Element&, SelectionMode = SelectionMode::Element, ScopeOrdinal = ScopeOrdinal::Element, const ContainerQueryEvaluationState* = nullptr);
 
 private:
     std::optional<MQ::FeatureEvaluationContext> featureEvaluationContextForQuery(const CQ::ContainerQuery&) const;
@@ -51,7 +56,7 @@ private:
     const Ref<const Element> m_element;
     const SelectionMode m_selectionMode;
     const ScopeOrdinal m_scopeOrdinal;
-    SelectorMatchingState* m_selectorMatchingState;
+    ContainerQueryEvaluationState* m_evaluationState { nullptr };
 };
 
 }

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -592,8 +592,10 @@ bool ElementRuleCollector::containerQueriesMatch(const RuleData& ruleData, const
         return ContainerQueryEvaluator::SelectionMode::Element;
     }();
 
+    auto* containerQueryEvaluationState = m_selectorMatchingState ? &m_selectorMatchingState->containerQueryEvaluationState : nullptr;
+
     // "Style rules defined on an element inside multiple nested container queries apply when all of the wrapping container queries are true for that element."
-    ContainerQueryEvaluator evaluator(element(), selectionMode, matchRequest.styleScopeOrdinal, m_selectorMatchingState);
+    ContainerQueryEvaluator evaluator(element(), selectionMode, matchRequest.styleScopeOrdinal, containerQueryEvaluationState);
     for (auto* query : queries) {
         if (!evaluator.evaluate(*query))
             return false;

--- a/Source/WebCore/style/SelectorMatchingState.h
+++ b/Source/WebCore/style/SelectorMatchingState.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "ContainerQuery.h"
+#include "ContainerQueryEvaluator.h"
 #include "HasSelectorFilter.h"
 #include "SelectorFilter.h"
 #include <wtf/HashMap.h>
@@ -39,7 +40,7 @@ enum class HasPseudoClassMatch : uint8_t { None, Matches, Fails, FailsSubtree };
 struct SelectorMatchingState {
     SelectorFilter selectorFilter;
 
-    CachedQueryContainers queryContainers;
+    ContainerQueryEvaluationState containerQueryEvaluationState;
 
     HashMap<HasPseudoClassCacheKey, HasPseudoClassMatch> hasPseudoClassMatchCache;
     HashMap<HasPseudoClassFilterKey, std::unique_ptr<HasSelectorFilter>> hasPseudoClassSelectorFilters;

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -91,7 +91,7 @@ private:
         RefPtr<ShadowRoot> shadowRoot;
         RefPtr<Scope> enclosingScope;
 
-        Scope(Document&);
+        Scope(Document&, Update&);
         Scope(ShadowRoot&, Scope& enclosingScope);
         ~Scope();
     };

--- a/Source/WebCore/style/StyleUpdate.cpp
+++ b/Source/WebCore/style/StyleUpdate.cpp
@@ -42,6 +42,8 @@ Update::Update(Document& document)
 {
 }
 
+Update::~Update() = default;
+
 const ElementUpdate* Update::elementUpdate(const Element& element) const
 {
     auto it = m_elements.find(&element);
@@ -132,6 +134,11 @@ void Update::addSVGRendererUpdate(SVGElement& element)
     m_roots.remove(&element);
     addPossibleRoot(parent);
     element.setNeedsSVGRendererUpdate(true);
+}
+
+void Update::addInitialContainingBlockUpdate(std::unique_ptr<RenderStyle> style)
+{
+    m_initialContainingBlockUpdate = WTFMove(style);
 }
 
 void Update::addPossibleRoot(Element* element)

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -54,10 +54,11 @@ struct TextUpdate {
     std::optional<std::unique_ptr<RenderStyle>> inheritedDisplayContentsStyle;
 };
 
-class Update {
+class Update : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     Update(Document&);
+    ~Update();
 
     const ListHashSet<RefPtr<ContainerNode>>& roots() const { return m_roots; }
     ListHashSet<RefPtr<Element>> takeRebuildRoots() { return WTFMove(m_rebuildRoots); }
@@ -81,7 +82,7 @@ public:
     void addText(Text&, Element* parent, TextUpdate&&);
     void addText(Text&, TextUpdate&&);
     void addSVGRendererUpdate(SVGElement&);
-    void addInitialContainingBlockUpdate(std::unique_ptr<RenderStyle> style) { m_initialContainingBlockUpdate = WTFMove(style); }
+    void addInitialContainingBlockUpdate(std::unique_ptr<RenderStyle>);
 
 private:
     void addPossibleRoot(Element*);


### PR DESCRIPTION
#### 2a76b5d5da5c7bdd0458253953c8e88e7f4a42f5
<pre>
[CSS Container Queries][Style queries] Basic evaluation support
<a href="https://bugs.webkit.org/show_bug.cgi?id=269061">https://bugs.webkit.org/show_bug.cgi?id=269061</a>
<a href="https://rdar.apple.com/122623247">rdar://122623247</a>

Reviewed by Alan Baradlay.

Evaluate @container style(--property:foo) queries.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-query-change-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/display-contents-dynamic-style-queries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-size-style-container-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-container-for-shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-container-invalidation-inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-query-with-unknown-width-expected.txt:
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
(WebCore::CSSParserTokenRange::consumeAllExcludingTrailingWhitespace):

Add a helper.

* Source/WebCore/css/parser/CSSParserTokenRange.h:
* Source/WebCore/css/query/ContainerQuery.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:

Evaluate the query by looking up and comparing the property value.

* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::consumeCustomPropertyValue):

Don&apos;t include trailing whitespace to custom property value.

(WebCore::MQ::FeatureParser::consumeBooleanOrPlainFeature):
* Source/WebCore/style/ContainerQueryEvaluator.h:

Pass the currently resolved style via ContainerQueryEvaluationState.

* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::ContainerQueryEvaluator):
(WebCore::Style::styleForContainer):
(WebCore::Style::ContainerQueryEvaluator::featureEvaluationContextForQuery const):

Look up the currently resolved style for the container. It may not have yet been committed to the render tree.
Allow containers that don&apos;t generate boxes.

(WebCore::Style::ContainerQueryEvaluator::selectContainer):

Similarly use the current style for container selection.
Allow any element to be a container for style queries.

* Source/WebCore/style/ContainerQueryEvaluator.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::containerQueriesMatch):
* Source/WebCore/style/SelectorMatchingState.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::Scope::Scope):

Pass a reference to the current style update to container query evaluation.

(WebCore::Style::TreeResolver::pushParent):
(WebCore::Style::TreeResolver::popParent):
(WebCore::Style::TreeResolver::resolve):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/StyleUpdate.cpp:
(WebCore::Style::Update::addInitialContainingBlockUpdate):
* Source/WebCore/style/StyleUpdate.h:
(WebCore::Style::Update::addInitialContainingBlockUpdate): Deleted.

Canonical link: <a href="https://commits.webkit.org/274364@main">https://commits.webkit.org/274364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/590c2bc5b43f90f24642ee3a3cb8d3be8995e21d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41420 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15169 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34975 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11295 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15305 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8701 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/14970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->