### PR TITLE
Make it possible to report GraphicsContext::save() call stack when restore() mismatch happens

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -593,6 +593,9 @@
 #define ENABLE_UNPREFIXED_BACKDROP_FILTER 0
 #endif
 
+#if !defined(ENABLE_CONTEXT_SAVE_STACK_CAPTURE)
+#define ENABLE_CONTEXT_SAVE_STACK_CAPTURE 0
+#endif
 
 /* FIXME: This section of the file has not been cleaned up yet and needs major work. */
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -43,6 +43,7 @@
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/OptionSet.h>
+#include <wtf/StackShot.h>
 
 namespace WebCore {
 
@@ -391,6 +392,10 @@ private:
     unsigned m_transparencyLayerCount { 0 };
     const IsDeferred m_isDeferred : 1; // NOLINT
     bool m_contentfulPaintDetected : 1 { false };
+
+#if ENABLE(CONTEXT_SAVE_STACK_CAPTURE)
+    Vector<WTF::StackShot, 1> m_saveStacks;
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### af40a5372c47ec53b8b0223e96efd92d85aa51aa
<pre>
Make it possible to report GraphicsContext::save() call stack when restore() mismatch happens
<a href="https://bugs.webkit.org/show_bug.cgi?id=269216">https://bugs.webkit.org/show_bug.cgi?id=269216</a>
<a href="https://rdar.apple.com/122819202">rdar://122819202</a>

Reviewed by NOBODY (OOPS!).

Not only GraphicsContext::save/restore have to balanced, but also their purposes
have to match. After 267803@main, we assert if the restore purpose does not match
the purpose of the current GraphicsContext state.

Although this assertion is helpful for debugging, sometimes it is hard to find out
where the save() call was issued.

To fix this, the save() call stack will be stored for debugging only and will be
printed before the restore() mismatch assertion. So we will have the unrestored
save() and the mismatch restore() call stacks.

* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::save):
(WebCore::GraphicsContext::restore):
* Source/WebCore/platform/graphics/GraphicsContext.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af40a5372c47ec53b8b0223e96efd92d85aa51aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33009 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43311 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32952 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39286 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39125 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15917 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46131 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15965 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9404 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->