### PR TITLE
Remove MediaPlayerPrivateInterface::duration() and co.

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -147,7 +147,7 @@ void ManagedMediaSource::monitorSourceBuffers()
             setStreaming(true);
             return;
         }
-        auto currentTime = currentMediaTime();
+        auto currentTime = this->currentTime();
 
         ensurePrefsRead();
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -189,7 +189,7 @@ MediaTime MediaSource::duration() const
     return isClosed() ? MediaTime::invalidTime() : m_private->duration();
 }
 
-MediaTime MediaSource::currentMediaTime() const
+MediaTime MediaSource::currentTime() const
 {
     assertIsCurrent(m_dispatcher.get());
 
@@ -199,7 +199,7 @@ MediaTime MediaSource::currentMediaTime() const
     if (m_pendingSeekTarget)
         return m_pendingSeekTarget->time;
 
-    return m_private->currentMediaTime();
+    return m_private->currentTime();
 }
 
 const PlatformTimeRanges& MediaSource::buffered() const
@@ -413,7 +413,7 @@ bool MediaSource::hasBufferedTime(const MediaTime& time)
 
 bool MediaSource::hasCurrentTime()
 {
-    return hasBufferedTime(currentMediaTime());
+    return hasBufferedTime(currentTime());
 }
 
 bool MediaSource::hasFutureTime()
@@ -423,7 +423,7 @@ bool MediaSource::hasFutureTime()
     if (isClosed())
         return false;
 
-    return m_private->hasFutureTime(currentMediaTime());
+    return m_private->hasFutureTime(currentTime());
 }
 
 void MediaSource::monitorSourceBuffers()

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -101,7 +101,7 @@ public:
 
     ExceptionOr<void> setDuration(double);
     ExceptionOr<void> setDurationInternal(const MediaTime&);
-    MediaTime currentMediaTime() const;
+    MediaTime currentTime() const;
 
     enum class ReadyState { Closed, Open, Ended };
     ReadyState readyState() const;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -346,7 +346,7 @@ void SourceBuffer::rangeRemoval(const MediaTime& start, const MediaTime& end)
     // 5. Return control to the caller and run the rest of the steps asynchronously.
     promisedWeakOnDispatcher([this, start, end] {
         // 6. Run the coded frame removal algorithm with start and end as the start and end of the removal range.
-        return m_private->removeCodedFrames(start, end, m_source->currentMediaTime());
+        return m_private->removeCodedFrames(start, end, m_source->currentTime());
     }, true)->whenSettled(m_dispatcher, [this, protectedThis = Ref { *this }] {
         m_removeCodedFramesPromise.complete();
 
@@ -526,7 +526,7 @@ ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, 
     m_source->openIfInEndedState();
 
     // 4. Run the coded frame eviction algorithm.
-    m_private->evictCodedFrames(size, maximumBufferSize(), m_source->currentMediaTime());
+    m_private->evictCodedFrames(size, maximumBufferSize(), m_source->currentTime());
 
     // 5. If the buffer full flag equals true, then throw a QuotaExceededError exception and abort these step.
     if (m_private->isBufferFullFor(size, maximumBufferSize())) {
@@ -593,7 +593,7 @@ void SourceBuffer::sourceBufferPrivateAppendComplete(MediaPromise::Result&& resu
     scheduleEvent(eventNames().updateendEvent);
 
     m_source->monitorSourceBuffers();
-    m_private->reenqueueMediaIfNeeded(m_source->currentMediaTime());
+    m_private->reenqueueMediaIfNeeded(m_source->currentTime());
 
     ALWAYS_LOG(LOGIDENTIFIER, "buffered = ", m_buffered->ranges(), ", totalBufferSize: ", m_private->totalTrackBufferSizeInBytes());
 }
@@ -1176,7 +1176,7 @@ bool SourceBuffer::canPlayThroughRange(const PlatformTimeRanges& ranges)
     if (!duration.isValid())
         return false;
 
-    MediaTime currentTime = m_source->currentMediaTime();
+    MediaTime currentTime = m_source->currentTime();
     if (duration <= currentTime)
         return true;
 
@@ -1411,7 +1411,7 @@ void SourceBuffer::memoryPressure()
 {
     if (!isManaged())
         return;
-    m_private->memoryPressure(maximumBufferSize(), m_source->currentMediaTime());
+    m_private->memoryPressure(maximumBufferSize(), m_source->currentTime());
 }
 
 void SourceBuffer::ensureWeakOnDispatcher(Function<void()>&& function) const

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1846,7 +1846,7 @@ void HTMLMediaElement::updateActiveTextTrackCues(const MediaTime& movieTime)
     INFO_LOG(identifier, "nextInterestingTime:", nextInterestingTime);
 
     if (RefPtr player = m_player; nextInterestingTime.isValid() && player) {
-        player->performTaskAtMediaTime([this, weakThis = WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> { *this }, identifier] {
+        player->performTaskAtTime([this, weakThis = WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> { *this }, identifier] {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -133,8 +133,6 @@ public:
 
     void setPageIsVisible(bool, String&&) final { }
 
-    double durationDouble() const final { return 0; }
-
     void seekToTarget(const SeekTarget&) final { }
     bool seeking() const final { return false; }
 
@@ -152,8 +150,6 @@ public:
     MediaPlayer::NetworkState networkState() const final { return MediaPlayer::NetworkState::Empty; }
     MediaPlayer::ReadyState readyState() const final { return MediaPlayer::ReadyState::HaveNothing; }
 
-    float maxTimeSeekable() const final { return 0; }
-    double minTimeSeekable() const final { return 0; }
     const PlatformTimeRanges& buffered() const final { return PlatformTimeRanges::emptyRanges(); }
 
     double seekableTimeRangesLastModifiedTime() const final { return 0; }
@@ -771,7 +767,7 @@ void MediaPlayer::setShouldContinueAfterKeyNeeded(bool should)
 
 MediaTime MediaPlayer::duration() const
 {
-    return m_private->durationMediaTime();
+    return m_private->duration();
 }
 
 MediaTime MediaPlayer::startTime() const
@@ -786,12 +782,12 @@ MediaTime MediaPlayer::initialTime() const
 
 MediaTime MediaPlayer::currentTime() const
 {
-    return m_private->currentMediaTime();
+    return m_private->currentTime();
 }
 
 bool MediaPlayer::currentTimeMayProgress() const
 {
-    return m_private->currentMediaTimeMayProgress();
+    return m_private->currentTimeMayProgress();
 }
 
 bool MediaPlayer::setCurrentTimeDidChangeCallback(CurrentTimeDidChangeCallback&& callback)
@@ -1066,12 +1062,12 @@ const PlatformTimeRanges& MediaPlayer::seekable() const
 
 MediaTime MediaPlayer::maxTimeSeekable() const
 {
-    return m_private->maxMediaTimeSeekable();
+    return m_private->maxTimeSeekable();
 }
 
 MediaTime MediaPlayer::minTimeSeekable() const
 {
-    return m_private->minMediaTimeSeekable();
+    return m_private->minTimeSeekable();
 }
 
 double MediaPlayer::seekableTimeRangesLastModifiedTime()
@@ -1817,9 +1813,9 @@ AVPlayer* MediaPlayer::objCAVFoundationAVPlayer() const
 
 #endif
 
-bool MediaPlayer::performTaskAtMediaTime(Function<void()>&& task, const MediaTime& time)
+bool MediaPlayer::performTaskAtTime(Function<void()>&& task, const MediaTime& time)
 {
-    return m_private->performTaskAtMediaTime(WTFMove(task), time);
+    return m_private->performTaskAtTime(WTFMove(task), time);
 }
 
 bool MediaPlayer::shouldIgnoreIntrinsicSize()

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -427,7 +427,7 @@ public:
     bool seeking() const;
     void seeked(const MediaTime&);
 
-    static double invalidTime() { return -1.0;}
+    static double invalidTime() { return -1.0; }
     MediaTime duration() const;
     MediaTime currentTime() const;
 
@@ -679,7 +679,7 @@ public:
     AVPlayer *objCAVFoundationAVPlayer() const;
 #endif
 
-    bool performTaskAtMediaTime(Function<void()>&&, const MediaTime&);
+    bool performTaskAtTime(Function<void()>&&, const MediaTime&);
 
     bool shouldIgnoreIntrinsicSize();
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -49,9 +49,9 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateInterface::videoFrameMetadat
 
 const PlatformTimeRanges& MediaPlayerPrivateInterface::seekable() const
 {
-    if (maxMediaTimeSeekable() == MediaTime::zeroTime())
+    if (maxTimeSeekable() == MediaTime::zeroTime())
         return PlatformTimeRanges::emptyRanges();
-    m_seekable = { minMediaTimeSeekable(), maxMediaTimeSeekable() };
+    m_seekable = { minTimeSeekable(), maxTimeSeekable() };
     return m_seekable;
 }
 
@@ -67,7 +67,7 @@ MediaTime MediaPlayerPrivateInterface::currentOrPendingSeekTime() const
     auto pendingSeekTime = this->pendingSeekTime();
     if (pendingSeekTime.isValid())
         return pendingSeekTime;
-    return currentMediaTime();
+    return currentTime();
 }
 
 }

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -121,13 +121,11 @@ public:
     virtual void setVisibleForCanvas(bool visible) { setPageIsVisible(visible); }
     virtual void setVisibleInViewport(bool) { }
 
-    virtual float duration() const { return 0; }
-    virtual double durationDouble() const { return duration(); }
-    virtual MediaTime durationMediaTime() const { return MediaTime::createWithDouble(durationDouble()); }
+    virtual MediaTime duration() const { return MediaTime::zeroTime(); }
 
     WEBCORE_EXPORT virtual MediaTime currentOrPendingSeekTime() const;
-    virtual MediaTime currentMediaTime() const { return MediaTime::zeroTime(); }
-    virtual bool currentMediaTimeMayProgress() const { return readyState() >= MediaPlayer::ReadyState::HaveFutureData; }
+    virtual MediaTime currentTime() const { return MediaTime::zeroTime(); }
+    virtual bool currentTimeMayProgress() const { return readyState() >= MediaPlayer::ReadyState::HaveFutureData; }
 
     virtual bool setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&&) { return false; }
 
@@ -169,10 +167,8 @@ public:
     virtual MediaPlayer::ReadyState readyState() const = 0;
 
     WEBCORE_EXPORT virtual const PlatformTimeRanges& seekable() const;
-    virtual float maxTimeSeekable() const { return 0; }
-    virtual MediaTime maxMediaTimeSeekable() const { return MediaTime::createWithDouble(maxTimeSeekable()); }
-    virtual double minTimeSeekable() const { return 0; }
-    virtual MediaTime minMediaTimeSeekable() const { return MediaTime::createWithDouble(minTimeSeekable()); }
+    virtual MediaTime maxTimeSeekable() const { return MediaTime::zeroTime(); }
+    virtual MediaTime minTimeSeekable() const { return MediaTime::zeroTime(); }
     virtual const PlatformTimeRanges& buffered() const = 0;
     virtual double seekableTimeRangesLastModifiedTime() const { return 0; }
     virtual double liveUpdateInterval() const { return 0; }
@@ -296,7 +292,7 @@ public:
 
     virtual size_t extraMemoryCost() const
     {
-        MediaTime duration = this->durationMediaTime();
+        MediaTime duration = this->duration();
         if (!duration)
             return 0;
 
@@ -325,7 +321,7 @@ public:
     virtual AVPlayer *objCAVFoundationAVPlayer() const { return nullptr; }
 #endif
 
-    virtual bool performTaskAtMediaTime(Function<void()>&&, const MediaTime&) { return false; }
+    virtual bool performTaskAtTime(Function<void()>&&, const MediaTime&) { return false; }
 
     virtual bool shouldIgnoreIntrinsicSize() { return false; }
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -189,7 +189,7 @@ void MediaSourcePrivate::ensureOnDispatcher(Function<void()>&& function) const
     m_dispatcher->dispatch(WTFMove(function));
 }
 
-MediaTime MediaSourcePrivate::currentMediaTime() const
+MediaTime MediaSourcePrivate::currentTime() const
 {
     if (RefPtr player = this->player())
         return player->currentOrPendingSeekTime();

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -87,7 +87,7 @@ public:
     virtual MediaPlayer::ReadyState mediaPlayerReadyState() const = 0;
     virtual void setMediaPlayerReadyState(MediaPlayer::ReadyState) = 0;
 
-    MediaTime currentMediaTime() const;
+    MediaTime currentTime() const;
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
     Ref<MediaPromise> seekToTime(const MediaTime&);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -91,10 +91,10 @@ void SourceBufferPrivate::setClient(SourceBufferPrivateClient& client)
     m_client = client;
 }
 
-MediaTime SourceBufferPrivate::currentMediaTime() const
+MediaTime SourceBufferPrivate::currentTime() const
 {
     if (RefPtr mediaSource = m_mediaSource.get())
-        return mediaSource->currentMediaTime();
+        return mediaSource->currentTime();
     return { };
 }
 
@@ -161,7 +161,7 @@ void SourceBufferPrivate::reenqueSamples(TrackID trackID)
     if (trackBuffer == m_trackBufferMap.end())
         return;
     trackBuffer->second->setNeedsReenqueueing(true);
-    reenqueueMediaForTime(trackBuffer->second, trackID, currentMediaTime());
+    reenqueueMediaForTime(trackBuffer->second, trackID, currentTime());
 }
 
 Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivate::computeSeekTime(const SeekTarget& target)
@@ -1044,7 +1044,7 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
 
             // Only force the TrackBuffer to re-enqueue if the removed ranges overlap with enqueued and possibly
             // not yet displayed samples.
-            MediaTime currentTime = currentMediaTime();
+            MediaTime currentTime = this->currentTime();
             if (trackBuffer.highestEnqueuedPresentationTime().isValid() && currentTime < trackBuffer.highestEnqueuedPresentationTime()) {
                 PlatformTimeRanges possiblyEnqueuedRanges(currentTime, trackBuffer.highestEnqueuedPresentationTime());
                 possiblyEnqueuedRanges.intersectWith(erasedRanges);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -163,7 +163,7 @@ public:
 
 protected:
     WEBCORE_EXPORT explicit SourceBufferPrivate(MediaSourcePrivate&, RefCountedSerialFunctionDispatcher&);
-    MediaTime currentMediaTime() const;
+    MediaTime currentTime() const;
     MediaTime mediaSourceDuration() const;
 
     WEBCORE_EXPORT void ensureOnDispatcher(Function<void()>&&) const;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -247,7 +247,7 @@ void MediaPlayerPrivateAVFoundation::pause()
     platformPause();
 }
 
-MediaTime MediaPlayerPrivateAVFoundation::durationMediaTime() const
+MediaTime MediaPlayerPrivateAVFoundation::duration() const
 {
     if (m_cachedDuration.isValid())
         return m_cachedDuration;
@@ -276,8 +276,8 @@ void MediaPlayerPrivateAVFoundation::seekToTarget(const SeekTarget& target)
         return;
 
     SeekTarget adjustedTarget = target;
-    if (target.time > durationMediaTime())
-        adjustedTarget.time = durationMediaTime();
+    if (target.time > duration())
+        adjustedTarget.time = duration();
 
     if (currentTextTrack())
         currentTextTrack()->beginSeeking();
@@ -415,7 +415,7 @@ const PlatformTimeRanges& MediaPlayerPrivateAVFoundation::buffered() const
     return platformBufferedTimeRanges();
 }
 
-MediaTime MediaPlayerPrivateAVFoundation::maxMediaTimeSeekable() const
+MediaTime MediaPlayerPrivateAVFoundation::maxTimeSeekable() const
 {
     if (!metaDataAvailable())
         return MediaTime::zeroTime();
@@ -426,7 +426,7 @@ MediaTime MediaPlayerPrivateAVFoundation::maxMediaTimeSeekable() const
     return m_cachedMaxTimeSeekable;
 }
 
-MediaTime MediaPlayerPrivateAVFoundation::minMediaTimeSeekable() const
+MediaTime MediaPlayerPrivateAVFoundation::minTimeSeekable() const
 {
     if (!metaDataAvailable())
         return MediaTime::zeroTime();
@@ -450,7 +450,7 @@ MediaTime MediaPlayerPrivateAVFoundation::maxTimeLoaded() const
 
 bool MediaPlayerPrivateAVFoundation::didLoadingProgress() const
 {
-    if (!durationMediaTime())
+    if (!duration())
         return false;
     MediaTime currentMaxTimeLoaded = maxTimeLoaded();
     bool didLoadingProgress = currentMaxTimeLoaded != m_maxTimeLoadedAtLastDidLoadingProgress;
@@ -557,7 +557,7 @@ void MediaPlayerPrivateAVFoundation::updateStates()
                 break;
 
             case MediaPlayerAVPlayerItemStatusReadyToPlay:
-                if (m_readyState != MediaPlayer::ReadyState::HaveEnoughData && (!m_cachedHasVideo || m_haveReportedFirstVideoFrame) && maxTimeLoaded() > currentMediaTime())
+                if (m_readyState != MediaPlayer::ReadyState::HaveEnoughData && (!m_cachedHasVideo || m_haveReportedFirstVideoFrame) && maxTimeLoaded() > currentTime())
                     newReadyState = MediaPlayer::ReadyState::HaveFutureData;
                 break;
 
@@ -571,7 +571,7 @@ void MediaPlayerPrivateAVFoundation::updateStates()
             else if (itemStatus == MediaPlayerAVPlayerItemStatusFailed)
                 newNetworkState = MediaPlayer::NetworkState::DecodeError;
             else if (itemStatus != MediaPlayerAVPlayerItemStatusPlaybackBufferFull && itemStatus >= MediaPlayerAVPlayerItemStatusReadyToPlay)
-                newNetworkState = (maxTimeLoaded() >= durationMediaTime()) ? MediaPlayer::NetworkState::Loaded : MediaPlayer::NetworkState::Loading;
+                newNetworkState = (maxTimeLoaded() >= duration()) ? MediaPlayer::NetworkState::Loaded : MediaPlayer::NetworkState::Loading;
         }
     }
 
@@ -692,7 +692,7 @@ void MediaPlayerPrivateAVFoundation::didEnd()
 {
     // Hang onto the current time and use it as duration from now on since we are definitely at
     // the end of the movie. Do this because the initial duration is sometimes an estimate.
-    MediaTime now = currentMediaTime();
+    MediaTime now = currentTime();
     ALWAYS_LOG(LOGIDENTIFIER, "currentTime: ", now, ", seeking: ", m_seeking);
     if (now > MediaTime::zeroTime() && !m_seeking)
         m_cachedDuration = now;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -184,8 +184,8 @@ protected:
     bool hasVideo() const override { return m_cachedHasVideo; }
     bool hasAudio() const override { return m_cachedHasAudio; }
     void setPageIsVisible(bool, String&& sceneIdentifier) final;
-    MediaTime durationMediaTime() const override;
-    MediaTime currentMediaTime() const override = 0;
+    MediaTime duration() const override;
+    MediaTime currentTime() const override = 0;
     void seekToTarget(const SeekTarget&) final;
     bool seeking() const final;
     bool paused() const override;
@@ -193,8 +193,8 @@ protected:
     bool hasClosedCaptions() const override { return m_cachedHasCaptions; }
     MediaPlayer::NetworkState networkState() const override { return m_networkState; }
     MediaPlayer::ReadyState readyState() const override { return m_readyState; }
-    MediaTime maxMediaTimeSeekable() const override;
-    MediaTime minMediaTimeSeekable() const override;
+    MediaTime maxTimeSeekable() const override;
+    MediaTime minTimeSeekable() const override;
     const PlatformTimeRanges& buffered() const override;
     bool didLoadingProgress() const override;
     void paint(GraphicsContext&, const FloatRect&) override = 0;
@@ -288,7 +288,7 @@ protected:
     void setDelayCharacteristicsChangedNotification(bool);
     void setIgnoreLoadStateChanges(bool delay) { m_ignoreLoadStateChanges = delay; }
     void setNaturalSize(FloatSize);
-    bool isLiveStream() const { return std::isinf(duration()); }
+    bool isLiveStream() const { return duration().isPositiveInfinite(); }
     void setNetworkState(MediaPlayer::NetworkState);
     void setReadyState(MediaPlayer::ReadyState);
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -128,7 +128,7 @@ public:
 
     void outputObscuredDueToInsufficientExternalProtectionChanged(bool);
 
-    MediaTime currentMediaTime() const final;
+    MediaTime currentTime() const final;
     void outputMediaDataWillChange();
     void processChapterTracks();
 
@@ -337,16 +337,16 @@ private:
 
     AVPlayer *objCAVFoundationAVPlayer() const final { return m_avPlayer.get(); }
 
-    bool performTaskAtMediaTime(Function<void()>&&, const MediaTime&) final;
+    bool performTaskAtTime(Function<void()>&&, const MediaTime&) final;
     void setShouldObserveTimeControlStatus(bool);
 
     void setPreferredDynamicRangeMode(DynamicRangeMode) final;
     void audioOutputDeviceChanged() final;
 
-    void currentMediaTimeDidChange(MediaTime&&) const;
+    void currentTimeDidChange(MediaTime&&) const;
     bool setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&&) final;
 
-    bool currentMediaTimeIsBuffered() const;
+    bool currentTimeIsBuffered() const;
 
     bool supportsPlayAtHostTime() const final { return true; }
     bool supportsPauseAtHostTime() const final { return true; }
@@ -441,7 +441,7 @@ private:
     RetainPtr<NSArray> m_currentMetaData;
     FloatSize m_cachedPresentationSize;
     mutable MediaPlayer::CurrentTimeDidChangeCallback m_currentTimeDidChangeCallback;
-    mutable MediaTime m_cachedCurrentMediaTime { -1, 1, 0 };
+    mutable MediaTime m_cachedCurrentTime { -1, 1, 0 };
     mutable MediaTime m_lastPeriodicObserverMediaTime;
     mutable Markable<WallTime> m_wallClockAtCachedCurrentTime;
     mutable int m_timeControlStatusAtCachedCurrentTime { 0 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -113,8 +113,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void flushPendingSizeChanges();
     void characteristicsChanged();
 
-    MediaTime currentMediaTime() const override;
-    bool currentMediaTimeMayProgress() const override;
+    MediaTime currentTime() const override;
+    bool currentTimeMayProgress() const override;
     AVSampleBufferDisplayLayer* sampleBufferDisplayLayer() const { return m_sampleBufferDisplayLayer.get(); }
     WebCoreDecompressionSession* decompressionSession() const { return m_decompressionSession.get(); }
 
@@ -208,7 +208,7 @@ private:
 
     void setPageIsVisible(bool, String&& sceneIdentifier) final;
 
-    MediaTime durationMediaTime() const override;
+    MediaTime duration() const override;
     MediaTime startTime() const override;
     MediaTime initialTime() const override;
 
@@ -220,8 +220,8 @@ private:
 
     void setPreservesPitch(bool) override;
 
-    MediaTime maxMediaTimeSeekable() const override;
-    MediaTime minMediaTimeSeekable() const override;
+    MediaTime maxTimeSeekable() const override;
+    MediaTime minTimeSeekable() const override;
     const PlatformTimeRanges& buffered() const override;
 
     bool didLoadingProgress() const override;
@@ -271,7 +271,7 @@ private:
     bool wirelessVideoPlaybackDisabled() const override { return false; }
 #endif
 
-    bool performTaskAtMediaTime(Function<void()>&&, const MediaTime&) final;
+    bool performTaskAtTime(Function<void()>&&, const MediaTime&) final;
     void audioOutputDeviceChanged() final;
 
     void ensureLayer();
@@ -336,7 +336,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     MediaPlayer::NetworkState m_networkState;
     MediaPlayer::ReadyState m_readyState;
     bool m_readyStateIsWaitingForAvailableFrame { false };
-    MediaTime m_mediaTimeDuration { MediaTime::invalidTime() };
+    MediaTime m_duration { MediaTime::invalidTime() };
     MediaTime m_lastSeekTime;
     FloatSize m_naturalSize;
     double m_rate { 1 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -135,8 +135,8 @@ private:
     void setVisibleForCanvas(bool) final;
     void setVisibleInViewport(bool) final;
 
-    MediaTime durationMediaTime() const override;
-    MediaTime currentMediaTime() const override;
+    MediaTime duration() const override;
+    MediaTime currentTime() const override;
 
     void seekToTarget(const SeekTarget&) final { };
     bool seeking() const final { return false; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -595,7 +595,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::pause()
     if (!metaDataAvailable() || !playing() || m_ended)
         return;
 
-    m_pausedTime = currentMediaTime();
+    m_pausedTime = currentTime();
     m_playbackState = PlaybackState::Paused;
 
     for (const auto& track : m_audioTrackMap.values())
@@ -664,12 +664,12 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setVisibleInViewport(bool isVisible)
     m_isVisibleInViewPort = isVisible;
 }
 
-MediaTime MediaPlayerPrivateMediaStreamAVFObjC::durationMediaTime() const
+MediaTime MediaPlayerPrivateMediaStreamAVFObjC::duration() const
 {
     return MediaTime::positiveInfiniteTime();
 }
 
-MediaTime MediaPlayerPrivateMediaStreamAVFObjC::currentMediaTime() const
+MediaTime MediaPlayerPrivateMediaStreamAVFObjC::currentTime() const
 {
     if (paused())
         return m_pausedTime;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -119,8 +119,8 @@ private:
     void setPageIsVisible(bool, String&& sceneIdentifier) final;
 
     MediaTime timeFudgeFactor() const { return { 1, 10 }; }
-    MediaTime currentMediaTime() const final;
-    MediaTime durationMediaTime() const final { return m_duration; }
+    MediaTime currentTime() const final;
+    MediaTime duration() const final { return m_duration; }
     MediaTime startTime() const final { return MediaTime::zeroTime(); }
     MediaTime initialTime() const final { return MediaTime::zeroTime(); }
 
@@ -134,8 +134,8 @@ private:
     MediaPlayer::NetworkState networkState() const final { return m_networkState; }
     MediaPlayer::ReadyState readyState() const final { return m_readyState; }
 
-    MediaTime maxMediaTimeSeekable() const final { return durationMediaTime(); }
-    MediaTime minMediaTimeSeekable() const final { return startTime(); }
+    MediaTime maxTimeSeekable() const final { return duration(); }
+    MediaTime minTimeSeekable() const final { return startTime(); }
     const PlatformTimeRanges& buffered() const final;
 
     void setBufferedRanges(PlatformTimeRanges);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -293,7 +293,7 @@ void MediaPlayerPrivateWebM::play()
 
     [m_synchronizer setRate:m_rate];
 
-    if (currentMediaTime() >= durationMediaTime())
+    if (currentTime() >= duration())
         seekToTarget(SeekTarget::zero());
 }
 
@@ -317,7 +317,7 @@ void MediaPlayerPrivateWebM::setPageIsVisible(bool visible, String&&)
     m_visible = visible;
 }
 
-MediaTime MediaPlayerPrivateWebM::currentMediaTime() const
+MediaTime MediaPlayerPrivateWebM::currentTime() const
 {
     MediaTime synchronizerTime = clampTimeToLastSeekTime(PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase])));
     if (synchronizerTime < MediaTime::zeroTime())
@@ -537,7 +537,7 @@ bool MediaPlayerPrivateWebM::updateLastPixelBuffer()
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
     if (m_videoLayer && isCopyDisplayedPixelBufferAvailable()) {
         if (RetainPtr pixelBuffer = m_videoLayer->copyDisplayedPixelBuffer()) {
-            INFO_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", currentMediaTime());
+            INFO_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", currentTime());
             m_lastPixelBuffer = WTFMove(pixelBuffer);
             return true;
         }
@@ -548,7 +548,7 @@ bool MediaPlayerPrivateWebM::updateLastPixelBuffer()
         return false;
 
     auto flags = !m_lastPixelBuffer ? WebCoreDecompressionSession::AllowLater : WebCoreDecompressionSession::ExactTime;
-    auto newPixelBuffer = m_decompressionSession->imageForTime(currentMediaTime(), flags);
+    auto newPixelBuffer = m_decompressionSession->imageForTime(currentTime(), flags);
     if (!newPixelBuffer)
         return false;
 
@@ -631,7 +631,7 @@ RefPtr<VideoFrame> MediaPlayerPrivateWebM::videoFrameForCurrentTime()
     }
     if (!m_lastPixelBuffer)
         return nullptr;
-    return VideoFrameCV::create(currentMediaTime(), false, VideoFrame::Rotation::None, RetainPtr { m_lastPixelBuffer });
+    return VideoFrameCV::create(currentTime(), false, VideoFrame::Rotation::None, RetainPtr { m_lastPixelBuffer });
 }
 
 DestinationColorSpace MediaPlayerPrivateWebM::colorSpace()
@@ -714,7 +714,7 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
         if (!protectedThis)
             return;
 
-        MediaTime now = currentMediaTime();
+        MediaTime now = currentTime();
         ALWAYS_LOG(logSiteIdentifier, "boundary time observer called, now = ", now);
 
         pause();
@@ -958,7 +958,7 @@ void MediaPlayerPrivateWebM::reenqueSamples(TrackID trackId)
         return;
     TrackBuffer& trackBuffer = it->second;
     trackBuffer.setNeedsReenqueueing(true);
-    reenqueueMediaForTime(trackBuffer, trackId, currentMediaTime());
+    reenqueueMediaForTime(trackBuffer, trackId, currentTime());
 }
 
 void MediaPlayerPrivateWebM::reenqueueMediaForTime(TrackBuffer& trackBuffer, TrackID trackId, const MediaTime& time)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -164,16 +164,11 @@ public:
     void setPageIsVisible(bool visible, String&&) final { m_visible = visible; }
     void setVisibleInViewport(bool isVisible) final;
     void setPresentationSize(const IntSize&) final;
-    // Prefer MediaTime based methods over float based.
-    float duration() const final { return durationMediaTime().toFloat(); }
-    double durationDouble() const final { return durationMediaTime().toDouble(); }
-    MediaTime durationMediaTime() const override;
-    MediaTime currentMediaTime() const override;
+    MediaTime duration() const override;
+    MediaTime currentTime() const override;
     const PlatformTimeRanges& buffered() const override;
-    float maxTimeSeekable() const final { return maxMediaTimeSeekable().toFloat(); }
-    MediaTime maxMediaTimeSeekable() const override;
-    double minTimeSeekable() const final { return minMediaTimeSeekable().toFloat(); }
-    MediaTime minMediaTimeSeekable() const final { return MediaTime::zeroTime(); }
+    MediaTime maxTimeSeekable() const override;
+    MediaTime minTimeSeekable() const final { return MediaTime::zeroTime(); }
     bool didLoadingProgress() const final;
     unsigned long long totalBytes() const final;
     std::optional<bool> isCrossOrigin(const SecurityOrigin&) const final;
@@ -190,7 +185,7 @@ public:
     unsigned decodedFrameCount() const final;
     unsigned droppedFrameCount() const final;
     void acceleratedRenderingStateChanged() final;
-    bool performTaskAtMediaTime(Function<void()>&&, const MediaTime&) override;
+    bool performTaskAtTime(Function<void()>&&, const MediaTime&) override;
     void isLoopingChanged() final;
 
 #if USE(TEXTURE_MAPPER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -153,7 +153,7 @@ void MediaPlayerPrivateGStreamerMSE::pause()
     updateStates();
 }
 
-MediaTime MediaPlayerPrivateGStreamerMSE::durationMediaTime() const
+MediaTime MediaPlayerPrivateGStreamerMSE::duration() const
 {
     if (UNLIKELY(!m_pipeline || m_didErrorOccur))
         return MediaTime();
@@ -264,7 +264,7 @@ void MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer()
 
     // The readyState change may be a result of monitorSourceBuffers() finding that currentTime == duration, which
     // should cause the video to be marked as ended. Let's have the player check that.
-    if (player && (!m_isWaitingForPreroll || currentMediaTime() == durationMediaTime()))
+    if (player && (!m_isWaitingForPreroll || currentTime() == duration()))
         player->timeChanged();
 }
 
@@ -277,7 +277,7 @@ void MediaPlayerPrivateGStreamerMSE::didPreroll()
     // c) At the end of a flush (forced quality change). These should not produce either of these outcomes.
     // We identify (a) and (b) by setting m_isWaitingForPreroll = true at the initialization of the player and
     // at the beginning of a seek.
-    GST_DEBUG("Pipeline prerolled. currentMediaTime = %s", currentMediaTime().toString().utf8().data());
+    GST_DEBUG("Pipeline prerolled. currentMediaTime = %s", currentTime().toString().utf8().data());
     if (!m_isWaitingForPreroll) {
         GST_DEBUG("Preroll was consequence of a flush, nothing to do at this level.");
         return;
@@ -290,9 +290,9 @@ void MediaPlayerPrivateGStreamerMSE::didPreroll()
 
     if (m_isSeeking) {
         m_isSeeking = false;
-        GST_DEBUG("Seek complete because of preroll. currentMediaTime = %s", currentMediaTime().toString().utf8().data());
+        GST_DEBUG("Seek complete because of preroll. currentMediaTime = %s", currentTime().toString().utf8().data());
         // By calling timeChanged(), m_isSeeking will be checked an a "seeked" event will be emitted.
-        timeChanged(currentMediaTime());
+        timeChanged(currentTime());
     }
 
     propagateReadyStateToPlayer();
@@ -415,13 +415,13 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const Med
     return result;
 }
 
-MediaTime MediaPlayerPrivateGStreamerMSE::maxMediaTimeSeekable() const
+MediaTime MediaPlayerPrivateGStreamerMSE::maxTimeSeekable() const
 {
     if (UNLIKELY(m_didErrorOccur))
         return MediaTime::zeroTime();
 
-    GST_DEBUG("maxMediaTimeSeekable");
-    MediaTime result = durationMediaTime();
+    GST_DEBUG("maxTimeSeekable");
+    MediaTime result = duration();
     // Infinite duration means live stream.
     if (result.isPositiveInfinite()) {
         MediaTime maxBufferedTime = buffered().maximumBufferedTime();
@@ -432,11 +432,11 @@ MediaTime MediaPlayerPrivateGStreamerMSE::maxMediaTimeSeekable() const
     return result;
 }
 
-bool MediaPlayerPrivateGStreamerMSE::currentMediaTimeMayProgress() const
+bool MediaPlayerPrivateGStreamerMSE::currentTimeMayProgress() const
 {
     if (!m_mediaSourcePrivate)
         return false;
-    return m_mediaSourcePrivate->hasFutureTime(currentMediaTime());
+    return m_mediaSourcePrivate->hasFutureTime(currentTime());
 }
 
 void MediaPlayerPrivateGStreamerMSE::notifyActiveSourceBuffersChanged()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -60,11 +60,11 @@ public:
     void updatePipelineState(GstState);
 
     void durationChanged() override;
-    MediaTime durationMediaTime() const override;
+    MediaTime duration() const override;
 
     const PlatformTimeRanges& buffered() const override;
-    MediaTime maxMediaTimeSeekable() const override;
-    bool currentMediaTimeMayProgress() const override;
+    MediaTime maxTimeSeekable() const override;
+    bool currentTimeMayProgress() const override;
     void notifyActiveSourceBuffersChanged() final;
 
     void sourceSetup(GstElement*) override;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -651,7 +651,7 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         // by however running time we're starting after the flush.
         MediaPlayerPrivateGStreamerMSE* player = webKitMediaSrcPlayer(stream->source);
         if (player) {
-            MediaTime streamTime = player->currentMediaTime();
+            MediaTime streamTime = player->currentTime();
             GstClockTime pipelineStreamTime = toGstClockTime(streamTime);
             DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
             // We need to increase the base by the running time accumulated during the previous segment.

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -295,7 +295,7 @@ void MediaPlayerPrivateMediaFoundation::setRate(float rate)
     rateControl->SetRate(reduceSamplesInStream, rate);
 }
 
-MediaTime MediaPlayerPrivateMediaFoundation::durationMediaTime() const
+MediaTime MediaPlayerPrivateMediaFoundation::duration() const
 {
     if (!m_mediaSource)
         return MediaTime::zeroTime();
@@ -312,10 +312,10 @@ MediaTime MediaPlayerPrivateMediaFoundation::durationMediaTime() const
     return MediaTime(duration, tenMegahertz);
 }
 
-MediaTime MediaPlayerPrivateMediaFoundation::currentMediaTime() const
+MediaTime MediaPlayerPrivateMediaFoundation::currentTime() const
 {
     if (m_sessionEnded)
-        return durationMediaTime();
+        return duration();
     if (!m_mediaSession)
         return MediaTime::invalidTime();
     COMPtr<IMFClock> clock;
@@ -380,9 +380,9 @@ MediaPlayer::ReadyState MediaPlayerPrivateMediaFoundation::readyState() const
     return m_readyState;
 }
 
-MediaTime MediaPlayerPrivateMediaFoundation::maxMediaTimeSeekable() const
+MediaTime MediaPlayerPrivateMediaFoundation::maxTimeSeekable() const
 {
-    return durationMediaTime();
+    return duration();
 }
 
 const PlatformTimeRanges& MediaPlayerPrivateMediaFoundation::buffered() const

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -87,9 +87,9 @@ public:
 
     void setRate(float) final;
 
-    MediaTime durationMediaTime() const final;
+    MediaTime duration() const final;
 
-    MediaTime currentMediaTime() const final;
+    MediaTime currentTime() const final;
 
     bool paused() const final;
 
@@ -100,7 +100,7 @@ public:
     MediaPlayer::NetworkState networkState() const final;
     MediaPlayer::ReadyState readyState() const final;
 
-    MediaTime maxMediaTimeSeekable() const final;
+    MediaTime maxTimeSeekable() const final;
 
     const PlatformTimeRanges& buffered() const final;
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -170,7 +170,7 @@ MediaPlayer::ReadyState MockMediaPlayerMediaSource::readyState() const
     return m_readyState;
 }
 
-MediaTime MockMediaPlayerMediaSource::maxMediaTimeSeekable() const
+MediaTime MockMediaPlayerMediaSource::maxTimeSeekable() const
 {
     return m_duration;
 }
@@ -193,14 +193,14 @@ void MockMediaPlayerMediaSource::paint(GraphicsContext&, const FloatRect&)
 {
 }
 
-MediaTime MockMediaPlayerMediaSource::currentMediaTime() const
+MediaTime MockMediaPlayerMediaSource::currentTime() const
 {
     return m_lastSeekTarget ? m_lastSeekTarget->time : m_currentTime;
 }
 
-bool MockMediaPlayerMediaSource::currentMediaTimeMayProgress() const
+bool MockMediaPlayerMediaSource::currentTimeMayProgress() const
 {
-    return m_mediaSourcePrivate && m_mediaSourcePrivate->hasFutureTime(currentMediaTime());
+    return m_mediaSourcePrivate && m_mediaSourcePrivate->hasFutureTime(currentTime());
 }
 
 void MockMediaPlayerMediaSource::notifyActiveSourceBuffersChanged()
@@ -209,7 +209,7 @@ void MockMediaPlayerMediaSource::notifyActiveSourceBuffersChanged()
         player->activeSourceBuffersChanged();
 }
 
-MediaTime MockMediaPlayerMediaSource::durationMediaTime() const
+MediaTime MockMediaPlayerMediaSource::duration() const
 {
     return m_mediaSourcePrivate ? m_mediaSourcePrivate->duration() : MediaTime::zeroTime();
 }

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -57,8 +57,8 @@ public:
     void deref() final { RefCounted::deref(); }
 
     void advanceCurrentTime();
-    MediaTime currentMediaTime() const override;
-    bool currentMediaTimeMayProgress() const override;
+    MediaTime currentTime() const override;
+    bool currentTimeMayProgress() const override;
     void notifyActiveSourceBuffersChanged() final;
     void updateDuration(const MediaTime&);
 
@@ -89,12 +89,12 @@ private:
     bool seeking() const final;
     bool paused() const override;
     MediaPlayer::NetworkState networkState() const override;
-    MediaTime maxMediaTimeSeekable() const override;
+    MediaTime maxTimeSeekable() const override;
     const PlatformTimeRanges& buffered() const override;
     bool didLoadingProgress() const override;
     void setPresentationSize(const IntSize&) override;
     void paint(GraphicsContext&, const FloatRect&) override;
-    MediaTime durationMediaTime() const override;
+    MediaTime duration() const override;
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() override;
     DestinationColorSpace colorSpace() override;
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -217,8 +217,8 @@ public:
     void videoTrackSetSelected(WebCore::TrackID, bool);
     void textTrackSetMode(WebCore::TrackID, WebCore::InbandTextTrackPrivate::Mode);
 
-    using PerformTaskAtMediaTimeCompletionHandler = CompletionHandler<void(std::optional<MediaTime>, std::optional<MonotonicTime>)>;
-    void performTaskAtMediaTime(const MediaTime&, MonotonicTime, PerformTaskAtMediaTimeCompletionHandler&&);
+    using PerformTaskAtTimeCompletionHandler = CompletionHandler<void(std::optional<MediaTime>, std::optional<MonotonicTime>)>;
+    void performTaskAtTime(const MediaTime&, MonotonicTime, PerformTaskAtTimeCompletionHandler&&);
     void isCrossOrigin(WebCore::SecurityOriginData, CompletionHandler<void(std::optional<bool>)>&&);
 
     void setVideoPlaybackMetricsUpdateInterval(double);
@@ -395,7 +395,7 @@ private:
     RunLoop::Timer m_updateCachedStateMessageTimer;
     RemoteMediaPlayerState m_cachedState;
     RemoteMediaPlayerProxyConfiguration m_configuration;
-    PerformTaskAtMediaTimeCompletionHandler m_performTaskAtMediaTimeCompletionHandler;
+    PerformTaskAtTimeCompletionHandler m_performTaskAtTimeCompletionHandler;
 #if ENABLE(MEDIA_SOURCE)
     RefPtr<RemoteMediaSourceProxy> m_mediaSourceProxy;
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -105,7 +105,7 @@ messages -> RemoteMediaPlayerProxy {
     VideoTrackSetSelected(WebCore::TrackID trackId, bool selected)
     TextTrackSetMode(WebCore::TrackID trackId, enum:uint8_t WebCore::InbandTextTrackPrivate::Mode mode)
 
-    PerformTaskAtMediaTime(MediaTime mediaTime, MonotonicTime messageTime) -> (std::optional<MediaTime> mediaTime, std::optional<MonotonicTime> monotonicTime)
+    PerformTaskAtTime(MediaTime mediaTime, MonotonicTime messageTime) -> (std::optional<MediaTime> mediaTime, std::optional<MonotonicTime> monotonicTime)
     IsCrossOrigin(WebCore::SecurityOriginData origin) -> (std::optional<bool> crossOrigin) Synchronous
 
     SetVideoPlaybackMetricsUpdateInterval(double interval)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -129,7 +129,7 @@ MediaTime MediaPlayerPrivateRemote::TimeProgressEstimator::currentTimeWithLockHe
         return m_cachedMediaTime;
 
     auto calculatedCurrentTime = m_cachedMediaTime + MediaTime::createWithDouble(m_rate * (MonotonicTime::now() - m_cachedMediaTimeQueryTime).seconds());
-    return std::min(std::max(calculatedCurrentTime, MediaTime::zeroTime()), m_parent.durationMediaTime());
+    return std::min(std::max(calculatedCurrentTime, MediaTime::zeroTime()), m_parent.duration());
 }
 
 MediaTime MediaPlayerPrivateRemote::TimeProgressEstimator::cachedTime() const
@@ -328,7 +328,7 @@ void MediaPlayerPrivateRemote::setPrivateBrowsingMode(bool privateMode)
     connection().send(Messages::RemoteMediaPlayerProxy::SetPrivateBrowsingMode(privateMode), m_id);
 }
 
-MediaTime MediaPlayerPrivateRemote::durationMediaTime() const
+MediaTime MediaPlayerPrivateRemote::duration() const
 {
 #if ENABLE(MEDIA_SOURCE)
     if (m_mediaSourcePrivate)
@@ -339,7 +339,7 @@ MediaTime MediaPlayerPrivateRemote::durationMediaTime() const
     return m_cachedState.duration;
 }
 
-MediaTime MediaPlayerPrivateRemote::currentMediaTime() const
+MediaTime MediaPlayerPrivateRemote::currentTime() const
 {
     return m_currentTimeEstimator.currentTime();
 }
@@ -1121,12 +1121,12 @@ double MediaPlayerPrivateRemote::minFastReverseRate() const
     return m_cachedState.minFastReverseRate;
 }
 
-MediaTime MediaPlayerPrivateRemote::maxMediaTimeSeekable() const
+MediaTime MediaPlayerPrivateRemote::maxTimeSeekable() const
 {
     return m_cachedState.maxTimeSeekable;
 }
 
-MediaTime MediaPlayerPrivateRemote::minMediaTimeSeekable() const
+MediaTime MediaPlayerPrivateRemote::minTimeSeekable() const
 {
     return m_cachedState.minTimeSeekable;
 }
@@ -1541,7 +1541,7 @@ void MediaPlayerPrivateRemote::setPreferredDynamicRangeMode(WebCore::DynamicRang
     connection().send(Messages::RemoteMediaPlayerProxy::SetPreferredDynamicRangeMode(mode), m_id);
 }
 
-bool MediaPlayerPrivateRemote::performTaskAtMediaTime(WTF::Function<void()>&& completionHandler, const MediaTime& mediaTime)
+bool MediaPlayerPrivateRemote::performTaskAtTime(WTF::Function<void()>&& completionHandler, const MediaTime& mediaTime)
 {
     auto asyncReplyHandler = [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](std::optional<MediaTime> currentTime, std::optional<MonotonicTime> queryTime) mutable {
         if (RefPtr protectedThis = weakThis.get(); protectedThis && currentTime && queryTime)
@@ -1549,7 +1549,7 @@ bool MediaPlayerPrivateRemote::performTaskAtMediaTime(WTF::Function<void()>&& co
         completionHandler();
     };
 
-    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::PerformTaskAtMediaTime(mediaTime, MonotonicTime::now()), WTFMove(asyncReplyHandler), m_id);
+    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::PerformTaskAtTime(mediaTime, MonotonicTime::now()), WTFMove(asyncReplyHandler), m_id);
 
     return true;
 }

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -198,8 +198,8 @@ public:
     LayerHostingContextID hostingContextID()const override;
     void setLayerHostingContextID(LayerHostingContextID  inID);
 
-    MediaTime durationMediaTime() const final;
-    MediaTime currentMediaTime() const final;
+    MediaTime duration() const final;
+    MediaTime currentTime() const final;
     MediaTime currentOrPendingSeekTime() const final;
 
 private:
@@ -315,8 +315,8 @@ private:
 
     WebCore::MediaPlayer::NetworkState networkState() const final { return m_cachedState.networkState; }
 
-    MediaTime maxMediaTimeSeekable() const final;
-    MediaTime minMediaTimeSeekable() const final;
+    MediaTime maxTimeSeekable() const final;
+    MediaTime minTimeSeekable() const final;
     const WebCore::PlatformTimeRanges& buffered() const final;
     double seekableTimeRangesLastModifiedTime() const final;
     double liveUpdateInterval() const final;
@@ -438,7 +438,7 @@ private:
     AVPlayer *objCAVFoundationAVPlayer() const final { return nullptr; }
 #endif
 
-    bool performTaskAtMediaTime(Function<void()>&&, const MediaTime&) final;
+    bool performTaskAtTime(Function<void()>&&, const MediaTime&) final;
 
     bool supportsPlayAtHostTime() const final { return m_configuration.supportsPlayAtHostTime; }
     bool supportsPauseAtHostTime() const final { return m_configuration.supportsPauseAtHostTime; }


### PR DESCRIPTION
#### 2178ec4c5a01347c4275adcbccdd86e1d053e5cd
<pre>
Remove MediaPlayerPrivateInterface::duration() and co.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269168">https://bugs.webkit.org/show_bug.cgi?id=269168</a>
<a href="https://rdar.apple.com/122743525">rdar://122743525</a>

Reviewed by Eric Carlson.

Once upon time, we had `currentTime()` and `duration()` that returned a float.
We then had `currentTimeDouble()` and `durationDouble()` that returned a double.
In 110313@main, MediaTime support was added and got quickly adopted across all
the media stack. And so we now had `currentMediaTime()` and `durationMediaTime()`.
The MediaTime prefix was added to all methods and members that were dealing with MediaTime (the object not the media&apos;s time).

Now that we have eliminated all but the methods using MediaTime and that MediaTime
is exclusively used to descrine a time, we no longer have to have MediaTime in
the methods&apos; name as when using any time values, a MediaTime type is implied.

Rename only, no change in observable behaviour.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::monitorSourceBuffers):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::currentTime const):
(WebCore::MediaSource::hasCurrentTime):
(WebCore::MediaSource::hasFutureTime):
(WebCore::MediaSource::currentMediaTime const): Deleted.
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::rangeRemoval):
(WebCore::SourceBuffer::appendBufferInternal):
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete):
(WebCore::SourceBuffer::canPlayThroughRange):
(WebCore::SourceBuffer::memoryPressure):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::duration const):
(WebCore::MediaPlayer::currentTime const):
(WebCore::MediaPlayer::currentTimeMayProgress const):
(WebCore::MediaPlayer::maxTimeSeekable const):
(WebCore::MediaPlayer::minTimeSeekable const):
(WebCore::MediaPlayer::performTaskAtTime):
(WebCore::MediaPlayer::performTaskAtMediaTime): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp:
(WebCore::MediaPlayerPrivateInterface::seekable const):
(WebCore::MediaPlayerPrivateInterface::currentOrPendingSeekTime const):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::duration const):
(WebCore::MediaPlayerPrivateInterface::currentTime const):
(WebCore::MediaPlayerPrivateInterface::currentTimeMayProgress const):
(WebCore::MediaPlayerPrivateInterface::maxTimeSeekable const):
(WebCore::MediaPlayerPrivateInterface::minTimeSeekable const):
(WebCore::MediaPlayerPrivateInterface::extraMemoryCost const):
(WebCore::MediaPlayerPrivateInterface::performTaskAtTime):
(WebCore::MediaPlayerPrivateInterface::durationDouble const): Deleted.
(WebCore::MediaPlayerPrivateInterface::durationMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateInterface::currentMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateInterface::currentMediaTimeMayProgress const): Deleted.
(WebCore::MediaPlayerPrivateInterface::maxMediaTimeSeekable const): Deleted.
(WebCore::MediaPlayerPrivateInterface::minMediaTimeSeekable const): Deleted.
(WebCore::MediaPlayerPrivateInterface::performTaskAtMediaTime): Deleted.
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::currentTime const):
(WebCore::MediaSourcePrivate::currentMediaTime const): Deleted.
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::currentTime const):
(WebCore::SourceBufferPrivate::reenqueSamples):
(WebCore::SourceBufferPrivate::processMediaSample):
(WebCore::SourceBufferPrivate::currentMediaTime const): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::duration const):
(WebCore::MediaPlayerPrivateAVFoundation::seekToTarget):
(WebCore::MediaPlayerPrivateAVFoundation::maxTimeSeekable const):
(WebCore::MediaPlayerPrivateAVFoundation::minTimeSeekable const):
(WebCore::MediaPlayerPrivateAVFoundation::didLoadingProgress const):
(WebCore::MediaPlayerPrivateAVFoundation::updateStates):
(WebCore::MediaPlayerPrivateAVFoundation::didEnd):
(WebCore::MediaPlayerPrivateAVFoundation::durationMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateAVFoundation::maxMediaTimeSeekable const): Deleted.
(WebCore::MediaPlayerPrivateAVFoundation::minMediaTimeSeekable const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::hasAvailableVideoFrame const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::currentTime const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::currentTimeDidChange const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformMaxTimeSeekable const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateLastPixelBuffer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::videoFrameForCurrentTime):
(WebCore::MediaPlayerPrivateAVFoundationObjC::performTaskAtTime):
(-[WebCoreAVFMovieObserver metadataOutput:didOutputTimedMetadataGroups:fromPlayerItemTrack:]):
(-[WebCoreAVFMovieObserver metadataCollector:didCollectDateRangeMetadataGroups:indexesOfNewGroups:indexesOfModifiedGroups:]):
(WebCore::MediaPlayerPrivateAVFoundationObjC::currentMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateAVFoundationObjC::currentMediaTimeDidChange const): Deleted.
(WebCore::MediaPlayerPrivateAVFoundationObjC::performTaskAtMediaTime): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::playInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::duration const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentTime const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentTimeMayProgress const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::maxTimeSeekable const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::minTimeSeekable const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::videoFrameForCurrentTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::durationChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::sizeWillChangeAtTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::performTaskAtTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::durationMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentMediaTimeMayProgress const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::maxMediaTimeSeekable const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::minMediaTimeSeekable const): Deleted.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::performTaskAtMediaTime): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::duration const):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::durationMediaTime const): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::play):
(WebCore::MediaPlayerPrivateWebM::currentTime const):
(WebCore::MediaPlayerPrivateWebM::updateLastPixelBuffer):
(WebCore::MediaPlayerPrivateWebM::videoFrameForCurrentTime):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::reenqueSamples):
(WebCore::MediaPlayerPrivateWebM::currentMediaTime const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pause):
(WebCore::MediaPlayerPrivateGStreamer::doSeek):
(WebCore::MediaPlayerPrivateGStreamer::seekToTarget):
(WebCore::MediaPlayerPrivateGStreamer::duration const):
(WebCore::MediaPlayerPrivateGStreamer::currentTime const):
(WebCore::MediaPlayerPrivateGStreamer::buffered const):
(WebCore::MediaPlayerPrivateGStreamer::maxTimeSeekable const):
(WebCore::MediaPlayerPrivateGStreamer::maxTimeLoaded const):
(WebCore::MediaPlayerPrivateGStreamer::didLoadingProgress const):
(WebCore::MediaPlayerPrivateGStreamer::durationChanged):
(WebCore::MediaPlayerPrivateGStreamer::playbackPosition const):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::updateMaxTimeLoaded):
(WebCore::MediaPlayerPrivateGStreamer::processMpegTsSection):
(WebCore::MediaPlayerPrivateGStreamer::didEnd):
(WebCore::MediaPlayerPrivateGStreamer::performTaskAtTime):
(WebCore::MediaPlayerPrivateGStreamer::durationMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateGStreamer::currentMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateGStreamer::maxMediaTimeSeekable const): Deleted.
(WebCore::MediaPlayerPrivateGStreamer::performTaskAtMediaTime): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::duration const):
(WebCore::MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer):
(WebCore::MediaPlayerPrivateGStreamerMSE::didPreroll):
(WebCore::MediaPlayerPrivateGStreamerMSE::maxTimeSeekable const):
(WebCore::MediaPlayerPrivateGStreamerMSE::currentTimeMayProgress const):
(WebCore::MediaPlayerPrivateGStreamerMSE::durationMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateGStreamerMSE::maxMediaTimeSeekable const): Deleted.
(WebCore::MediaPlayerPrivateGStreamerMSE::currentMediaTimeMayProgress const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcStreamFlush):
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
(WebCore::MediaPlayerPrivateMediaFoundation::duration const):
(WebCore::MediaPlayerPrivateMediaFoundation::currentTime const):
(WebCore::MediaPlayerPrivateMediaFoundation::maxTimeSeekable const):
(WebCore::MediaPlayerPrivateMediaFoundation::durationMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateMediaFoundation::currentMediaTime const): Deleted.
(WebCore::MediaPlayerPrivateMediaFoundation::maxMediaTimeSeekable const): Deleted.
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::maxTimeSeekable const):
(WebCore::MockMediaPlayerMediaSource::currentTime const):
(WebCore::MockMediaPlayerMediaSource::currentTimeMayProgress const):
(WebCore::MockMediaPlayerMediaSource::duration const):
(WebCore::MockMediaPlayerMediaSource::maxMediaTimeSeekable const): Deleted.
(WebCore::MockMediaPlayerMediaSource::currentMediaTime const): Deleted.
(WebCore::MockMediaPlayerMediaSource::currentMediaTimeMayProgress const): Deleted.
(WebCore::MockMediaPlayerMediaSource::durationMediaTime const): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::performTaskAtMediaTime):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::TimeProgressEstimator::currentTimeWithLockHeld const):
(WebKit::MediaPlayerPrivateRemote::duration const):
(WebKit::MediaPlayerPrivateRemote::currentTime const):
(WebKit::MediaPlayerPrivateRemote::maxTimeSeekable const):
(WebKit::MediaPlayerPrivateRemote::minTimeSeekable const):
(WebKit::MediaPlayerPrivateRemote::performTaskAtTime):
(WebKit::MediaPlayerPrivateRemote::durationMediaTime const): Deleted.
(WebKit::MediaPlayerPrivateRemote::currentMediaTime const): Deleted.
(WebKit::MediaPlayerPrivateRemote::maxMediaTimeSeekable const): Deleted.
(WebKit::MediaPlayerPrivateRemote::minMediaTimeSeekable const): Deleted.
(WebKit::MediaPlayerPrivateRemote::performTaskAtMediaTime): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/274449@main">https://commits.webkit.org/274449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/809efe5a91ac6ea6cb048bb40514e00aba3ef9cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39153 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34870 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15461 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35205 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11521 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15571 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8754 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->