### PR TITLE
[WebGPU] Crash PresentationContextIOSurface::getCurrentTexture if context is not configured

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
@@ -91,8 +91,10 @@ RefPtr<Texture> PresentationContextImpl::getCurrentTexture()
         return nullptr; // FIXME: This should return an invalid texture instead.
 
     if (!m_currentTexture) {
-        ASSERT(m_swapChain);
-        m_currentTexture = TextureImpl::create(WebGPUPtr<WGPUTexture> { wgpuSwapChainGetCurrentTexture(m_swapChain.get()) }, m_format, TextureDimension::_2d, m_convertToBackingContext);
+        auto texturePtr = wgpuSwapChainGetCurrentTexture(m_swapChain.get());
+        if (!texturePtr)
+            return nullptr;
+        m_currentTexture = TextureImpl::create(WebGPUPtr<WGPUTexture> { texturePtr }, m_format, TextureDimension::_2d, m_convertToBackingContext);
     }
 
     return m_currentTexture;

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -164,7 +164,9 @@ void PresentationContextIOSurface::present()
 
 Texture* PresentationContextIOSurface::getCurrentTexture()
 {
-    ASSERT(m_ioSurfaces.count == m_renderBuffers.size());
+    if (m_ioSurfaces.count != m_renderBuffers.size() || m_renderBuffers.size() <= m_currentIndex)
+        return nullptr;
+
     auto& texture = m_renderBuffers[m_currentIndex].texture;
     texture->recreateIfNeeded();
     return texture.ptr();
@@ -172,7 +174,9 @@ Texture* PresentationContextIOSurface::getCurrentTexture()
 
 TextureView* PresentationContextIOSurface::getCurrentTextureView()
 {
-    ASSERT(m_ioSurfaces.count == m_renderBuffers.size());
+    if (m_ioSurfaces.count != m_renderBuffers.size() || m_renderBuffers.size() <= m_currentIndex)
+        return nullptr;
+
     return m_renderBuffers[m_currentIndex].textureView.ptr();
 }
 


### PR DESCRIPTION
#### 5bb758bb78c90c5bf10aba2341f18b2dfee4bed2
<pre>
[WebGPU] Crash PresentationContextIOSurface::getCurrentTexture if context is not configured
<a href="https://bugs.webkit.org/show_bug.cgi?id=269103">https://bugs.webkit.org/show_bug.cgi?id=269103</a>
&lt;radar://122671890&gt;

Reviewed by Dan Glastonbury.

An IPC call made directly to getCurrentTexture may result in a scenario where
the IOSurfaces have not yet been created. In this case, we want to return nullptr
to the caller.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp:
(WebCore::WebGPU::PresentationContextImpl::getCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::getCurrentTexture):
(WebGPU::PresentationContextIOSurface::getCurrentTextureView):

Canonical link: <a href="https://commits.webkit.org/274452@main">https://commits.webkit.org/274452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aae5fadd7481668bf542bc762ade48e02ba4af7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41516 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32644 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13107 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13098 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38899 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37121 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15400 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8756 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->