### PR TITLE
Remove prefixed `HTMLMediaElement.webkitPreservesPitch`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/historical-expected.txt
@@ -45,8 +45,8 @@ PASS audio.mozSrcObject should not be supported
 PASS video.mozSrcObject should not be supported
 PASS audio.mozPreservesPitch should not be supported
 PASS video.mozPreservesPitch should not be supported
-FAIL audio.webkitPreservesPitch should not be supported assert_false: expected false got true
-FAIL video.webkitPreservesPitch should not be supported assert_false: expected false got true
+PASS audio.webkitPreservesPitch should not be supported
+PASS video.webkitPreservesPitch should not be supported
 FAIL audio.mediaGroup should not be supported assert_false: expected false got true
 FAIL video.mediaGroup should not be supported assert_false: expected false got true
 FAIL audio.controller should not be supported assert_false: expected false got true

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -100,9 +100,6 @@ typedef (
     attribute boolean muted;
     [CEReactions=NotNeeded, Reflect=muted] attribute boolean defaultMuted;
 
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250871
-    [CEReactions=NotNeeded, ImplementedAs=preservesPitch] attribute boolean webkitPreservesPitch;
-
     // The number of bytes consumed by the media decoder.
     [Conditional=MEDIA_STATISTICS] readonly attribute unsigned long webkitAudioDecodedByteCount;
     [Conditional=MEDIA_STATISTICS] readonly attribute unsigned long webkitVideoDecodedByteCount;


### PR DESCRIPTION
#### 4ed49192487b2b842b62b35aabde3c9a039b7ed4
<pre>
Remove prefixed `HTMLMediaElement.webkitPreservesPitch`

<a href="https://bugs.webkit.org/show_bug.cgi?id=250871">https://bugs.webkit.org/show_bug.cgi?id=250871</a>
<a href="https://rdar.apple.com/problem/104451631">rdar://problem/104451631</a>

Reviewed by Eric Carlson.

In 267341@main, WebKit exposed `preservesPitch` while retaining prefixed
`webkitPreservesPitch` for web compatibility, since then Safari had two major
releases (17.3 and 17.4 as beta).

So this patch is to remove prefixed `webkitPreservesPitch` and align completely
with other web browsers.

* Source/WebCore/html/HTMLMediaElement.idl:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/historical-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/274551@main">https://commits.webkit.org/274551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8780998abc3f53dfd1a756c4982b505ed45f95a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13244 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42960 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39029 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37260 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15567 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8815 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->