### PR TITLE
[Site Isolation] Context menu events are always sent to the main frame

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/context-menu-main-frame-event-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/context-menu-main-frame-event-expected.txt
@@ -1,0 +1,10 @@
+Verifies that the iframe receives a context menu event and the main frame does not.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframe received context menu event.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mouse-events/context-menu-main-frame-event.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/context-menu-main-frame-event.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that the iframe receives a context menu event and the main frame does not.");
+jsTestIsAsync = true;
+
+addEventListener("message", (event) => {
+    if (event.data == "contextmenu") {
+        testPassed("iframe received context menu event.");
+        finishJSTest();
+    }
+});
+
+addEventListener("contextmenu", () => {
+    testFailed("Main frame contextmenu event listener was called.");
+    finishJSTest();
+});
+
+function onLoad() {
+    let frame = document.getElementById("frame");
+    let x = frame.offsetParent.offsetLeft + frame.offsetLeft + frame.offsetWidth / 2;
+    let y = frame.offsetParent.offsetTop + frame.offsetTop + frame.offsetHeight / 2;
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown(2);
+    eventSender.mouseUp(2);
+}
+</script>
+<iframe onload="onLoad()" id="frame" src="http://localhost:8000/site-isolation/mouse-events/resources/context-menu-event-listener.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/resources/context-menu-event-listener.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/resources/context-menu-event-listener.html
@@ -1,0 +1,5 @@
+<script>
+addEventListener("contextmenu", () => {
+    window.parent.postMessage("contextmenu", "*"); 
+});
+</script>

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1256,7 +1256,7 @@ WebCore::HandleUserInputEventResult WebFrame::handleMouseEvent(const WebMouseEve
 
         auto mousePressEventResult = coreLocalFrame->eventHandler().handleMousePressEvent(platformMouseEvent);
 #if ENABLE(CONTEXT_MENU_EVENT)
-        if (isContextClick(platformMouseEvent))
+        if (isContextClick(platformMouseEvent) && !mousePressEventResult.remoteUserInputEventData())
             mousePressEventResult.setHandled(handleContextMenuEvent(platformMouseEvent));
 #endif
         return mousePressEventResult;


### PR DESCRIPTION
#### fda388552a877f757aa8216c8d116937fe8651f2
<pre>
[Site Isolation] Context menu events are always sent to the main frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=269217">https://bugs.webkit.org/show_bug.cgi?id=269217</a>
<a href="https://rdar.apple.com/122819286">rdar://122819286</a>

Reviewed by Alex Christensen.

Context menu events should not be handled if the mouse event hit a remote frame.

* LayoutTests/http/tests/site-isolation/mouse-events/context-menu-main-frame-event-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/context-menu-main-frame-event.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/resources/context-menu-event-listener.html: Added.
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::handleMouseEvent):

Canonical link: <a href="https://commits.webkit.org/274516@main">https://commits.webkit.org/274516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed7d1e1aeeb3dd9f30313fb60b05c4a585f79f72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41885 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15659 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39925 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43163 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/35715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/34302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5150 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->