### PR TITLE
[Wasm-GC] Fix assertions for global init import case

### DIFF
--- a/JSTests/wasm/gc/const-exprs.js
+++ b/JSTests/wasm/gc/const-exprs.js
@@ -221,13 +221,13 @@ async function testInvalidConstExprs() {
 }
 
 async function testConstExprGlobalOrdering() {
-  compile(`
+  instantiate(`
     (module
       (global i32 (i32.const 0))
       (global i32 (global.get 0)))
   `);
 
-  compile(`
+  instantiate(`
     (module
       (global i32 (i32.const 0))
       (global i32 (i32.const 1))
@@ -246,14 +246,13 @@ async function testConstExprGlobalOrdering() {
     assert.eq(m.exports.g.value, 2);
   }
 
-  compile(`
+  instantiate(`
     (module
       (global (import "m" "g") externref)
-      (table 10 externref (global.get 0))
-      )
-  `);
+      (table 10 externref (global.get 0)))
+  `, { m: { g: "foo" } });
 
-  compile(`
+  instantiate(`
     (module
       (global i32 (i32.const 0))
       (global i32 (i32.const 1))
@@ -262,7 +261,7 @@ async function testConstExprGlobalOrdering() {
       (global i32 (global.get 3)))
   `);
 
-  compile(`
+  instantiate(`
     (module
       (table (export "t") 64 funcref)
       (global i32 (i32.const 5))

--- a/JSTests/wasm/gc/simd.js
+++ b/JSTests/wasm/gc/simd.js
@@ -404,6 +404,18 @@ function testJSAPI() {
   }
 }
 
+function testSIMDGlobal() {
+  instantiate(`
+    (module
+      (global v128 (v128.const i64x2 0 0))
+      (global v128 (v128.const i64x2 1 1))
+      (global v128 (v128.const i64x2 2 2))
+      (global v128 (global.get 1))
+      (global v128 (global.get 3)))
+  `);
+}
+
 testSIMDStruct();
 testSIMDArray();
 testJSAPI();
+testSIMDGlobal();

--- a/JSTests/wasm/gc/table_init.js
+++ b/JSTests/wasm/gc/table_init.js
@@ -51,6 +51,28 @@ function testTableInit() {
       assert.eq(m.exports.t.get(i), 42);
     }
   }
+
+  {
+    const m = instantiate(`
+      (module
+        (global (import "m" "g") i31ref)
+        (table (export "t") 10 i31ref (global.get 0)))
+    `, { m: { g: 42 } });
+    for (var i = 0; i < m.exports.t.length; i++) {
+      assert.eq(m.exports.t.get(i), 42);
+    }
+  }
+
+  // Table init can't refer to non-imported globals.
+  assert.throws(
+    () => instantiate(`
+      (module
+        (global i31ref (ref.i31 (i32.const 42)))
+        (table (export "t") 10 i31ref (global.get 0)))
+    `),
+    WebAssembly.CompileError,
+    "get_global's index 0 exceeds the number of globals 0"
+  );
 }
 
 testTableValidation();

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -590,7 +590,8 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
                 v128_t initialVector;
 
                 if (global.initializationType == Wasm::GlobalInformation::FromGlobalImport) {
-                    ASSERT(global.initialBits.initialBitsOrImportNumber < moduleInformation.firstInternalGlobal);
+                    ASSERT(global.initialBits.initialBitsOrImportNumber < m_instance->module()->moduleInformation().globals.size());
+                    ASSERT_IMPLIES(!Options::useWebAssemblyGC(), global.initialBits.initialBitsOrImportNumber < moduleInformation.firstInternalGlobal);
                     initialVector = m_instance->instance().loadV128Global(global.initialBits.initialBitsOrImportNumber);
                 } else if (global.initializationType == Wasm::GlobalInformation::FromExpression)
                     initialVector = global.initialBits.initialVector;
@@ -616,7 +617,8 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
 
             uint64_t initialBits = 0;
             if (global.initializationType == Wasm::GlobalInformation::FromGlobalImport) {
-                ASSERT(global.initialBits.initialBitsOrImportNumber < moduleInformation.firstInternalGlobal);
+                ASSERT(global.initialBits.initialBitsOrImportNumber < m_instance->module()->moduleInformation().globals.size());
+                ASSERT_IMPLIES(!Options::useWebAssemblyGC(), global.initialBits.initialBitsOrImportNumber < moduleInformation.firstInternalGlobal);
                 initialBits = m_instance->instance().loadI64Global(global.initialBits.initialBitsOrImportNumber);
             } else if (global.initializationType == Wasm::GlobalInformation::FromRefFunc) {
                 ASSERT(global.initialBits.initialBitsOrImportNumber < moduleInformation.functionIndexSpaceSize());


### PR DESCRIPTION
#### 803d3064cdeb810bbf07b64288b06b5493b7d68d
<pre>
[Wasm-GC] Fix assertions for global init import case
<a href="https://bugs.webkit.org/show_bug.cgi?id=269123">https://bugs.webkit.org/show_bug.cgi?id=269123</a>

Reviewed by Justin Michaud.

Fixes assertions for the &quot;import&quot; (referring to previous globals) case of
global init expressions. Also adds tests for various cases (including for
tables) to cover these cases better.

* JSTests/wasm/gc/const-exprs.js:
(async testConstExprGlobalOrdering):
* JSTests/wasm/gc/simd.js:
(testSIMDGlobal):
* JSTests/wasm/gc/table_init.js:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):

Canonical link: <a href="https://commits.webkit.org/274637@main">https://commits.webkit.org/274637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e406a2fb205503c509d9f3ae06d1dc9a262476ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34752 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32668 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13144 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42846 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32488 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35095 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38931 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38661 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37158 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15453 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45667 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8879 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15114 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9419 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->