### PR TITLE
Further adoption of smart pointers in SVG code

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10448,6 +10448,11 @@ RefPtr<LocalFrameView> Document::protectedView() const
     return view();
 }
 
+CheckedPtr<RenderView> Document::checkedRenderView() const
+{
+    return m_renderView.get();
+}
+
 } // namespace WebCore
 
 #undef DOCUMENT_RELEASE_LOG

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -765,6 +765,7 @@ public:
     void suspendFontLoading();
 
     RenderView* renderView() const { return m_renderView.get(); }
+    CheckedPtr<RenderView> checkedRenderView() const;
     const RenderStyle* initialContainingBlockStyle() const { return m_initialContainingBlockStyle.get(); } // This may end up differing from renderView()->style() due to adjustments.
 
     bool renderTreeBeingDestroyed() const { return m_renderTreeBeingDestroyed; }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -87,6 +87,11 @@ RenderSVGViewportContainer* RenderSVGRoot::viewportContainer() const
     return dynamicDowncast<RenderSVGViewportContainer>(child);
 }
 
+CheckedPtr<RenderSVGViewportContainer> RenderSVGRoot::checkedViewportContainer() const
+{
+    return viewportContainer();
+}
+
 bool RenderSVGRoot::hasIntrinsicAspectRatio() const
 {
     return computeIntrinsicAspectRatio();

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -67,6 +67,7 @@ public:
     LayoutRect visualOverflowRectEquivalent() const { return SVGBoundingBoxComputation::computeVisualOverflowRect(*this); }
 
     RenderSVGViewportContainer* viewportContainer() const;
+    CheckedPtr<RenderSVGViewportContainer> checkedViewportContainer() const;
 
 private:
     void element() const = delete;

--- a/Source/WebCore/svg/SVGPolyElement.cpp
+++ b/Source/WebCore/svg/SVGPolyElement.cpp
@@ -60,10 +60,10 @@ void SVGPolyElement::svgAttributeChanged(const QualifiedName& attrName)
         InstanceInvalidationGuard guard(*this);
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-        if (auto* path = dynamicDowncast<RenderSVGPath>(renderer()))
+        if (CheckedPtr path = dynamicDowncast<RenderSVGPath>(renderer()))
             path->setNeedsShapeUpdate();
 #endif
-        if (auto* path = dynamicDowncast<LegacyRenderSVGPath>(renderer()))
+        if (CheckedPtr path = dynamicDowncast<LegacyRenderSVGPath>(renderer()))
             path->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -70,22 +70,22 @@ void SVGRadialGradientElement::attributeChanged(const QualifiedName& name, const
 
     switch (name.nodeName()) {
     case AttributeNames::cxAttr:
-        m_cx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_cx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::cyAttr:
-        m_cy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_cy }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::rAttr:
-        m_r->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_r }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::fxAttr:
-        m_fx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_fx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::fyAttr:
-        m_fy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_fy }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::frAttr:
-        m_fr->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_fr }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     default:
         break;
@@ -158,7 +158,7 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
         return false;
 
     HashSet<RefPtr<SVGGradientElement>> processedGradients;
-    SVGGradientElement* current = this;
+    RefPtr<SVGGradientElement> current = this;
 
     setGradientAttributes(*current, attributes);
     processedGradients.add(current);
@@ -166,8 +166,8 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
     while (true) {
         // Respect xlink:href, take attributes from referenced element
         auto target = SVGURIReference::targetElementFromIRIString(current->href(), treeScopeForSVGReferences());
-        if (auto* gradientElement = dynamicDowncast<SVGGradientElement>(target.element.get())) {
-            current = gradientElement;
+        if (RefPtr gradientElement = dynamicDowncast<SVGGradientElement>(target.element.get())) {
+            current = WTFMove(gradientElement);
 
             // Cycle detection
             if (processedGradients.contains(current))

--- a/Source/WebCore/svg/SVGRectElement.cpp
+++ b/Source/WebCore/svg/SVGRectElement.cpp
@@ -61,22 +61,22 @@ void SVGRectElement::attributeChanged(const QualifiedName& name, const AtomStrin
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::rxAttr:
-        m_rx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_rx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::ryAttr:
-        m_ry->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_ry }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::widthAttr:
-        m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::heightAttr:
-        m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -92,7 +92,7 @@ public:
     using SVGGraphicsElement::deref;
 
     SMILTimeContainer& timeContainer() { return m_timeContainer.get(); }
-    Ref<SMILTimeContainer> protectedTimeContainer();
+    Ref<SMILTimeContainer> protectedTimeContainer() const;
 
     void setCurrentTranslate(const FloatPoint&); // Used to pan.
     void updateCurrentTranslate();

--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -54,9 +54,9 @@ void SVGStopElement::attributeChanged(const QualifiedName& name, const AtomStrin
 {
     if (name == SVGNames::offsetAttr) {
         if (newValue.endsWith('%'))
-            m_offset->setBaseValInternal(newValue.string().left(newValue.length() - 1).toFloat() / 100.0f);
+            Ref { m_offset }->setBaseValInternal(newValue.string().left(newValue.length() - 1).toFloat() / 100.0f);
         else
-            m_offset->setBaseValInternal(newValue.toFloat());
+            Ref { m_offset }->setBaseValInternal(newValue.toFloat());
     }
 
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGStyleElement.cpp
+++ b/Source/WebCore/svg/SVGStyleElement.cpp
@@ -96,8 +96,8 @@ void SVGStyleElement::attributeChanged(const QualifiedName& name, const AtomStri
 {
     switch (name.nodeName()) {
     case AttributeNames::titleAttr:
-        if (sheet() && !isInShadowTree())
-            sheet()->setTitle(newValue);
+        if (RefPtr sheet = this->sheet(); sheet && !isInShadowTree())
+            sheet->setTitle(newValue);
         break;
     case AttributeNames::typeAttr:
         m_styleSheetOwner.setContentType(newValue);

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -41,6 +41,8 @@ private:
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTRefElement, SVGTextPositioningElement, SVGURIReference>;
 
+    Ref<SVGTRefTargetEventListener> protectedTargetListener() const;
+
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -140,17 +140,32 @@ bool SVGTests::isValid() const
     return true;
 }
 
+Ref<SVGStringList> SVGTests::protectedRequiredFeatures()
+{
+    return requiredFeatures();
+}
+
+Ref<SVGStringList> SVGTests::protectedRequiredExtensions()
+{
+    return requiredExtensions();
+}
+
+Ref<SVGStringList> SVGTests::protectedSystemLanguage()
+{
+    return systemLanguage();
+}
+
 void SVGTests::parseAttribute(const QualifiedName& attributeName, const AtomString& value)
 {
     switch (attributeName.nodeName()) {
     case AttributeNames::requiredFeaturesAttr:
-        requiredFeatures().reset(value);
+        protectedRequiredFeatures()->reset(value);
         break;
     case AttributeNames::requiredExtensionsAttr:
-        requiredExtensions().reset(value);
+        protectedRequiredExtensions()->reset(value);
         break;
     case AttributeNames::systemLanguageAttr:
-        systemLanguage().reset(value);
+        protectedSystemLanguage()->reset(value);
         break;
     default:
         break;
@@ -162,9 +177,10 @@ void SVGTests::svgAttributeChanged(const QualifiedName& attrName)
     if (!PropertyRegistry::isKnownAttribute(attrName))
         return;
 
-    if (!m_contextElement.isConnected())
+    Ref contextElement = m_contextElement.get();
+    if (!contextElement->isConnected())
         return;
-    m_contextElement.invalidateStyleAndRenderersForSubtree();
+    contextElement->invalidateStyleAndRenderersForSubtree();
 }
 
 void SVGTests::addSupportedAttributes(MemoryCompactLookupOnlyRobinHoodHashSet<QualifiedName>& supportedAttributes)
@@ -195,14 +211,20 @@ bool SVGTests::hasFeatureForLegacyBindings(const String& feature, const String& 
     return false;
 }
 
+Ref<SVGElement> SVGTests::protectedContextElement() const
+{
+    return m_contextElement.get();
+}
+
 SVGConditionalProcessingAttributes& SVGTests::conditionalProcessingAttributes()
 {
-    return m_contextElement.conditionalProcessingAttributes();
+    RefAllowingPartiallyDestroyed<SVGElement> contextElement = m_contextElement.get();
+    return contextElement->conditionalProcessingAttributes();
 }
 
 SVGConditionalProcessingAttributes* SVGTests::conditionalProcessingAttributesIfExists() const
 {
-    return m_contextElement.conditionalProcessingAttributesIfExists();
+    return protectedContextElement()->conditionalProcessingAttributesIfExists();
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/svg/SVGTests.h
+++ b/Source/WebCore/svg/SVGTests.h
@@ -23,6 +23,7 @@
 
 #include "QualifiedName.h"
 #include "SVGStringList.h"
+#include <wtf/Forward.h>
 #include <wtf/RobinHoodHashSet.h>
 
 namespace WebCore {
@@ -70,14 +71,19 @@ public:
 
     // These methods are called from DOM through the super classes.
     SVGStringList& requiredFeatures() { return conditionalProcessingAttributes().requiredFeatures(); }
+    Ref<SVGStringList> protectedRequiredFeatures();
     SVGStringList& requiredExtensions() { return conditionalProcessingAttributes().requiredExtensions(); }
+    Ref<SVGStringList> protectedRequiredExtensions();
     SVGStringList& systemLanguage() { return conditionalProcessingAttributes().systemLanguage(); }
+    Ref<SVGStringList> protectedSystemLanguage();
 
 protected:
     SVGTests(SVGElement* contextElement);
 
 private:
-    SVGElement& m_contextElement;
+    Ref<SVGElement> protectedContextElement() const;
+
+    WeakRef<SVGElement, WeakPtrImplWithEventTargetData> m_contextElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -56,14 +56,14 @@ SVGTextContentElement::SVGTextContentElement(const QualifiedName& tagName, Docum
 
 unsigned SVGTextContentElement::getNumberOfChars()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
-    return SVGTextQuery(renderer()).numberOfCharacters();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    return SVGTextQuery(checkedRenderer().get()).numberOfCharacters();
 }
 
 float SVGTextContentElement::getComputedTextLength()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
-    return SVGTextQuery(renderer()).textLength();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    return SVGTextQuery(checkedRenderer().get()).textLength();
 }
 
 ExceptionOr<float> SVGTextContentElement::getSubStringLength(unsigned charnum, unsigned nchars)
@@ -73,7 +73,7 @@ ExceptionOr<float> SVGTextContentElement::getSubStringLength(unsigned charnum, u
         return Exception { ExceptionCode::IndexSizeError };
 
     nchars = std::min(nchars, numberOfChars - charnum);
-    return SVGTextQuery(renderer()).subStringLength(charnum, nchars);
+    return SVGTextQuery(checkedRenderer().get()).subStringLength(charnum, nchars);
 }
 
 ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getStartPositionOfChar(unsigned charnum)
@@ -81,7 +81,7 @@ ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getStartPositionOfChar(unsigne
     if (charnum >= getNumberOfChars())
         return Exception { ExceptionCode::IndexSizeError };
 
-    return SVGPoint::create(SVGTextQuery(renderer()).startPositionOfCharacter(charnum));
+    return SVGPoint::create(SVGTextQuery(checkedRenderer().get()).startPositionOfCharacter(charnum));
 }
 
 ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getEndPositionOfChar(unsigned charnum)
@@ -89,7 +89,7 @@ ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getEndPositionOfChar(unsigned 
     if (charnum >= getNumberOfChars())
         return Exception { ExceptionCode::IndexSizeError };
 
-    return SVGPoint::create(SVGTextQuery(renderer()).endPositionOfCharacter(charnum));
+    return SVGPoint::create(SVGTextQuery(checkedRenderer().get()).endPositionOfCharacter(charnum));
 }
 
 ExceptionOr<Ref<SVGRect>> SVGTextContentElement::getExtentOfChar(unsigned charnum)
@@ -97,7 +97,7 @@ ExceptionOr<Ref<SVGRect>> SVGTextContentElement::getExtentOfChar(unsigned charnu
     if (charnum >= getNumberOfChars())
         return Exception { ExceptionCode::IndexSizeError };
 
-    return SVGRect::create(SVGTextQuery(renderer()).extentOfCharacter(charnum));
+    return SVGRect::create(SVGTextQuery(checkedRenderer().get()).extentOfCharacter(charnum));
 }
 
 ExceptionOr<float> SVGTextContentElement::getRotationOfChar(unsigned charnum)
@@ -105,14 +105,14 @@ ExceptionOr<float> SVGTextContentElement::getRotationOfChar(unsigned charnum)
     if (charnum >= getNumberOfChars())
         return Exception { ExceptionCode::IndexSizeError };
 
-    return SVGTextQuery(renderer()).rotationOfCharacter(charnum);
+    return SVGTextQuery(checkedRenderer().get()).rotationOfCharacter(charnum);
 }
 
 int SVGTextContentElement::getCharNumAtPosition(DOMPointInit&& pointInit)
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
     FloatPoint transformPoint {static_cast<float>(pointInit.x), static_cast<float>(pointInit.y)};
-    return SVGTextQuery(renderer()).characterNumberAtPosition(transformPoint);
+    return SVGTextQuery(checkedRenderer().get()).characterNumberAtPosition(transformPoint);
 }
 
 ExceptionOr<void> SVGTextContentElement::selectSubString(unsigned charnum, unsigned nchars)
@@ -123,9 +123,9 @@ ExceptionOr<void> SVGTextContentElement::selectSubString(unsigned charnum, unsig
 
     nchars = std::min(nchars, numberOfChars - charnum);
 
-    ASSERT(document().frame());
-
-    FrameSelection& selection = document().frame()->selection();
+    RefPtr frame = document().frame();
+    ASSERT(frame);
+    CheckedRef selection = frame->selection();
 
     // Find selection start
     VisiblePosition start(firstPositionInNode(const_cast<SVGTextContentElement*>(this)));
@@ -137,7 +137,7 @@ ExceptionOr<void> SVGTextContentElement::selectSubString(unsigned charnum, unsig
     for (unsigned i = 0; i < nchars; ++i)
         end = end.next();
 
-    selection.setSelection(VisibleSelection(start, end));
+    selection->setSelection(VisibleSelection(start, end));
 
     return { };
 }

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -72,18 +72,18 @@ void SVGTextPathElement::attributeChanged(const QualifiedName& name, const AtomS
 
     switch (name.nodeName()) {
     case AttributeNames::startOffsetAttr:
-        m_startOffset->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError));
+        Ref { m_startOffset }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError));
         break;
     case AttributeNames::methodAttr: {
         SVGTextPathMethodType propertyValue = SVGPropertyTraits<SVGTextPathMethodType>::fromString(newValue);
         if (propertyValue > 0)
-            m_method->setBaseValInternal<SVGTextPathMethodType>(propertyValue);
+            Ref { m_method }->setBaseValInternal<SVGTextPathMethodType>(propertyValue);
         break;
     }
     case AttributeNames::spacingAttr: {
         SVGTextPathSpacingType propertyValue = SVGPropertyTraits<SVGTextPathSpacingType>::fromString(newValue);
         if (propertyValue > 0)
-            m_spacing->setBaseValInternal<SVGTextPathSpacingType>(propertyValue);
+            Ref { m_spacing }->setBaseValInternal<SVGTextPathSpacingType>(propertyValue);
         break;
     }
     default:
@@ -151,12 +151,12 @@ void SVGTextPathElement::buildPendingResource()
     auto target = SVGURIReference::targetElementFromIRIString(href(), treeScopeForSVGReferences());
     if (!target.element) {
         // Do not register as pending if we are already pending this resource.
-        auto& treeScope = treeScopeForSVGReferences();
-        if (treeScope.isPendingSVGResource(*this, target.identifier))
+        CheckedRef treeScope = treeScopeForSVGReferences();
+        if (treeScope->isPendingSVGResource(*this, target.identifier))
             return;
 
         if (!target.identifier.isEmpty()) {
-            treeScope.addPendingSVGResource(target.identifier, *this);
+            treeScope->addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
     } else if (RefPtr pathElement = dynamicDowncast<SVGPathElement>(*target.element))

--- a/Source/WebCore/svg/SVGTextPositioningElement.cpp
+++ b/Source/WebCore/svg/SVGTextPositioningElement.cpp
@@ -56,19 +56,19 @@ void SVGTextPositioningElement::attributeChanged(const QualifiedName& name, cons
 {
     switch (name.nodeName()) {
     case AttributeNames::xAttr:
-        m_x->baseVal()->parse(newValue);
+        Ref { m_x }->baseVal()->parse(newValue);
         break;
     case AttributeNames::yAttr:
-        m_y->baseVal()->parse(newValue);
+        Ref { m_y }->baseVal()->parse(newValue);
         break;
     case AttributeNames::dxAttr:
-        m_dx->baseVal()->parse(newValue);
+        Ref { m_dx }->baseVal()->parse(newValue);
         break;
     case AttributeNames::dyAttr:
-        m_dy->baseVal()->parse(newValue);
+        Ref { m_dy }->baseVal()->parse(newValue);
         break;
     case AttributeNames::rotateAttr:
-        m_rotate->baseVal()->parse(newValue);
+        Ref { m_rotate }->baseVal()->parse(newValue);
         break;
     default:
         break;
@@ -99,8 +99,8 @@ void SVGTextPositioningElement::svgAttributeChanged(const QualifiedName& attrNam
         if (attrName != SVGNames::rotateAttr)
             updateRelativeLengthsInformation();
 
-        if (auto renderer = this->renderer()) {
-            if (auto* textAncestor = RenderSVGText::locateRenderSVGTextAncestor(*renderer))
+        if (CheckedPtr renderer = this->renderer()) {
+            if (CheckedPtr textAncestor = RenderSVGText::locateRenderSVGTextAncestor(*renderer))
                 textAncestor->setNeedsPositioningValuesUpdate();
         }
         updateSVGRendererForElementChange();

--- a/Source/WebCore/svg/SVGTitleElement.cpp
+++ b/Source/WebCore/svg/SVGTitleElement.cpp
@@ -46,7 +46,7 @@ Node::InsertedIntoAncestorResult SVGTitleElement::insertedIntoAncestor(Insertion
 {
     auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument && parentNode() == document().documentElement())
-        document().titleElementAdded(*this);
+        protectedDocument()->titleElementAdded(*this);
     return result;
 }
 
@@ -62,15 +62,17 @@ static bool isTitleElementRemovedFromSVGSVGElement(SVGTitleElement& title, Conta
 void SVGTitleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-    if (removalType.disconnectedFromDocument && isTitleElementRemovedFromSVGSVGElement(*this, oldParentOfRemovedTree))
-        document().titleElementRemoved(*this);
+    if (removalType.disconnectedFromDocument && isTitleElementRemovedFromSVGSVGElement(*this, oldParentOfRemovedTree)) {
+        RefAllowingPartiallyDestroyed<Document> document = this->document();
+        document->titleElementRemoved(*this);
+    }
 }
 
 void SVGTitleElement::childrenChanged(const ChildChange& change)
 {
     SVGElement::childrenChanged(change);
     if (isConnected() && parentNode() == document().documentElement())
-        document().titleElementTextChanged(*this);
+        protectedDocument()->titleElementTextChanged(*this);
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -54,7 +54,7 @@ static inline void append32(V& result, uint32_t value)
     result.append(value);
 }
 
-class SVGToOTFFontConverter {
+class SVGToOTFFontConverter : public CanMakeWeakPtr<SVGToOTFFontConverter> {
 public:
     SVGToOTFFontConverter(const SVGFontElement&);
     bool convertSVGToOTFFont();
@@ -83,7 +83,7 @@ private:
         FloatRect boundingBox;
         Vector<char> charString;
         String codepoints;
-        const SVGGlyphElement* glyphElement;
+        WeakPtr<const SVGGlyphElement, WeakPtrImplWithEventTargetData> glyphElement;
         float horizontalAdvance;
         float verticalAdvance;
     };
@@ -93,9 +93,9 @@ private:
         Placeholder(SVGToOTFFontConverter& converter, size_t baseOfOffset)
             : m_converter(converter)
             , m_baseOfOffset(baseOfOffset)
-            , m_location(m_converter.m_result.size())
+            , m_location(m_converter->m_result.size())
         {
-            m_converter.append16(0);
+            m_converter->append16(0);
         }
 
         Placeholder(Placeholder&& other)
@@ -103,20 +103,17 @@ private:
             , m_baseOfOffset(other.m_baseOfOffset)
             , m_location(other.m_location)
 #if ASSERT_ENABLED
-            , m_active(other.m_active)
+            , m_active(std::exchange(other.m_active, false))
 #endif
         {
-#if ASSERT_ENABLED
-            other.m_active = false;
-#endif
         }
 
         void populate()
         {
             ASSERT(m_active);
-            size_t delta = m_converter.m_result.size() - m_baseOfOffset;
+            size_t delta = m_converter->m_result.size() - m_baseOfOffset;
             ASSERT(delta < std::numeric_limits<uint16_t>::max());
-            m_converter.overwrite16(m_location, delta);
+            m_converter->overwrite16(m_location, delta);
 #if ASSERT_ENABLED
             m_active = false;
 #endif
@@ -128,7 +125,7 @@ private:
         }
 
     private:
-        SVGToOTFFontConverter& m_converter;
+        WeakRef<SVGToOTFFontConverter> m_converter;
         const size_t m_baseOfOffset;
         const size_t m_location;
 #if ASSERT_ENABLED
@@ -250,9 +247,9 @@ private:
     Vector<uint8_t> m_result;
     Vector<char, 17> m_emptyGlyphCharString;
     FloatRect m_boundingBox;
-    const SVGFontElement& m_fontElement;
-    const SVGFontFaceElement* m_fontFaceElement;
-    const SVGMissingGlyphElement* m_missingGlyphElement;
+    WeakRef<const SVGFontElement, WeakPtrImplWithEventTargetData> m_fontElement;
+    WeakPtr<const SVGFontFaceElement, WeakPtrImplWithEventTargetData> m_fontFaceElement;
+    WeakPtr<const SVGMissingGlyphElement, WeakPtrImplWithEventTargetData> m_missingGlyphElement;
     String m_fontFamily;
     float m_advanceWidthMax;
     float m_advanceHeightMax;
@@ -491,7 +488,7 @@ void SVGToOTFFontConverter::appendNAMETable()
 void SVGToOTFFontConverter::appendOS2Table()
 {
     int16_t averageAdvance = s_outputUnitsPerEm;
-    auto horizAdvX = parseHTMLInteger(m_fontElement.attributeWithoutSynchronization(SVGNames::horiz_adv_xAttr));
+    auto horizAdvX = parseHTMLInteger(m_fontElement->attributeWithoutSynchronization(SVGNames::horiz_adv_xAttr));
     if (!horizAdvX && m_missingGlyphElement)
         horizAdvX = parseHTMLInteger(m_missingGlyphElement->attributeWithoutSynchronization(SVGNames::horiz_adv_xAttr));
     if (horizAdvX)
@@ -947,7 +944,7 @@ void SVGToOTFFontConverter::appendVORGTable()
     append16(1); // Major version
     append16(0); // Minor version
 
-    auto vertOriginY = parseHTMLInteger(m_fontElement.attributeWithoutSynchronization(SVGNames::vert_origin_yAttr));
+    auto vertOriginY = parseHTMLInteger(m_fontElement->attributeWithoutSynchronization(SVGNames::vert_origin_yAttr));
     if (!vertOriginY && m_missingGlyphElement)
         vertOriginY = parseHTMLInteger(m_missingGlyphElement->attributeWithoutSynchronization(SVGNames::vert_origin_yAttr));
     append16(clampTo<int16_t>(scaleUnitsPerEm(vertOriginY.value_or(0))));
@@ -955,7 +952,7 @@ void SVGToOTFFontConverter::appendVORGTable()
     auto tableSizeOffset = m_result.size();
     append16(0); // Place to write table size.
     for (Glyph i = 0; i < m_glyphs.size(); ++i) {
-        if (auto* glyph = m_glyphs[i].glyphElement) {
+        if (auto& glyph = m_glyphs[i].glyphElement) {
             if (auto verticalOriginY = parseHTMLInteger(glyph->attributeWithoutSynchronization(SVGNames::vert_origin_yAttr))) {
                 append16(i);
                 append16(clampTo<int16_t>(scaleUnitsPerEm(*verticalOriginY)));

--- a/Source/WebCore/svg/SVGTransform.h
+++ b/Source/WebCore/svg/SVGTransform.h
@@ -46,7 +46,7 @@ public:
 
     static Ref<SVGTransform> create(const SVGTransformValue& value)
     {
-        return adoptRef(*new SVGTransform(value.type(), value.matrix()->value(), value.angle(), value.rotationCenter()));
+        return adoptRef(*new SVGTransform(value.type(), value.matrix().value(), value.angle(), value.rotationCenter()));
     }
 
     static Ref<SVGTransform> create(SVGTransformValue&& value)
@@ -64,7 +64,7 @@ public:
 
     ~SVGTransform()
     {
-        m_value.matrix()->detach();
+        m_value.protectedMatrix()->detach();
     }
 
     Ref<SVGTransform> clone() const
@@ -74,7 +74,8 @@ public:
 
     unsigned short type() { return m_value.type(); }
     float angle() { return m_value.angle(); }
-    const Ref<SVGMatrix>& matrix() { return m_value.matrix(); }
+    SVGMatrix& matrix() { return m_value.matrix(); }
+    Ref<SVGMatrix> protectedMatrix() { return matrix(); }
 
     ExceptionOr<void> setMatrix(DOMMatrix2DInit&& matrixInit)
     {
@@ -153,14 +154,14 @@ public:
     {
         Base::attach(owner, access);
         // Reattach the SVGMatrix to the SVGTransformValue with the new SVGPropertyAccess.
-        m_value.matrix()->reattach(this, access);
+        m_value.protectedMatrix()->reattach(this, access);
     }
 
     void detach() override
     {
         Base::detach();
         // Reattach the SVGMatrix to the SVGTransformValue with the SVGPropertyAccess::ReadWrite.
-        m_value.matrix()->reattach(this, access());
+        m_value.protectedMatrix()->reattach(this, access());
     }
 
 private:
@@ -174,14 +175,14 @@ private:
     SVGTransform(SVGTransformValue&& value)
         : Base(WTFMove(value))
     {
-        m_value.matrix()->attach(this, SVGPropertyAccess::ReadWrite);
+        m_value.protectedMatrix()->attach(this, SVGPropertyAccess::ReadWrite);
     }
 
     SVGPropertyOwner* owner() const override { return m_owner; }
 
     void commitPropertyChange(SVGProperty* property) override
     {
-        ASSERT_UNUSED(property, property == m_value.matrix().ptr());
+        ASSERT_UNUSED(property, property == &m_value.matrix());
         if (owner())
             owner()->commitPropertyChange(this);
         m_value.matrixDidChange();

--- a/Source/WebCore/svg/SVGTransformList.cpp
+++ b/Source/WebCore/svg/SVGTransformList.cpp
@@ -58,7 +58,7 @@ AffineTransform SVGTransformList::concatenate() const
 {
     AffineTransform result;
     for (auto& transform : m_items)
-        result *= transform->matrix()->value();
+        result *= transform->matrix().value();
     return result;
 }
 

--- a/Source/WebCore/svg/SVGTransformList.h
+++ b/Source/WebCore/svg/SVGTransformList.h
@@ -51,7 +51,7 @@ public:
 
     ExceptionOr<Ref<SVGTransform>> createSVGTransformFromMatrix(DOMMatrix2DInit&& matrixInit)
     {
-        auto svgTransform =  SVGTransform::create();
+        Ref svgTransform =  SVGTransform::create();
         svgTransform->setMatrix(WTFMove(matrixInit));
         return svgTransform;
     }

--- a/Source/WebCore/svg/SVGTransformValue.h
+++ b/Source/WebCore/svg/SVGTransformValue.h
@@ -76,7 +76,7 @@ public:
 
     SVGTransformValue(const SVGTransformValue& other)
         : m_type(other.m_type)
-        , m_matrix(SVGMatrix::create(other.matrix()->value()))
+        , m_matrix(SVGMatrix::create(other.matrix().value()))
         , m_angle(other.m_angle)
         , m_rotationCenter(other.m_rotationCenter)
     {
@@ -108,7 +108,8 @@ public:
     }
 
     SVGTransformType type() const { return m_type; }
-    const Ref<SVGMatrix>& matrix() const { return m_matrix; }
+    SVGMatrix& matrix() const { return m_matrix; }
+    Ref<SVGMatrix> protectedMatrix() const { return m_matrix; }
     float angle() const { return m_angle; }
     FloatPoint rotationCenter() const { return m_rotationCenter; }
 
@@ -119,7 +120,7 @@ public:
         m_type = SVG_TRANSFORM_MATRIX;
         m_angle = 0;
         m_rotationCenter = { };
-        m_matrix->setValue(matrix);
+        protectedMatrix()->setValue(matrix);
     }
 
     void matrixDidChange()

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -77,8 +77,8 @@ Ref<SVGUseElement> SVGUseElement::create(const QualifiedName& tagName, Document&
 
 SVGUseElement::~SVGUseElement()
 {
-    if (m_externalDocument)
-        m_externalDocument->removeClient(*this);
+    if (CachedResourceHandle externalDocument = m_externalDocument)
+        externalDocument->removeClient(*this);
 }
 
 void SVGUseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -87,16 +87,16 @@ void SVGUseElement::attributeChanged(const QualifiedName& name, const AtomString
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::widthAttr:
-        m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     case AttributeNames::heightAttr:
-        m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
         break;
     default:
         break;
@@ -112,7 +112,7 @@ Node::InsertedIntoAncestorResult SVGUseElement::insertedIntoAncestor(InsertionTy
     auto result = SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument) {
         if (m_shadowTreeNeedsUpdate)
-            document().addElementWithPendingUserAgentShadowTreeUpdate(*this);
+            protectedDocument()->addElementWithPendingUserAgentShadowTreeUpdate(*this);
         invalidateShadowTree();
         // FIXME: Move back the call to updateExternalDocument() here once notifyFinished is made always async.
         return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
@@ -131,8 +131,10 @@ void SVGUseElement::removedFromAncestor(RemovalType removalType, ContainerNode& 
     // Check m_shadowTreeNeedsUpdate before calling SVGElement::removedFromAncestor which calls SVGElement::invalidateInstances
     // and SVGUseElement::updateExternalDocument which calls invalidateShadowTree().
     if (removalType.disconnectedFromDocument) {
-        if (m_shadowTreeNeedsUpdate)
-            document().removeElementWithPendingUserAgentShadowTreeUpdate(*this);
+        if (m_shadowTreeNeedsUpdate) {
+            RefAllowingPartiallyDestroyed<Document> document = this->document();
+            document->removeElementWithPendingUserAgentShadowTreeUpdate(*this);
+        }
     }
     SVGGraphicsElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument) {
@@ -231,13 +233,13 @@ static inline bool isDisallowedElement(const SVGElement& element)
 
 static inline bool isDisallowedElement(const Element& element)
 {
-    auto* svgElement = dynamicDowncast<SVGElement>(element);
+    RefPtr svgElement = dynamicDowncast<SVGElement>(element);
     return !svgElement || isDisallowedElement(*svgElement);
 }
 
 void SVGUseElement::clearShadowTree()
 {
-    if (auto root = userAgentShadowRoot()) {
+    if (RefPtr root = userAgentShadowRoot()) {
         // Safe because SVG use element's shadow tree is never used to fire synchronous events during layout or DOM mutations.
         ScriptDisallowedScope::EventAllowedScope scope(*root);
         root->removeChildren();
@@ -258,18 +260,18 @@ void SVGUseElement::updateUserAgentShadowTree()
 
     if (!isConnected())
         return;
-    document().removeElementWithPendingUserAgentShadowTreeUpdate(*this);
+    protectedDocument()->removeElementWithPendingUserAgentShadowTreeUpdate(*this);
 
     AtomString targetID;
-    auto* target = findTarget(&targetID);
+    RefPtr target = findTarget(&targetID);
     if (!target) {
         treeScopeForSVGReferences().addPendingSVGResource(targetID, *this);
         return;
     }
 
-    RELEASE_ASSERT(!isDescendantOf(target));
+    RELEASE_ASSERT(!isDescendantOf(target.get()));
     {
-        auto& shadowRoot = ensureUserAgentShadowRoot();
+        Ref shadowRoot = ensureUserAgentShadowRoot();
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
         cloneTarget(shadowRoot, *target);
         expandUseElementsInShadowTree();
@@ -291,7 +293,7 @@ void SVGUseElement::updateUserAgentShadowTree()
 
 RefPtr<SVGElement> SVGUseElement::targetClone() const
 {
-    auto root = userAgentShadowRoot();
+    RefPtr root = userAgentShadowRoot();
     if (!root)
         return nullptr;
     return childrenOfType<SVGElement>(*root).first();
@@ -344,7 +346,7 @@ Path SVGUseElement::toClipPath()
 
 RefPtr<SVGElement> SVGUseElement::clipChild() const
 {
-    auto targetClone = this->targetClone();
+    RefPtr targetClone = this->targetClone();
     if (!targetClone || !isDirectReference(*targetClone))
         return nullptr;
     return targetClone;
@@ -352,7 +354,7 @@ RefPtr<SVGElement> SVGUseElement::clipChild() const
 
 RenderElement* SVGUseElement::rendererClipChild() const
 {
-    auto targetClone = this->targetClone();
+    RefPtr targetClone = this->targetClone();
     if (!targetClone)
         return nullptr;
     if (!isDirectReference(*targetClone))
@@ -362,10 +364,10 @@ RenderElement* SVGUseElement::rendererClipChild() const
 
 static inline void disassociateAndRemoveClones(const Vector<Ref<Element>>& clones)
 {
-    for (auto& clone : clones) {
-        for (auto& descendant : descendantsOfType<SVGElement>(clone.get()))
-            descendant.setCorrespondingElement(nullptr);
-        if (auto* svgClone = dynamicDowncast<SVGElement>(clone.get()))
+    for (Ref clone : clones) {
+        for (Ref descendant : descendantsOfType<SVGElement>(clone.get()))
+            descendant->setCorrespondingElement(nullptr);
+        if (RefPtr svgClone = dynamicDowncast<SVGElement>(clone.get()))
             svgClone->setCorrespondingElement(nullptr);
         clone->remove();
     }
@@ -427,10 +429,10 @@ static void associateClonesWithOriginals(SVGElement& clone, SVGElement& original
 
 static void associateReplacementCloneWithOriginal(SVGElement& replacementClone, SVGElement& originalClone)
 {
-    auto* correspondingElement = originalClone.correspondingElement();
+    RefPtr correspondingElement = originalClone.correspondingElement();
     ASSERT(correspondingElement);
     originalClone.setCorrespondingElement(nullptr);
-    replacementClone.setCorrespondingElement(correspondingElement);
+    replacementClone.setCorrespondingElement(correspondingElement.get());
 }
 
 static void associateReplacementClonesWithOriginals(SVGElement& replacementClone, SVGElement& originalClone)
@@ -446,22 +448,22 @@ static void associateReplacementClonesWithOriginals(SVGElement& replacementClone
         associateReplacementCloneWithOriginal(pair.first, pair.second);
 }
 
-SVGElement* SVGUseElement::findTarget(AtomString* targetID) const
+RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
 {
-    auto* correspondingElement = this->correspondingElement();
-    auto& original = correspondingElement ? downcast<SVGUseElement>(*correspondingElement) : *this;
+    RefPtr correspondingElement = this->correspondingElement();
+    Ref original = correspondingElement ? downcast<SVGUseElement>(*correspondingElement) : *this;
 
-    auto targetResult = targetElementFromIRIString(original.href(), original.treeScope(), original.externalDocument());
+    auto targetResult = targetElementFromIRIString(original->href(), original->treeScope(), original->externalDocument());
     if (targetID) {
         *targetID = WTFMove(targetResult.identifier);
         // If the reference is external, don't return the target ID to the caller.
         // The caller would use the target ID to wait for a pending resource on the wrong document.
         // If we ever want the change that and let the caller to wait on the external document,
         // we should change this function so it returns the appropriate document to go with the ID.
-        if (!targetID->isNull() && isExternalURIReference(original.href(), original.document()))
+        if (!targetID->isNull() && isExternalURIReference(original->href(), original->document()))
             *targetID = nullAtom();
     }
-    auto* target = dynamicDowncast<SVGElement>(targetResult.element.get());
+    RefPtr target = dynamicDowncast<SVGElement>(targetResult.element.get());
     if (!target)
         return nullptr;
 
@@ -477,7 +479,7 @@ SVGElement* SVGUseElement::findTarget(AtomString* targetID) const
         if (target->contains(this))
             return nullptr;
         // Target should only refer to a node in the same tree or a node in another document.
-        ASSERT(!isDescendantOrShadowDescendantOf(target));
+        ASSERT(!isDescendantOrShadowDescendantOf(target.get()));
     }
 
     return target;
@@ -485,7 +487,7 @@ SVGElement* SVGUseElement::findTarget(AtomString* targetID) const
 
 void SVGUseElement::cloneTarget(ContainerNode& container, SVGElement& target) const
 {
-    Ref<SVGElement> targetClone = static_cast<SVGElement&>(target.cloneElementWithChildren(document()).get());
+    Ref targetClone = static_cast<SVGElement&>(target.cloneElementWithChildren(document()).get());
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { targetClone };
     associateClonesWithOriginals(targetClone.get(), target);
     removeDisallowedElementsFromSubtree(targetClone.get());
@@ -510,15 +512,15 @@ void SVGUseElement::expandUseElementsInShadowTree() const
 {
     auto descendants = descendantsOfType<SVGUseElement>(*userAgentShadowRoot());
     for (auto it = descendants.begin(); it; ) {
-        SVGUseElement& originalClone = *it;
+        Ref originalClone = *it;
         it.dropAssertions();
 
-        auto* target = originalClone.findTarget();
+        RefPtr target = originalClone->findTarget();
 
         // Spec: In the generated content, the 'use' will be replaced by 'g', where all attributes from the
         // 'use' element except for x, y, width, height and xlink:href are transferred to the generated 'g' element.
 
-        auto replacementClone = SVGGElement::create(document());
+        Ref replacementClone = SVGGElement::create(document());
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { replacementClone };
 
         cloneDataAndChildren(replacementClone.get(), originalClone);
@@ -531,9 +533,9 @@ void SVGUseElement::expandUseElementsInShadowTree() const
         replacementClone->removeAttribute(XLinkNames::hrefAttr);
 
         if (target)
-            originalClone.cloneTarget(replacementClone.get(), *target);
+            originalClone->cloneTarget(replacementClone.get(), *target);
 
-        originalClone.parentNode()->replaceChild(replacementClone, originalClone);
+        originalClone->protectedParentNode()->replaceChild(replacementClone, originalClone);
 
         // Resume iterating, starting just inside the replacement clone.
         it = descendants.from(replacementClone.get());
@@ -544,7 +546,7 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
 {
     auto descendants = descendantsOfType<SVGSymbolElement>(*userAgentShadowRoot());
     for (auto it = descendants.begin(); it; ) {
-        SVGSymbolElement& originalClone = *it;
+        Ref originalClone = *it;
         it.dropAssertions();
 
         // Spec: The referenced 'symbol' and its contents are deep-cloned into the generated tree,
@@ -554,12 +556,12 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
         // the generated 'svg'. If attributes width and/or height are not specified, the generated
         // 'svg' element will use values of 100% for these attributes.
 
-        auto replacementClone = SVGSVGElement::create(document());
+        Ref replacementClone = SVGSVGElement::create(document());
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { replacementClone };
 
         cloneDataAndChildren(replacementClone.get(), originalClone);
 
-        originalClone.parentNode()->replaceChild(replacementClone, originalClone);
+        originalClone->protectedParentNode()->replaceChild(replacementClone, originalClone);
 
         // Resume iterating, starting just inside the replacement clone.
         it = descendants.from(replacementClone.get());
@@ -569,9 +571,9 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
 void SVGUseElement::transferEventListenersToShadowTree() const
 {
     // FIXME: Don't directly add event listeners on each descendant. Copy event listeners on the use element instead.
-    for (auto& descendant : descendantsOfType<SVGElement>(*userAgentShadowRoot())) {
-        if (EventTargetData* data = descendant.correspondingElement()->eventTargetData())
-            data->eventListenerMap.copyEventListenersNotCreatedFromMarkupToTarget(&descendant);
+    for (Ref descendant : descendantsOfType<SVGElement>(*userAgentShadowRoot())) {
+        if (EventTargetData* data = descendant->correspondingElement()->eventTargetData())
+            data->eventListenerMap.copyEventListenersNotCreatedFromMarkupToTarget(descendant.ptr());
     }
 }
 
@@ -582,14 +584,16 @@ void SVGUseElement::invalidateShadowTree()
     m_shadowTreeNeedsUpdate = true;
     invalidateStyleAndRenderersForSubtree();
     invalidateDependentShadowTrees();
-    if (isConnected())
-        document().addElementWithPendingUserAgentShadowTreeUpdate(*this);
+    if (isConnected()) {
+        RefAllowingPartiallyDestroyed<Document> document = this->document();
+        document->addElementWithPendingUserAgentShadowTreeUpdate(*this);
+    }
 }
 
 void SVGUseElement::invalidateDependentShadowTrees()
 {
     for (auto& instance : copyToVectorOf<Ref<SVGElement>>(instances())) {
-        if (auto element = instance->correspondingUseElement())
+        if (RefPtr element = instance->correspondingUseElement())
             element->invalidateShadowTree();
     }
 }
@@ -599,7 +603,7 @@ bool SVGUseElement::selfHasRelativeLengths() const
     if (x().isRelative() || y().isRelative() || width().isRelative() || height().isRelative())
         return true;
 
-    auto targetClone = this->targetClone();
+    RefPtr targetClone = this->targetClone();
     return targetClone && targetClone->hasRelativeLengths();
 }
 
@@ -617,8 +621,9 @@ void SVGUseElement::notifyFinished(CachedResource& resource, const NetworkLoadMe
 void SVGUseElement::updateExternalDocument()
 {
     URL externalDocumentURL;
-    if (isConnected() && isExternalURIReference(href(), document())) {
-        externalDocumentURL = document().completeURL(href());
+    RefAllowingPartiallyDestroyed<Document> document = this->document();
+    if (isConnected() && isExternalURIReference(href(), document)) {
+        externalDocumentURL = document->completeURL(href());
         if (!externalDocumentURL.hasFragmentIdentifier())
             externalDocumentURL = URL();
     }
@@ -626,8 +631,8 @@ void SVGUseElement::updateExternalDocument()
     if (externalDocumentURL == (m_externalDocument ? m_externalDocument->url() : URL()))
         return;
 
-    if (m_externalDocument)
-        m_externalDocument->removeClient(*this);
+    if (CachedResourceHandle externalDocument = m_externalDocument)
+        externalDocument->removeClient(*this);
 
     if (externalDocumentURL.isNull())
         m_externalDocument = nullptr;
@@ -638,9 +643,9 @@ void SVGUseElement::updateExternalDocument()
         options.destination = FetchOptions::Destination::Image;
         CachedResourceRequest request { ResourceRequest { externalDocumentURL }, options };
         request.setInitiator(*this);
-        m_externalDocument = document().cachedResourceLoader().requestSVGDocument(WTFMove(request)).value_or(nullptr);
-        if (m_externalDocument)
-            m_externalDocument->addClient(*this);
+        m_externalDocument = document->protectedCachedResourceLoader()->requestSVGDocument(WTFMove(request)).value_or(nullptr);
+        if (CachedResourceHandle externalDocument = m_externalDocument)
+            externalDocument->addClient(*this);
     }
 
     invalidateShadowTree();

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -73,7 +73,7 @@ private:
     Document* externalDocument() const;
     void updateExternalDocument();
 
-    SVGElement* findTarget(AtomString* targetID = nullptr) const;
+    RefPtr<SVGElement> findTarget(AtomString* targetID = nullptr) const;
 
     void cloneTarget(ContainerNode&, SVGElement& target) const;
     RefPtr<SVGElement> targetClone() const;

--- a/Source/WebCore/svg/SVGViewElement.cpp
+++ b/Source/WebCore/svg/SVGViewElement.cpp
@@ -59,10 +59,11 @@ void SVGViewElement::svgAttributeChanged(const QualifiedName& attrName)
         return;
 
     if (SVGFitToViewBox::isKnownAttribute(attrName)) {
-        if (!m_targetElement)
+        RefPtr targetElement = m_targetElement.get();
+        if (!targetElement)
             return;
-        m_targetElement->inheritViewAttributes(*this);
-        m_targetElement->updateSVGRendererForElementChange();
+        targetElement->inheritViewAttributes(*this);
+        targetElement->updateSVGRendererForElementChange();
         return;
     }
 

--- a/Source/WebCore/svg/SVGViewSpec.cpp
+++ b/Source/WebCore/svg/SVGViewSpec.cpp
@@ -45,15 +45,21 @@ SVGViewSpec::SVGViewSpec(SVGElement& contextElement)
 
 RefPtr<SVGElement> SVGViewSpec::viewTarget() const
 {
-    if (!m_contextElement)
+    RefPtr contextElement = m_contextElement.get();
+    if (!contextElement)
         return nullptr;
-    return dynamicDowncast<SVGElement>(m_contextElement->treeScope().getElementById(m_viewTargetString));
+    return dynamicDowncast<SVGElement>(contextElement->treeScope().getElementById(m_viewTargetString));
+}
+
+Ref<SVGTransformList> SVGViewSpec::protectedTransform()
+{
+    return m_transform;
 }
 
 void SVGViewSpec::reset()
 {
     m_viewTargetString = emptyString();
-    m_transform->clearItems();
+    protectedTransform()->clearItems();
     SVGFitToViewBox::reset();
     SVGZoomAndPan::reset();
 }
@@ -128,7 +134,7 @@ bool SVGViewSpec::parseViewSpec(StringView string)
                     return false;
                 if (!skipExactly(buffer, '('))
                     return false;
-                m_transform->parse(buffer);
+                protectedTransform()->parse(buffer);
                 if (!skipExactly(buffer, ')'))
                     return false;
             } else

--- a/Source/WebCore/svg/SVGViewSpec.h
+++ b/Source/WebCore/svg/SVGViewSpec.h
@@ -46,6 +46,7 @@ public:
 
     String transformString() const { return m_transform->valueAsString(); }
     Ref<SVGTransformList>& transform() { return m_transform; }
+    Ref<SVGTransformList> protectedTransform();
 
     const WeakPtr<SVGElement, WeakPtrImplWithEventTargetData>& contextElementConcurrently() const { return m_contextElement; }
 

--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -83,7 +83,7 @@ void SMILTimeContainer::notifyIntervalsChanged()
 
 Seconds SMILTimeContainer::animationFrameDelay() const
 {
-    auto* page = m_ownerSVGElement.document().page();
+    auto* page = m_ownerSVGElement->document().page();
     if (!page)
         return SMILAnimationFrameDelay;
     return page->isLowPowerModeEnabled() ? SMILAnimationFrameThrottledDelay : SMILAnimationFrameDelay;
@@ -217,8 +217,8 @@ void SMILTimeContainer::updateDocumentOrderIndexes()
 {
     unsigned timingElementCount = 0;
 
-    for (auto& smilElement : descendantsOfType<SVGSMILElement>(m_ownerSVGElement))
-        smilElement.setDocumentOrderIndex(timingElementCount++);
+    for (Ref smilElement : descendantsOfType<SVGSMILElement>(m_ownerSVGElement))
+        smilElement->setDocumentOrderIndex(timingElementCount++);
 
     m_documentOrderIndexesDirty = false;
 }
@@ -250,7 +250,7 @@ void SMILTimeContainer::sortByPriority(AnimationsVector& animations, SMILTime el
 void SMILTimeContainer::processScheduledAnimations(const Function<void(SVGSMILElement&)>& callback)
 {
     for (auto& animations : copyToVector(m_scheduledAnimations.values())) {
-        for (auto* animation : animations)
+        for (RefPtr animation : animations)
             callback(*animation);
     }
 }
@@ -280,7 +280,7 @@ void SMILTimeContainer::updateAnimations(SMILTime elapsed, bool seekToTime)
         sortByPriority(animations, elapsed);
 
         RefPtr<SVGSMILElement> firstAnimation;
-        for (auto* animation : animations) {
+        for (RefPtr animation : animations) {
             ASSERT(animation->timeContainer() == this);
             ASSERT(animation->targetElement());
             ASSERT(animation->hasValidAttributeName());
@@ -306,7 +306,7 @@ void SMILTimeContainer::updateAnimations(SMILTime elapsed, bool seekToTime)
     }
 
     // Apply results to target elements.
-    for (auto& animation : animationsToApply)
+    for (RefPtr animation : animationsToApply)
         animation->applyResultsToTarget();
 
     startTimer(elapsed, earliestFireTime, animationFrameDelay());

--- a/Source/WebCore/svg/animation/SMILTimeContainer.h
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class SVGElement;
 class SVGSMILElement;
 class SVGSVGElement;
+class WeakPtrImplWithEventTargetData;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SMILTimeContainer);
 class SMILTimeContainer final : public RefCounted<SMILTimeContainer>  {
@@ -88,7 +89,7 @@ private:
     bool m_documentOrderIndexesDirty { false };
     Timer m_timer;
     GroupedAnimationsMap m_scheduledAnimations;
-    SVGSVGElement& m_ownerSVGElement;
+    WeakRef<SVGSVGElement, WeakPtrImplWithEventTargetData> m_ownerSVGElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -57,6 +57,7 @@ public:
     virtual void animationAttributeChanged() = 0;
 
     SMILTimeContainer* timeContainer() { return m_timeContainer.get(); }
+    RefPtr<SMILTimeContainer> protectedTimeContainer() const;
 
     SVGElement* targetElement() const { return m_targetElement.get(); }
     RefPtr<SVGElement> protectedTargetElement() const { return m_targetElement.get(); }

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -46,6 +46,7 @@ public:
 
     RenderBox* embeddedContentBox() const;
     LocalFrameView* frameView() const;
+    RefPtr<LocalFrameView> protectedFrameView() const;
 
     bool isSVGImage() const final { return true; }
     FloatSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final { return m_intrinsicSize; }

--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -61,12 +61,17 @@ void SVGImageCache::setContainerContextForClient(const CachedImageClient& client
     FloatSize containerSizeWithoutZoom(containerSize);
     containerSizeWithoutZoom.scale(1 / containerZoom);
 
-    m_imageForContainerMap.set(&client, SVGImageForContainer::create(m_svgImage, containerSizeWithoutZoom, containerZoom, imageURL));
+    m_imageForContainerMap.set(&client, SVGImageForContainer::create(protectedSVGImage().get(), containerSizeWithoutZoom, containerZoom, imageURL));
 }
 
 Image* SVGImageCache::findImageForRenderer(const RenderObject* renderer) const
 {
     return renderer ? m_imageForContainerMap.get(renderer) : nullptr;
+}
+
+RefPtr<SVGImage> SVGImageCache::protectedSVGImage() const
+{
+    return m_svgImage.get();
 }
 
 FloatSize SVGImageCache::imageSizeForRenderer(const RenderObject* renderer) const

--- a/Source/WebCore/svg/graphics/SVGImageCache.h
+++ b/Source/WebCore/svg/graphics/SVGImageCache.h
@@ -49,10 +49,11 @@ public:
 
 private:
     Image* findImageForRenderer(const RenderObject*) const;
+    RefPtr<SVGImage> protectedSVGImage() const;
 
     typedef HashMap<const CachedImageClient*, RefPtr<SVGImageForContainer>> ImageForContainerMap;
 
-    SVGImage* m_svgImage;
+    WeakPtr<SVGImage> m_svgImage;
     ImageForContainerMap m_imageForContainerMap;
 };
 

--- a/Source/WebCore/svg/graphics/SVGImageClients.h
+++ b/Source/WebCore/svg/graphics/SVGImageClients.h
@@ -64,7 +64,7 @@ private:
         if (!image || !image->internalPage())
             return;
 
-        auto imageObserver = image->imageObserver();
+        RefPtr imageObserver = image->imageObserver();
         if (!imageObserver)
             return;
 
@@ -76,7 +76,7 @@ private:
         RefPtr image { m_image.get() };
         if (!image)
             return true;
-        if (auto imageObserver = image->imageObserver())
+        if (RefPtr imageObserver = image->imageObserver())
             imageObserver->scheduleRenderingUpdate(*image);
         return true;
     }

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
@@ -27,13 +27,17 @@
 
 namespace WebCore {
 
-
 SVGImageForContainer::SVGImageForContainer(SVGImage* image, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL)
     : m_image(image)
     , m_containerSize(containerSize)
     , m_containerZoom(containerZoom)
     , m_initialFragmentURL(initialFragmentURL)
 {
+}
+
+RefPtr<SVGImage> SVGImageForContainer::protectedImage() const
+{
+    return m_image.get();
 }
 
 FloatSize SVGImageForContainer::size(ImageOrientation) const
@@ -45,18 +49,18 @@ FloatSize SVGImageForContainer::size(ImageOrientation) const
 
 ImageDrawResult SVGImageForContainer::draw(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    return m_image->drawForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, dstRect, srcRect, options);
+    return protectedImage()->drawForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, dstRect, srcRect, options);
 }
 
 void SVGImageForContainer::drawPattern(GraphicsContext& context, const FloatRect& dstRect, const FloatRect& srcRect, const AffineTransform& patternTransform,
     const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    m_image->drawPatternForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, srcRect, patternTransform, phase, spacing, dstRect, options);
+    protectedImage()->drawPatternForContainer(context, m_containerSize, m_containerZoom, m_initialFragmentURL, srcRect, patternTransform, phase, spacing, dstRect, options);
 }
 
 RefPtr<NativeImage> SVGImageForContainer::nativeImageForCurrentFrame()
 {
-    return m_image->nativeImageForCurrentFrame();
+    return protectedImage()->nativeImageForCurrentFrame();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.h
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.h
@@ -50,7 +50,7 @@ public:
     bool hasRelativeHeight() const final { return m_image->hasRelativeHeight(); }
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio) final
     {
-        m_image->computeIntrinsicDimensions(intrinsicWidth, intrinsicHeight, intrinsicRatio);
+        protectedImage()->computeIntrinsicDimensions(intrinsicWidth, intrinsicHeight, intrinsicRatio);
     }
 
     ImageDrawResult draw(GraphicsContext&, const FloatRect&, const FloatRect&, ImagePaintingOptions = { }) final;
@@ -64,8 +64,9 @@ public:
 
 private:
     WEBCORE_EXPORT SVGImageForContainer(SVGImage*, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL);
+    RefPtr<SVGImage> protectedImage() const;
 
-    SVGImage* m_image;
+    WeakPtr<SVGImage> m_image;
     const FloatSize m_containerSize;
     const float m_containerZoom;
     const URL m_initialFragmentURL;

--- a/Source/WebCore/svg/graphics/SVGResourceImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGResourceImage.cpp
@@ -45,7 +45,7 @@ SVGResourceImage::SVGResourceImage(LegacyRenderSVGResourceContainer& renderResou
 
 ImageDrawResult SVGResourceImage::draw(GraphicsContext& context, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions options)
 {
-    if (auto* masker = dynamicDowncast<LegacyRenderSVGResourceMasker>(m_renderResource.get())) {
+    if (CheckedPtr masker = dynamicDowncast<LegacyRenderSVGResourceMasker>(m_renderResource.get())) {
         if (masker->drawContentIntoContext(context, destinationRect, sourceRect, options))
             return ImageDrawResult::DidDraw;
     }
@@ -55,7 +55,7 @@ ImageDrawResult SVGResourceImage::draw(GraphicsContext& context, const FloatRect
 
 void SVGResourceImage::drawPattern(GraphicsContext& context, const FloatRect& destinationRect, const FloatRect& sourceRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    auto imageBuffer = context.createImageBuffer(size());
+    RefPtr imageBuffer = context.createImageBuffer(size());
     if (!imageBuffer)
         return;
 


### PR DESCRIPTION
#### 2f2b5910c34e6b13e2a688151d9149f93dd92331
<pre>
Further adoption of smart pointers in SVG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=269133">https://bugs.webkit.org/show_bug.cgi?id=269133</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::checkedRenderView const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::checkedViewportContainer const):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/svg/SVGPolyElement.cpp:
(WebCore::SVGPolyElement::svgAttributeChanged):
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::attributeChanged):
(WebCore::SVGRadialGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGRectElement.cpp:
(WebCore::SVGRectElement::attributeChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::~SVGSVGElement):
(WebCore::SVGSVGElement::didMoveToNewDocument):
(WebCore::SVGSVGElement::updateCurrentTranslate):
(WebCore::SVGSVGElement::attributeChanged):
(WebCore::SVGSVGElement::svgAttributeChanged):
(WebCore::SVGSVGElement::collectIntersectionOrEnclosureList):
(WebCore::checkIntersectionWithoutUpdatingLayout):
(WebCore::checkEnclosureWithoutUpdatingLayout):
(WebCore::SVGSVGElement::getIntersectionList):
(WebCore::SVGSVGElement::getEnclosureList):
(WebCore::SVGSVGElement::checkIntersection):
(WebCore::SVGSVGElement::checkEnclosure):
(WebCore::SVGSVGElement::deselectAll):
(WebCore::SVGSVGElement::localCoordinateSpaceTransform const):
(WebCore::SVGSVGElement::createElementRenderer):
(WebCore::SVGSVGElement::pauseAnimations):
(WebCore::SVGSVGElement::unpauseAnimations):
(WebCore::SVGSVGElement::animationsPaused const):
(WebCore::SVGSVGElement::hasActiveAnimation const):
(WebCore::SVGSVGElement::getCurrentTime const):
(WebCore::SVGSVGElement::setCurrentTime):
(WebCore::SVGSVGElement::currentViewBoxRect const):
(WebCore::SVGSVGElement::currentViewportSizeExcludingZoom const):
(WebCore::SVGSVGElement::viewBoxToViewTransform const):
(WebCore::SVGSVGElement::findViewAnchor const):
(WebCore::SVGSVGElement::scrollToFragment):
(WebCore::SVGSVGElement::protectedTimeContainer const):
(WebCore::SVGSVGElement::resetScrollAnchor):
(WebCore::SVGSVGElement::inheritViewAttributes):
(WebCore::SVGSVGElement::protectedTimeContainer): Deleted.
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/SVGStopElement.cpp:
(WebCore::SVGStopElement::attributeChanged):
* Source/WebCore/svg/SVGStyleElement.cpp:
(WebCore::SVGStyleElement::attributeChanged):
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::create):
(WebCore::SVGTRefTargetEventListener::SVGTRefTargetEventListener):
(WebCore::SVGTRefTargetEventListener::detach):
(WebCore::SVGTRefTargetEventListener::handleEvent):
(WebCore::SVGTRefElement::~SVGTRefElement):
(WebCore::SVGTRefElement::protectedTargetListener const):
(WebCore::SVGTRefElement::updateReferencedText):
(WebCore::SVGTRefElement::detachTarget):
(WebCore::SVGTRefElement::clearTarget):
(WebCore::SVGTRefElement::buildPendingResource):
(WebCore::SVGTRefElement::removedFromAncestor):
* Source/WebCore/svg/SVGTRefElement.h:
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGTests::protectedRequiredFeatures):
(WebCore::SVGTests::protectedRequiredExtensions):
(WebCore::SVGTests::protectedSystemLanguage):
(WebCore::SVGTests::parseAttribute):
(WebCore::SVGTests::svgAttributeChanged):
(WebCore::SVGTests::protectedContextElement const):
(WebCore::SVGTests::conditionalProcessingAttributes):
(WebCore::SVGTests::conditionalProcessingAttributesIfExists const):
* Source/WebCore/svg/SVGTests.h:
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::getNumberOfChars):
(WebCore::SVGTextContentElement::getComputedTextLength):
(WebCore::SVGTextContentElement::getSubStringLength):
(WebCore::SVGTextContentElement::getStartPositionOfChar):
(WebCore::SVGTextContentElement::getEndPositionOfChar):
(WebCore::SVGTextContentElement::getExtentOfChar):
(WebCore::SVGTextContentElement::getRotationOfChar):
(WebCore::SVGTextContentElement::getCharNumAtPosition):
(WebCore::SVGTextContentElement::selectSubString):
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::attributeChanged):
(WebCore::SVGTextPathElement::buildPendingResource):
* Source/WebCore/svg/SVGTextPositioningElement.cpp:
(WebCore::SVGTextPositioningElement::attributeChanged):
(WebCore::SVGTextPositioningElement::svgAttributeChanged):
* Source/WebCore/svg/SVGTitleElement.cpp:
(WebCore::SVGTitleElement::insertedIntoAncestor):
(WebCore::SVGTitleElement::removedFromAncestor):
(WebCore::SVGTitleElement::childrenChanged):
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::Placeholder::Placeholder):
(WebCore::SVGToOTFFontConverter::Placeholder::populate):
(WebCore::SVGToOTFFontConverter::appendOS2Table):
(WebCore::SVGToOTFFontConverter::appendVORGTable):
* Source/WebCore/svg/SVGTransform.h:
(WebCore::SVGTransform::create):
(WebCore::SVGTransform::~SVGTransform):
(WebCore::SVGTransform::matrix):
(WebCore::SVGTransform::protectedMatrix):
(WebCore::SVGTransform::SVGTransform):
* Source/WebCore/svg/SVGTransformList.cpp:
(WebCore::SVGTransformList::concatenate const):
* Source/WebCore/svg/SVGTransformList.h:
* Source/WebCore/svg/SVGTransformValue.h:
(WebCore::SVGTransformValue::SVGTransformValue):
(WebCore::SVGTransformValue::matrix const):
(WebCore::SVGTransformValue::protectedMatrix const):
(WebCore::SVGTransformValue::setMatrix):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::~SVGUseElement):
(WebCore::SVGUseElement::attributeChanged):
(WebCore::SVGUseElement::insertedIntoAncestor):
(WebCore::SVGUseElement::removedFromAncestor):
(WebCore::isDisallowedElement):
(WebCore::SVGUseElement::clearShadowTree):
(WebCore::SVGUseElement::updateUserAgentShadowTree):
(WebCore::SVGUseElement::targetClone const):
(WebCore::SVGUseElement::clipChild const):
(WebCore::SVGUseElement::rendererClipChild const):
(WebCore::disassociateAndRemoveClones):
(WebCore::associateReplacementCloneWithOriginal):
(WebCore::SVGUseElement::findTarget const):
(WebCore::SVGUseElement::cloneTarget const):
(WebCore::SVGUseElement::expandUseElementsInShadowTree const):
(WebCore::SVGUseElement::expandSymbolElementsInShadowTree const):
(WebCore::SVGUseElement::transferEventListenersToShadowTree const):
(WebCore::SVGUseElement::invalidateShadowTree):
(WebCore::SVGUseElement::invalidateDependentShadowTrees):
(WebCore::SVGUseElement::selfHasRelativeLengths const):
(WebCore::SVGUseElement::updateExternalDocument):
* Source/WebCore/svg/SVGUseElement.h:
* Source/WebCore/svg/SVGViewElement.cpp:
(WebCore::SVGViewElement::svgAttributeChanged):
* Source/WebCore/svg/SVGViewSpec.cpp:
(WebCore::SVGViewSpec::viewTarget const):
(WebCore::SVGViewSpec::protectedTransform):
(WebCore::SVGViewSpec::reset):
(WebCore::SVGViewSpec::parseViewSpec):
* Source/WebCore/svg/SVGViewSpec.h:
* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::animationFrameDelay const):
(WebCore::SMILTimeContainer::updateDocumentOrderIndexes):
(WebCore::SMILTimeContainer::processScheduledAnimations):
(WebCore::SMILTimeContainer::updateAnimations):
* Source/WebCore/svg/animation/SMILTimeContainer.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::ConditionEventListener::handleEvent):
(WebCore::SVGSMILElement::~SVGSMILElement):
(WebCore::SVGSMILElement::reset):
(WebCore::SVGSMILElement::protectedTimeContainer const):
(WebCore::SVGSMILElement::insertedIntoAncestor):
(WebCore::SVGSMILElement::connectConditions):
(WebCore::SVGSMILElement::setAttributeName):
(WebCore::SVGSMILElement::setTargetElement):
(WebCore::SVGSMILElement::resolveFirstInterval):
(WebCore::SVGSMILElement::beginListChanged):
(WebCore::SVGSMILElement::endListChanged):
(WebCore::SVGSMILElement::notifyDependentsIntervalChanged):
* Source/WebCore/svg/animation/SVGSMILElement.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::rootElement const):
(WebCore::SVGImage::renderingTaintsOrigin const):
(WebCore::SVGImage::setContainerSize):
(WebCore::SVGImage::containerSize const):
(WebCore::SVGImage::drawForContainer):
(WebCore::SVGImage::nativeImage):
(WebCore::SVGImage::drawPatternForContainer):
(WebCore::SVGImage::draw):
(WebCore::SVGImage::embeddedContentBox const):
(WebCore::SVGImage::protectedFrameView const):
(WebCore::SVGImage::hasRelativeWidth const):
(WebCore::SVGImage::hasRelativeHeight const):
(WebCore::SVGImage::computeIntrinsicDimensions):
(WebCore::SVGImage::scheduleStartAnimation):
(WebCore::SVGImage::startAnimation):
(WebCore::SVGImage::resumeAnimation):
(WebCore::SVGImage::stopAnimation):
(WebCore::SVGImage::isAnimating const):
(WebCore::SVGImage::reportApproximateMemoryCost const):
(WebCore::SVGImage::dataChanged):
(WebCore::isInSVGImage):
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebCore/svg/graphics/SVGImageCache.cpp:
(WebCore::SVGImageCache::setContainerContextForClient):
(WebCore::SVGImageCache::protectedSVGImage const):
* Source/WebCore/svg/graphics/SVGImageCache.h:
* Source/WebCore/svg/graphics/SVGImageClients.h:
* Source/WebCore/svg/graphics/SVGImageForContainer.cpp:
(WebCore::SVGImageForContainer::protectedImage const):
(WebCore::SVGImageForContainer::draw):
(WebCore::SVGImageForContainer::drawPattern):
(WebCore::SVGImageForContainer::nativeImageForCurrentFrame):
* Source/WebCore/svg/graphics/SVGImageForContainer.h:
* Source/WebCore/svg/graphics/SVGResourceImage.cpp:
(WebCore::SVGResourceImage::draw):
(WebCore::SVGResourceImage::drawPattern):

Canonical link: <a href="https://commits.webkit.org/274436@main">https://commits.webkit.org/274436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a724362906f615f5c44d207d0da40c0b24713bf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39047 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41581 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32678 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38942 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37173 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15127 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5108 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->