### PR TITLE
[build.webkit.org] [WPE] Add build bot using Skia backend

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -690,6 +690,7 @@
                   {
                     "name": "WPE-Linux-64-bit-Release-Skia-Build", "factory": "BuildFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
+                    "additionalArguments": ["--cmakeargs=-DUSE_SKIA=ON"],
                     "workernames": ["wpe-linux-bot-35"]
                   }
                 ],


### PR DESCRIPTION
#### c541c9fc4bfa8fa1d9e8b62227498a33a0ae9f96
<pre>
[build.webkit.org] [WPE] Add build bot using Skia backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=268806">https://bugs.webkit.org/show_bug.cgi?id=268806</a>

Reviewed by NOBODY (OOPS!).

* Tools/CISupport/build-webkit-org/config.json: Arrange passing
--cmakeargs=-DUSE_SKIA=ON as additional arguments to build-webkit
for the WPE-Linux-64-bit-Release-Skia-Build queue.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c541c9fc4bfa8fa1d9e8b62227498a33a0ae9f96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41434 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32601 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13038 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38824 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37054 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/38951 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15320 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14983 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->