### PR TITLE
Implement field-sizing support for select

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
@@ -1,7 +1,7 @@
 
 
-FAIL dropdown: The width should depend on the selected OPTION assert_greater_than: expected a number greater than 95 but got 95
-FAIL dropdown: Change the field-sizing value dynamically assert_less_than: expected a number less than 114 but got 114
+PASS dropdown: The width should depend on the selected OPTION
+PASS dropdown: Change the field-sizing value dynamically
 PASS listbox: The size depend on the content
 PASS listbox: The size attribute value is ignored
 PASS listbox: Change the field-sizing value dynamically

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
@@ -1,8 +1,0 @@
-
-
-FAIL dropdown: The width should depend on the selected OPTION assert_greater_than: expected a number greater than 114 but got 114
-FAIL dropdown: Change the field-sizing value dynamically assert_less_than: expected a number less than 139 but got 139
-PASS listbox: The size depend on the content
-PASS listbox: The size attribute value is ignored
-PASS listbox: Change the field-sizing value dynamically
-

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt
@@ -1,8 +1,0 @@
-
-
-FAIL dropdown: The width should depend on the selected OPTION assert_greater_than: expected a number greater than 108 but got 108
-FAIL dropdown: Change the field-sizing value dynamically assert_less_than: expected a number less than 133 but got 133
-PASS listbox: The size depend on the content
-PASS listbox: The size attribute value is ignored
-PASS listbox: Change the field-sizing value dynamically
-

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -327,6 +327,11 @@ LayoutRect RenderMenuList::controlClipRect(const LayoutPoint& additionalOffset) 
 
 void RenderMenuList::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
+    // FIXME: Fix field-sizing: content with size containment
+    // https://bugs.webkit.org/show_bug.cgi?id=269169
+    if (style().fieldSizing() == FieldSizing::Content)
+        return RenderFlexibleBox::computeIntrinsicLogicalWidths(minLogicalWidth, maxLogicalWidth);
+
     maxLogicalWidth = shouldApplySizeContainment() ? theme().minimumMenuListSize(style()) : std::max(m_optionsWidth, theme().minimumMenuListSize(style()));
     maxLogicalWidth += m_innerBlock->paddingStart() + m_innerBlock->paddingEnd();
     if (shouldApplySizeOrInlineSizeContainment()) {
@@ -339,6 +344,11 @@ void RenderMenuList::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, 
 
 void RenderMenuList::computePreferredLogicalWidths()
 {
+    if (style().fieldSizing() == FieldSizing::Content) {
+        RenderFlexibleBox::computePreferredLogicalWidths();
+        return;
+    }
+
     m_minPreferredLogicalWidth = 0;
     m_maxPreferredLogicalWidth = 0;
     


### PR DESCRIPTION
#### 40981b4a16b926588c4728336922676a52c2c8c3
<pre>
Implement field-sizing support for select
<a href="https://bugs.webkit.org/show_bug.cgi?id=269124">https://bugs.webkit.org/show_bug.cgi?id=269124</a>

Reviewed by Alan Baradlay.

Selects with &quot;field-sizing: content&quot; applied now correctly size based on the selected options width.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt: Removed.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-select-expected.txt: Removed.
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::computeIntrinsicLogicalWidths const):
(RenderMenuList::computePreferredLogicalWidths):

Canonical link: <a href="https://commits.webkit.org/274443@main">https://commits.webkit.org/274443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ba0d643393c3f19b4334b4dd60e1e31959d2a31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39135 "Failed to checkout and rebase branch from PR 24194") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34852 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15440 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39709 "Failed to checkout and rebase branch from PR 24194") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15239 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13201 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35535 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/42946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13947 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15553 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15216 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5110 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->