### PR TITLE
Adopt more smart pointers in HTMLMediaElement.cpp

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -186,6 +186,11 @@ void MediaKeys::unrequestedInitializationDataReceived(const String& initDataType
         cdmClient.cdmClientUnrequestedInitializationDataReceived(initDataType, initData.copyRef());
 }
 
+Ref<CDMInstance> MediaKeys::protectedCDMInstance() const
+{
+    return m_instance;
+}
+
 #if !RELEASE_LOG_DISABLED
 const void* MediaKeys::nextChildIdentifier() const
 {

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
@@ -75,6 +75,7 @@ public:
     bool hasOpenSessions() const;
     CDMInstance& cdmInstance() { return m_instance; }
     const CDMInstance& cdmInstance() const { return m_instance; }
+    Ref<CDMInstance> protectedCDMInstance() const;
 
 #if !RELEASE_LOG_DISABLED
     const void* nextChildIdentifier() const;

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -380,6 +380,11 @@ bool MediaStream::virtualHasPendingActivity() const
     return m_isActive;
 }
 
+Ref<MediaStreamPrivate> MediaStream::protectedPrivateStream()
+{
+    return m_private;
+}
+
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaStream::logChannel() const
 {

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -88,6 +88,7 @@ public:
     template<typename Function> bool hasMatchingTrack(Function&& function) const { return anyOf(m_trackMap.values(), std::forward<Function>(function)); }
 
     MediaStreamPrivate& privateStream() { return m_private.get(); }
+    Ref<MediaStreamPrivate> protectedPrivateStream();
 
     void startProducingData();
     void stopProducingData();

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -46,6 +46,10 @@ public:
 
     virtual ~MediaElementAudioSourceNode();
 
+    using AudioNode::weakPtrFactory;
+    using AudioNode::WeakValueType;
+    using AudioNode::WeakPtrImplType;
+
     HTMLMediaElement& mediaElement() { return m_mediaElement; }
 
     // AudioNode

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -124,7 +124,7 @@ template<typename, typename> class PODInterval;
 class RemotePlayback;
 #endif
 
-using CueInterval = PODInterval<MediaTime, TextTrackCue*>;
+using CueInterval = PODInterval<MediaTime, WeakPtr<TextTrackCue, WeakPtrImplWithEventTargetData>>;
 using CueList = Vector<CueInterval>;
 
 using MediaProvider = std::optional < std::variant <
@@ -177,7 +177,7 @@ public:
     bool hasAudio() const override;
     bool hasRenderer() const { return static_cast<bool>(renderer()); }
 
-    WEBCORE_EXPORT static HashSet<HTMLMediaElement*>& allMediaElements();
+    WEBCORE_EXPORT static HashSet<WeakRef<HTMLMediaElement, WeakPtrImplWithEventTargetData>>& allMediaElements();
 
     WEBCORE_EXPORT static RefPtr<HTMLMediaElement> bestMediaElementForRemoteControls(MediaElementSession::PlaybackControlsPurpose, const Document* = nullptr);
 
@@ -376,7 +376,7 @@ public:
     void addTextTrack(Ref<TextTrack>&&);
     void addVideoTrack(Ref<VideoTrack>&&);
     void removeAudioTrack(Ref<AudioTrack>&&);
-    void removeTextTrack(Ref<TextTrack>&&, bool scheduleEvent = true);
+    void removeTextTrack(TextTrack&, bool scheduleEvent = true);
     void removeVideoTrack(Ref<VideoTrack>&&);
     void forgetResourceSpecificTracks();
     void closeCaptionTracksChanged();
@@ -500,7 +500,7 @@ public:
     bool isPlaying() const final { return m_playing; }
 
 #if ENABLE(WEB_AUDIO)
-    MediaElementAudioSourceNode* audioSourceNode() { return m_audioSourceNode; }
+    MediaElementAudioSourceNode* audioSourceNode();
     void setAudioSourceNode(MediaElementAudioSourceNode*);
 
     AudioSourceProvider* audioSourceProvider();
@@ -578,6 +578,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return *m_logger.get(); }
+    Ref<Logger> protectedLogger() const;
     const void* logIdentifier() const final { return m_logIdentifier; }
     const char* logClassName() const final { return "HTMLMediaElement"; }
     WTFLogChannel& logChannel() const final;
@@ -635,6 +636,7 @@ public:
     WEBCORE_EXPORT RefPtr<TextTrackCue> cueBeingSpoken() const;
 #if ENABLE(SPEECH_SYNTHESIS)
     WEBCORE_EXPORT SpeechSynthesis& speechSynthesis();
+    Ref<SpeechSynthesis> protectedSpeechSynthesis();
 #endif
 
     bool hasSource() const { return hasCurrentSrc() || srcObject(); }
@@ -1248,7 +1250,7 @@ private:
     // This is a weak reference, since m_audioSourceNode holds a reference to us.
     // The value is set just after the MediaElementAudioSourceNode is created.
     // The value is cleared in MediaElementAudioSourceNode::~MediaElementAudioSourceNode().
-    MediaElementAudioSourceNode* m_audioSourceNode { nullptr };
+    WeakPtr<MediaElementAudioSourceNode, WeakPtrImplWithEventTargetData> m_audioSourceNode;
 #endif
 
     String m_mediaGroup;

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -87,7 +87,7 @@ RenderPtr<RenderElement> MediaControlTextTrackContainerElement::createElementRen
 
 static bool compareCueIntervalForDisplay(const CueInterval& one, const CueInterval& two)
 {
-    return one.data()->isPositionedAbove(two.data());
+    return one.data()->isPositionedAbove(two.data().get());
 };
 
 void MediaControlTextTrackContainerElement::updateDisplay()
@@ -156,7 +156,7 @@ void MediaControlTextTrackContainerElement::updateDisplay()
         removeChildren();
 
     activeCues.removeAllMatching([] (CueInterval& cueInterval) {
-        RefPtr<TextTrackCue> cue = cueInterval.data();
+        RefPtr cue = cueInterval.data().get();
         return !cue->track()
             || !cue->track()->isRendered()
             || cue->track()->mode() == TextTrack::Mode::Disabled
@@ -256,7 +256,7 @@ void MediaControlTextTrackContainerElement::updateActiveCuesFontSize()
     m_fontSize = lroundf(100 * fontScale);
 
     for (auto& activeCue : m_mediaElement->currentlyActiveCues()) {
-        RefPtr<TextTrackCue> cue = activeCue.data();
+        RefPtr cue = activeCue.data().get();
         if (cue->isRenderable())
             cue->setFontSize(m_fontSize, m_fontSizeIsImportant);
     }

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -305,6 +305,11 @@ TextTrackCueList* TextTrack::cues()
     return &ensureTextTrackCueList();
 }
 
+RefPtr<TextTrackCueList> TextTrack::protectedCues()
+{
+    return cues();
+}
+
 void TextTrack::removeAllCues()
 {
     if (!m_cues)

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -77,6 +77,7 @@ public:
     void setReadinessState(ReadinessState state) { m_readinessState = state; }
 
     TextTrackCueList* cues();
+    RefPtr<TextTrackCueList> protectedCues();
     TextTrackCueList* activeCues() const;
 
     TextTrackCueList* cuesInternal() const { return m_cues.get(); }

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -259,7 +259,12 @@ void TextTrackCue::didChange(bool affectOrder)
 
 TextTrack* TextTrackCue::track() const
 {
-    return m_track;
+    return m_track.get();
+}
+
+RefPtr<TextTrack> TextTrackCue::protectedTrack() const
+{
+    return m_track.get();
 }
 
 void TextTrackCue::setTrack(TextTrack* track)

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -70,6 +70,7 @@ public:
     static ExceptionOr<Ref<TextTrackCue>> create(Document&, double start, double end, DocumentFragment&);
 
     TextTrack* track() const;
+    RefPtr<TextTrack> protectedTrack() const;
     void setTrack(TextTrack*);
 
     const AtomString& id() const { return m_id; }
@@ -161,7 +162,7 @@ private:
     MediaTime m_endTime;
     int m_processingCueChanges { 0 };
 
-    TextTrack* m_track { nullptr };
+    WeakPtr<TextTrack, WeakPtrImplWithEventTargetData> m_track;
 
     RefPtr<DocumentFragment> m_cueNode;
     RefPtr<TextTrackCueBox> m_displayTree;

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.cpp
@@ -192,7 +192,7 @@ bool ApplicationCacheHost::maybeLoadResource(ResourceLoader& loader, const Resou
     if (loader.options().serviceWorkerRegistrationIdentifier)
         return false;
 
-    ApplicationCacheResource* resource;
+    RefPtr<ApplicationCacheResource> resource;
     if (!shouldLoadResourceFromApplicationCache(request, resource))
         return false;
 
@@ -255,7 +255,7 @@ static inline RefPtr<SharedBuffer> bufferFromResource(ApplicationCacheResource& 
 
 bool ApplicationCacheHost::maybeLoadSynchronously(ResourceRequest& request, ResourceError& error, ResourceResponse& response, RefPtr<SharedBuffer>& data)
 {
-    ApplicationCacheResource* resource;
+    RefPtr<ApplicationCacheResource> resource;
     if (!shouldLoadResourceFromApplicationCache(request, resource))
         return false;
 
@@ -278,7 +278,7 @@ void ApplicationCacheHost::maybeLoadFallbackSynchronously(const ResourceRequest&
     if ((!error.isNull() && !error.isCancellation())
          || response.httpStatusCode() / 100 == 4 || response.httpStatusCode() / 100 == 5
          || !protocolHostAndPortAreEqual(request.url(), response.url())) {
-        ApplicationCacheResource* resource;
+        RefPtr<ApplicationCacheResource> resource;
         if (getApplicationCacheFallbackResource(request, resource)) {
             response = resource->response();
             data = resource->data().makeContiguous();
@@ -398,7 +398,7 @@ void ApplicationCacheHost::setApplicationCache(RefPtr<ApplicationCache>&& applic
     m_applicationCache = WTFMove(applicationCache);
 }
 
-bool ApplicationCacheHost::shouldLoadResourceFromApplicationCache(const ResourceRequest& originalRequest, ApplicationCacheResource*& resource)
+bool ApplicationCacheHost::shouldLoadResourceFromApplicationCache(const ResourceRequest& originalRequest, RefPtr<ApplicationCacheResource>& resource)
 {
     auto* cache = applicationCache();
     if (!cache || !cache->isComplete())
@@ -429,7 +429,7 @@ bool ApplicationCacheHost::shouldLoadResourceFromApplicationCache(const Resource
     return true;
 }
 
-bool ApplicationCacheHost::getApplicationCacheFallbackResource(const ResourceRequest& request, ApplicationCacheResource*& resource, ApplicationCache* cache)
+bool ApplicationCacheHost::getApplicationCacheFallbackResource(const ResourceRequest& request, RefPtr<ApplicationCacheResource>& resource, ApplicationCache* cache)
 {
     if (!cache) {
         cache = applicationCache();
@@ -465,7 +465,7 @@ bool ApplicationCacheHost::scheduleLoadFallbackResourceFromApplicationCache(Reso
     if (loader->options().serviceWorkerRegistrationIdentifier)
         return false;
 
-    ApplicationCacheResource* resource;
+    RefPtr<ApplicationCacheResource> resource;
     if (!getApplicationCacheFallbackResource(loader->request(), resource, cache))
         return false;
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.h
@@ -127,8 +127,8 @@ public:
     Vector<ResourceInfo> resourceList();
     CacheInfo applicationCacheInfo();
 
-    bool shouldLoadResourceFromApplicationCache(const ResourceRequest&, ApplicationCacheResource*&);
-    bool getApplicationCacheFallbackResource(const ResourceRequest&, ApplicationCacheResource*&, ApplicationCache* = nullptr);
+    bool shouldLoadResourceFromApplicationCache(const ResourceRequest&, RefPtr<ApplicationCacheResource>&);
+    bool getApplicationCacheFallbackResource(const ResourceRequest&, RefPtr<ApplicationCacheResource>&, ApplicationCache* = nullptr);
 
 private:
     friend class ApplicationCacheGroup;

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -136,8 +136,8 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
         GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
 
 #if ENABLE(VIDEO)
-    for (auto* mediaElement : HTMLMediaElement::allMediaElements())
-        mediaElement->purgeBufferedDataIfPossible();
+    for (auto& mediaElement : HTMLMediaElement::allMediaElements())
+        Ref { mediaElement.get() }->purgeBufferedDataIfPossible();
 #endif
 
     if (synchronous == Synchronous::Yes) {

--- a/Source/WebCore/platform/PODInterval.h
+++ b/Source/WebCore/platform/PODInterval.h
@@ -146,6 +146,13 @@ public:
         return Base::high() < other.Base::high();
     }
 
+    bool operator==(const PODInterval& other) const
+    {
+        return Base::low() == other.Base::low()
+            && Base::high() == other.Base::high()
+            && Base::data() == other.Base::data();
+    }
+
 private:
     using Base = PODIntervalBase<T, WeakPtr<U, WeakPtrImpl>>;
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4262,7 +4262,7 @@ unsigned Internals::mediaElementCount()
         return 0;
 
     unsigned number = 0;
-    for (auto* mediaElement : HTMLMediaElement::allMediaElements()) {
+    for (auto& mediaElement : HTMLMediaElement::allMediaElements()) {
         if (&mediaElement->document() == document)
             ++number;
     }


### PR DESCRIPTION
#### 362800062a07444fcece8106dee1adb993ebaafb
<pre>
Adopt more smart pointers in HTMLMediaElement.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=269154">https://bugs.webkit.org/show_bug.cgi?id=269154</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp:
(WebCore::MediaKeys::protectedCDMInstance const):
* Source/WebCore/Modules/encryptedmedia/MediaKeys.h:
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::protectedPrivateStream):
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::TrackDisplayUpdateScope::TrackDisplayUpdateScope):
(WebCore::TrackDisplayUpdateScope::~TrackDisplayUpdateScope):
(WebCore::HTMLMediaElement::allMediaElements):
(WebCore::mediaElementSessionInfoForSession):
(WebCore::m_remote):
(WebCore::HTMLMediaElement::initializeMediaSession):
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::unregisterWithDocument):
(WebCore::HTMLMediaElement::prepareForDocumentSuspension):
(WebCore::HTMLMediaElement::resumeFromDocumentSuspension):
(WebCore::HTMLMediaElement::removeAllEventListeners):
(WebCore::HTMLMediaElement::attributeChanged):
(WebCore::HTMLMediaElement::didFinishInsertingNode):
(WebCore::HTMLMediaElement::updateRenderer):
(WebCore::HTMLMediaElement::didAttachRenderers):
(WebCore::HTMLMediaElement::willDetachRenderers):
(WebCore::HTMLMediaElement::didDetachRenderers):
(WebCore::HTMLMediaElement::notifyAboutPlaying):
(WebCore::HTMLMediaElement::checkPlaybackTargetCompatibility):
(WebCore::HTMLMediaElement::setSrcObject):
(WebCore::HTMLMediaElement::load):
(WebCore::HTMLMediaElement::mediaPlayerReloadAndResumePlaybackIfNeeded):
(WebCore::HTMLMediaElement::selectMediaResource):
(WebCore::HTMLMediaElement::loadResource):
(WebCore::trackIndexCompare):
(WebCore::eventTimeCueCompare):
(WebCore::compareCueInterval):
(WebCore::HTMLMediaElement::updateActiveTextTrackCues):
(WebCore::HTMLMediaElement::speakCueText):
(WebCore::HTMLMediaElement::protectedSpeechSynthesis):
(WebCore::HTMLMediaElement::speechSynthesis):
(WebCore::HTMLMediaElement::executeCueEnterOrExitActionForTime):
(WebCore::HTMLMediaElement::audioTrackEnabledChanged):
(WebCore::HTMLMediaElement::audioTrackKindChanged):
(WebCore::HTMLMediaElement::audioTrackLabelChanged):
(WebCore::HTMLMediaElement::audioTrackLanguageChanged):
(WebCore::HTMLMediaElement::textTrackModeChanged):
(WebCore::HTMLMediaElement::textTrackKindChanged):
(WebCore::HTMLMediaElement::textTrackLabelChanged):
(WebCore::HTMLMediaElement::textTrackLanguageChanged):
(WebCore::HTMLMediaElement::videoTrackSelectedChanged):
(WebCore::HTMLMediaElement::videoTrackKindChanged):
(WebCore::HTMLMediaElement::videoTrackLabelChanged):
(WebCore::HTMLMediaElement::videoTrackLanguageChanged):
(WebCore::HTMLMediaElement::textTrackAddCues):
(WebCore::HTMLMediaElement::textTrackRemoveCues):
(WebCore::HTMLMediaElement::textTrackRemoveCue):
(WebCore::HTMLMediaElement::isSafeToLoadURL const):
(WebCore::HTMLMediaElement::cancelPendingEventsAndCallbacks):
(WebCore::HTMLMediaElement::mediaLoadingFailed):
(WebCore::HTMLMediaElement::durationChanged):
(WebCore::HTMLMediaElement::setReadyState):
(WebCore::HTMLMediaElement::updateShouldContinueAfterNeedKey):
(WebCore::HTMLMediaElement::mediaPlayerKeyNeeded):
(WebCore::HTMLMediaElement::webkitSetMediaKeys):
(WebCore::HTMLMediaElement::keyAdded):
(WebCore::HTMLMediaElement::setMediaKeys):
(WebCore::HTMLMediaElement::attemptToDecrypt):
(WebCore::HTMLMediaElement::progressEventTimerFired):
(WebCore::HTMLMediaElement::prepareToPlay):
(WebCore::HTMLMediaElement::setAudioOutputDevice):
(WebCore::HTMLMediaElement::seekTask):
(WebCore::HTMLMediaElement::finishSeek):
(WebCore::HTMLMediaElement::setPlaybackRate):
(WebCore::HTMLMediaElement::updatePlaybackRate):
(WebCore::HTMLMediaElement::setPreservesPitch):
(WebCore::HTMLMediaElement::playInternal):
(WebCore::HTMLMediaElement::detachMediaSource):
(WebCore::HTMLMediaElement::setLoop):
(WebCore::HTMLMediaElement::setMuted):
(WebCore::HTMLMediaElement::playbackProgressTimerFired):
(WebCore::HTMLMediaElement::mediaPlayerDidAddAudioTrack):
(WebCore::HTMLMediaElement::mediaPlayerDidAddTextTrack):
(WebCore::HTMLMediaElement::mediaPlayerDidAddVideoTrack):
(WebCore::HTMLMediaElement::addAudioTrack):
(WebCore::HTMLMediaElement::addTextTrack):
(WebCore::HTMLMediaElement::addVideoTrack):
(WebCore::HTMLMediaElement::removeTextTrack):
(WebCore::HTMLMediaElement::removeVideoTrack):
(WebCore::HTMLMediaElement::forgetResourceSpecificTracks):
(WebCore::HTMLMediaElement::protectedLogger const):
(WebCore::HTMLMediaElement::audioSourceNode):
(WebCore::HTMLMediaElement::ensureAudioTracks):
(WebCore::HTMLMediaElement::ensureTextTracks):
(WebCore::HTMLMediaElement::ensureVideoTracks):
(WebCore::HTMLMediaElement::didRemoveTextTrack):
(WebCore::HTMLMediaElement::configureTextTrackGroup):
(WebCore::HTMLMediaElement::setupAndCallJS):
(WebCore::HTMLMediaElement::layoutSizeChanged):
(WebCore::HTMLMediaElement::setSelectedTextTrack):
(WebCore::HTMLMediaElement::scheduleConfigureTextTracks):
(WebCore::HTMLMediaElement::configureTextTracks):
(WebCore::HTMLMediaElement::havePotentialSourceChild):
(WebCore::HTMLMediaElement::selectNextSourceChild):
(WebCore::HTMLMediaElement::sourceWasAdded):
(WebCore::HTMLMediaElement::sourceWasRemoved):
(WebCore::HTMLMediaElement::mediaPlayerRepaint):
(WebCore::HTMLMediaElement::mediaPlayerSizeChanged):
(WebCore::HTMLMediaElement::scheduleMediaEngineWasUpdated):
(WebCore::HTMLMediaElement::mediaEngineWasUpdated):
(WebCore::HTMLMediaElement::mediaPlayerCharacteristicChanged):
(WebCore::HTMLMediaElement::stoppedDueToErrors const):
(WebCore::HTMLMediaElement::updateVolume):
(WebCore::HTMLMediaElement::scheduleUpdatePlayState):
(WebCore::HTMLMediaElement::updatePlayState):
(WebCore::HTMLMediaElement::playPlayer):
(WebCore::HTMLMediaElement::pausePlayer):
(WebCore::HTMLMediaElement::setPlaying):
(WebCore::HTMLMediaElement::clearMediaPlayer):
(WebCore::HTMLMediaElement::stop):
(WebCore::HTMLMediaElement::suspend):
(WebCore::HTMLMediaElement::visibilityStateChanged):
(WebCore::HTMLMediaElement::setTextTrackRepresentation):
(WebCore::HTMLMediaElement::syncTextTrackBounds):
(WebCore::HTMLMediaElement::wirelessRoutesAvailableDidChange):
(WebCore::HTMLMediaElement::setIsPlayingToWirelessTarget):
(WebCore::HTMLMediaElement::enqueuePlaybackTargetAvailabilityChangedEvent):
(WebCore::HTMLMediaElement::setWirelessPlaybackTarget):
(WebCore::HTMLMediaElement::setShouldPlayToPlaybackTarget):
(WebCore::HTMLMediaElement::playbackTargetPickerWasDismissed):
(WebCore::HTMLMediaElement::dispatchEvent):
(WebCore::HTMLMediaElement::enterFullscreen):
(WebCore::HTMLMediaElement::exitFullscreen):
(WebCore::HTMLMediaElement::prepareForVideoFullscreenStandby):
(WebCore::HTMLMediaElement::setVideoFullscreenStandby):
(WebCore::HTMLMediaElement::willExitFullscreen):
(WebCore::HTMLMediaElement::createVideoFullscreenLayer):
(WebCore::HTMLMediaElement::setVideoFullscreenLayer):
(WebCore::HTMLMediaElement::setVideoFullscreenFrame):
(WebCore::HTMLMediaElement::setVideoFullscreenGravity):
(WebCore::HTMLMediaElement::setClosedCaptionsVisible):
(WebCore::HTMLMediaElement::setShouldDelayLoadEvent):
(WebCore::HTMLMediaElement::privateBrowsingStateDidChange):
(WebCore::HTMLMediaElement::captionPreferencesChanged):
(WebCore::HTMLMediaElement::markCaptionAndSubtitleTracksAsUnconfigured):
(WebCore::HTMLMediaElement::setAudioSourceNode):
(WebCore::HTMLMediaElement::setMediaGroup):
(WebCore::HTMLMediaElement::setController):
(WebCore::HTMLMediaElement::updateMediaController):
(WebCore::HTMLMediaElement::updateSleepDisabling):
(WebCore::HTMLMediaElement::mediaPlayerCreateResourceLoader):
(WebCore::HTMLMediaElement::setPreferredDynamicRangeMode):
(WebCore::HTMLMediaElement::setOverridePreferredDynamicRangeMode):
(WebCore::HTMLMediaElement::mediaPlayerGetRawCookies const):
(WebCore::HTMLMediaElement::mediaPlayerEngineFailedToLoad const):
(WebCore::HTMLMediaElement::mediaPlayerBufferedTimeRangesChanged):
(WebCore::HTMLMediaElement::removeBehaviorRestrictionsAfterFirstUserGesture):
(WebCore::HTMLMediaElement::ensureIsolatedWorld):
(WebCore::HTMLMediaElement::ensureMediaControls):
(WebCore::HTMLMediaElement::requestHostingContextID):
(WebCore::HTMLMediaElement::setVideoLayerSizeFenced):
(WebCore::HTMLMediaElement::scheduleUpdateMediaState):
(WebCore::HTMLMediaElement::updateMediaState):
(WebCore::HTMLMediaElement::handleAutoplayEvent):
(WebCore::HTMLMediaElement::pageMutedStateDidChange):
(WebCore::HTMLMediaElement::setBufferingPolicy):
(WebCore::HTMLMediaElement::isVisibleInViewportChanged):
(WebCore::HTMLMediaElement::schedulePlaybackControlsManagerUpdate):
(WebCore::HTMLMediaElement::setFullscreenMode):
(WebCore::HTMLMediaElement::applicationWillResignActive):
(WebCore::HTMLMediaElement::applicationDidBecomeActive):
(WebCore::HTMLMediaElement::updateMediaPlayer):
(WebCore::HTMLMediaElement::mediaPlayerQueueTaskOnEventLoop):
(WebCore::HTMLMediaElement::shouldDisableHDR const):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::audioSourceNode): Deleted.
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::compareCueIntervalForDisplay):
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::updateActiveCuesFontSize):
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::protectedCues):
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::track const):
(WebCore::TextTrackCue::protectedTrack const):
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::didCreateFrontendAndBackend):
(WebCore::InspectorDOMAgent::mediaMetricsTimerFired):
* Source/WebCore/loader/appcache/ApplicationCacheHost.cpp:
(WebCore::ApplicationCacheHost::maybeLoadResource):
(WebCore::ApplicationCacheHost::maybeLoadSynchronously):
(WebCore::ApplicationCacheHost::maybeLoadFallbackSynchronously):
(WebCore::ApplicationCacheHost::shouldLoadResourceFromApplicationCache):
(WebCore::ApplicationCacheHost::getApplicationCacheFallbackResource):
(WebCore::ApplicationCacheHost::scheduleLoadFallbackResourceFromApplicationCache):
* Source/WebCore/loader/appcache/ApplicationCacheHost.h:
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseCriticalMemory):
* Source/WebCore/platform/PODInterval.h:

Canonical link: <a href="https://commits.webkit.org/274445@main">https://commits.webkit.org/274445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fef61cf02026faa978d87e3c140eee76281ddbfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32739 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42929 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39004 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37230 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15199 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5111 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->