### PR TITLE
[WebGPU] usesFeature should be considered on an entry point basis

### DIFF
--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3090,8 +3090,7 @@ NSString* Texture::errorValidatingImageCopyTexture(const WGPUImageCopyTexture& i
         || fromAPI(imageCopyTexture.texture).sampleCount() > 1) {
         auto subresourceSize = imageCopyTextureSubresourceSize(imageCopyTexture);
         if (subresourceSize.width != copySize.width
-            || (copySize.height > 1 && subresourceSize.height != copySize.height)
-            || (copySize.depthOrArrayLayers > 1 && subresourceSize.depthOrArrayLayers != copySize.depthOrArrayLayers))
+            || (copySize.height > 1 && subresourceSize.height != copySize.height))
             return [NSString stringWithFormat:@"subresourceSize.width(%u) != copySize.width(%u) || subresourceSize.height(%u) != copySize.height(%u) || subresourceSize.depthOrArrayLayers(%u) != copySize.depthOrArrayLayers(%u)", subresourceSize.width, copySize.width, subresourceSize.height, copySize.height, subresourceSize.depthOrArrayLayers, copySize.depthOrArrayLayers];
     }
 


### PR DESCRIPTION
#### 4e820e51d023639ce378712eb3f6640e8db7fe02
<pre>
[WebGPU] usesFeature should be considered on an entry point basis
<a href="https://bugs.webkit.org/show_bug.cgi?id=269091">https://bugs.webkit.org/show_bug.cgi?id=269091</a>
&lt;radar://122666801&gt;

Reviewed by Dan Glastonbury.

Previously we considered if an entire shader module used
a feature on a global basis.

This is incorrect as it should only matter if the entry
point uses a specific feature.

Correct this by storing usesFeature per entry point.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::errorValidatingInterstageShaderInterfaces):
(WebGPU::Device::createRenderPipeline):
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::parseFragmentReturnType):
(WebGPU::ShaderModule::shaderModuleState const):
(WebGPU::ShaderModule::populateShaderModuleState):
(WebGPU::ShaderModule::usesFrontFacingInInput const):
(WebGPU::ShaderModule::usesSampleIndexInInput const):
(WebGPU::ShaderModule::usesSampleMaskInInput const):
(WebGPU::ShaderModule::usesSampleMaskInOutput const):
(WebGPU::ShaderModule::usesFragDepth const):
(WebGPU::ShaderModule::populateFragmentInputs):
(WebGPU::ShaderModule::parseFragmentInputs):
(WebGPU::ShaderModule::ShaderModule):
(WebGPU::parseFragmentReturnType): Deleted.
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::errorValidatingImageCopyTexture):

Canonical link: <a href="https://commits.webkit.org/274474@main">https://commits.webkit.org/274474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1bce29008568fc338bbac4c33a121f113b615fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41497 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34680 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32636 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13053 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42774 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38885 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37109 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15381 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8773 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->