### PR TITLE
[threaded-animation-resolution] add support for blending `transform` values

### DIFF
--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Markable.h>
+#include <wtf/OptionSet.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -86,6 +87,13 @@ enum class AcceleratedEffectProperty : uint16_t {
     OffsetRotate = 1 << 10,
     Filter = 1 << 11,
     BackdropFilter = 1 << 12
+};
+
+constexpr OptionSet<AcceleratedEffectProperty> transformRelatedAcceleratedProperties = {
+    AcceleratedEffectProperty::Transform,
+    AcceleratedEffectProperty::Translate,
+    AcceleratedEffectProperty::Rotate,
+    AcceleratedEffectProperty::Scale
 };
 
 struct CSSPropertiesBitSet {

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -40,6 +40,7 @@
 
 namespace WebCore {
 
+class FloatRect;
 class IntRect;
 class KeyframeEffect;
 
@@ -79,7 +80,7 @@ public:
     WEBCORE_EXPORT Ref<AcceleratedEffect> clone() const;
     WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&) const;
 
-    WEBCORE_EXPORT void apply(Seconds, AcceleratedEffectValues&);
+    WEBCORE_EXPORT void apply(Seconds, AcceleratedEffectValues&, const FloatRect&);
 
     // Encoding and decoding support
     AnimationEffectTiming timing() const { return m_timing; }

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -171,6 +171,41 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
     }));
 }
 
+TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const FloatRect& boundingBox) const
+{
+    // https://www.w3.org/TR/css-transforms-2/#ctm
+    // The transformation matrix is computed from the transform, transform-origin, translate, rotate, scale, and offset properties as follows:
+    // 1. Start with the identity matrix.
+    TransformationMatrix matrix;
+
+    // 2. Translate by the computed X, Y, and Z values of transform-origin.
+    // (not needed, the GraphicsLayer handles that)
+
+    // 3. Translate by the computed X, Y, and Z values of translate.
+    if (translate)
+        translate->apply(matrix, boundingBox.size());
+
+    // 4. Rotate by the computed <angle> about the specified axis of rotate.
+    if (rotate)
+        rotate->apply(matrix, boundingBox.size());
+
+    // 5. Scale by the computed X, Y, and Z values of scale.
+    if (scale)
+        scale->apply(matrix, boundingBox.size());
+
+    // 6. Translate and rotate by the transform specified by offset.
+    // FIXME: implement this step to support CSS Motion Path properties.
+
+    // 7. Multiply by each of the transform functions in transform from left to right.
+    for (auto& transformOperation : transform.operations())
+        transformOperation->apply(matrix, boundingBox.size());
+
+    // 8. Translate by the negated computed X, Y and Z values of transform-origin.
+    // (not needed, the GraphicsLayer handles that)
+
+    return matrix;
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -87,6 +87,8 @@ struct AcceleratedEffectValues {
     WEBCORE_EXPORT AcceleratedEffectValues(const AcceleratedEffectValues&);
     AcceleratedEffectValues(const RenderStyle&, const IntRect&);
     AcceleratedEffectValues& operator=(const AcceleratedEffectValues&) = default;
+
+    WEBCORE_EXPORT TransformationMatrix computedTransformationMatrix(const FloatRect&) const;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1736,6 +1736,7 @@ enum class WebCore::ScrollSnapStrictness : uint8_t {
 
 enum class WebCore::LengthType : uint8_t {
     Auto,
+    Normal,
     Relative,
     Percent,
     Fixed,

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
@@ -41,7 +41,7 @@ namespace WebKit {
 class RemoteAcceleratedEffectStack final : public WebCore::AcceleratedEffectStack {
     WTF_MAKE_ISO_ALLOCATED(RemoteAcceleratedEffectStack);
 public:
-    static Ref<RemoteAcceleratedEffectStack> create(Seconds);
+    static Ref<RemoteAcceleratedEffectStack> create(WebCore::FloatRect, Seconds);
 
     void setEffects(WebCore::AcceleratedEffects&&) final;
 
@@ -55,21 +55,23 @@ public:
     void clear(PlatformLayer*);
 
 private:
-    explicit RemoteAcceleratedEffectStack(Seconds);
+    explicit RemoteAcceleratedEffectStack(WebCore::FloatRect, Seconds);
 
     WebCore::AcceleratedEffectValues computeValues(MonotonicTime now) const;
 
     enum class LayerProperty : uint8_t {
-        None = 1 << 0,
-        Opacity = 1 << 1
+        Opacity = 1 << 1,
+        Transform = 1 << 2
     };
 
     OptionSet<LayerProperty> m_affectedLayerProperties;
 
+    WebCore::FloatRect m_bounds;
     Seconds m_acceleratedTimelineTimeOrigin;
 
     RetainPtr<CAPresentationModifierGroup> m_presentationModifierGroup;
     RetainPtr<CAPresentationModifier> m_opacityPresentationModifier;
+    RetainPtr<CAPresentationModifier> m_transformPresentationModifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -260,7 +260,7 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
     if (effects.isEmpty())
         return;
 
-    m_effectStack = RemoteAcceleratedEffectStack::create(host.acceleratedTimelineTimeOrigin());
+    m_effectStack = RemoteAcceleratedEffectStack::create(layer().bounds, host.acceleratedTimelineTimeOrigin());
 
     auto clonedEffects = effects;
     auto clonedBaseValues = baseValues.clone();


### PR DESCRIPTION
#### a22a2bc8c50a344b844e5bec2372f4752e703529
<pre>
[threaded-animation-resolution] add support for blending `transform` values
<a href="https://bugs.webkit.org/show_bug.cgi?id=269226">https://bugs.webkit.org/show_bug.cgi?id=269226</a>

Reviewed by Simon Fraser.

We&apos;ve added the general system to blend accelerated properties with 274102@main.
We now add support for blending the transform-related properties affecting the
`CALayer.transform` property. To do this, we need to provide the `RemoteAcceleratedEffectStack`
with the bounds of the targeted layer. Note that we don&apos;t yet account for the
various properties defined by CSS Motion Path, but only account for the CSS
properties `transform`, `translate`, `scale` and `rotate`.

* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::blend):
(WebCore::AcceleratedEffect::apply):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::computedTransformationMatrix const):
* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm:
(WebKit::RemoteAcceleratedEffectStack::create):
(WebKit::RemoteAcceleratedEffectStack::RemoteAcceleratedEffectStack):
(WebKit::RemoteAcceleratedEffectStack::setEffects):
(WebKit::RemoteAcceleratedEffectStack::initEffectsFromMainThread):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread const):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromMainThread const):
(WebKit::RemoteAcceleratedEffectStack::computeValues const):
(WebKit::RemoteAcceleratedEffectStack::clear):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/274487@main">https://commits.webkit.org/274487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bdab8df724f0a5378de81622c455bf7f89dd0f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39264 "Failed to checkout and rebase branch from PR 24272") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18243 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/41617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41570 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/21100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/15572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/41798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39838 "Failed to checkout and rebase branch from PR 24272") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/21100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/41617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/21100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/41617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43076 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/21100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/41617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/15572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/41617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5125 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15168 "Build is in progress. Recent messages:") | | | 
<!--EWS-Status-Bubble-End-->