### PR TITLE
Make requestStorageAccess return NoModificationAllowedError until frame is reloaded

### DIFF
--- a/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-expected.txt
+++ b/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-expected.txt
@@ -1,0 +1,11 @@
+Tests that requestStorageAccess throws exception on cross-site iframe until iframe is reloaded
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS requestStorageAccess result: NoModificationAllowedError
+PASS requestStorageAccess result: Granted
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html
+++ b/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="/js-test-resources/ui-helper.js"></script>
+    <script src="/resourceLoadStatistics/resources/util.js"></script>
+    <script>
+        description("Tests that requestStorageAccess throws exception on cross-site iframe until iframe is reloaded");
+        jsTestIsAsync = true;
+        testEnded = false;
+        testStarted = false;
+
+        function endTest() {
+            if (testEnded)
+                return;
+
+            testEnded = true;
+            testRunner.setRequestStorageAccessThrowsExceptionUntilReload(false);
+            setEnableFeature(false, finishJSTest);
+        }
+
+        function receiveMessage(event) {
+            if (event.origin !== "http://localhost:8000") {
+                testFailed("Unexpected origin: " + event.origin);
+                endTest();
+                return;
+            }
+
+            if (event.data == "NoModificationAllowedError") {
+                testPassed("requestStorageAccess result: " + event.data);
+                return;
+            }
+
+            if (event.data == "Done") {
+                testPassed("requestStorageAccess result: Granted");
+                endTest();
+                return;
+            }
+
+            testFailed("Unexpected message: " + event.data);
+            endTest();
+        }
+
+        function activateElement(elementId) {
+            var element = document.getElementById(elementId);
+            var centerX = element.offsetLeft + element.offsetWidth / 2;
+            var centerY = element.offsetTop + element.offsetHeight / 2;
+            UIHelper.activateAt(centerX, centerY).then(() => {
+                if (window.eventSender)
+                    eventSender.keyDown("escape");
+                else {
+                    testFailed("eventSender is missing");
+                    endTest();
+                }
+            }).catch(() => {
+                testFailed("activateAt failed");
+                endTest();
+            });
+        }
+
+        function frameLoaded() {
+            if (!testStarted) {
+                setEnableFeature(true, function() {
+                    activateElement("TheIframeThatRequestsStorageAccess");
+                });
+                return;
+            }
+
+            testStarted = true;
+            activateElement("TheIframeThatRequestsStorageAccess");
+        }
+
+        window.addEventListener("message", receiveMessage, false);
+        if (window.testRunner)
+            testRunner.setRequestStorageAccessThrowsExceptionUntilReload(true);
+    </script>
+</head>
+<body>
+    <iframe sandbox="allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-modals" onload="frameLoaded()" id="TheIframeThatRequestsStorageAccess" src="http://localhost:8000/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html
+++ b/LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+    <script>
+        function messageToTop(message) {
+            top.postMessage(message, "http://127.0.0.1:8000");
+        }
+
+        function performStorageAccessRequest() {
+            document.requestStorageAccess().then(() => {
+                messageToTop("Done");
+            }).catch((error) => {
+                if (!error) {
+                    messageToTop("None");
+                    return;
+                }
+
+                messageToTop(error.name);
+                if (!window.location.hash && error.name == "NoModificationAllowedError") 
+                    location.reload();
+            });
+        }
+    </script>
+</head>
+<body onclick="performStorageAccessRequest()">
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5559,6 +5559,20 @@ RequestIdleCallbackEnabled:
     WebCore:
       default: false
 
+RequestStorageAccessThrowsExceptionUntilReload:
+  type: bool
+  status: unstable
+  category: dom
+  humanReadableName: "requestStorageAccess throws execption until reload"
+  humanReadableDescription: "requestStorageAccess throws execption until reload"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 RequestSubmitEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -36,7 +36,7 @@ class Document;
 class UserGestureIndicator;
 class WeakPtrImplWithEventTargetData;
 
-enum class StorageAccessWasGranted : bool { No, Yes };
+enum class StorageAccessWasGranted : uint8_t { No, Yes, YesWithException };
 
 enum class StorageAccessPromptWasShown : bool { No, Yes };
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -45,7 +45,7 @@ class SecurityOriginData;
 class WeakPtrImplWithEventTargetData;
 
 enum class IsSyntheticClick : bool;
-enum class StorageAccessWasGranted : bool;
+enum class StorageAccessWasGranted : uint8_t;
 
 class Quirks {
     WTF_MAKE_NONCOPYABLE(Quirks); WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -44,7 +44,7 @@ class KeyedDecoder;
 class KeyedEncoder;
 class SQLiteStatement;
 enum class StorageAccessPromptWasShown : bool;
-enum class StorageAccessWasGranted : bool;
+enum class StorageAccessWasGranted : uint8_t;
 struct ResourceLoadStatistics;
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -232,6 +232,7 @@ public:
 #endif
 
     WebSWServerToContextConnection* swContextConnection() { return m_swContextConnection.get(); }
+    void clearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier);
 
 private:
     NetworkConnectionToWebProcess(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -135,4 +135,6 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
 
     InitializeWebTransportSession(URL url) -> (std::optional<WebKit::WebTransportSessionIdentifier> identifier)
     DestroyWebTransportSession(WebKit::WebTransportSessionIdentifier identifier)
+
+    ClearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier frameID)
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2943,10 +2943,15 @@ void NetworkProcess::addWebPageNetworkParameters(PAL::SessionID sessionID, WebPa
 
 void NetworkProcess::removeWebPageNetworkParameters(PAL::SessionID sessionID, WebPageProxyIdentifier pageID)
 {
-    if (auto* session = networkSession(sessionID)) {
-        session->removeWebPageNetworkParameters(pageID);
-        session->storageManager().clearStorageForWebPage(pageID);
-    }
+    auto* session = networkSession(sessionID);
+    if (!session)
+        return;
+
+    session->removeWebPageNetworkParameters(pageID);
+    session->storageManager().clearStorageForWebPage(pageID);
+
+    if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
+        resourceLoadStatistics->clearFrameLoadRecordsForStorageAccess(pageID);
 }
 
 void NetworkProcess::countNonDefaultSessionSets(PAL::SessionID sessionID, CompletionHandler<void(size_t)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -96,7 +96,7 @@ enum class HTTPCookieAcceptPolicy : uint8_t;
 enum class IncludeHttpOnlyCookies : bool;
 enum class StoredCredentialsPolicy : uint8_t;
 enum class StorageAccessPromptWasShown : bool;
-enum class StorageAccessWasGranted : bool;
+enum class StorageAccessWasGranted : uint8_t;
 struct ClientOrigin;
 struct MessageWithMessagePorts;
 class SecurityOriginData;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -73,6 +73,7 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
     , bool pageHasExtensionController
 #endif
     , bool linkPreconnectEarlyHintsEnabled
+    , bool shouldRecordFrameLoadForStorageAccess
     ) : NetworkLoadParameters(WTFMove(networkLoadParameters))
         , identifier(identifier)
         , maximumBufferingTime(maximumBufferingTime)
@@ -111,6 +112,7 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
         , pageHasExtensionController(pageHasExtensionController)
 #endif
         , linkPreconnectEarlyHintsEnabled(linkPreconnectEarlyHintsEnabled)
+        , shouldRecordFrameLoadForStorageAccess(shouldRecordFrameLoadForStorageAccess)
 {
     if (httpBody) {
         request.setHTTPBody(WTFMove(httpBody));

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -90,6 +90,7 @@ public:
         , bool pageHasExtensionController
 #endif
         , bool linkPreconnectEarlyHintsEnabled
+        , bool shouldRecordFrameLoadForStorageAccess
     );
     
     std::optional<Vector<SandboxExtension::Handle>> sandboxExtensionsIfHttpBody() const;
@@ -141,6 +142,7 @@ public:
 #endif
 
     bool linkPreconnectEarlyHintsEnabled { false };
+    bool shouldRecordFrameLoadForStorageAccess { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -111,4 +111,5 @@ class WebKit::NetworkResourceLoadParameters : WebKit::NetworkLoadParameters {
 #endif
 
     bool linkPreconnectEarlyHintsEnabled;
+    bool shouldRecordFrameLoadForStorageAccess;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4965,7 +4965,11 @@ struct WebCore::MessageWithMessagePorts {
     Vector<WebCore::TransferredMessagePort> transferredPorts;
 };
 
-enum class WebCore::StorageAccessWasGranted : bool
+enum class WebCore::StorageAccessWasGranted : uint8_t {
+    No,
+    Yes,
+    YesWithException
+};
 
 enum class WebCore::StorageAccessPromptWasShown : bool
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -76,7 +76,7 @@ class SecurityOrigin;
 class SecurityOriginData;
 enum class ShouldSample : bool;
 enum class StorageAccessPromptWasShown : bool;
-enum class StorageAccessWasGranted : bool;
+enum class StorageAccessWasGranted : uint8_t;
 enum class StoredCredentialsPolicy : uint8_t;
 struct ClientOrigin;
 struct NotificationData;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -422,6 +422,8 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     loadParameters.httpHeadersToKeep = resourceLoader.options().httpHeadersToKeep;
     if (resourceLoader.options().navigationPreloadIdentifier)
         loadParameters.navigationPreloadIdentifier = resourceLoader.options().navigationPreloadIdentifier;
+    if (frame && !frame->isMainFrame())
+        loadParameters.shouldRecordFrameLoadForStorageAccess = frame->settings().requestStorageAccessThrowsExceptionUntilReload();
 
     auto* document = frame ? frame->document() : nullptr;
     if (resourceLoader.options().cspResponseHeaders)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -35,7 +35,7 @@ class RegistrableDomain;
 enum class CookieConsentDecisionResult : uint8_t;
 enum class DidFilterLinkDecoration : bool;
 enum class StorageAccessPromptWasShown : bool;
-enum class StorageAccessWasGranted : bool;
+enum class StorageAccessWasGranted : uint8_t;
 struct TextRecognitionOptions;
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -998,7 +998,9 @@ void WebProcess::addWebFrame(FrameIdentifier frameID, WebFrame* frame)
 
 void WebProcess::removeWebFrame(FrameIdentifier frameID, std::optional<WebPageProxyIdentifier> pageID)
 {
-    m_frameMap.remove(frameID);
+    auto frame = m_frameMap.take(frameID);
+    if (frame && frame->coreLocalFrame() && m_networkProcessConnection)
+        m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::ClearFrameLoadRecordsForStorageAccess(frameID), 0);
 
     // We can end up here after our connection has closed when WebCore's frame life-support timer
     // fires when the application is shutting down. There's no need (and no way) to update the UI

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -382,6 +382,7 @@ interface TestRunner {
 
     // Storage Access API
     undefined getAllStorageAccessEntries(object callback);
+    undefined setRequestStorageAccessThrowsExceptionUntilReload(boolean enabled);
 
     // Open panel
     undefined setOpenPanelFiles(object filesArray);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1876,10 +1876,16 @@ static JSValueRef makeDomainsValue(const Vector<String>& domains)
     builder.append(']');
     return JSValueMakeFromJSONString(mainFrameJSContext(), createJSString(builder.toString().utf8().data()).get());
 }
+
 void TestRunner::callDidReceiveAllStorageAccessEntriesCallback(Vector<String>& domains)
 {
     auto result = makeDomainsValue(domains);
     callTestRunnerCallback(AllStorageAccessEntriesCallbackID, 1, &result);
+}
+
+void TestRunner::setRequestStorageAccessThrowsExceptionUntilReload(bool enabled)
+{
+    postSynchronousPageMessage("SetRequestStorageAccessThrowsExceptionUntilReload", enabled);
 }
 
 void TestRunner::loadedSubresourceDomains(JSValueRef callback)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -507,6 +507,7 @@ public:
     // Storage Access API
     void getAllStorageAccessEntries(JSValueRef callback);
     void callDidReceiveAllStorageAccessEntriesCallback(Vector<String>& domains);
+    void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
 
     // Open panel
     void setOpenPanelFiles(JSValueRef);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -4312,4 +4312,11 @@ void TestController::setShouldAllowDeviceOrientationAndMotionAccess(bool value)
     WKWebsiteDataStoreClearAllDeviceOrientationPermissions(websiteDataStore());
 }
 
+void TestController::setRequestStorageAccessThrowsExceptionUntilReload(bool enabled)
+{
+    auto configuration = adoptWK(WKPageCopyPageConfiguration(m_mainWebView->page()));
+    auto preferences = WKPageConfigurationGetPreferences(configuration.get());
+    WKPreferencesSetBoolValueForKeyForTesting(preferences, enabled, toWK("RequestStorageAccessThrowsExceptionUntilReload").get());
+}
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -279,6 +279,7 @@ public:
     void removeAllCookies();
 
     void getAllStorageAccessEntries();
+    void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
     void loadedSubresourceDomains();
     void clearLoadedSubresourceDomains();
     void clearAppBoundSession();

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1603,6 +1603,11 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetRequestStorageAccessThrowsExceptionUntilReload")) {
+        TestController::singleton().setRequestStorageAccessThrowsExceptionUntilReload(booleanValue(messageBody));
+        return nullptr;
+    }
+
     ASSERT_NOT_REACHED();
     return nullptr;
 }


### PR DESCRIPTION
#### 65461aad5f3fbb4bd347ab2bff74ce2bdf66b2d7
<pre>
Make requestStorageAccess return NoModificationAllowedError until frame is reloaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=269108">https://bugs.webkit.org/show_bug.cgi?id=269108</a>
<a href="https://rdar.apple.com/122676929">rdar://122676929</a>

Reviewed by Alex Christensen.

Add a feature flag to make requestStorageAccess return NoModificationAllowedError on granted request until frame is
reloaded, to faciliate testing behavior change on requestStorageAccess when site isolation is enabled.

Test: http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html

* LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload-expected.txt: Added.
* LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html: Added.
* LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::requestStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccessQuirk):
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/page/Quirks.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::grantStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::grantStorageAccessEphemeral):
(WebKit::WebResourceLoadStatisticsStore::grantStorageAccessInStorageSession):
(WebKit::WebResourceLoadStatisticsStore::recordFrameLoadForStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::clearFrameLoadRecordsForStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::storageAccessWasGrantedValueForFrame):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
(WebKit::NetworkConnectionToWebProcess::clearFrameLoadRecordsForStorageAccess):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::removeWebPageNetworkParameters):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::NetworkResourceLoadParameters):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::removeWebFrame):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setRequestStorageAccessThrowsExceptionUntilReload):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::setRequestStorageAccessThrowsExceptionUntilReload):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/274636@main">https://commits.webkit.org/274636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de87e6c2876d5b854985bfd3604d5cb000d89f76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33064 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13585 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43411 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33052 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39350 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39225 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37617 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34502 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46231 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8881 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16065 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9427 "Found 231 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_sort3.js.default, ChakraCore.yaml/ChakraCore/test/Array/join2.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInArrayAdd.js.default, ChakraCore.yaml/ChakraCore/test/Lib/uri.js.default, ChakraCore.yaml/ChakraCore/test/Object/defineProperty.js.default, ChakraCore.yaml/ChakraCore/test/Strings/property_and_index_of_string.js.default, ChakraCore.yaml/ChakraCore/test/fieldopts/fixedfieldmonocheck6.js.default, cdjs-tests.yaml/red_black_tree_test.js.dfg-eager, jsc-layout-tests.yaml/js/script-tests/dfg-arguments-osr-exit-multiple-blocks.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/dfg-getter-throw.js.layout-no-cjit ... (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->