### PR TITLE
[CSS Container Queries][Style queries] Resolve custom properties in style queries if needed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt
@@ -5,8 +5,8 @@ PASS style(not ((--foo: calc(10px + 2em)) and ((--foo: url(x)))))
 PASS style((--foo: bar) or (--bar: 10px))
 PASS style(--my-prop:)
 PASS style(--my-prop: )
-PASS style(--foo: bar !important)
+FAIL style(--foo: bar !important) assert_equals: expected "true" but got ""
 PASS style(--foo)
-FAIL style(--foo: bar;) assert_equals: expected "" but got "true"
+PASS style(--foo: bar;)
 PASS style(style(--foo: bar))
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
@@ -48,28 +48,28 @@ PASS outer style(--outer-space-after:true)
 PASS outer style(--outer-space-after:true )
 PASS outer style(--outer-space-after: true )
 FAIL Query custom property with !important declaration assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Query custom property using var() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Query custom property using var()
 PASS Query custom property including unknown var() reference
 PASS Query custom property including unknown var() reference with non-matching fallback
-FAIL Query custom property including unknown var() reference with matching fallback assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Query custom property matching guaranteed-invalid values assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Query custom property including unknown var() reference with matching fallback
+PASS Query custom property matching guaranteed-invalid values
 PASS Style query with revert keyword is false
 PASS Style query with revert-layer keyword is false
-FAIL Style query 'initial' matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Style query 'initial' matching
 PASS Style query matching negated value-less query against initial value
 PASS Style query 'initial' not matching
 PASS Style query matching value-less query against non-initial value
-FAIL Style query 'inherit' matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Style query 'inherit' matching
 PASS Style query 'inherit' not matching
-FAIL Style query 'unset' matching assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Style query 'unset' matching
 PASS Style query 'unset' not matching
-FAIL Match registered <length> custom property with px. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match registered <length> custom property with px via initial keyword. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match registered <length> custom property with em in query. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match registered <length> custom property with em in computed value. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match registered <length> custom property with px.
+PASS Match registered <length> custom property with px via initial keyword.
+PASS Match registered <length> custom property with em in query.
+PASS Match registered <length> custom property with em in computed value.
 FAIL Match registered <length> custom property with cqi unit. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match registered <length> custom property with initial value. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match registered <length> custom property with initial value via initial keyword. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match registered <length> custom property with initial value.
+PASS Match registered <length> custom property with initial value via initial keyword.
 FAIL Should only match exact string for numbers in non-registered custom properties assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 PASS Spaces should not collapse in non-registered custom properties
 

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -59,7 +59,9 @@ static RefPtr<CSSValue> consumeCustomPropertyValue(AtomString propertyName, CSSP
 {
     auto propertyValueRange = range.consumeAllExcludingTrailingWhitespace();
     range.consumeWhitespace();
-    return CSSCustomPropertyValue::createSyntaxAll(propertyName, CSSVariableData::create(propertyValueRange));
+    if (propertyValueRange.atEnd())
+        return CSSCustomPropertyValue::createEmpty(propertyName);
+    return CSSVariableParser::parseDeclarationValue(propertyName, propertyValueRange, strictCSSParserContext());
 }
 
 std::optional<Feature> FeatureParser::consumeBooleanOrPlainFeature(CSSParserTokenRange& range, const MediaQueryParserContext& context)

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -87,11 +87,14 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
     if (!containerStyle)
         return { };
 
+    auto* containerParent = container->parentElementInComposedTree();
+    auto* containerParentStyle = containerParent ? styleForContainer(*containerParent, containerQuery.requiredAxes, m_evaluationState) : nullptr;
+
     auto* rootStyle = m_element->document().documentElement()->renderStyle();
 
     return MQ::FeatureEvaluationContext {
         m_element->document(),
-        CSSToLengthConversionData { *containerStyle, rootStyle, nullptr, m_element->document().renderView(), container },
+        CSSToLengthConversionData { *containerStyle, rootStyle, containerParentStyle, m_element->document().renderView(), container },
         container->renderer()
     };
 }

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -46,6 +46,8 @@ public:
     void applyProperty(CSSPropertyID propertyID) { applyProperties(propertyID, propertyID); }
     void applyCustomProperty(const AtomString& name);
 
+    RefPtr<const CSSCustomPropertyValue> resolveCustomPropertyForContainerQueries(const CSSCustomPropertyValue&);
+
     BuilderState& state() { return m_state; }
 
     const HashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const { return m_cascade.overriddenAnimatedProperties(); }


### PR DESCRIPTION
#### 9c97e55d92afcdf5c161edf21a59efe47a86d10c
<pre>
[CSS Container Queries][Style queries] Resolve custom properties in style queries if needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=269189">https://bugs.webkit.org/show_bug.cgi?id=269189</a>
<a href="https://rdar.apple.com/122793669">rdar://122793669</a>

Reviewed by Alan Baradlay.

Handle style(--foo:var(bar)), style(--foo:inherit) and registered custom properties.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:

Resolve custom property values in style queries against the current style and registered property enviroment using Style::Builder.

* Source/WebCore/css/query/GenericMediaQueryParser.cpp:

Parse the custom property value in query using the path that returns unresolved and css-wide keyword values if needed.

(WebCore::MQ::consumeCustomPropertyValue):
* Source/WebCore/style/ContainerQueryEvaluator.cpp:

Pass also the parent style so &apos;inherit&apos; can be resolved correctly.

(WebCore::Style::ContainerQueryEvaluator::featureEvaluationContextForQuery const):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveCustomPropertyForContainerQueries):

Expose a helper for this case.

* Source/WebCore/style/StyleBuilder.h:

Canonical link: <a href="https://commits.webkit.org/274471@main">https://commits.webkit.org/274471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a89272047b2ff05aa5cc859d36269e378aae99e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41739 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15513 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32812 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13293 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43016 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39077 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14017 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37310 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15623 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8769 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->