### PR TITLE
RTCController should use a WeakHashSet

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCController.h
+++ b/Source/WebCore/Modules/mediastream/RTCController.h
@@ -26,11 +26,13 @@
 
 #include "SecurityOrigin.h"
 #include <wtf/Vector.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
 class Document;
 class RTCPeerConnection;
+class WeakPtrImplWithEventTargetData;
 
 class RTCController {
 public:
@@ -57,7 +59,7 @@ private:
         Ref<SecurityOrigin> clientOrigin;
     };
     Vector<PeerConnectionOrigin> m_filteringDisabledOrigins;
-    Vector<std::reference_wrapper<RTCPeerConnection>> m_peerConnections;
+    WeakHashSet<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_peerConnections;
     bool m_shouldFilterICECandidates { true };
 #endif
 };


### PR DESCRIPTION
#### 618934b27e385cc641923328a25d64c3a343d37f
<pre>
RTCController should use a WeakHashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=269191">https://bugs.webkit.org/show_bug.cgi?id=269191</a>
<a href="https://rdar.apple.com/122798016">rdar://122798016</a>

Reviewed by Jean-Yves Avenard.

This makes us use more smart pointers.

* Source/WebCore/Modules/mediastream/RTCController.cpp:
(WebCore::RTCController::~RTCController):
(WebCore::RTCController::remove):
(WebCore::RTCController::add):
(WebCore::RTCController::disableICECandidateFilteringForAllOrigins):
(WebCore::RTCController::disableICECandidateFilteringForDocument):
(WebCore::RTCController::enableICECandidateFiltering):
* Source/WebCore/Modules/mediastream/RTCController.h:

Canonical link: <a href="https://commits.webkit.org/274531@main">https://commits.webkit.org/274531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afd20259c804de051fc72ba2ae5eba9848b40b08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32800 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13280 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39064 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37297 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15607 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8801 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->