### PR TITLE
[WebGPU] Device lost promise takes too long to resolve

### DIFF
--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -222,7 +222,7 @@ Device::~Device()
 
 void Device::loseTheDevice(WGPUDeviceLostReason reason)
 {
-    // https://gpuweb.github.io/gpuweb/#lose-the-device
+    m_device = nil;
 
     m_adapter->makeInvalid();
 
@@ -233,11 +233,7 @@ void Device::loseTheDevice(WGPUDeviceLostReason reason)
         m_deviceLostCallback = nullptr;
     }
 
-    // FIXME: The spec doesn't actually say to do this, but it's pretty important because
-    // the total number of command queues alive at a time is limited to a pretty low limit.
-    // We should make sure either that this is unobservable or that the spec says to do this.
     m_defaultQueue->makeInvalid();
-
     m_isLost = true;
 }
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -70,7 +70,7 @@ public:
     void onSubmittedWorkScheduled(CompletionHandler<void()>&&);
 
     bool isValid() const { return m_commandQueue; }
-    void makeInvalid() { m_commandQueue = nil; }
+    void makeInvalid();
 
     const Device& device() const;
     void waitUntilIdle();


### PR DESCRIPTION
#### dd3938f3a697ffa59cc01085bd850fb4983d6dea
<pre>
[WebGPU] Device lost promise takes too long to resolve
<a href="https://bugs.webkit.org/show_bug.cgi?id=269019">https://bugs.webkit.org/show_bug.cgi?id=269019</a>
&lt;radar://122582535&gt;

Reviewed by Dan Glastonbury.

We weren&apos;t resolving onSubmittedWorkDone in a timely fashion
when the device was lost, leading to perceived hang running
api,validation,state,detroy,* tests.

* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::loseTheDevice):
* Source/WebGPU/WebGPU/Queue.h:
(WebGPU::Queue::makeInvalid): Deleted.
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::makeInvalid):
(WebGPU::Queue::onSubmittedWorkDone):
(WebGPU::Queue::onSubmittedWorkScheduled):

Canonical link: <a href="https://commits.webkit.org/274482@main">https://commits.webkit.org/274482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a24e2a4701691450ac664f9e4d4cfaf3e9389db7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41765 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15539 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15328 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13315 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35623 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37331 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15649 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8778 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->