### PR TITLE
Implement field-sizing support for file inputs

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1970,6 +1970,16 @@ String RenderTheme::fileListNameForWidth(const FileList* fileList, const FontCas
     return StringTruncator::centerTruncate(string, width, font);
 }
 
+String RenderTheme::fileListName(const FileList* fileList, bool multipleFilesAllowed) const
+{
+    if (fileList->isEmpty())
+        return fileListDefaultLabel(multipleFilesAllowed);
+    if (fileList->length() == 1)
+        return fileList->item(0)->name();
+
+    return multipleFileUploadText(fileList->length());
+}
+
 #if USE(SYSTEM_PREVIEW)
 void RenderTheme::paintSystemPreviewBadge(Image& image, const PaintInfo& paintInfo, const FloatRect& rect)
 {

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -237,6 +237,7 @@ public:
 
     virtual String fileListDefaultLabel(bool multipleFilesAllowed) const;
     virtual String fileListNameForWidth(const FileList*, const FontCascade&, int width, bool multipleFilesAllowed) const;
+    virtual String fileListName(const FileList*, bool multipleFilesAllowed) const;
 
     enum class FileUploadDecorations : bool { SingleFile, MultipleFiles };
     virtual void paintFileUploadIconDecorations(const RenderObject& /*inputRenderer*/, const RenderObject& /*buttonRenderer*/, const PaintInfo&, const IntRect&, Icon*, FileUploadDecorations) { }

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -137,6 +137,7 @@ private:
 
 private:
     String fileListNameForWidth(const FileList*, const FontCascade&, int width, bool multipleFilesAllowed) const final;
+    String fileListName(const FileList*, bool multipleFilesAllowed) const final;
 
     Color systemColor(CSSValueID, OptionSet<StyleColorOptions>) const final;
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1203,6 +1203,16 @@ String RenderThemeMac::fileListNameForWidth(const FileList* fileList, const Font
     return StringTruncator::centerTruncate(strToTruncate, width, font);
 }
 
+String RenderThemeMac::fileListName(const FileList* fileList, bool multipleFilesAllowed) const
+{
+    if (fileList->isEmpty())
+        return fileListDefaultLabel(multipleFilesAllowed);
+    if (fileList->length() == 1)
+        return [[NSFileManager defaultManager] displayNameAtPath:(fileList->item(0)->path())];
+
+    return multipleFileUploadText(fileList->length());
+}
+
 #if ENABLE(SERVICE_CONTROLS)
 IntSize RenderThemeMac::imageControlsButtonSize() const
 {


### PR DESCRIPTION
#### a64318156bb2cbd3d7c6902a32a1b86224430101
<pre>
Implement field-sizing support for file inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=269178">https://bugs.webkit.org/show_bug.cgi?id=269178</a>

Reviewed by NOBODY (OOPS!).

Updates RenderFileUploadControl to be able to size according to the contents sizing.
This is done by adding a method to get the full label string and sizing based on that.

* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::computeIntrinsicLogicalWidths const):
(WebCore::RenderFileUploadControl::computePreferredLogicalWidths):
(WebCore::RenderFileUploadControl::fileTextValue const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::fileListName const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::fileListName const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a64318156bb2cbd3d7c6902a32a1b86224430101

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35148 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41828 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40437 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18888 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18533 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->