### PR TITLE
[JSC] Skip notifyOne when all JIT threads are running

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -53,7 +53,7 @@ JITWorklist::JITWorklist()
 
     Locker locker { *m_lock };
     for (unsigned i = 0; i < Options::numberOfWorklistThreads(); ++i)
-        m_threads.append(new JITWorklistThread(locker, *this));
+        m_threads.append(*new JITWorklistThread(locker, *this));
 }
 
 JITWorklist::~JITWorklist()
@@ -96,7 +96,15 @@ CompilationResult JITWorklist::enqueue(Ref<JITPlan> plan)
     ASSERT(m_plans.find(plan->key()) == m_plans.end());
     m_plans.add(plan->key(), plan.copyRef());
     m_queues[static_cast<unsigned>(plan->tier())].append(WTFMove(plan));
-    m_planEnqueued->notifyOne(locker);
+
+    // Notify when some of thread is waiting.
+    for (auto& thread : m_threads) {
+        if (thread->state() == JITWorklistThread::State::NotCompiling) {
+            m_planEnqueued->notifyOne(locker);
+            break;
+        }
+    }
+
     return CompilationDeferred;
 }
 
@@ -117,14 +125,19 @@ size_t JITWorklist::queueLength(const AbstractLocker&) const
 void JITWorklist::suspendAllThreads() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     m_suspensionLock.lock();
-    for (unsigned i = m_threads.size(); i--;)
-        m_threads[i]->m_rightToRun.lock();
+    Vector<Ref<JITWorklistThread>, 8> busyThreads;
+    for (auto& thread : m_threads) {
+        if (!thread->m_rightToRun.tryLock())
+            busyThreads.append(thread.copyRef());
+    }
+    for (auto& thread : busyThreads)
+        thread->m_rightToRun.lock();
 }
 
 void JITWorklist::resumeAllThreads() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
-    for (unsigned i = m_threads.size(); i--;)
-        m_threads[i]->m_rightToRun.unlock();
+    for (auto& thread : m_threads)
+        thread->m_rightToRun.unlock();
     m_suspensionLock.unlock();
 }
 
@@ -241,8 +254,8 @@ void JITWorklist::removeDeadPlans(VM& vm)
     });
 
     // No locking needed for this part, see comment in visitWeakReferences().
-    for (unsigned i = m_threads.size(); i--;) {
-        Safepoint* safepoint = m_threads[i].get()->m_safepoint;
+    for (auto& thread : m_threads) {
+        Safepoint* safepoint = thread->m_safepoint;
         if (!safepoint)
             continue;
         if (safepoint->vm() != &vm)
@@ -283,8 +296,8 @@ void JITWorklist::visitWeakReferences(Visitor& visitor)
     // (1) no new threads can be added to m_threads. Hence, it is immutable and needs no locks.
     // (2) JITWorklistThread::m_safepoint is protected by that thread's m_rightToRun which we must be
     //     holding here because of a prior call to suspendAllThreads().
-    for (unsigned i = m_threads.size(); i--;) {
-        Safepoint* safepoint = m_threads[i]->m_safepoint;
+    for (auto& thread : m_threads) {
+        Safepoint* safepoint = thread->m_safepoint;
         if (safepoint && safepoint->vm() == vm)
             safepoint->checkLivenessAndVisitChildren(visitor);
     }

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -103,7 +103,7 @@ private:
     std::array<unsigned, static_cast<size_t>(JITPlan::Tier::Count)> m_ongoingCompilationsPerTier { 0, 0, 0 };
     std::array<unsigned, static_cast<size_t>(JITPlan::Tier::Count)> m_maximumNumberOfConcurrentCompilationsPerTier;
 
-    Vector<RefPtr<JITWorklistThread>> m_threads;
+    Vector<Ref<JITWorklistThread>> m_threads;
 
     // Used to inform the thread about what work there is left to do.
     std::array<Deque<RefPtr<JITPlan>>, static_cast<size_t>(JITPlan::Tier::Count)> m_queues;

--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -109,6 +109,7 @@ auto JITWorklistThread::work() -> WorkResult
         Locker locker { *m_worklist.m_lock };
         if (m_plan->stage() == JITPlanStage::Canceled)
             return WorkResult::Continue;
+        m_state = State::Compiling;
         m_plan->notifyCompiling();
     }
 
@@ -130,6 +131,7 @@ auto JITWorklistThread::work() -> WorkResult
 
     {
         Locker locker { *m_worklist.m_lock };
+        m_state = State::NotCompiling;
         if (m_plan->stage() == JITPlanStage::Canceled)
             return WorkResult::Continue;
 

--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -42,10 +42,17 @@ class JITWorklistThread final : public AutomaticThread {
     friend class WorkScope;
     friend class JITWorklist;
 
+    enum class State : uint8_t {
+        NotCompiling,
+        Compiling,
+    };
+
 public:
     JITWorklistThread(const AbstractLocker&, JITWorklist&);
 
     const char* name() const final;
+
+    State state() const { return m_state; }
 
 private:
     PollResult poll(const AbstractLocker&) final;
@@ -56,6 +63,7 @@ private:
     void threadIsStopping(const AbstractLocker&) final;
 
     Lock m_rightToRun;
+    State m_state { State::NotCompiling };
     JITWorklist& m_worklist;
     RefPtr<JITPlan> m_plan { nullptr };
     Safepoint* m_safepoint { nullptr };


### PR DESCRIPTION
#### 17e76f594e5e272dd97df44490f16d5079daa273
<pre>
[JSC] Skip notifyOne when all JIT threads are running
<a href="https://bugs.webkit.org/show_bug.cgi?id=269111">https://bugs.webkit.org/show_bug.cgi?id=269111</a>
<a href="https://rdar.apple.com/122677279">rdar://122677279</a>

Reviewed by Mark Lam.

Let&apos;s avoid calling notifyOne when all JIT threads are currently running.
In that case, they will pick the enqueued plan without notifying anyway.
This can skip some of costly syscalls like pthread_condvar related ones.
We also change JITWorklist::suspendAllThreads to first use tryLock for all threads.
So then, we can eagerly suspend currently-not-running-threads. And after that,
we eventually ensure all threads are not running. This avoids starting JIT compilation
in the latter thread while it was not having that when JITWorklist::suspendAllThreads started.

* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::JITWorklist):
(JSC::JITWorklist::enqueue):
(JSC::JITWorklist::removeDeadPlans):
(JSC::JITWorklist::visitWeakReferences):
* Source/JavaScriptCore/jit/JITWorklist.h:
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::work):
* Source/JavaScriptCore/jit/JITWorklistThread.h:

Canonical link: <a href="https://commits.webkit.org/274407@main">https://commits.webkit.org/274407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb608e05dd76e2ff0ef0196c663c1d4542cb8558

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41533 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15280 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13119 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42810 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/32452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38912 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/38625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37145 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15417 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45631 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15078 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9302 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5094 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->