### PR TITLE
Add support for loading and connecting the Web Extension devtools background page.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionConstants.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionConstants.h
@@ -35,7 +35,7 @@ static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfEnabledR
 static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules = 5000;
 
 // MARK: Storage constants.
-static constexpr double webExtensionUnlimitedStorageQuotaBytes = DBL_MAX;
+static constexpr double webExtensionUnlimitedStorageQuotaBytes = std::numeric_limits<double>::max();
 
 static constexpr size_t webExtensionStorageAreaLocalQuotaBytes = 5 * 1024 * 1024;
 static constexpr size_t webExtensionStorageAreaSessionQuotaBytes = 10 * 1024 * 1024;

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -50,6 +50,9 @@ struct WebExtensionContextParameters {
     bool isSessionStorageAllowedInContentScripts { false };
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    Vector<WebExtensionContext::PageIdentifierTuple> inspectorBackgroundPageIdentifiers;
+#endif
     Vector<WebExtensionContext::PageIdentifierTuple> popupPageIdentifiers;
     Vector<WebExtensionContext::PageIdentifierTuple> tabPageIdentifiers;
 };

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -36,6 +36,9 @@ struct WebKit::WebExtensionContextParameters {
     bool isSessionStorageAllowedInContentScripts;
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    Vector<WebKit::WebExtensionContext::PageIdentifierTuple> inspectorBackgroundPageIdentifiers;
+#endif
     Vector<WebKit::WebExtensionContext::PageIdentifierTuple> popupPageIdentifiers;
     Vector<WebKit::WebExtensionContext::PageIdentifierTuple> tabPageIdentifiers;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -97,6 +97,8 @@ static NSString * const backgroundPageTypeModuleValue = @"module";
 
 static NSString * const generatedBackgroundPageFilename = @"_generated_background_page.html";
 
+static NSString * const devtoolsPageManifestKey = @"devtools_page";
+
 static NSString * const contentScriptsManifestKey = @"content_scripts";
 static NSString * const contentScriptsMatchesManifestKey = @"matches";
 static NSString * const contentScriptsExcludeMatchesManifestKey = @"exclude_matches";
@@ -1299,6 +1301,32 @@ void WebExtension::populateBackgroundPropertiesIfNeeded()
     if (m_backgroundContentIsPersistent)
         recordError(createError(Error::InvalidBackgroundPersistence, WEB_UI_STRING("Invalid `persistent` manifest entry. A non-persistent background is required on iOS and iPadOS.", "WKWebExtensionErrorInvalidBackgroundPersistence description for iOS")));
 #endif
+}
+
+bool WebExtension::hasInspectorBackgroundPage()
+{
+    return !!inspectorBackgroundPagePath();
+}
+
+NSString *WebExtension::inspectorBackgroundPagePath()
+{
+    populateInspectorPropertiesIfNeeded();
+    return m_inspectorBackgroundPagePath.get();
+}
+
+void WebExtension::populateInspectorPropertiesIfNeeded()
+{
+    if (!manifestParsedSuccessfully())
+        return;
+
+    if (m_parsedManifestInspectorProperties)
+        return;
+
+    m_parsedManifestInspectorProperties = true;
+
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page
+
+    m_inspectorBackgroundPagePath = objectForKey<NSString>(m_manifest, devtoolsPageManifestKey);
 }
 
 bool WebExtension::hasOptionsPage()

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -245,6 +245,9 @@ public:
     NSString *backgroundContentPath();
     NSString *generatedBackgroundContent();
 
+    bool hasInspectorBackgroundPage();
+    NSString *inspectorBackgroundPagePath();
+
     bool hasOptionsPage();
     bool hasOverrideNewTabPage();
 
@@ -295,6 +298,7 @@ private:
     void populateDisplayStringsIfNeeded();
     void populateActionPropertiesIfNeeded();
     void populateBackgroundPropertiesIfNeeded();
+    void populateInspectorPropertiesIfNeeded();
     void populateContentScriptPropertiesIfNeeded();
     void populatePermissionsPropertiesIfNeeded();
     void populatePagePropertiesIfNeeded();
@@ -350,6 +354,8 @@ private:
     RetainPtr<NSString> m_backgroundServiceWorkerPath;
     RetainPtr<NSString> m_generatedBackgroundContent;
 
+    RetainPtr<NSString> m_inspectorBackgroundPagePath;
+
     RetainPtr<NSString> m_optionsPagePath;
     RetainPtr<NSString> m_overrideNewTabPagePath;
 
@@ -360,6 +366,7 @@ private:
     bool m_parsedManifestContentSecurityPolicyStrings : 1 { false };
     bool m_parsedManifestActionProperties : 1 { false };
     bool m_parsedManifestBackgroundProperties : 1 { false };
+    bool m_parsedManifestInspectorProperties : 1 { false };
     bool m_parsedManifestContentScriptProperties : 1 { false };
     bool m_parsedManifestPermissionProperties : 1 { false };
     bool m_parsedManifestPageProperties : 1 { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -68,6 +68,9 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
         inTestingMode(),
         isSessionStorageAllowedInContentScripts(),
         backgroundPageIdentifier(),
+#if ENABLE(INSPECTOR_EXTENSIONS)
+        inspectorBackgroundPageIdentifiers(),
+#endif
         popupPageIdentifiers(),
         tabPageIdentifiers()
     };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -61,6 +61,10 @@ class WebProcessPool;
 class WebsiteDataStore;
 struct WebExtensionControllerParameters;
 
+#if ENABLE(INSPECTOR_EXTENSIONS)
+class WebInspectorUIProxy;
+#endif
+
 class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
     WTF_MAKE_NONCOPYABLE(WebExtensionController);
 
@@ -134,7 +138,11 @@ public:
 
     void handleContentRuleListNotification(WebPageProxyIdentifier, URL&, WebCore::ContentRuleListResults&);
 
-    // webRequest support
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    void inspectorWillOpen(WebInspectorUIProxy&, WebPageProxy&);
+    void inspectorWillClose(WebInspectorUIProxy&, WebPageProxy&);
+#endif
+
     void resourceLoadDidSendRequest(WebPageProxyIdentifier, const ResourceLoadInfo&, const WebCore::ResourceRequest&);
     void resourceLoadDidPerformHTTPRedirection(WebPageProxyIdentifier, const ResourceLoadInfo&, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&);
     void resourceLoadDidReceiveChallenge(WebPageProxyIdentifier, const ResourceLoadInfo&, const WebCore::AuthenticationChallenge&);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -33,6 +33,7 @@
 #import "CocoaHelpers.h"
 #import "JSWebExtensionWrapper.h"
 #import "MessageSenderInlines.h"
+#import "WebExtensionTabIdentifier.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
 
@@ -54,13 +55,12 @@ void WebExtensionAPIDevToolsInspectedWindow::reload(NSDictionary *options, NSStr
     // FIXME: <https://webkit.org/b/246485> Implement.
 }
 
-double WebExtensionAPIDevToolsInspectedWindow::tabId()
+double WebExtensionAPIDevToolsInspectedWindow::tabId(WebPage& page)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/tabId
 
-    // FIXME: <https://webkit.org/b/246485> Implement.
-
-    return -1;
+    auto result = extensionContext().tabIdentifier(page);
+    return toWebAPI(result ? result.value() : WebExtensionTabConstants::NoneIdentifier);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -36,7 +36,7 @@
 
 namespace WebKit {
 
-bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPage&)
+bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPage& page)
 {
     if (name == "action"_s)
         return extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"action");
@@ -49,7 +49,10 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     if (name == "devtools"_s)
-        return objectForKey<NSDictionary>(extensionContext().manifest(), @"devtools_page");
+        return objectForKey<NSString>(extensionContext().manifest(), @"devtools_page") && (page.isInspectorPage() || extensionContext().isInspectorBackgroundPage(page));
+#else
+    if (name == "devtools"_s)
+        return false;
 #endif
 
     if (name == "notifications"_s) {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -273,19 +273,19 @@ double WebExtensionAPIStorageArea::quotaBytesPerItem()
     return webExtensionStorageAreaSyncQuotaBytesPerItem;
 }
 
-NSUInteger WebExtensionAPIStorageArea::maxItems()
+double WebExtensionAPIStorageArea::maxItems()
 {
     ASSERT(m_type == WebExtensionStorageType::Sync);
     return webExtensionStorageAreaSyncMaximumItems;
 }
 
-NSUInteger WebExtensionAPIStorageArea::maxWriteOperationsPerHour()
+double WebExtensionAPIStorageArea::maxWriteOperationsPerHour()
 {
     ASSERT(m_type == WebExtensionStorageType::Sync);
     return webExtensionStorageAreaSyncMaximumWriteOperationsPerHour;
 }
 
-NSUInteger WebExtensionAPIStorageArea::maxWriteOperationsPerMinute()
+double WebExtensionAPIStorageArea::maxWriteOperationsPerMinute()
 {
     ASSERT(m_type == WebExtensionStorageType::Sync);
     return webExtensionStorageAreaSyncMaximumWriteOperationsPerMinute;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
@@ -38,15 +38,10 @@ class WebExtensionAPIDevToolsInspectedWindow : public WebExtensionAPIObject, pub
 
 public:
 #if PLATFORM(COCOA)
-    bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage&);
-
     void eval(NSString *expression, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void reload(NSDictionary *options, NSString **outExceptionString);
-    void getResources(NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    double tabId();
-
-    WebExtensionAPIEvent& onResourceAdded();
+    double tabId(WebPage&);
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -55,9 +55,9 @@ public:
 
     // Exposed only by storage.sync.
     double quotaBytesPerItem();
-    NSUInteger maxItems();
-    NSUInteger maxWriteOperationsPerHour();
-    NSUInteger maxWriteOperationsPerMinute();
+    double maxItems();
+    double maxWriteOperationsPerHour();
+    double maxWriteOperationsPerMinute();
 
     WebExtensionAPIEvent& onChanged();
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl
@@ -31,6 +31,6 @@
     [RaisesException] void eval(DOMString expression, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
     [RaisesException] void reload([Optional, NSDictionary] any options);
 
-    readonly attribute double tabId;
+    [NeedsPage] readonly attribute double tabId;
 
 };

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -95,8 +95,15 @@ public:
 
     void addFrameWithExtensionContent(WebFrame&);
 
+    std::optional<WebExtensionTabIdentifier> tabIdentifier(WebPage&) const;
+
     RefPtr<WebPage> backgroundPage() const;
     void setBackgroundPage(WebPage&);
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    void addInspectorBackgroundPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
+    bool isInspectorBackgroundPage(WebPage&) const;
+#endif
 
     Vector<Ref<WebPage>> popupPages(std::optional<WebExtensionTabIdentifier> = std::nullopt, std::optional<WebExtensionWindowIdentifier> = std::nullopt) const;
     void addPopupPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
@@ -135,6 +142,11 @@ private:
 
     // Cookies
     void dispatchCookiesChangedEvent();
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    // DevTools
+    void addInspectorBackgroundPageIdentifier(WebCore::PageIdentifier, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
+#endif
 
     // Extension
     void setBackgroundPageIdentifier(WebCore::PageIdentifier);
@@ -201,6 +213,9 @@ private:
     RefPtr<WebCore::DOMWrapperWorld> m_contentScriptWorld;
     WeakFrameSet m_extensionContentFrames;
     WeakPtr<WebPage> m_backgroundPage;
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    WeakPageTabWindowMap m_inspectorBackgroundPageMap;
+#endif
     WeakPageTabWindowMap m_popupPageMap;
     WeakPageTabWindowMap m_tabPageMap;
 };

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -39,6 +39,11 @@ messages -> WebExtensionContextProxy {
     // Cookies
     DispatchCookiesChangedEvent()
 
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    // DevTools
+    AddInspectorBackgroundPageIdentifier(WebCore::PageIdentifier pageID, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier)
+#endif
+
     // Extension
     SetBackgroundPageIdentifier(WebCore::PageIdentifier pageID)
     AddPopupPageIdentifier(WebCore::PageIdentifier pageID, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier)

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -295,6 +295,7 @@ Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm
 Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
 Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
 Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
 Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm
 Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
 Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -546,9 +546,9 @@
 		71E88C4524B534B700665160 /* img-with-base64-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 71E88C4324B533EC00665160 /* img-with-base64-url.html */; };
 		725C3EF322058A5B007C36FC /* AdditionalSupportedImageTypes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */; };
 		7283A9D222FB1E0600B21C7D /* exif-orientation-8-llo.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7283A9D122FB1D9700B21C7D /* exif-orientation-8-llo.jpg */; };
+		72F21E9828C9216B007BF315 /* 100x100-red.jp2 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 72F21E9728C9214C007BF315 /* 100x100-red.jp2 */; };
 		7498C3D72A94435F009A387E /* TestUTIUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7498C3CF2A94435F009A387E /* TestUTIUtilities.cpp */; };
 		74DEF2252A946FD800E034A3 /* TestUTIRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74DEF21D2A946FD700E034A3 /* TestUTIRegistry.cpp */; };
-		72F21E9828C9216B007BF315 /* 100x100-red.jp2 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 72F21E9728C9214C007BF315 /* 100x100-red.jp2 */; };
 		751B05D61F8EAC410028A09E /* DatabaseTrackerTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */; };
 		754CEC811F6722F200D0039A /* AutoFillAvailable.mm in Sources */ = {isa = PBXBuildFile; fileRef = 754CEC801F6722DC00D0039A /* AutoFillAvailable.mm */; };
 		7673499D1930C5BB00E44DF9 /* StopLoadingDuringDidFailProvisionalLoad_bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7673499A1930182E00E44DF9 /* StopLoadingDuringDidFailProvisionalLoad_bundle.cpp */; };
@@ -2106,6 +2106,7 @@
 		1C2B81811C891EFA00A5529F /* CancelFontSubresourcePlugIn.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CancelFontSubresourcePlugIn.mm; sourceTree = "<group>"; };
 		1C2B81841C8924A200A5529F /* webfont.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = webfont.html; sourceTree = "<group>"; };
 		1C2B81851C89252300A5529F /* Ahem.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Ahem.ttf; sourceTree = "<group>"; };
+		1C38A9192B7AB310006B1333 /* WKWebExtensionAPIDevTools.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIDevTools.mm; sourceTree = "<group>"; };
 		1C40052E2B2CEE8C00F2D9EE /* WKWebExtensionAPICookies.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPICookies.mm; sourceTree = "<group>"; };
 		1C46169E26BA510700F8C9F6 /* TextStreamCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextStreamCocoa.mm; sourceTree = "<group>"; };
 		1C4616A626BB172F00F8C9F6 /* TextStreamCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextStreamCocoa.cpp; sourceTree = "<group>"; };
@@ -4275,6 +4276,7 @@
 				1C8ECFF12AFD6F49007BAA62 /* WKWebExtensionAPICommands.mm */,
 				1C40052E2B2CEE8C00F2D9EE /* WKWebExtensionAPICookies.mm */,
 				33C39CFF2B07D4B9008FA14B /* WKWebExtensionAPIDeclarativeNetRequest.mm */,
+				1C38A9192B7AB310006B1333 /* WKWebExtensionAPIDevTools.mm */,
 				B6E1E1E02942B0DD00F314D2 /* WKWebExtensionAPIEvent.mm */,
 				1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */,
 				B6D1708E2A9F9C9F004C72E6 /* WKWebExtensionAPILocalization.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
+
+#import "WebExtensionUtilities.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKInspectorPrivate.h>
+
+namespace TestWebKitAPI {
+
+static auto *devToolsManifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"Test DevTools",
+    @"description": @"Test DevTools",
+    @"version": @"1.0",
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+
+    @"devtools_page": @"devtools.html"
+};
+
+TEST(WKWebExtensionAPIDevTools, Basics)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser?.devtools, undefined, 'browser.devtools should be undefined in background script')",
+    ]);
+
+    auto *devToolsScript = Util::constructScript(@[
+        @"browser.test.assertEq(typeof browser?.devtools, 'object', 'browser.devtools should be available in devtools page script')",
+        @"browser.test.assertEq(typeof browser?.devtools?.panels, 'object', 'browser.devtools.panels should be available')",
+        @"browser.test.assertEq(typeof browser?.devtools?.network, 'object', 'browser.devtools.network should be available')",
+        @"browser.test.assertEq(typeof browser?.devtools?.inspectedWindow, 'object', 'browser.devtools.inspectedWindow should be available')",
+        @"browser.test.assertEq(typeof browser?.devtools?.inspectedWindow?.tabId, 'number', 'browser.devtools.inspectedWindow.tabId should be available')",
+        @"browser.test.assertTrue(browser?.devtools?.inspectedWindow?.tabId > 0, 'browser.devtools.inspectedWindow.tabId should be a positive value')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"devtools.html": @"<script type='module' src='devtools.js'></script>",
+        @"devtools.js": devToolsScript
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.mainWebView._inspector show];
+
+    [manager loadAndRun];
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 
 #import "PlatformUtilities.h"
+#import "Test.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewConfiguration.h>

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -33,6 +33,7 @@
 
 #import "TestWebExtensionsDelegate.h"
 #import "WebExtensionUtilities.h"
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKWebExtensionTabCreationOptions.h>
@@ -327,6 +328,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         configuration._webExtensionController = extensionController;
         configuration.websiteDataStore = usingPrivateBrowsing ? WKWebsiteDataStore.nonPersistentDataStore : WKWebsiteDataStore.defaultDataStore;
         configuration.userContentController = userContentController(usingPrivateBrowsing);
+        configuration.preferences._developerExtrasEnabled = YES;
 
         _mainWebView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
         _mainWebView.navigationDelegate = self;


### PR DESCRIPTION
#### 0b519b877420bd9b534b8ca4b8341952ab698208
<pre>
Add support for loading and connecting the Web Extension devtools background page.
<a href="https://webkit.org/b/246485">https://webkit.org/b/246485</a>
<a href="https://rdar.apple.com/problem/114823326">rdar://problem/114823326</a>

Reviewed by Jeff Miller.

Hook up loading the devtools_page when Web Inspector opens, or an extension is loaded
when Inspectors are already open during load, or private browsing is toggled.

* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::hasInspectorBackgroundPage):
(WebKit::WebExtension::inspectorBackgroundPagePath):
(WebKit::WebExtension::populateInspectorPropertiesIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::setHasAccessInPrivateBrowsing):
(WebKit::WebExtensionContext::inspectorBackgroundPageIdentifiers const):
(WebKit::WebExtensionContext::decidePolicyForNavigationAction):
(WebKit::WebExtensionContext::webViewWebContentProcessDidTerminate):
(WebKit::WebExtensionContext::inspectorBackgroundPageURL const):
(WebKit::WebExtensionContext::openInspectors const):
(WebKit::WebExtensionContext::loadedInspectors const):
(WebKit::WebExtensionContext::isInspectorBackgroundPage const):
(WebKit::WebExtensionContext::loadInspectorBackgroundPagesDuringLoad):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPages):
(WebKit::WebExtensionContext::loadInspectorBackgroundPagesForPrivateBrowsing):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPagesForPrivateBrowsing):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPage):
(WebKit::WebExtensionContext::inspectorWillOpen):
(WebKit::WebExtensionContext::inspectorWillClose):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
(WebKit::WebExtensionController::unload):
(WebKit::WebExtensionController::unloadAll):
(WebKit::WebExtensionController::addProcessPool):
(WebKit::WebExtensionController::removeProcessPool):
(WebKit::WebExtensionController::addUserContentController):
(WebKit::WebExtensionController::removeUserContentController):
(WebKit::WebExtensionController::removeWebsiteDataStore):
(WebKit::WebExtensionController::cookiesDidChange):
(WebKit::WebExtensionController::extensionContext const):
(WebKit::WebExtensionController::extensions const):
(WebKit::WebExtensionController::addItemsToContextMenu):
(WebKit::WebExtensionController::didStartProvisionalLoadForFrame):
(WebKit::WebExtensionController::didCommitLoadForFrame):
(WebKit::WebExtensionController::didFinishLoadForFrame):
(WebKit::WebExtensionController::didFailLoadForFrame):
(WebKit::WebExtensionController::handleContentRuleListNotification):
(WebKit::WebExtensionController::purgeOldMatchedRules):
(WebKit::WebExtensionController::resourceLoadDidSendRequest):
(WebKit::WebExtensionController::resourceLoadDidPerformHTTPRedirection):
(WebKit::WebExtensionController::resourceLoadDidReceiveChallenge):
(WebKit::WebExtensionController::resourceLoadDidReceiveResponse):
(WebKit::WebExtensionController::resourceLoadDidCompleteWithError):
(WebKit::WebExtensionController::inspectorWillOpen):
(WebKit::WebExtensionController::inspectorWillClose):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::openLocalInspectorFrontend):
(WebKit::WebInspectorUIProxy::closeFrontendPageAndWindow):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::tabId):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::tabIdentifier const):
(WebKit::WebExtensionContextProxy::addInspectorBackgroundPageIdentifier):
(WebKit::WebExtensionContextProxy::addInspectorBackgroundPage):
(WebKit::WebExtensionContextProxy::isInspectorBackgroundPage const):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm: Added.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab initWithWindow:extensionController:]):

Canonical link: <a href="https://commits.webkit.org/274506@main">https://commits.webkit.org/274506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faa96bab18273c19f37ea37a9f66d0ffd31d30f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41800 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15574 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13350 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13314 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43078 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35304 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37358 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15684 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15347 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5144 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->