### PR TITLE
[Digital Identity]: credentials.requestIdentity() method was dropped from spec

### DIFF
--- a/LayoutTests/http/wpt/credential-management/setDigitalIdentityEnable.https.html
+++ b/LayoutTests/http/wpt/credential-management/setDigitalIdentityEnable.https.html
@@ -10,10 +10,6 @@
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
 
-        if (window.navigator.credentials.requestIdentity !== undefined) {
-            console.log("FAIL: requestIdentity() must not be exposed by default.");
-        }
-
         if (window.DigitalIdentity !== undefined) {
             console.log(
                 "FAIL: DigitalIdentity interface must not be exposed by default."
@@ -25,9 +21,9 @@
         async function checkIFrame() {
             const iframeWin = document.querySelector("iframe").contentWindow;
 
-            if (!iframeWin.navigator.credentials.requestIdentity) {
+            if (iframeWin.navigator.credentials.requestIdentity) {
                 console.log(
-                    "FAIL: navigator.credentials.requestIdentity() must be exposed. Was enabled by pref."
+                    "FAIL: navigator.credentials.requestIdentity() was removed from the spec!"
                 );
             }
 

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -144,17 +144,6 @@ void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promis
     promise.resolve();
 }
 
-void CredentialsContainer::requestIdentity(DigitalCredentialRequestOptions&& options, DigitalIdentityPromise&& promise)
-{
-    if (options.signal && options.signal->aborted()) {
-        promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
-        return;
-    }
-    std::span<uint8_t> emptySpan;
-    Ref<ArrayBuffer> emptyArrayBuffer = ArrayBuffer::create(emptySpan);
-    promise.resolve(DigitalIdentity::create(WTFMove(emptyArrayBuffer)));
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -58,8 +58,6 @@ public:
 
     void preventSilentAccess(DOMPromiseDeferred<void>&&) const;
 
-    void requestIdentity(DigitalCredentialRequestOptions&&, DigitalIdentityPromise&&);
-
 private:
     CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);
 

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
@@ -34,5 +34,4 @@
     Promise<BasicCredential> store(BasicCredential credential);
     Promise<BasicCredential?> create(optional CredentialCreationOptions options);
     Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalIdentityEnabled] Promise<DigitalIdentity> requestIdentity(DigitalCredentialRequestOptions options);
 };


### PR DESCRIPTION
#### a4f52392d5bbe9518e71d63f188274beaf486b71
<pre>
[Digital Identity]: credentials.requestIdentity() method was dropped from spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=269167">https://bugs.webkit.org/show_bug.cgi?id=269167</a>
<a href="https://rdar.apple.com/122742758">rdar://122742758</a>

Reviewed by Chris Dumez.

Removed the requestIdentity() method from CredentialsContainer

* LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https.html:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::requestIdentity): Deleted.
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl:

Canonical link: <a href="https://commits.webkit.org/274489@main">https://commits.webkit.org/274489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22ffdb37cf3e89f630fc225853d07de88c9dc946

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35132 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15540 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13316 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13289 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43044 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35277 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37332 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8782 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15313 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->