### PR TITLE
Fix http/tests/pdf/linearized-pdf-in-iframe to actually test incremental PDF loading

### DIFF
--- a/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe-expected.html
+++ b/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe-expected.html
@@ -14,7 +14,7 @@
         
         function testComplete()
         {
-            const pdfFadeInDelay = 250;
+            const pdfFadeInDelay = 300;
             requestAnimationFrame(() => {
                 setTimeout(() => {
                     if (window.testRunner)

--- a/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
+++ b/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
@@ -25,6 +25,6 @@
     </script>
 </head>
 <body>
-    <iframe onload="testComplete()" src="/resources/network-simulator.py?test=pdf-load&path=/pdf/resources/linearized.pdf&chunksize=4094&chunkdelay=16"></iframe>
+    <iframe onload="testComplete()" src="/resources/network-simulator.py?test=pdf-load&path=/pdf/resources/linearized.pdf&chunksize=1024&chunkdelay=16"></iframe>
 </body>
 </html>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -196,6 +196,8 @@ void PDFPluginStreamLoaderClient::didReceiveResponse(NetscapePlugInStreamLoader*
     if (response.httpStatusCode() == httpStatus206PartialContent)
         return;
 
+    LOG_WITH_STREAM(IncrementalPDF, stream << "Range request " << request->identifier() << " response was not 206, it was " << response.httpStatusCode());
+
     // If the response wasn't a successful range response, we don't need this stream loader anymore.
     // This can happen, for example, if the server doesn't support range requests.
     // We'll still resolve the ByteRangeRequest later once enough of the full resource has loaded.
@@ -618,10 +620,8 @@ static void dataProviderReleaseInfoCallback(void* info)
 size_t PDFIncrementalLoader::dataProviderGetBytesAtPosition(void* buffer, off_t position, size_t count)
 {
     if (isMainRunLoop()) {
-#if !LOG_DISABLED
-        incrementalLoaderLog(makeString("Handling request for ", count, " bytes at position ", position, " synchronously on the main thread"));
-#endif
-        ASSERT(documentFinishedLoading());
+        LOG_WITH_STREAM(IncrementalPDF, stream << "Handling request for " << count << " bytes at position " << position << " synchronously on the main thread. Finished loading:" << documentFinishedLoading());
+        // FIXME: if documentFinishedLoading() is false, we may not be able to fulfill this request, but that should only happen if we trigger painting on the main thread.
         return getResourceBytesAtPositionAfterLoadingComplete(buffer, position, count);
     }
 


### PR DESCRIPTION
#### 44ecdd4e8ee1c31d2e2c85cd5665c965199a8857
<pre>
Fix http/tests/pdf/linearized-pdf-in-iframe to actually test incremental PDF loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=269102">https://bugs.webkit.org/show_bug.cgi?id=269102</a>
<a href="https://rdar.apple.com/122672100">rdar://122672100</a>

Reviewed by Tim Horton.

Triggering the incremental PDF loading code path requires a fairly exact set of conditions
that need to be satisfied by the HTTP server:
1. Support for byte-range requests
2. Multithreading (handle a byte-range request while the main request is also being served)
3. Slow enough that a couple of initial byte-range requests complete before the main resource request

This PR enhances network-simulator.py to support byte-range requests, and tweaks the laoding speed
in the test.

With UnifiedPDF enabled, we hit a couple of `ASSERT(documentFinishedLoading())` in the data
provider callbacks on the main thread, under a painting callstack. This happens because UnifiedPDF
currently paints on the main thread, so relax those assertions (with some logging).

* LayoutTests/http/tests/pdf/linearized-pdf-in-iframe-expected.html:
* LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html:
* LayoutTests/http/tests/resources/network-simulator.py:
(generate_response):
(file_to_stdout):
(range_of_file_to_stdout):
(chunked_file_to_stdout):
(parse_byte_range):
(temp_path_base):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFPluginStreamLoaderClient::didReceiveResponse):
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::copyDataAtPosition const):
(WebKit::PDFPluginBase::streamDidReceiveData):
(WebKit::PDFPluginBase::streamDidFinishLoading):

Canonical link: <a href="https://commits.webkit.org/274412@main">https://commits.webkit.org/274412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86146c7b8d4efe9ce6d61a3d26d9da68145b2484

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41549 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15296 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13130 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42826 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38921 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37148 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34038 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8734 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->