### PR TITLE
[MSE] Remove HTMLMedia Element access from MediaSource

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -130,11 +130,12 @@ bool ManagedMediaSource::isBuffered(const PlatformTimeRanges& ranges) const
 
 void ManagedMediaSource::ensurePrefsRead()
 {
+    assertIsCurrent(m_dispatcher);
+
     if (m_lowThreshold && m_highThreshold)
         return;
-    ASSERT(mediaElement());
-    m_lowThreshold = mediaElement()->document().settings().managedMediaSourceLowThreshold();
-    m_highThreshold = mediaElement()->document().settings().managedMediaSourceHighThreshold();
+    m_lowThreshold = settings().managedMediaSourceLowThreshold();
+    m_highThreshold = settings().managedMediaSourceHighThreshold();
 }
 
 void ManagedMediaSource::monitorSourceBuffers()
@@ -146,7 +147,7 @@ void ManagedMediaSource::monitorSourceBuffers()
             setStreaming(true);
             return;
         }
-        auto currentTime = this->currentTime();
+        auto currentTime = currentMediaTime();
 
         ensurePrefsRead();
 
@@ -172,18 +173,6 @@ void ManagedMediaSource::streamingTimerFired()
     ALWAYS_LOG(LOGIDENTIFIER, "Disabling streaming due to policy ", *m_highThreshold);
     m_streamingAllowed = false;
     notifyElementUpdateMediaState();
-}
-
-bool ManagedMediaSource::isOpen() const
-{
-#if !ENABLE(WIRELESS_PLAYBACK_TARGET)
-    return MediaSource::isOpen();
-#else
-    return MediaSource::isOpen()
-        && (mediaElement() && (!mediaElement()->document().settings().managedMediaSourceNeedsAirPlay()
-            || mediaElement()->isWirelessPlaybackTargetDisabled()
-            || mediaElement()->hasWirelessPlaybackTargetAlternative()));
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -52,7 +52,6 @@ public:
 private:
     explicit ManagedMediaSource(ScriptExecutionContext&);
     void monitorSourceBuffers() final;
-    bool isOpen() const final;
     void elementDetached() final;
     bool isBuffered(const PlatformTimeRanges&) const;
     void setStreaming(bool);

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -120,7 +120,6 @@ public:
     using SourceBufferPrivateClient::ref;
     using SourceBufferPrivateClient::deref;
 
-    Document& document() const;
     enum class AppendMode { Segments, Sequence };
     AppendMode mode() const { return m_mode; }
     ExceptionOr<void> setMode(AppendMode);
@@ -151,6 +150,8 @@ public:
 
 protected:
     SourceBuffer(Ref<SourceBufferPrivate>&&, MediaSource&);
+    Document& document() const;
+    const Settings& settings() const;
 
 private:
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -140,6 +140,7 @@
 #include <wtf/Language.h>
 #include <wtf/MathExtras.h>
 #include <wtf/MemoryPressureHandler.h>
+#include <wtf/NativePromise.h>
 #include <wtf/Ref.h>
 #include <wtf/text/CString.h>
 
@@ -3467,6 +3468,8 @@ void HTMLMediaElement::seekWithTolerance(const SeekTarget& target, bool fromDOM)
             addPlayedRange(m_lastSeekTime, now);
     }
     m_lastSeekTime = target.time;
+    if (m_player)
+        m_player->willSeekToTarget(target.time);
 
     // 5 - If the seek was in response to a DOM method call or setting of an IDL attribute, then continue
     // the script. The remainder of these steps must be run asynchronously.
@@ -3583,6 +3586,8 @@ void HTMLMediaElement::seekTask()
 
 void HTMLMediaElement::clearSeeking()
 {
+    if (m_player)
+        m_player->willSeekToTarget(MediaTime::invalidTime());
     setSeeking(false);
     m_seekRequested = false;
     m_pendingSeekType = NoSeek;
@@ -4205,6 +4210,17 @@ void HTMLMediaElement::detachMediaSource()
     m_mediaSource->detachFromElement(*this);
     m_mediaSource->setAsSrcObject(false);
     m_mediaSource = nullptr;
+}
+
+bool HTMLMediaElement::deferredMediaSourceOpenCanProgress() const
+{
+#if !ENABLE(WIRELESS_PLAYBACK_TARGET)
+    return true;
+#else
+    return !document().settings().managedMediaSourceNeedsAirPlay()
+        || isWirelessPlaybackTargetDisabled()
+        || hasWirelessPlaybackTargetAlternative();
+#endif
 }
 
 #endif
@@ -8389,13 +8405,6 @@ bool HTMLMediaElement::isSuspended() const
 {
     return document().activeDOMObjectsAreSuspended() || document().activeDOMObjectsAreStopped();
 }
-
-#if ENABLE(MEDIA_SOURCE)
-size_t HTMLMediaElement::maximumSourceBufferSize(const SourceBuffer& buffer) const
-{
-    return mediaSession().maximumMediaSourceBufferSize(buffer);
-}
-#endif
 
 void HTMLMediaElement::suspendPlayback()
 {

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -47,6 +47,7 @@
 #include "URLKeepingBlobAlive.h"
 #include "VideoTrackClient.h"
 #include "VisibilityChangeClient.h"
+#include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/Observer.h>
@@ -315,7 +316,7 @@ public:
 //  Media Source.
     void detachMediaSource();
     void incrementDroppedFrameCount() { ++m_droppedVideoFrames; }
-    size_t maximumSourceBufferSize(const SourceBuffer&) const;
+    bool deferredMediaSourceOpenCanProgress() const;
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -956,30 +956,6 @@ bool MediaElementSession::requiresPlaybackTargetRouteMonitoring() const
 }
 #endif
 
-#if ENABLE(MEDIA_SOURCE)
-size_t MediaElementSession::maximumMediaSourceBufferSize(const SourceBuffer& buffer) const
-{
-    // A good quality 1080p video uses 8,000 kbps and stereo audio uses 384 kbps, so assume 95% for video and 5% for audio.
-    const float bufferBudgetPercentageForVideo = .95;
-    const float bufferBudgetPercentageForAudio = .05;
-
-    size_t maximum = buffer.document().settings().maximumSourceBufferSize();
-
-    // Allow a SourceBuffer to buffer as though it is audio-only even if it doesn't have any active tracks (yet).
-    size_t bufferSize = static_cast<size_t>(maximum * bufferBudgetPercentageForAudio);
-    if (buffer.hasVideo())
-        bufferSize += static_cast<size_t>(maximum * bufferBudgetPercentageForVideo);
-
-    // FIXME: we might want to modify this algorithm to:
-    // - decrease the maximum size for background tabs
-    // - decrease the maximum size allowed for inactive elements when a process has more than one
-    //   element, eg. so a page with many elements which are played one at a time doesn't keep
-    //   everything buffered after an element has finished playing.
-
-    return bufferSize;
-}
-#endif
-
 static bool isElementMainContentForPurposesOfAutoplay(const HTMLMediaElement& element, bool shouldHitTestMainFrame)
 {
     Document& document = element.document();

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -140,10 +140,6 @@ public:
     WEBCORE_EXPORT void removeBehaviorRestriction(BehaviorRestrictions);
     bool hasBehaviorRestriction(BehaviorRestrictions restriction) const { return restriction & m_restrictions; }
 
-#if ENABLE(MEDIA_SOURCE)
-    size_t maximumMediaSourceBufferSize(const SourceBuffer&) const;
-#endif
-
     HTMLMediaElement& element() const { return m_element; }
 
     bool wantsToObserveViewportVisibilityForMediaControls() const;

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -135,7 +135,6 @@ public:
 
     double durationDouble() const final { return 0; }
 
-    double currentTimeDouble() const final { return 0; }
     void seekToTarget(const SeekTarget&) final { }
     bool seeking() const final { return false; }
 
@@ -805,8 +804,14 @@ MediaTime MediaPlayer::getStartDate() const
     return m_private->getStartDate();
 }
 
+void MediaPlayer::willSeekToTarget(const MediaTime& time)
+{
+    m_private->willSeekToTarget(time);
+}
+
 void MediaPlayer::seekToTarget(const SeekTarget& target)
 {
+    m_private->willSeekToTarget(MediaTime::invalidTime());
     m_private->seekToTarget(target);
 }
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -420,6 +420,7 @@ public:
     void queueTaskOnEventLoop(Function<void()>&&);
 
     bool paused() const;
+    void willSeekToTarget(const MediaTime&);
     void seekToTime(const MediaTime&);
     void seekWhenPossible(const MediaTime&);
     void seekToTarget(const SeekTarget&);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -62,6 +62,14 @@ auto MediaPlayerPrivateInterface::asyncVideoPlaybackQualityMetrics() -> Ref<Vide
     return VideoPlaybackQualityMetricsPromise::createAndReject(PlatformMediaError::NotSupportedError);
 }
 
+MediaTime MediaPlayerPrivateInterface::currentOrPendingSeekTime() const
+{
+    auto pendingSeekTime = this->pendingSeekTime();
+    if (pendingSeekTime.isValid())
+        return pendingSeekTime;
+    return currentMediaTime();
+}
+
 }
 
 #endif

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -125,15 +125,16 @@ public:
     virtual double durationDouble() const { return duration(); }
     virtual MediaTime durationMediaTime() const { return MediaTime::createWithDouble(durationDouble()); }
 
-    virtual float currentTime() const { return 0; }
-    virtual double currentTimeDouble() const { return currentTime(); }
-    virtual MediaTime currentMediaTime() const { return MediaTime::createWithDouble(currentTimeDouble()); }
+    WEBCORE_EXPORT virtual MediaTime currentOrPendingSeekTime() const;
+    virtual MediaTime currentMediaTime() const { return MediaTime::zeroTime(); }
     virtual bool currentMediaTimeMayProgress() const { return readyState() >= MediaPlayer::ReadyState::HaveFutureData; }
 
     virtual bool setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&&) { return false; }
 
     virtual MediaTime getStartDate() const { return MediaTime::createWithDouble(std::numeric_limits<double>::quiet_NaN()); }
 
+    virtual void willSeekToTarget(const MediaTime& time) { m_pendingSeekTime = time; }
+    virtual MediaTime pendingSeekTime() const { return m_pendingSeekTime; }
     virtual void seekToTarget(const SeekTarget&) = 0;
     virtual bool seeking() const = 0;
 
@@ -359,6 +360,7 @@ public:
 protected:
     mutable PlatformTimeRanges m_seekable;
     bool m_shouldCheckHardwareSupport { false };
+    MediaTime m_pendingSeekTime { MediaTime::invalidTime() };
 };
 
 }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -189,6 +189,13 @@ void MediaSourcePrivate::ensureOnDispatcher(Function<void()>&& function) const
     m_dispatcher->dispatch(WTFMove(function));
 }
 
+MediaTime MediaSourcePrivate::currentMediaTime() const
+{
+    if (RefPtr player = this->player())
+        return player->currentOrPendingSeekTime();
+    return MediaTime::invalidTime();
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -70,6 +70,7 @@ public:
     virtual ~MediaSourcePrivate();
 
     RefPtr<MediaSourcePrivateClient> client() const;
+    virtual RefPtr<MediaPlayerPrivateInterface> player() const = 0;
 
     virtual constexpr MediaPlatformType platformType() const = 0;
     virtual AddStatus addSourceBuffer(const ContentType&, bool webMParserEnabled, RefPtr<SourceBufferPrivate>&) = 0;
@@ -86,7 +87,7 @@ public:
     virtual MediaPlayer::ReadyState mediaPlayerReadyState() const = 0;
     virtual void setMediaPlayerReadyState(MediaPlayer::ReadyState) = 0;
 
-    virtual MediaTime currentMediaTime() const = 0;
+    MediaTime currentMediaTime() const;
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
     Ref<MediaPromise> seekToTime(const MediaTime&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -141,8 +141,6 @@ private:
     bool waitingForKey() const final { return m_waitingForKey; }
 #endif
 
-    float currentTime() const final;
-
     // engine support
     class Factory;
     static bool isAvailable();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1555,11 +1555,6 @@ MediaTime MediaPlayerPrivateAVFoundationObjC::platformDuration() const
     return MediaTime::invalidTime();
 }
 
-float MediaPlayerPrivateAVFoundationObjC::currentTime() const
-{
-    return currentMediaTime().toFloat();
-}
-
 MediaTime MediaPlayerPrivateAVFoundationObjC::currentMediaTime() const
 {
     if (!metaDataAvailable() || !m_avPlayerItem)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -466,6 +466,8 @@ MediaTime MediaPlayerPrivateMediaSourceAVFObjC::durationMediaTime() const
 
 MediaTime MediaPlayerPrivateMediaSourceAVFObjC::currentMediaTime() const
 {
+    if (seeking())
+        return m_pendingSeek ? m_pendingSeek->time : m_lastSeekTime;
     MediaTime synchronizerTime = clampTimeToLastSeekTime(PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase])));
     if (synchronizerTime < MediaTime::zeroTime())
         return MediaTime::zeroTime();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -64,7 +64,7 @@ public:
 
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::AVFObjC; }
 
-    MediaPlayerPrivateMediaSourceAVFObjC* player() const { return m_player.get(); }
+    RefPtr<MediaPlayerPrivateInterface> player() const final;
 
     AddStatus addSourceBuffer(const ContentType&, bool webMParserEnabled, RefPtr<SourceBufferPrivate>&) final;
     void durationChanged(const MediaTime&) final;
@@ -75,7 +75,6 @@ public:
 
     bool hasSelectedVideo() const;
 
-    MediaTime currentMediaTime() const final;
     void willSeek();
 
     FloatSize naturalSize() const;
@@ -111,6 +110,7 @@ public:
 
 private:
     MediaSourcePrivateAVFObjC(MediaPlayerPrivateMediaSourceAVFObjC&, MediaSourcePrivateClient&);
+    MediaPlayerPrivateMediaSourceAVFObjC* platformPlayer() const { return m_player.get(); }
 
     void notifyActiveSourceBuffersChanged() final;
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -111,42 +111,40 @@ void MediaSourcePrivateAVFObjC::removeSourceBuffer(SourceBufferPrivate& sourceBu
 
 void MediaSourcePrivateAVFObjC::notifyActiveSourceBuffersChanged()
 {
-    if (auto* player = this->player())
+    if (auto player = this->player())
         player->notifyActiveSourceBuffersChanged();
+}
+
+RefPtr<MediaPlayerPrivateInterface> MediaSourcePrivateAVFObjC::player() const
+{
+    return RefPtr { m_player.get() };
 }
 
 void MediaSourcePrivateAVFObjC::durationChanged(const MediaTime& duration)
 {
     MediaSourcePrivate::durationChanged(duration);
-    if (auto* player = this->player())
+    if (auto player = platformPlayer())
         player->durationChanged();
 }
 
 void MediaSourcePrivateAVFObjC::markEndOfStream(EndOfStreamStatus status)
 {
-    if (auto* player = this->player(); status == EndOfStreamStatus::NoError && player)
+    if (auto player = platformPlayer(); status == EndOfStreamStatus::NoError && player)
         player->setNetworkState(MediaPlayer::NetworkState::Loaded);
     MediaSourcePrivate::markEndOfStream(status);
 }
 
 MediaPlayer::ReadyState MediaSourcePrivateAVFObjC::mediaPlayerReadyState() const
 {
-    if (auto* player = this->player())
+    if (auto player = this->player())
         return player->readyState();
     return MediaPlayer::ReadyState::HaveNothing;
 }
 
 void MediaSourcePrivateAVFObjC::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
-    if (auto* player = this->player())
+    if (auto player = platformPlayer())
         player->setReadyState(readyState);
-}
-
-MediaTime MediaSourcePrivateAVFObjC::currentMediaTime() const
-{
-    if (auto* player = this->player())
-        return player->currentMediaTime();
-    return MediaTime::invalidTime();
 }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
@@ -154,7 +152,7 @@ void MediaSourcePrivateAVFObjC::sourceBufferKeyNeeded(SourceBufferPrivateAVFObjC
 {
     m_sourceBuffersNeedingSessions.append(buffer);
 
-    if (auto* player = this->player())
+    if (auto player = platformPlayer())
         player->keyNeeded(initData);
 }
 #endif
@@ -260,7 +258,7 @@ void MediaSourcePrivateAVFObjC::setSourceBufferWithSelectedVideo(SourceBufferPri
 
     m_sourceBufferWithSelectedVideo = sourceBuffer;
 
-    if (auto* player = this->player(); m_sourceBufferWithSelectedVideo && player) {
+    if (auto player = platformPlayer(); m_sourceBufferWithSelectedVideo && player) {
         m_sourceBufferWithSelectedVideo->setVideoLayer(player->sampleBufferDisplayLayer());
         m_sourceBufferWithSelectedVideo->setDecompressionSession(player->decompressionSession());
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1312,8 +1312,8 @@ void SourceBufferPrivateAVFObjC::setDecompressionSession(WebCoreDecompressionSes
 
 RefPtr<MediaPlayerPrivateMediaSourceAVFObjC> SourceBufferPrivateAVFObjC::player() const
 {
-    if (RefPtr mediaSource = downcast<MediaSourcePrivateAVFObjC>(m_mediaSource.get()))
-        return mediaSource->player();
+    if (RefPtr mediaSource = m_mediaSource.get())
+        return static_cast<MediaPlayerPrivateMediaSourceAVFObjC*>(mediaSource->player().get());
     return nullptr;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -168,8 +168,6 @@ public:
     float duration() const final { return durationMediaTime().toFloat(); }
     double durationDouble() const final { return durationMediaTime().toDouble(); }
     MediaTime durationMediaTime() const override;
-    float currentTime() const final { return currentMediaTime().toFloat(); }
-    double currentTimeDouble() const final { return currentMediaTime().toDouble(); }
     MediaTime currentMediaTime() const override;
     const PlatformTimeRanges& buffered() const override;
     float maxTimeSeekable() const final { return maxMediaTimeSeekable().toFloat(); }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -94,6 +94,11 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
     return MediaSourcePrivateGStreamer::AddStatus::Ok;
 }
 
+RefPtr<MediaPlayerPrivateInterface> MediaSourcePrivateGStreamer::player() const
+{
+    return &m_playerPrivate;
+}
+
 void MediaSourcePrivateGStreamer::durationChanged(const MediaTime& duration)
 {
     ASSERT(isMainThread());
@@ -137,11 +142,6 @@ MediaPlayer::ReadyState MediaSourcePrivateGStreamer::mediaPlayerReadyState() con
 void MediaSourcePrivateGStreamer::setMediaPlayerReadyState(MediaPlayer::ReadyState state)
 {
     m_playerPrivate.setReadyState(state);
-}
-
-MediaTime MediaSourcePrivateGStreamer::currentMediaTime() const
-{
-    return m_playerPrivate.currentMediaTime();
 }
 
 void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -56,6 +56,8 @@ public:
     static Ref<MediaSourcePrivateGStreamer> open(MediaSourcePrivateClient&, MediaPlayerPrivateGStreamerMSE&);
     virtual ~MediaSourcePrivateGStreamer();
 
+    RefPtr<MediaPlayerPrivateInterface> player() const final;
+
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::GStreamer; }
 
     AddStatus addSourceBuffer(const ContentType&, bool, RefPtr<SourceBufferPrivate>&) override;
@@ -65,8 +67,6 @@ public:
 
     MediaPlayer::ReadyState mediaPlayerReadyState() const override;
     void setMediaPlayerReadyState(MediaPlayer::ReadyState) override;
-
-    MediaTime currentMediaTime() const final;
 
     void notifyActiveSourceBuffersChanged() final;
 

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -51,7 +51,7 @@
 static const GUID MFSamplePresenterSampleCounter =
 { 0x869f1f7c, 0x3496, 0x48a9, { 0x88, 0xe3, 0x69, 0x85, 0x79, 0xd0, 0x8c, 0xb6 } };
 
-static const double tenMegahertz = 10000000;
+static constexpr uint32_t tenMegahertz = 10000000;
 
 namespace WebCore {
 
@@ -295,46 +295,46 @@ void MediaPlayerPrivateMediaFoundation::setRate(float rate)
     rateControl->SetRate(reduceSamplesInStream, rate);
 }
 
-float MediaPlayerPrivateMediaFoundation::duration() const
+MediaTime MediaPlayerPrivateMediaFoundation::durationMediaTime() const
 {
     if (!m_mediaSource)
-        return 0;
+        return MediaTime::zeroTime();
 
     IMFPresentationDescriptor* descriptor;
     if (!SUCCEEDED(m_mediaSource->CreatePresentationDescriptor(&descriptor)))
-        return 0;
+        return MediaTime::zeroTime();
     
     UINT64 duration;
     if (!SUCCEEDED(descriptor->GetUINT64(MF_PD_DURATION, &duration)))
         duration = 0;
     descriptor->Release();
     
-    return static_cast<float>(duration) / tenMegahertz;
+    return MediaTime(duration, tenMegahertz);
 }
 
-float MediaPlayerPrivateMediaFoundation::currentTime() const
+MediaTime MediaPlayerPrivateMediaFoundation::currentMediaTime() const
 {
     if (m_sessionEnded)
-        return duration();
+        return durationMediaTime();
     if (!m_mediaSession)
-        return 0;
+        return MediaTime::invalidTime();
     COMPtr<IMFClock> clock;
     HRESULT hr = m_mediaSession->GetClock(&clock);
     if (FAILED(hr))
-        return 0;
+        return MediaTime::invalidTime();
 
     LONGLONG clockTime;
     MFTIME systemTime;
     hr = clock->GetCorrelatedTime(0, &clockTime, &systemTime);
     if (FAILED(hr))
-        return 0;
+        return MediaTime::invalidTime();
 
     // clockTime is in 100 nanoseconds, we need to convert to seconds.
-    float currentTime = clockTime / tenMegahertz;
+    auto currentTime = MediaTime(clockTime, tenMegahertz);
 
-    if (m_buffered.length() && currentTime > m_buffered.maximumBufferedTime().toFloat()) {
+    if (m_buffered.length() && currentTime > m_buffered.maximumBufferedTime()) {
         PlatformTimeRanges ranges;
-        ranges.add(MediaTime::zeroTime(), MediaTime::createWithFloat(currentTime));
+        ranges.add(MediaTime::zeroTime(), currentTime);
         m_buffered = WTFMove(ranges);
     }
     return currentTime;
@@ -380,9 +380,9 @@ MediaPlayer::ReadyState MediaPlayerPrivateMediaFoundation::readyState() const
     return m_readyState;
 }
 
-float MediaPlayerPrivateMediaFoundation::maxTimeSeekable() const
+MediaTime MediaPlayerPrivateMediaFoundation::maxMediaTimeSeekable() const
 {
-    return durationDouble();
+    return durationMediaTime();
 }
 
 const PlatformTimeRanges& MediaPlayerPrivateMediaFoundation::buffered() const

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -87,9 +87,9 @@ public:
 
     void setRate(float) final;
 
-    float duration() const final;
+    MediaTime durationMediaTime() const final;
 
-    float currentTime() const final;
+    MediaTime currentMediaTime() const final;
 
     bool paused() const final;
 
@@ -100,7 +100,7 @@ public:
     MediaPlayer::NetworkState networkState() const final;
     MediaPlayer::ReadyState readyState() const final;
 
-    float maxTimeSeekable() const final;
+    MediaTime maxMediaTimeSeekable() const final;
 
     const PlatformTimeRanges& buffered() const final;
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -152,7 +152,7 @@ void MockMediaPlayerMediaSource::setPageIsVisible(bool, String&&)
 
 bool MockMediaPlayerMediaSource::seeking() const
 {
-    return !m_seekCompleted;
+    return !!m_lastSeekTarget;
 }
 
 bool MockMediaPlayerMediaSource::paused() const
@@ -195,7 +195,7 @@ void MockMediaPlayerMediaSource::paint(GraphicsContext&, const FloatRect&)
 
 MediaTime MockMediaPlayerMediaSource::currentMediaTime() const
 {
-    return m_currentTime;
+    return m_lastSeekTarget ? m_lastSeekTarget->time : m_currentTime;
 }
 
 bool MockMediaPlayerMediaSource::currentMediaTimeMayProgress() const
@@ -216,7 +216,7 @@ MediaTime MockMediaPlayerMediaSource::durationMediaTime() const
 
 void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
 {
-    m_seekCompleted = false;
+    m_lastSeekTarget = target;
     m_mediaSourcePrivate->waitForTarget(target)->whenSettled(RunLoop::current(), [this, weakThis = WeakPtr { this }](auto&& result) {
         if (!weakThis || !result)
             return;
@@ -225,7 +225,7 @@ void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
-            m_seekCompleted = true;
+            m_lastSeekTarget.reset();
             m_currentTime = seekTime;
 
             if (auto player = m_player.get()) {

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -103,10 +103,10 @@ private:
 
     MediaTime m_currentTime;
     MediaTime m_duration;
+    std::optional<SeekTarget> m_lastSeekTarget;
     MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
     MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
     bool m_playing { false };
-    bool m_seekCompleted { false };
 };
 
 }

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -73,6 +73,11 @@ MediaSourcePrivate::AddStatus MockMediaSourcePrivate::addSourceBuffer(const Cont
     return AddStatus::Ok;
 }
 
+RefPtr<MediaPlayerPrivateInterface> MockMediaSourcePrivate::player() const
+{
+    return m_player.get();
+}
+
 void MockMediaSourcePrivate::durationChanged(const MediaTime& duration)
 {
     MediaSourcePrivate::durationChanged(duration);
@@ -104,13 +109,6 @@ void MockMediaSourcePrivate::notifyActiveSourceBuffersChanged()
 {
     if (m_player)
         m_player->notifyActiveSourceBuffersChanged();
-}
-
-MediaTime MockMediaSourcePrivate::currentMediaTime() const
-{
-    if (m_player)
-        return m_player->currentMediaTime();
-    return MediaTime::invalidTime();
 }
 
 std::optional<VideoPlaybackQualityMetrics> MockMediaSourcePrivate::videoPlaybackQualityMetrics()

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -48,9 +48,7 @@ public:
 
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::Mock; }
 
-    WeakPtr<MockMediaPlayerMediaSource> player() const { return m_player; }
-
-    MediaTime currentMediaTime() const final;
+    RefPtr<MediaPlayerPrivateInterface> player() const final;
 
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics();
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -138,6 +138,11 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
     return returnedStatus;
 }
 
+RefPtr<WebCore::MediaPlayerPrivateInterface> MediaSourcePrivateRemote::player() const
+{
+    return m_mediaPlayerPrivate.get();
+}
+
 void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
 {
     // Called from the MediaSource's dispatcher.

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -62,6 +62,7 @@ public:
     virtual ~MediaSourcePrivateRemote();
 
     // MediaSourcePrivate overrides
+    RefPtr<WebCore::MediaPlayerPrivateInterface> player() const final;
     constexpr WebCore::MediaPlatformType platformType() const final { return WebCore::MediaPlatformType::Remote; }
     AddStatus addSourceBuffer(const WebCore::ContentType&, bool webMParserEnabled, RefPtr<WebCore::SourceBufferPrivate>&) final;
     void removeSourceBuffer(WebCore::SourceBufferPrivate&) final { }
@@ -73,12 +74,6 @@ public:
     void setMediaPlayerReadyState(WebCore::MediaPlayer::ReadyState) final;
 
     void setTimeFudgeFactor(const MediaTime&) final;
-
-    MediaTime currentMediaTime() const final
-    {
-        ASSERT_NOT_REACHED();
-        return { };
-    }
 
     static WorkQueue& queue();
 


### PR DESCRIPTION
#### b0908a7024e145b4957d96953f1576ce62db91a8
<pre>
[MSE] Remove HTMLMedia Element access from MediaSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=268796">https://bugs.webkit.org/show_bug.cgi?id=268796</a>
<a href="https://rdar.apple.com/122359957">rdar://122359957</a>

Reviewed by Eric Carlson.

If the MediaSource object lives in a worker thread, it will not be possible
for it to access the HTMLMediaElement directly.
We remove most access from the MediaSource to the media element.

One attribute accessed often is the HTMLMediaElement&apos;s currentTime value.
Instead we access the MediaPlayerPrivate value. As the HTMLMediaElement returns
the seekTime if a seek has been started we need a way to reproduce a similar
behaviour from the MediaPlayerPrivate. We add a `willSeekToTarget()` and `pendingSeekTime()`
method that will receive the seek time from the HTMLMediaElement.
To differentiate the behaviour between the actual player&apos;s time and what the
time according to the media element is, we add a `currentOrPendingSeekTime` method.

The handling of the Tracks hasn&apos;t been converted yet and will be done in
a follow-up change.

The MediaSourcePrivate::mediaTime method was duplicated in all implementations.
To simplify, we move it to the base class.

Fly-By: there were 3 virtual methods in the MediaPlayerPrivateInterface class
to retrieve the current time. We only leave on: currentMediaTime.
Fly-By: the static implementation to retrieve a SourceBuffer maximum size was
living in the MediaElementSession. We move it to the SourceBuffer instead.
Fly-By: The MockMediaPlayerMediaSource::isSeeking() would have always returned true
before seeking at least once. Correct logic.

Covered by existing tests, no change in observable behaviour.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::isOpen const): Deleted.
(WebCore::ManagedMediaSource::ensurePrefsRead):
(WebCore::ManagedMediaSource::monitorSourceBuffers):
(WebCore::ManagedMediaSource::isOpen const):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setPrivateAndOpen):
(WebCore::MediaSource::currentMediaTime const):
For consistency with other classes naming, rename currentTime() to currentMediaTime().
(WebCore::MediaSource::buffered const):
(WebCore::MediaSource::completeSeek):
(WebCore::MediaSource::hasBufferedTime):
(WebCore::MediaSource::hasCurrentTime):
(WebCore::MediaSource::hasFutureTime):
(WebCore::MediaSource::streamEndedWithError):
(WebCore::MediaSource::addSourceBuffer):
(WebCore::MediaSource::removeSourceBuffer):
(WebCore::MediaSource::detachFromElement):
(WebCore::MediaSource::attachToElement):
(WebCore::MediaSource::settings const):
(WebCore::MediaSource::stop):
(WebCore::MediaSource::notifyElementUpdateMediaState const):
(WebCore::MediaSource::incrementDroppedFrameCount):
(WebCore::MediaSource::addAudioTrackToElement):
(WebCore::MediaSource::addTextTrackToElement):
(WebCore::MediaSource::addVideoTrackToElement):
(WebCore::MediaSource::currentTime const): Deleted.
* Source/WebCore/Modules/mediasource/MediaSource.h:
(WebCore::MediaSource::mediaElement const): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::rangeRemoval):
(WebCore::SourceBuffer::changeType):
(WebCore::SourceBuffer::appendBufferInternal):
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete):
(WebCore::SourceBuffer::maximumBufferSize const):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::sourceBufferPrivateDidDropSample):
(WebCore::SourceBuffer::canPlayThroughRange):
(WebCore::SourceBuffer::settings const):
(WebCore::SourceBuffer::memoryPressure):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::deferredMediaSourceOpenCanProgress const):
move check to see if the ManagedMediaSource can progress to open to the HTMLMediaElement class.
(WebCore::HTMLMediaElement::seekWithTolerance):
(WebCore::HTMLMediaElement::seekTask):
(WebCore::HTMLMediaElement::clearSeeking):
(WebCore::HTMLMediaElement::maximumSourceBufferSize const): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::incrementDroppedFrameCount):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::maximumMediaSourceBufferSize const): Deleted.
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::willSeekToTarget):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp:
(WebCore::MediaPlayerPrivateInterface::currentOrPendingSeekTime const):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::currentMediaTime const):
(WebCore::MediaPlayerPrivateInterface::willSeekToTarget):
(WebCore::MediaPlayerPrivateInterface::pendingSeekTime const):
(WebCore::MediaPlayerPrivateInterface::currentTime const): Deleted.
(WebCore::MediaPlayerPrivateInterface::currentTimeDouble const): Deleted.
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::currentMediaTime const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
To allow for a common currentMediaTime() implementation we need a generic
way to access the associated MediaPlayerPrivate.
Add a pure virtual `parent()`.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::currentTime const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentMediaTime const):
While seeking, return the last seekTime.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::notifyActiveSourceBuffersChanged):
(WebCore::MediaSourcePrivateAVFObjC::player const):
(WebCore::MediaSourcePrivateAVFObjC::durationChanged):
(WebCore::MediaSourcePrivateAVFObjC::markEndOfStream):
(WebCore::MediaSourcePrivateAVFObjC::mediaPlayerReadyState const):
(WebCore::MediaSourcePrivateAVFObjC::setMediaPlayerReadyState):
(WebCore::MediaSourcePrivateAVFObjC::sourceBufferKeyNeeded):
(WebCore::MediaSourcePrivateAVFObjC::setSourceBufferWithSelectedVideo):
(WebCore::MediaSourcePrivateAVFObjC::currentMediaTime const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::player const):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::currentMediaTime const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
Use MediaTime instead of floats.
(WebCore::MediaPlayerPrivateMediaFoundation::currentMediaTime const):
(WebCore::MediaPlayerPrivateMediaFoundation::currentTime const): Deleted.
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seeking const): Fix logic, m_seekCompleted
was initialised to false, making seeking() return the wrong value.
(WebCore::MockMediaPlayerMediaSource::currentMediaTime const): Return last seek time
while seek hasn&apos;t completed.
(WebCore::MockMediaPlayerMediaSource::seekToTarget):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::player const):
(WebCore::MockMediaSourcePrivate::currentMediaTime const): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::willSeekToTarget):
(WebKit::MediaPlayerPrivateRemote::pendingSeekTime const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::player const):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/274442@main">https://commits.webkit.org/274442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eb28bb15ab384316bf4426e50132b0cc41f5504

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41660 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15431 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42937 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37243 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15544 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8751 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->