### PR TITLE
Adopt fast character comparison in a few more places

### DIFF
--- a/Source/WebCore/svg/SVGAngleValue.cpp
+++ b/Source/WebCore/svg/SVGAngleValue.cpp
@@ -24,6 +24,7 @@
 
 #include "SVGParserUtilities.h"
 #include <wtf/MathExtras.h>
+#include <wtf/text/FastCharacterComparison.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/text/StringParsingBuffer.h>
 
@@ -87,13 +88,13 @@ template<typename CharacterType> static inline SVGAngleValue::Type parseAngleTyp
     case 0:
         return SVGAngleValue::SVG_ANGLETYPE_UNSPECIFIED;
     case 3:
-        if (buffer[0] == 'd' && buffer[1] == 'e' && buffer[2] == 'g')
+        if (compareCharacters(buffer.position(), 'd', 'e', 'g'))
             return SVGAngleValue::SVG_ANGLETYPE_DEG;
-        if (buffer[0] == 'r' && buffer[1] == 'a' && buffer[2] == 'd')
+        if (compareCharacters(buffer.position(), 'r', 'a', 'd'))
             return SVGAngleValue::SVG_ANGLETYPE_RAD;
         break;
     case 4:
-        if (buffer[0] == 'g' && buffer[1] == 'r' && buffer[2] == 'a' && buffer[3] == 'd')
+        if (compareCharacters(buffer.position(), 'g', 'r', 'a', 'd'))
             return SVGAngleValue::SVG_ANGLETYPE_GRAD;
         break;
     }

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -26,6 +26,7 @@
 #include "SVGElement.h"
 #include "SVGLengthContext.h"
 #include "SVGParserUtilities.h"
+#include <wtf/text/FastCharacterComparison.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/TextStream.h>
@@ -67,31 +68,32 @@ template<typename CharacterType> static inline SVGLengthType parseLengthType(Str
     if (buffer.atEnd())
         return SVGLengthType::Number;
 
-    auto firstChar = *buffer++;
+    auto firstCharacterPosition = buffer.position();
+    buffer.advance();
 
     if (buffer.atEnd())
-        return firstChar == '%' ? SVGLengthType::Percentage : SVGLengthType::Unknown;
+        return *firstCharacterPosition == '%' ? SVGLengthType::Percentage : SVGLengthType::Unknown;
 
-    auto secondChar = *buffer++;
+    buffer.advance();
 
     if (!buffer.atEnd())
         return SVGLengthType::Unknown;
 
-    if (firstChar == 'e' && secondChar == 'm')
+    if (compareCharacters(firstCharacterPosition, 'e', 'm'))
         return SVGLengthType::Ems;
-    if (firstChar == 'e' && secondChar == 'x')
+    if (compareCharacters(firstCharacterPosition, 'e', 'x'))
         return SVGLengthType::Exs;
-    if (firstChar == 'p' && secondChar == 'x')
+    if (compareCharacters(firstCharacterPosition, 'p', 'x'))
         return SVGLengthType::Pixels;
-    if (firstChar == 'c' && secondChar == 'm')
+    if (compareCharacters(firstCharacterPosition, 'c', 'm'))
         return SVGLengthType::Centimeters;
-    if (firstChar == 'm' && secondChar == 'm')
+    if (compareCharacters(firstCharacterPosition, 'm', 'm'))
         return SVGLengthType::Millimeters;
-    if (firstChar == 'i' && secondChar == 'n')
+    if (compareCharacters(firstCharacterPosition, 'i', 'n'))
         return SVGLengthType::Inches;
-    if (firstChar == 'p' && secondChar == 't')
+    if (compareCharacters(firstCharacterPosition, 'p', 't'))
         return SVGLengthType::Points;
-    if (firstChar == 'p' && secondChar == 'c')
+    if (compareCharacters(firstCharacterPosition, 'p', 'c'))
         return SVGLengthType::Picas;
 
     return SVGLengthType::Unknown;


### PR DESCRIPTION
#### 1f54053a713efc3134f2e52be5d3b83b1412fe29
<pre>
Adopt fast character comparison in a few more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=269077">https://bugs.webkit.org/show_bug.cgi?id=269077</a>

Reviewed by Sam Weinig and Yusuke Suzuki.

* Source/WebCore/svg/SVGAngleValue.cpp:
(WebCore::parseAngleType):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::parseLengthType):

Canonical link: <a href="https://commits.webkit.org/274388@main">https://commits.webkit.org/274388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94d764714ebcf9b41b252f3d86db7df3832b15c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41467 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20732 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15215 "Build is in progress. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15037 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13068 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38857 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37086 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15353 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8719 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15014 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->