### PR TITLE
[WPE] WPE Platform: Implement monitors API in DRM platform

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -9,12 +9,14 @@ set(WPEPlatformDRM_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDRMSession.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEMonitorDRM.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEViewDRM.cpp
 )
 
 set(WPEPlatformDRM_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/wpe-drm.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDisplayDRM.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEMonitorDRM.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEViewDRM.h
 )
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
@@ -61,6 +61,10 @@ std::unique_ptr<Crtc> Crtc::create(int fd, drmModeCrtc* crtc, unsigned index)
 Crtc::Crtc(drmModeCrtc* crtc, unsigned index, Properties&& properties)
     : m_id(crtc->crtc_id)
     , m_index(index)
+    , m_x(crtc->x)
+    , m_y(crtc->y)
+    , m_width(crtc->width)
+    , m_height(crtc->height)
     , m_properties(WTFMove(properties))
 {
     if (crtc->mode_valid)
@@ -88,6 +92,8 @@ std::unique_ptr<Connector> Connector::create(int fd, drmModeConnector* connector
 Connector::Connector(drmModeConnector* connector, Properties&& properties)
     : m_id(connector->connector_id)
     , m_encoderID(connector->encoder_id)
+    , m_widthMM(connector->mmWidth)
+    , m_heightMM(connector->mmHeight)
     , m_properties(WTFMove(properties))
 {
     m_modes.reserveInitialCapacity(connector->count_modes);

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
@@ -51,6 +51,10 @@ public:
 
     uint32_t id() const { return m_id; }
     unsigned index() const { return m_index; }
+    uint32_t x() const { return m_x; }
+    uint32_t y() const { return m_y; }
+    uint32_t width() const { return m_width; }
+    uint32_t height() const { return m_height; }
     const std::optional<drmModeModeInfo>& currentMode() const { return m_currentMode; }
     const Properties& properties() const { return m_properties; }
 
@@ -59,6 +63,10 @@ public:
 private:
     uint32_t m_id { 0 };
     unsigned m_index { 0 };
+    uint32_t m_x { 0 };
+    uint32_t m_y { 0 };
+    uint32_t m_width { 0 };
+    uint32_t m_height { 0 };
     std::optional<drmModeModeInfo> m_currentMode;
     Properties m_properties;
 };
@@ -78,6 +86,8 @@ public:
 
     uint32_t id() const { return m_id; }
     uint32_t encoderID() const { return m_encoderID; }
+    uint32_t widthMM() const { return m_widthMM; }
+    uint32_t heightMM() const { return m_heightMM; }
     const Vector<drmModeModeInfo>& modes() const { return m_modes; }
     const std::optional<unsigned> preferredModeIndex() const { return m_preferredModeIndex; }
     const Properties& properties() const { return m_properties; }
@@ -85,6 +95,8 @@ public:
 private:
     uint32_t m_id { 0 };
     uint32_t m_encoderID { 0 };
+    uint32_t m_widthMM { 0 };
+    uint32_t m_heightMM { 0 };
     Vector<drmModeModeInfo> m_modes;
     std::optional<unsigned> m_preferredModeIndex;
     Properties m_properties;

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEMonitorDRM.h"
+
+#include "WPEMonitorDRMPrivate.h"
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WPEMonitorDRM:
+ *
+ */
+struct _WPEMonitorDRMPrivate {
+    std::unique_ptr<WPE::DRM::Crtc> crtc;
+    drmModeModeInfo mode;
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEMonitorDRM, wpe_monitor_drm, WPE_TYPE_MONITOR, WPEMonitor)
+
+static void wpeMonitorDRMInvalidate(WPEMonitor* monitor)
+{
+    auto* priv = WPE_MONITOR_DRM(monitor)->priv;
+    priv->crtc = nullptr;
+}
+
+static void wpeMonitorDRMDispose(GObject* object)
+{
+    wpeMonitorDRMInvalidate(WPE_MONITOR(object));
+
+    G_OBJECT_CLASS(wpe_monitor_drm_parent_class)->dispose(object);
+}
+
+static void wpe_monitor_drm_class_init(WPEMonitorDRMClass* monitorDRMClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(monitorDRMClass);
+    objectClass->dispose = wpeMonitorDRMDispose;
+
+    WPEMonitorClass* monitorClass = WPE_MONITOR_CLASS(monitorDRMClass);
+    monitorClass->invalidate = wpeMonitorDRMInvalidate;
+}
+
+WPEMonitor* wpeMonitorDRMCreate(std::unique_ptr<WPE::DRM::Crtc>&& crtc, const WPE::DRM::Connector& connector)
+{
+    auto* monitor = WPE_MONITOR(g_object_new(WPE_TYPE_MONITOR_DRM, "id", crtc->id(), nullptr));
+    auto* priv = WPE_MONITOR_DRM(monitor)->priv;
+    priv->crtc = WTFMove(crtc);
+
+    wpe_monitor_set_position(monitor, priv->crtc->x(), priv->crtc->y());
+    wpe_monitor_set_size(monitor, priv->crtc->width(), priv->crtc->height());
+    wpe_monitor_set_physical_size(monitor, connector.widthMM(), connector.heightMM());
+
+    if (const char* scaleString = getenv("WPE_DRM_SCALE"))
+        wpe_monitor_set_scale(monitor, g_ascii_strtod(scaleString, nullptr));
+
+    if (const auto& mode = priv->crtc->currentMode())
+        priv->mode = mode.value();
+    else {
+        if (const auto& preferredModeIndex = connector.preferredModeIndex())
+            priv->mode = connector.modes()[preferredModeIndex.value()];
+        else {
+            int area = 0;
+            for (const auto& mode : connector.modes()) {
+                int modeArea = mode.hdisplay * mode.vdisplay;
+                if (modeArea > area) {
+                    priv->mode = mode;
+                    area = modeArea;
+                }
+            }
+        }
+    }
+
+    uint32_t refresh = [](drmModeModeInfo* info) -> uint32_t {
+        uint64_t refresh = (info->clock * 1000000LL / info->htotal + info->vtotal / 2) / info->vtotal;
+        if (info->flags & DRM_MODE_FLAG_INTERLACE)
+            refresh *= 2;
+        if (info->flags & DRM_MODE_FLAG_DBLSCAN)
+            refresh /= 2;
+        if (info->vscan > 1)
+            refresh /= info->vscan;
+
+        return refresh;
+    }(&priv->mode);
+
+    wpe_monitor_set_refresh_rate(monitor, refresh);
+
+    return WPE_MONITOR(monitor);
+}
+
+drmModeModeInfo* wpeMonitorDRMGetMode(WPEMonitorDRM* monitor)
+{
+    return &monitor->priv->mode;
+}
+
+const WPE::DRM::Crtc wpeMonitorDRMGetCrtc(WPEMonitorDRM* monitor)
+{
+    return *monitor->priv->crtc;
+}
+
+/**
+ * wpe_monitor_drm_get_crtc_index: (skip)
+ * @monitor: a #WPEMonitorDRM
+ *
+ * Get the DRM CRTC index of @monitor
+ *
+ * Returns: the CRTC index
+ */
+guint wpe_monitor_drm_get_crtc_index(WPEMonitorDRM* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR_DRM(monitor), 0);
+
+    return monitor->priv->crtc->index();
+}

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,15 +23,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef WPEMonitorDRM_h
+#define WPEMonitorDRM_h
 
-#include "WPEDRM.h"
-#include "WPEDRMCursor.h"
-#include "WPEDRMSeat.h"
-#include "WPEMonitor.h"
+#if !defined(__WPE_DRM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/drm/wpe-drm.h> can be included directly."
+#endif
 
-const WPE::DRM::Connector& wpeDisplayDRMGetConnector(WPEDisplayDRM*);
-WPEMonitor* wpeDisplayDRMGetMonitor(WPEDisplayDRM*);
-const WPE::DRM::Plane& wpeDisplayDRMGetPrimaryPlane(WPEDisplayDRM*);
-WPE::DRM::Cursor* wpeDisplayDRMGetCursor(WPEDisplayDRM*);
-const WPE::DRM::Seat& wpeDisplayDRMGetSeat(WPEDisplayDRM*);
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_MONITOR_DRM (wpe_monitor_drm_get_type())
+WPE_API G_DECLARE_FINAL_TYPE (WPEMonitorDRM, wpe_monitor_drm, WPE, MONITOR_DRM, WPEMonitor)
+
+WPE_API guint wpe_monitor_drm_get_crtc_index(WPEMonitorDRM *monitor);
+
+G_END_DECLS
+
+#endif /* WPEMonitorDRM_h */

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRMPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRMPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,12 +26,8 @@
 #pragma once
 
 #include "WPEDRM.h"
-#include "WPEDRMCursor.h"
-#include "WPEDRMSeat.h"
-#include "WPEMonitor.h"
+#include "WPEMonitorDRM.h"
 
-const WPE::DRM::Connector& wpeDisplayDRMGetConnector(WPEDisplayDRM*);
-WPEMonitor* wpeDisplayDRMGetMonitor(WPEDisplayDRM*);
-const WPE::DRM::Plane& wpeDisplayDRMGetPrimaryPlane(WPEDisplayDRM*);
-WPE::DRM::Cursor* wpeDisplayDRMGetCursor(WPEDisplayDRM*);
-const WPE::DRM::Seat& wpeDisplayDRMGetSeat(WPEDisplayDRM*);
+WPEMonitor* wpeMonitorDRMCreate(std::unique_ptr<WPE::DRM::Crtc>&&, const WPE::DRM::Connector&);
+drmModeModeInfo* wpeMonitorDRMGetMode(WPEMonitorDRM*);
+const WPE::DRM::Crtc wpeMonitorDRMGetCrtc(WPEMonitorDRM*);

--- a/Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h
@@ -28,6 +28,7 @@
 #define __WPE_DRM_H_INSIDE__
 
 #include <wpe/drm/WPEDisplayDRM.h>
+#include <wpe/drm/WPEMonitorDRM.h>
 #include <wpe/drm/WPEViewDRM.h>
 
 #undef __WPE_DRM_H_INSIDE__


### PR DESCRIPTION
#### b96094f5ce941b472f4490d05cef37214fc6f2e4
<pre>
[WPE] WPE Platform: Implement monitors API in DRM platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=269062">https://bugs.webkit.org/show_bug.cgi?id=269062</a>

Reviewed by Adrian Perez de Castro.

Add WPEMonitor implementation for DRM.

* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp:
(WebKit::DisplayVBlankMonitorDRM::create):
* Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp:
(WPE::DRM::Crtc::Crtc):
(WPE::DRM::Connector::Connector):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h:
(WPE::DRM::Crtc::x const):
(WPE::DRM::Crtc::y const):
(WPE::DRM::Crtc::width const):
(WPE::DRM::Crtc::height const):
(WPE::DRM::Connector::widthMM const):
(WPE::DRM::Connector::heightMM const):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMConnect):
(wpeDisplayDRMGetNMonitors):
(wpeDisplayDRMGetMonitor):
(wpe_display_drm_class_init):
(wpeDisplayDRMGetCrtc): Deleted.
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRMPrivate.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.cpp: Added.
(wpeMonitorDRMInvalidate):
(wpeMonitorDRMDispose):
(wpe_monitor_drm_class_init):
(wpeMonitorDRMCreate):
(wpeMonitorDRMGetMode):
(wpeMonitorDRMGetCrtc):
(wpe_monitor_drm_get_crtc_index):
* Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.h: Copied from Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h.
* Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRMPrivate.h: Copied from Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h.
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(wpeViewDRMConstructed):
(wpeViewDRMCommitAtomic):
(wpeViewDRMCommitLegacy):
(wpeViewDRMGetMonitor):
(wpeViewDRMScheduleCursorUpdate):
(wpe_view_drm_class_init):
* Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h:

Canonical link: <a href="https://commits.webkit.org/274619@main">https://commits.webkit.org/274619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3529ba43e628786aba1252c9f11bf623926383f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34539 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32578 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12971 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42691 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38807 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37032 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15301 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14966 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5190 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->