### PR TITLE
TextTrack should be constructed with a ScriptExecutionContext rather than a Document

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -883,7 +883,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
                 // FIXME: Implement steps 5.4.1-5.4.8.1 as per Editor's Draft 09 January 2015, and reorder this
                 // 5.4.1 Let new text track be a new TextTrack object with its properties populated with the
                 // appropriate information from the initialization segment.
-                auto newTextTrack = InbandTextTrack::create(document(), textTrackPrivate);
+                auto newTextTrack = InbandTextTrack::create(*scriptExecutionContext(), textTrackPrivate);
                 newTextTrack->addClient(*this);
 
                 // 5.4.2 If the mode property on new text track equals "showing" or "hidden", then set active
@@ -1229,14 +1229,6 @@ MediaTime SourceBuffer::minimumUpcomingPresentationTimeForTrackID(TrackID trackI
 void SourceBuffer::setMaximumQueueDepthForTrackID(TrackID trackID, uint64_t maxQueueDepth)
 {
     m_private->setMaximumQueueDepthForTrackID(trackID, maxQueueDepth);
-}
-
-Document& SourceBuffer::document() const
-{
-    ASSERT(isMainThread());
-
-    ASSERT(scriptExecutionContext());
-    return downcast<Document>(*scriptExecutionContext());
 }
 
 const Settings& SourceBuffer::settings() const

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -150,7 +150,6 @@ public:
 
 protected:
     SourceBuffer(Ref<SourceBufferPrivate>&&, MediaSource&);
-    Document& document() const;
     const Settings& settings() const;
 
 private:

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -42,6 +42,8 @@ class HTMLTrackElement final : public HTMLElement, public ActiveDOMObject, publi
 public:
     static Ref<HTMLTrackElement> create(const QualifiedName&, Document&);
 
+    using HTMLElement::scriptExecutionContext;
+
     const AtomString& kind();
     void setKind(const AtomString&);
 

--- a/Source/WebCore/html/track/InbandDataTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandDataTextTrack.cpp
@@ -38,14 +38,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(InbandDataTextTrack);
 
-inline InbandDataTextTrack::InbandDataTextTrack(Document& document, InbandTextTrackPrivate& trackPrivate)
-    : InbandTextTrack(document, trackPrivate)
+inline InbandDataTextTrack::InbandDataTextTrack(ScriptExecutionContext& context, InbandTextTrackPrivate& trackPrivate)
+    : InbandTextTrack(context, trackPrivate)
 {
 }
 
-Ref<InbandDataTextTrack> InbandDataTextTrack::create(Document& document, InbandTextTrackPrivate& trackPrivate)
+Ref<InbandDataTextTrack> InbandDataTextTrack::create(ScriptExecutionContext& context, InbandTextTrackPrivate& trackPrivate)
 {
-    auto textTrack = adoptRef(*new InbandDataTextTrack(document, trackPrivate));
+    auto textTrack = adoptRef(*new InbandDataTextTrack(context, trackPrivate));
     textTrack->suspendIfNeeded();
     return textTrack;
 }
@@ -54,17 +54,24 @@ InbandDataTextTrack::~InbandDataTextTrack() = default;
 
 void InbandDataTextTrack::addDataCue(const MediaTime& start, const MediaTime& end, const void* data, unsigned length)
 {
-    addCue(DataCue::create(document(), start, end, data, length));
+    // FIXME: handle datacue creation on worker.
+    if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext()))
+        addCue(DataCue::create(*document, start, end, data, length));
 }
 
 #if ENABLE(DATACUE_VALUE)
 
 void InbandDataTextTrack::addDataCue(const MediaTime& start, const MediaTime& end, Ref<SerializedPlatformDataCue>&& platformValue, const String& type)
 {
+    // FIXME: handle datacue creation on worker.
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document)
+        return;
+
     if (findIncompleteCue(platformValue))
         return;
 
-    auto cue = DataCue::create(document(), start, end, platformValue.copyRef(), type);
+    auto cue = DataCue::create(*document, start, end, platformValue.copyRef(), type);
     if (hasCue(cue, TextTrackCue::IgnoreDuration)) {
         INFO_LOG(LOGIDENTIFIER, "ignoring already added cue: ", cue.get());
         return;

--- a/Source/WebCore/html/track/InbandDataTextTrack.h
+++ b/Source/WebCore/html/track/InbandDataTextTrack.h
@@ -37,11 +37,11 @@ class DataCue;
 class InbandDataTextTrack final : public InbandTextTrack {
     WTF_MAKE_ISO_ALLOCATED(InbandDataTextTrack);
 public:
-    static Ref<InbandDataTextTrack> create(Document&, InbandTextTrackPrivate&);
+    static Ref<InbandDataTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandDataTextTrack();
 
 private:
-    InbandDataTextTrack(Document&, InbandTextTrackPrivate&);
+    InbandDataTextTrack(ScriptExecutionContext&, InbandTextTrackPrivate&);
 
     void addDataCue(const MediaTime& start, const MediaTime& end, const void*, unsigned) final;
 

--- a/Source/WebCore/html/track/InbandGenericTextTrack.h
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.h
@@ -53,11 +53,11 @@ private:
 class InbandGenericTextTrack final : public InbandTextTrack, private WebVTTParserClient {
     WTF_MAKE_ISO_ALLOCATED(InbandGenericTextTrack);
 public:
-    static Ref<InbandGenericTextTrack> create(Document&, InbandTextTrackPrivate&);
+    static Ref<InbandGenericTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandGenericTextTrack();
 
 private:
-    InbandGenericTextTrack(Document&, InbandTextTrackPrivate&);
+    InbandGenericTextTrack(ScriptExecutionContext&, InbandTextTrackPrivate&);
 
     void addGenericCue(InbandGenericCue&) final;
     void updateGenericCue(InbandGenericCue&) final;

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -28,11 +28,11 @@
 
 #if ENABLE(VIDEO)
 
-#include "Document.h"
 #include "InbandDataTextTrack.h"
 #include "InbandGenericTextTrack.h"
 #include "InbandTextTrackPrivate.h"
 #include "InbandWebVTTTextTrack.h"
+#include "ScriptExecutionContext.h"
 #include "TextTrackClient.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -40,24 +40,24 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(InbandTextTrack);
 
-Ref<InbandTextTrack> InbandTextTrack::create(Document& document, InbandTextTrackPrivate& trackPrivate)
+Ref<InbandTextTrack> InbandTextTrack::create(ScriptExecutionContext& context, InbandTextTrackPrivate& trackPrivate)
 {
     switch (trackPrivate.cueFormat()) {
     case InbandTextTrackPrivate::CueFormat::Data:
-        return InbandDataTextTrack::create(document, trackPrivate);
+        return InbandDataTextTrack::create(context, trackPrivate);
     case InbandTextTrackPrivate::CueFormat::Generic:
-        return InbandGenericTextTrack::create(document, trackPrivate);
+        return InbandGenericTextTrack::create(context, trackPrivate);
     case InbandTextTrackPrivate::CueFormat::WebVTT:
-        return InbandWebVTTTextTrack::create(document, trackPrivate);
+        return InbandWebVTTTextTrack::create(context, trackPrivate);
     }
     ASSERT_NOT_REACHED();
-    auto textTrack = InbandDataTextTrack::create(document, trackPrivate);
+    auto textTrack = InbandDataTextTrack::create(context, trackPrivate);
     textTrack->suspendIfNeeded();
     return textTrack;
 }
 
-InbandTextTrack::InbandTextTrack(Document& document, InbandTextTrackPrivate& trackPrivate)
-    : TextTrack(&document, emptyAtom(), trackPrivate.id(), trackPrivate.label(), trackPrivate.language(), InBand)
+InbandTextTrack::InbandTextTrack(ScriptExecutionContext& context, InbandTextTrackPrivate& trackPrivate)
+    : TextTrack(&context, emptyAtom(), trackPrivate.id(), trackPrivate.label(), trackPrivate.language(), InBand)
     , m_private(trackPrivate)
 {
     m_private->setClient(*this);

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class InbandTextTrack : public TextTrack, private InbandTextTrackPrivateClient {
     WTF_MAKE_ISO_ALLOCATED(InbandTextTrack);
 public:
-    static Ref<InbandTextTrack> create(Document&, InbandTextTrackPrivate&);
+    static Ref<InbandTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandTextTrack();
 
     bool isClosedCaptions() const override;
@@ -55,7 +55,7 @@ public:
 #endif
 
 protected:
-    InbandTextTrack(Document&, InbandTextTrackPrivate&);
+    InbandTextTrack(ScriptExecutionContext&, InbandTextTrackPrivate&);
 
     void setModeInternal(Mode);
     void updateKindFromPrivate();

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.h
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.h
@@ -36,11 +36,11 @@ namespace WebCore {
 class InbandWebVTTTextTrack final : public InbandTextTrack, private WebVTTParserClient {
     WTF_MAKE_ISO_ALLOCATED(InbandWebVTTTextTrack);
 public:
-    static Ref<InbandTextTrack> create(Document&, InbandTextTrackPrivate&);
+    static Ref<InbandTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandWebVTTTextTrack();
 
 private:
-    InbandWebVTTTextTrack(Document&, InbandTextTrackPrivate&);
+    InbandWebVTTTextTrack(ScriptExecutionContext&, InbandTextTrackPrivate&);
 
     WebVTTParser& parser();
     void parseWebVTTCueData(const uint8_t* data, unsigned length) final;

--- a/Source/WebCore/html/track/LoadableTextTrack.cpp
+++ b/Source/WebCore/html/track/LoadableTextTrack.cpp
@@ -29,9 +29,9 @@
 
 #if ENABLE(VIDEO)
 
-#include "Document.h"
 #include "ElementInlines.h"
 #include "HTMLTrackElement.h"
+#include "ScriptExecutionContext.h"
 #include "TextTrackCueList.h"
 #include "VTTCue.h"
 #include "VTTRegionList.h"
@@ -43,7 +43,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LoadableTextTrack);
 
 LoadableTextTrack::LoadableTextTrack(HTMLTrackElement& track, const AtomString& kind, const AtomString& label, const AtomString& language)
-    : TextTrack(&track.document(), kind, emptyAtom(), label, language, TrackElement)
+    : TextTrack(track.scriptExecutionContext(), kind, emptyAtom(), label, language, TrackElement)
     , m_trackElement(&track)
 {
 }

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -36,7 +36,6 @@
 
 #include "CommonAtomStrings.h"
 #include "DataCue.h"
-#include "Document.h"
 #include "Event.h"
 #include "SourceBuffer.h"
 #include "TextTrackClient.h"
@@ -118,16 +117,16 @@ TextTrack::TextTrack(ScriptExecutionContext* context, const AtomString& kind, co
 {
 }
 
-Ref<TextTrack> TextTrack::create(Document* document, const AtomString& kind, TrackID id, const AtomString& label, const AtomString& language)
+Ref<TextTrack> TextTrack::create(ScriptExecutionContext* context, const AtomString& kind, TrackID id, const AtomString& label, const AtomString& language)
 {
-    auto textTrack = adoptRef(*new TextTrack(document, kind, id, label, language, AddTrack));
+    auto textTrack = adoptRef(*new TextTrack(context, kind, id, label, language, AddTrack));
     textTrack->suspendIfNeeded();
     return textTrack;
 }
 
-Ref<TextTrack> TextTrack::create(Document* document, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language)
+Ref<TextTrack> TextTrack::create(ScriptExecutionContext* context, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language)
 {
-    auto textTrack = adoptRef(*new TextTrack(document, kind, id, label, language, AddTrack));
+    auto textTrack = adoptRef(*new TextTrack(context, kind, id, label, language, AddTrack));
     textTrack->suspendIfNeeded();
     return textTrack;
 }
@@ -162,12 +161,6 @@ void TextTrack::clearClient(TextTrackClient& client)
 {
     ASSERT(m_clients.contains(client));
     m_clients.remove(client);
-}
-
-Document& TextTrack::document() const
-{
-    ASSERT(scriptExecutionContext());
-    return downcast<Document>(*scriptExecutionContext());
 }
 
 bool TextTrack::enabled() const

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -46,8 +46,8 @@ class VTTRegionList;
 class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(TextTrack);
 public:
-    static Ref<TextTrack> create(Document*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language);
-    static Ref<TextTrack> create(Document*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);
+    static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language);
+    static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);
     virtual ~TextTrack();
 
     static TextTrack& captionMenuOffItem();
@@ -133,7 +133,7 @@ public:
     virtual bool shouldPurgeCuesFromUnbufferedRanges() const { return false; }
     virtual void removeCuesNotInTimeRanges(const PlatformTimeRanges&);
 
-    Document& document() const;
+    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
 protected:
     TextTrack(ScriptExecutionContext*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language, TextTrackType);
@@ -151,7 +151,6 @@ protected:
 
 private:
     EventTargetInterface eventTargetInterface() const final { return TextTrackEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     bool enabled() const override;
 

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1446,7 +1446,7 @@ void VTTCue::prepareToSpeak(SpeechSynthesis& speechSynthesis, double rate, doubl
 
     auto& track = *this->track();
     m_speechSynthesis = &speechSynthesis;
-    m_speechUtterance = SpeechSynthesisUtterance::create(track.document(), m_content, [protectedThis = Ref { *this }, completion = WTFMove(completion)](const SpeechSynthesisUtterance&) {
+    m_speechUtterance = SpeechSynthesisUtterance::create(*track.scriptExecutionContext(), m_content, [protectedThis = Ref { *this }, completion = WTFMove(completion)](const SpeechSynthesisUtterance&) {
         protectedThis->m_speechUtterance = nullptr;
         protectedThis->m_speechSynthesis = nullptr;
         completion(protectedThis.get());


### PR DESCRIPTION
#### 21b659583b5f8410887b7fada7bf8775ced3f3db
<pre>
TextTrack should be constructed with a ScriptExecutionContext rather than a Document
<a href="https://bugs.webkit.org/show_bug.cgi?id=269181">https://bugs.webkit.org/show_bug.cgi?id=269181</a>
<a href="https://rdar.apple.com/122776217">rdar://122776217</a>

Reviewed by Eric Carlson and Ryosuke Niwa.

In order to have MSE in a Worker, we&apos;ll need to have {Text/Audio/Video} to be available in DedicatedWorker.

This change just the TextTracks constructors to take a ScriptExecutionContext ; it still requires it
to be a Document for now.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::document const): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/track/InbandDataTextTrack.cpp:
(WebCore::InbandDataTextTrack::InbandDataTextTrack):
(WebCore::InbandDataTextTrack::create):
(WebCore::InbandDataTextTrack::addDataCue):
* Source/WebCore/html/track/InbandDataTextTrack.h:
* Source/WebCore/html/track/InbandGenericTextTrack.cpp:
(WebCore::InbandGenericTextTrack::InbandGenericTextTrack):
(WebCore::InbandGenericTextTrack::create):
(WebCore::InbandGenericTextTrack::addGenericCue):
(WebCore::InbandGenericTextTrack::parser):
(WebCore::InbandGenericTextTrack::newCuesParsed):
* Source/WebCore/html/track/InbandGenericTextTrack.h:
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::create):
(WebCore::InbandTextTrack::InbandTextTrack):
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/InbandWebVTTTextTrack.cpp:
(WebCore::InbandWebVTTTextTrack::InbandWebVTTTextTrack):
(WebCore::InbandWebVTTTextTrack::create):
(WebCore::InbandWebVTTTextTrack::parser):
(WebCore::InbandWebVTTTextTrack::newCuesParsed):
* Source/WebCore/html/track/InbandWebVTTTextTrack.h:
* Source/WebCore/html/track/LoadableTextTrack.cpp:
(WebCore::LoadableTextTrack::LoadableTextTrack):
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::create):
(WebCore::TextTrack::document const): Deleted.
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::prepareToSpeak):

Canonical link: <a href="https://commits.webkit.org/274455@main">https://commits.webkit.org/274455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/389ca12f71fa4cedbee37e7652c7c0e961e24fed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32780 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39044 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37275 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15584 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8760 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->