### PR TITLE
[UnifiedPDF] Selections should no longer be tracked when window loses focus

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -211,6 +211,7 @@ private:
     void extendCurrentSelectionIfNeeded();
     void updateCurrentSelectionForContextMenuEventIfNeeded();
     void continueTrackingSelection(PDFDocumentLayout::PageIndex, const WebCore::IntPoint& pagePoint);
+    void stopTrackingSelection();
     void setCurrentSelection(RetainPtr<PDFSelection>&&);
     void repaintOnSelectionActiveStateChangeIfNeeded(ActiveStateChangeReason);
     bool isSelectionActiveAfterContextMenuInteraction() const;
@@ -319,6 +320,7 @@ private:
     AnnotationTrackingState m_annotationTrackingState;
 
     struct SelectionTrackingData {
+        bool isActivelyTrackingSelection { false };
         bool shouldExtendCurrentSelection { false };
         bool shouldMakeMarqueeSelection { false };
         bool lastHandledEventWasContextMenuEvent { false };


### PR DESCRIPTION
#### 8250b6757382e71497e86efb939be39112150fc0
<pre>
[UnifiedPDF] Selections should no longer be tracked when window loses focus
<a href="https://bugs.webkit.org/show_bug.cgi?id=269149">https://bugs.webkit.org/show_bug.cgi?id=269149</a>
<a href="https://rdar.apple.com/122722850">rdar://122722850</a>

Reviewed by Tim Horton.

We were not formally distinguishing when a selection should be tracked,
with the wrong assumption that all selection tracking interactions would
start with a mousedown event. This means that we may pick up bogus
selections when we click on the PDF while out of focus, since that sends
a mousemove event to the plugin, which causes us to extend the selection
based on stale selection tracking data.

This commit corrects against such cases by ensuring we stay aware of
when a selection is being actively tracked. We only activate selection
tracking if we execute beginTrackingSelection, and explicitly deactivate
selection tracking if we receive a mouseup event or we have interacted
with a context menu.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::handleContextMenuEvent):
(WebKit::UnifiedPDFPlugin::extendCurrentSelectionIfNeeded):
(WebKit::UnifiedPDFPlugin::continueTrackingSelection):

Canonical link: <a href="https://commits.webkit.org/274441@main">https://commits.webkit.org/274441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a09fb96468d3181aaee7d3e6eed8d048df6d64a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34841 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32744 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13189 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39010 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37241 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15542 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8750 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->