### PR TITLE
Implement field-sizing support for listboxes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1062,7 +1062,6 @@ imported/w3c/web-platform-tests/content-security-policy [ DumpJSConsoleLogInStdE
 # field-sizing is not supported
 imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html [ Skip ]
 imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text.html [ Skip ]
-imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select.html [ Skip ]
 imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html [ Skip ]
 
 # FIXME: Skip Content Security Policy tests that are dumping the render tree instead of text:

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
@@ -2,7 +2,7 @@
 
 FAIL dropdown: The width should depend on the selected OPTION assert_greater_than: expected a number greater than 95 but got 95
 FAIL dropdown: Change the field-sizing value dynamically assert_less_than: expected a number less than 114 but got 114
-FAIL listbox: The size depend on the content assert_greater_than: expected a number greater than 57 but got 57
-FAIL listbox: The size attribute value is ignored assert_greater_than: expected a number greater than 57 but got 57
-FAIL listbox: Change the field-sizing value dynamically assert_less_than: expected a number less than 57 but got 57
+PASS listbox: The size depend on the content
+PASS listbox: The size attribute value is ignored
+PASS listbox: Change the field-sizing value dynamically
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
@@ -1,0 +1,8 @@
+
+
+FAIL dropdown: The width should depend on the selected OPTION assert_greater_than: expected a number greater than 114 but got 114
+FAIL dropdown: Change the field-sizing value dynamically assert_less_than: expected a number less than 139 but got 139
+PASS listbox: The size depend on the content
+PASS listbox: The size attribute value is ignored
+PASS listbox: Change the field-sizing value dynamically
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
@@ -1,0 +1,8 @@
+
+
+FAIL dropdown: The width should depend on the selected OPTION assert_greater_than: expected a number greater than 108 but got 108
+FAIL dropdown: Change the field-sizing value dynamically assert_less_than: expected a number less than 133 but got 133
+PASS listbox: The size depend on the content
+PASS listbox: The size attribute value is ignored
+PASS listbox: Change the field-sizing value dynamically
+

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -260,6 +260,9 @@ void RenderListBox::computePreferredLogicalWidths()
 
 unsigned RenderListBox::size() const
 {
+    if (style().fieldSizing() == FieldSizing::Content)
+        return static_cast<unsigned>(numItems());
+
     unsigned specifiedSize = selectElement().size();
     if (specifiedSize >= 1)
         return specifiedSize;


### PR DESCRIPTION
#### cf51aaac17a75e4035b00844e53fdfcf33cff3da
<pre>
Implement field-sizing support for listboxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=269069">https://bugs.webkit.org/show_bug.cgi?id=269069</a>

Reviewed by Aditya Keerthi.

Selects with &quot;field-sizing: content&quot; applied now correctly size based on their contents rather than the size attribute when in listbox mode.

Listbox mode is used when the size attribute is greater than 1 or the multiple attribute is applied.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt: Added.
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::size const):

Canonical link: <a href="https://commits.webkit.org/274414@main">https://commits.webkit.org/274414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f81ed054acfd0fb0e77c1144131c354e6089ec65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34711 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32649 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13116 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42805 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38909 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37133 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15412 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8735 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->