### PR TITLE
Enforce requirement that keyword sources in CSP source expressions must be separated by whitespace

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/default-src/manifest-v3-default-src-block-non-https-scheme.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/default-src/manifest-v3-default-src-block-non-https-scheme.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><!-- webkit-test-runner [ contentSecurityPolicyExtensionMode=v3 ] -->
 <html>
 <head>
-    <meta http-equiv="Content-Security-Policy" content="script-src blob: 'self'';">
+    <meta http-equiv="Content-Security-Policy" content="script-src blob: 'self';">
     <script src="../../../resources/dump-as-text.js"></script>
     <script src="../../../resources/wait-until-done.js"></script>
     <p><br>Tests CSP for manifest v3 extensions does not permit non https schemes</p>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/script-src/manifest-v3-script-src-block-non-https-scheme.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/script-src/manifest-v3-script-src-block-non-https-scheme.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><!-- webkit-test-runner [ contentSecurityPolicyExtensionMode=v3 ] -->
 <html>
 <head>
-    <meta http-equiv="Content-Security-Policy" content="script-src blob: 'self'';">
+    <meta http-equiv="Content-Security-Policy" content="script-src blob: 'self';">
     <script src="../../../resources/dump-as-text.js"></script>
     <script src="../../../resources/wait-until-done.js"></script>
     <p><br>Tests CSP for manifest v3 extensions does not permit non https schemes</p>

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -85,11 +85,16 @@ template<typename CharacterType> static bool isNotColonOrSlash(CharacterType c)
     return c != ':' && c != '/';
 }
 
+template<typename CharacterType> static bool isKeywordSource(StringParsingBuffer<CharacterType>& buffer, ASCIILiteral literal)
+{
+    return skipExactlyIgnoringASCIICase(buffer, literal) && (buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
+}
+
 template<typename CharacterType> static bool isSourceListNone(StringParsingBuffer<CharacterType> buffer)
 {
     skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
-    if (!skipExactlyIgnoringASCIICase(buffer, "'none'"_s))
+    if (!isKeywordSource(buffer, "'none'"_s))
         return false;
 
     skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
@@ -290,7 +295,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
     if (buffer.atEnd())
         return std::nullopt;
 
-    if (skipExactlyIgnoringASCIICase(buffer, "'none'"_s))
+    if (isKeywordSource(buffer, "'none'"_s))
         return std::nullopt;
 
     Source source;
@@ -300,7 +305,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
         return source;
     }
 
-    if (skipExactlyIgnoringASCIICase(buffer, "'strict-dynamic'"_s)
+    if (isKeywordSource(buffer, "'strict-dynamic'"_s)
         && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)
         && (m_directiveName == ContentSecurityPolicyDirectiveNames::scriptSrc
             || m_directiveName == ContentSecurityPolicyDirectiveNames::scriptSrcElem || m_directiveName == ContentSecurityPolicyDirectiveNames::defaultSrc)) {
@@ -310,33 +315,33 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
         return source;
     }
 
-    if (skipExactlyIgnoringASCIICase(buffer, "'self'"_s)) {
+    if (isKeywordSource(buffer, "'self'"_s)) {
         m_allowSelf = !m_allowNonParserInsertedScripts;
-        return source;
+            return source;
     }
 
-    if (skipExactlyIgnoringASCIICase(buffer, "'unsafe-inline'"_s) && !isRestrictedDirectiveForMode(m_directiveName, m_contentSecurityPolicyModeForExtension)) {
+    if (isKeywordSource(buffer, "'unsafe-inline'"_s) && !isRestrictedDirectiveForMode(m_directiveName, m_contentSecurityPolicyModeForExtension)) {
         m_allowInline = !m_allowNonParserInsertedScripts;
         return source;
     }
 
-    if (skipExactlyIgnoringASCIICase(buffer, "'unsafe-eval'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
+    if (isKeywordSource(buffer, "'unsafe-eval'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
         m_allowEval = true;
         m_allowWasmEval = true;
         return source;
     }
 
-    if (skipExactlyIgnoringASCIICase(buffer, "'wasm-unsafe-eval'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
+    if (isKeywordSource(buffer, "'wasm-unsafe-eval'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
         m_allowWasmEval = true;
         return source;
     }
 
-    if (skipExactlyIgnoringASCIICase(buffer, "'unsafe-hashes'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
+    if (isKeywordSource(buffer, "'unsafe-hashes'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
         m_allowUnsafeHashes = true;
         return source;
     }
 
-    if (skipExactlyIgnoringASCIICase(buffer, "'report-sample'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
+    if (isKeywordSource(buffer, "'report-sample'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
         m_reportSample = true;
         return source;
     }


### PR DESCRIPTION
#### 97e49d90942a980b9c8e10b19e6113923dff3379
<pre>
Enforce requirement that keyword sources in CSP source expressions must be separated by whitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=267579">https://bugs.webkit.org/show_bug.cgi?id=267579</a>

Reviewed by NOBODY (OOPS!).

This change makes WebKit report an expected “invalid source expression”
error for any CSP policy having a source expression with a keyword source
(such as &apos;self&apos;) which isn’t either followed by whitespace or else at the
end of the source expression; for example, “&apos;self&apos;&apos;unsafe-inline&apos;”, with
no whitespace after the keyword &apos;self&apos; and before &apos;unsafe-inline&apos;.

Otherwise, without this change, if a CSP policy contains a source
expression such as “&apos;self&apos;&apos;unsafe-inline&apos;” – with no whitespace between
keywords – WebKit unexpectedly fails to report any error.

* LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/default-src/manifest-v3-default-src-block-non-https-scheme.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/extensions/manifest-v3/script-src/manifest-v3-script-src-block-non-https-scheme.html:
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::isKeywordSource):
(WebCore::isSourceListNone):
(WebCore::ContentSecurityPolicySourceList::parseSource):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97e49d90942a980b9c8e10b19e6113923dff3379

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132720 "Failed to checkout and rebase branch from PR 24217") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18062 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43794 "Failed to checkout and rebase branch from PR 24217") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140249 "Failed to checkout and rebase branch from PR 24217") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84747 "Failed to checkout and rebase branch from PR 24217") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134590 "Failed to checkout and rebase branch from PR 24217") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32727 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/84747 "Failed to checkout and rebase branch from PR 24217") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135666 "Failed to checkout and rebase branch from PR 24217") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13215 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13173 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/43794 "Failed to checkout and rebase branch from PR 24217") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83483 "Failed to checkout and rebase branch from PR 24217") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34836 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142905 "Failed to checkout and rebase branch from PR 24217") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4885 "Failed to checkout and rebase branch from PR 24217") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38992 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4967 "Failed to checkout and rebase branch from PR 24217") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37220 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34115 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58367 "Failed to checkout and rebase branch from PR 24217") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13919 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/43794 "Failed to checkout and rebase branch from PR 24217") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15525 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68390 "Failed to checkout and rebase branch from PR 24217") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->