### PR TITLE
Network Cache: do not use disk cache for Fetch media loads

### DIFF
--- a/LayoutTests/http/tests/cache/disk-cache/disk-cache-media-expected.txt
+++ b/LayoutTests/http/tests/cache/disk-cache/disk-cache-media-expected.txt
@@ -1,9 +1,9 @@
-Tests that media resources loaded via XHR is not cached.
+Tests that media resources loaded via XHR or Fetch is not cached.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-running 6 tests
+running 12 tests
 
 --------Testing loads from disk cache--------
 response headers: {"Cache-control":"max-age=0","Content-Type":"text/plain"}
@@ -24,6 +24,24 @@ response source: Network
 response headers: {"Cache-control":"max-age=100","Content-Type":"audio/mp4"}
 response source: Network
 
+response headers: {"Cache-control":"max-age=0","Content-Type":"text/plain"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"text/plain"}
+response source: Disk cache (fetch)
+
+response headers: {"Cache-control":"max-age=0","Content-Type":"video/mp4"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"video/mp4"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=0","Content-Type":"audio/mp4"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"audio/mp4"}
+response source: Network (fetch)
+
 --------Testing loads through memory cache (XHR behavior)--------
 response headers: {"Cache-control":"max-age=0","Content-Type":"text/plain"}
 response source: Network
@@ -43,6 +61,24 @@ response source: Network
 response headers: {"Cache-control":"max-age=100","Content-Type":"audio/mp4"}
 response source: Memory cache
 
+response headers: {"Cache-control":"max-age=0","Content-Type":"text/plain"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"text/plain"}
+response source: Disk cache (fetch)
+
+response headers: {"Cache-control":"max-age=0","Content-Type":"video/mp4"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"video/mp4"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=0","Content-Type":"audio/mp4"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"audio/mp4"}
+response source: Network (fetch)
+
 --------Testing loads through memory cache (subresource behavior)--------
 response headers: {"Cache-control":"max-age=0","Content-Type":"text/plain"}
 response source: Network
@@ -61,6 +97,24 @@ response source: Network
 
 response headers: {"Cache-control":"max-age=100","Content-Type":"audio/mp4"}
 response source: Memory cache
+
+response headers: {"Cache-control":"max-age=0","Content-Type":"text/plain"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"text/plain"}
+response source: Memory cache (fetch)
+
+response headers: {"Cache-control":"max-age=0","Content-Type":"video/mp4"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"video/mp4"}
+response source: Memory cache (fetch)
+
+response headers: {"Cache-control":"max-age=0","Content-Type":"audio/mp4"}
+response source: Network (fetch)
+
+response headers: {"Cache-control":"max-age=100","Content-Type":"audio/mp4"}
+response source: Memory cache (fetch)
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/cache/disk-cache/disk-cache-media.html
+++ b/LayoutTests/http/tests/cache/disk-cache/disk-cache-media.html
@@ -16,9 +16,14 @@ var testMatrix =
   ],
  ];
 
-description("Tests that media resources loaded via XHR is not cached.");
+description("Tests that media resources loaded via XHR or Fetch is not cached.");
 
 var tests = generateTests(testMatrix);
+
+var l = tests.length;
+for (var i = 0; i < l; ++i) {
+    tests.push({ ...tests[i], method: "fetch" });
+}
 
 debug("running " + tests.length + " tests");
 debug("");

--- a/LayoutTests/http/tests/cache/disk-cache/resources/cache-test.js
+++ b/LayoutTests/http/tests/cache/disk-cache/resources/cache-test.js
@@ -78,6 +78,14 @@ function loadResource(test, onload)
     if (test.fragment)
         test.url = addFragmentToURL(test.url);
 
+    if (test.method == "fetch") {
+        fetch(test.url, test.requestHeaders).then((result) => {
+            test.fetchResult = result;
+            onload();
+        });
+        return;
+    }
+
     test.xhr = new XMLHttpRequest();
     test.xhr.onload = onload;
     test.xhr.onerror = onload;
@@ -120,7 +128,7 @@ function printResults(tests)
             debug("response's 'Expires' header is overriden by future date in 304 response");
         if (test.requestHeaders)
             debug("request headers: " + JSON.stringify(test.requestHeaders));
-        responseSource = internals.xhrResponseSource(test.xhr);
+        responseSource = test.xhr ? internals.xhrResponseSource(test.xhr) : internals.fetchResponseSource(test.fetchResult) + " (fetch)";
         debug("response source: " + responseSource);
         debug("");
     }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -830,6 +830,22 @@ static BrowsingContextGroupSwitchDecision toBrowsingContextGroupSwitchDecision(c
     return BrowsingContextGroupSwitchDecision::NewSharedGroup;
 }
 
+bool NetworkResourceLoader::isLikelyStreamingMedia(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response)
+{
+    auto isFetchOrXHR = [] (WebCore::ResourceRequestRequester requester) {
+        return requester == WebCore::ResourceRequestRequester::Fetch
+            || requester == WebCore::ResourceRequestRequester::XHR;
+    };
+
+    auto isMediaMIMEType = [] (const String& mimeType) {
+        return startsWithLettersIgnoringASCIICase(mimeType, "audio/"_s)
+            || startsWithLettersIgnoringASCIICase(mimeType, "video/"_s)
+            || equalLettersIgnoringASCIICase(mimeType, "application/octet-stream"_s);
+    };
+
+    return isFetchOrXHR(request.requester()) && isMediaMIMEType(response.mimeType());
+}
+
 void NetworkResourceLoader::didReceiveInformationalResponse(ResourceResponse&& response)
 {
     if (response.httpStatusCode() != httpStatus103EarlyHints)
@@ -865,21 +881,9 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
 
     auto resourceLoadInfo = this->resourceLoadInfo();
 
-    auto isFetchOrXHR = [] (const ResourceLoadInfo& info) {
-        return info.type == ResourceLoadInfo::Type::Fetch
-            || info.type == ResourceLoadInfo::Type::XMLHTTPRequest;
-    };
-
-    auto isMediaMIMEType = [] (const String& mimeType) {
-        return startsWithLettersIgnoringASCIICase(mimeType, "audio/"_s)
-            || startsWithLettersIgnoringASCIICase(mimeType, "video/"_s)
-            || equalLettersIgnoringASCIICase(mimeType, "application/octet-stream"_s);
-    };
-
     if (!m_bufferedData
         && m_response.expectedContentLength() > static_cast<long long>(1 * MB)
-        && isFetchOrXHR(resourceLoadInfo)
-        && isMediaMIMEType(m_response.mimeType())) {
+        && isLikelyStreamingMedia(originalRequest(), m_response)) {
         m_bufferedData.empty();
         m_parameters.maximumBufferingTime = WebLoaderStrategy::mediaMaximumBufferingTime;
     }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -147,6 +147,8 @@ public:
     bool isMainFrameLoad() const { return isMainResource() && m_parameters.frameAncestorOrigins.isEmpty(); }
     bool isCrossOriginPrefetch() const;
 
+    static bool isLikelyStreamingMedia(const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
+
 #if !RELEASE_LOG_DISABLED
     static bool shouldLogCookieInformation(NetworkConnectionToWebProcess&, PAL::SessionID);
     static void logCookieInformation(NetworkConnectionToWebProcess&, ASCIILiteral label, const void* loggedObject, const WebCore::NetworkStorageSession&, const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, const String& referrer, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, std::optional<WebCore::ResourceLoaderIdentifier>);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -32,6 +32,7 @@
 #include "NetworkCacheSpeculativeLoadManager.h"
 #include "NetworkCacheStorage.h"
 #include "NetworkProcess.h"
+#include "NetworkResourceLoader.h"
 #include "NetworkSession.h"
 #include "WebsiteDataType.h"
 #include <WebCore/CacheValidation.h>
@@ -263,11 +264,6 @@ static RetrieveDecision makeRetrieveDecision(const WebCore::ResourceRequest& req
     return RetrieveDecision::Yes;
 }
 
-static bool isMediaMIMEType(const String& type)
-{
-    return startsWithLettersIgnoringASCIICase(type, "video/"_s) || startsWithLettersIgnoringASCIICase(type, "audio/"_s);
-}
-
 static StoreDecision makeStoreDecision(const WebCore::ResourceRequest& originalRequest, const WebCore::ResourceResponse& response, size_t bodySize)
 {
     if (!originalRequest.url().protocolIsInHTTPFamily() || !response.isInHTTPFamily())
@@ -317,8 +313,7 @@ static StoreDecision makeStoreDecision(const WebCore::ResourceRequest& originalR
     // FIXME: We should also make sure make the MSE paths are copy-free so we can use mapped buffers from disk effectively.
     auto requester = originalRequest.requester();
     bool isDefinitelyStreamingMedia = requester == WebCore::ResourceRequestRequester::Media;
-    bool isLikelyStreamingMedia = requester == WebCore::ResourceRequestRequester::XHR && isMediaMIMEType(response.mimeType());
-    if (isLikelyStreamingMedia || isDefinitelyStreamingMedia)
+    if (NetworkResourceLoader::isLikelyStreamingMedia(originalRequest, response) || isDefinitelyStreamingMedia)
         return StoreDecision::NoDueToStreamingMedia;
 
     return StoreDecision::Yes;


### PR DESCRIPTION
#### 7a624208fd6011fe2e8a1b0a715053e10f0aad36
<pre>
Network Cache: do not use disk cache for Fetch media loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=235535">https://bugs.webkit.org/show_bug.cgi?id=235535</a>

Reviewed by NOBODY (OOPS!).

In 162325@main (00f55b7be743), checks have been added to avoid putting
media resources from XHR requests in the disk cache, since they are
likely specific to MSE streaming.
But this did not check for Fetch requests, which can also be used
for MSE streaming.

Similar checks for MSE buffers have been added in 241310@main
(9ad624cd83a4), factorize them in a common
NetworkResourceLoader::isLikelyStreamingMedia() method.

Also extend the disk-cache-media test to check for Fetch behavior.

This issue has been found by using Shaka Player on a low-end device.
Playing high quality MSE content was pushing to the disk cache
faster than the device could handle.
Media data was accumulating in the the background IOQueue thread,
and the NetworkProcess memory was constantly increasing.

* LayoutTests/http/tests/cache/disk-cache/disk-cache-media-expected.txt:
* LayoutTests/http/tests/cache/disk-cache/disk-cache-media.html:
* LayoutTests/http/tests/cache/disk-cache/resources/cache-test.js:
(loadResource):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::isLikelyStreamingMedia):
(WebKit::NetworkResourceLoader::didReceiveResponse):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::makeStoreDecision):
(WebKit::NetworkCache::isMediaMIMEType): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a624208fd6011fe2e8a1b0a715053e10f0aad36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41704 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34887 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15478 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32782 "Found 3 new test failures: http/tests/cache/disk-cache/disk-cache-204-status-code.html, http/tests/cache/disk-cache/disk-cache-redirect.html, http/tests/cache/disk-cache/resource-becomes-uncacheable.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39744 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15268 "Found 1 new test failure: http/tests/cache/disk-cache/resource-becomes-uncacheable.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13262 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35564 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35219 "Found 2 new test failures: http/tests/cache/disk-cache/disk-cache-redirect.html, http/tests/cache/disk-cache/resource-becomes-uncacheable.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39047 "Found 3 new test failures: http/tests/cache/disk-cache/disk-cache-204-status-code.html, http/tests/cache/disk-cache/disk-cache-redirect.html, http/tests/cache/disk-cache/resource-becomes-uncacheable.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13982 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11536 "Found 2 new test failures: http/tests/cache/disk-cache/disk-cache-redirect.html, media/track/track-in-band-chapters-invalid-client-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37278 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15588 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34168 "Exiting early after 10 failures. 16 tests run. 1 flakes") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->