### PR TITLE
ShadowRoot.h shouldn't include HTMLVideoElement.h

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMConvertInterface.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertInterface.h
@@ -27,6 +27,7 @@
 
 #include "IDLTypes.h"
 #include "JSDOMConvertBase.h"
+#include "JSDOMGlobalObject.h"
 #include <JavaScriptCore/Error.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -409,7 +409,7 @@ Vector<Ref<ShadowRoot>> assignedShadowRootsIfSlotted(const Node& node)
 }
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-HTMLVideoElement* ShadowRoot::pictureInPictureElement() const
+Element* ShadowRoot::pictureInPictureElement() const
 {
     notImplemented();
     return nullptr;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -26,13 +26,9 @@
 
 #pragma once
 
-#include "Document.h"
 #include "DocumentFragment.h"
 #include "Element.h"
 #include "StyleScopeOrdinal.h"
-#if ENABLE(PICTURE_IN_PICTURE_API)
-#include "HTMLVideoElement.h"
-#endif
 #include "ShadowRootMode.h"
 #include "SlotAssignmentMode.h"
 #include <wtf/HashMap.h>
@@ -141,7 +137,7 @@ public:
     void invalidatePartMappings();
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-    HTMLVideoElement* pictureInPictureElement() const;
+    Element* pictureInPictureElement() const;
 #endif
 
     Vector<RefPtr<WebAnimation>> getAnimations();


### PR DESCRIPTION
#### cd3428091d601012e1311c695be3e43437fcd092
<pre>
ShadowRoot.h shouldn&apos;t include HTMLVideoElement.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=269155">https://bugs.webkit.org/show_bug.cgi?id=269155</a>

Reviewed by Jean-Yves Avenard.

Remove #include &quot;HTMLVideoElement.h&quot; from ShadowRoot.h.

* Source/WebCore/bindings/js/JSDOMConvertInterface.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::pictureInPictureElement const): Now returns Element*. Forward declaring
HTMLVideoElement isn&apos;t sufficient since DocumentOrShadowRoot+FullScreen.idl requires converting
the return value of this function to Element.
* Source/WebCore/dom/ShadowRoot.h:

Canonical link: <a href="https://commits.webkit.org/274450@main">https://commits.webkit.org/274450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b956becd6c396a1b56b4562bb36bd0834a45c1f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32741 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39008 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37235 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15539 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15202 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5113 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15025 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->