### PR TITLE
Load WebArchives with non-persistent datastore

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -895,6 +895,7 @@ void Connection::processIncomingMessage(UniqueRef<Decoder> message)
     }
 
     if (!MessageReceiveQueueMap::isValidMessage(*message)) {
+        WTFLogAlways("Connection::processIncomingMessage: MessageReceiveQueueMap::isValidMessage");
         dispatchDidReceiveInvalidMessage(message->messageName());
         return;
     }
@@ -943,6 +944,7 @@ void Connection::processIncomingMessage(UniqueRef<Decoder> message)
     }
 
     if ((message->shouldDispatchMessageWhenWaitingForSyncReply() == ShouldDispatchWhenWaitingForSyncReply::YesDuringUnboundedIPC && !message->isAllowedWhenWaitingForUnboundedSyncReply()) || (message->shouldDispatchMessageWhenWaitingForSyncReply() == ShouldDispatchWhenWaitingForSyncReply::Yes && !message->isAllowedWhenWaitingForSyncReply())) {
+        WTFLogAlways("Connection::processIncomingMessage: shouldDispatchMessageWhenWaitingForSyncReply: %d, shouldDispatchMessageWhenWaitingForSyncReply: %d, isAllowedWhenWaitingForUnboundedSyncReply: %d", message->shouldDispatchMessageWhenWaitingForSyncReply() == ShouldDispatchWhenWaitingForSyncReply::YesDuringUnboundedIPC, message->shouldDispatchMessageWhenWaitingForSyncReply() == ShouldDispatchWhenWaitingForSyncReply::Yes, message->isAllowedWhenWaitingForUnboundedSyncReply());
         dispatchDidReceiveInvalidMessage(message->messageName());
         return;
     }
@@ -1133,6 +1135,7 @@ void Connection::dispatchSyncMessage(Decoder& decoder)
 
 void Connection::dispatchDidReceiveInvalidMessage(MessageName messageName)
 {
+    WTFReportBacktrace();
     dispatchToClient([protectedThis = Ref { *this }, messageName] {
         if (!protectedThis->isValid())
             return;

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -111,6 +111,7 @@ public:
     WARN_UNUSED_RETURN bool isValid() const { return !!m_buffer.data(); }
     void markInvalid()
     {
+        WTFReportBacktrace();
         auto buffer = std::exchange(m_buffer, { });
         if (m_bufferDeallocator && !buffer.empty())
             m_bufferDeallocator(WTFMove(buffer));

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -94,7 +94,7 @@ void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationPa
 
 void AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName)
 {
-    WTFLogAlways("AuxiliaryProcess::didReceiveInvalidMessage");
+    WTFLogAlways("AuxiliaryProcess::didReceiveInvalidMessage (Cocoa): isInWebProcess: %d", WebCore::isInWebProcess());
     WTFReportBacktrace();
     auto errorMessage = makeString("Received invalid message: '", description(messageName), "' (", messageName, ')');
     logAndSetCrashLogMessage(errorMessage.utf8().data());

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -94,6 +94,8 @@ void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationPa
 
 void AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName)
 {
+    WTFLogAlways("AuxiliaryProcess::didReceiveInvalidMessage");
+    WTFReportBacktrace();
     auto errorMessage = makeString("Received invalid message: '", description(messageName), "' (", messageName, ')');
     logAndSetCrashLogMessage(errorMessage.utf8().data());
     CRASH_WITH_INFO(WTF::enumToUnderlyingType(messageName));

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -84,6 +84,7 @@ struct LoadParameters {
     std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
     std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
     bool isServiceWorkerLoad { false };
+    bool isRequestFromClientOrUserInput;
 
 #if PLATFORM(COCOA)
     std::optional<double> dataDetectionReferenceDate;

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -48,6 +48,7 @@
     std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
     std::optional<WebKit::NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
     bool isServiceWorkerLoad;
+    bool isRequestFromClientOrUserInput;
 
 #if PLATFORM(COCOA)
     std::optional<double> dataDetectionReferenceDate;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -571,6 +571,8 @@ void GPUProcessProxy::didClose(IPC::Connection&)
 
 void GPUProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC::MessageName messageName)
 {
+    WTFLogAlways("GPUProcessProxy::didReceiveInvalidMessage");
+    WTFReportBacktrace();
     logInvalidMessage(connection, messageName);
 
     WebProcessPool::didReceiveInvalidMessage(messageName);

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -198,6 +198,8 @@ void ModelProcessProxy::didClose(IPC::Connection&)
 
 void ModelProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC::MessageName messageName)
 {
+    WTFLogAlways("ModelProcessProxy::didReceiveInvalidMessage");
+    WTFReportBacktrace();
     logInvalidMessage(connection, messageName);
 
     WebProcessPool::didReceiveInvalidMessage(messageName);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1206,6 +1206,8 @@ void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReas
 
 void WebProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC::MessageName messageName)
 {
+    WTFLogAlways("WebProcessProxy::didReceiveInvalidMessage");
+    WTFReportBacktrace();
     logInvalidMessage(connection, messageName);
 
     WebProcessPool::didReceiveInvalidMessage(messageName);


### PR DESCRIPTION
#### d032dc63720ef3926b69544b3459593d0c405dc5
<pre>
Load WebArchives with non-persistent datastore
<a href="https://bugs.webkit.org/show_bug.cgi?id=268724">https://bugs.webkit.org/show_bug.cgi?id=268724</a>
<a href="https://rdar.apple.com/122290562">rdar://122290562</a>

Reviewed by NOBODY (OOPS!).

Let&apos;s try loading web archives in non-persistent datastores.

* LayoutTests/platform/mac-wk1/webarchive/loading/test-loading-archive-subresource-expected.txt:
* LayoutTests/platform/mac-wk2/webarchive/loading/cache-expired-subresource-expected.txt: Copied from LayoutTests/platform/mac/webarchive/loading/cache-expired-subresource-expected.txt.
* LayoutTests/platform/mac-wk2/webarchive/loading/javascript-url-iframe-crash-expected.txt: Copied from LayoutTests/platform/wk2/webarchive/loading/video-in-webarchive-expected.txt.
* LayoutTests/platform/mac-wk2/webarchive/loading/object-expected.txt: Copied from LayoutTests/platform/wk2/webarchive/loading/video-in-webarchive-expected.txt.
* LayoutTests/platform/mac-wk2/webarchive/loading/test-loading-top-archive-expected.txt: Copied from LayoutTests/platform/wk2/webarchive/loading/video-in-webarchive-expected.txt.
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/mac/webarchive/loading/cache-expired-subresource-expected.txt:
* LayoutTests/platform/wk2/webarchive/loading/video-in-webarchive-expected.txt:
* LayoutTests/webarchive/loading/test-loading-archive-subresource-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::disallowWebArchive const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadWithNavigationAction):
(WebCore::FrameLoader::loadDifferentDocumentItem):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::isWebArchiveMIMEType):
* Source/WebCore/platform/MIMETypeRegistry.h:
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::dataStoreForWebArchive const):
(WebKit::WebBackForwardListItem::setDataStoreForWebArchive):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::backForwardAddItem):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
(WebKit::ProvisionalPageProxy::replacedDataStoreForWebArchiveLoad const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
(WebKit::WebPageProxy::backForwardAddItem):
(WebKit::WebPageProxy::backForwardAddItemShared):
(WebKit::WebPageProxy::queryPermission):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/download.example.webarchive: Added.
* Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm:
(TestWebKitAPI::TEST):
(TestWebKitAPI::constructArchive):
</pre>