### PR TITLE
Don't allow playback to start when in the background and interrupted by the system

### DIFF
--- a/LayoutTests/media/video-playback-system-interruption-expected.txt
+++ b/LayoutTests/media/video-playback-system-interruption-expected.txt
@@ -1,0 +1,14 @@
+
+RUN(internals.setMediaElementRestrictions(video, 'NoRestrictions'))
+RUN(internals.beginMediaSessionInterruption("EnteringBackground"))
+RUN(internals.beginMediaSessionInterruption("System"))
+RUN(video.volume = 0.1)
+RUN(video.src = findMediaFile("video", "content/audio-tracks"))
+EVENT(canplaythrough)
+EXPECTED (video.paused == 'true') OK
+EXPECTED (internals.mediaSessionState(video) == 'Interrupted') OK
+RUN(internals.endMediaSessionInterruption("MayResumePlaying"))
+EVENT(playing)
+EXPECTED (internals.mediaSessionState(video) != 'Interrupted') OK
+END OF TEST
+

--- a/LayoutTests/media/video-playback-system-interruption.html
+++ b/LayoutTests/media/video-playback-system-interruption.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="media-file.js"></script>
+        <script src="video-test.js"></script>
+        <script>
+
+            window.addEventListener('load', async event => {
+                if (!window.internals) {
+                    failTest('This test must be run in DumpRenderTree or WebKitTestRunner.');
+                    return;
+                }
+    
+                findMediaElement();
+                run(`internals.setMediaElementRestrictions(video, 'NoRestrictions')`);
+                run('internals.beginMediaSessionInterruption("EnteringBackground")');
+                run('internals.beginMediaSessionInterruption("System")');
+
+                run('video.volume = 0.1');
+                run('video.src = findMediaFile("video", "content/audio-tracks")');
+
+                waitForEvent('playing', () => { testExpected('internals.mediaSessionState(video)', 'Interrupted', '!=') });
+                await waitFor(video, 'canplaythrough');
+                
+                await sleepFor(250);
+                testExpected('video.paused', true);
+                testExpected('internals.mediaSessionState(video)', 'Interrupted');
+            
+                run('internals.endMediaSessionInterruption("MayResumePlaying")');
+                
+                // Wait some time before ending the test to ensure the session interruption is cancelled.
+                endTestLater();
+            });
+            
+        </script>
+    </head>
+    <body>
+        <video autoplay controls></video>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5872,6 +5872,12 @@ bool HTMLMediaElement::couldPlayIfEnoughData() const
     if (pausedForUserInteraction())
         return false;
 
+    if (!canProduceAudio() || PlatformMediaSessionManager::sharedManager().hasActiveAudioSession())
+        return true;
+
+    if (mediaSession().activeAudioSessionRequired() && mediaSession().blockedBySystemInterruption())
+        return false;
+
     return true;
 }
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -139,7 +139,7 @@ public:
 
     using InterruptionType = PlatformMediaSessionInterruptionType;
 
-    InterruptionType interruptionType() const { return m_interruptionType; }
+    InterruptionType interruptionType() const;
 
     using EndInterruptionFlags = PlatformMediaSessionEndInterruptionFlags;
 
@@ -198,6 +198,7 @@ public:
     virtual bool requiresPlaybackTargetRouteMonitoring() const { return false; }
 #endif
 
+    bool blockedBySystemInterruption() const;
     bool activeAudioSessionRequired() const;
     bool canProduceAudio() const;
     bool hasMediaStreamSource() const;
@@ -241,12 +242,13 @@ protected:
 
 private:
     bool processClientWillPausePlayback(DelayCallingUpdateNowPlaying);
+    size_t interruptionCount() const { return m_interruptionStack.size(); }
 
     PlatformMediaSessionClient& m_client;
     MediaSessionIdentifier m_mediaSessionIdentifier;
     State m_state { State::Idle };
     State m_stateToRestore { State::Idle };
-    InterruptionType m_interruptionType { InterruptionType::NoInterruption };
+    Vector<InterruptionType> m_interruptionStack;
     int m_interruptionCount { 0 };
     bool m_active { false };
     bool m_notifyingClient { false };

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -142,6 +142,15 @@ bool PlatformMediaSessionManager::activeAudioSessionRequired() const
     });
 }
 
+bool PlatformMediaSessionManager::hasActiveAudioSession() const
+{
+#if USE(AUDIO_SESSION)
+    return m_becameActive;
+#else
+    return true;
+#endif
+}
+
 bool PlatformMediaSessionManager::canProduceAudio() const
 {
     return anyOfSessions([] (auto& session) {

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -88,6 +88,7 @@ public:
     bool has(PlatformMediaSession::MediaType) const;
     int count(PlatformMediaSession::MediaType) const;
     bool activeAudioSessionRequired() const;
+    bool hasActiveAudioSession() const;
     bool canProduceAudio() const;
 
     virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return { }; }


### PR DESCRIPTION
#### 537043c0738d31cf15247da8fe11c0e85838a1e5
<pre>
Don&apos;t allow playback to start when in the background and interrupted by the system
<a href="https://bugs.webkit.org/show_bug.cgi?id=269081">https://bugs.webkit.org/show_bug.cgi?id=269081</a>
<a href="https://rdar.apple.com/117928506">rdar://117928506</a>

Reviewed by Jer Noble.

Don&apos;t allow playback to begin when WebKit is in the background and has also been interrupted
by the audio session. This can happen, for example, when playback is started from Control
Center on the lock screen and the user switches to the camera app and activates the video
camera. Allowing playback activates WebKit&apos;s AVAudioSession and prevents the camera app
from using the volume buttons to trigger start/stop recording.

* LayoutTests/media/video-playback-system-interruption-expected.txt: Added.
* LayoutTests/media/video-playback-system-interruption.html: Added.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::couldPlayIfEnoughData const): Return false if the element
needs an active audio session and it was paused by a system interruption.

* Source/WebCore/platform/audio/PlatformMediaSession.cpp: Keep a vector of interruption types
instead of an interruption count so we know the type of the most recent interruption.
(WebCore::PlatformMediaSession::interruptionType const): Return the type of the most recent
interruption, not the first.
(WebCore::PlatformMediaSession::beginInterruption): Update for interruption stack.
(WebCore::PlatformMediaSession::endInterruption): Ditto.
(WebCore::PlatformMediaSession::isPlayingToWirelessPlaybackTargetChanged): Can no longer
save and restore the interruption count, but the issue that caused the change appears to
have been fixed.
(WebCore::PlatformMediaSession::blockedBySystemInterruption const):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WebCore::PlatformMediaSession::interruptionCount const):
(WebCore::PlatformMediaSession::interruptionType const): Deleted.

Canonical link: <a href="https://commits.webkit.org/274438@main">https://commits.webkit.org/274438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73b24c85bf7e54ff23990eabea4f3ec210634b5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41498 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32638 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13094 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38888 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37111 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33993 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8749 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->