### PR TITLE
Import `video-error-abort.html` from Blink using `testharness`

### DIFF
--- a/LayoutTests/http/tests/media/video-error-abort-expected.txt
+++ b/LayoutTests/http/tests/media/video-error-abort-expected.txt
@@ -1,21 +1,4 @@
 
 
-Test before movie is open
-EXPECTED (video.error == 'null') OK
-
-'loadstart' event
-EXPECTED (video.error == 'null') OK
-RUN(video.load())
-
-'abort' event
-EXPECTED (video.error == 'null') OK
-EXPECTED (event.lengthComputable == 'undefined') OK
-
-'loadstart' event
-EXPECTED (video.error == 'null') OK
-
-'canplaythrough' event
-EXPECTED (video.error == 'null') OK
-
-END OF TEST
+PASS Test "abort" event.
 

--- a/LayoutTests/http/tests/media/video-error-abort.html
+++ b/LayoutTests/http/tests/media/video-error-abort.html
@@ -1,65 +1,31 @@
-<!DOCTYPE HTML>
-<html>
-    <head>
-        <title>'abort' event test</title>
-        <script src=../../media-resources/media-file.js></script>
-        <script src=../../media-resources/video-test.js></script>
-        <script>
-            var didLoad = false;
+<!DOCTYPE html>
+<title>Test "abort" event.</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<video></video>
+<script>
+async_test(function(t) {
+    var video = document.querySelector("video");
+    // Test before movie is open.
+    assert_equals(video.error, null);
+    video.onerror = t.unreached_func();
 
-            function loadstart()
-            {
-                consoleWrite("<br><b><em>'loadstart'</em> event</b>");
-                testExpected("video.error", null);
+    var watcher = new EventWatcher(t, video, ["loadstart", "abort", "canplaythrough"]);
+    watcher.wait_for("loadstart").then(t.step_func(function() {
+        assert_equals(video.error, null);
+        video.load();
+        return watcher.wait_for("abort");
+    })).then(t.step_func(function() {
+        assert_equals(video.error, null);
+        return watcher.wait_for("loadstart");
+    })).then(t.step_func(function() {
+        assert_equals(video.error, null);
+        return watcher.wait_for("canplaythrough");
+    })).then(t.step_func_done(function() {
+        assert_equals(video.error, null);
+    }));
 
-                if (didLoad)
-                    return; 
-                didLoad = true; 
-
-                // Force the element to reload, while the current movie is still loading,
-                // this should generate an 'abort' event
-                run("video.load()");
-            }
-
-            function abort()
-            {
-                consoleWrite("<br><b><em>'abort'</em> event</b>");
-                testExpected("video.error", null);
-
-                // Progress events have a 'lengthComputable' field, check to make sure this event
-                // doesn't have one.
-                testExpected("event.lengthComputable", undefined);
-            }
-
-            function canplaythrough()
-            {
-                consoleWrite("<br><b><em>'canplaythrough'</em> event</b>");
-                testExpected("video.error", null);
-
-                consoleWrite("");
-                endTest();
-            }
-
-            function start()
-            {
-                findMediaElement();
-
-                waitForEvent("error");
-
-                consoleWrite("<br><b>Test before movie is open</b>");
-                testExpected("video.error", null);
-
-                var movie = findMediaFile("video", "../resources/test");
-                video.src = "http://127.0.0.1:8000/media/video-throttled-load.cgi?name=" + movie + "&throttle=256&nph=1";
-            }
-        </script>
-    </head>
-
-    <body onload="start()">
-        <video controls
-            onloadstart="loadstart()"
-            onabort="abort()"
-            oncanplaythrough="canplaythrough()"
-            ></video>
-    </body>
-</html>
+    var movie = "resources/test.mp4";
+    video.src = "http://127.0.0.1:8000/media/video-throttled-load.cgi?name=" + movie + "&throttle=256";
+});
+</script>


### PR DESCRIPTION
#### 2582df18b6d41723de507d03879ab2428f9284e4
<pre>
Import `video-error-abort.html` from Blink using `testharness`

<a href="https://bugs.webkit.org/show_bug.cgi?id=269142">https://bugs.webkit.org/show_bug.cgi?id=269142</a>

Reviewed by Eric Carlson.

This patch is to import test from Blink, which was updated to use `testharness`.

Partial Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/5fbfa5d22ad8d973ecbd66c416ff3182eee623a4">https://source.chromium.org/chromium/chromium/src/+/5fbfa5d22ad8d973ecbd66c416ff3182eee623a4</a>

* LayoutTests/http/tests/media/video-error-abort.html: Updated Test Case
* LayoutTests/http/tests/media/video-error-abort-expected.txt: Updated Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/274550@main">https://commits.webkit.org/274550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/986d76b12df13dfaa2cc100f958b66b0079f7b36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41633 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34816 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32722 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42910 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38985 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37213 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34106 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8814 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->