### PR TITLE
Generate serialization for NSDateComponents

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -225,6 +225,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDDActionContext.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCData.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDate.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCDateComponents.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDictionary.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCError.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCFont.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -550,6 +550,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCDDScannerResult.serialization.in \
 	Shared/Cocoa/CoreIPCData.serialization.in \
 	Shared/Cocoa/CoreIPCDate.serialization.in \
+	Shared/Cocoa/CoreIPCDateComponents.serialization.in \
 	Shared/Cocoa/CoreIPCDictionary.serialization.in \
 	Shared/Cocoa/CoreIPCError.serialization.in \
 	Shared/Cocoa/CoreIPCFont.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -569,7 +569,7 @@ static constexpr bool haveSecureActionContext = false;
     static constexpr bool haveStrictDecodablePKPaymentPass = false;
 #endif
 
-    // FIXME: Remove these checks for CNContact, NSDateComponents, and PKSecureElementPass
+    // FIXME: Remove these checks for CNContact, and PKSecureElementPass
     // once we directly serialize them ourselves.
     auto isDecodingPKPaymentRelatedType = [&] () {
         if (!PAL::isPassKitCoreFrameworkAvailable())
@@ -579,8 +579,6 @@ static constexpr bool haveSecureActionContext = false;
         if (PAL::getPKSecureElementPassClass() && allowedClasses.contains(PAL::getPKSecureElementPassClass()))
             return true;
         if (PAL::isContactsFrameworkAvailable() && PAL::getCNContactClass() && allowedClasses.contains(PAL::getCNContactClass()))
-            return true;
-        if (allowedClasses.contains(NSDateComponents.class))
             return true;
         return false;
     };
@@ -667,8 +665,7 @@ template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClas
         allowedClasses.add(NSMutableParagraphStyle.class);
 
 #if USE(PASSKIT)
-
-    // FIXME: Remove these exceptions for CNContact, NSDateComponents, and PKSecureElementPass
+    // FIXME: Remove these exceptions for CNContact and PKSecureElementPass
     // once we directly serialize them ourselves.
     if (PAL::isContactsFrameworkAvailable()) {
         if (allowedClasses.contains(PAL::getPKPaymentClass()) || allowedClasses.contains(PAL::getPKPaymentMethodClass()) || allowedClasses.contains(PAL::getPKPaymentTokenClass())) {
@@ -676,13 +673,9 @@ template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClas
             allowedClasses.add(PAL::getPKSecureElementPassClass());
         }
 
-        if (allowedClasses.contains(PAL::getPKShippingMethodClass()) || allowedClasses.contains(PAL::getPKDateComponentsRangeClass()) || allowedClasses.contains(PAL::getPKPaymentClass()))
-            allowedClasses.add([NSDateComponents class]);
-
         if (allowedClasses.contains(PAL::getCNContactClass()))
             allowedClasses.add(PAL::getCNMutableContactClass());
     }
-
 #endif
 
     auto allowedClassSet = adoptNS([[NSMutableSet alloc] initWithCapacity:allowedClasses.size()]);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,23 +25,28 @@
 
 #pragma once
 
-#import "CoreIPCArray.h"
-#import "CoreIPCCFType.h"
-#import "CoreIPCColor.h"
-#import "CoreIPCContacts.h"
-#import "CoreIPCData.h"
-#import "CoreIPCDate.h"
-#import "CoreIPCDateComponents.h"
-#import "CoreIPCDictionary.h"
-#import "CoreIPCError.h"
-#import "CoreIPCFont.h"
-#import "CoreIPCLocale.h"
-#import "CoreIPCNSValue.h"
-#import "CoreIPCNumber.h"
-#import "CoreIPCPassKit.h"
-#import "CoreIPCPersonNameComponents.h"
-#import "CoreIPCPresentationIntent.h"
-#import "CoreIPCSecureCoding.h"
-#import "CoreIPCString.h"
-#import "CoreIPCURL.h"
-#import "GeneratedWebKitSecureCoding.h"
+#include <wtf/ArgumentCoder.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class CoreIPCDateComponents {
+public:
+    CoreIPCDateComponents(NSDateComponents *);
+    RetainPtr<id> toID() const;
+
+    static bool hasCorrectNumberOfComponentValues(const Vector<NSInteger>&);
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCDateComponents, void>;
+    CoreIPCDateComponents()
+    {
+    };
+
+    String m_calendarIdentifier;
+    String m_timeZoneName;
+    Vector<NSInteger> m_componentValues;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCDateComponents.h"
+
+namespace WebKit {
+
+NSUInteger calendarUnitForComponentIndex[] = {
+    NSCalendarUnitEra,
+    NSCalendarUnitYear,
+    NSCalendarUnitYearForWeekOfYear,
+    NSCalendarUnitQuarter,
+    NSCalendarUnitMonth,
+    NSCalendarUnitHour,
+    NSCalendarUnitMinute,
+    NSCalendarUnitSecond,
+    NSCalendarUnitNanosecond,
+    NSCalendarUnitWeekOfYear,
+    NSCalendarUnitWeekOfMonth,
+    NSCalendarUnitWeekday,
+    NSCalendarUnitWeekdayOrdinal,
+    NSCalendarUnitDay
+};
+static size_t numberOfComponentIndexes = sizeof(calendarUnitForComponentIndex) / sizeof(NSUInteger);
+
+CoreIPCDateComponents::CoreIPCDateComponents(NSDateComponents *components)
+{
+    if (components.calendar)
+        m_calendarIdentifier = components.calendar.calendarIdentifier;
+    if (components.timeZone)
+        m_timeZoneName = components.timeZone.name;
+
+    m_componentValues.reserveInitialCapacity(numberOfComponentIndexes);
+    for (size_t i = 0; i < numberOfComponentIndexes; ++i)
+        m_componentValues.append([components valueForComponent:calendarUnitForComponentIndex[i]]);
+}
+
+RetainPtr<id> CoreIPCDateComponents::toID() const
+{
+    RetainPtr<NSDateComponents> components = adoptNS([NSDateComponents new]);
+
+    for (size_t i = 0; i < numberOfComponentIndexes; ++i)
+        [components setValue:m_componentValues[i] forComponent:calendarUnitForComponentIndex[i]];
+
+    if (!m_calendarIdentifier.isEmpty())
+        components.get().calendar = [NSCalendar calendarWithIdentifier:(NSString *)m_calendarIdentifier];
+    if (!m_timeZoneName.isEmpty())
+        components.get().timeZone = [NSTimeZone timeZoneWithName:(NSString *)m_timeZoneName];
+
+    return components;
+}
+
+bool CoreIPCDateComponents::hasCorrectNumberOfComponentValues(const Vector<NSInteger>& componentValues)
+{
+    return componentValues.size() == numberOfComponentIndexes;
+}
+
+} // namespace WebKit
+

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.serialization.in
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCDateComponents.h"
+
+[WebKitPlatform, LegacyPopulateFromEmptyConstructor] class WebKit::CoreIPCDateComponents {
+    String m_calendarIdentifier;
+    String m_timeZoneName;
+    [Validator='WebKit::CoreIPCDateComponents::hasCorrectNumberOfComponentValues(*m_componentValues)'] Vector<NSInteger> m_componentValues;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -51,6 +51,7 @@ class CoreIPCDDScannerResult;
 #endif
 class CoreIPCData;
 class CoreIPCDate;
+class CoreIPCDateComponents;
 class CoreIPCDictionary;
 class CoreIPCError;
 class CoreIPCFont;
@@ -71,6 +72,7 @@ using ObjectValue = std::variant<
 #if USE(PASSKIT)
     CoreIPCCNPhoneNumber,
     CoreIPCCNPostalAddress,
+    CoreIPCDateComponents,
     CoreIPCPKContact,
     CoreIPCPKPaymentMerchantSession,
     CoreIPCPKPayment,

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -70,8 +70,7 @@ static ObjectValue valueFromID(id object)
     case IPC::NSType::CNPostalAddress:
         return CoreIPCCNPostalAddress((CNPostalAddress *)object);
     case IPC::NSType::NSDateComponents:
-        // FIXME: Serialize NSDateComponents directly instead of relying on secure coding.
-        return CoreIPCSecureCoding(object);
+        return CoreIPCDateComponents((NSDateComponents *)object);
     case IPC::NSType::PKContact:
         return CoreIPCPKContact((PKContact *)object);
     case IPC::NSType::PKPaymentMerchantSession:

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1242,6 +1242,8 @@
 		517CF0E3163A486C00C2950E /* NetworkProcessConnectionMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 517CF0E1163A486C00C2950E /* NetworkProcessConnectionMessageReceiver.cpp */; };
 		517CF0E4163A486C00C2950E /* NetworkProcessConnectionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 517CF0E2163A486C00C2950E /* NetworkProcessConnectionMessages.h */; };
 		517D7B812AAA624500BAA3EB /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* WebKit.framework */; };
+		518198902B7585EB0084E292 /* CoreIPCDateComponents.h in Headers */ = {isa = PBXBuildFile; fileRef = 5181988E2B7585E30084E292 /* CoreIPCDateComponents.h */; };
+		518198912B7585F80084E292 /* CoreIPCDateComponents.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5181988F2B7585E30084E292 /* CoreIPCDateComponents.mm */; };
 		5183722223CE97410003CF83 /* APIContentWorld.h in Headers */ = {isa = PBXBuildFile; fileRef = 5183722023CE973A0003CF83 /* APIContentWorld.h */; };
 		51871B5C127CB89D00F76232 /* WebContextMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = 51871B5A127CB89D00F76232 /* WebContextMenu.h */; };
 		5187BDEA2AFF5419008A6EE5 /* CoreIPCArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5187BDE82AFF4A3A008A6EE5 /* CoreIPCArray.mm */; };
@@ -5513,6 +5515,9 @@
 		517B5F98275EC600002DC22D /* WebPushMessageCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPushMessageCocoa.mm; sourceTree = "<group>"; };
 		517CF0E1163A486C00C2950E /* NetworkProcessConnectionMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkProcessConnectionMessageReceiver.cpp; sourceTree = "<group>"; };
 		517CF0E2163A486C00C2950E /* NetworkProcessConnectionMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkProcessConnectionMessages.h; sourceTree = "<group>"; };
+		5181988D2B7585E30084E292 /* CoreIPCDateComponents.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCDateComponents.serialization.in; sourceTree = "<group>"; };
+		5181988E2B7585E30084E292 /* CoreIPCDateComponents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCDateComponents.h; sourceTree = "<group>"; };
+		5181988F2B7585E30084E292 /* CoreIPCDateComponents.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCDateComponents.mm; sourceTree = "<group>"; };
 		5183722023CE973A0003CF83 /* APIContentWorld.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContentWorld.h; sourceTree = "<group>"; };
 		5183722123CE973A0003CF83 /* APIContentWorld.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIContentWorld.cpp; sourceTree = "<group>"; };
 		518405282A9E861F00630A12 /* com.apple.webkit.webpushd.relocatable.mac.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.apple.webkit.webpushd.relocatable.mac.plist; sourceTree = "<group>"; };
@@ -11420,6 +11425,9 @@
 				F48C81E52AE0E1DF00073850 /* CoreIPCData.serialization.in */,
 				F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */,
 				F49EE21F2AE87ED7003E3C34 /* CoreIPCDate.serialization.in */,
+				5181988E2B7585E30084E292 /* CoreIPCDateComponents.h */,
+				5181988F2B7585E30084E292 /* CoreIPCDateComponents.mm */,
+				5181988D2B7585E30084E292 /* CoreIPCDateComponents.serialization.in */,
 				51AD56892B1C3BA1001A0ECB /* CoreIPCDDActionContext.serialization.in */,
 				51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */,
 				5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */,
@@ -15804,6 +15812,7 @@
 				5157AE022B23C33500C0E095 /* CoreIPCContacts.h in Headers */,
 				F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */,
 				F49EE2212AE87F41003E3C34 /* CoreIPCDate.h in Headers */,
+				518198902B7585EB0084E292 /* CoreIPCDateComponents.h in Headers */,
 				5197FAEA2AFD33CF009180C5 /* CoreIPCDictionary.h in Headers */,
 				F4ABDB632B018C4B00C5471A /* CoreIPCError.h in Headers */,
 				5197FAE32AFD33CF009180C5 /* CoreIPCFont.h in Headers */,
@@ -18679,6 +18688,7 @@
 				5CFC9C812B71809600F8D289 /* CoreIPCCFDictionary.mm in Sources */,
 				519F6F7F2B2D7A4500559CB3 /* CoreIPCCFURL.mm in Sources */,
 				5157AE032B23C34700C0E095 /* CoreIPCContacts.mm in Sources */,
+				518198912B7585F80084E292 /* CoreIPCDateComponents.mm in Sources */,
 				5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */,
 				F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */,
 				5187BDF02B007445008A6EE5 /* CoreIPCFont.mm in Sources */,


### PR DESCRIPTION
#### a121d7bf849bd4dd467af64329886e705fdad64e
<pre>
Generate serialization for NSDateComponents
<a href="https://bugs.webkit.org/show_bug.cgi?id=269099">https://bugs.webkit.org/show_bug.cgi?id=269099</a>

Reviewed by Alex Christensen.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSObject&lt;NSSecureCoding&gt;&gt;):
* Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCTypes.h.
(WebKit::CoreIPCDateComponents::CoreIPCDateComponents):
* Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.mm: Added.
(WebKit::CoreIPCDateComponents::CoreIPCDateComponents):
(WebKit::CoreIPCDateComponents::toID const):
(WebKit::CoreIPCDateComponents::hasCorrectNumberOfComponentValues):
* Source/WebKit/Shared/Cocoa/CoreIPCDateComponents.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCTypes.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(nsDateComponentsTesting_isEqual):
(operator==):
(TEST):

Canonical link: <a href="https://commits.webkit.org/274405@main">https://commits.webkit.org/274405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb156300dc3da92d32410b3b5dee9be3aff0f40f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41550 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15297 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39590 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13132 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42827 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/35416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5093 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->