### PR TITLE
Enforce conformant whitespace requirements for CSP policies

### DIFF
--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -253,7 +253,7 @@ void ContentSecurityPolicy::didReceiveHeader(const String& header, ContentSecuri
     // be combined with a comma. Walk the header string, and parse each comma
     // separated chunk as a separate header.
     readCharactersForParsing(header, [&](auto buffer) {
-        skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+        skipWhile<isASCIIWhitespace>(buffer);
         auto begin = buffer.position();
 
         while (buffer.hasCharactersRemaining()) {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -44,7 +44,7 @@ template<typename CharacterType> static bool isDirectiveNameCharacter(CharacterT
 
 template<typename CharacterType> static bool isDirectiveValueCharacter(CharacterType c)
 {
-    return isUnicodeCompatibleASCIIWhitespace(c) || (c >= 0x21 && c <= 0x7e); // Whitespace + VCHAR
+    return isASCIIWhitespace(c) || (c >= 0x21 && c <= 0x7e); // Whitespace + VCHAR
 }
 
 static inline bool checkEval(ContentSecurityPolicySourceListDirective* directive)
@@ -506,7 +506,7 @@ void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecu
 //
 template<typename CharacterType> auto ContentSecurityPolicyDirectiveList::parseDirective(StringParsingBuffer<CharacterType> buffer) -> std::optional<ParsedDirective>
 {
-    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+    skipWhile<isASCIIWhitespace>(buffer);
 
     // Empty directive (e.g. ";;;"). Exit early.
     if (buffer.atEnd())
@@ -527,13 +527,13 @@ template<typename CharacterType> auto ContentSecurityPolicyDirectiveList::parseD
     if (buffer.atEnd())
         return ParsedDirective { WTFMove(name), { } };
 
-    if (!skipExactly<isUnicodeCompatibleASCIIWhitespace>(buffer)) {
+    if (!skipExactly<isASCIIWhitespace>(buffer)) {
         skipWhile<isNotASCIISpace>(buffer);
         m_policy.reportUnsupportedDirective(String(nameBegin, buffer.position() - nameBegin));
         return std::nullopt;
     }
 
-    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+    skipWhile<isASCIIWhitespace>(buffer);
 
     auto valueBegin = buffer.position();
     skipWhile<isDirectiveValueCharacter>(buffer);
@@ -561,7 +561,7 @@ void ContentSecurityPolicyDirectiveList::parseReportURI(ParsedDirective&& direct
     readCharactersForParsing(directive.value, [&](auto buffer) {
         auto begin = buffer.position();
         while (buffer.hasCharactersRemaining()) {
-            skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+            skipWhile<isASCIIWhitespace>(buffer);
 
             auto urlBegin = buffer.position();
             skipWhile<isNotASCIISpace>(buffer);
@@ -582,7 +582,7 @@ void ContentSecurityPolicyDirectiveList::parseReportTo(ParsedDirective&& directi
     readCharactersForParsing(directive.value, [&](auto buffer) {
         auto begin = buffer.position();
         while (buffer.hasCharactersRemaining()) {
-            skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+            skipWhile<isASCIIWhitespace>(buffer);
 
             auto urlBegin = buffer.position();
             skipWhile<isNotASCIISpace>(buffer);
@@ -602,7 +602,7 @@ void ContentSecurityPolicyDirectiveList::parseRequireTrustedTypesFor(ParsedDirec
 
     readCharactersForParsing(directive.value, [&](auto buffer) {
         while (buffer.hasCharactersRemaining()) {
-            skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+            skipWhile<isASCIIWhitespace>(buffer);
             if (buffer.atEnd()) {
                 policy().reportEmptyRequireTrustedTypesForDirective();
                 continue;
@@ -614,7 +614,7 @@ void ContentSecurityPolicyDirectiveList::parseRequireTrustedTypesFor(ParsedDirec
             else
                 policy().reportInvalidTrustedTypesSinkGroup(String(begin, buffer.position() - begin));
 
-            ASSERT(buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
+            ASSERT(buffer.atEnd() || isASCIIWhitespace(*buffer));
         }
     });
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 template<typename CharacterType> static bool isMediaTypeCharacter(CharacterType c)
 {
-    return !isUnicodeCompatibleASCIIWhitespace(c) && c != '/';
+    return !isASCIIWhitespace(c) && c != '/';
 }
 
 ContentSecurityPolicyMediaListDirective::ContentSecurityPolicyMediaListDirective(const ContentSecurityPolicyDirectiveList& directiveList, const String& name, const String& value)
@@ -63,7 +63,7 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
         while (buffer.hasCharactersRemaining()) {
             // _____ OR _____mime1/mime1
             // ^        ^
-            skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+            skipWhile<isASCIIWhitespace>(buffer);
             if (buffer.atEnd())
                 return;
 
@@ -103,7 +103,7 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
             }
             m_pluginTypes.add(String(begin, buffer.position() - begin));
 
-            ASSERT(buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
+            ASSERT(buffer.atEnd() || isASCIIWhitespace(*buffer));
         }
     });
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -62,7 +62,7 @@ static bool isCSPDirectiveName(StringView name)
 
 template<typename CharacterType> static bool isSourceCharacter(CharacterType c)
 {
-    return !isUnicodeCompatibleASCIIWhitespace(c);
+    return !isASCIIWhitespace(c);
 }
 
 template<typename CharacterType> static bool isHostCharacter(CharacterType c)
@@ -87,12 +87,12 @@ template<typename CharacterType> static bool isNotColonOrSlash(CharacterType c)
 
 template<typename CharacterType> static bool isSourceListNone(StringParsingBuffer<CharacterType> buffer)
 {
-    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+    skipWhile<isASCIIWhitespace>(buffer);
 
     if (!skipExactlyIgnoringASCIICase(buffer, "'none'"_s))
         return false;
 
-    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+    skipWhile<isASCIIWhitespace>(buffer);
 
     return buffer.atEnd();
 }
@@ -247,7 +247,7 @@ static bool extensionModeAllowsKeywordsForDirective(ContentSecurityPolicyModeFor
 template<typename CharacterType> void ContentSecurityPolicySourceList::parse(StringParsingBuffer<CharacterType> buffer)
 {
     while (buffer.hasCharactersRemaining()) {
-        skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+        skipWhile<isASCIIWhitespace>(buffer);
         if (buffer.atEnd())
             return;
 
@@ -275,7 +275,7 @@ template<typename CharacterType> void ContentSecurityPolicySourceList::parse(Str
         } else
             m_policy.reportInvalidSourceExpression(m_directiveName, String(beginSource, buffer.position() - beginSource));
 
-        ASSERT(buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
+        ASSERT(buffer.atEnd() || isASCIIWhitespace(*buffer));
     }
     
     m_list.shrinkToFit();


### PR DESCRIPTION
#### a19a4413f05df939a6e5f78b89dd7e1359faff05
<pre>
Enforce conformant whitespace requirements for CSP policies
<a href="https://bugs.webkit.org/show_bug.cgi?id=269156">https://bugs.webkit.org/show_bug.cgi?id=269156</a>

Reviewed by NOBODY (OOPS!).

This change makes WebKit conform to the current CSP spec requirements for
the set of code points treated as whitespace characters in CSP policies.
Specifically, it restricts that set of code points to those defined as
in <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a> “ASCII whitespace” —
which doesn’t include the U+000B LINE TABULATION code point which some
other specs additionally allow as whitespace.

Otherwise, without this change, WebKit treats U+000B as whitespace in
places in CSP policies where per-spec it mustn’t be treated as whitespace.

* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::didReceiveHeader):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::isDirectiveValueCharacter):
(WebCore::ContentSecurityPolicyDirectiveList::parseDirective):
(WebCore::ContentSecurityPolicyDirectiveList::parseReportURI):
(WebCore::ContentSecurityPolicyDirectiveList::parseReportTo):
(WebCore::ContentSecurityPolicyDirectiveList::parseRequireTrustedTypesFor):
* Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp:
(WebCore::isMediaTypeCharacter):
(WebCore::ContentSecurityPolicyMediaListDirective::parse):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::isSourceCharacter):
(WebCore::isSourceListNone):
(WebCore::ContentSecurityPolicySourceList::parse):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a19a4413f05df939a6e5f78b89dd7e1359faff05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132722 "Failed to checkout and rebase branch from PR 24222") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18074 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43796 "Failed to checkout and rebase branch from PR 24222") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140251 "Failed to checkout and rebase branch from PR 24222") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84749 "Failed to checkout and rebase branch from PR 24222") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134592 "Failed to checkout and rebase branch from PR 24222") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32738 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/84749 "Failed to checkout and rebase branch from PR 24222") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135668 "Failed to checkout and rebase branch from PR 24222") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13183 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/43796 "Failed to checkout and rebase branch from PR 24222") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83485 "Failed to checkout and rebase branch from PR 24222") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34842 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142907 "Failed to checkout and rebase branch from PR 24222") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4887 "Failed to checkout and rebase branch from PR 24222") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39005 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4969 "Failed to checkout and rebase branch from PR 24222") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37231 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58369 "Failed to checkout and rebase branch from PR 24222") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13931 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/43796 "Failed to checkout and rebase branch from PR 24222") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15537 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68392 "Failed to checkout and rebase branch from PR 24222") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->