### PR TITLE
[WebGPU] GPURenderPassEncoder.beginOcclusionQuery should work with destroyed buffers

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -654,7 +654,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
             return RenderPassEncoder::createInvalid(*this, m_device, @"querySet for occlusion query was not of type occlusion");
         mtlDescriptor.visibilityResultBuffer = occlusionQuery.visibilityBuffer();
         visibilityResultBuffer = mtlDescriptor.visibilityResultBuffer;
-        visibilityResultBufferSize = occlusionQuery.visibilityBuffer().length;
+        visibilityResultBufferSize = occlusionQuery.isDestroyed() ? NSUIntegerMax : occlusionQuery.visibilityBuffer().length;
     }
 
     if (m_device->baseCapabilities().counterSamplingAPI == HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::StageBoundary

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -114,6 +114,7 @@ private:
     uint32_t maxBindGroupIndex() const;
     bool issuedDrawCall() const;
     void incrementDrawCount(uint32_t = 1);
+    bool occlusionQueryIsDestroyed() const;
 
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -155,19 +155,33 @@ RenderPassEncoder::~RenderPassEncoder()
     m_renderCommandEncoder = nil;
 }
 
+bool RenderPassEncoder::occlusionQueryIsDestroyed() const
+{
+    return m_visibilityResultBufferSize == NSUIntegerMax;
+}
+
 void RenderPassEncoder::beginOcclusionQuery(uint32_t queryIndex)
 {
     RETURN_IF_FINISHED();
 
     queryIndex *= sizeof(uint64_t);
-    if (m_occlusionQueryActive || m_queryBufferIndicesToClear.contains(queryIndex) || !m_visibilityResultBufferSize || queryIndex >= m_visibilityResultBufferSize) {
+    if (m_occlusionQueryActive || m_queryBufferIndicesToClear.contains(queryIndex)) {
         makeInvalid(@"beginOcclusionQuery validation failure");
         return;
     }
     m_occlusionQueryActive = true;
     m_visibilityResultBufferOffset = queryIndex;
-    [m_renderCommandEncoder setVisibilityResultMode:MTLVisibilityResultModeCounting offset:queryIndex];
     m_queryBufferIndicesToClear.add(m_visibilityResultBufferOffset);
+
+
+    if (occlusionQueryIsDestroyed())
+        return;
+    if (!m_visibilityResultBufferSize || queryIndex >= m_visibilityResultBufferSize) {
+        makeInvalid(@"beginOcclusionQuery validation failure");
+        return;
+    }
+
+    [m_renderCommandEncoder setVisibilityResultMode:MTLVisibilityResultModeCounting offset:queryIndex];
 }
 
 void RenderPassEncoder::endOcclusionQuery()
@@ -178,6 +192,9 @@ void RenderPassEncoder::endOcclusionQuery()
         return;
     }
     m_occlusionQueryActive = false;
+
+    if (occlusionQueryIsDestroyed())
+        return;
     [m_renderCommandEncoder setVisibilityResultMode:MTLVisibilityResultModeDisabled offset:m_visibilityResultBufferOffset];
 }
 
@@ -581,7 +598,7 @@ void RenderPassEncoder::endPass()
     m_renderCommandEncoder = nil;
     m_parentEncoder->lock(false);
 
-    if (m_queryBufferIndicesToClear.size()) {
+    if (m_queryBufferIndicesToClear.size() && !occlusionQueryIsDestroyed()) {
         id<MTLBlitCommandEncoder> blitCommandEncoder = m_parentEncoder->ensureBlitCommandEncoder();
         for (auto& offset : m_queryBufferIndicesToClear)
             [blitCommandEncoder fillBuffer:m_visibilityResultBuffer range:NSMakeRange(static_cast<NSUInteger>(offset), sizeof(uint64_t)) value:0];


### PR DESCRIPTION
#### 644537567f5ee493e65511597205600e123d5880
<pre>
[WebGPU] GPURenderPassEncoder.beginOcclusionQuery should work with destroyed buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=269016">https://bugs.webkit.org/show_bug.cgi?id=269016</a>
&lt;radar://122577504&gt;

Reviewed by Dan Glastonbury.

If the occlusion query buffer is destroyed, its visibility buffer
size will be zero but the specification still expects operations
to work on the destroyed query set.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::occlusionQueryIsDestroyed const):
(WebGPU::RenderPassEncoder::beginOcclusionQuery):
(WebGPU::RenderPassEncoder::endOcclusionQuery):
(WebGPU::RenderPassEncoder::endPass):

Canonical link: <a href="https://commits.webkit.org/274372@main">https://commits.webkit.org/274372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b8d07d6dff0239ab071ea240a60760786abc18a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41449 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15197 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15027 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33748 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13052 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42726 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35326 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11328 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8713 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/14994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->