### PR TITLE
Import `video-cookie.html` from Blink

### DIFF
--- a/LayoutTests/http/tests/media/video-cookie-expected.txt
+++ b/LayoutTests/http/tests/media/video-cookie-expected.txt
@@ -1,4 +1,4 @@
 
-EVENT(canplay)
-Tests that the media player will send the relevant cookies when requesting the media file.
+
+PASS Tests that the media player will send the relevant cookies when requesting the media file.
 

--- a/LayoutTests/http/tests/media/video-cookie.html
+++ b/LayoutTests/http/tests/media/video-cookie.html
@@ -1,38 +1,22 @@
-<html>
-<head>
-</head>
-<body onload="loadCookie()">
-<video id="video"></video>
-<script src=../../media-resources/video-test.js></script>
-<script src=../../media-resources/media-file.js></script>
+<!DOCTYPE html>
+<title>Tests that the media player will send the relevant cookies when requesting the media file.</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<body>
+<video></video>
 <script>
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        testRunner.setAlwaysAcceptCookies(true);
-        testRunner.waitUntilDone();
-    }
+async_test(function(t) {
+    var movie = "resources/test.mp4";
+    var frame = document.createElement("iframe");
+    document.body.appendChild(frame);
 
-    function loadCookie () {
-        var movie = findMediaFile("video", "resources/test");
-        var frame = document.createElement("iframe");
-        document.body.appendChild(frame);
+    frame.onload = t.step_func(function() {
+        var video = document.querySelector("video");
+        video.src="http://127.0.0.1:8000/media/resources/video-cookie-check-cookie.py";
+        video.oncanplay = t.step_func_done();
+        video.play();
+    });
 
-        frame.addEventListener('load', function () {
-                video = document.getElementById('video');
-                video.src="http://127.0.0.1:8000/media/resources/video-cookie-check-cookie.py";
-                video.play();
-        });
-
-        frame.width = 0;
-        frame.height = 0;
-        frame.src = "http://127.0.0.1:8000/media/resources/setCookie.cgi?name=" + movie;
-    }
-
-    waitForEvent("canplay", function () {
-        if (window.testRunner)
-            window.testRunner.notifyDone();
-    } );
+    frame.src = "http://127.0.0.1:8000/media/resources/setCookie.cgi?name=" + movie;
+});
 </script>
-Tests that the media player will send the relevant cookies when requesting the media file.<br/>
-</body>
-</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -751,8 +751,6 @@ webkit.org/b/236722 http/tests/media/video-play-waiting.html [ Timeout ]
 # This test requires generation of progress events during loading
 webkit.org/b/100984 media/progress-events-generated-correctly.html [ Failure ]
 
-webkit.org/b/34287 http/tests/media/video-cookie.html
-
 # needs enhanced eventSender.contextMenu() return value
 webkit.org/b/116651 media/context-menu-actions.html [ Skip ]
 


### PR DESCRIPTION
#### c2fcf98ab3ae6ce8936e952c96769bef6db6642b
<pre>
Import `video-cookie.html` from Blink

<a href="https://bugs.webkit.org/show_bug.cgi?id=34287">https://bugs.webkit.org/show_bug.cgi?id=34287</a>

Reviewed by Jean-Yves Avenard.

This patch is to import test from Blink with two changes:

1) Use `python` script for setting up server
2) Use `mp4` test file

Partial Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/5fbfa5d22ad8d973ecbd66c416ff3182eee623a4">https://source.chromium.org/chromium/chromium/src/+/5fbfa5d22ad8d973ecbd66c416ff3182eee623a4</a>

* LayoutTests/platform/mac/TestExpectations: Remove Test Expectation
* LayoutTests/http/tests/media/video-cookie.html: Updated Test Case
* LayoutTests/http/tests/media/video-cookie-expected.txt: Updated Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/274451@main">https://commits.webkit.org/274451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5628f600becac3de7b2a7eab1864559f860d845

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34796 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32700 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38966 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37194 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34083 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8755 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->