### PR TITLE
NativePromise: ASSERTION FAILED: !m_callback

### DIFF
--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -313,9 +313,7 @@ public:
         ASSERT(m_callback);
         if (!m_callback)
             return;
-        m_callback->disconnect();
-        m_callback = nullptr;
-
+        std::exchange(m_callback, nullptr)->disconnect();
     }
 
 private:

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -1678,6 +1678,20 @@ TEST(NativePromise, CreateSettledPromise)
     });
 }
 
+TEST(NativePromise, DisconnectNotOwnedInstance)
+{
+    GenericPromise::Producer producer;
+    auto request = makeUnique<NativePromiseRequest>();
+    WeakPtr weakRequest { *request };
+    producer->whenSettled(RunLoop::main(), [request = WTFMove(request)] (auto&& result) mutable {
+        request->complete();
+        EXPECT_TRUE(false);
+    })->track(*weakRequest);
+    weakRequest->disconnect();
+    EXPECT_FALSE(!!weakRequest);
+    producer.resolve();
+}
+
 // Example:
 // Consider a PhotoProducer class that can take a photo and returns an image and its mimetype.
 // The PhotoProducer uses some system framework that takes a completion handler which will receive the photo once taken.


### PR DESCRIPTION
#### ac976a6da88c92945dd495cc2a204d89a4953fe9
<pre>
NativePromise: ASSERTION FAILED: !m_callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=269160">https://bugs.webkit.org/show_bug.cgi?id=269160</a>
<a href="https://rdar.apple.com/122738739">rdar://122738739</a>

Reviewed by Youenn Fablet.

Following 273828@main, NativePromiseRequest now inherits from CanMakeWeakPtr,
making it possible to disconnect it while not owning it. If the NativePromiseRequest
was owned by the NativePromise callback, when disconnecting the NativePromiseRequest
the callback would be deleted before the NativePromiseRequest::m_callback member
got cleared, which trigger the assertion.
We clear m_callback prior call disconnect().

Added API test.

* Source/WTF/wtf/NativePromise.h:
(WTF::NativePromiseRequest::disconnect):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/274448@main">https://commits.webkit.org/274448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9edf41cbe438bfb98c65daa90098aa468b2f3fea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42944 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32586 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39020 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38759 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37250 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15551 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45765 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8752 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15214 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9326 "Found unexpected failure with change (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->