### PR TITLE
Draft: [WKTR][WPE] Use threaded scrolling

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -45,6 +45,11 @@ WKPageConfigurationRef WKPageConfigurationCreate()
     return toAPI(&API::PageConfiguration::create().leakRef());
 }
 
+WKPageConfigurationRef WKPageConfigurationCopy(WKPageConfigurationRef configuration)
+{
+    return toAPI(toImpl(configuration)->copy().leakRef());
+}
+
 WKContextRef WKPageConfigurationGetContext(WKPageConfigurationRef configuration)
 {
     return toAPI(toImpl(configuration)->processPool());

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
@@ -37,6 +37,8 @@ WK_EXPORT WKTypeID WKPageConfigurationGetTypeID(void);
 
 WK_EXPORT WKPageConfigurationRef WKPageConfigurationCreate(void);
 
+WK_EXPORT WKPageConfigurationRef WKPageConfigurationCopy(WKPageConfigurationRef configuration);
+
 WK_EXPORT WKContextRef WKPageConfigurationGetContext(WKPageConfigurationRef configuration);
 WK_EXPORT void WKPageConfigurationSetContext(WKPageConfigurationRef configuration, WKContextRef context);
 

--- a/Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp
@@ -29,6 +29,7 @@
 #include "PlatformWebViewClientLibWPE.h"
 #include "PlatformWebViewClientWPE.h"
 #include "TestController.h"
+#include <WebKit/WKPreferencesRefPrivate.h>
 #include <cstdio>
 #include <wtf/RunLoop.h>
 #include <wtf/text/WTFString.h>
@@ -39,6 +40,9 @@ PlatformWebView::PlatformWebView(WKPageConfigurationRef configuration, const Tes
     : m_windowIsKey(true)
     , m_options(options)
 {
+    auto copiedConfiguration = adoptWK(WKPageConfigurationCopy(configuration));
+    WKPreferencesSetThreadedScrollingEnabled(WKPageConfigurationGetPreferences(copiedConfiguration.get()), m_options.useThreadedScrolling());
+
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     if (TestController::singleton().useWPEPlatformAPI())
         m_window = new PlatformWebViewClientWPE(configuration);

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -141,6 +141,7 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions&)
 TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCommand&) const
 {
     TestFeatures features;
+    features.boolTestRunnerFeatures.insert({ "useThreadedScrolling", true });
     features.boolWebPreferenceFeatures.insert({ "AsyncOverflowScrollingEnabled", true });
     return features;
 }


### PR DESCRIPTION
#### a4825617c924a6ee7ee1acec4f012483a65b9921
<pre>
Draft: [WKTR][WPE] Use threaded scrolling
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationCopy):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h:
* Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp:
(WTR::PlatformWebView::PlatformWebView):
* Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp:
(WTR::TestController::platformSpecificFeatureDefaultsForTest const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4825617c924a6ee7ee1acec4f012483a65b9921

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34617 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32598 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38819 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37048 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->