### PR TITLE
More dynamicDowncast<> adoption in accessibility code

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -64,22 +64,20 @@ Ref<AccessibilityTableCell> AccessibilityTableCell::create(Node& node)
 
 bool AccessibilityTableCell::computeAccessibilityIsIgnored() const
 {
-    AccessibilityObjectInclusion decision = defaultObjectInclusion();
+    auto decision = defaultObjectInclusion();
     if (decision == AccessibilityObjectInclusion::IncludeObject)
         return false;
     if (decision == AccessibilityObjectInclusion::IgnoreObject)
         return true;
-    
+
     // Ignore anonymous table cells as long as they're not in a table (ie. when display:table is used).
-    RenderObject* renderTable = is<RenderTableCell>(renderer()) ? downcast<RenderTableCell>(*m_renderer).table() : nullptr;
-    bool inTable = renderTable && renderTable->node() && (renderTable->node()->hasTagName(tableTag) || nodeHasGridRole(renderTable->node()));
-    if (!node() && !inTable)
+    auto* renderTableCell = dynamicDowncast<RenderTableCell>(renderer());
+    auto* renderTable = renderTableCell ? renderTableCell->table() : nullptr;
+    bool inTable = renderTable && renderTable->element() && (renderTable->element()->hasTagName(tableTag) || nodeHasGridRole(renderTable->element()));
+    if (!element() && !inTable)
         return true;
-        
-    if (!isExposedTableCell())
-        return AccessibilityRenderObject::computeAccessibilityIsIgnored();
-    
-    return false;
+
+    return !isExposedTableCell() && AccessibilityRenderObject::computeAccessibilityIsIgnored();
 }
 
 AccessibilityTable* AccessibilityTableCell::parentTable() const

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -73,8 +73,8 @@ AccessibilityRole AccessibilityTableRow::determineAccessibilityRole()
 
 bool AccessibilityTableRow::isTableRow() const
 {
-    AccessibilityObject* table = parentTable();
-    return is<AccessibilityTable>(table) && downcast<AccessibilityTable>(*table).isExposable();
+    auto* table = parentTable();
+    return table && table->isExposable();
 }
     
 AccessibilityObject* AccessibilityTableRow::observableObject() const
@@ -107,15 +107,13 @@ AccessibilityTable* AccessibilityTableRow::parentTable() const
     for (AccessibilityObject* parent = parentObject(); parent; parent = parent->parentObject()) {
         // If this is a non-anonymous table object, but not an accessibility table, we should stop because we don't want to
         // choose another ancestor table as this row's table.
-        if (is<AccessibilityTable>(*parent)) {
-            auto& parentTable = downcast<AccessibilityTable>(*parent);
-            if (parentTable.isExposable())
-                return &parentTable;
-            if (parentTable.node())
+        if (auto* parentTable = dynamicDowncast<AccessibilityTable>(*parent)) {
+            if (parentTable->isExposable())
+                return parentTable;
+            if (parentTable->node())
                 break;
         }
     }
-    
     return nullptr;
 }
 

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1401,7 +1401,7 @@ inline void BuilderCustom::applyInheritStroke(BuilderState& builderState)
 inline void BuilderCustom::applyValueStroke(BuilderState& builderState, CSSValue& value)
 {
     auto& svgStyle = builderState.style().accessSVGStyle();
-    const auto* localValue = value.isPrimitiveValue() ? &downcast<CSSPrimitiveValue>(value) : nullptr;
+    const auto* localValue = dynamicDowncast<CSSPrimitiveValue>(value);
     String url;
     if (auto* list = dynamicDowncast<CSSValueList>(value)) {
         url = downcast<CSSPrimitiveValue>(list->item(0))->stringValue();


### PR DESCRIPTION
#### 9aa547bb5ff18e5ecfd244ec5ba4b7c9632e25d0
<pre>
More dynamicDowncast&lt;&gt; adoption in accessibility code
<a href="https://bugs.webkit.org/show_bug.cgi?id=269170">https://bugs.webkit.org/show_bug.cgi?id=269170</a>

Reviewed by Tyler Wilcock.

* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::computeAccessibilityIsIgnored const):
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::isTableRow const):
(WebCore::AccessibilityTableRow::parentTable const):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueStroke):

Canonical link: <a href="https://commits.webkit.org/274722@main">https://commits.webkit.org/274722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd8d3f96c0e2028703333cc8a0bbcefee5495a28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42186 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33101 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39390 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37667 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16069 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8937 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->