### PR TITLE
Canvas captureStream produces stuttering with WebGL

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -764,12 +764,10 @@ void GraphicsContextGLCocoa::prepareForDisplayWithFinishedSignal(Function<void()
     prepareTexture();
     // The fence inserted by this will be scheduled because next BindTexImage will wait until scheduled.
     insertFinishedSignalOrInvoke(WTFMove(finishedSignal));
-    if (!bindNextDrawingBuffer()) {
-        // If the allocation failed, BindTexImage did not run. The fence must be scheduled.
-        waitUntilWorkScheduled();
+    bool success = bindNextDrawingBuffer();
+    waitUntilWorkScheduled();
+    if (!success)
         forceContextLost();
-        return;
-    }
 }
 
 


### PR DESCRIPTION
#### 18019ceed4fbceaa9fcc23b2f36758831b23a155
<pre>
Canvas captureStream produces stuttering with WebGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=268613">https://bugs.webkit.org/show_bug.cgi?id=268613</a>
<a href="https://rdar.apple.com/122619662">rdar://122619662</a>

Reviewed by Youenn Fablet.

GraphicsContextGLCocoa::surfaceBufferToVideoFrame() will access the
display buffer IOSurface. The display buffer drawing must be scheduled
to Metal before this happens.

EGL_ReleaseTexImage() in bindNextDrawingBuffer used to ensure this, due
to ReleaseTexImage being specified as inducing a flush.

ANGLE changed flush semantics so that it does not wait until the
commands are scheduled. Thus long running WebGL could be left
unscheduled at the display buffer read for MSE capture track.

Fix by ensuring the display buffer commands are scheduled during
prepare, as is the intention.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::prepareForDisplayWithFinishedSignal):

Canonical link: <a href="https://commits.webkit.org/274454@main">https://commits.webkit.org/274454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aa5b83a3b36d175c57ab6f55656549baa84bc4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32604 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33745 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13049 "Found 1 new API test failure: /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13013 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42720 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34998 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38842 "Found 1 new test failure: fast/repaint/animation-after-layer-scroll.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37067 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15329 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8758 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->