### PR TITLE
[WTF] Define ENABLE(WYHASH_STRING_HASHER)

### DIFF
--- a/Source/JavaScriptCore/create_hash_table
+++ b/Source/JavaScriptCore/create_hash_table
@@ -145,7 +145,7 @@ sub ceilingToPowerOf2
 
 sub calcPerfectHashSize($)
 {
-    my ($isMac) = @_;
+    my ($useWYHash) = @_;
 tableSizeLoop:
     for ($perfectHashSize = ceilingToPowerOf2(scalar @keys); ; $perfectHashSize += $perfectHashSize) {
         if ($perfectHashSize > 2**15) {
@@ -153,7 +153,7 @@ tableSizeLoop:
         }
         my @table = ();
         foreach my $key (@keys) {
-            my $h = hashValue($key, $isMac) % $perfectHashSize;
+            my $h = hashValue($key, $useWYHash) % $perfectHashSize;
             next tableSizeLoop if $table[$h];
             $table[$h] = 1;
         }
@@ -168,7 +168,7 @@ sub leftShift($$) {
 
 sub calcCompactHashSize($)
 {
-    my ($isMac) = @_;
+    my ($useWYHash) = @_;
     my $compactHashSize = ceilingToPowerOf2(2 * @keys);
     $compactHashSizeMask = $compactHashSize - 1;
     $compactSize = $compactHashSize;
@@ -177,7 +177,7 @@ sub calcCompactHashSize($)
     my $i = 0;
     foreach my $key (@keys) {
         my $depth = 0;
-        my $h = hashValue($key, $isMac) % $compactHashSize;
+        my $h = hashValue($key, $useWYHash) % $compactHashSize;
         while (defined($table[$h])) {
             if ($compactSize > 1000) {
                 die "The hash size is far too big. This should not be reached.";
@@ -406,10 +406,10 @@ sub wyhash {
 }
 
 sub hashValue($$) {
-    my ($string, $isMac) = @_;
+    my ($string, $useWYHash) = @_;
     my @chars = split(/ */, $string);
     my $charCount = scalar @chars;
-    if ($isMac) {
+    if ($useWYHash) {
         if ($charCount <= 48) {
             return superFastHash(@chars);
         }
@@ -438,11 +438,11 @@ sub output() {
     print "\n";
 
     local *generateHashTableHelper = sub {
-        my ($isMac, $setToOldValues) = @_;
+        my ($useWYHash, $setToOldValues) = @_;
         my $oldCompactSize = $compactSize;
         my $oldCompactHashSizeMask = $compactHashSizeMask;
-        calcPerfectHashSize($isMac);
-        calcCompactHashSize($isMac);
+        calcPerfectHashSize($useWYHash);
+        calcCompactHashSize($useWYHash);
 
         my $hashTableString = "";
 
@@ -533,11 +533,11 @@ sub output() {
         return $hashTableString;
     };
 
-    my $hashTableForMacOS = generateHashTableHelper(1, 1);
-    my $hashTableForNonMacOSPlatforms = generateHashTableHelper(0, 0);
-    my $hashTableToWrite = $hashTableForMacOS;
-    if ($hashTableForMacOS ne $hashTableForNonMacOSPlatforms) {
-        $hashTableToWrite = "#if PLATFORM(MAC)\n" . $hashTableForMacOS . "#else\n" . $hashTableForNonMacOSPlatforms . "#endif\n";
+    my $hashTableForWYHash = generateHashTableHelper(1, 1);
+    my $hashTableForSFHash = generateHashTableHelper(0, 0);
+    my $hashTableToWrite = $hashTableForWYHash;
+    if ($hashTableForWYHash ne $hashTableForSFHash) {
+        $hashTableToWrite = "#if ENABLE(WYHASH_STRING_HASHER)\n" . $hashTableForWYHash . "#else\n" . $hashTableForSFHash . "#endif\n";
     }
     print $hashTableToWrite;
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -748,7 +748,7 @@ JSC_DEFINE_CUSTOM_SETTER(testStaticAccessorPutter, (JSGlobalObject* globalObject
     return thisObject->putDirect(vm, PropertyName(Identifier::fromString(vm, "testField"_s)), JSValue::decode(value));
 }
 
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
 static const struct CompactHashIndex staticCustomAccessorTableIndex[5] = {
     { 0, 4 },
     { -1, -1 },
@@ -854,7 +854,7 @@ JSC_DEFINE_CUSTOM_SETTER(testStaticValuePutterSetFlag, (JSGlobalObject* globalOb
     return thisObject->putDirect(vm, PropertyName(Identifier::fromString(vm, "testStaticValueSetterCalled"_s)), jsBoolean(true));
 }
 
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
 static const struct CompactHashIndex staticCustomValueTableIndex[5] = {
     { 1, 4 },
     { 2, -1 },
@@ -958,7 +958,7 @@ JSC_DEFINE_HOST_FUNCTION(staticDontDeleteDontEnumMethod, (JSGlobalObject*, CallF
     return encodedJSUndefined();
 }
 
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
 static const struct CompactHashIndex staticDontDeleteDontEnumTableIndex[5] = {
     { 0, -1 },
     { 1, 4 },

--- a/Source/JavaScriptCore/yarr/hasher.py
+++ b/Source/JavaScriptCore/yarr/hasher.py
@@ -31,9 +31,9 @@ mask32 = 2**32 - 1
 secret = [11562461410679940143, 16646288086500911323, 10285213230658275043, 6384245875588680899]
 
 
-def stringHash(str, isMac):
+def stringHash(str, useWYHash):
     strLen = len(str)
-    if isMac:
+    if useWYHash:
         if strLen <= 48:
             return superFastHash(str)
         return wyhash(str)
@@ -216,7 +216,7 @@ def ceilingToPowerOf2(v):
 # where the indexMask in the corresponding HashTable should
 # be numEntries - 1.
 def createHashTable(keys, hashTableName):
-    def createHashTableHelper(keys, hashTableName, isMac):
+    def createHashTableHelper(keys, hashTableName, useWYHash):
         table = {}
         links = {}
         compactSize = ceilingToPowerOf2(len(keys))
@@ -227,7 +227,7 @@ def createHashTable(keys, hashTableName):
         i = 0
         for key in keys:
             depth = 0
-            hashValue = stringHash(key, isMac) % numEntries
+            hashValue = stringHash(key, useWYHash) % numEntries
             while hashValue in table:
                 if hashValue in links:
                     hashValue = links[hashValue]
@@ -254,10 +254,10 @@ def createHashTable(keys, hashTableName):
         string += '};\n'
         return string
 
-    hashTableForMacOS = createHashTableHelper(keys, hashTableName, True)
-    hashTableForIOS = createHashTableHelper(keys, hashTableName, False)
-    result = hashTableForMacOS
-    if hashTableForMacOS != hashTableForIOS:
-        result = "#if PLATFORM(MAC)\n{}#else\n{}#endif".format(hashTableForMacOS, hashTableForIOS)
+    hashTableForWYHash = createHashTableHelper(keys, hashTableName, True)
+    hashTableForSFHash = createHashTableHelper(keys, hashTableName, False)
+    result = hashTableForWYHash
+    if hashTableForWYHash != hashTableForSFHash:
+        result = "#if ENABLE(WYHASH_STRING_HASHER)\n{}#else\n{}#endif".format(hashTableForWYHash, hashTableForSFHash)
     print(result)
 

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -603,6 +603,11 @@
 #endif
 #endif
 
+/* wyhash-based StringHasher */
+#if !defined(ENABLE_WYHASH_STRING_HASHER) && PLATFORM(MAC)
+#define ENABLE_WYHASH_STRING_HASHER 1
+#endif
+
 /* The JIT is enabled by default on all x86-64 & ARM64 platforms. */
 #if !defined(ENABLE_JIT) && (CPU(X86_64) || (CPU(ARM64) && CPU(ADDRESS64)))
 #define ENABLE_JIT 1

--- a/Source/WTF/wtf/text/StringHasher.h
+++ b/Source/WTF/wtf/text/StringHasher.h
@@ -108,7 +108,7 @@ private:
         return 0x80000000 >> flagCount;
     }
 
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
     bool m_pendingHashValue { false };
     unsigned m_numberOfProcessedCharacters { 0 };
     uint64_t m_seed { 0 };

--- a/Source/WTF/wtf/text/StringHasherInlines.h
+++ b/Source/WTF/wtf/text/StringHasherInlines.h
@@ -30,7 +30,7 @@ namespace WTF {
 template<typename T, typename Converter>
 unsigned StringHasher::computeHashAndMaskTop8Bits(const T* data, unsigned characterCount)
 {
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
     if (LIKELY(characterCount <= smallStringThreshold))
         return SuperFastHash::computeHashAndMaskTop8Bits<T, Converter>(data, characterCount);
     return WYHash::computeHashAndMaskTop8Bits<T, Converter>(data, characterCount);
@@ -43,7 +43,7 @@ template<typename T, unsigned characterCount>
 constexpr unsigned StringHasher::computeLiteralHashAndMaskTop8Bits(const T (&characters)[characterCount])
 {
     constexpr unsigned characterCountWithoutNull = characterCount - 1;
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
     if constexpr (LIKELY(characterCountWithoutNull <= smallStringThreshold))
         return SuperFastHash::computeHashAndMaskTop8Bits<T>(characters, characterCountWithoutNull);
     return WYHash::computeHashAndMaskTop8Bits<T>(characters, characterCountWithoutNull);
@@ -54,7 +54,7 @@ constexpr unsigned StringHasher::computeLiteralHashAndMaskTop8Bits(const T (&cha
 
 inline void StringHasher::addCharacter(UChar character)
 {
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
     if (m_bufferSize == smallStringThreshold) {
         // This algorithm must stay in sync with WYHash::hash function.
         if (!m_pendingHashValue) {
@@ -82,7 +82,7 @@ inline void StringHasher::addCharacter(UChar character)
 
 inline unsigned StringHasher::hashWithTop8BitsMasked()
 {
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
     unsigned hashValue;
     if (!m_pendingHashValue) {
         ASSERT(m_bufferSize <= smallStringThreshold);

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -7712,7 +7712,7 @@ sub GenerateHashTable
     # Generate size data for compact' size hash table
 
     local *generateHashTableHelper = sub {
-        my ($isMac) = @_;
+        my ($useWYHash) = @_;
         my @table = ();
         my @links = ();
 
@@ -7725,7 +7725,7 @@ sub GenerateHashTable
         my $i = 0;
         foreach (@{$keys}) {
             my $depth = 0;
-            my $h = Hasher::GenerateHashValue($_, $isMac) % $numEntries;
+            my $h = Hasher::GenerateHashValue($_, $useWYHash) % $numEntries;
 
             while (defined($table[$h])) {
                 if (defined($links[$h])) {
@@ -7773,11 +7773,11 @@ sub GenerateHashTable
         return $hashTableString
     };
 
-    my $hashTableForMacOS = generateHashTableHelper(1);
-    my $hashTableForIOS = generateHashTableHelper(0);
-    my $hashTableToWrite = $hashTableForMacOS;
-    if ($hashTableForMacOS ne $hashTableForIOS) {
-        $hashTableToWrite = "#if PLATFORM(MAC)\n" . $hashTableForMacOS . "#else\n" . $hashTableForIOS . "#endif\n";
+    my $hashTableForWYHash = generateHashTableHelper(1);
+    my $hashTableForSFHash = generateHashTableHelper(0);
+    my $hashTableToWrite = $hashTableForWYHash;
+    if ($hashTableForWYHash ne $hashTableForSFHash) {
+        $hashTableToWrite = "#if ENABLE(WYHASH_STRING_HASHER)\n" . $hashTableForWYHash . "#else\n" . $hashTableForSFHash . "#endif\n";
     }
     push(@implContent, $hashTableToWrite);
 }

--- a/Source/WebCore/bindings/scripts/Hasher.pm
+++ b/Source/WebCore/bindings/scripts/Hasher.pm
@@ -243,10 +243,10 @@ sub wyhash {
 
 
 sub GenerateHashValue($$) {
-    my ($string, $isMac) = @_;
+    my ($string, $useWYHash) = @_;
     my @chars = split(/ */, $string);
     my $charCount = scalar @chars;
-    if ($isMac) {
+    if ($useWYHash) {
         if ($charCount <= 48) {
             return superFastHash(@chars);
         }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
@@ -251,7 +251,7 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTestGlobalObject_TestTypedefsConstructor);
 using JSTestGlobalObjectDOMConstructor = JSDOMConstructorNotConstructable<JSTestGlobalObject>;
 
 /* Hash table */
-#if PLATFORM(MAC)
+#if ENABLE(WYHASH_STRING_HASHER)
 
 static const struct CompactHashIndex JSTestGlobalObjectTableIndex[268] = {
     { -1, -1 },


### PR DESCRIPTION
#### 25af4548095896bc7fcb7cc232bcfd9f40cb4913
<pre>
[WTF] Define ENABLE(WYHASH_STRING_HASHER)
<a href="https://bugs.webkit.org/show_bug.cgi?id=269130">https://bugs.webkit.org/show_bug.cgi?id=269130</a>
<a href="https://rdar.apple.com/122690122">rdar://122690122</a>

Reviewed by Alexey Shvayka.

Let&apos;s define ENABLE(WYHASH_STRING_HASHER) and use it instead of PLATFORM(MAC).
It allows us to easily enable / disable WYHash-based StringHasher by just flipping this flag.
And it is also super easy to read (And allows the other platforms to enable it easily).

* Source/JavaScriptCore/create_hash_table:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
* Source/JavaScriptCore/yarr/hasher.py:
(stringHash):
(createHashTable.createHashTableHelper):
(createHashTable):
* Source/WTF/wtf/PlatformEnable.h:
* Source/WTF/wtf/text/StringHasher.h:
* Source/WTF/wtf/text/StringHasherInlines.h:
(WTF::StringHasher::computeHashAndMaskTop8Bits):
(WTF::StringHasher::computeLiteralHashAndMaskTop8Bits):
(WTF::StringHasher::addCharacter):
(WTF::StringHasher::hashWithTop8BitsMasked):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateHashTable):
* Source/WebCore/bindings/scripts/Hasher.pm:
* Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp:

Canonical link: <a href="https://commits.webkit.org/274416@main">https://commits.webkit.org/274416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a13a98ffd200231b987a4151be39a99d7acb337b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41574 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15321 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13149 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42851 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/32493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38936 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38666 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37163 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15458 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45672 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15120 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9307 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5098 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->