### PR TITLE
Adopt more smart pointers under WebCore/page/

### DIFF
--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -184,6 +184,11 @@ JSC::GCClient::IsoSubspace* JSWindowProxy::subspaceForImpl(JSC::VM& vm)
     return &static_cast<JSVMClientData*>(vm.clientData)->windowProxySpace();
 }
 
+Ref<DOMWrapperWorld> JSWindowProxy::protectedWorld()
+{
+    return m_world;
+}
+
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
 
 struct FrameInfo {

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -65,6 +65,7 @@ public:
     static WindowProxy* toWrapped(JSC::VM&, JSC::JSValue);
 
     DOMWrapperWorld& world() { return m_world; }
+    Ref<DOMWrapperWorld> protectedWorld();
 
     void attachDebugger(JSC::Debugger*);
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1273,6 +1273,16 @@ ShadowRoot* Node::containingShadowRoot() const
     return dynamicDowncast<ShadowRoot>(treeScope().rootNode());
 }
 
+RefPtr<ShadowRoot> Node::protectedContainingShadowRoot() const
+{
+    return containingShadowRoot();
+}
+
+CheckedPtr<RenderObject> Node::checkedRenderer() const
+{
+    return renderer();
+}
+
 #if ASSERT_ENABLED
 // https://dom.spec.whatwg.org/#concept-closed-shadow-hidden
 static bool isClosedShadowHiddenUsingSpecDefinition(const Node& A, const Node& B)

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -265,6 +265,7 @@ public:
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
     WEBCORE_EXPORT Element* shadowHost() const;
     ShadowRoot* containingShadowRoot() const;
+    RefPtr<ShadowRoot> protectedContainingShadowRoot() const;
     inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
     bool isClosedShadowHidden(const Node&) const;
 
@@ -449,6 +450,7 @@ public:
 
     // As renderer() includes a branch you should avoid calling it repeatedly in hot code paths.
     RenderObject* renderer() const { return m_rendererWithStyleFlags.pointer(); }
+    CheckedPtr<RenderObject> checkedRenderer() const;
     void setRenderer(RenderObject*); // Defined in RenderObject.h
 
     // Use these two methods with caution.

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -87,8 +87,13 @@ void HTMLFrameOwnerElement::disconnectContentFrame()
 
 HTMLFrameOwnerElement::~HTMLFrameOwnerElement()
 {
-    if (m_contentFrame)
-        m_contentFrame->disconnectOwnerElement();
+    if (RefPtr contentFrame = m_contentFrame.get())
+        contentFrame->disconnectOwnerElement();
+}
+
+RefPtr<Frame> HTMLFrameOwnerElement::protectedContentFrame() const
+{
+    return m_contentFrame.get();
 }
 
 Document* HTMLFrameOwnerElement::contentDocument() const

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -38,6 +38,7 @@ public:
     virtual ~HTMLFrameOwnerElement();
 
     Frame* contentFrame() const { return m_contentFrame.get(); }
+    RefPtr<Frame> protectedContentFrame() const;
     WEBCORE_EXPORT WindowProxy* contentWindow() const;
     WEBCORE_EXPORT Document* contentDocument() const;
     RefPtr<Document> protectedContentDocument() const { return contentDocument(); }

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -55,7 +55,7 @@ using namespace Inspector;
 PageRuntimeAgent::PageRuntimeAgent(PageAgentContext& context)
     : InspectorRuntimeAgent(context)
     , m_frontendDispatcher(makeUnique<Inspector::RuntimeFrontendDispatcher>(context.frontendRouter))
-    , m_backendDispatcher(Inspector::RuntimeBackendDispatcher::create(context.backendDispatcher, this))
+    , m_backendDispatcher(Inspector::RuntimeBackendDispatcher::create(Ref { context.backendDispatcher }, this))
     , m_instrumentingAgents(context.instrumentingAgents)
     , m_inspectedPage(context.inspectedPage)
 {
@@ -153,8 +153,8 @@ void PageRuntimeAgent::reportExecutionContextCreation()
             if (globalObject == &mainGlobalObject)
                 continue;
 
-            auto& securityOrigin = downcast<LocalDOMWindow>(jsWindowProxy->wrapped()).document()->securityOrigin();
-            notifyContextCreated(frameId, globalObject, jsWindowProxy->world(), &securityOrigin);
+            Ref securityOrigin = downcast<LocalDOMWindow>(jsWindowProxy->wrapped()).document()->securityOrigin();
+            notifyContextCreated(frameId, globalObject, jsWindowProxy->protectedWorld(), securityOrigin.ptr());
         }
     });
 }

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -476,7 +476,7 @@ Vector<Ref<StaticRange>> DOMSelection::getComposedRanges(FixedVector<std::refere
 
     Ref startNode = range->startContainer();
     unsigned startOffset = range->startOffset();
-    while (startNode->isInShadowTree() && !shadowRootSet.contains(startNode->containingShadowRoot())) {
+    while (startNode->isInShadowTree() && !shadowRootSet.contains(startNode->protectedContainingShadowRoot().get())) {
         RefPtr host = startNode->shadowHost();
         ASSERT(host && host->parentNode());
         startNode = *host->parentNode();
@@ -485,7 +485,7 @@ Vector<Ref<StaticRange>> DOMSelection::getComposedRanges(FixedVector<std::refere
 
     Ref endNode = range->endContainer();
     unsigned endOffset = range->endOffset();
-    while (endNode->isInShadowTree() && !shadowRootSet.contains(endNode->containingShadowRoot())) {
+    while (endNode->isInShadowTree() && !shadowRootSet.contains(endNode->protectedContainingShadowRoot().get())) {
         RefPtr host = endNode->shadowHost();
         ASSERT(host && host->parentNode());
         endNode = *host->parentNode();

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -120,8 +120,9 @@ private:
     void findFocusCandidateInContainer(Node& container, const LayoutRect& startingRect, FocusDirection, KeyboardEvent*, FocusCandidate& closest);
 
     void focusRepaintTimerFired();
+    Ref<Page> protectedPage() const;
 
-    Page& m_page;
+    SingleThreadWeakRef<Page> m_page;
     WeakPtr<Frame> m_focusedFrame;
     bool m_isChangingFocusedFrame;
     OptionSet<ActivityState> m_activityState;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -825,7 +825,7 @@ bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world)
         return false;
 
     bool hasUserMessageHandler = false;
-    page->userContentProvider().forEachUserMessageHandler([&](const UserMessageHandlerDescriptor& descriptor) {
+    page->protectedUserContentProvider()->forEachUserMessageHandler([&](const UserMessageHandlerDescriptor& descriptor) {
         if (&descriptor.world() == &world) {
             hasUserMessageHandler = true;
             return;
@@ -843,7 +843,7 @@ WebKitNamespace* LocalDOMWindow::webkitNamespace()
     if (!page)
         return nullptr;
     if (!m_webkitNamespace)
-        m_webkitNamespace = WebKitNamespace::create(*this, page->userContentProvider());
+        m_webkitNamespace = WebKitNamespace::create(*this, page->protectedUserContentProvider());
     return m_webkitNamespace.get();
 }
 
@@ -2071,8 +2071,9 @@ bool LocalDOMWindow::isAllowedToUseDeviceMotion(String& message) const
     if (!isAllowedToUseDeviceMotionOrOrientation(message))
         return false;
 
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Gyroscope, *document(), LogFeaturePolicyFailure::No)
-        || !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Accelerometer, *document(), LogFeaturePolicyFailure::No)) {
+    Ref document = *this->document();
+    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Gyroscope, document, LogFeaturePolicyFailure::No)
+        || !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Accelerometer, document, LogFeaturePolicyFailure::No)) {
         message = "Third-party iframes are not allowed access to device motion unless explicitly allowed via Feature-Policy (gyroscope & accelerometer)"_s;
         return false;
     }
@@ -2641,7 +2642,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     RefPtr mainFrameDocument = localFrame ? localFrame->document() : nullptr;
     RefPtr mainFrameDocumentLoader = mainFrameDocument ? mainFrameDocument->loader() : nullptr;
     if (firstFrameDocument && page && mainFrameDocumentLoader) {
-        auto results = page->userContentProvider().processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *mainFrameDocumentLoader);
+        auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *mainFrameDocumentLoader);
         if (results.summary.blockedLoad)
             return RefPtr<WindowProxy> { nullptr };
     }

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1140,7 +1140,7 @@ FloatSize LocalFrame::screenSize() const
     if (!m_overrideScreenSize.isEmpty())
         return m_overrideScreenSize;
 
-    auto defaultSize = screenRect(view()).size();
+    auto defaultSize = screenRect(protectedView().get()).size();
     RefPtr document = this->document();
     if (!document)
         return defaultSize;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -937,7 +937,7 @@ void LocalFrameView::updateSnapOffsets()
     LayoutRect viewport = LayoutRect(IntPoint(), baseLayoutViewportSize());
     viewport.move(-rootRenderer->marginLeft(), -rootRenderer->marginTop());
 
-    updateSnapOffsetsForScrollableArea(*this, *rootRenderer, *styleToUse, viewport, rootRenderer->style().writingMode(), rootRenderer->style().direction(), m_frame->document()->focusedElement());
+    updateSnapOffsetsForScrollableArea(*this, *rootRenderer, *styleToUse, viewport, rootRenderer->style().writingMode(), rootRenderer->style().direction(), m_frame->document()->protectedFocusedElement().get());
 }
 
 bool LocalFrameView::isScrollSnapInProgress() const

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -146,7 +146,7 @@ void LocalFrameViewLayoutContext::layout()
 {
     LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " LocalFrameViewLayoutContext::layout() with size " << view().layoutSize());
 
-    Ref<LocalFrameView> protectView(view());
+    Ref protectedView(view());
 
     performLayout();
 
@@ -169,13 +169,14 @@ void LocalFrameViewLayoutContext::layout()
 
 void LocalFrameViewLayoutContext::performLayout()
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!frame().document()->inRenderTreeUpdate());
+    Ref frame = this->frame();
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!frame->document()->inRenderTreeUpdate());
     ASSERT(LayoutDisallowedScope::isLayoutAllowed());
     ASSERT(!view().isPainting());
-    ASSERT(frame().view() == &view());
-    ASSERT(frame().document());
-    ASSERT(frame().document()->backForwardCacheState() == Document::NotInBackForwardCache
-        || frame().document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache);
+    ASSERT(frame->view() == &view());
+    ASSERT(frame->document());
+    ASSERT(frame->document()->backForwardCacheState() == Document::NotInBackForwardCache
+        || frame->document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache);
     if (!canPerformLayout()) {
         LOG(Layout, "  is not allowed, bailing");
         return;
@@ -184,24 +185,24 @@ void LocalFrameViewLayoutContext::performLayout()
     LayoutScope layoutScope(*this);
     TraceScope tracingScope(PerformLayoutStart, PerformLayoutEnd);
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-    InspectorInstrumentation::willLayout(view().frame());
+    InspectorInstrumentation::willLayout(frame);
     SingleThreadWeakPtr<RenderElement> layoutRoot;
     
     m_layoutTimer.stop();
     m_setNeedsLayoutWasDeferred = false;
 
 #if !LOG_DISABLED
-    if (m_firstLayout && !frame().ownerElement())
+    if (m_firstLayout && !frame->ownerElement())
         LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " elapsed time before first layout: " << document()->timeSinceDocumentCreation());
 #endif
 #if PLATFORM(IOS_FAMILY)
-    if (view().updateFixedPositionLayoutRect() && subtreeLayoutRoot())
+    if (protectedView()->updateFixedPositionLayoutRect() && subtreeLayoutRoot())
         convertSubtreeLayoutToFullLayout();
 #endif
     {
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InPreLayout);
 
-        if (!frame().document()->isResolvingContainerQueriesForSelfOrAncestor()) {
+        if (!frame->document()->isResolvingContainerQueriesForSelfOrAncestor()) {
             // If this is a new top-level layout and there are any remaining tasks from the previous layout, finish them now.
             if (!isLayoutNested() && m_postLayoutTaskTimer.isActive())
                 runPostLayoutTasks();
@@ -212,7 +213,7 @@ void LocalFrameViewLayoutContext::performLayout()
         if (view().hasOneRef())
             return;
 
-        view().autoSizeIfEnabled();
+        protectedView()->autoSizeIfEnabled();
         if (!renderView())
             return;
 
@@ -221,7 +222,7 @@ void LocalFrameViewLayoutContext::performLayout()
 
         LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " layout " << m_layoutCount << " - subtree root " << subtreeLayoutRoot() << ", needsFullRepaint " << m_needsFullRepaint);
 
-        view().willDoLayout(layoutRoot);
+        protectedView()->willDoLayout(layoutRoot);
         m_firstLayout = false;
     }
     {
@@ -254,7 +255,7 @@ void LocalFrameViewLayoutContext::performLayout()
         if (is<RenderView>(layoutRoot) && !renderView()->printing()) {
             // This is to protect m_needsFullRepaint's value when layout() is getting re-entered through adjustViewSize().
             SetForScope needsFullRepaint(m_needsFullRepaint);
-            view().adjustViewSize();
+            protectedView()->adjustViewSize();
             // FIXME: Firing media query callbacks synchronously on nested frames could produced a detached FrameView here by
             // navigating away from the current document (see webkit.org/b/173329).
             if (view().hasOneRef())
@@ -266,11 +267,11 @@ void LocalFrameViewLayoutContext::performLayout()
         if (m_needsFullRepaint)
             renderView()->repaintRootContents();
         ASSERT(!layoutRoot->needsLayout());
-        view().didLayout(layoutRoot);
+        protectedView()->didLayout(layoutRoot);
         runOrScheduleAsynchronousTasks();
     }
-    InspectorInstrumentation::didLayout(view().frame(), *layoutRoot);
-    DebugPageOverlays::didLayout(view().frame());
+    InspectorInstrumentation::didLayout(frame, *layoutRoot);
+    DebugPageOverlays::didLayout(frame);
 }
 
 void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks()
@@ -305,7 +306,7 @@ void LocalFrameViewLayoutContext::runPostLayoutTasks()
     if (m_inAsynchronousTasks)
         return;
     SetForScope inAsynchronousTasks(m_inAsynchronousTasks, true);
-    view().performPostLayoutTasks();
+    protectedView()->performPostLayoutTasks();
 }
 
 void LocalFrameViewLayoutContext::flushPostLayoutTasks()
@@ -380,7 +381,7 @@ void LocalFrameViewLayoutContext::scheduleLayout()
     if (!frame().document()->shouldScheduleLayout())
         return;
 
-    InspectorInstrumentation::didInvalidateLayout(frame());
+    InspectorInstrumentation::didInvalidateLayout(protectedFrame());
     if (m_layoutTimer.isActive())
         return;
 
@@ -425,7 +426,7 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     if (!isLayoutPending() && isLayoutSchedulingEnabled()) {
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
         setSubtreeLayoutRoot(layoutRoot);
-        InspectorInstrumentation::didInvalidateLayout(frame());
+        InspectorInstrumentation::didInvalidateLayout(protectedFrame());
         m_layoutTimer.startOneShot(0_s);
         return;
     }
@@ -437,7 +438,7 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     if (!subtreeLayoutRoot) {
         // We already have a pending (full) layout. Just mark the subtree for layout.
         layoutRoot.markContainingBlocksForLayout(ScheduleRelayout::No);
-        InspectorInstrumentation::didInvalidateLayout(frame());
+        InspectorInstrumentation::didInvalidateLayout(protectedFrame());
         return;
     }
 
@@ -453,13 +454,13 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
         subtreeLayoutRoot->markContainingBlocksForLayout(ScheduleRelayout::No, &layoutRoot);
         setSubtreeLayoutRoot(layoutRoot);
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        InspectorInstrumentation::didInvalidateLayout(frame());
+        InspectorInstrumentation::didInvalidateLayout(protectedFrame());
         return;
     }
     // Two disjoint subtrees need layout. Mark both of them and issue a full layout instead.
     convertSubtreeLayoutToFullLayout();
     layoutRoot.markContainingBlocksForLayout(ScheduleRelayout::No);
-    InspectorInstrumentation::didInvalidateLayout(frame());
+    InspectorInstrumentation::didInvalidateLayout(protectedFrame());
 }
 
 void LocalFrameViewLayoutContext::layoutTimerFired()
@@ -528,22 +529,22 @@ void LocalFrameViewLayoutContext::applyTextSizingIfNeeded(RenderElement& layoutR
 void LocalFrameViewLayoutContext::updateStyleForLayout()
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-    Document& document = *frame().document();
+    Ref document = *frame().document();
 
     // FIXME: This shouldn't be necessary, but see rdar://problem/36670246.
-    if (!document.styleScope().resolverIfExists())
-        document.styleScope().didChangeStyleSheetEnvironment();
+    if (!document->styleScope().resolverIfExists())
+        document->styleScope().didChangeStyleSheetEnvironment();
 
     // Viewport-dependent media queries may cause us to need completely different style information.
-    document.styleScope().evaluateMediaQueriesForViewportChange();
+    document->styleScope().evaluateMediaQueriesForViewportChange();
 
-    document.updateElementsAffectedByMediaQueries();
+    document->updateElementsAffectedByMediaQueries();
     // If there is any pagination to apply, it will affect the RenderView's style, so we should
     // take care of that now.
-    view().applyPaginationToViewport();
+    protectedView()->applyPaginationToViewport();
     // Always ensure our style info is up-to-date. This can happen in situations where
     // the layout beats any sort of style recalc update that needs to occur.
-    document.updateStyleIfNeeded();
+    document->updateStyleIfNeeded();
 }
 
 LayoutSize LocalFrameViewLayoutContext::layoutDelta() const
@@ -643,9 +644,19 @@ LocalFrame& LocalFrameViewLayoutContext::frame() const
     return view().frame();
 }
 
+Ref<LocalFrame> LocalFrameViewLayoutContext::protectedFrame()
+{
+    return frame();
+}
+
 LocalFrameView& LocalFrameViewLayoutContext::view() const
 {
-    return m_frameView;
+    return m_frameView.get();
+}
+
+Ref<LocalFrameView> LocalFrameViewLayoutContext::protectedView() const
+{
+    return m_frameView.get();
 }
 
 RenderView* LocalFrameViewLayoutContext::renderView() const

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -172,11 +172,13 @@ private:
     void enablePaintOffsetCache() { ASSERT(m_paintOffsetCacheDisableCount > 0); m_paintOffsetCacheDisableCount--; }
 
     LocalFrame& frame() const;
+    Ref<LocalFrame> protectedFrame();
     LocalFrameView& view() const;
+    Ref<LocalFrameView> protectedView() const;
     RenderView* renderView() const;
     Document* document() const;
 
-    LocalFrameView& m_frameView;
+    SingleThreadWeakRef<LocalFrameView> m_frameView;
     Timer m_layoutTimer;
     Timer m_postLayoutTaskTimer;
     SingleThreadWeakPtr<RenderElement> m_subtreeLayoutRoot;

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -270,22 +270,22 @@ void Location::reload(LocalDOMWindow& activeWindow)
     ASSERT(localFrame->document());
     ASSERT(localFrame->document()->domWindow());
 
-    auto& activeDocument = *activeWindow.document();
-    auto& targetDocument = *localFrame->document();
+    Ref activeDocument = *activeWindow.document();
+    Ref targetDocument = *localFrame->document();
 
     // FIXME: It's not clear this cross-origin security check is valuable.
     // We allow one page to change the location of another. Why block attempts to reload?
     // Other location operations simply block use of JavaScript URLs cross origin.
-    if (!activeDocument.securityOrigin().isSameOriginDomain(targetDocument.securityOrigin())) {
-        auto& targetWindow = *targetDocument.domWindow();
-        targetWindow.printErrorMessage(targetWindow.crossDomainAccessErrorMessage(activeWindow, IncludeTargetOrigin::Yes));
+    if (!activeDocument->protectedSecurityOrigin()->isSameOriginDomain(targetDocument->protectedSecurityOrigin())) {
+        Ref targetWindow = *targetDocument->domWindow();
+        targetWindow->printErrorMessage(targetWindow->crossDomainAccessErrorMessage(activeWindow, IncludeTargetOrigin::Yes));
         return;
     }
 
-    if (targetDocument.url().protocolIsJavaScript())
+    if (targetDocument->url().protocolIsJavaScript())
         return;
 
-    localFrame->navigationScheduler().scheduleRefresh(activeDocument);
+    localFrame->checkedNavigationScheduler()->scheduleRefresh(activeDocument);
 }
 
 ExceptionOr<void> Location::setLocation(LocalDOMWindow& incumbentWindow, LocalDOMWindow& firstWindow, const String& urlString)

--- a/Source/WebCore/page/MouseEventWithHitTestResults.h
+++ b/Source/WebCore/page/MouseEventWithHitTestResults.h
@@ -38,6 +38,7 @@ public:
     bool isOverLink() const;
     bool isOverWidget() const { return m_hitTestResult.isOverWidget(); }
     Node* targetNode() const { return m_hitTestResult.targetNode(); }
+    RefPtr<Node> protectedTargetNode() const  { return m_hitTestResult.protectedTargetNode(); }
 
 private:
     PlatformMouseEvent m_event;

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -85,7 +85,7 @@ String Navigator::appVersion() const
     if (!frame)
         return String();
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::AppVersion);
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::AppVersion);
     return NavigatorBase::appVersion();
 }
 
@@ -95,7 +95,7 @@ const String& Navigator::userAgent() const
     if (!frame || !frame->page())
         return m_userAgent;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::UserAgent);
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::UserAgent);
     if (m_userAgent.isNull())
         m_userAgent = frame->loader().userAgent(frame->document()->url());
     return m_userAgent;
@@ -309,7 +309,7 @@ void Navigator::initializePluginAndMimeTypeArrays()
 DOMPluginArray& Navigator::plugins()
 {
     if (auto* frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::Plugins);
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::Plugins);
 
     initializePluginAndMimeTypeArrays();
     return *m_plugins;
@@ -318,7 +318,7 @@ DOMPluginArray& Navigator::plugins()
 DOMMimeTypeArray& Navigator::mimeTypes()
 {
     if (auto* frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::MimeTypes);
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::MimeTypes);
 
     initializePluginAndMimeTypeArrays();
     return *m_mimeTypes;
@@ -338,7 +338,7 @@ bool Navigator::cookieEnabled() const
         return false;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::CookieEnabled);
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::CookieEnabled);
 
     auto* page = frame->page();
     if (!page)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -325,6 +325,7 @@ public:
 
     Frame& mainFrame() { return m_mainFrame.get(); }
     const Frame& mainFrame() const { return m_mainFrame.get(); }
+    Ref<Frame> protectedMainFrame() const;
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     const URL& mainFrameURL() const { return m_mainFrameURL; }
     WEBCORE_EXPORT void setMainFrameURL(const URL&);
@@ -1110,7 +1111,7 @@ private:
 
     unsigned findMatchesForText(const String&, FindOptions, unsigned maxMatchCount, ShouldHighlightMatches, ShouldMarkMatches);
 
-    std::optional<std::pair<MediaCanStartListener&, Document&>> takeAnyMediaCanStartListener();
+    std::optional<std::pair<WeakRef<MediaCanStartListener>, WeakRef<Document, WeakPtrImplWithEventTargetData>>> takeAnyMediaCanStartListener();
 
 #if ENABLE(VIDEO)
     void playbackControlsManagerUpdateTimerFired();

--- a/Source/WebCore/page/PageConsoleClient.h
+++ b/Source/WebCore/page/PageConsoleClient.h
@@ -83,7 +83,9 @@ private:
     void recordEnd(JSC::JSGlobalObject*, Ref<Inspector::ScriptArguments>&&) override;
     void screenshot(JSC::JSGlobalObject*, Ref<Inspector::ScriptArguments>&&) override;
 
-    Page& m_page;
+    Ref<Page> protectedPage() const;
+
+    SingleThreadWeakRef<Page> m_page;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -49,6 +49,7 @@ public:
 
     GraphicsLayer& layerWithDocumentOverlays();
     GraphicsLayer& layerWithViewOverlays();
+    Ref<GraphicsLayer> protectedLayerWithViewOverlays();
 
     const Vector<RefPtr<PageOverlay>>& pageOverlays() const { return m_pageOverlays; }
 
@@ -99,7 +100,9 @@ private:
     bool shouldDumpPropertyForLayer(const GraphicsLayer*, const char* propertyName, OptionSet<LayerTreeAsTextOptions>) const override;
     void tiledBackingUsageChanged(const GraphicsLayer*, bool) override;
 
-    Page& m_page;
+    Ref<Page> protectedPage() const;
+
+    SingleThreadWeakRef<Page> m_page;
     RefPtr<GraphicsLayer> m_documentOverlayRootLayer;
     RefPtr<GraphicsLayer> m_viewOverlayRootLayer;
 

--- a/Source/WebCore/page/PerformanceMonitor.h
+++ b/Source/WebCore/page/PerformanceMonitor.h
@@ -52,7 +52,7 @@ private:
     void processMayBecomeInactiveTimerFired();
     static void updateProcessStateForMemoryPressure();
 
-    Page& m_page;
+    SingleThreadWeakRef<Page> m_page;
 
     Timer m_postPageLoadCPUUsageTimer;
     std::optional<CPUTime> m_postLoadCPUTime;

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -194,6 +194,8 @@ private:
     bool isGoogleMaps() const;
 #endif
 
+    RefPtr<Document> protectedDocument() const;
+
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
     mutable std::optional<bool> m_hasBrokenEncryptedMediaAPISupportQuirk;

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -57,7 +57,7 @@ Screen::~Screen() = default;
 
 static bool fingerprintingProtectionsEnabled(const LocalFrame& frame)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
     if (!localFrame)
         return false;
 
@@ -75,7 +75,7 @@ int Screen::height() const
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::Height);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::Height);
     return static_cast<int>(frame->screenSize().height());
 }
 
@@ -85,7 +85,7 @@ int Screen::width() const
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::Width);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::Width);
     return static_cast<int>(frame->screenSize().width());
 }
 
@@ -95,8 +95,8 @@ unsigned Screen::colorDepth() const
     if (!frame)
         return 24;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::ColorDepth);
-    return static_cast<unsigned>(screenDepth(frame->view()));
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::ColorDepth);
+    return static_cast<unsigned>(screenDepth(frame->protectedView().get()));
 }
 
 int Screen::availLeft() const
@@ -106,12 +106,12 @@ int Screen::availLeft() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailLeft);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailLeft);
 
     if (fingerprintingProtectionsEnabled(*frame))
         return 0;
 
-    return static_cast<int>(screenAvailableRect(frame->view()).x());
+    return static_cast<int>(screenAvailableRect(frame->protectedView().get()).x());
 }
 
 int Screen::availTop() const
@@ -121,12 +121,12 @@ int Screen::availTop() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailTop);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailTop);
 
     if (fingerprintingProtectionsEnabled(*frame))
         return 0;
 
-    return static_cast<int>(screenAvailableRect(frame->view()).y());
+    return static_cast<int>(screenAvailableRect(frame->protectedView().get()).y());
 }
 
 int Screen::availHeight() const
@@ -136,12 +136,12 @@ int Screen::availHeight() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailHeight);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailHeight);
 
     if (fingerprintingProtectionsEnabled(*frame))
         return static_cast<int>(frame->screenSize().height());
 
-    return static_cast<int>(screenAvailableRect(frame->view()).height());
+    return static_cast<int>(screenAvailableRect(frame->protectedView().get()).height());
 }
 
 int Screen::availWidth() const
@@ -151,18 +151,18 @@ int Screen::availWidth() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailWidth);
+        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailWidth);
 
     if (fingerprintingProtectionsEnabled(*frame))
         return static_cast<int>(frame->screenSize().width());
 
-    return static_cast<int>(screenAvailableRect(frame->view()).width());
+    return static_cast<int>(screenAvailableRect(frame->protectedView().get()).width());
 }
 
 ScreenOrientation& Screen::orientation()
 {
     if (!m_screenOrientation)
-        m_screenOrientation = ScreenOrientation::create(window() ? window()->document() : nullptr);
+        m_screenOrientation = ScreenOrientation::create(window() ? window()->protectedDocument().get() : nullptr);
     return *m_screenOrientation;
 }
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -57,10 +57,7 @@ static void entryAndExitPointsForDirection(FocusDirection, const LayoutRect& sta
 static bool isScrollableNode(const Node*);
 
 FocusCandidate::FocusCandidate(Node* node, FocusDirection direction)
-    : visibleNode(nullptr)
-    , focusableNode(nullptr)
-    , enclosingScrollableBox(nullptr)
-    , distance(maxDistance())
+    : distance(maxDistance())
     , alignment(RectsAlignment::None)
     , isOffscreen(true)
     , isOffscreenAfterScrolling(true)
@@ -84,8 +81,9 @@ FocusCandidate::FocusCandidate(Node* node, FocusDirection direction)
     }
 
     focusableNode = node;
-    isOffscreen = hasOffscreenRect(visibleNode);
-    isOffscreenAfterScrolling = hasOffscreenRect(visibleNode, direction);
+    RefPtr protectedVisibleNode { visibleNode.get() };
+    isOffscreen = hasOffscreenRect(protectedVisibleNode.get());
+    isOffscreenAfterScrolling = hasOffscreenRect(protectedVisibleNode.get(), direction);
 }
 
 bool isSpatialNavigationEnabled(const LocalFrame* frame)
@@ -450,7 +448,7 @@ bool canScrollInDirection(const Node* container, FocusDirection direction)
         return false;
 
     if (is<Document>(*container))
-        return canScrollInDirection(downcast<Document>(*container).frame(), direction);
+        return canScrollInDirection(downcast<Document>(*container).protectedFrame().get(), direction);
 
     if (!isScrollableNode(container))
         return false;
@@ -521,11 +519,11 @@ LayoutRect nodeRectInAbsoluteCoordinates(Node* node, bool ignoreBorder)
     ASSERT(node && node->renderer() && !node->document().view()->needsLayout());
 
     if (is<Document>(*node))
-        return frameRectInAbsoluteCoordinates(downcast<Document>(*node).frame());
+        return frameRectInAbsoluteCoordinates(downcast<Document>(*node).protectedFrame().get());
 
     LayoutRect rect;
-    if (RenderObject* renderer = node->renderer())
-        rect = rectToAbsoluteCoordinates(node->document().frame(), renderer->absoluteBoundingBoxRect());
+    if (CheckedPtr renderer = node->renderer())
+        rect = rectToAbsoluteCoordinates(node->document().protectedFrame().get(), renderer->absoluteBoundingBoxRect());
 
     // For authors that use border instead of outline in their CSS, we compensate by ignoring the border when calculating
     // the rect of the focused element.
@@ -760,13 +758,13 @@ LayoutRect virtualRectForAreaElementAndDirection(HTMLAreaElement* area, FocusDir
     ASSERT(area->imageElement());
     // Area elements tend to overlap more than other focusable elements. We flatten the rect of the area elements
     // to minimize the effect of overlapping areas.
-    LayoutRect rect = virtualRectForDirection(direction, rectToAbsoluteCoordinates(area->document().frame(), area->computeRect(area->imageElement()->renderer())), 1);
+    LayoutRect rect = virtualRectForDirection(direction, rectToAbsoluteCoordinates(area->document().protectedFrame().get(), area->computeRect(area->imageElement()->checkedRenderer().get())), 1);
     return rect;
 }
 
 HTMLFrameOwnerElement* frameOwnerElement(FocusCandidate& candidate)
 {
-    return dynamicDowncast<HTMLFrameOwnerElement>(candidate.visibleNode);
+    return dynamicDowncast<HTMLFrameOwnerElement>(candidate.visibleNode.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/SpatialNavigation.h
+++ b/Source/WebCore/page/SpatialNavigation.h
@@ -116,9 +116,9 @@ struct FocusCandidate {
     // We handle differently visibleNode and FocusableNode to properly handle the areas of imagemaps,
     // where visibleNode would represent the image element and focusableNode would represent the area element.
     // In all other cases, visibleNode and focusableNode are one and the same.
-    Node* visibleNode;
-    Node* focusableNode;
-    Node* enclosingScrollableBox;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> visibleNode;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> focusableNode;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> enclosingScrollableBox;
     long long distance;
     RectsAlignment alignment;
     LayoutRect rect;

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 
 WebKitNamespace::WebKitNamespace(LocalDOMWindow& window, UserContentProvider& userContentProvider)
     : LocalDOMWindowProperty(&window)
-    , m_messageHandlerNamespace(UserMessageHandlersNamespace::create(*window.frame(), userContentProvider))
+    , m_messageHandlerNamespace(UserMessageHandlersNamespace::create(*window.protectedFrame(), userContentProvider))
 {
     ASSERT(window.frame());
 }

--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
@@ -303,9 +303,10 @@ static RetainPtr<CABasicAnimation> createFadeInAnimation(CFTimeInterval duration
 
 - (void)present
 {
-    bool wantsBounce = [self indicatorWantsBounce:*_textIndicator];
-    bool wantsCrossfade = indicatorWantsContentCrossfade(*_textIndicator);
-    bool wantsFadeIn = indicatorWantsFadeIn(*_textIndicator);
+    RefPtr textIndicator = _textIndicator;
+    bool wantsBounce = [self indicatorWantsBounce:*textIndicator];
+    bool wantsCrossfade = indicatorWantsContentCrossfade(*textIndicator);
+    bool wantsFadeIn = indicatorWantsFadeIn(*textIndicator);
     CFTimeInterval animationDuration = [self _animationDuration];
 
     _hasCompletedAnimation = false;
@@ -319,13 +320,13 @@ static RetainPtr<CABasicAnimation> createFadeInAnimation(CFTimeInterval duration
     RetainPtr<CABasicAnimation> crossfadeAnimation;
     RetainPtr<CABasicAnimation> fadeShadowInAnimation;
     if (wantsCrossfade) {
-        crossfadeAnimation = createContentCrossfadeAnimation(animationDuration, *_textIndicator);
+        crossfadeAnimation = createContentCrossfadeAnimation(animationDuration, *textIndicator);
         fadeShadowInAnimation = createShadowFadeAnimation(animationDuration);
     }
 
     [CATransaction begin];
     for (CALayer *bounceLayer in _bounceLayers.get()) {
-        if ([self indicatorWantsManualAnimation:*_textIndicator])
+        if ([self indicatorWantsManualAnimation:*textIndicator])
             bounceLayer.speed = 0;
 
         if (!wantsFadeIn)

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -203,12 +203,12 @@ bool EventHandler::passWidgetMouseDownEventToWidget(const MouseEventWithHitTestR
     // just pass currentEvent down to the widget, we don't want to call it for events that
     // don't correspond to Cocoa events. The mousedown/ups will have already been passed on as
     // part of the pressed/released handling.
-    return passMouseDownEventToWidget(downcast<RenderWidget>(*target).widget());
+    return passMouseDownEventToWidget(downcast<RenderWidget>(*target).protectedWidget().get());
 }
 
 bool EventHandler::passWidgetMouseDownEventToWidget(RenderWidget* renderWidget)
 {
-    return passMouseDownEventToWidget(renderWidget->widget());
+    return passMouseDownEventToWidget(renderWidget->protectedWidget().get());
 }
 
 static bool lastEventIsMouseUp()

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -88,8 +88,8 @@ private:
 
     Page& page() const { return m_page; }
 
-    Page& m_page;
-    PageOverlay* m_servicesOverlay { nullptr };
+    SingleThreadWeakRef<Page> m_page;
+    WeakPtr<PageOverlay> m_servicesOverlay;
 
     RefPtr<DataDetectorHighlight> m_activeHighlight;
     RefPtr<DataDetectorHighlight> m_nextActiveHighlight;

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -803,6 +803,11 @@ Vector<String> HitTestResult::dictationAlternatives() const
     return frame->editor().dictationAlternativesForMarker(*marker);
 }
 
+RefPtr<Node> HitTestResult::protectedTargetNode() const
+{
+    return innerNode();
+}
+
 Element* HitTestResult::targetElement() const
 {
     for (Node* node = m_innerNode.get(); node; node = node->parentInComposedTree()) {
@@ -810,6 +815,11 @@ Element* HitTestResult::targetElement() const
             return element;
     }
     return nullptr;
+}
+
+RefPtr<Element> HitTestResult::protectedTargetElement() const
+{
+    return targetElement();
 }
 
 Element* HitTestResult::innerNonSharedElement() const

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -156,7 +156,9 @@ public:
     Vector<String> dictationAlternatives() const;
 
     Node* targetNode() const { return innerNode(); }
+    RefPtr<Node> protectedTargetNode() const;
     WEBCORE_EXPORT Element* targetElement() const;
+    RefPtr<Element> protectedTargetElement() const;
 
 private:
     NodeSet& mutableListBasedTestResult(); // See above.

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -70,6 +70,7 @@ public:
     HTMLFrameOwnerElement& frameOwnerElement() const { return downcast<HTMLFrameOwnerElement>(nodeForNonAnonymous()); }
 
     Widget* widget() const { return m_widget.get(); }
+    RefPtr<Widget> protectedWidget() const { return m_widget; }
     WEBCORE_EXPORT void setWidget(RefPtr<Widget>&&);
 
     static RenderWidget* find(const Widget&);


### PR DESCRIPTION
#### cac77a010b989177ff66d391dacea5563cd4f48f
<pre>
Adopt more smart pointers under WebCore/page/
<a href="https://bugs.webkit.org/show_bug.cgi?id=269209">https://bugs.webkit.org/show_bug.cgi?id=269209</a>

Reviewed by Brent Fulgham.

* Source/WebCore/bindings/js/JSWindowProxy.cpp:
(WebCore::JSWindowProxy::protectedWorld):
* Source/WebCore/bindings/js/JSWindowProxy.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::protectedContainingShadowRoot const):
(WebCore::Node::checkedRenderer const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::~HTMLFrameOwnerElement):
(WebCore::HTMLFrameOwnerElement::protectedContentFrame const):
* Source/WebCore/html/HTMLFrameOwnerElement.h:
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::PageRuntimeAgent::PageRuntimeAgent):
(WebCore::PageRuntimeAgent::reportExecutionContextCreation):
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::getComposedRanges):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateSelectionForMouseDrag):
(WebCore::EventHandler::hitTestResultAtPoint const):
(WebCore::EventHandler::performDragAndDrop):
(WebCore::EventHandler::dispatchMouseEvent):
(WebCore::EventHandler::sendContextMenuEvent):
(WebCore::EventHandler::dispatchEventToDragSourceElement):
(WebCore::EventHandler::handleDrag):
(WebCore::EventHandler::keyboardScrollRecursively):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):
(WebCore::FocusController::focusedOrMainFrame const):
(WebCore::FocusController::setFocused):
(WebCore::FocusController::setFocusedInternal):
(WebCore::FocusController::relinquishFocusToChrome):
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::shouldClearSelectionWhenChangingFocusedElement):
(WebCore::FocusController::setFocusedElement):
(WebCore::FocusController::protectedPage const):
(WebCore::FocusController::setActive):
(WebCore::FocusController::setActiveInternal):
(WebCore::FocusController::setIsVisibleAndActiveInternal):
(WebCore::FocusController::advanceFocusDirectionallyInContainer):
* Source/WebCore/page/FocusController.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
(WebCore::LocalDOMWindow::webkitNamespace):
(WebCore::LocalDOMWindow::isAllowedToUseDeviceMotion const):
(WebCore::LocalDOMWindow::open):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::screenSize const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateSnapOffsets):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::layout):
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::runPostLayoutTasks):
(WebCore::LocalFrameViewLayoutContext::scheduleLayout):
(WebCore::LocalFrameViewLayoutContext::scheduleSubtreeLayout):
(WebCore::LocalFrameViewLayoutContext::updateStyleForLayout):
(WebCore::LocalFrameViewLayoutContext::protectedFrame):
(WebCore::LocalFrameViewLayoutContext::view const):
(WebCore::LocalFrameViewLayoutContext::protectedView const):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Location.cpp:
(WebCore::Location::reload):
* Source/WebCore/page/MouseEventWithHitTestResults.h:
(WebCore::MouseEventWithHitTestResults::protectedTargetNode const):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::appVersion const):
(WebCore::Navigator::userAgent const):
(WebCore::Navigator::plugins):
(WebCore::Navigator::mimeTypes):
(WebCore::Navigator::cookieEnabled const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::viewportArguments const):
(WebCore::Page::takeAnyMediaCanStartListener):
(WebCore::Page::setCanStartMedia):
(WebCore::Page::protectedMainFrame const):
(WebCore::Page::forEachDocument const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::addMessage):
(WebCore::PageConsoleClient::messageWithTypeAndLevel):
(WebCore::PageConsoleClient::count):
(WebCore::PageConsoleClient::countReset):
(WebCore::PageConsoleClient::profile):
(WebCore::PageConsoleClient::profileEnd):
(WebCore::PageConsoleClient::takeHeapSnapshot):
(WebCore::PageConsoleClient::time):
(WebCore::PageConsoleClient::timeLog):
(WebCore::PageConsoleClient::timeEnd):
(WebCore::PageConsoleClient::timeStamp):
(WebCore::PageConsoleClient::screenshot):
(WebCore::PageConsoleClient::protectedPage const):
* Source/WebCore/page/PageConsoleClient.h:
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::createRootLayersIfNeeded):
(WebCore::PageOverlayController::installedPageOverlaysChanged):
(WebCore::PageOverlayController::protectedPage const):
(WebCore::PageOverlayController::attachViewOverlayLayers):
(WebCore::PageOverlayController::detachViewOverlayLayers):
(WebCore::PageOverlayController::layerWithDocumentOverlays):
(WebCore::PageOverlayController::layerWithViewOverlays):
(WebCore::PageOverlayController::protectedLayerWithViewOverlays):
(WebCore::PageOverlayController::installPageOverlay):
(WebCore::PageOverlayController::updateForceSynchronousScrollLayerPositionUpdates):
(WebCore::PageOverlayController::didChangeViewExposedRect):
(WebCore::PageOverlayController::updateSettingsForLayer):
(WebCore::PageOverlayController::deviceScaleFactor const):
(WebCore::PageOverlayController::notifyFlushRequired):
(WebCore::PageOverlayController::didChangeOverlayFrame):
(WebCore::PageOverlayController::didChangeOverlayBackgroundColor):
(WebCore::PageOverlayController::tiledBackingUsageChanged):
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/PerformanceMonitor.cpp:
(WebCore::PerformanceMonitor::didFinishLoad):
(WebCore::PerformanceMonitor::activityStateChanged):
(WebCore::PerformanceMonitor::measurePostLoadCPUUsage):
(WebCore::PerformanceMonitor::measurePostLoadMemoryUsage):
(WebCore::PerformanceMonitor::measurePostBackgroundingMemoryUsage):
(WebCore::PerformanceMonitor::measurePostBackgroundingCPUUsage):
(WebCore::PerformanceMonitor::measurePerActivityStateCPUUsage):
(WebCore::PerformanceMonitor::measureCPUUsageInActivityState):
* Source/WebCore/page/PerformanceMonitor.h:
* Source/WebCore/page/PointerLockController.cpp:
(WebCore::PointerLockController::didAcquirePointerLock):
(WebCore::PointerLockController::didNotAcquirePointerLock):
(WebCore::PointerLockController::didLosePointerLock):
(WebCore::PointerLockController::enqueueEvent):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsAutoplayPlayPauseEvents const):
(WebCore::Quirks::needsPerDocumentAutoplayBehavior const):
(WebCore::Quirks::shouldSynthesizeTouchEvents const):
(WebCore::Quirks::shouldBypassBackForwardCache const):
(WebCore::Quirks::shouldAvoidPastingImagesAsWebContent const):
(WebCore::Quirks::requestStorageAccessAndHandleClick const):
(WebCore::Quirks::protectedDocument const):
(WebCore::Quirks::triggerOptionalStorageAccessIframeQuirk const):
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
(WebCore::Quirks::needsDisableDOMPasteAccessQuirk const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/ResourceUsageOverlay.cpp:
(WebCore::ResourceUsageOverlay::~ResourceUsageOverlay):
(WebCore::ResourceUsageOverlay::initialize):
(WebCore::ResourceUsageOverlay::mouseEvent):
* Source/WebCore/page/Screen.cpp:
(WebCore::fingerprintingProtectionsEnabled):
(WebCore::Screen::height const):
(WebCore::Screen::width const):
(WebCore::Screen::colorDepth const):
(WebCore::Screen::availLeft const):
(WebCore::Screen::availTop const):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):
(WebCore::Screen::orientation):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::FocusCandidate::FocusCandidate):
(WebCore::canScrollInDirection):
(WebCore::nodeRectInAbsoluteCoordinates):
(WebCore::virtualRectForAreaElementAndDirection):
(WebCore::frameOwnerElement):
* Source/WebCore/page/SpatialNavigation.h:
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::WebKitNamespace):
* Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm:
(-[WebTextIndicatorLayer present]):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passWidgetMouseDownEventToWidget):
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::invalidateHighlightsOfType):
(WebCore::ServicesOverlayController::buildPotentialHighlightsIfNeeded):
(WebCore::ServicesOverlayController::remainingTimeUntilHighlightShouldBeShown const):
(WebCore::ServicesOverlayController::buildPhoneNumberHighlights):
(WebCore::ServicesOverlayController::buildSelectionHighlight):
(WebCore::ServicesOverlayController::hasRelevantSelectionServices):
(WebCore::ServicesOverlayController::createOverlayIfNeeded):
(WebCore::ServicesOverlayController::telephoneNumberRangesForFocusedFrame):
(WebCore::ServicesOverlayController::findTelephoneNumberHighlightContainingSelectionHighlight):
(WebCore::ServicesOverlayController::mouseEvent):
(WebCore::ServicesOverlayController::handleClick):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::protectedTargetNode const):
(WebCore::HitTestResult::protectedTargetElement const):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebCore/rendering/RenderWidget.h:
(WebCore::RenderWidget::protectedWidget const):

Canonical link: <a href="https://commits.webkit.org/274488@main">https://commits.webkit.org/274488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/348f1efc647dadc7ed5887e6486afc7805b62d62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41759 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15533 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43037 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35271 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37342 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15306 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5127 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->