### PR TITLE
Adopt even more smart pointers in WebCore/page

### DIFF
--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -48,13 +48,13 @@ DeviceMotionController::DeviceMotionController(DeviceMotionClient& client)
 
 void DeviceMotionController::suspendUpdates()
 {
-    m_client.stopUpdating();
+    m_client->stopUpdating();
 }
 
 void DeviceMotionController::resumeUpdates()
 {
     if (!m_listeners.isEmpty())
-        m_client.startUpdating();
+        m_client->startUpdating();
 }
 
 #endif
@@ -66,7 +66,7 @@ void DeviceMotionController::didChangeDeviceMotion(DeviceMotionData* deviceMotio
 
 DeviceMotionClient& DeviceMotionController::deviceMotionClient()
 {
-    return static_cast<DeviceMotionClient&>(m_client);
+    return static_cast<DeviceMotionClient&>(m_client.get());
 }
 
 bool DeviceMotionController::hasLastData()

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -48,7 +48,7 @@ void DeviceOrientationController::didChangeDeviceOrientation(DeviceOrientationDa
 
 DeviceOrientationClient& DeviceOrientationController::deviceOrientationClient()
 {
-    return static_cast<DeviceOrientationClient&>(m_client);
+    return static_cast<DeviceOrientationClient&>(m_client.get());
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -58,13 +58,13 @@ DeviceOrientationClient& DeviceOrientationController::deviceOrientationClient()
 
 void DeviceOrientationController::suspendUpdates()
 {
-    m_client.stopUpdating();
+    m_client->stopUpdating();
 }
 
 void DeviceOrientationController::resumeUpdates()
 {
     if (!m_listeners.isEmpty())
-        m_client.startUpdating();
+        m_client->startUpdating();
 }
 
 #else

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -169,15 +169,15 @@ DOMTimer::DOMTimer(ScriptExecutionContext& context, Function<void(ScriptExecutio
     , m_currentTimerInterval(intervalClampedToMinimum())
     , m_userGestureTokenToForward(UserGestureIndicator::currentUserGesture())
 {
-    auto& eventLoop = context.eventLoop();
+    CheckedRef eventLoop = context.eventLoop();
     m_hasReachedMaxNestingLevel = m_nestingLevel >= (m_oneShot ? maxTimerNestingLevelForOneShotTimers : maxTimerNestingLevelForRepeatingTimers);
     if (m_oneShot) {
-        m_timer = eventLoop.scheduleTask(m_currentTimerInterval, context, m_hasReachedMaxNestingLevel ? HasReachedMaxNestingLevel::Yes : HasReachedMaxNestingLevel::No, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
+        m_timer = eventLoop->scheduleTask(m_currentTimerInterval, context, m_hasReachedMaxNestingLevel ? HasReachedMaxNestingLevel::Yes : HasReachedMaxNestingLevel::No, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->fired();
         });
     } else {
-        m_timer = eventLoop.scheduleRepeatingTask(m_originalInterval, m_currentTimerInterval, context, m_hasReachedMaxNestingLevel ? HasReachedMaxNestingLevel::Yes : HasReachedMaxNestingLevel::No, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
+        m_timer = eventLoop->scheduleRepeatingTask(m_originalInterval, m_currentTimerInterval, context, m_hasReachedMaxNestingLevel ? HasReachedMaxNestingLevel::Yes : HasReachedMaxNestingLevel::No, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->fired();
         });
@@ -196,7 +196,7 @@ int DOMTimer::install(ScriptExecutionContext& context, std::unique_ptr<Scheduled
 
 int DOMTimer::install(ScriptExecutionContext& context, Function<void(ScriptExecutionContext&)>&& action, Seconds timeout, Type type)
 {
-    Ref<DOMTimer> timer = adoptRef(*new DOMTimer(context, WTFMove(action), timeout, type));
+    Ref timer = adoptRef(*new DOMTimer(context, WTFMove(action), timeout, type));
     timer->suspendIfNeeded();
     timer->makeImminentlyScheduledWorkScopeIfPossible(context);
 
@@ -230,7 +230,7 @@ void DOMTimer::removeById(ScriptExecutionContext& context, int timeoutId)
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
     if (RefPtr document = dynamicDowncast<Document>(context)) {
-        if (auto* timer = document->findTimeout(timeoutId)) {
+        if (RefPtr timer = document->findTimeout(timeoutId)) {
             document->contentChangeObserver().didRemoveDOMTimer(*timer);
             if (auto* holdingTank = document->domTimerHoldingTankIfExists())
                 holdingTank->remove(*timer);
@@ -243,7 +243,7 @@ void DOMTimer::removeById(ScriptExecutionContext& context, int timeoutId)
 
     InspectorInstrumentation::didRemoveTimer(context, timeoutId);
 
-    if (auto timer = context.takeTimeout(timeoutId)) {
+    if (RefPtr timer = context.takeTimeout(timeoutId)) {
         timer->clearImminentlyScheduledWorkScope();
         timer->m_timer = nullptr;
     }
@@ -259,7 +259,7 @@ inline bool DOMTimer::isDOMTimersThrottlingEnabled(const Document& document) con
 
 void DOMTimer::updateThrottlingStateIfNecessary(const DOMTimerFireState& fireState)
 {
-    auto* contextDocument = fireState.contextDocument();
+    RefPtr contextDocument = fireState.contextDocument();
     // We don't throttle timers in worker threads.
     if (!contextDocument)
         return;
@@ -300,15 +300,15 @@ void DOMTimer::fired()
     // Retain this - if the timer is cancelled while this function is on the stack (implicitly and always
     // for one-shot timers, or if removeById is called on itself from within an interval timer fire) then
     // wait unit the end of this function to delete DOMTimer.
-    Ref<DOMTimer> protectedThis(*this);
+    Ref protectedThis { *this };
 
     ASSERT(scriptExecutionContext());
-    ScriptExecutionContext& context = *scriptExecutionContext();
+    Ref context = *scriptExecutionContext();
 
 #if PLATFORM(IOS_FAMILY)
     if (RefPtr document = dynamicDowncast<Document>(context); document && m_oneShot) {
         if (auto* holdingTank = document->domTimerHoldingTankIfExists(); holdingTank && holdingTank->contains(*this)) {
-            m_timer = document->eventLoop().scheduleTask(0_s, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
+            m_timer = document->checkedEventLoop()->scheduleTask(0_s, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->fired();
             });
@@ -322,7 +322,7 @@ void DOMTimer::fired()
     if (m_userGestureTokenToForward && m_userGestureTokenToForward->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwarding))
         m_userGestureTokenToForward = nullptr;
 
-    ASSERT(!context.activeDOMObjectsAreSuspended());
+    ASSERT(!context->activeDOMObjectsAreSuspended());
     UserGestureIndicator gestureIndicator(m_userGestureTokenToForward);
     // Only the first execution of a multi-shot timer should get an affirmative user gesture indicator.
     m_userGestureTokenToForward = nullptr;
@@ -334,7 +334,7 @@ void DOMTimer::fired()
         if (m_nestingLevel < maxTimerNestingLevel) {
             m_nestingLevel++;
             m_hasReachedMaxNestingLevel = m_nestingLevel >= maxTimerNestingLevelForRepeatingTimers;
-            context.eventLoop().setTimerHasReachedMaxNestingLevel(m_timer, m_hasReachedMaxNestingLevel);
+            context->checkedEventLoop()->setTimerHasReachedMaxNestingLevel(m_timer, m_hasReachedMaxNestingLevel);
             updateTimerIntervalIfNecessary();
         }
 
@@ -348,7 +348,7 @@ void DOMTimer::fired()
         return;
     }
 
-    context.takeTimeout(m_timeoutId);
+    context->takeTimeout(m_timeoutId);
 
     // Keep track nested timer installs.
     NestedTimersMap* nestedTimers = NestedTimersMap::instanceForContext(context);
@@ -356,7 +356,7 @@ void DOMTimer::fired()
         nestedTimers->startTracking();
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
-    ContentChangeObserver::DOMTimerScope observingScope(dynamicDowncast<Document>(context), *this);
+    ContentChangeObserver::DOMTimerScope observingScope(dynamicDowncast<Document>(context.get()), *this);
 #endif
     m_action(context);
 
@@ -365,7 +365,7 @@ void DOMTimer::fired()
     // Check if we should throttle nested single-shot timers.
     if (nestedTimers) {
         for (auto& idAndTimer : *nestedTimers) {
-            auto& timer = idAndTimer.value;
+            Ref timer = idAndTimer.value;
             if (timer->m_oneShot)
                 timer->updateThrottlingStateIfNecessary(fireState);
         }
@@ -398,13 +398,13 @@ void DOMTimer::updateTimerIntervalIfNecessary()
     if (previousInterval == m_currentTimerInterval)
         return;
 
-    ScriptExecutionContext& context = *scriptExecutionContext();
+    Ref context = *scriptExecutionContext();
     if (m_oneShot) {
         LOG(DOMTimers, "%p - Updating DOMTimer's fire interval from %.2f ms to %.2f ms due to throttling.", this, previousInterval.milliseconds(), m_currentTimerInterval.milliseconds());
-        context.eventLoop().adjustTimerNextFireTime(m_timer, m_currentTimerInterval - previousInterval);
+        context->checkedEventLoop()->adjustTimerNextFireTime(m_timer, m_currentTimerInterval - previousInterval);
     } else {
         LOG(DOMTimers, "%p - Updating DOMTimer's repeat interval from %.2f ms to %.2f ms due to throttling.", this, previousInterval.milliseconds(), m_currentTimerInterval.milliseconds());
-        context.eventLoop().adjustTimerRepeatInterval(m_timer, m_currentTimerInterval - previousInterval);
+        context->checkedEventLoop()->adjustTimerRepeatInterval(m_timer, m_currentTimerInterval - previousInterval);
     }
 }
 
@@ -455,7 +455,7 @@ void DOMTimer::makeImminentlyScheduledWorkScopeIfPossible(ScriptExecutionContext
     if (!document)
         return;
 
-    auto* page = document->page();
+    RefPtr page = document->page();
     if (!page)
         return;
 

--- a/Source/WebCore/page/DOMWindowExtension.h
+++ b/Source/WebCore/page/DOMWindowExtension.h
@@ -52,6 +52,7 @@ public:
     void willDetachGlobalObjectFromFrame() final;
 
     WEBCORE_EXPORT LocalFrame* frame() const;
+    RefPtr<LocalFrame> protectedFrame() const;
     DOMWrapperWorld& world() const { return m_world; }
 
 private:

--- a/Source/WebCore/page/DebugPageOverlays.h
+++ b/Source/WebCore/page/DebugPageOverlays.h
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
@@ -65,10 +66,7 @@ private:
 
     void regionChanged(LocalFrame&, RegionType);
 
-    bool hasOverlaysForPage(Page& page) const
-    {
-        return m_pageRegionOverlays.contains(&page);
-    }
+    bool hasOverlaysForPage(Page&) const;
     
     void updateOverlayRegionVisibility(Page&, OptionSet<DebugOverlayRegions>);
 
@@ -77,7 +75,7 @@ private:
     RegionOverlay* regionOverlayForPage(Page&, RegionType) const;
     RegionOverlay& ensureRegionOverlayForPage(Page&, RegionType);
 
-    HashMap<Page*, Vector<RefPtr<RegionOverlay>>> m_pageRegionOverlays;
+    SingleThreadWeakHashMap<Page, Vector<RefPtr<RegionOverlay>>> m_pageRegionOverlays;
 
     static DebugPageOverlays* sharedDebugOverlays;
 };

--- a/Source/WebCore/page/DeviceClient.h
+++ b/Source/WebCore/page/DeviceClient.h
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include <wtf/WeakPtr.h>
+
 namespace WebCore {
 
-class DeviceClient {
+class DeviceClient : public CanMakeWeakPtr<DeviceClient> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~DeviceClient() = default;

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -50,7 +50,7 @@ void DeviceController::addDeviceEventListener(LocalDOMWindow& window)
     }
 
     if (wasEmpty)
-        m_client.startUpdating();
+        m_client->startUpdating();
 }
 
 void DeviceController::removeDeviceEventListener(LocalDOMWindow& window)
@@ -58,7 +58,7 @@ void DeviceController::removeDeviceEventListener(LocalDOMWindow& window)
     m_listeners.remove(&window);
     m_lastEventListeners.remove(&window);
     if (m_listeners.isEmpty())
-        m_client.stopUpdating();
+        m_client->stopUpdating();
 }
 
 void DeviceController::removeAllDeviceEventListeners(LocalDOMWindow& window)
@@ -66,7 +66,7 @@ void DeviceController::removeAllDeviceEventListeners(LocalDOMWindow& window)
     m_listeners.removeAll(&window);
     m_lastEventListeners.removeAll(&window);
     if (m_listeners.isEmpty())
-        m_client.stopUpdating();
+        m_client->stopUpdating();
 }
 
 bool DeviceController::hasDeviceEventListener(LocalDOMWindow& window) const
@@ -83,6 +83,11 @@ void DeviceController::dispatchDeviceEvent(Event& event)
     }
 }
 
+DeviceClient& DeviceController::client()
+{
+    return m_client.get();
+}
+
 void DeviceController::fireDeviceEvent()
 {
     ASSERT(hasLastData());
@@ -93,7 +98,7 @@ void DeviceController::fireDeviceEvent()
     for (auto& listener : listenerVector) {
         auto document = listener->document();
         if (document && !document->activeDOMObjectsAreSuspended() && !document->activeDOMObjectsAreStopped()) {
-            if (auto lastEvent = getLastEvent())
+            if (RefPtr lastEvent = getLastEvent())
                 listener->dispatchEvent(*lastEvent);
         }
     }

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -51,7 +51,7 @@ public:
 
     void dispatchDeviceEvent(Event&);
     bool isActive() { return !m_listeners.isEmpty(); }
-    DeviceClient& client() { return m_client; }
+    DeviceClient& client();
 
     virtual bool hasLastData() { return false; }
     virtual RefPtr<Event> getLastEvent() { return nullptr; }
@@ -61,7 +61,7 @@ protected:
 
     HashCountedSet<RefPtr<LocalDOMWindow>> m_listeners;
     HashCountedSet<RefPtr<LocalDOMWindow>> m_lastEventListeners;
-    DeviceClient& m_client;
+    WeakRef<DeviceClient> m_client;
     Timer m_timer;
 };
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -147,15 +147,15 @@ static RefPtr<DocumentFragment> documentFragmentFromDragData(const DragData& dra
     chosePlainText = false;
 
     if (dragData.containsCompatibleContent()) {
-        if (auto fragment = frame.editor().webContentFromPasteboard(*Pasteboard::create(dragData), context, allowPlainText, chosePlainText))
+        if (RefPtr fragment = frame.editor().webContentFromPasteboard(*Pasteboard::create(dragData), context, allowPlainText, chosePlainText))
             return fragment;
 
         if (dragData.containsURL(DragData::DoNotConvertFilenames)) {
             String title;
             String url = dragData.asURL(DragData::DoNotConvertFilenames, &title);
             if (!url.isEmpty()) {
-                auto& document = context.start.document();
-                auto anchor = HTMLAnchorElement::create(document);
+                Ref document = context.start.document();
+                Ref anchor = HTMLAnchorElement::create(document);
                 anchor->setHref(AtomString { url });
                 if (title.isEmpty()) {
                     // Try the plain text first because the URL might be normalized or escaped.
@@ -164,8 +164,8 @@ static RefPtr<DocumentFragment> documentFragmentFromDragData(const DragData& dra
                     if (title.isEmpty())
                         title = url;
                 }
-                anchor->appendChild(document.createTextNode(WTFMove(title)));
-                auto fragment = document.createDocumentFragment();
+                anchor->appendChild(document->createTextNode(WTFMove(title)));
+                Ref fragment = document->createDocumentFragment();
                 fragment->appendChild(anchor);
                 return fragment;
             }
@@ -173,7 +173,7 @@ static RefPtr<DocumentFragment> documentFragmentFromDragData(const DragData& dra
     }
     if (allowPlainText && dragData.containsPlainText()) {
         chosePlainText = true;
-        return createFragmentFromText(context, dragData.asPlainText()).ptr();
+        return createFragmentFromText(context, dragData.asPlainText());
     }
 
     return nullptr;
@@ -196,7 +196,7 @@ bool DragController::dragIsMove(FrameSelection& selection, const DragData& dragD
 
 void DragController::clearDragCaret()
 {
-    m_page.dragCaretController().clear();
+    m_page->dragCaretController().clear();
 }
 
 void DragController::dragEnded()
@@ -214,11 +214,10 @@ void DragController::dragExited(LocalFrame& frame, DragData&& dragData)
 {
     disallowFileAccessIfNeeded(dragData);
     if (frame.view())
-        frame.eventHandler().cancelDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
+        frame.checkedEventHandler()->cancelDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
     mouseMovedIntoDocument(nullptr);
-    if (m_fileInputElementUnderMouse)
-        m_fileInputElementUnderMouse->setCanReceiveDroppedFiles(false);
-    m_fileInputElementUnderMouse = nullptr;
+    if (RefPtr fileInput = std::exchange(m_fileInputElementUnderMouse, nullptr))
+        fileInput->setCanReceiveDroppedFiles(false);
 }
 
 inline static bool dragIsHandledByDocument(DragHandlingMethod dragHandlingMethod)
@@ -239,9 +238,9 @@ bool DragController::performDragOperation(DragData&& dragData)
     removeAllDroppedImagePlaceholders();
 
     SetForScope isPerformingDrop(m_isPerformingDrop, true);
-    IgnoreSelectionChangeForScope ignoreSelectionChanges { m_page.focusController().focusedOrMainFrame() };
+    IgnoreSelectionChangeForScope ignoreSelectionChanges { m_page->focusController().focusedOrMainFrame() };
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)
         return false;
 
@@ -250,15 +249,14 @@ bool DragController::performDragOperation(DragData&& dragData)
     disallowFileAccessIfNeeded(dragData);
 
     ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow;
-    if (m_documentUnderMouse)
-        shouldOpenExternalURLsPolicy = m_documentUnderMouse->shouldOpenExternalURLsPolicyToPropagate();
+    if (RefPtr document = m_documentUnderMouse)
+        shouldOpenExternalURLsPolicy = document->shouldOpenExternalURLsPolicyToPropagate();
 
     if ((m_dragDestinationActionMask.contains(DragDestinationAction::DHTML)) && dragIsHandledByDocument(m_dragHandlingMethod)) {
         client().willPerformDragDestinationAction(DragDestinationAction::DHTML, dragData);
-        Ref protectedLocalMainFrame(*localMainFrame);
         bool preventedDefault = false;
-        if (protectedLocalMainFrame->view())
-            preventedDefault = protectedLocalMainFrame->eventHandler().performDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
+        if (localMainFrame->view())
+            preventedDefault = localMainFrame->checkedEventHandler()->performDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
         if (preventedDefault) {
             clearDragCaret();
             m_documentUnderMouse = nullptr;
@@ -289,11 +287,11 @@ bool DragController::performDragOperation(DragData&& dragData)
     FrameLoadRequest frameLoadRequest { *localMainFrame, resourceRequest };
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     frameLoadRequest.setIsRequestFromClientOrUserInput();
-    localMainFrame->loader().load(WTFMove(frameLoadRequest));
+    localMainFrame->checkedLoader()->load(WTFMove(frameLoadRequest));
     return true;
 }
 
-void DragController::mouseMovedIntoDocument(Document* newDocument)
+void DragController::mouseMovedIntoDocument(RefPtr<Document>&& newDocument)
 {
     if (m_documentUnderMouse == newDocument)
         return;
@@ -301,7 +299,7 @@ void DragController::mouseMovedIntoDocument(Document* newDocument)
     // If we were over another document clear the selection
     if (m_documentUnderMouse)
         clearDragCaret();
-    m_documentUnderMouse = newDocument;
+    m_documentUnderMouse = WTFMove(newDocument);
 }
 
 std::variant<std::optional<DragOperation>, RemoteUserInputEventData> DragController::dragEnteredOrUpdated(LocalFrame& frame, DragData&& dragData)
@@ -318,7 +316,7 @@ std::variant<std::optional<DragOperation>, RemoteUserInputEventData> DragControl
         return RemoteUserInputEventData { remoteSubframe->frameID(), dragData.clientPosition() };
     }
 
-    mouseMovedIntoDocument(hitTestResult.innerNode() ? &hitTestResult.innerNode()->document() : nullptr);
+    mouseMovedIntoDocument(hitTestResult.innerNode() ? RefPtr { hitTestResult.innerNode()->protectedDocument() } : nullptr);
 
     m_dragDestinationActionMask = dragData.dragDestinationActionMask();
     if (m_dragDestinationActionMask.isEmpty()) {
@@ -409,12 +407,17 @@ void DragController::updateSupportedTypeIdentifiersForDragHandlingMethod(DragHan
 
 #endif
 
+Ref<Page> DragController::protectedPage() const
+{
+    return m_page.get();
+}
+
 DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const DragData& dragData, OptionSet<DragDestinationAction> destinationActionMask, std::optional<DragOperation>& dragOperation)
 {
     if (!m_documentUnderMouse)
         return DragHandlingMethod::None;
 
-    if (m_dragInitiator && !m_documentUnderMouse->securityOrigin().canReceiveDragData(m_dragInitiator->securityOrigin()))
+    if (m_dragInitiator && !m_documentUnderMouse->protectedSecurityOrigin()->canReceiveDragData(m_dragInitiator->securityOrigin()))
         return DragHandlingMethod::None;
 
     bool isHandlingDrag = false;
@@ -460,18 +463,18 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
         }
         
         if (!m_fileInputElementUnderMouse)
-            m_page.dragCaretController().setCaretPosition(m_documentUnderMouse->frame()->visiblePositionForPoint(point));
+            protectedPage()->dragCaretController().setCaretPosition(m_documentUnderMouse->frame()->visiblePositionForPoint(point));
         else
             clearDragCaret();
 
-        auto* innerFrame = element->document().frame();
-        dragOperation = dragIsMove(innerFrame->selection(), dragData) ? DragOperation::Move : DragOperation::Copy;
+        RefPtr innerFrame = element->document().frame();
+        dragOperation = dragIsMove(innerFrame->checkedSelection().get(), dragData) ? DragOperation::Move : DragOperation::Copy;
 
         unsigned numberOfFiles = dragData.numberOfFiles();
-        if (m_fileInputElementUnderMouse) {
-            if (m_fileInputElementUnderMouse->isDisabledFormControl())
+        if (RefPtr fileInput = m_fileInputElementUnderMouse) {
+            if (fileInput->isDisabledFormControl())
                 m_numberOfItemsToBeAccepted = 0;
-            else if (m_fileInputElementUnderMouse->multiple())
+            else if (fileInput->multiple())
                 m_numberOfItemsToBeAccepted = numberOfFiles;
             else if (numberOfFiles > 1)
                 m_numberOfItemsToBeAccepted = 0;
@@ -480,7 +483,7 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
             
             if (!m_numberOfItemsToBeAccepted)
                 dragOperation = std::nullopt;
-            m_fileInputElementUnderMouse->setCanReceiveDroppedFiles(m_numberOfItemsToBeAccepted);
+            fileInput->setCanReceiveDroppedFiles(m_numberOfItemsToBeAccepted);
         } else {
             // We are not over a file input element. The dragged item(s) will loaded into the view,
             // dropped as text paths on other input elements, or handled by script on the page.
@@ -490,7 +493,7 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
         if (m_fileInputElementUnderMouse)
             return DragHandlingMethod::UploadFile;
 
-        if (m_page.dragCaretController().isContentRichlyEditable())
+        if (m_page->dragCaretController().isContentRichlyEditable())
             return DragHandlingMethod::EditRichText;
 
         return DragHandlingMethod::EditPlainText;
@@ -498,9 +501,8 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
     
     // We are not over an editable region. Make sure we're clearing any prior drag cursor.
     clearDragCaret();
-    if (m_fileInputElementUnderMouse)
-        m_fileInputElementUnderMouse->setCanReceiveDroppedFiles(false);
-    m_fileInputElementUnderMouse = nullptr;
+    if (RefPtr fileInput = std::exchange(m_fileInputElementUnderMouse, nullptr))
+        fileInput->setCanReceiveDroppedFiles(false);
     return DragHandlingMethod::None;
 }
 
@@ -512,14 +514,14 @@ OptionSet<DragSourceAction> DragController::delegateDragSourceAction(const IntPo
 
 std::optional<DragOperation> DragController::operationForLoad(const DragData& dragData)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)
         return std::nullopt;
-    Document* document = localMainFrame->documentAtPoint(dragData.clientPosition());
+    RefPtr document = localMainFrame->documentAtPoint(dragData.clientPosition());
 
     bool pluginDocumentAcceptsDrags = false;
-    if (auto* pluginDocument = dynamicDowncast<PluginDocument>(document)) {
-        if (auto* pluginView = pluginDocument->pluginWidget())
+    if (RefPtr pluginDocument = dynamicDowncast<PluginDocument>(document)) {
+        if (RefPtr pluginView = pluginDocument->pluginWidget())
             pluginDocumentAcceptsDrags = pluginView->shouldAllowNavigationFromDrags();
     }
 
@@ -530,22 +532,22 @@ std::optional<DragOperation> DragController::operationForLoad(const DragData& dr
 
 static bool setSelectionToDragCaret(LocalFrame* frame, VisibleSelection& dragCaret, const IntPoint& point)
 {
-    Ref protector(*frame);
+    Ref protectedFrame { *frame };
     frame->selection().setSelection(dragCaret);
     if (frame->selection().selection().isNone()) {
         dragCaret = frame->visiblePositionForPoint(point);
-        frame->selection().setSelection(dragCaret);
+        frame->checkedSelection()->setSelection(dragCaret);
     }
     return !frame->selection().isNone() && frame->selection().selection().isContentEditable();
 }
 
 bool DragController::dispatchTextInputEventFor(LocalFrame* innerFrame, const DragData& dragData)
 {
-    ASSERT(m_page.dragCaretController().hasCaret());
-    String text = m_page.dragCaretController().isContentRichlyEditable() ? emptyString() : dragData.asPlainText();
-    auto target = innerFrame->editor().findEventTargetFrom(m_page.dragCaretController().caretPosition());
+    ASSERT(m_page->dragCaretController().hasCaret());
+    String text = m_page->dragCaretController().isContentRichlyEditable() ? emptyString() : dragData.asPlainText();
+    auto target = innerFrame->editor().findEventTargetFrom(m_page->dragCaretController().caretPosition());
     // FIXME: What guarantees target is not null?
-    auto event = TextEvent::createForDrop(&innerFrame->windowProxy(), text);
+    Ref event = TextEvent::createForDrop(innerFrame->protectedWindowProxy().ptr(), WTFMove(text));
     target->dispatchEvent(event);
     return !event->defaultPrevented();
 }
@@ -553,22 +555,20 @@ bool DragController::dispatchTextInputEventFor(LocalFrame* innerFrame, const Dra
 bool DragController::concludeEditDrag(const DragData& dragData)
 {
     RefPtr<HTMLInputElement> fileInput = m_fileInputElementUnderMouse;
-    if (m_fileInputElementUnderMouse) {
-        m_fileInputElementUnderMouse->setCanReceiveDroppedFiles(false);
-        m_fileInputElementUnderMouse = nullptr;
-    }
+    if (RefPtr fileInput = std::exchange(m_fileInputElementUnderMouse, nullptr))
+        fileInput->setCanReceiveDroppedFiles(false);
 
     if (!m_documentUnderMouse)
         return false;
 
-    IntPoint point = m_documentUnderMouse->view()->windowToContents(dragData.clientPosition());
+    IntPoint point = m_documentUnderMouse->protectedView()->windowToContents(dragData.clientPosition());
     RefPtr element = elementUnderMouse(*protectedDocumentUnderMouse(), point);
     if (!element)
         return false;
     RefPtr innerFrame = element->document().frame();
     ASSERT(innerFrame);
 
-    if (m_page.dragCaretController().hasCaret() && !dispatchTextInputEventFor(innerFrame.get(), dragData))
+    if (m_page->dragCaretController().hasCaret() && !dispatchTextInputEventFor(innerFrame.get(), dragData))
         return true;
 
     if (dragData.containsColor()) {
@@ -585,12 +585,12 @@ bool DragController::concludeEditDrag(const DragData& dragData)
         auto innerRange = innerFrame->selection().selection().toNormalizedRange();
         if (!innerRange)
             return false;
-        auto style = MutableStyleProperties::create();
+        Ref style = MutableStyleProperties::create();
         style->setProperty(CSSPropertyColor, serializationForHTML(color), false);
-        if (!innerFrame->editor().shouldApplyStyle(style, *innerRange))
+        if (!innerFrame->checkedEditor()->shouldApplyStyle(style, *innerRange))
             return false;
         client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData);
-        innerFrame->editor().applyStyle(style.ptr(), EditAction::SetColor);
+        innerFrame->checkedEditor()->applyStyle(style.ptr(), EditAction::SetColor);
         return true;
     }
 
@@ -604,12 +604,12 @@ bool DragController::concludeEditDrag(const DragData& dragData)
         return fileInput->receiveDroppedFiles(dragData);
     }
 
-    if (!m_page.dragController().canProcessDrag(dragData))
+    if (!m_page->dragController().canProcessDrag(dragData))
         return false;
 
-    VisibleSelection dragCaret = m_page.dragCaretController().caretPosition();
+    VisibleSelection dragCaret = m_page->dragCaretController().caretPosition();
     auto range = dragCaret.toNormalizedRange();
-    RefPtr<Element> rootEditableElement = innerFrame->selection().selection().rootEditableElement();
+    RefPtr rootEditableElement = innerFrame->selection().selection().rootEditableElement();
 
     // For range to be null a WebKit client must have done something bad while
     // manually controlling drag behaviour
@@ -617,23 +617,23 @@ bool DragController::concludeEditDrag(const DragData& dragData)
         return false;
 
     ResourceCacheValidationSuppressor validationSuppressor(range->start.document().cachedResourceLoader());
-    auto& editor = innerFrame->editor();
+    CheckedRef editor = innerFrame->editor();
     bool isMove = dragIsMove(innerFrame->selection(), dragData);
     if (isMove || dragCaret.isContentRichlyEditable()) {
         bool chosePlainText = false;
-        auto fragment = documentFragmentFromDragData(dragData, *innerFrame, *range, true, chosePlainText);
-        if (!fragment || !editor.shouldInsertFragment(*fragment, range, EditorInsertAction::Dropped))
+        RefPtr fragment = documentFragmentFromDragData(dragData, *innerFrame, *range, true, chosePlainText);
+        if (!fragment || !editor->shouldInsertFragment(*fragment, range, EditorInsertAction::Dropped))
             return false;
 
         client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData);
 
-        if (editor.client() && editor.client()->performTwoStepDrop(*fragment, *range, isMove))
+        if (editor->client() && editor->client()->performTwoStepDrop(*fragment, *range, isMove))
             return true;
 
         if (isMove) {
             // NSTextView behavior is to always smart delete on moving a selection,
             // but only to smart insert if the selection granularity is word granularity.
-            bool smartDelete = editor.smartInsertDeleteEnabled();
+            bool smartDelete = editor->smartInsertDeleteEnabled();
             bool smartInsert = smartDelete && innerFrame->selection().granularity() == TextGranularity::WordGranularity && dragData.canSmartReplace();
             MoveSelectionCommand::create(fragment.releaseNonNull(), dragCaret.base(), smartInsert, smartDelete)->apply();
         } else {
@@ -643,26 +643,26 @@ bool DragController::concludeEditDrag(const DragData& dragData)
                     options.add(ReplaceSelectionCommand::SmartReplace);
                 if (chosePlainText)
                     options.add(ReplaceSelectionCommand::MatchStyle);
-                ReplaceSelectionCommand::create(*m_documentUnderMouse, fragment.releaseNonNull(), options, EditAction::InsertFromDrop)->apply();
+                ReplaceSelectionCommand::create(protectedDocumentUnderMouse().releaseNonNull(), fragment.releaseNonNull(), options, EditAction::InsertFromDrop)->apply();
             }
         }
     } else {
         String text = dragData.asPlainText();
-        if (text.isEmpty() || !editor.shouldInsertText(text, *range, EditorInsertAction::Dropped))
+        if (text.isEmpty() || !editor->shouldInsertText(text, *range, EditorInsertAction::Dropped))
             return false;
 
         client().willPerformDragDestinationAction(DragDestinationAction::Edit, dragData);
-        auto fragment = createFragmentFromText(*range, text);
-        if (editor.client() && editor.client()->performTwoStepDrop(fragment.get(), *range, isMove))
+        Ref fragment = createFragmentFromText(*range, text);
+        if (editor->client() && editor->client()->performTwoStepDrop(fragment.get(), *range, isMove))
             return true;
 
         if (setSelectionToDragCaret(innerFrame.get(), dragCaret, point))
-            ReplaceSelectionCommand::create(*m_documentUnderMouse, WTFMove(fragment), { ReplaceSelectionCommand::SelectReplacement, ReplaceSelectionCommand::MatchStyle, ReplaceSelectionCommand::PreventNesting }, EditAction::InsertFromDrop)->apply();
+            ReplaceSelectionCommand::create(protectedDocumentUnderMouse().releaseNonNull(), WTFMove(fragment), { ReplaceSelectionCommand::SelectReplacement, ReplaceSelectionCommand::MatchStyle, ReplaceSelectionCommand::PreventNesting }, EditAction::InsertFromDrop)->apply();
     }
 
     if (rootEditableElement) {
-        if (auto* frame = rootEditableElement->document().frame())
-            frame->eventHandler().updateDragStateAfterEditDragIfNeeded(*rootEditableElement);
+        if (RefPtr frame = rootEditableElement->document().frame())
+            frame->checkedEventHandler()->updateDragStateAfterEditDragIfNeeded(*rootEditableElement);
     }
 
     return true;
@@ -670,18 +670,18 @@ bool DragController::concludeEditDrag(const DragData& dragData)
 
 bool DragController::canProcessDrag(const DragData& dragData)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)
         return false;
-    IntPoint point = localMainFrame->view()->windowToContents(dragData.clientPosition());
+    IntPoint point = localMainFrame->protectedView()->windowToContents(dragData.clientPosition());
     HitTestResult result = HitTestResult(point);
     if (!localMainFrame->contentRenderer())
         return false;
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent };
-    result = localMainFrame->eventHandler().hitTestResultAtPoint(point, hitType);
+    result = localMainFrame->checkedEventHandler()->hitTestResultAtPoint(point, hitType);
 
-    auto* dragNode = result.innerNonSharedNode();
+    RefPtr dragNode = result.innerNonSharedNode();
     if (!dragNode)
         return false;
 
@@ -738,12 +738,12 @@ bool DragController::tryDHTMLDrag(LocalFrame& frame, const DragData& dragData, s
 {
     ASSERT(m_documentUnderMouse);
     Ref protectedFrame(frame);
-    RefPtr viewProtector = protectedFrame->view();
-    if (!viewProtector)
+    RefPtr view = protectedFrame->view();
+    if (!view)
         return false;
 
     auto sourceOperationMask = dragData.draggingSourceOperationMask();
-    auto targetResponse = protectedFrame->eventHandler().updateDragAndDrop(createMouseEvent(dragData), [&dragData]() {
+    auto targetResponse = protectedFrame->checkedEventHandler()->updateDragAndDrop(createMouseEvent(dragData), [&dragData]() {
         return Pasteboard::create(dragData);
     }, sourceOperationMask, dragData.containsFiles());
     if (!targetResponse.accept)
@@ -764,13 +764,12 @@ static bool imageElementIsDraggable(const HTMLImageElement& image, const LocalFr
     if (sourceFrame.settings().loadsImagesAutomatically())
         return true;
 
-    auto* renderer = image.renderer();
-    CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer);
+    CheckedPtr renderImage = dynamicDowncast<RenderImage>(image.renderer());
     if (!renderImage)
         return false;
 
     CachedResourceHandle cachedImage = renderImage->cachedImage();
-    return cachedImage && !cachedImage->errorOccurred() && cachedImage->imageForRenderer(renderer);
+    return cachedImage && !cachedImage->errorOccurred() && cachedImage->imageForRenderer(renderImage.get());
 }
 
 #if ENABLE(MODEL_ELEMENT)
@@ -878,7 +877,7 @@ static CachedImage* getCachedImage(Element& element)
 
 static Image* getImage(Element& element)
 {
-    CachedImage* cachedImage = getCachedImage(element);
+    CachedResourceHandle cachedImage = getCachedImage(element);
     // Don't use cachedImage->imageForRenderer() here as that may return BitmapImages for cached SVG Images.
     // Users of getImage() want access to the SVGImage, in order to figure out the filename extensions,
     // which would be empty when asking the cached BitmapImages.
@@ -888,9 +887,9 @@ static Image* getImage(Element& element)
 
 static void selectElement(Element& element)
 {
-    if (auto frame = element.document().frame()) {
+    if (RefPtr frame = element.document().frame()) {
         if (auto range = makeRangeSelectingNode(element))
-            frame->selection().setSelection(*range);
+            frame->checkedSelection()->setSelection(*range);
     }
 }
 
@@ -938,31 +937,31 @@ static IntPoint dragLocForSelectionDrag(LocalFrame& src)
 void DragController::prepareForDragStart(LocalFrame& source, OptionSet<DragSourceAction> actionMask, Element& element, DataTransfer& dataTransfer, const IntPoint& dragOrigin) const
 {
 #if !PLATFORM(WIN)
-    Ref protector(source);
+    Ref protectedSource { source };
     auto hitTestResult = hitTestResultForDragStart(source, element, dragOrigin);
     if (!hitTestResult)
         return;
 
     auto& pasteboard = dataTransfer.pasteboard();
-    auto& editor = source.editor();
+    CheckedRef editor = source.editor();
     if (actionMask == DragSourceAction::Selection) {
         if (enclosingTextFormControl(source.selection().selection().start()))
-            pasteboard.writePlainText(editor.selectedTextForDataTransfer(), Pasteboard::CannotSmartReplace);
+            pasteboard.writePlainText(editor->selectedTextForDataTransfer(), Pasteboard::CannotSmartReplace);
         else
-            editor.writeSelectionToPasteboard(pasteboard);
+            editor->writeSelectionToPasteboard(pasteboard);
         return;
     }
 
-    auto* image = getImage(element);
+    RefPtr image = getImage(element);
     auto imageURL = hitTestResult->absoluteImageURL();
     if (actionMask.contains(DragSourceAction::Image) && !imageURL.isEmpty() && image && !image->isNull()) {
-        editor.writeImageToPasteboard(pasteboard, element, imageURL, { });
+        editor->writeImageToPasteboard(pasteboard, element, imageURL, { });
         return;
     }
 
     auto linkURL = hitTestResult->absoluteLinkURL();
     if (actionMask.contains(DragSourceAction::Link) && !linkURL.isEmpty() && source.document()->securityOrigin().canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton()))
-        editor.copyURL(linkURL, hitTestResult->textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline), pasteboard);
+        editor->copyURL(linkURL, hitTestResult->textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline), pasteboard);
 #else
     // FIXME: Make this work on Windows by implementing Editor::writeSelectionToPasteboard and Editor::writeImageToPasteboard.
     UNUSED_PARAM(source);
@@ -1002,7 +1001,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         return false;
 #endif
 
-    Ref protector(src);
+    Ref protectedSrc { src };
     auto hitTestResult = hitTestResultForDragStart(src, *state.source, dragOrigin);
     if (!hitTestResult)
         return false;
@@ -1021,9 +1020,9 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 
     ASSERT(state.dataTransfer);
 
-    DataTransfer& dataTransfer = *state.dataTransfer;
+    Ref dataTransfer = *state.dataTransfer;
     if (state.type == DragSourceAction::DHTML) {
-        dragImage = DragImage { dataTransfer.createDragImage(dragImageOffset) };
+        dragImage = DragImage { dataTransfer->createDragImage(dragImageOffset) };
         // We allow DHTML/JS to set the drag image, even if its a link, image or text we're dragging.
         // This is in the spirit of the IE API, which allows overriding of pasteboard data and DragOp.
         if (dragImage) {
@@ -1040,12 +1039,12 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
     }
 
     ASSERT(state.source);
-    Element& element = *state.source;
+    Ref element = *state.source;
 
     bool mustUseLegacyDragClient = hasData == HasNonDefaultPasteboardData::Yes || client().useLegacyDragClient();
 
     IntRect dragImageBounds;
-    Image* image = getImage(element);
+    RefPtr image = getImage(element);
     if (state.type == DragSourceAction::Selection) {
         PasteboardWriterData pasteboardWriterData;
 
@@ -1060,7 +1059,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             auto selectionRange = src.selection().selection().toNormalizedRange();
             ASSERT(selectionRange);
 
-            src.editor().willWriteSelectionToPasteboard(*selectionRange);
+            src.checkedEditor()->willWriteSelectionToPasteboard(*selectionRange);
             auto selection = src.selection().selection();
             bool shouldDragAsPlainText = enclosingTextFormControl(selection.start());
             if (auto range = selection.range(); range && ImageOverlay::isInsideOverlay(*range))
@@ -1068,7 +1067,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 
             if (shouldDragAsPlainText) {
                 if (mustUseLegacyDragClient)
-                    dataTransfer.pasteboard().writePlainText(src.editor().selectedTextForDataTransfer(), Pasteboard::CannotSmartReplace);
+                    dataTransfer->pasteboard().writePlainText(src.editor().selectedTextForDataTransfer(), Pasteboard::CannotSmartReplace);
                 else {
                     PasteboardWriterData::PlainText plainText;
                     plainText.canSmartCopyOrDelete = false;
@@ -1078,19 +1077,19 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             } else {
                 if (mustUseLegacyDragClient) {
 #if !PLATFORM(WIN)
-                    src.editor().writeSelectionToPasteboard(dataTransfer.pasteboard());
+                    src.checkedEditor()->writeSelectionToPasteboard(dataTransfer->pasteboard());
 #else
                     // FIXME: Convert Windows to match the other platforms and delete this.
-                    dataTransfer.pasteboard().writeSelection(*selectionRange, src.editor().canSmartCopyOrDelete(), src, IncludeImageAltTextForDataTransfer);
+                    dataTransfer->pasteboard().writeSelection(*selectionRange, src.editor().canSmartCopyOrDelete(), src, IncludeImageAltTextForDataTransfer);
 #endif
                 } else {
 #if PLATFORM(COCOA)
-                    src.editor().writeSelection(pasteboardWriterData);
+                    src.checkedEditor()->writeSelection(pasteboardWriterData);
 #endif
                 }
             }
 
-            src.editor().didWriteSelectionToPasteboard();
+            src.checkedEditor()->didWriteSelectionToPasteboard();
         }
         client().willPerformDragSourceAction(DragSourceAction::Selection, dragOrigin, dataTransfer);
         if (!dragImage) {
@@ -1121,8 +1120,8 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         return true;
     }
 
-    if (!src.document()->securityOrigin().canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton())) {
-        src.document()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Not allowed to drag local resource: " + linkURL.stringCenterEllipsizedToLength());
+    if (!src.document()->protectedSecurityOrigin()->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton())) {
+        src.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Not allowed to drag local resource: " + linkURL.stringCenterEllipsizedToLength());
         return false;
     }
 
@@ -1139,7 +1138,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 
         if (hasData == HasNonDefaultPasteboardData::No) {
             m_draggingImageURL = imageURL;
-            if (element.isContentRichlyEditable())
+            if (element->isContentRichlyEditable())
                 selectElement(element);
             if (!attachmentInfo)
                 declareAndWriteDragImage(dataTransfer, element, !linkURL.isEmpty() ? linkURL : imageURL, hitTestResult->altDisplayString());
@@ -1166,16 +1165,16 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             // Simplify whitespace so the title put on the dataTransfer resembles what the user sees
             // on the web page. This includes replacing newlines with spaces.
             if (mustUseLegacyDragClient)
-                src.editor().copyURL(linkURL, textContentWithSimplifiedWhiteSpace, dataTransfer.pasteboard());
+                src.editor().copyURL(linkURL, textContentWithSimplifiedWhiteSpace, dataTransfer->pasteboard());
             else
                 pasteboardWriterData.setURLData(src.editor().pasteboardWriterURL(linkURL, textContentWithSimplifiedWhiteSpace));
-        } else if (dataTransfer.pasteboard().canWriteTrustworthyWebURLsPboardType()) {
+        } else if (dataTransfer->pasteboard().canWriteTrustworthyWebURLsPboardType()) {
             // Make sure the pasteboard also contains trustworthy link data
             // but don't overwrite more general pasteboard types.
             PasteboardURL pasteboardURL;
             pasteboardURL.url = linkURL;
             pasteboardURL.title = hitTestResult->textContent();
-            dataTransfer.pasteboard().writeTrustworthyWebURLsPboardType(pasteboardURL);
+            dataTransfer->pasteboard().writeTrustworthyWebURLsPboardType(pasteboardURL);
         }
 
         const VisibleSelection& sourceSelection = src.selection().selection();
@@ -1185,17 +1184,17 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             // the enclosing anchor element
             Position pos = sourceSelection.base();
             if (RefPtr node = enclosingAnchorElement(pos))
-                src.selection().setSelection(VisibleSelection::selectionFromContentsOfNode(node.get()));
+                src.checkedSelection()->setSelection(VisibleSelection::selectionFromContentsOfNode(node.get()));
         }
 
         client().willPerformDragSourceAction(DragSourceAction::Link, dragOrigin, dataTransfer);
         if (!dragImage) {
             TextIndicatorData textIndicator;
-            dragImage = DragImage { createDragImageForLink(element, linkURL, textContentWithSimplifiedWhiteSpace, textIndicator, m_page.deviceScaleFactor()) };
+            dragImage = DragImage { createDragImageForLink(element, linkURL, textContentWithSimplifiedWhiteSpace, textIndicator, m_page->deviceScaleFactor()) };
             if (dragImage) {
                 m_dragOffset = dragOffsetForLinkDragImage(dragImage.get());
                 dragLoc = IntPoint(dragOrigin.x() + m_dragOffset.x(), dragOrigin.y() + m_dragOffset.y());
-                dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page.deviceScaleFactor()) };
+                dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page->deviceScaleFactor()) };
                 if (textIndicator.contentImage)
                     dragImage.setIndicatorData(textIndicator);
             }
@@ -1219,20 +1218,20 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     if (RefPtr attachment = dynamicDowncast<HTMLAttachmentElement>(element); attachment && m_dragSourceAction.contains(DragSourceAction::Attachment)) {
-        src.editor().setIgnoreSelectionChanges(true);
+        src.checkedEditor()->setIgnoreSelectionChanges(true);
         auto previousSelection = src.selection().selection();
         selectElement(element);
 
         PromisedAttachmentInfo promisedAttachment;
         if (hasData == HasNonDefaultPasteboardData::No) {
-            auto& editor = src.editor();
-            promisedAttachment = editor.promisedAttachmentInfo(*attachment);
+            CheckedRef editor = src.editor();
+            promisedAttachment = editor->promisedAttachmentInfo(*attachment);
 #if PLATFORM(COCOA)
-            if (!promisedAttachment && editor.client()) {
+            if (!promisedAttachment && editor->client()) {
                 // Otherwise, if no file URL is specified, call out to the injected bundle to populate the pasteboard with data.
-                editor.willWriteSelectionToPasteboard(src.selection().selection().toNormalizedRange());
-                editor.writeSelectionToPasteboard(dataTransfer.pasteboard());
-                editor.didWriteSelectionToPasteboard();
+                editor->willWriteSelectionToPasteboard(src.selection().selection().toNormalizedRange());
+                editor->writeSelectionToPasteboard(dataTransfer->pasteboard());
+                editor->didWriteSelectionToPasteboard();
             }
 #endif
         }
@@ -1241,7 +1240,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         
         if (!dragImage) {
             TextIndicatorData textIndicator;
-            auto* attachmentRenderer = dynamicDowncast<RenderAttachment>(attachment->renderer());
+            CheckedPtr attachmentRenderer = dynamicDowncast<RenderAttachment>(attachment->renderer());
             if (attachmentRenderer)
                 attachmentRenderer->setShouldDrawBorder(false);
             dragImage = DragImage { dissolveDragImageToFraction(createDragImageForSelection(src, textIndicator), DragImageAlpha) };
@@ -1253,9 +1252,9 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             m_dragOffset = IntPoint(dragOrigin.x() - dragLoc.x(), dragOrigin.y() - dragLoc.y());
         }
         doSystemDrag(WTFMove(dragImage), dragLoc, dragOrigin, src, state, WTFMove(promisedAttachment));
-        if (!element.isContentRichlyEditable())
-            src.selection().setSelection(previousSelection);
-        src.editor().setIgnoreSelectionChanges(false);
+        if (!element->isContentRichlyEditable())
+            src.checkedSelection()->setSelection(previousSelection);
+        src.checkedEditor()->setIgnoreSelectionChanges(false);
         return true;
     }
 #endif
@@ -1269,7 +1268,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         Path visiblePath;
         dragImage = DragImage { createDragImageForColor(color, input->boundsInRootViewSpace(), input->document().page()->pageScaleFactor(), visiblePath) };
         dragImage.setVisiblePath(visiblePath);
-        dataTransfer.pasteboard().write(color);
+        dataTransfer->pasteboard().write(color);
         dragImageOffset = IntPoint { dragImageSize(dragImage.get()) };
         dragLoc = dragLocForDHTMLDrag(mouseDraggedPoint, dragOrigin, dragImageOffset, false);
 
@@ -1287,7 +1286,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         pasteboardImage.suggestedName = modelElement->currentSrc().lastPathComponent().toString();
         pasteboardImage.resourceMIMEType = modelElement->model()->mimeType();
         pasteboardImage.resourceData = modelElement->model()->data();
-        dataTransfer.pasteboard().write(pasteboardImage);
+        dataTransfer->pasteboard().write(pasteboardImage);
 
         dragImageOffset = IntPoint { dragImageSize(dragImage.get()) };
         dragLoc = dragLocForDHTMLDrag(mouseDraggedPoint, dragOrigin, dragImageOffset, false);
@@ -1319,12 +1318,12 @@ void DragController::doImageDrag(Element& element, const IntPoint& dragOrigin, c
 
     ImageOrientation orientation = element.renderer()->imageOrientation();
 
-    Image* image = getImage(element);
-    if (image && !layoutRect.isEmpty() && shouldUseCachedImageForDragImage(*image) && (dragImage = DragImage { createDragImageFromImage(image, orientation) })) {
+    RefPtr image = getImage(element);
+    if (image && !layoutRect.isEmpty() && shouldUseCachedImageForDragImage(*image) && (dragImage = DragImage { createDragImageFromImage(image.get(), orientation) })) {
         dragImage = DragImage { fitDragImageToMaxSize(dragImage.get(), layoutRect.size(), maxDragImageSize()) };
         IntSize fittedSize = dragImageSize(dragImage.get());
 
-        dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page.deviceScaleFactor()) };
+        dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page->deviceScaleFactor()) };
         dragImage = DragImage { dissolveDragImageToFraction(dragImage.get(), DragImageAlpha) };
 
         // Properly orient the drag image and orient it differently if it's smaller than the original.
@@ -1338,10 +1337,10 @@ void DragController::doImageDrag(Element& element, const IntPoint& dragOrigin, c
         float dy = scale * (originY - mouseDownPoint.y());
         scaledOrigin = IntPoint((int)(dx + 0.5), (int)(dy + 0.5));
     } else {
-        if (CachedImage* cachedImage = getCachedImage(element)) {
+        if (CachedResourceHandle cachedImage = getCachedImage(element)) {
             dragImage = DragImage { createDragImageIconForCachedImageFilename(cachedImage->response().suggestedFilename()) };
             if (dragImage) {
-                dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page.deviceScaleFactor()) };
+                dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page->deviceScaleFactor()) };
                 scaledOrigin = IntPoint(DragIconRightInset - dragImageSize(dragImage.get()).width(), DragIconBottomInset);
             }
         }
@@ -1362,11 +1361,12 @@ void DragController::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPo
     m_dragInitiator = frame.document();
 
     // Protect this frame and view, as a load may occur mid drag and attempt to unload this frame
-    Ref protectedLocalMainFrame(m_page.mainFrame());
-    RefPtr viewProtector = protectedLocalMainFrame->virtualView();
+    Ref protectedLocalMainFrame(m_page->mainFrame());
+    RefPtr frameView = frame.view();
+    RefPtr mainFrameView = protectedLocalMainFrame->virtualView();
 
-    auto mouseDownPointInRootViewCoordinates = viewProtector->rootViewToContents(frame.view()->contentsToRootView(mouseDownPoint));
-    auto mouseDraggedPointInRootViewCoordinates = viewProtector->rootViewToContents(frame.view()->contentsToRootView(mouseDraggedPoint));
+    auto mouseDownPointInRootViewCoordinates = mainFrameView->rootViewToContents(frameView->contentsToRootView(mouseDownPoint));
+    auto mouseDraggedPointInRootViewCoordinates = mainFrameView->rootViewToContents(frameView->contentsToRootView(mouseDraggedPoint));
 
     client().beginDrag(WTFMove(dragItem), frame, mouseDownPointInRootViewCoordinates, mouseDraggedPointInRootViewCoordinates, dataTransfer, dragSourceAction);
 }
@@ -1385,8 +1385,9 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
     m_didInitiateDrag = true;
     m_dragInitiator = frame.document();
     // Protect this frame and view, as a load may occur mid drag and attempt to unload this frame
-    Ref protectedMainFrame(m_page.mainFrame());
-    RefPtr viewProtector = protectedMainFrame->virtualView();
+    Ref mainFrame = m_page->mainFrame();
+    RefPtr frameView = frame.view();
+    RefPtr mainFrameView = mainFrame->virtualView();
 
     DragItem item;
     item.image = WTFMove(image);
@@ -1395,13 +1396,13 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
     item.promisedAttachmentInfo = WTFMove(promisedAttachmentInfo);
     item.containsSelection = frame.selection().contains(eventPos);
 
-    auto eventPositionInRootViewCoordinates = frame.view()->contentsToRootView(eventPos);
-    auto dragLocationInRootViewCoordinates = frame.view()->contentsToRootView(dragLoc);
-    item.eventPositionInContentCoordinates = viewProtector->rootViewToContents(eventPositionInRootViewCoordinates);
-    item.dragLocationInContentCoordinates = viewProtector->rootViewToContents(dragLocationInRootViewCoordinates);
-    item.dragLocationInWindowCoordinates = viewProtector->contentsToWindow(item.dragLocationInContentCoordinates);
-    if (auto element = state.source) {
-        auto dataTransferImageElement = state.dataTransfer->dragImageElement();
+    auto eventPositionInRootViewCoordinates = frameView->contentsToRootView(eventPos);
+    auto dragLocationInRootViewCoordinates = frameView->contentsToRootView(dragLoc);
+    item.eventPositionInContentCoordinates = mainFrameView->rootViewToContents(eventPositionInRootViewCoordinates);
+    item.dragLocationInContentCoordinates = mainFrameView->rootViewToContents(dragLocationInRootViewCoordinates);
+    item.dragLocationInWindowCoordinates = mainFrameView->contentsToWindow(item.dragLocationInContentCoordinates);
+    if (RefPtr element = state.source) {
+        RefPtr dataTransferImageElement = state.dataTransfer->dragImageElement();
         if (state.type == DragSourceAction::DHTML) {
             // If the drag image has been customized, fall back to positioning the preview relative to the drag event location.
             IntSize dragPreviewSize;
@@ -1409,7 +1410,7 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
                 dragPreviewSize = dataTransferImageElement->boundsInRootViewSpace().size();
             else {
                 dragPreviewSize = dragImageSize(item.image.get());
-                if (auto* page = frame.page())
+                if (RefPtr page = frame.page())
                     dragPreviewSize.scale(1 / page->deviceScaleFactor());
             }
             item.dragPreviewFrameInRootViewCoordinates = { dragLocationInRootViewCoordinates, WTFMove(dragPreviewSize) };
@@ -1424,9 +1425,9 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
             item.url = frame.document()->completeURL(link->getAttribute(HTMLNames::hrefAttr));
         }
     }
-    client().startDrag(WTFMove(item), *state.dataTransfer, protectedMainFrame.get());
+    client().startDrag(WTFMove(item), *state.dataTransfer, mainFrame.get());
     // DragClient::startDrag can cause our Page to dispear, deallocating |this|.
-    if (!protectedMainFrame->page())
+    if (!mainFrame->page())
         return;
 
     cleanupAfterSystemDrag();
@@ -1455,7 +1456,7 @@ bool DragController::tryToUpdateDroppedImagePlaceholders(const DragData& dragDat
     auto pasteboard = Pasteboard::create(dragData);
     pasteboard->read(reader);
 
-    auto fragment = reader.protectedFragment();
+    RefPtr fragment = reader.protectedFragment();
     if (!fragment)
         return false;
 
@@ -1473,7 +1474,7 @@ bool DragController::tryToUpdateDroppedImagePlaceholders(const DragData& dragDat
         auto& placeholder = m_droppedImagePlaceholders[i];
         placeholder->setAttributeWithoutSynchronization(HTMLNames::srcAttr, imageElement->attributeWithoutSynchronization(HTMLNames::srcAttr));
 #if ENABLE(ATTACHMENT_ELEMENT)
-        if (auto attachment = imageElement->attachmentElement())
+        if (RefPtr attachment = imageElement->attachmentElement())
             placeholder->setAttachmentElement(attachment.releaseNonNull());
 #endif
     }
@@ -1482,7 +1483,7 @@ bool DragController::tryToUpdateDroppedImagePlaceholders(const DragData& dragDat
 
 void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>& imageSizes)
 {
-    auto& caretController = m_page.dragCaretController();
+    auto& caretController = m_page->dragCaretController();
     if (!caretController.isContentRichlyEditable())
         return;
 
@@ -1500,10 +1501,10 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
 
     IgnoreSelectionChangeForScope selectionChange { *frame };
 
-    auto fragment = DocumentFragment::create(*document);
+    Ref fragment = DocumentFragment::create(*document);
     for (auto& size : imageSizes) {
         ASSERT(!size.isEmpty());
-        auto image = HTMLImageElement::create(*document);
+        Ref image = HTMLImageElement::create(*document);
         image->setAttributeWithoutSynchronization(HTMLNames::widthAttr, AtomString::number(size.width()));
         image->setAttributeWithoutSynchronization(HTMLNames::heightAttr, AtomString::number(size.height()));
         image->setInlineStyleProperty(CSSPropertyMaxWidth, 100, CSSUnitType::CSS_PERCENTAGE);
@@ -1512,9 +1513,9 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
         fragment->appendChild(WTFMove(image));
     }
 
-    frame->selection().setSelection(dropCaret);
+    frame->checkedSelection()->setSelection(dropCaret);
 
-    auto command = ReplaceSelectionCommand::create(*document, WTFMove(fragment), { ReplaceSelectionCommand::PreventNesting, ReplaceSelectionCommand::SmartReplace }, EditAction::InsertFromDrop);
+    Ref command = ReplaceSelectionCommand::create(*document, WTFMove(fragment), { ReplaceSelectionCommand::PreventNesting, ReplaceSelectionCommand::SmartReplace }, EditAction::InsertFromDrop);
     command->apply();
 
     auto insertedContentRange = command->insertedContentRange();
@@ -1553,13 +1554,13 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
     m_droppedImagePlaceholders = WTFMove(placeholders);
     m_droppedImagePlaceholderRange = WTFMove(insertedContentRange);
 
-    frame->selection().clear();
+    frame->checkedSelection()->clear();
     caretController.setCaretPosition(makeDeprecatedLegacyPosition(m_droppedImagePlaceholderRange->start));
 }
 
 void DragController::finalizeDroppedImagePlaceholder(HTMLImageElement& placeholder, CompletionHandler<void()>&& completion)
 {
-    placeholder.document().eventLoop().queueTask(TaskSource::InternalAsyncTask, [completion = WTFMove(completion), placeholder = Ref { placeholder }] () mutable {
+    placeholder.protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [completion = WTFMove(completion), placeholder = Ref { placeholder }] () mutable {
         if (placeholder->isDroppedImagePlaceholder()) {
             placeholder->removeAttribute(HTMLNames::heightAttr);
             placeholder->removeInlineStyleProperty(CSSPropertyBackgroundColor);
@@ -1571,19 +1572,19 @@ void DragController::finalizeDroppedImagePlaceholder(HTMLImageElement& placehold
 // Manual drag caret manipulation
 void DragController::placeDragCaret(const IntPoint& windowPoint)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)
         return;
-    mouseMovedIntoDocument(localMainFrame->documentAtPoint(windowPoint));
+    mouseMovedIntoDocument(RefPtr { localMainFrame->documentAtPoint(windowPoint) });
     if (!m_documentUnderMouse)
         return;
-    auto* frame = m_documentUnderMouse->frame();
-    auto* frameView = frame->view();
+    RefPtr frame = m_documentUnderMouse->frame();
+    RefPtr frameView = frame->view();
     if (!frameView)
         return;
     IntPoint framePoint = frameView->windowToContents(windowPoint);
 
-    m_page.dragCaretController().setCaretPosition(frame->visiblePositionForPoint(framePoint));
+    protectedPage()->dragCaretController().setCaretPosition(frame->visiblePositionForPoint(framePoint));
 }
 
 bool DragController::shouldUseCachedImageForDragImage(const Image& image) const

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -32,6 +32,7 @@
 #include "SimpleRange.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/URL.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -119,7 +120,7 @@ private:
     bool dragIsMove(FrameSelection&, const DragData&);
     bool isCopyKeyDown(const DragData&);
 
-    void mouseMovedIntoDocument(Document*);
+    void mouseMovedIntoDocument(RefPtr<Document>&&);
     bool shouldUseCachedImageForDragImage(const Image&) const;
     void disallowFileAccessIfNeeded(DragData&);
 
@@ -146,8 +147,9 @@ private:
 
     void cleanupAfterSystemDrag();
     void declareAndWriteDragImage(DataTransfer&, Element&, const URL&, const String& label);
+    Ref<Page> protectedPage() const;
 
-    Page& m_page;
+    SingleThreadWeakRef<Page> m_page;
     std::unique_ptr<DragClient> m_client;
 
     RefPtr<Document> m_documentUnderMouse; // The document the mouse was last dragged over.

--- a/Source/WebCore/page/mac/DragControllerMac.mm
+++ b/Source/WebCore/page/mac/DragControllerMac.mm
@@ -101,7 +101,7 @@ void DragController::cleanupAfterSystemDrag()
     // We don't want to do this for WebKit2, since the client call to start the drag
     // is asynchronous.
 
-    if (m_page.mainFrame().virtualView()->platformWidget())
+    if (m_page->mainFrame().virtualView()->platformWidget())
         dragEnded();
 #endif
 }


### PR DESCRIPTION
#### 5a7f28d6380cd44da002dedcbce3f011cbf8a74e
<pre>
Adopt even more smart pointers in WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=269097">https://bugs.webkit.org/show_bug.cgi?id=269097</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/DeviceMotionController.cpp:
(WebCore::DeviceMotionController::deviceMotionClient):
* Source/WebCore/dom/DeviceOrientationController.cpp:
(WebCore::DeviceOrientationController::deviceOrientationClient):
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::selectionShadowAncestor):
(WebCore::DOMSelection::range const):
(WebCore::DOMSelection::anchorPosition const):
(WebCore::DOMSelection::focusPosition const):
(WebCore::DOMSelection::basePosition const):
(WebCore::DOMSelection::extentPosition const):
(WebCore::DOMSelection::isCollapsed const):
(WebCore::DOMSelection::type const):
(WebCore::DOMSelection::direction const):
(WebCore::DOMSelection::collapse):
(WebCore::DOMSelection::collapseToEnd):
(WebCore::DOMSelection::collapseToStart):
(WebCore::DOMSelection::setBaseAndExtent):
(WebCore::DOMSelection::modify):
(WebCore::DOMSelection::extend):
(WebCore::createLiveRangeBeforeShadowHostWithSelection):
(WebCore::DOMSelection::getRangeAt):
(WebCore::DOMSelection::removeAllRanges):
(WebCore::DOMSelection::addRange):
(WebCore::DOMSelection::removeRange):
(WebCore::DOMSelection::getComposedRanges):
(WebCore::DOMSelection::deleteFromDocument):
(WebCore::DOMSelection::toString const):
(WebCore::DOMSelection::shadowAdjustedNode const):
(WebCore::DOMSelection::shadowAdjustedOffset const):
(WebCore::DOMSelection::isValidForPosition const):
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::DOMTimer):
(WebCore::DOMTimer::install):
(WebCore::DOMTimer::removeById):
(WebCore::DOMTimer::updateThrottlingStateIfNecessary):
(WebCore::DOMTimer::fired):
(WebCore::DOMTimer::updateTimerIntervalIfNecessary):
(WebCore::DOMTimer::makeImminentlyScheduledWorkScopeIfPossible):
* Source/WebCore/page/DOMWindowExtension.cpp:
(WebCore::DOMWindowExtension::DOMWindowExtension):
(WebCore::DOMWindowExtension::~DOMWindowExtension):
(WebCore::DOMWindowExtension::protectedFrame const):
(WebCore::DOMWindowExtension::suspendForBackForwardCache):
(WebCore::DOMWindowExtension::resumeFromBackForwardCache):
(WebCore::DOMWindowExtension::willDestroyGlobalObjectInCachedFrame):
(WebCore::DOMWindowExtension::willDestroyGlobalObjectInFrame):
(WebCore::DOMWindowExtension::willDetachGlobalObjectFromFrame):
* Source/WebCore/page/DOMWindowExtension.h:
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::RegionOverlay::protectedOverlay):
(WebCore::RegionOverlay::protectedPage const):
(WebCore::MouseWheelRegionOverlay::updateRegion):
(WebCore::NonFastScrollableRegionOverlay::updateRegion):
(WebCore::InteractionRegionOverlay::activeLayer const):
(WebCore::InteractionRegionOverlay::activeRegion const):
(WebCore::InteractionRegionOverlay::rectForSettingAtIndex const):
(WebCore::InteractionRegionOverlay::mouseEvent):
(WebCore::RegionOverlay::~RegionOverlay):
(WebCore::RegionOverlay::recomputeRegion):
(WebCore::DebugPageOverlays::ensureRegionOverlayForPage):
(WebCore::DebugPageOverlays::hideRegionOverlay):
(WebCore::DebugPageOverlays::regionChanged):
(WebCore::DebugPageOverlays::hasOverlaysForPage const):
(WebCore::DebugPageOverlays::updateRegionIfNecessary):
(WebCore::DebugPageOverlays::regionOverlayForPage const):
(WebCore::DebugPageOverlays::shouldPaintOverlayIntoLayer const):
* Source/WebCore/page/DebugPageOverlays.h:
(WebCore::DebugPageOverlays::hasOverlaysForPage const): Deleted.
* Source/WebCore/page/DeviceClient.h:
* Source/WebCore/page/DeviceController.cpp:
(WebCore::DeviceController::addDeviceEventListener):
(WebCore::DeviceController::removeDeviceEventListener):
(WebCore::DeviceController::removeAllDeviceEventListeners):
(WebCore::DeviceController::client):
(WebCore::DeviceController::fireDeviceEvent):
* Source/WebCore/page/DeviceController.h:
(WebCore::DeviceController::client): Deleted.
* Source/WebCore/page/DragController.cpp:
(WebCore::documentFragmentFromDragData):
(WebCore::DragController::clearDragCaret):
(WebCore::DragController::dragExited):
(WebCore::DragController::performDragOperation):
(WebCore::DragController::mouseMovedIntoDocument):
(WebCore::DragController::dragEnteredOrUpdated):
(WebCore::DragController::protectedPage const):
(WebCore::DragController::tryDocumentDrag):
(WebCore::DragController::operationForLoad):
(WebCore::setSelectionToDragCaret):
(WebCore::DragController::dispatchTextInputEventFor):
(WebCore::DragController::concludeEditDrag):
(WebCore::DragController::canProcessDrag):
(WebCore::DragController::tryDHTMLDrag):
(WebCore::imageElementIsDraggable):
(WebCore::getImage):
(WebCore::selectElement):
(WebCore::DragController::prepareForDragStart const):
(WebCore::DragController::startDrag):
(WebCore::DragController::doImageDrag):
(WebCore::DragController::beginDrag):
(WebCore::DragController::doSystemDrag):
(WebCore::DragController::tryToUpdateDroppedImagePlaceholders):
(WebCore::DragController::insertDroppedImagePlaceholdersAtCaret):
(WebCore::DragController::finalizeDroppedImagePlaceholder):
(WebCore::DragController::placeDragCaret):
* Source/WebCore/page/DragController.h:
* Source/WebCore/page/mac/DragControllerMac.mm:
(WebCore::DragController::cleanupAfterSystemDrag):

Canonical link: <a href="https://commits.webkit.org/274404@main">https://commits.webkit.org/274404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf30dc7ae49285f4e522a16278a33308295469a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41510 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15257 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13103 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38894 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37116 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15055 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5092 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->