### PR TITLE
Adopt more smart pointers in EditingStyle.cpp

### DIFF
--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -70,6 +70,7 @@ public:
     bool isImportant() const { return m_metadata.m_important; }
 
     CSSValue* value() const { return m_value.get(); }
+    RefPtr<CSSValue> protectedValue() const { return m_value; }
 
     static CSSPropertyID resolveDirectionAwareProperty(CSSPropertyID, TextDirection, WritingMode);
     static CSSPropertyID unresolvePhysicalProperty(CSSPropertyID, TextDirection, WritingMode);

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -262,6 +262,11 @@ Ref<StyleRule> StyleRule::copy() const
     return adoptRef(*new StyleRule(*this));
 }
 
+Ref<const StyleProperties> StyleRule::protectedProperties() const
+{
+    return m_properties;
+}
+
 void StyleRule::setProperties(Ref<StyleProperties>&& properties)
 {
     m_properties = WTFMove(properties);

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -118,6 +118,7 @@ public:
 
     const CSSSelectorList& selectorList() const { return m_selectorList; }
     const StyleProperties& properties() const { return m_properties.get(); }
+    Ref<const StyleProperties> protectedProperties() const;
     MutableStyleProperties& mutableProperties();
 
     bool isSplitRule() const { return m_isSplitRule; }

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -183,6 +183,11 @@ void StyledElement::invalidateStyleAttribute()
     }
 }
 
+RefPtr<StyleProperties> StyledElement::protectedInlineStyle() const
+{
+    return elementData() ? elementData()->m_inlineStyle : nullptr;
+}
+
 void StyledElement::inlineStyleChanged()
 {
     invalidateStyleAttribute();

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -47,6 +47,7 @@ public:
     void invalidateStyleAttribute();
 
     const StyleProperties* inlineStyle() const { return elementData() ? elementData()->m_inlineStyle.get() : nullptr; }
+    RefPtr<StyleProperties> protectedInlineStyle() const;
     
     bool setInlineStyleProperty(CSSPropertyID, CSSValueID identifier, bool important = false);
     bool setInlineStyleProperty(CSSPropertyID, CSSPropertyID identifier, bool important = false);

--- a/Source/WebCore/editing/EditingStyle.h
+++ b/Source/WebCore/editing/EditingStyle.h
@@ -109,6 +109,7 @@ public:
     WEBCORE_EXPORT ~EditingStyle();
 
     MutableStyleProperties* style() { return m_mutableStyle.get(); }
+    RefPtr<MutableStyleProperties> protectedStyle();
     Ref<MutableStyleProperties> styleWithResolvedTextDecorations() const;
     std::optional<WritingDirection> textDirection() const;
     bool isEmpty() const;


### PR DESCRIPTION
#### 0b368a6170699e69ad169293ae208da1ec4499ac
<pre>
Adopt more smart pointers in EditingStyle.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=269194">https://bugs.webkit.org/show_bug.cgi?id=269194</a>

Reviewed by Darin Adler.

* Source/WebCore/css/CSSProperty.h:
(WebCore::CSSProperty::protectedValue const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::protectedProperties const):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::protectedInlineStyle const):
* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::EditingStyle):
(WebCore::EditingStyle::removeStyleAddedByNode):
(WebCore::EditingStyle::removeStyleConflictingWithStyleOfNode):
(WebCore::EditingStyle::triStateOfStyle const):
(WebCore::EditingStyle::styleIsPresentInComputedStyleOfNode const):
(WebCore::EditingStyle::prepareToApplyAt):
(WebCore::EditingStyle::protectedStyle):
(WebCore::EditingStyle::mergeTypingStyle):
(WebCore::EditingStyle::mergeInlineStyleOfElement):
(WebCore::elementMatchesAndPropertyIsNotInInlineStyleDecl):
(WebCore::EditingStyle::mergeInlineAndImplicitStyleOfElement):
(WebCore::styleFromMatchedRulesForElement):
(WebCore::EditingStyle::mergeStyleFromRules):
(WebCore::loneFontFamilyName):
(WebCore::EditingStyle::mergeStyleFromRulesForSerialization):
(WebCore::EditingStyle::removeStyleFromRulesAndContext):
(WebCore::EditingStyle::removePropertiesInElementDefaultStyle):
(WebCore::EditingStyle::removeEquivalentProperties):
(WebCore::EditingStyle::styleAtSelectionStart):
(WebCore::EditingStyle::inverseTransformColorIfNeeded):
(WebCore::StyleChange::StyleChange):
* Source/WebCore/editing/EditingStyle.h:

Canonical link: <a href="https://commits.webkit.org/274465@main">https://commits.webkit.org/274465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f6235126dc0e5d28d56ec045c1ef370bc3595bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41729 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15503 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13290 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34919 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35249 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39078 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37311 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15276 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5116 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->