### PR TITLE
[iOS] Pinch zooming then fullscreening causes fullscreen presentation to be zoomed unexpectedly

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -133,6 +133,12 @@ struct OverriddenLayoutParameters {
     CGSize maximumUnobscuredSize { CGSizeZero };
 };
 
+struct OverriddenZoomScaleParameters {
+    CGFloat minimumZoomScale { 1 };
+    CGFloat maximumZoomScale { 1 };
+    BOOL allowUserScaling { YES };
+};
+
 // This holds state that should be reset when the web process exits.
 struct PerWebProcessState {
     CGFloat viewportMetaTagWidth { WebCore::ViewportArguments::ValueAuto };
@@ -248,6 +254,7 @@ struct PerWebProcessState {
     PerWebProcessState _perProcessState;
 
     std::optional<OverriddenLayoutParameters> _overriddenLayoutParameters;
+    std::optional<OverriddenZoomScaleParameters> _overriddenZoomScaleParameters;
     CGRect _inputViewBoundsInWindow;
 
     BOOL _fastClickingIsDisabled;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -212,6 +212,8 @@ enum class TapHandlingResult : uint8_t;
 - (void)_resetUnobscuredSafeAreaInsets;
 - (void)_resetObscuredInsets;
 
+- (void)_overrideZoomScaleParametersWithMinimumZoomScale:(CGFloat)minimumZoomScale maximumZoomScale:(CGFloat)maximumZoomScale allowUserScaling:(BOOL)allowUserScaling;
+- (void)_clearOverrideZoomScaleParameters;
 @end
 
 _WKTapHandlingResult wkTapHandlingResult(WebKit::TapHandlingResult);

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -154,8 +154,6 @@ struct WKWebViewState {
 #endif
     UIScrollViewContentInsetAdjustmentBehavior _savedContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
     CGPoint _savedContentOffset = CGPointZero;
-    CGFloat _savedMinimumZoomScale = 1;
-    CGFloat _savedMaximumZoomScale = 1;
     BOOL _savedBouncesZoom = NO;
     BOOL _savedForceAlwaysUserScalable = NO;
     CGFloat _savedMinimumEffectiveDeviceWidth = 0;
@@ -207,8 +205,6 @@ struct WKWebViewState {
         }
         [webView _setViewScale:_savedViewScale];
         scrollView.zoomScale = _savedZoomScale;
-        scrollView.minimumZoomScale = _savedMinimumZoomScale;
-        scrollView.maximumZoomScale = _savedMaximumZoomScale;
         scrollView.bouncesZoom = _savedBouncesZoom;
         webView._minimumEffectiveDeviceWidth = _savedMinimumEffectiveDeviceWidth;
     }
@@ -236,8 +232,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _savedViewScale = webView._viewScale;
         _savedZoomScale = scrollView.zoomScale;
         _savedContentZoomScale = webView._contentZoomScale;
-        _savedMinimumZoomScale = scrollView.minimumZoomScale;
-        _savedMaximumZoomScale = scrollView.maximumZoomScale;
         _savedBouncesZoom = scrollView.bouncesZoom;
         _savedMinimumEffectiveDeviceWidth = webView._minimumEffectiveDeviceWidth;
         _savedHaveSetUnobscuredSafeAreaInsets = webView._haveSetUnobscuredSafeAreaInsets;
@@ -960,6 +954,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         [webView _setMinimumEffectiveDeviceWidth:0];
         [webView _setViewScale:1.f];
         WebKit::WKWebViewState().applyTo(webView.get());
+        [webView _overrideZoomScaleParametersWithMinimumZoomScale:1 maximumZoomScale:1 allowUserScaling:NO];
         [webView _resetContentOffset];
         [_window insertSubview:webView.get() atIndex:0];
         [webView setNeedsLayout];
@@ -1225,6 +1220,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     [[webView window] makeKeyAndVisible];
     [webView becomeFirstResponder];
 
+    [webView _clearOverrideZoomScaleParameters];
     _viewState.applyTo(webView.get());
     if (auto page = [webView _page])
         page->setOverrideViewportArguments(std::nullopt);


### PR DESCRIPTION
#### 1b857d6d225136cda2fb75066538ca6798845d80
<pre>
[iOS] Pinch zooming then fullscreening causes fullscreen presentation to be zoomed unexpectedly
<a href="https://bugs.webkit.org/show_bug.cgi?id=269195">https://bugs.webkit.org/show_bug.cgi?id=269195</a>
<a href="https://rdar.apple.com/121898126">rdar://121898126</a>

Reviewed by Andy Estes.

The intent of the fullscreen presentation on iOS is to disable zooming &amp; lock the zoom level to an
extent to which the entire contents of the fulscreen element are visible in the viewport. However,
the web page itself can change the minimum and maximum zoom levels (and even the current zoom
level). When this happens, it breaks the expected behavior of fullscreen mode, which is to show the
entire contents of the fullscreen element in the viewport.

The previous implementation attempted to save and restore the min, max, and current zoom levels when
entering and exiting fullscreen, assuming those levels would not be re-set during fullscreen mode.
This assumption was not met. Instead, add an IPI to override zoom levels sent by the page during
rendering, and a matching IPI to remove that override. Only the current zoom level is saved and restored.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
(-[WKWebView _overrideZoomScaleParametersWithMinimumZoomScale:maximumZoomScale:allowUserScaling:]):
(-[WKWebView _clearOverrideZoomScaleParameters]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
(WebKit::WKWebViewState::store):
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController _reinsertWebViewUnderPlaceholder]):

Canonical link: <a href="https://commits.webkit.org/274503@main">https://commits.webkit.org/274503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38ab9729be8f0605b09c3535896e0eba747471d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35102 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32811 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13294 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43014 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39076 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37315 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15621 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8789 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->