### PR TITLE
Deadlock under ~PluginView() with PDFPlugin.

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not timeout.
+
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html
@@ -1,0 +1,17 @@
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  onload = async () => {
+    let iframe0 = document.createElement('iframe');
+    iframe0.src = 'data:application/pdf,x';
+    document.body.append(iframe0);
+
+    await caches.has('a');
+    await caches.has('a');
+
+    $vm.print('before');
+    iframe0.remove();
+    $vm.print('after');
+  };
+</script>
+<p>This test passes if it does not timeout.</p>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -31,6 +31,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Threading.h>
+#include <wtf/threads/BinarySemaphore.h>
 
 OBJC_CLASS PDFDocument;
 
@@ -118,6 +119,7 @@ private:
 
     RetainPtr<PDFDocument> m_backgroundThreadDocument;
     RefPtr<Thread> m_pdfThread;
+    BinarySemaphore m_dataSemaphore;
 
     Ref<PDFPluginStreamLoaderClient> m_streamLoaderClient;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -294,6 +294,7 @@ void PDFIncrementalLoader::clear()
     // we can force the PDFThread to complete quickly
     if (m_pdfThread) {
         unconditionalCompleteOutstandingRangeRequests();
+        m_dataSemaphore.signal();
         m_pdfThread->waitForCompletion();
     }
 }
@@ -649,19 +650,21 @@ size_t PDFIncrementalLoader::dataProviderGetBytesAtPosition(void* buffer, off_t 
         return 0;
     }
 
-    WTF::Semaphore dataSemaphore { 0 };
     size_t bytesProvided = 0;
+    // Do not dispatch main runloop (again) and wait anymore if plugin has been destroyed.
+    if (plugin->hasBeenDestroyed())
+        return 0;
 
-    RunLoop::main().dispatch([protectedLoader = Ref { *this }, position, count, buffer, &dataSemaphore, &bytesProvided] {
-        protectedLoader->getResourceBytesAtPosition(count, position, [count, buffer, &dataSemaphore, &bytesProvided](const uint8_t* bytes, size_t bytesCount) {
+    RunLoop::main().dispatch([this, protectedLoader = Ref { *this }, position, count, buffer, &bytesProvided] {
+        protectedLoader->getResourceBytesAtPosition(count, position, [this, count, buffer, &bytesProvided](const uint8_t* bytes, size_t bytesCount) {
             RELEASE_ASSERT(bytesCount <= count);
             memcpy(buffer, bytes, bytesCount);
             bytesProvided = bytesCount;
-            dataSemaphore.signal();
+            m_dataSemaphore.signal();
         });
     });
 
-    dataSemaphore.wait();
+    m_dataSemaphore.wait();
 
 #if !LOG_DISABLED
     decrementThreadsWaitingOnCallback();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -225,6 +225,7 @@ public:
 
 private:
     bool documentFinishedLoading() const { return m_documentFinishedLoading; }
+    bool hasBeenDestroyed() const { return m_hasBeenDestroyed; }
     uint64_t streamedBytes() const { return m_streamedBytes; }
     void ensureDataBufferLength(uint64_t);
 


### PR DESCRIPTION
#### 7175cd9a22b4a115e8fc413db3fb759b193b0b80
<pre>
Deadlock under ~PluginView() with PDFPlugin.
<a href="https://rdar.apple.com/108489643">rdar://108489643</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268536">https://bugs.webkit.org/show_bug.cgi?id=268536</a>

Reviewed by Simon Fraser.

dataProviderGetBytesAtPosition might be invoked recursively from CG, and it highly increased the possiblity when the main runloop is destructing the PDFPlugin,
while the another main runloop is dispatched from dataProviderGetBytesAtPosition and does not get chance to signal semaphore as it is waiting current runloop to finish,
that causes deadlock. This change is to stop dispatch main runloop when plugin has been destroyed and signal the semaphore before main thread calling waitForCompletion for m_pdfThread.

* LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt: Added.
* LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html: Added.
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::clear):
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::hasBeenDestroyed const):

Canonical link: <a href="https://commits.webkit.org/274694@main">https://commits.webkit.org/274694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d768c0b724254c2c2bdfed9e5ecbd89984cdc419

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42107 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35472 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33047 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43384 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39329 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37591 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8919 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->