### PR TITLE
UnifiedPDF: Support for loading PDFs with #page= fragments

### DIFF
--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -65,6 +65,7 @@ public:
 
     virtual bool usesAsyncScrolling() const { return false; }
     virtual ScrollingNodeID scrollingNodeID() const { return 0; }
+    virtual void didAttachScrollingNode() { }
 
 #if PLATFORM(COCOA)
     virtual id accessibilityAssociatedPluginParentForElement(Element*) const { return nullptr; }

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -127,6 +127,14 @@ ScrollingNodeID RenderEmbeddedObject::scrollingNodeID() const
     return pluginViewBase->scrollingNodeID();
 }
 
+void RenderEmbeddedObject::didAttachScrollingNode()
+{
+    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    if (!pluginViewBase)
+        return;
+    pluginViewBase->didAttachScrollingNode();
+}
+
 #if !PLATFORM(IOS_FAMILY)
 static String unavailablePluginReplacementText(RenderEmbeddedObject::PluginUnavailabilityReason pluginUnavailabilityReason)
 {

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -63,6 +63,7 @@ public:
 
     bool usesAsyncScrolling() const;
     ScrollingNodeID scrollingNodeID() const;
+    void didAttachScrollingNode();
 
 private:
     void paintReplaced(PaintInfo&, const LayoutPoint&) final;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2654,8 +2654,10 @@ bool RenderLayerCompositor::attachWidgetContentLayers(RenderWidget& renderer)
                 if (auto pluginHostingNodeID = backing->scrollingNodeIDForRole(ScrollCoordinationRole::PluginHosting)) {
                     auto* renderEmbeddedObject = dynamicDowncast<RenderEmbeddedObject>(renderer);
                     if (auto pluginScrollingNodeID = renderEmbeddedObject->scrollingNodeID()) {
-                        if (auto* scrollingCoordinator = this->scrollingCoordinator())
+                        if (auto* scrollingCoordinator = this->scrollingCoordinator()) {
                             scrollingCoordinator->insertNode(ScrollingNodeType::PluginScrolling, pluginScrollingNodeID, pluginHostingNodeID, 0);
+                            renderEmbeddedObject->didAttachScrollingNode();
+                        }
                     }
                 }
             }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -175,6 +175,8 @@ public:
     WebCore::Scrollbar* horizontalScrollbar() const override { return m_horizontalScrollbar.get(); }
     WebCore::Scrollbar* verticalScrollbar() const override { return m_verticalScrollbar.get(); }
 
+    virtual void didAttachScrollingNode() { }
+
     virtual void didChangeSettings() { }
 
     // HUD Actions.
@@ -211,6 +213,8 @@ public:
     void notifySelectionChanged();
 
     virtual void windowActivityDidChange() { }
+
+    virtual void didSameDocumentNavigationForFrame(WebFrame&) { }
 
 #if PLATFORM(MAC)
     void writeItemsToPasteboard(NSString *pasteboardName, NSArray *items, NSArray *types) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -94,6 +94,8 @@ public:
     void attemptToUnlockPDF(const String& password) final;
     void windowActivityDidChange() final;
 
+    void didSameDocumentNavigationForFrame(WebFrame&) final;
+
     float documentFittingScale() const { return m_documentLayout.scale(); }
 
 private:
@@ -137,6 +139,8 @@ private:
     WebCore::IntSize documentSize() const;
     WebCore::IntSize contentsSize() const override;
     unsigned firstPageHeight() const override;
+    unsigned heightForPage(PDFDocumentLayout::PageIndex) const;
+
 
     void scheduleRenderingUpdate();
 
@@ -148,6 +152,8 @@ private:
 
     void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) override;
     void updateScrollbars() override;
+    void didAttachScrollingNode() final;
+
     bool geometryDidChange(const WebCore::IntSize&, const WebCore::AffineTransform&) override;
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
@@ -271,7 +277,9 @@ private:
     void createScrollingNodeIfNecessary();
 
     void scrollToPDFDestination(PDFDestination *);
-    void scrollToPointInPDF(WebCore::IntPoint pointInPDFPageSpace, PDFDocumentLayout::PageIndex);
+    void scrollToPointInPage(WebCore::IntPoint pointInPDFPageSpace, PDFDocumentLayout::PageIndex);
+    void scrollToPage(PDFDocumentLayout::PageIndex);
+    void scrollToFragmentIfNeeded();
 
     // ScrollableArea
     bool requestScrollToPosition(const WebCore::ScrollPosition&, const WebCore::ScrollPositionChangeOptions& = WebCore::ScrollPositionChangeOptions::createProgrammatic()) override;
@@ -317,6 +325,9 @@ private:
 
     float m_scaleFactor { 1 };
     bool m_inMagnificationGesture { false };
+
+    bool m_didAttachScrollingTreeNode { false };
+    bool m_didScrollToFragment { false };
 
     AnnotationTrackingState m_annotationTrackingState;
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -687,6 +687,14 @@ ScrollingNodeID PluginView::scrollingNodeID() const
     return m_plugin->scrollingNodeID();
 }
 
+void PluginView::didAttachScrollingNode()
+{
+    if (!m_isInitialized)
+        return;
+
+    return m_plugin->didAttachScrollingNode();
+}
+
 RefPtr<FragmentedSharedBuffer> PluginView::liveResourceData() const
 {
     if (!m_isInitialized) {
@@ -954,6 +962,14 @@ void PluginView::didChangeSettings()
 void PluginView::windowActivityDidChange()
 {
     m_plugin->windowActivityDidChange();
+}
+
+void PluginView::didSameDocumentNavigationForFrame(WebFrame& frame)
+{
+    if (!m_isInitialized)
+        return;
+
+    return m_plugin->didSameDocumentNavigationForFrame(frame);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -49,6 +49,7 @@ class ShareableBitmap;
 namespace WebKit {
 
 class PDFPluginBase;
+class WebFrame;
 class WebPage;
 
 struct WebHitTestResultData;
@@ -110,6 +111,8 @@ public:
 
     void windowActivityDidChange();
 
+    void didSameDocumentNavigationForFrame(WebFrame&);
+
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);
     virtual ~PluginView();
@@ -151,6 +154,7 @@ private:
 
     bool usesAsyncScrolling() const final;
     WebCore::ScrollingNodeID scrollingNodeID() const final;
+    void didAttachScrollingNode() final;
 
     // WebCore::Widget
     void setFrameRect(const WebCore::IntRect&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7400,6 +7400,11 @@ void WebPage::didSameDocumentNavigationForFrame(WebFrame& frame)
 
     // Notify the UIProcess.
     send(Messages::WebPageProxy::DidSameDocumentNavigationForFrame(frame.frameID(), navigationID, SameDocumentNavigationType::AnchorNavigation, frame.coreLocalFrame()->document()->url(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+
+#if ENABLE(PDF_PLUGIN)
+    for (auto& pluginView : m_pluginViews)
+        pluginView.didSameDocumentNavigationForFrame(frame);
+#endif
 }
 
 void WebPage::testProcessIncomingSyncMessagesWhenWaitingForSyncReply(CompletionHandler<void(bool)>&& reply)


### PR DESCRIPTION
#### 63dde78713856ee9925a6802d16d971d1547babf
<pre>
UnifiedPDF: Support for loading PDFs with #page= fragments
<a href="https://bugs.webkit.org/show_bug.cgi?id=269180">https://bugs.webkit.org/show_bug.cgi?id=269180</a>
<a href="https://rdar.apple.com/122765668">rdar://122765668</a>

Reviewed by Simon Fraser.

* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::didAttachScrollingNode):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::didAttachScrollingNode):
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::attachWidgetContentLayers):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::didAttachScrollingNode):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::didAttachScrollingNode):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
Let the plugin know when it&apos;s in the scrolling tree and it&apos;s safe to start scrolling.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::didAttachScrollingNode):
Scroll to the fragment in the URL whenever *both* the PDF document is installed and we&apos;re in the scrolling tree.

(WebKit::UnifiedPDFPlugin::pageHeight const):
(WebKit::UnifiedPDFPlugin::firstPageHeight const):
Factor out pageHeight() from firstPageHeight().

(WebKit::UnifiedPDFPlugin::scrollToPDFDestination):
Fix a mistake in here: indexForPage is zero-based like PageIndex, but the origin
is flipped, so the y origin of the page is at its height instead of 0 (which is
how I was misled into subtracting 1 from the page index...).

(WebKit::UnifiedPDFPlugin::scrollToPointInPage):
Fix the local name here to say `contents` instead of `document`.
Rename this to &quot;point in page&quot;, to go along with...

(WebKit::UnifiedPDFPlugin::scrollToPage):
... this new function, which just scrolls to the origin of a page.

(WebKit::UnifiedPDFPlugin::scrollToFragmentIfNeeded):
Parse the fragment out. For now, only support page=; for parity with
PDFPlugin we also need to support nameddest=.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::didSameDocumentNavigationForFrame):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::didSameDocumentNavigationForFrame):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didSameDocumentNavigationForFrame):
Plumb fragment changes through to the plugin, so that dynamically editing
the URL navigates to the new fragment (instead of having to force a reload).

Canonical link: <a href="https://commits.webkit.org/274496@main">https://commits.webkit.org/274496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54329afb37a86a4e8bca49e853be0f847b97345d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41795 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15569 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13345 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43073 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35300 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37356 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15679 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8785 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->