### PR TITLE
[LBSE] Improve RenderSVGResourcePattern

### DIFF
--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
@@ -358,7 +358,6 @@ svg/as-image/img-preserveAspectRatio-support-1.html                       [ Imag
 # Pattern problems
 svg/W3C-SVG-1.1/pservers-grad-06-b.svg                                      [ Failure ]
 svg/custom/js-late-pattern-creation.svg                                     [ Failure ]
-svg/custom/nested-pattern-boundingBoxModeContent.svg                        [ Failure ]
 svg/custom/pattern-content-inheritance-cycle.svg                            [ ImageOnlyFailure ]
 svg/custom/stroked-pattern.svg                                              [ Failure ]
 svg/transforms/text-with-pattern-inside-transformed-html.xhtml              [ Failure ]
@@ -507,9 +506,6 @@ webkit.org/b/222952 svg/dom/replaceChild-document-crash.html [ Pass Crash ]
 # 2) RenderLayerFilters doesn't yet protect us from negative 'deviations' values in the effect stack
 svg/filters/feDropShadow-negative-deviation.svg   [ ImageOnlyFailure Crash ]
 svg/filters/feGaussianBlur-negative-deviation.svg [ ImageOnlyFailure Crash ]
-
-# 3) Deep nesting invalidating via repaintAllClients() has expontential complexity in LBSE, fix that.
-svg/custom/pattern-nested-reference.html [ Timeout ]
 
 ###############
 #  OVERRIDES  #

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/nested-pattern-boundingBoxModeContent-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/nested-pattern-boundingBoxModeContent-expected.txt
@@ -1,0 +1,64 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (0,0) size 1x1
+  RenderSVGHiddenContainer {pattern} at (0,0) size 1x1
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 1x1 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 0.50x0.50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=0.50] [height=0.50]
+layer at (0,0) size 1x1
+  RenderSVGHiddenContainer {pattern} at (0,0) size 1x1
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 1x1 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 0.50x0.50 [fill={[type=SOLID] [color=#FFA500]}] [x=0.00] [y=0.00] [width=0.50] [height=0.50]
+layer at (0,0) size 1x1
+  RenderSVGHiddenContainer {pattern} at (0,0) size 1x1
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 1x1 [fill={[type=SOLID] [color=#808080]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 0.50x0.50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=0.50] [height=0.50]
+layer at (0,0) size 1x1
+  RenderSVGHiddenContainer {pattern} at (0,0) size 1x1
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 1x1 [fill={[type=SOLID] [color=#FFFF00]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 0.50x0.50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=0.50] [height=0.50]
+layer at (0,0) size 1x1
+  RenderSVGHiddenContainer {pattern} at (0,0) size 1x1
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 0.50x0.50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=0.50] [height=0.50]
+layer at (0.50,0.50) size 1x1
+  RenderSVGRect {rect} at (0.50,0.50) size 0.50x0.50 [fill={[type=SOLID] [color=#000000]}] [x=0.50] [y=0.50] [width=0.50] [height=0.50]
+layer at (50,50) size 200x200
+  RenderSVGRect {rect} at (50,50) size 200x200 [fill={[type=SOLID] [color=#000000]}] [x=50.00] [y=50.00] [width=200.00] [height=200.00]
+layer at (50,300) size 200x200
+  RenderSVGTransformableContainer {g} at (50,300) size 200x200
+layer at (50,300) size 200x200
+  RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#FF0000]}] [x=50.00] [y=300.00] [width=200.00] [height=200.00]
+layer at (50,300) size 100x100
+  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=300.00] [width=100.00] [height=100.00]
+layer at (50,300) size 50x50
+  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#FFA500]}] [x=50.00] [y=300.00] [width=50.00] [height=50.00]
+layer at (300,50) size 200x200
+  RenderSVGRect {rect} at (300,50) size 200x200 [fill={[type=SOLID] [color=#000000]}] [x=300.00] [y=50.00] [width=200.00] [height=200.00]
+layer at (300,300) size 200x200
+  RenderSVGTransformableContainer {g} at (300,300) size 200x200
+layer at (300,300) size 200x200
+  RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#808080]}] [x=300.00] [y=300.00] [width=200.00] [height=200.00]
+layer at (300,300) size 100x100
+  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#FFFF00]}] [x=300.00] [y=300.00] [width=100.00] [height=100.00]
+layer at (300,300) size 25x25
+  RenderSVGRect {rect} at (0,0) size 25x25 [fill={[type=SOLID] [color=#FF0000]}] [x=300.00] [y=300.00] [width=25.00] [height=25.00]
+layer at (300,300) size 13x13
+  RenderSVGRect {rect} at (0,0) size 12.50x12.50 [fill={[type=SOLID] [color=#008000]}] [x=300.00] [y=300.00] [width=12.50] [height=12.50]
+layer at (300,300) size 7x7
+  RenderSVGRect {rect} at (0,0) size 6.25x6.25 [fill={[type=SOLID] [color=#FFA500]}] [x=300.00] [y=300.00] [width=6.25] [height=6.25]
+layer at (325,325) size 25x25
+  RenderSVGRect {rect} at (25,25) size 25x25 [fill={[type=SOLID] [color=#008000]}] [x=325.00] [y=325.00] [width=25.00] [height=25.00]
+layer at (325,325) size 13x13
+  RenderSVGRect {rect} at (25,25) size 12.50x12.50 [fill={[type=SOLID] [color=#FFA500]}] [x=325.00] [y=325.00] [width=12.50] [height=12.50]

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
@@ -40,10 +40,14 @@ public:
     bool prepareFillOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) final;
     bool prepareStrokeOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) final;
 
-    void invalidatePattern()
+    enum class SuppressRepaint { Yes, No };
+    void invalidatePattern(SuppressRepaint suppressRepaint = SuppressRepaint::No)
     {
         m_attributes = std::nullopt;
-        repaintAllClients();
+        m_imageMap.clear();
+        m_transformMap.clear();
+        if (suppressRepaint == SuppressRepaint::No)
+            repaintAllClients();
     }
 
 protected:
@@ -53,9 +57,14 @@ protected:
 
     bool buildTileImageTransform(const RenderElement&, const PatternAttributes&, const SVGPatternElement&, FloatRect& patternBoundaries, AffineTransform& tileImageTransform) const;
 
-    RefPtr<ImageBuffer> createTileImage(const PatternAttributes&, const FloatRect&, const FloatRect& scale, const AffineTransform& tileImageTransform) const;
+    RefPtr<ImageBuffer> createTileImage(GraphicsContext&, const PatternAttributes&, const FloatSize&, const FloatSize& scale, const AffineTransform& tileImageTransform) const;
+
+    void removeReferencingCSSClient(const RenderElement&) override;
 
     std::optional<PatternAttributes> m_attributes;
+
+    HashMap<SingleThreadWeakRef<const RenderLayerModelObject>, RefPtr<ImageBuffer>> m_imageMap;
+    HashMap<SingleThreadWeakRef<const RenderLayerModelObject>, AffineTransform> m_transformMap;
 };
 
 }

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -31,6 +31,7 @@
 #include "RenderSVGHiddenContainer.h"
 #include "RenderSVGPath.h"
 #include "RenderSVGResourceMasker.h"
+#include "RenderSVGResourcePattern.h"
 #include "SVGMatrix.h"
 #include "SVGNames.h"
 #include "SVGPathData.h"
@@ -221,8 +222,12 @@ void SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded()
         return;
     if (CheckedPtr svgRenderer = dynamicDowncast<RenderLayerModelObject>(renderer())) {
         if (auto* container = svgRenderer->enclosingLayer()->enclosingSVGHiddenOrResourceContainer()) {
-            if (auto* patternRenderer = dynamicDowncast<RenderSVGResourceMasker>(container))
-                patternRenderer->invalidateMask();
+            if (auto* maskRenderer = dynamicDowncast<RenderSVGResourceMasker>(container))
+                maskRenderer->invalidateMask();
+        }
+        if (auto* container = svgRenderer->enclosingLayer()->enclosingSVGHiddenOrResourceContainer()) {
+            if (auto* patternRenderer = dynamicDowncast<RenderSVGResourcePattern>(container))
+                patternRenderer->invalidatePattern(RenderSVGResourcePattern::SuppressRepaint::Yes);
         }
     }
 }

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -141,6 +141,11 @@ void SVGPatternElement::childrenChanged(const ChildChange& change)
     if (change.source == ChildChange::Source::Parser)
         return;
 
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        if (CheckedPtr patternRenderer = dynamicDowncast<RenderSVGResourcePattern>(renderer()))
+            patternRenderer->invalidatePattern();
+    }
+
     updateSVGRendererForElementChange();
 }
 

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -256,6 +256,7 @@ void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)
                     renderer->checkedView()->setNeedsLayout(MarkOnlyThis);
             }
         }
+        invalidateResourceImageBuffersIfNeeded();
         updateSVGRendererForElementChange();
         return;
     }
@@ -276,6 +277,7 @@ void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)
         if (CheckedPtr renderer = this->renderer())
             renderer->setNeedsTransformUpdate();
 
+        invalidateResourceImageBuffersIfNeeded();
         updateSVGRendererForElementChange();
         return;
     }


### PR DESCRIPTION
#### 9e8747f4819708b1c2cfa80ba0bf32a6042e9a2f
<pre>
[LBSE] Improve RenderSVGResourcePattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=269184">https://bugs.webkit.org/show_bug.cgi?id=269184</a>

Reviewed by Nikolas Zimmermann.

Improve pattern resource implementation in the following ways:
- take legacy pattern resource calculations to fix custom/nested-pattern-boundingBoxModeContent.svg
- cache pattern tiles as image bitmaps (like legacy did). This allows pattern-nested-reference.html to not time out
- take care of correctly invalidating in case pattern contents change or a referencing client is added or removed

This PR relies on SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded introduced in r277292 and adds
patterns as an SVG resource to invalidate for image buffer caching. The expectation is that this is the final
SVG resource that needs to be taken into account in SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded.

* LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/nested-pattern-boundingBoxModeContent-expected.txt: Added.
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::buildPattern):
(WebCore::RenderSVGResourcePattern::prepareFillOperation):
(WebCore::RenderSVGResourcePattern::prepareStrokeOperation):
(WebCore::RenderSVGResourcePattern::createTileImage const):
(WebCore::RenderSVGResourcePattern::removeReferencingCSSClient):
(WebCore::clear2DRotation): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.h:
(WebCore::RenderSVGResourcePattern::invalidatePattern):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::childrenChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/277306@main">https://commits.webkit.org/277306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86e1eed2da029f7a30f7a3645928263f203686d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43321 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38496 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19810 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41903 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5316 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43631 "Found 1 new API test failure: TestWebKitAPI.SleepDisabler.Close (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42306 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22302 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18649 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45790 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23577 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44802 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10419 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->