### PR TITLE
Adopt even more smart pointers in SVG

### DIFF
--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -905,4 +905,9 @@ RenderBox* RenderImage::embeddedContentBox() const
     return nullptr;
 }
 
+CheckedRef<RenderImageResource> RenderImage::checkedImageResource() const
+{
+    return *m_imageResource;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -46,6 +46,7 @@ public:
 
     RenderImageResource& imageResource() { return *m_imageResource; }
     const RenderImageResource& imageResource() const { return *m_imageResource; }
+    CheckedRef<RenderImageResource> checkedImageResource() const;
     CachedImage* cachedImage() const { return imageResource().cachedImage(); }
 
     ImageSizeChangeType setImageSizeForAltText(CachedImage* newImage = nullptr);

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -60,6 +60,11 @@ RenderSVGImage::RenderSVGImage(SVGImageElement& element, RenderStyle&& style)
 
 RenderSVGImage::~RenderSVGImage() = default;
 
+CheckedRef<RenderImageResource> RenderSVGImage::checkedImageResource() const
+{
+    return *m_imageResource;
+}
+
 void RenderSVGImage::willBeDestroyed()
 {
     imageResource().shutdown();

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -43,6 +43,7 @@ public:
 
     RenderImageResource& imageResource() { return *m_imageResource; }
     const RenderImageResource& imageResource() const { return *m_imageResource; }
+    CheckedRef<RenderImageResource> checkedImageResource() const;
 
     bool updateImageViewport();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -59,6 +59,11 @@ LegacyRenderSVGImage::LegacyRenderSVGImage(SVGImageElement& element, RenderStyle
 
 LegacyRenderSVGImage::~LegacyRenderSVGImage() = default;
 
+CheckedRef<RenderImageResource> LegacyRenderSVGImage::checkedImageResource() const
+{
+    return *m_imageResource;
+}
+
 void LegacyRenderSVGImage::willBeDestroyed()
 {
     imageResource().shutdown();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -47,6 +47,7 @@ public:
 
     RenderImageResource& imageResource() { return *m_imageResource; }
     const RenderImageResource& imageResource() const { return *m_imageResource; }
+    CheckedRef<RenderImageResource> checkedImageResource() const;
 
     // Note: Assumes the PaintInfo context has had all local transforms applied.
     void paintForeground(PaintInfo&);

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -56,23 +56,23 @@ void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, co
     case AttributeNames::xChannelSelectorAttr: {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(newValue);
         if (enumToUnderlyingType(propertyValue))
-            m_xChannelSelector->setBaseValInternal<ChannelSelectorType>(propertyValue);
+            Ref { m_xChannelSelector }->setBaseValInternal<ChannelSelectorType>(propertyValue);
         break;
     }
     case AttributeNames::yChannelSelectorAttr: {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(newValue);
         if (enumToUnderlyingType(propertyValue))
-            m_yChannelSelector->setBaseValInternal<ChannelSelectorType>(propertyValue);
+            Ref { m_yChannelSelector }->setBaseValInternal<ChannelSelectorType>(propertyValue);
         break;
     }
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::in2Attr:
-        m_in2->setBaseValInternal(newValue);
+        Ref { m_in2 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::scaleAttr:
-        m_scale->setBaseValInternal(newValue.toFloat());
+        Ref { m_scale }->setBaseValInternal(newValue.toFloat());
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -53,8 +53,8 @@ Ref<SVGFEDropShadowElement> SVGFEDropShadowElement::create(const QualifiedName& 
 
 void SVGFEDropShadowElement::setStdDeviation(float x, float y)
 {
-    m_stdDeviationX->setBaseValInternal(x);
-    m_stdDeviationY->setBaseValInternal(y);
+    Ref { m_stdDeviationX }->setBaseValInternal(x);
+    Ref { m_stdDeviationY }->setBaseValInternal(y);
     updateSVGRendererForElementChange();
 }
 
@@ -63,18 +63,18 @@ void SVGFEDropShadowElement::attributeChanged(const QualifiedName& name, const A
     switch (name.nodeName()) {
     case AttributeNames::stdDeviationAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
-            m_stdDeviationX->setBaseValInternal(result->first);
-            m_stdDeviationY->setBaseValInternal(result->second);
+            Ref { m_stdDeviationX }->setBaseValInternal(result->first);
+            Ref { m_stdDeviationY }->setBaseValInternal(result->second);
         }
         break;
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::dxAttr:
-        m_dx->setBaseValInternal(newValue.toFloat());
+        Ref { m_dx }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::dyAttr:
-        m_dy->setBaseValInternal(newValue.toFloat());
+        Ref { m_dy }->setBaseValInternal(newValue.toFloat());
         break;
     default:
         break;
@@ -148,7 +148,7 @@ IntOutsets SVGFEDropShadowElement::outsets(const FloatRect& targetBoundingBox, S
 
 RefPtr<FilterEffect> SVGFEDropShadowElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const
 {
-    RenderObject* renderer = this->renderer();
+    CheckedPtr renderer = this->renderer();
     if (!renderer)
         return nullptr;
 

--- a/Source/WebCore/svg/SVGFEFloodElement.cpp
+++ b/Source/WebCore/svg/SVGFEFloodElement.cpp
@@ -45,9 +45,9 @@ Ref<SVGFEFloodElement> SVGFEFloodElement::create(const QualifiedName& tagName, D
 
 bool SVGFEFloodElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)
 {
-    RenderObject* renderer = this->renderer();
+    CheckedPtr renderer = this->renderer();
     ASSERT(renderer);
-    const RenderStyle& style = renderer->style();
+    auto& style = renderer->style();
 
     auto& feFlood = downcast<FEFlood>(effect);
     if (attrName == SVGNames::flood_colorAttr)
@@ -61,12 +61,12 @@ bool SVGFEFloodElement::setFilterEffectAttribute(FilterEffect& effect, const Qua
 
 RefPtr<FilterEffect> SVGFEFloodElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const
 {
-    RenderObject* renderer = this->renderer();
+    CheckedPtr renderer = this->renderer();
     if (!renderer)
         return nullptr;
 
     auto& style = renderer->style();
-    const SVGRenderStyle& svgStyle = style.svgStyle();
+    auto& svgStyle = style.svgStyle();
 
     auto color = style.colorWithColorFilter(svgStyle.floodColor());
     float opacity = svgStyle.floodOpacity();

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -52,8 +52,8 @@ Ref<SVGFEGaussianBlurElement> SVGFEGaussianBlurElement::create(const QualifiedNa
 
 void SVGFEGaussianBlurElement::setStdDeviation(float x, float y)
 {
-    m_stdDeviationX->setBaseValInternal(x);
-    m_stdDeviationY->setBaseValInternal(y);
+    Ref { m_stdDeviationX }->setBaseValInternal(x);
+    Ref { m_stdDeviationY }->setBaseValInternal(y);
     updateSVGRendererForElementChange();
 }
 
@@ -62,17 +62,17 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
     switch (name.nodeName()) {
     case AttributeNames::stdDeviationAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
-            m_stdDeviationX->setBaseValInternal(result->first);
-            m_stdDeviationY->setBaseValInternal(result->second);
+            Ref { m_stdDeviationX }->setBaseValInternal(result->first);
+            Ref { m_stdDeviationY }->setBaseValInternal(result->second);
         }
         break;
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::edgeModeAttr: {
         auto propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(newValue);
         if (propertyValue != EdgeModeType::Unknown)
-            m_edgeMode->setBaseValInternal<EdgeModeType>(propertyValue);
+            Ref { m_edgeMode }->setBaseValInternal<EdgeModeType>(propertyValue);
         else
             protectedDocument()->checkedSVGExtensions()->reportWarning("feGaussianBlur: problem parsing edgeMode=\"" + newValue + "\". Filtered element will not be displayed.");
         break;

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -73,34 +73,34 @@ void SVGFELightElement::attributeChanged(const QualifiedName& name, const AtomSt
 {
     switch (name.nodeName()) {
     case AttributeNames::azimuthAttr:
-        m_azimuth->setBaseValInternal(newValue.toFloat());
+        Ref { m_azimuth }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::elevationAttr:
-        m_elevation->setBaseValInternal(newValue.toFloat());
+        Ref { m_elevation }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(newValue.toFloat());
+        Ref { m_x }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(newValue.toFloat());
+        Ref { m_y }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::zAttr:
-        m_z->setBaseValInternal(newValue.toFloat());
+        Ref { m_z }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::pointsAtXAttr:
-        m_pointsAtX->setBaseValInternal(newValue.toFloat());
+        Ref { m_pointsAtX }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::pointsAtYAttr:
-        m_pointsAtY->setBaseValInternal(newValue.toFloat());
+        Ref { m_pointsAtY }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::pointsAtZAttr:
-        m_pointsAtZ->setBaseValInternal(newValue.toFloat());
+        Ref { m_pointsAtZ }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::specularExponentAttr:
-        m_specularExponent->setBaseValInternal(newValue.toFloat());
+        Ref { m_specularExponent }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::limitingConeAngleAttr:
-        m_limitingConeAngle->setBaseValInternal(newValue.toFloat());
+        Ref { m_limitingConeAngle }->setBaseValInternal(newValue.toFloat());
         break;
     default:
         break;
@@ -120,7 +120,7 @@ void SVGFELightElement::svgAttributeChanged(const QualifiedName& attrName)
         if (!parent)
             return;
 
-        auto* renderer = parent->renderer();
+        CheckedPtr renderer = parent->renderer();
         if (!renderer || !renderer->isRenderSVGResourceFilterPrimitive())
             return;
 

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
@@ -51,7 +51,7 @@ Ref<SVGFEMergeNodeElement> SVGFEMergeNodeElement::create(const QualifiedName& ta
 void SVGFEMergeNodeElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::inAttr)
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
 
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -56,16 +56,16 @@ void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const A
     case AttributeNames::operatorAttr: {
         MorphologyOperatorType propertyValue = SVGPropertyTraits<MorphologyOperatorType>::fromString(newValue);
         if (propertyValue != MorphologyOperatorType::Unknown)
-            m_svgOperator->setBaseValInternal<MorphologyOperatorType>(propertyValue);
+            Ref { m_svgOperator }->setBaseValInternal<MorphologyOperatorType>(propertyValue);
         break;
     }
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::radiusAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
-            m_radiusX->setBaseValInternal(result->first);
-            m_radiusY->setBaseValInternal(result->second);
+            Ref { m_radiusX }->setBaseValInternal(result->first);
+            Ref { m_radiusY }->setBaseValInternal(result->second);
         }
         break;
     default:

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -53,13 +53,13 @@ void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomS
 {
     switch (name.nodeName()) {
     case AttributeNames::dxAttr:
-        m_dx->setBaseValInternal(newValue.toFloat());
+        Ref { m_dx }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::dyAttr:
-        m_dy->setBaseValInternal(newValue.toFloat());
+        Ref { m_dy }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -60,21 +60,21 @@ void SVGFESpecularLightingElement::attributeChanged(const QualifiedName& name, c
 {
     switch (name.nodeName()) {
     case AttributeNames::inAttr:
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::surfaceScaleAttr:
-        m_surfaceScale->setBaseValInternal(newValue.toFloat());
+        Ref { m_surfaceScale }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::specularConstantAttr:
-        m_specularConstant->setBaseValInternal(newValue.toFloat());
+        Ref { m_specularConstant }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::specularExponentAttr:
-        m_specularExponent->setBaseValInternal(newValue.toFloat());
+        Ref { m_specularExponent }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::kernelUnitLengthAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
-            m_kernelUnitLengthX->setBaseValInternal(result->first);
-            m_kernelUnitLengthY->setBaseValInternal(result->second);
+            Ref { m_kernelUnitLengthX }->setBaseValInternal(result->first);
+            Ref { m_kernelUnitLengthY }->setBaseValInternal(result->second);
         }
         break;
     default:
@@ -159,11 +159,11 @@ RefPtr<FilterEffect> SVGFESpecularLightingElement::createFilterEffect(const Filt
     if (!lightElement)
         return nullptr;
 
-    auto* renderer = this->renderer();
+    CheckedPtr renderer = this->renderer();
     if (!renderer)
         return nullptr;
 
-    auto lightSource = lightElement->lightSource();
+    Ref lightSource = lightElement->lightSource();
     auto& style = renderer->style();
 
     auto color = style.colorWithColorFilter(style.svgStyle().lightingColor());

--- a/Source/WebCore/svg/SVGFETileElement.cpp
+++ b/Source/WebCore/svg/SVGFETileElement.cpp
@@ -49,7 +49,7 @@ Ref<SVGFETileElement> SVGFETileElement::create(const QualifiedName& tagName, Doc
 void SVGFETileElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::inAttr)
-        m_in1->setBaseValInternal(newValue);
+        Ref { m_in1 }->setBaseValInternal(newValue);
 
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -58,26 +58,26 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
     case AttributeNames::typeAttr: {
         TurbulenceType propertyValue = SVGPropertyTraits<TurbulenceType>::fromString(newValue);
         if (propertyValue != TurbulenceType::Unknown)
-            m_type->setBaseValInternal<TurbulenceType>(propertyValue);
+            Ref { m_type }->setBaseValInternal<TurbulenceType>(propertyValue);
         break;
     }
     case AttributeNames::stitchTilesAttr: {
         SVGStitchOptions propertyValue = SVGPropertyTraits<SVGStitchOptions>::fromString(newValue);
         if (propertyValue > 0)
-            m_stitchTiles->setBaseValInternal<SVGStitchOptions>(propertyValue);
+            Ref { m_stitchTiles }->setBaseValInternal<SVGStitchOptions>(propertyValue);
         break;
     }
     case AttributeNames::baseFrequencyAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
-            m_baseFrequencyX->setBaseValInternal(result->first);
-            m_baseFrequencyY->setBaseValInternal(result->second);
+            Ref { m_baseFrequencyX }->setBaseValInternal(result->first);
+            Ref { m_baseFrequencyY }->setBaseValInternal(result->second);
         }
         break;
     case AttributeNames::seedAttr:
-        m_seed->setBaseValInternal(newValue.toFloat());
+        Ref { m_seed }->setBaseValInternal(newValue.toFloat());
         break;
     case AttributeNames::numOctavesAttr:
-        m_numOctaves->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
+        Ref { m_numOctaves }->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -71,26 +71,26 @@ void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomStr
     case AttributeNames::filterUnitsAttr: {
         SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
-            m_filterUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+            Ref { m_filterUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::primitiveUnitsAttr: {
         SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
-            m_primitiveUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+            Ref { m_primitiveUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::widthAttr:
-        m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::heightAttr:
-        m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -52,19 +52,19 @@ void SVGFilterPrimitiveStandardAttributes::attributeChanged(const QualifiedName&
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::widthAttr:
-        m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::heightAttr:
-        m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::resultAttr:
-        m_result->setBaseValInternal(newValue);
+        Ref { m_result }->setBaseValInternal(newValue);
         break;
     default:
         break;
@@ -99,28 +99,30 @@ RefPtr<FilterEffect> SVGFilterPrimitiveStandardAttributes::filterEffect(const Fi
 
 void SVGFilterPrimitiveStandardAttributes::primitiveAttributeChanged(const QualifiedName& attribute)
 {
-    if (m_effect && !setFilterEffectAttribute(*m_effect, attribute))
+    RefPtr effect = m_effect;
+    if (effect && !setFilterEffectAttribute(*effect, attribute))
         return;
 
-    if (auto* renderer = this->renderer())
-        static_cast<LegacyRenderSVGResourceFilterPrimitive*>(renderer)->markFilterEffectForRepaint(m_effect.get());
+    if (CheckedPtr renderer = this->renderer())
+        static_cast<LegacyRenderSVGResourceFilterPrimitive&>(*renderer).markFilterEffectForRepaint(effect.get());
 }
 
 void SVGFilterPrimitiveStandardAttributes::primitiveAttributeOnChildChanged(const Element& child, const QualifiedName& attribute)
 {
     ASSERT(child.parentNode() == this);
 
-    if (m_effect && !setFilterEffectAttributeFromChild(*m_effect, child, attribute))
+    RefPtr effect = m_effect;
+    if (effect && !setFilterEffectAttributeFromChild(*effect, child, attribute))
         return;
 
-    if (auto* renderer = this->renderer())
-        static_cast<LegacyRenderSVGResourceFilterPrimitive*>(renderer)->markFilterEffectForRepaint(m_effect.get());
+    if (CheckedPtr renderer = this->renderer())
+        static_cast<LegacyRenderSVGResourceFilterPrimitive&>(*renderer).markFilterEffectForRepaint(effect.get());
 }
 
 void SVGFilterPrimitiveStandardAttributes::markFilterEffectForRebuild()
 {
-    if (auto* renderer = this->renderer())
-        static_cast<LegacyRenderSVGResourceFilterPrimitive*>(renderer)->markFilterEffectForRebuild();
+    if (CheckedPtr renderer = this->renderer())
+        static_cast<LegacyRenderSVGResourceFilterPrimitive&>(*renderer).markFilterEffectForRebuild();
 
     m_effect = nullptr;
 }
@@ -167,7 +169,7 @@ void SVGFilterPrimitiveStandardAttributes::invalidateFilterPrimitiveParent(SVGEl
     if (!parent)
         return;
 
-    RenderElement* renderer = parent->renderer();
+    CheckedPtr renderer = parent->renderer();
     if (!renderer || !renderer->isRenderSVGResourceFilterPrimitive())
         return;
 

--- a/Source/WebCore/svg/SVGFitToViewBox.cpp
+++ b/Source/WebCore/svg/SVGFitToViewBox.cpp
@@ -48,13 +48,13 @@ SVGFitToViewBox::SVGFitToViewBox(SVGElement* contextElement, SVGPropertyAccess a
 
 void SVGFitToViewBox::setViewBox(const FloatRect& viewBox)
 {
-    m_viewBox->setBaseValInternal(viewBox);
+    Ref { m_viewBox }->setBaseValInternal(viewBox);
     m_isViewBoxValid = true;
 }
 
 void SVGFitToViewBox::resetViewBox()
 {
-    m_viewBox->setBaseValInternal({ });
+    Ref { m_viewBox }->setBaseValInternal({ });
     m_isViewBoxValid = false;
 }
 

--- a/Source/WebCore/svg/SVGFontFaceElement.h
+++ b/Source/WebCore/svg/SVGFontFaceElement.h
@@ -47,9 +47,11 @@ public:
     String fontFamily() const;
 
     SVGFontElement* associatedFontElement() const;
+    RefPtr<SVGFontElement> protectedFontElement() const;
     void rebuildFontFace();
     
     StyleRuleFontFace& fontFaceRule() { return m_fontFaceRule.get(); }
+    Ref<StyleRuleFontFace> protectedFontFaceRule() const;
 
 private:
     SVGFontFaceElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -52,8 +52,8 @@ Ref<SVGFontFaceUriElement> SVGFontFaceUriElement::create(const QualifiedName& ta
 
 SVGFontFaceUriElement::~SVGFontFaceUriElement()
 {
-    if (m_cachedFont)
-        m_cachedFont->removeClient(*this);
+    if (CachedResourceHandle cachedFont = m_cachedFont)
+        cachedFont->removeClient(*this);
 }
 
 Ref<CSSFontFaceSrcResourceValue> SVGFontFaceUriElement::createSrcValue() const
@@ -99,8 +99,8 @@ static bool isSVGFontTarget(const SVGFontFaceUriElement& element)
 
 void SVGFontFaceUriElement::loadFont()
 {
-    if (m_cachedFont)
-        m_cachedFont->removeClient(*this);
+    if (CachedResourceHandle cachedFont = m_cachedFont)
+        cachedFont->removeClient(*this);
 
     const AtomString& href = getAttribute(SVGNames::hrefAttr, XLinkNames::hrefAttr);
     if (!href.isNull()) {
@@ -111,9 +111,9 @@ void SVGFontFaceUriElement::loadFont()
         CachedResourceRequest request(ResourceRequest(document().completeURL(href)), options);
         request.setInitiator(*this);
         m_cachedFont = cachedResourceLoader.requestFont(WTFMove(request), isSVGFontTarget(*this)).value_or(nullptr);
-        if (m_cachedFont) {
-            m_cachedFont->addClient(*this);
-            m_cachedFont->beginLoadIfNeeded(cachedResourceLoader);
+        if (CachedResourceHandle cachedFont = m_cachedFont) {
+            cachedFont->addClient(*this);
+            cachedFont->beginLoadIfNeeded(cachedResourceLoader);
         }
     } else
         m_cachedFont = nullptr;

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -62,16 +62,16 @@ void SVGForeignObjectElement::attributeChanged(const QualifiedName& name, const 
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::widthAttr:
-        m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::heightAttr:
-        m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     default:
         break;
@@ -100,7 +100,7 @@ void SVGForeignObjectElement::svgAttributeChanged(const QualifiedName& attrName)
 
 RenderPtr<RenderElement> SVGForeignObjectElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    document().setMayHaveRenderedSVGForeignObjects();
+    protectedDocument()->setMayHaveRenderedSVGForeignObjects();
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (document().settings().layerBasedSVGEngineEnabled())
         return createRenderer<RenderSVGForeignObject>(*this, WTFMove(style));

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -47,17 +47,17 @@ SVGGeometryElement::SVGGeometryElement(const QualifiedName& tagName, Document& d
 
 float SVGGeometryElement::getTotalLength() const
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
     auto* renderer = this->renderer();
     if (!renderer)
         return 0;
 
-    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
         return renderSVGShape->getTotalLength();
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
         return renderSVGShape->getTotalLength();
 #endif
 
@@ -67,7 +67,7 @@ float SVGGeometryElement::getTotalLength() const
 
 ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) const
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
     // Spec: Clamp distance to [0, length].
     distance = clampTo<float>(distance, 0, getTotalLength());
@@ -78,11 +78,11 @@ ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) 
         return Exception { ExceptionCode::InvalidStateError, "The current element is a non-rendered element."_s };
 
     // Spec: Return a newly created, detached SVGPoint object.
-    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
         return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
         return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
 #endif
 
@@ -92,18 +92,18 @@ ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) 
 
 bool SVGGeometryElement::isPointInFill(DOMPointInit&& pointInit)
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
     auto* renderer = this->renderer();
     if (!renderer)
         return false;
 
     FloatPoint point {static_cast<float>(pointInit.x), static_cast<float>(pointInit.y)};
-    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
         return renderSVGShape->isPointInFill(point);
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
         return renderSVGShape->isPointInFill(point);
 #endif
 
@@ -113,18 +113,18 @@ bool SVGGeometryElement::isPointInFill(DOMPointInit&& pointInit)
 
 bool SVGGeometryElement::isPointInStroke(DOMPointInit&& pointInit)
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
     auto* renderer = this->renderer();
     if (!renderer)
         return false;
 
     FloatPoint point {static_cast<float>(pointInit.x), static_cast<float>(pointInit.y)};
-    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
         return renderSVGShape->isPointInStroke(point);
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
         return renderSVGShape->isPointInStroke(point);
 #endif
 
@@ -135,8 +135,9 @@ bool SVGGeometryElement::isPointInStroke(DOMPointInit&& pointInit)
 void SVGGeometryElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == SVGNames::pathLengthAttr) {
-        m_pathLength->setBaseValInternal(newValue.toFloat());
-        if (m_pathLength->baseVal() < 0)
+        Ref pathLength = m_pathLength;
+        pathLength->setBaseValInternal(newValue.toFloat());
+        if (pathLength->baseVal() < 0)
             protectedDocument()->checkedSVGExtensions()->reportError("A negative value for path attribute <pathLength> is not allowed"_s);
     }
 

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -58,16 +58,16 @@ void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomS
     case AttributeNames::gradientUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
-            m_gradientUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+            Ref { m_gradientUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::gradientTransformAttr:
-        m_gradientTransform->baseVal()->parse(newValue);
+        Ref { m_gradientTransform }->baseVal()->parse(newValue);
         break;
     case AttributeNames::spreadMethodAttr: {
         auto propertyValue = SVGPropertyTraits<SVGSpreadMethodType>::fromString(newValue);
         if (propertyValue > 0)
-            m_spreadMethod->setBaseValInternal<SVGSpreadMethodType>(propertyValue);
+            Ref { m_spreadMethod }->setBaseValInternal<SVGSpreadMethodType>(propertyValue);
         break;
     }
     default:
@@ -82,7 +82,7 @@ void SVGGradientElement::invalidateGradientResource()
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (document().settings().layerBasedSVGEngineEnabled()) {
-        if (auto* gradientRenderer = dynamicDowncast<RenderSVGResourceGradient>(renderer()))
+        if (CheckedPtr gradientRenderer = dynamicDowncast<RenderSVGResourceGradient>(renderer()))
             gradientRenderer->invalidateGradient();
         return;
     }

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -68,6 +68,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGraphicsElement, SVGElement, SVGTests>;
 
     const SVGTransformList& transform() const { return m_transform->currentValue(); }
+    Ref<const SVGTransformList> protectedTransform() const;
     SVGAnimatedTransformList& transformAnimated() { return m_transform; }
 
 protected:

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -70,7 +70,7 @@ CachedImage* SVGImageElement::cachedImage() const
 
 bool SVGImageElement::renderingTaintsOrigin() const
 {
-    auto cachedImage = this->cachedImage();
+    CachedResourceHandle cachedImage = this->cachedImage();
     if (!cachedImage)
         return false;
 
@@ -92,19 +92,19 @@ void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomStri
     SVGParsingError parseError = NoError;
     switch (name.nodeName()) {
     case AttributeNames::preserveAspectRatioAttr:
-        m_preserveAspectRatio->setBaseValInternal(SVGPreserveAspectRatioValue { newValue });
+        Ref { m_preserveAspectRatio }->setBaseValInternal(SVGPreserveAspectRatioValue { newValue });
         return;
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::widthAttr:
-        m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::heightAttr:
-        m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::crossoriginAttr:
         if (parseCORSSettingsAttribute(oldValue) != parseCORSSettingsAttribute(newValue))
@@ -130,7 +130,7 @@ void SVGImageElement::svgAttributeChanged(const QualifiedName& attrName)
             if (is<RenderSVGImage>(renderer()))
                 updateSVGRendererForElementChange();
 #endif
-            if (auto* image = dynamicDowncast<LegacyRenderSVGImage>(renderer())) {
+            if (CheckedPtr image = dynamicDowncast<LegacyRenderSVGImage>(renderer())) {
                 if (!image->updateImageViewport())
                     return;
                 updateSVGRendererForElementChange();
@@ -171,14 +171,14 @@ void SVGImageElement::didAttachRenderers()
     SVGGraphicsElement::didAttachRenderers();
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* image = dynamicDowncast<RenderSVGImage>(renderer()); image && !image->imageResource().cachedImage()) {
-        image->imageResource().setCachedImage(m_imageLoader.image());
+    if (CheckedPtr image = dynamicDowncast<RenderSVGImage>(renderer()); image && !image->imageResource().cachedImage()) {
+        image->checkedImageResource()->setCachedImage(m_imageLoader.image());
         return;
     }
 #endif
 
-    if (auto* image = dynamicDowncast<LegacyRenderSVGImage>(renderer()); image && !image->imageResource().cachedImage()) {
-        image->imageResource().setCachedImage(m_imageLoader.image());
+    if (CheckedPtr image = dynamicDowncast<LegacyRenderSVGImage>(renderer()); image && !image->imageResource().cachedImage()) {
+        image->checkedImageResource()->setCachedImage(m_imageLoader.protectedImage().get());
         return;
     }
 }

--- a/Source/WebCore/svg/SVGImageLoader.cpp
+++ b/Source/WebCore/svg/SVGImageLoader.cpp
@@ -39,9 +39,9 @@ SVGImageLoader::~SVGImageLoader() = default;
 void SVGImageLoader::dispatchLoadEvent()
 {
     if (image()->errorOccurred())
-        element().dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        protectedElement()->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
     else
-        downcast<SVGImageElement>(ImageLoader::element()).sendLoadEventIfPossible();
+        downcast<SVGImageElement>(ImageLoader::protectedElement())->sendLoadEventIfPossible();
 }
 
 }

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -241,9 +241,14 @@ static inline const RenderStyle* renderStyleForLengthResolving(const SVGElement*
     return nullptr;
 }
 
+RefPtr<const SVGElement> SVGLengthContext::protectedContext() const
+{
+    return m_context.get();
+}
+
 ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEMS(float value) const
 {
-    auto* style = renderStyleForLengthResolving(m_context);
+    auto* style = renderStyleForLengthResolving(protectedContext().get());
     if (!style)
         return Exception { ExceptionCode::NotSupportedError };
 
@@ -256,7 +261,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEMS(float value)
 
 ExceptionOr<float> SVGLengthContext::convertValueFromEMSToUserUnits(float value) const
 {
-    auto* style = renderStyleForLengthResolving(m_context);
+    auto* style = renderStyleForLengthResolving(protectedContext().get());
     if (!style)
         return Exception { ExceptionCode::NotSupportedError };
 
@@ -265,7 +270,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromEMSToUserUnits(float value)
 
 ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value) const
 {
-    auto* style = renderStyleForLengthResolving(m_context);
+    auto* style = renderStyleForLengthResolving(protectedContext().get());
     if (!style)
         return Exception { ExceptionCode::NotSupportedError };
 
@@ -280,7 +285,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value)
 
 ExceptionOr<float> SVGLengthContext::convertValueFromEXSToUserUnits(float value) const
 {
-    auto* style = renderStyleForLengthResolving(m_context);
+    auto* style = renderStyleForLengthResolving(protectedContext().get());
     if (!style)
         return Exception { ExceptionCode::NotSupportedError };
 
@@ -316,7 +321,7 @@ std::optional<FloatSize> SVGLengthContext::computeViewportSize() const
     // applies zooming/panning for the whole SVG subtree as affine transform. Therefore
     // any length within the SVG subtree needs to exclude the 'zoom' information.
     if (m_context->isOutermostSVGSVGElement())
-        return downcast<SVGSVGElement>(*m_context).currentViewportSizeExcludingZoom();
+        return downcast<SVGSVGElement>(*protectedContext()).currentViewportSizeExcludingZoom();
 
     // Take size from nearest viewport element.
     RefPtr svg = dynamicDowncast<SVGSVGElement>(m_context->viewportElement());

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -28,6 +28,7 @@
 namespace WebCore {
 
 class SVGElement;
+class WeakPtrImplWithEventTargetData;
 
 struct Length;
 
@@ -65,7 +66,9 @@ private:
 
     std::optional<FloatSize> computeViewportSize() const;
 
-    const SVGElement* m_context;
+    RefPtr<const SVGElement> protectedContext() const;
+
+    WeakPtr<const SVGElement, WeakPtrImplWithEventTargetData> m_context;
     FloatRect m_overriddenViewport; // Ideally this would be std::optional<FloatRect>, but some tests depend on the behavior of it being a zero rect.
     mutable std::optional<FloatSize> m_viewportSize;
 };

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -261,8 +261,8 @@ SVGLengthValue SVGLengthValue::fromCSSPrimitiveValue(const CSSPrimitiveValue& va
 
 Ref<CSSPrimitiveValue> SVGLengthValue::toCSSPrimitiveValue(const Element* element) const
 {
-    if (auto* svgElement = dynamicDowncast<SVGElement>(element)) {
-        SVGLengthContext context { svgElement };
+    if (RefPtr svgElement = dynamicDowncast<SVGElement>(element)) {
+        SVGLengthContext context { svgElement.get() };
         auto computedValue = context.convertValueToUserUnits(valueInSpecifiedUnits(), lengthType(), lengthMode());
         if (!computedValue.hasException())
             return CSSPrimitiveValue::create(computedValue.releaseReturnValue(), CSSUnitType::CSS_PX);

--- a/Source/WebCore/svg/SVGLineElement.cpp
+++ b/Source/WebCore/svg/SVGLineElement.cpp
@@ -58,16 +58,16 @@ void SVGLineElement::attributeChanged(const QualifiedName& name, const AtomStrin
 
     switch (name.nodeName()) {
     case AttributeNames::x1Attr:
-        m_x1->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::y1Attr:
-        m_y1->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::x2Attr:
-        m_x2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::y2Attr:
-        m_y2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     default:
         break;
@@ -84,10 +84,10 @@ void SVGLineElement::svgAttributeChanged(const QualifiedName& attrName)
         updateRelativeLengthsInformation();
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-        if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer()))
+        if (CheckedPtr shape = dynamicDowncast<RenderSVGShape>(renderer()))
             shape->setNeedsShapeUpdate();
 #endif
-        if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(renderer()))
+        if (CheckedPtr shape = dynamicDowncast<LegacyRenderSVGShape>(renderer()))
             shape->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -68,16 +68,16 @@ void SVGLinearGradientElement::attributeChanged(const QualifiedName& name, const
 
     switch (name.nodeName()) {
     case AttributeNames::x1Attr:
-        m_x1->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::y1Attr:
-        m_y1->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::x2Attr:
-        m_x2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::y2Attr:
-        m_y2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -67,7 +67,7 @@ void SVGMPathElement::buildPendingResource()
             treeScope.addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
-    } else if (auto* svgElement = dynamicDowncast<SVGElement>(*target.element))
+    } else if (RefPtr svgElement = dynamicDowncast<SVGElement>(*target.element))
         svgElement->addReferencingElement(*this);
 
     targetPathChanged();
@@ -124,8 +124,7 @@ RefPtr<SVGPathElement> SVGMPathElement::pathElement()
 
 void SVGMPathElement::targetPathChanged()
 {
-    auto* parent = parentNode();
-    if (auto* animateMotionElement = dynamicDowncast<SVGAnimateMotionElement>(parent))
+    if (RefPtr animateMotionElement = dynamicDowncast<SVGAnimateMotionElement>(parentNode()))
         animateMotionElement->updateAnimationPath();
 }
 

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -69,26 +69,26 @@ void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomStr
     case AttributeNames::markerUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGMarkerUnitsType>::fromString(newValue);
         if (propertyValue > 0)
-            m_markerUnits->setBaseValInternal<SVGMarkerUnitsType>(propertyValue);
+            Ref { m_markerUnits }->setBaseValInternal<SVGMarkerUnitsType>(propertyValue);
         return;
     }
     case AttributeNames::orientAttr: {
         auto pair = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(newValue);
-        m_orientAngle->setBaseValInternal(pair.first);
-        m_orientType->setBaseValInternal(pair.second);
+        Ref { m_orientAngle }->setBaseValInternal(pair.first);
+        Ref { m_orientType }->setBaseValInternal(pair.second);
         return;
     }
     case AttributeNames::refXAttr:
-        m_refX->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_refX }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::refYAttr:
-        m_refY->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_refY }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::markerWidthAttr:
-        m_markerWidth->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_markerWidth }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::markerHeightAttr:
-        m_markerHeight->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_markerHeight }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     default:
         break;
@@ -103,7 +103,7 @@ void SVGMarkerElement::invalidateMarkerResource()
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (document().settings().layerBasedSVGEngineEnabled()) {
-        if (auto* markerRenderer = dynamicDowncast<RenderSVGResourceMarker>(renderer()))
+        if (CheckedPtr markerRenderer = dynamicDowncast<RenderSVGResourceMarker>(renderer()))
             markerRenderer->invalidateMarker();
         return;
     }
@@ -156,13 +156,13 @@ void SVGMarkerElement::setOrient(const AtomString& orient)
 
 void SVGMarkerElement::setOrientToAuto()
 {
-    m_orientType->setBaseVal(SVGMarkerOrientAuto);
+    Ref { m_orientType }->setBaseVal(SVGMarkerOrientAuto);
     invalidateMarkerResource();
 }
 
 void SVGMarkerElement::setOrientToAngle(const SVGAngle& angle)
 {
-    m_orientAngle->baseVal()->newValueSpecifiedUnits(angle.unitType(), angle.valueInSpecifiedUnits());
+    Ref { m_orientAngle }->baseVal()->newValueSpecifiedUnits(angle.unitType(), angle.valueInSpecifiedUnits());
     invalidateMarkerResource();
 }
 

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -75,26 +75,26 @@ void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomStrin
     case AttributeNames::maskUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
-            m_maskUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+            Ref { m_maskUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::maskContentUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
-            m_maskContentUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+            Ref { m_maskContentUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::widthAttr:
-        m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::heightAttr:
-        m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     default:
         break;
@@ -174,7 +174,7 @@ FloatRect SVGMaskElement::calculateMaskContentRepaintRect(RepaintRectCalculation
     };
     FloatRect maskRepaintRect;
     for (auto* childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
-        auto* renderer = childNode->renderer();
+        CheckedPtr renderer = childNode->renderer();
         if (!childNode->isSVGElement() || !renderer)
             continue;
         const auto& style = renderer->style();

--- a/Source/WebCore/svg/SVGPathAbsoluteConverter.cpp
+++ b/Source/WebCore/svg/SVGPathAbsoluteConverter.cpp
@@ -36,21 +36,21 @@ SVGPathAbsoluteConverter::SVGPathAbsoluteConverter(SVGPathConsumer& consumer)
 
 void SVGPathAbsoluteConverter::incrementPathSegmentCount()
 {
-    m_consumer.incrementPathSegmentCount();
+    m_consumer->incrementPathSegmentCount();
 }
 
 bool SVGPathAbsoluteConverter::continueConsuming()
 {
-    return m_consumer.continueConsuming();
+    return m_consumer->continueConsuming();
 }
 
 void SVGPathAbsoluteConverter::moveTo(const FloatPoint& targetPoint, bool closed, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.moveTo(targetPoint, closed, AbsoluteCoordinates);
+        m_consumer->moveTo(targetPoint, closed, AbsoluteCoordinates);
         m_currentPoint = targetPoint;
     } else {
-        m_consumer.moveTo(m_currentPoint + targetPoint, closed, AbsoluteCoordinates);
+        m_consumer->moveTo(m_currentPoint + targetPoint, closed, AbsoluteCoordinates);
         m_currentPoint += targetPoint;
     }
 
@@ -60,10 +60,10 @@ void SVGPathAbsoluteConverter::moveTo(const FloatPoint& targetPoint, bool closed
 void SVGPathAbsoluteConverter::lineTo(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.lineTo(targetPoint, AbsoluteCoordinates);
+        m_consumer->lineTo(targetPoint, AbsoluteCoordinates);
         m_currentPoint = targetPoint;
     } else {
-        m_consumer.lineTo(m_currentPoint + targetPoint, AbsoluteCoordinates);
+        m_consumer->lineTo(m_currentPoint + targetPoint, AbsoluteCoordinates);
         m_currentPoint += targetPoint;
     }
 }
@@ -71,29 +71,29 @@ void SVGPathAbsoluteConverter::lineTo(const FloatPoint& targetPoint, PathCoordin
 void SVGPathAbsoluteConverter::curveToCubic(const FloatPoint& point1, const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.curveToCubic(point1, point2, targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToCubic(point1, point2, targetPoint, AbsoluteCoordinates);
         m_currentPoint = targetPoint;
     } else {
-        m_consumer.curveToCubic(m_currentPoint + point1, m_currentPoint + point2, m_currentPoint + targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToCubic(m_currentPoint + point1, m_currentPoint + point2, m_currentPoint + targetPoint, AbsoluteCoordinates);
         m_currentPoint += targetPoint;
     }
 }
 
 void SVGPathAbsoluteConverter::closePath()
 {
-    m_consumer.closePath();
+    m_consumer->closePath();
     m_currentPoint = m_subpathPoint;
 }
 
 void SVGPathAbsoluteConverter::lineToHorizontal(float targetX, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.lineToHorizontal(targetX, AbsoluteCoordinates);
+        m_consumer->lineToHorizontal(targetX, AbsoluteCoordinates);
         m_currentPoint.setX(targetX);
     } else {
         auto absoluteTargetX = m_currentPoint.x() + targetX;
 
-        m_consumer.lineToHorizontal(absoluteTargetX, AbsoluteCoordinates);
+        m_consumer->lineToHorizontal(absoluteTargetX, AbsoluteCoordinates);
         m_currentPoint.setX(absoluteTargetX);
     }
 }
@@ -101,12 +101,12 @@ void SVGPathAbsoluteConverter::lineToHorizontal(float targetX, PathCoordinateMod
 void SVGPathAbsoluteConverter::lineToVertical(float targetY, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.lineToVertical(targetY, AbsoluteCoordinates);
+        m_consumer->lineToVertical(targetY, AbsoluteCoordinates);
         m_currentPoint.setY(targetY);
     } else {
         auto absoluteTargetY = m_currentPoint.y() + targetY;
 
-        m_consumer.lineToVertical(absoluteTargetY, AbsoluteCoordinates);
+        m_consumer->lineToVertical(absoluteTargetY, AbsoluteCoordinates);
         m_currentPoint.setY(absoluteTargetY);
     }
 }
@@ -114,10 +114,10 @@ void SVGPathAbsoluteConverter::lineToVertical(float targetY, PathCoordinateMode 
 void SVGPathAbsoluteConverter::curveToCubicSmooth(const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.curveToCubicSmooth(point2, targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToCubicSmooth(point2, targetPoint, AbsoluteCoordinates);
         m_currentPoint = targetPoint;
     } else {
-        m_consumer.curveToCubicSmooth(m_currentPoint + point2, m_currentPoint + targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToCubicSmooth(m_currentPoint + point2, m_currentPoint + targetPoint, AbsoluteCoordinates);
         m_currentPoint += targetPoint;
     }
 }
@@ -125,10 +125,10 @@ void SVGPathAbsoluteConverter::curveToCubicSmooth(const FloatPoint& point2, cons
 void SVGPathAbsoluteConverter::curveToQuadratic(const FloatPoint& point1, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.curveToQuadratic(point1, targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToQuadratic(point1, targetPoint, AbsoluteCoordinates);
         m_currentPoint = targetPoint;
     } else {
-        m_consumer.curveToQuadratic(m_currentPoint + point1, m_currentPoint + targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToQuadratic(m_currentPoint + point1, m_currentPoint + targetPoint, AbsoluteCoordinates);
         m_currentPoint += targetPoint;
     }
 }
@@ -136,10 +136,10 @@ void SVGPathAbsoluteConverter::curveToQuadratic(const FloatPoint& point1, const 
 void SVGPathAbsoluteConverter::curveToQuadraticSmooth(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.curveToQuadraticSmooth(targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToQuadraticSmooth(targetPoint, AbsoluteCoordinates);
         m_currentPoint = targetPoint;
     } else {
-        m_consumer.curveToQuadraticSmooth(m_currentPoint + targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToQuadraticSmooth(m_currentPoint + targetPoint, AbsoluteCoordinates);
         m_currentPoint += targetPoint;
     }
 }
@@ -147,10 +147,10 @@ void SVGPathAbsoluteConverter::curveToQuadraticSmooth(const FloatPoint& targetPo
 void SVGPathAbsoluteConverter::arcTo(float r1, float r2, float angle, bool largeArcFlag, bool sweepFlag, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates) {
-        m_consumer.arcTo(r1, r2, angle, largeArcFlag, sweepFlag, targetPoint, AbsoluteCoordinates);
+        m_consumer->arcTo(r1, r2, angle, largeArcFlag, sweepFlag, targetPoint, AbsoluteCoordinates);
         m_currentPoint = targetPoint;
     } else {
-        m_consumer.arcTo(r1, r2, angle, largeArcFlag, sweepFlag, m_currentPoint + targetPoint, AbsoluteCoordinates);
+        m_consumer->arcTo(r1, r2, angle, largeArcFlag, sweepFlag, m_currentPoint + targetPoint, AbsoluteCoordinates);
         m_currentPoint += targetPoint;
     }
 }

--- a/Source/WebCore/svg/SVGPathAbsoluteConverter.h
+++ b/Source/WebCore/svg/SVGPathAbsoluteConverter.h
@@ -54,7 +54,7 @@ private:
     void curveToQuadraticSmooth(const FloatPoint& targetPoint, PathCoordinateMode) final;
     void arcTo(float r1, float r2, float angle, bool largeArcFlag, bool sweepFlag, const FloatPoint& targetPoint, PathCoordinateMode) final;
 
-    SVGPathConsumer& m_consumer;
+    SingleThreadWeakRef<SVGPathConsumer> m_consumer;
     FloatPoint m_currentPoint;
     FloatPoint m_subpathPoint;
 };

--- a/Source/WebCore/svg/SVGPathBlender.cpp
+++ b/Source/WebCore/svg/SVGPathBlender.cpp
@@ -352,16 +352,16 @@ bool SVGPathBlender::addAnimatedPath(unsigned repeatCount)
 bool SVGPathBlender::canBlendPaths()
 {
     float progress = 0.5;
-    bool fromSourceHadData = m_fromSource.hasMoreData();
-    while (m_toSource.hasMoreData()) {
+    bool fromSourceHadData = m_fromSource->hasMoreData();
+    while (m_toSource->hasMoreData()) {
         SVGPathSegType fromCommand;
         if (fromSourceHadData) {
-            auto parsedFromCommand = m_fromSource.parseSVGSegmentType();
+            auto parsedFromCommand = m_fromSource->parseSVGSegmentType();
             if (!parsedFromCommand)
                 return false;
             fromCommand = *parsedFromCommand;
         }
-        auto parsedtoCommand = m_toSource.parseSVGSegmentType();
+        auto parsedtoCommand = m_toSource->parseSVGSegmentType();
         if (!parsedtoCommand)
             return false;
         SVGPathSegType toCommand = *parsedtoCommand;
@@ -428,9 +428,9 @@ bool SVGPathBlender::canBlendPaths()
 
         if (!fromSourceHadData)
             continue;
-        if (m_fromSource.hasMoreData() != m_toSource.hasMoreData())
+        if (m_fromSource->hasMoreData() != m_toSource->hasMoreData())
             return false;
-        if (!m_fromSource.hasMoreData() || !m_toSource.hasMoreData())
+        if (!m_fromSource->hasMoreData() || !m_toSource->hasMoreData())
             return true;
     }
 
@@ -441,16 +441,16 @@ bool SVGPathBlender::blendAnimatedPath(float progress)
 {
     m_isInFirstHalfOfAnimation = progress < 0.5f;
 
-    bool fromSourceHadData = m_fromSource.hasMoreData();
-    while (m_toSource.hasMoreData()) {
+    bool fromSourceHadData = m_fromSource->hasMoreData();
+    while (m_toSource->hasMoreData()) {
         SVGPathSegType fromCommand;
         if (fromSourceHadData) {
-            auto parsedFromCommand = m_fromSource.parseSVGSegmentType();
+            auto parsedFromCommand = m_fromSource->parseSVGSegmentType();
             if (!parsedFromCommand)
                 return false;
             fromCommand = *parsedFromCommand;
         }
-        auto parsedToCommand = m_toSource.parseSVGSegmentType();
+        auto parsedToCommand = m_toSource->parseSVGSegmentType();
         if (!parsedToCommand)
             return false;
         SVGPathSegType toCommand = *parsedToCommand;
@@ -518,9 +518,9 @@ bool SVGPathBlender::blendAnimatedPath(float progress)
 
         if (!fromSourceHadData)
             continue;
-        if (m_fromSource.hasMoreData() != m_toSource.hasMoreData())
+        if (m_fromSource->hasMoreData() != m_toSource->hasMoreData())
             return false;
-        if (!m_fromSource.hasMoreData() || !m_toSource.hasMoreData())
+        if (!m_fromSource->hasMoreData() || !m_toSource->hasMoreData())
             return true;
     }
 

--- a/Source/WebCore/svg/SVGPathBlender.h
+++ b/Source/WebCore/svg/SVGPathBlender.h
@@ -61,9 +61,9 @@ private:
     float blendAnimatedDimensonalFloat(float from, float to, FloatBlendMode, float progress);
     FloatPoint blendAnimatedFloatPoint(const FloatPoint& from, const FloatPoint& to, float progress);
 
-    SVGPathSource& m_fromSource;
-    SVGPathSource& m_toSource;
-    SVGPathConsumer* m_consumer; // A null consumer indicates that we're just checking blendability.
+    SingleThreadWeakRef<SVGPathSource> m_fromSource;
+    SingleThreadWeakRef<SVGPathSource> m_toSource;
+    SingleThreadWeakPtr<SVGPathConsumer> m_consumer; // A null consumer indicates that we're just checking blendability.
 
     FloatPoint m_fromCurrentPoint;
     FloatPoint m_toCurrentPoint;

--- a/Source/WebCore/svg/SVGPathBuilder.h
+++ b/Source/WebCore/svg/SVGPathBuilder.h
@@ -52,7 +52,7 @@ private:
     void curveToQuadraticSmooth(const FloatPoint&, PathCoordinateMode) final { ASSERT_NOT_REACHED(); }
     void arcTo(float, float, float, bool, bool, const FloatPoint&, PathCoordinateMode) final { ASSERT_NOT_REACHED(); }
 
-    Path& m_path;
+    Path& m_path; // FIXME: This should use a WeakRef.
     FloatPoint m_current;
 };
 

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -23,10 +23,11 @@
 #include "SVGPathUtilities.h"
 #include "SVGPropertyTraits.h"
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class SVGPathByteStream {
+class SVGPathByteStream : public CanMakeSingleThreadWeakPtr<SVGPathByteStream> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     typedef Vector<uint8_t> Data;
@@ -40,6 +41,7 @@ public:
     }
 
     SVGPathByteStream(const SVGPathByteStream& other)
+        : CanMakeSingleThreadWeakPtr<SVGPathByteStream>()
     {
         *this = other;
     }
@@ -70,7 +72,7 @@ public:
         return *this;
     }
 
-    friend bool operator==(const SVGPathByteStream&, const SVGPathByteStream&) = default;
+    friend bool operator==(const SVGPathByteStream& a, const SVGPathByteStream& b) { return a.m_data == b.m_data; }
 
     std::unique_ptr<SVGPathByteStream> copy() const
     {

--- a/Source/WebCore/svg/SVGPathByteStreamBuilder.h
+++ b/Source/WebCore/svg/SVGPathByteStreamBuilder.h
@@ -60,16 +60,16 @@ private:
         } ByteType;
 
         ByteType type = { data };
-        m_byteStream.append(std::span { type.bytes, sizeof(ByteType) });
+        m_byteStream->append(std::span { type.bytes, sizeof(ByteType) });
     }
 
     void writeSegmentType(SVGPathSegType type)
     {
         static_assert(std::is_same_v<std::underlying_type_t<SVGPathSegType>, uint8_t>);
-        m_byteStream.append(enumToUnderlyingType(type));
+        m_byteStream->append(enumToUnderlyingType(type));
     }
 
-    SVGPathByteStream& m_byteStream;
+    SingleThreadWeakRef<SVGPathByteStream> m_byteStream;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathConsumer.h
+++ b/Source/WebCore/svg/SVGPathConsumer.h
@@ -26,6 +26,7 @@
 #include "FloatPoint.h"
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -39,7 +40,7 @@ enum PathParsingMode {
     UnalteredParsing
 };
 
-class SVGPathConsumer {
+class SVGPathConsumer : public CanMakeSingleThreadWeakPtr<SVGPathConsumer> {
     WTF_MAKE_NONCOPYABLE(SVGPathConsumer); WTF_MAKE_FAST_ALLOCATED;
 public:
     SVGPathConsumer() = default;

--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -70,12 +70,12 @@ void SVGPathParser::parseClosePathSegment()
     if (m_pathParsingMode == NormalizedParsing)
         m_currentPoint = m_subPathPoint;
     m_closePath = true;
-    m_consumer.closePath();
+    m_consumer->closePath();
 }
 
 bool SVGPathParser::parseMoveToSegment()
 {
-    auto result = m_source.parseMoveToSegment();
+    auto result = m_source->parseMoveToSegment();
     if (!result)
         return false;
 
@@ -85,16 +85,16 @@ bool SVGPathParser::parseMoveToSegment()
         else
             m_currentPoint = result->targetPoint;
         m_subPathPoint = m_currentPoint;
-        m_consumer.moveTo(m_currentPoint, m_closePath, AbsoluteCoordinates);
+        m_consumer->moveTo(m_currentPoint, m_closePath, AbsoluteCoordinates);
     } else
-        m_consumer.moveTo(result->targetPoint, m_closePath, m_mode);
+        m_consumer->moveTo(result->targetPoint, m_closePath, m_mode);
     m_closePath = false;
     return true;
 }
 
 bool SVGPathParser::parseLineToSegment()
 {
-    auto result = m_source.parseLineToSegment();
+    auto result = m_source->parseLineToSegment();
     if (!result)
         return false;
 
@@ -103,15 +103,15 @@ bool SVGPathParser::parseLineToSegment()
             m_currentPoint += result->targetPoint;
         else
             m_currentPoint = result->targetPoint;
-        m_consumer.lineTo(m_currentPoint, AbsoluteCoordinates);
+        m_consumer->lineTo(m_currentPoint, AbsoluteCoordinates);
     } else
-        m_consumer.lineTo(result->targetPoint, m_mode);
+        m_consumer->lineTo(result->targetPoint, m_mode);
     return true;
 }
 
 bool SVGPathParser::parseLineToHorizontalSegment()
 {
-    auto result = m_source.parseLineToHorizontalSegment();
+    auto result = m_source->parseLineToHorizontalSegment();
     if (!result)
         return false;
 
@@ -120,15 +120,15 @@ bool SVGPathParser::parseLineToHorizontalSegment()
             m_currentPoint.move(result->x, 0);
         else
             m_currentPoint.setX(result->x);
-        m_consumer.lineTo(m_currentPoint, AbsoluteCoordinates);
+        m_consumer->lineTo(m_currentPoint, AbsoluteCoordinates);
     } else
-        m_consumer.lineToHorizontal(result->x, m_mode);
+        m_consumer->lineToHorizontal(result->x, m_mode);
     return true;
 }
 
 bool SVGPathParser::parseLineToVerticalSegment()
 {
-    auto result = m_source.parseLineToVerticalSegment();
+    auto result = m_source->parseLineToVerticalSegment();
     if (!result)
         return false;
 
@@ -137,15 +137,15 @@ bool SVGPathParser::parseLineToVerticalSegment()
             m_currentPoint.move(0, result->y);
         else
             m_currentPoint.setY(result->y);
-        m_consumer.lineTo(m_currentPoint, AbsoluteCoordinates);
+        m_consumer->lineTo(m_currentPoint, AbsoluteCoordinates);
     } else
-        m_consumer.lineToVertical(result->y, m_mode);
+        m_consumer->lineToVertical(result->y, m_mode);
     return true;
 }
 
 bool SVGPathParser::parseCurveToCubicSegment()
 {
-    auto result = m_source.parseCurveToCubicSegment();
+    auto result = m_source->parseCurveToCubicSegment();
     if (!result)
         return false;
 
@@ -155,18 +155,18 @@ bool SVGPathParser::parseCurveToCubicSegment()
             result->point2 += m_currentPoint;
             result->targetPoint += m_currentPoint;
         }
-        m_consumer.curveToCubic(result->point1, result->point2, result->targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToCubic(result->point1, result->point2, result->targetPoint, AbsoluteCoordinates);
 
         m_controlPoint = result->point2;
         m_currentPoint = result->targetPoint;
     } else
-        m_consumer.curveToCubic(result->point1, result->point2, result->targetPoint, m_mode);
+        m_consumer->curveToCubic(result->point1, result->point2, result->targetPoint, m_mode);
     return true;
 }
 
 bool SVGPathParser::parseCurveToCubicSmoothSegment()
 {
-    auto result = m_source.parseCurveToCubicSmoothSegment();
+    auto result = m_source->parseCurveToCubicSmoothSegment();
     if (!result)
         return false;
 
@@ -185,18 +185,18 @@ bool SVGPathParser::parseCurveToCubicSmoothSegment()
             result->targetPoint += m_currentPoint;
         }
 
-        m_consumer.curveToCubic(point1, result->point2, result->targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToCubic(point1, result->point2, result->targetPoint, AbsoluteCoordinates);
 
         m_controlPoint = result->point2;
         m_currentPoint = result->targetPoint;
     } else
-        m_consumer.curveToCubicSmooth(result->point2, result->targetPoint, m_mode);
+        m_consumer->curveToCubicSmooth(result->point2, result->targetPoint, m_mode);
     return true;
 }
 
 bool SVGPathParser::parseCurveToQuadraticSegment()
 {
-    auto result = m_source.parseCurveToQuadraticSegment();
+    auto result = m_source->parseCurveToQuadraticSegment();
     if (!result)
         return false;
 
@@ -214,19 +214,19 @@ bool SVGPathParser::parseCurveToQuadraticSegment()
         point1.scale(gOneOverThree);
         point2.scale(gOneOverThree);
 
-        m_consumer.curveToCubic(point1, point2, result->targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToCubic(point1, point2, result->targetPoint, AbsoluteCoordinates);
 
         if (m_mode == RelativeCoordinates)
             m_controlPoint += m_currentPoint;
         m_currentPoint = result->targetPoint;
     } else
-        m_consumer.curveToQuadratic(result->point1, result->targetPoint, m_mode);
+        m_consumer->curveToQuadratic(result->point1, result->targetPoint, m_mode);
     return true;
 }
 
 bool SVGPathParser::parseCurveToQuadraticSmoothSegment()
 {
-    auto result = m_source.parseCurveToQuadraticSmoothSegment();
+    auto result = m_source->parseCurveToQuadraticSmoothSegment();
     if (!result)
         return false;
 
@@ -249,18 +249,18 @@ bool SVGPathParser::parseCurveToQuadraticSmoothSegment()
         point1.scale(gOneOverThree);
         point2.scale(gOneOverThree);
 
-        m_consumer.curveToCubic(point1, point2, result->targetPoint, AbsoluteCoordinates);
+        m_consumer->curveToCubic(point1, point2, result->targetPoint, AbsoluteCoordinates);
 
         m_controlPoint = cubicPoint;
         m_currentPoint = result->targetPoint;
     } else
-        m_consumer.curveToQuadraticSmooth(result->targetPoint, m_mode);
+        m_consumer->curveToQuadraticSmooth(result->targetPoint, m_mode);
     return true;
 }
 
 bool SVGPathParser::parseArcToSegment()
 {
-    auto result = m_source.parseArcToSegment();
+    auto result = m_source->parseArcToSegment();
     if (!result)
         return false;
 
@@ -283,9 +283,9 @@ bool SVGPathParser::parseArcToSegment()
                 m_currentPoint += result->targetPoint;
             else
                 m_currentPoint = result->targetPoint;
-            m_consumer.lineTo(m_currentPoint, AbsoluteCoordinates);
+            m_consumer->lineTo(m_currentPoint, AbsoluteCoordinates);
         } else
-            m_consumer.lineTo(result->targetPoint, m_mode);
+            m_consumer->lineTo(result->targetPoint, m_mode);
         return true;
     }
 
@@ -296,17 +296,17 @@ bool SVGPathParser::parseArcToSegment()
         m_currentPoint = result->targetPoint;
         return decomposeArcToCubic(result->angle, result->rx, result->ry, point1, result->targetPoint, result->largeArc, result->sweep);
     }
-    m_consumer.arcTo(result->rx, result->ry, result->angle, result->largeArc, result->sweep, result->targetPoint, m_mode);
+    m_consumer->arcTo(result->rx, result->ry, result->angle, result->largeArc, result->sweep, result->targetPoint, m_mode);
     return true;
 }
 
 bool SVGPathParser::parsePathData(bool checkForInitialMoveTo)
 {
     // Skip any leading spaces.
-    if (!m_source.moveToNextToken())
+    if (!m_source->moveToNextToken())
         return true;
 
-    auto parsedCommand = m_source.parseSVGSegmentType();
+    auto parsedCommand = m_source->parseSVGSegmentType();
     if (!parsedCommand)
         return false;
 
@@ -318,7 +318,7 @@ bool SVGPathParser::parsePathData(bool checkForInitialMoveTo)
 
     while (true) {
         // Skip spaces between command and first coordinate.
-        m_source.moveToNextToken();
+        m_source->moveToNextToken();
         m_mode = AbsoluteCoordinates;
         switch (command) {
         case SVGPathSegType::MoveToRel:
@@ -390,15 +390,15 @@ bool SVGPathParser::parsePathData(bool checkForInitialMoveTo)
         default:
             return false;
         }
-        if (!m_consumer.continueConsuming())
+        if (!m_consumer->continueConsuming())
             return true;
 
         m_lastCommand = command;
 
-        if (!m_source.hasMoreData())
+        if (!m_source->hasMoreData())
             return true;
 
-        command = m_source.nextCommand(command);
+        command = m_source->nextCommand(command);
 
         if (m_lastCommand != SVGPathSegType::CurveToCubicAbs
             && m_lastCommand != SVGPathSegType::CurveToCubicRel
@@ -410,7 +410,7 @@ bool SVGPathParser::parsePathData(bool checkForInitialMoveTo)
             && m_lastCommand != SVGPathSegType::CurveToQuadraticSmoothRel)
             m_controlPoint = m_currentPoint;
 
-        m_consumer.incrementPathSegmentCount();
+        m_consumer->incrementPathSegmentCount();
     }
 
     return false;
@@ -496,7 +496,7 @@ bool SVGPathParser::decomposeArcToCubic(float angle, float rx, float ry, FloatPo
         point2 = targetPoint;
         point2.move(t * sinEndTheta, -t * cosEndTheta);
 
-        m_consumer.curveToCubic(pointTransform.mapPoint(point1), pointTransform.mapPoint(point2),
+        m_consumer->curveToCubic(pointTransform.mapPoint(point1), pointTransform.mapPoint(point2),
                                  pointTransform.mapPoint(targetPoint), AbsoluteCoordinates);
     }
     return true;

--- a/Source/WebCore/svg/SVGPathParser.h
+++ b/Source/WebCore/svg/SVGPathParser.h
@@ -55,8 +55,8 @@ private:
     bool parseCurveToQuadraticSmoothSegment();
     bool parseArcToSegment();
 
-    SVGPathSource& m_source;
-    SVGPathConsumer& m_consumer;
+    SingleThreadWeakRef<SVGPathSource> m_source;
+    SingleThreadWeakRef<SVGPathConsumer> m_consumer;
     FloatPoint m_controlPoint;
     FloatPoint m_currentPoint;
     FloatPoint m_subPathPoint;

--- a/Source/WebCore/svg/SVGPathSegList.h
+++ b/Source/WebCore/svg/SVGPathSegList.h
@@ -24,10 +24,11 @@
 #include "SVGPathByteStream.h"
 #include "SVGPathSeg.h"
 #include "SVGPropertyList.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class SVGPathSegList final : public SVGPropertyList<SVGPathSeg> {
+class SVGPathSegList final : public SVGPropertyList<SVGPathSeg>, public CanMakeSingleThreadWeakPtr<SVGPathSegList> {
     friend class SVGAnimatedPathSegListAnimator;
     friend class SVGPathSegListBuilder;
     friend class SVGPathSegListSource;
@@ -208,7 +209,7 @@ private:
         if (m_pathByteStream.isEmpty())
             return;
 
-        Ref<SVGPathSegList> pathSegList = SVGPathSegList::create(item.copyRef());
+        Ref pathSegList = SVGPathSegList::create(item.copyRef());
         SVGPathByteStream pathSegStream;
 
         if (!buildSVGPathByteStreamFromSVGPathSegList(pathSegList, pathSegStream, UnalteredParsing, false))

--- a/Source/WebCore/svg/SVGPathSegListBuilder.cpp
+++ b/Source/WebCore/svg/SVGPathSegListBuilder.cpp
@@ -39,78 +39,78 @@ SVGPathSegListBuilder::SVGPathSegListBuilder(SVGPathSegList& pathSegList)
 void SVGPathSegListBuilder::moveTo(const FloatPoint& targetPoint, bool, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegMovetoAbs::create(targetPoint.x(), targetPoint.y()));
+        m_pathSegList->append(SVGPathSegMovetoAbs::create(targetPoint.x(), targetPoint.y()));
     else
-        m_pathSegList.append(SVGPathSegMovetoRel::create(targetPoint.x(), targetPoint.y()));
+        m_pathSegList->append(SVGPathSegMovetoRel::create(targetPoint.x(), targetPoint.y()));
 }
 
 void SVGPathSegListBuilder::lineTo(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegLinetoAbs::create(targetPoint.x(), targetPoint.y()));
+        m_pathSegList->append(SVGPathSegLinetoAbs::create(targetPoint.x(), targetPoint.y()));
     else
-        m_pathSegList.append(SVGPathSegLinetoRel::create(targetPoint.x(), targetPoint.y()));
+        m_pathSegList->append(SVGPathSegLinetoRel::create(targetPoint.x(), targetPoint.y()));
 }
 
 void SVGPathSegListBuilder::lineToHorizontal(float x, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegLinetoHorizontalAbs::create(x));
+        m_pathSegList->append(SVGPathSegLinetoHorizontalAbs::create(x));
     else
-        m_pathSegList.append(SVGPathSegLinetoHorizontalRel::create(x));
+        m_pathSegList->append(SVGPathSegLinetoHorizontalRel::create(x));
 }
 
 void SVGPathSegListBuilder::lineToVertical(float y, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegLinetoVerticalAbs::create(y));
+        m_pathSegList->append(SVGPathSegLinetoVerticalAbs::create(y));
     else
-        m_pathSegList.append(SVGPathSegLinetoVerticalRel::create(y));
+        m_pathSegList->append(SVGPathSegLinetoVerticalRel::create(y));
 }
 
 void SVGPathSegListBuilder::curveToCubic(const FloatPoint& point1, const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegCurvetoCubicAbs::create(targetPoint.x(), targetPoint.y(), point1.x(), point1.y(), point2.x(), point2.y()));
+        m_pathSegList->append(SVGPathSegCurvetoCubicAbs::create(targetPoint.x(), targetPoint.y(), point1.x(), point1.y(), point2.x(), point2.y()));
     else
-        m_pathSegList.append(SVGPathSegCurvetoCubicRel::create(targetPoint.x(), targetPoint.y(), point1.x(), point1.y(), point2.x(), point2.y()));
+        m_pathSegList->append(SVGPathSegCurvetoCubicRel::create(targetPoint.x(), targetPoint.y(), point1.x(), point1.y(), point2.x(), point2.y()));
 }
 
 void SVGPathSegListBuilder::curveToCubicSmooth(const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegCurvetoCubicSmoothAbs::create(targetPoint.x(), targetPoint.y(), point2.x(), point2.y()));
+        m_pathSegList->append(SVGPathSegCurvetoCubicSmoothAbs::create(targetPoint.x(), targetPoint.y(), point2.x(), point2.y()));
     else
-        m_pathSegList.append(SVGPathSegCurvetoCubicSmoothRel::create(targetPoint.x(), targetPoint.y(), point2.x(), point2.y()));
+        m_pathSegList->append(SVGPathSegCurvetoCubicSmoothRel::create(targetPoint.x(), targetPoint.y(), point2.x(), point2.y()));
 }
 
 void SVGPathSegListBuilder::curveToQuadratic(const FloatPoint& point1, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegCurvetoQuadraticAbs::create(targetPoint.x(), targetPoint.y(), point1.x(), point1.y()));
+        m_pathSegList->append(SVGPathSegCurvetoQuadraticAbs::create(targetPoint.x(), targetPoint.y(), point1.x(), point1.y()));
     else
-        m_pathSegList.append(SVGPathSegCurvetoQuadraticRel::create(targetPoint.x(), targetPoint.y(), point1.x(), point1.y()));
+        m_pathSegList->append(SVGPathSegCurvetoQuadraticRel::create(targetPoint.x(), targetPoint.y(), point1.x(), point1.y()));
 }
 
 void SVGPathSegListBuilder::curveToQuadraticSmooth(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegCurvetoQuadraticSmoothAbs::create(targetPoint.x(), targetPoint.y()));
+        m_pathSegList->append(SVGPathSegCurvetoQuadraticSmoothAbs::create(targetPoint.x(), targetPoint.y()));
     else
-        m_pathSegList.append(SVGPathSegCurvetoQuadraticSmoothRel::create(targetPoint.x(), targetPoint.y()));
+        m_pathSegList->append(SVGPathSegCurvetoQuadraticSmoothRel::create(targetPoint.x(), targetPoint.y()));
 }
 
 void SVGPathSegListBuilder::arcTo(float r1, float r2, float angle, bool largeArcFlag, bool sweepFlag, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_pathSegList.append(SVGPathSegArcAbs::create(targetPoint.x(), targetPoint.y(), r1, r2, angle, largeArcFlag, sweepFlag));
+        m_pathSegList->append(SVGPathSegArcAbs::create(targetPoint.x(), targetPoint.y(), r1, r2, angle, largeArcFlag, sweepFlag));
     else
-        m_pathSegList.append(SVGPathSegArcRel::create(targetPoint.x(), targetPoint.y(), r1, r2, angle, largeArcFlag, sweepFlag));
+        m_pathSegList->append(SVGPathSegArcRel::create(targetPoint.x(), targetPoint.y(), r1, r2, angle, largeArcFlag, sweepFlag));
 }
 
 void SVGPathSegListBuilder::closePath()
 {
-    m_pathSegList.append(SVGPathSegClosePath::create());
+    m_pathSegList->append(SVGPathSegClosePath::create());
 }
 
 }

--- a/Source/WebCore/svg/SVGPathSegListBuilder.h
+++ b/Source/WebCore/svg/SVGPathSegListBuilder.h
@@ -53,7 +53,7 @@ private:
     void curveToQuadraticSmooth(const FloatPoint&, PathCoordinateMode) final;
     void arcTo(float, float, float, bool largeArcFlag, bool sweepFlag, const FloatPoint&, PathCoordinateMode) final;
 
-    SVGPathSegList& m_pathSegList;
+    SingleThreadWeakRef<SVGPathSegList> m_pathSegList;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathSegListSource.cpp
+++ b/Source/WebCore/svg/SVGPathSegListSource.cpp
@@ -32,7 +32,7 @@ SVGPathSegListSource::SVGPathSegListSource(const SVGPathSegList& pathSegList)
     : m_pathSegList(pathSegList)
 {
     m_itemCurrent = 0;
-    m_itemEnd = m_pathSegList.size();
+    m_itemEnd = m_pathSegList->size();
 }
 
 bool SVGPathSegListSource::hasMoreData() const
@@ -42,7 +42,7 @@ bool SVGPathSegListSource::hasMoreData() const
 
 SVGPathSegType SVGPathSegListSource::nextCommand(SVGPathSegType)
 {
-    m_segment = m_pathSegList.at(m_itemCurrent);
+    m_segment = m_pathSegList->at(m_itemCurrent);
     SVGPathSegType pathSegType = static_cast<SVGPathSegType>(m_segment->pathSegType());
     ++m_itemCurrent;
     return pathSegType;
@@ -50,7 +50,7 @@ SVGPathSegType SVGPathSegListSource::nextCommand(SVGPathSegType)
 
 std::optional<SVGPathSegType> SVGPathSegListSource::parseSVGSegmentType()
 {
-    m_segment = m_pathSegList.at(m_itemCurrent);
+    m_segment = m_pathSegList->at(m_itemCurrent);
     SVGPathSegType pathSegType = static_cast<SVGPathSegType>(m_segment->pathSegType());
     ++m_itemCurrent;
     return pathSegType;
@@ -60,7 +60,7 @@ std::optional<SVGPathSource::MoveToSegment> SVGPathSegListSource::parseMoveToSeg
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::MoveToAbs || m_segment->pathSegType() == SVGPathSegType::MoveToRel);
-    SVGPathSegSingleCoordinate* moveTo = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
+    RefPtr moveTo = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
 
     MoveToSegment segment;
     segment.targetPoint = FloatPoint(moveTo->x(), moveTo->y());
@@ -71,7 +71,7 @@ std::optional<SVGPathSource::LineToSegment> SVGPathSegListSource::parseLineToSeg
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToAbs || m_segment->pathSegType() == SVGPathSegType::LineToRel);
-    SVGPathSegSingleCoordinate* lineTo = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
+    RefPtr lineTo = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
     
     LineToSegment segment;
     segment.targetPoint = FloatPoint(lineTo->x(), lineTo->y());
@@ -82,7 +82,7 @@ std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathSegListSource::pars
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToHorizontalAbs || m_segment->pathSegType() == SVGPathSegType::LineToHorizontalRel);
-    SVGPathSegLinetoHorizontal* horizontal = static_cast<SVGPathSegLinetoHorizontal*>(m_segment.get());
+    RefPtr horizontal = static_cast<SVGPathSegLinetoHorizontal*>(m_segment.get());
     
     LineToHorizontalSegment segment;
     segment.x = horizontal->x();
@@ -93,7 +93,7 @@ std::optional<SVGPathSource::LineToVerticalSegment> SVGPathSegListSource::parseL
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToVerticalAbs || m_segment->pathSegType() == SVGPathSegType::LineToVerticalRel);
-    SVGPathSegLinetoVertical* vertical = static_cast<SVGPathSegLinetoVertical*>(m_segment.get());
+    RefPtr vertical = static_cast<SVGPathSegLinetoVertical*>(m_segment.get());
     
     LineToVerticalSegment segment;
     segment.y = vertical->y();
@@ -104,7 +104,7 @@ std::optional<SVGPathSource::CurveToCubicSegment> SVGPathSegListSource::parseCur
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToCubicAbs || m_segment->pathSegType() == SVGPathSegType::CurveToCubicRel);
-    SVGPathSegCurvetoCubic* cubic = static_cast<SVGPathSegCurvetoCubic*>(m_segment.get());
+    RefPtr cubic = static_cast<SVGPathSegCurvetoCubic*>(m_segment.get());
     
     CurveToCubicSegment segment;
     segment.point1 = FloatPoint(cubic->x1(), cubic->y1());
@@ -117,7 +117,7 @@ std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathSegListSource::pa
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToCubicSmoothAbs || m_segment->pathSegType() == SVGPathSegType::CurveToCubicSmoothRel);
-    SVGPathSegCurvetoCubicSmooth* cubicSmooth = static_cast<SVGPathSegCurvetoCubicSmooth*>(m_segment.get());
+    RefPtr cubicSmooth = static_cast<SVGPathSegCurvetoCubicSmooth*>(m_segment.get());
     
     CurveToCubicSmoothSegment segment;
     segment.point2 = FloatPoint(cubicSmooth->x2(), cubicSmooth->y2());
@@ -129,7 +129,7 @@ std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathSegListSource::pars
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticAbs || m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticRel);
-    SVGPathSegCurvetoQuadratic* quadratic = static_cast<SVGPathSegCurvetoQuadratic*>(m_segment.get());
+    RefPtr quadratic = static_cast<SVGPathSegCurvetoQuadratic*>(m_segment.get());
     
     CurveToQuadraticSegment segment;
     segment.point1 = FloatPoint(quadratic->x1(), quadratic->y1());
@@ -141,7 +141,7 @@ std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathSegListSource
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticSmoothAbs || m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticSmoothRel);
-    SVGPathSegSingleCoordinate* quadraticSmooth = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
+    RefPtr quadraticSmooth = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
     
     CurveToQuadraticSmoothSegment segment;
     segment.targetPoint = FloatPoint(quadraticSmooth->x(), quadraticSmooth->y());
@@ -152,7 +152,7 @@ std::optional<SVGPathSource::ArcToSegment> SVGPathSegListSource::parseArcToSegme
 {
     ASSERT(m_segment);
     ASSERT(m_segment->pathSegType() == SVGPathSegType::ArcAbs || m_segment->pathSegType() == SVGPathSegType::ArcRel);
-    SVGPathSegArc* arcTo = static_cast<SVGPathSegArc*>(m_segment.get());
+    RefPtr arcTo = static_cast<SVGPathSegArc*>(m_segment.get());
     
     ArcToSegment segment;
     segment.rx = arcTo->r1();

--- a/Source/WebCore/svg/SVGPathSegListSource.h
+++ b/Source/WebCore/svg/SVGPathSegListSource.h
@@ -24,6 +24,7 @@
 #include "SVGPathSeg.h"
 #include "SVGPathSource.h"
 #include <wtf/RefPtr.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -49,7 +50,7 @@ private:
     std::optional<CurveToQuadraticSmoothSegment> parseCurveToQuadraticSmoothSegment() final;
     std::optional<ArcToSegment> parseArcToSegment() final;
 
-    const SVGPathSegList& m_pathSegList;
+    SingleThreadWeakRef<const SVGPathSegList> m_pathSegList;
     RefPtr<SVGPathSeg> m_segment;
     size_t m_itemCurrent;
     size_t m_itemEnd;

--- a/Source/WebCore/svg/SVGPathSource.h
+++ b/Source/WebCore/svg/SVGPathSource.h
@@ -21,11 +21,12 @@
 
 #include "FloatPoint.h"
 #include "SVGPathSeg.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 
-class SVGPathSource {
+class SVGPathSource : public CanMakeSingleThreadWeakPtr<SVGPathSource> {
     WTF_MAKE_NONCOPYABLE(SVGPathSource); WTF_MAKE_FAST_ALLOCATED;
 public:
     SVGPathSource() = default;

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -79,30 +79,30 @@ void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomSt
     case AttributeNames::patternUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
-            m_patternUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+            Ref { m_patternUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::patternContentUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
-            m_patternContentUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
+            Ref { m_patternContentUnits }->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         break;
     }
     case AttributeNames::patternTransformAttr: {
-        m_patternTransform->baseVal()->parse(newValue);
+        Ref { m_patternTransform }->baseVal()->parse(newValue);
         break;
     }
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::widthAttr:
-        m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::heightAttr:
-        m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     default:
         break;
@@ -123,7 +123,7 @@ void SVGPatternElement::svgAttributeChanged(const QualifiedName& attrName)
             setPresentationalHintStyleIsDirty();
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
         if (document().settings().layerBasedSVGEngineEnabled()) {
-            if (auto* patternRenderer = dynamicDowncast<RenderSVGResourcePattern>(renderer()))
+            if (CheckedPtr patternRenderer = dynamicDowncast<RenderSVGResourcePattern>(renderer()))
                 patternRenderer->invalidatePattern();
             return;
         }
@@ -188,9 +188,14 @@ void SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes) 
         attributes.setPatternContentElement(this);
 }
 
+Ref<const SVGTransformList> SVGPatternElement::protectedPatternTransform() const
+{
+    return m_patternTransform->currentValue();
+}
+
 AffineTransform SVGPatternElement::localCoordinateSpaceTransform(SVGLocatable::CTMScope) const
 {
-    return patternTransform().concatenate();
+    return protectedPatternTransform()->concatenate();
 }
 
 }

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -48,6 +48,7 @@ public:
     SVGUnitTypes::SVGUnitType patternUnits() const { return m_patternUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     SVGUnitTypes::SVGUnitType patternContentUnits() const { return m_patternContentUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     const SVGTransformList& patternTransform() const { return m_patternTransform->currentValue(); }
+    Ref<const SVGTransformList> protectedPatternTransform() const;
 
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }


### PR DESCRIPTION
#### cd033b774e3a39c18129f294a306d5e7c6350a4c
<pre>
Adopt even more smart pointers in SVG
<a href="https://bugs.webkit.org/show_bug.cgi?id=269073">https://bugs.webkit.org/show_bug.cgi?id=269073</a>

Reviewed by Darin Adler.

* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::checkedImageResource const):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::checkedImageResource const):
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::checkedImageResource const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
(WebCore::SVGFEDisplacementMapElement::attributeChanged):
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::setStdDeviation):
(WebCore::SVGFEDropShadowElement::attributeChanged):
(WebCore::SVGFEDropShadowElement::createFilterEffect const):
* Source/WebCore/svg/SVGFEFloodElement.cpp:
(WebCore::SVGFEFloodElement::setFilterEffectAttribute):
(WebCore::SVGFEFloodElement::createFilterEffect const):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::setStdDeviation):
(WebCore::SVGFEGaussianBlurElement::attributeChanged):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::renderingTaintsOrigin const):
(WebCore::SVGFEImageElement::clearResourceReferences):
(WebCore::SVGFEImageElement::requestImageResource):
(WebCore::SVGFEImageElement::notifyFinished):
(WebCore::SVGFEImageElement::imageBufferForEffect const):
(WebCore::SVGFEImageElement::createFilterEffect const):
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::attributeChanged):
(WebCore::SVGFELightElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEMergeNodeElement.cpp:
(WebCore::SVGFEMergeNodeElement::attributeChanged):
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::attributeChanged):
* Source/WebCore/svg/SVGFEOffsetElement.cpp:
(WebCore::SVGFEOffsetElement::attributeChanged):
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::attributeChanged):
(WebCore::SVGFESpecularLightingElement::createFilterEffect const):
* Source/WebCore/svg/SVGFETileElement.cpp:
(WebCore::SVGFETileElement::attributeChanged):
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::attributeChanged):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::attributeChanged):
(WebCore::SVGFilterPrimitiveStandardAttributes::primitiveAttributeChanged):
(WebCore::SVGFilterPrimitiveStandardAttributes::primitiveAttributeOnChildChanged):
(WebCore::SVGFilterPrimitiveStandardAttributes::markFilterEffectForRebuild):
(WebCore::SVGFilterPrimitiveStandardAttributes::invalidateFilterPrimitiveParent):
* Source/WebCore/svg/SVGFitToViewBox.cpp:
(WebCore::SVGFitToViewBox::setViewBox):
(WebCore::SVGFitToViewBox::resetViewBox):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::protectedFontFaceRule const):
(WebCore::SVGFontFaceElement::attributeChanged):
(WebCore::SVGFontFaceElement::fontFamily const):
(WebCore::SVGFontFaceElement::protectedFontElement const):
(WebCore::SVGFontFaceElement::rebuildFontFace):
(WebCore::SVGFontFaceElement::removedFromAncestor):
* Source/WebCore/svg/SVGFontFaceElement.h:
* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
(WebCore::SVGFontFaceUriElement::~SVGFontFaceUriElement):
(WebCore::SVGFontFaceUriElement::loadFont):
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::attributeChanged):
(WebCore::SVGForeignObjectElement::createElementRenderer):
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::getTotalLength const):
(WebCore::SVGGeometryElement::getPointAtLength const):
(WebCore::SVGGeometryElement::isPointInFill):
(WebCore::SVGGeometryElement::isPointInStroke):
(WebCore::SVGGeometryElement::attributeChanged):
* Source/WebCore/svg/SVGGradientElement.cpp:
(WebCore::SVGGradientElement::attributeChanged):
(WebCore::SVGGradientElement::invalidateGradientResource):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::protectedTransform const):
(WebCore::SVGGraphicsElement::animatedLocalTransform const):
(WebCore::SVGGraphicsElement::attributeChanged):
(WebCore::SVGGraphicsElement::svgAttributeChanged):
(WebCore::SVGGraphicsElement::didAttachRenderers):
* Source/WebCore/svg/SVGGraphicsElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::renderingTaintsOrigin const):
(WebCore::SVGImageElement::attributeChanged):
(WebCore::SVGImageElement::svgAttributeChanged):
(WebCore::SVGImageElement::didAttachRenderers):
* Source/WebCore/svg/SVGImageLoader.cpp:
(WebCore::SVGImageLoader::dispatchLoadEvent):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::protectedContext const):
(WebCore::SVGLengthContext::convertValueFromUserUnitsToEMS const):
(WebCore::SVGLengthContext::convertValueFromEMSToUserUnits const):
(WebCore::SVGLengthContext::convertValueFromUserUnitsToEXS const):
(WebCore::SVGLengthContext::convertValueFromEXSToUserUnits const):
(WebCore::SVGLengthContext::computeViewportSize const):
* Source/WebCore/svg/SVGLengthContext.h:
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::toCSSPrimitiveValue const):
* Source/WebCore/svg/SVGLineElement.cpp:
(WebCore::SVGLineElement::attributeChanged):
(WebCore::SVGLineElement::svgAttributeChanged):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::attributeChanged):
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::SVGLocatable::getBBox):
(WebCore::SVGLocatable::computeCTM):
(WebCore::SVGLocatable::getTransformToElement):
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::buildPendingResource):
(WebCore::SVGMPathElement::targetPathChanged):
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::attributeChanged):
(WebCore::SVGMarkerElement::invalidateMarkerResource):
(WebCore::SVGMarkerElement::setOrientToAuto):
(WebCore::SVGMarkerElement::setOrientToAngle):
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::attributeChanged):
(WebCore::SVGMaskElement::calculateMaskContentRepaintRect):
* Source/WebCore/svg/SVGPathAbsoluteConverter.cpp:
(WebCore::SVGPathAbsoluteConverter::incrementPathSegmentCount):
(WebCore::SVGPathAbsoluteConverter::continueConsuming):
(WebCore::SVGPathAbsoluteConverter::moveTo):
(WebCore::SVGPathAbsoluteConverter::lineTo):
(WebCore::SVGPathAbsoluteConverter::curveToCubic):
(WebCore::SVGPathAbsoluteConverter::closePath):
(WebCore::SVGPathAbsoluteConverter::lineToHorizontal):
(WebCore::SVGPathAbsoluteConverter::lineToVertical):
(WebCore::SVGPathAbsoluteConverter::curveToCubicSmooth):
(WebCore::SVGPathAbsoluteConverter::curveToQuadratic):
(WebCore::SVGPathAbsoluteConverter::curveToQuadraticSmooth):
(WebCore::SVGPathAbsoluteConverter::arcTo):
* Source/WebCore/svg/SVGPathAbsoluteConverter.h:
* Source/WebCore/svg/SVGPathBlender.cpp:
(WebCore::SVGPathBlender::canBlendPaths):
(WebCore::SVGPathBlender::blendAnimatedPath):
* Source/WebCore/svg/SVGPathBlender.h:
* Source/WebCore/svg/SVGPathBuilder.h:
* Source/WebCore/svg/SVGPathByteStream.h:
(WebCore::SVGPathByteStream::operator==):
* Source/WebCore/svg/SVGPathByteStreamBuilder.h:
* Source/WebCore/svg/SVGPathConsumer.h:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::attributeChanged):
(WebCore::SVGPathElement::svgAttributeChanged):
(WebCore::SVGPathElement::invalidateMPathDependencies):
(WebCore::SVGPathElement::getPointAtLength const):
(WebCore::SVGPathElement::getBBox):
* Source/WebCore/svg/SVGPathParser.cpp:
(WebCore::SVGPathParser::parseClosePathSegment):
(WebCore::SVGPathParser::parseMoveToSegment):
(WebCore::SVGPathParser::parseLineToSegment):
(WebCore::SVGPathParser::parseLineToHorizontalSegment):
(WebCore::SVGPathParser::parseLineToVerticalSegment):
(WebCore::SVGPathParser::parseCurveToCubicSegment):
(WebCore::SVGPathParser::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathParser::parseCurveToQuadraticSegment):
(WebCore::SVGPathParser::parseCurveToQuadraticSmoothSegment):
(WebCore::SVGPathParser::parseArcToSegment):
(WebCore::SVGPathParser::parsePathData):
(WebCore::SVGPathParser::decomposeArcToCubic):
* Source/WebCore/svg/SVGPathParser.h:
* Source/WebCore/svg/SVGPathSegList.h:
* Source/WebCore/svg/SVGPathSegListBuilder.cpp:
(WebCore::SVGPathSegListBuilder::moveTo):
(WebCore::SVGPathSegListBuilder::lineTo):
(WebCore::SVGPathSegListBuilder::lineToHorizontal):
(WebCore::SVGPathSegListBuilder::lineToVertical):
(WebCore::SVGPathSegListBuilder::curveToCubic):
(WebCore::SVGPathSegListBuilder::curveToCubicSmooth):
(WebCore::SVGPathSegListBuilder::curveToQuadratic):
(WebCore::SVGPathSegListBuilder::curveToQuadraticSmooth):
(WebCore::SVGPathSegListBuilder::arcTo):
(WebCore::SVGPathSegListBuilder::closePath):
* Source/WebCore/svg/SVGPathSegListBuilder.h:
* Source/WebCore/svg/SVGPathSegListSource.cpp:
(WebCore::SVGPathSegListSource::SVGPathSegListSource):
(WebCore::SVGPathSegListSource::nextCommand):
(WebCore::SVGPathSegListSource::parseSVGSegmentType):
(WebCore::SVGPathSegListSource::parseMoveToSegment):
(WebCore::SVGPathSegListSource::parseLineToSegment):
(WebCore::SVGPathSegListSource::parseLineToHorizontalSegment):
(WebCore::SVGPathSegListSource::parseLineToVerticalSegment):
(WebCore::SVGPathSegListSource::parseCurveToCubicSegment):
(WebCore::SVGPathSegListSource::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathSegListSource::parseCurveToQuadraticSegment):
(WebCore::SVGPathSegListSource::parseCurveToQuadraticSmoothSegment):
(WebCore::SVGPathSegListSource::parseArcToSegment):
* Source/WebCore/svg/SVGPathSegListSource.h:
* Source/WebCore/svg/SVGPathSource.h:
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::attributeChanged):
(WebCore::SVGPatternElement::svgAttributeChanged):
(WebCore::SVGPatternElement::protectedPatternTransform const):
(WebCore::SVGPatternElement::localCoordinateSpaceTransform const):
* Source/WebCore/svg/SVGPatternElement.h:

Canonical link: <a href="https://commits.webkit.org/274391@main">https://commits.webkit.org/274391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c4ecdd4dc7892ff1cfc2ff796ec08a62f3a6abc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41473 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15221 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13072 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38868 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11359 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37089 "Found 1 new API test failure: /WebKitGTK/TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15020 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5084 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->