### PR TITLE
[GStreamer] Implement "id" property for in-band audio, text and video tracks

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1052,7 +1052,7 @@ webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavai
 webkit.org/b/218317 media/media-source/media-source-trackid-change.html [ Failure ]
 webkit.org/b/238201 media/media-source/media-mp4-hevc-bframes.html [ Failure ]
 
-# GStreamer doesn't set the track's id to the container's value.
+# GStreamer (< 1.24) doesn't set the track's id to the container's value.
 webkit.org/b/265919 media/track/media-audio-track.html [ Failure ]
 webkit.org/b/265919 media/track/media-source-audio-track.html [ Failure ]
 

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
@@ -56,7 +56,7 @@ public:
 
     int trackIndex() const final { return m_index; }
 
-    TrackID id() const final { return m_index; }
+    TrackID id() const final { return m_trackID.value_or(m_index); }
     std::optional<AtomString> trackUID() const final { return m_stringId; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
@@ -74,6 +74,7 @@ private:
     AudioTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, unsigned index, GstStream*);
 
     WeakPtr<MediaPlayerPrivateGStreamer> m_player;
+    std::optional<TrackID> m_trackID;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
@@ -53,13 +53,16 @@ public:
     }
 
     Kind kind() const final { return m_kind; }
-    TrackID id() const final { return m_index; }
+    TrackID id() const final { return m_trackID.value_or(m_index); }
     std::optional<AtomString> trackUID() const final { return m_stringId; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
     int trackIndex() const final { return m_index; }
 
     void handleSample(GRefPtr<GstSample>);
+
+protected:
+    void tagsChanged(GRefPtr<GstTagList>&&) final;
 
 private:
     InbandTextTrackPrivateGStreamer(unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
@@ -70,6 +73,7 @@ private:
     Vector<GRefPtr<GstSample>> m_pendingSamples WTF_GUARDED_BY_LOCK(m_sampleMutex);
     Kind m_kind;
     Lock m_sampleMutex;
+    std::optional<TrackID> m_trackID;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -34,6 +34,7 @@
 #include "VP9Utilities.h"
 #include <gst/pbutils/pbutils.h>
 #include <wtf/Scope.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
 
@@ -94,6 +95,16 @@ void VideoTrackPrivateGStreamer::updateConfigurationFromTags(GRefPtr<GstTagList>
     GST_DEBUG_OBJECT(objectForLogging(), "Updating video configuration from %" GST_PTR_FORMAT, tags.get());
     if (!tags)
         return;
+
+    GUniqueOutPtr<char> trackIDString;
+    if (gst_tag_list_get_string(tags.get(), "container-specific-track-id", &trackIDString.outPtr())) {
+        if (auto trackID = WTF::parseInteger<TrackID>(StringView { trackIDString.get(), static_cast<unsigned>(strlen(trackIDString.get())) })) {
+            m_trackID = *trackID;
+            GST_DEBUG_OBJECT(objectForLogging(), "Video track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_trackID);
+            m_stringId = AtomString::number(static_cast<unsigned long long>(*m_trackID));
+            client()->idChanged(*m_trackID);
+        }
+    }
 
     unsigned bitrate;
     if (!gst_tag_list_get_uint(tags.get(), GST_TAG_BITRATE, &bitrate))

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
@@ -57,7 +57,7 @@ public:
 
     int trackIndex() const final { return m_index; }
 
-    TrackID id() const final { return m_index; }
+    TrackID id() const final { return m_trackID.value_or(m_index); }
     std::optional<AtomString> trackUID() const final { return m_stringId; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
@@ -75,6 +75,7 @@ private:
     VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, unsigned index, GstStream*);
 
     WeakPtr<MediaPlayerPrivateGStreamer> m_player;
+    std::optional<TrackID> m_trackID;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### cb24c51631e89c0a0c1facdba4de43c59746205c
<pre>
[GStreamer] Implement &quot;id&quot; property for in-band audio, text and video tracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=123901">https://bugs.webkit.org/show_bug.cgi?id=123901</a>

Reviewed by Xabier Rodriguez-Calvar.

Support for container-specific-track-id GStreamer tag was implemented in:
<a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/6041">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/6041</a>

Which is scheduled to ship in GStreamer 1.24. The demuxers supported initially are DASH, qtdemux and
matroskademux, so we have coverage for the most common formats.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromTags):
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp:
(WebCore::ensureTextTrackDebugCategoryInitialized):
(WebCore::InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer):
(WebCore::InbandTextTrackPrivateGStreamer::tagsChanged):
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromTags):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/274623@main">https://commits.webkit.org/274623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcf5b21920d9e929715d54346d70288eea004c12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32791 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39057 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37289 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15601 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8861 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->