### PR TITLE
[Xcode] Teach "Create symlinks to XPC services" build phase to also symlink libWebKitSwift.dylib

### DIFF
--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -17476,7 +17476,7 @@
 				A55DEAA61670402E003DB841 /* Check For Inappropriate Macros in External Headers */,
 				1A2180161B5454620046AEC4 /* Add Symlink in /System/Library/PrivateFrameworks */,
 				5379C7AC21E5288500E4A8F6 /* Check .xcfilelists */,
-				933170072234674500B32554 /* Create symlinks to XPC services */,
+				933170072234674500B32554 /* Create symlinks to XPC services and dylibs */,
 				0FB94836239F31B700926A8F /* Copy Testing Headers */,
 				6577FFB92769C1460011AEC8 /* Create Symlink to Alt Root Path */,
 				EBE4D2AD28A2F3BD00C0FAE7 /* Copy Signpost Plists */,
@@ -18410,7 +18410,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [ \"${ACTION}\" = \"installhdrs\" -o \"${ACTION}\" = \"installapi\" ]; then\n    exit 0;\nfi\n\"${SCRIPT_INPUT_FILE_2}\"\n";
 		};
-		933170072234674500B32554 /* Create symlinks to XPC services */ = {
+		933170072234674500B32554 /* Create symlinks to XPC services and dylibs */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -18419,7 +18419,7 @@
 			);
 			inputPaths = (
 			);
-			name = "Create symlinks to XPC services";
+			name = "Create symlinks to XPC services and dylibs";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -18429,10 +18429,11 @@
 				"$(BUILT_PRODUCTS_DIR)/$(XPCSERVICES_FOLDER_PATH)/com.apple.WebKit.Networking.xpc",
 				"$(BUILT_PRODUCTS_DIR)/$(XPCSERVICES_FOLDER_PATH)/com.apple.WebKit.GPU.xpc",
 				"$(BUILT_PRODUCTS_DIR)/$(XPCSERVICES_FOLDER_PATH)/com.apple.WebKit.Model.xpc",
+				"$(BUILT_PRODUCTS_DIR)/WebKit.framework/$(WK_FRAMEWORK_VERSION_PREFIX)/Frameworks/libWebKitSwift.dylib",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"${WK_PLATFORM_NAME}\" == macosx || \"${WK_PLATFORM_NAME}\" == maccatalyst || \"${WK_PLATFORM_NAME}\" == iosmac ]]; then\n    ln -sfhv \"Versions/Current/XPCServices\" \"${BUILT_PRODUCTS_DIR}/WebKit.framework/XPCServices\";\nfi\n\nif [[ \"${DEPLOYMENT_LOCATION}\" == \"YES\" ]]; then\n    exit\nfi\n\nif [[ ${WK_PLATFORM_NAME} != \"macosx\" ]]; then\n    BUILT_PRODUCTS_DIR_RELATIVE_PATH_FROM_XPC_SERVICES=\"../..\"\nelse\n    BUILT_PRODUCTS_DIR_RELATIVE_PATH_FROM_XPC_SERVICES=\"../../../..\"\nfi\n\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH_FROM_XPC_SERVICES}/com.apple.WebKit.WebContent.xpc\" \"${SCRIPT_OUTPUT_FILE_0}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH_FROM_XPC_SERVICES}/com.apple.WebKit.WebContent.CaptivePortal.xpc\" \"${SCRIPT_OUTPUT_FILE_1}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH_FROM_XPC_SERVICES}/com.apple.WebKit.WebContent.Development.xpc\" \"${SCRIPT_OUTPUT_FILE_2}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH_FROM_XPC_SERVICES}/com.apple.WebKit.Networking.xpc\" \"${SCRIPT_OUTPUT_FILE_3}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH_FROM_XPC_SERVICES}/com.apple.WebKit.GPU.xpc\" \"${SCRIPT_OUTPUT_FILE_4}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH_FROM_XPC_SERVICES}/com.apple.WebKit.Model.xpc\" \"${SCRIPT_OUTPUT_FILE_5}\"\n";
+			shellScript = "if [[ \"${WK_PLATFORM_NAME}\" == macosx || \"${WK_PLATFORM_NAME}\" == maccatalyst || \"${WK_PLATFORM_NAME}\" == iosmac ]]; then\n    ln -sfhv \"Versions/Current/XPCServices\" \"${BUILT_PRODUCTS_DIR}/WebKit.framework/XPCServices\";\nfi\n\nif [[ \"${DEPLOYMENT_LOCATION}\" == \"YES\" ]]; then\n    exit\nfi\n\nif [[ ${WK_PLATFORM_NAME} != \"macosx\" ]]; then\n    BUILT_PRODUCTS_DIR_RELATIVE_PATH=\"../..\"\nelse\n    BUILT_PRODUCTS_DIR_RELATIVE_PATH=\"../../../..\"\nfi\n\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH}/com.apple.WebKit.WebContent.xpc\" \"${SCRIPT_OUTPUT_FILE_0}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH}/com.apple.WebKit.WebContent.CaptivePortal.xpc\" \"${SCRIPT_OUTPUT_FILE_1}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH}/com.apple.WebKit.WebContent.Development.xpc\" \"${SCRIPT_OUTPUT_FILE_2}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH}/com.apple.WebKit.Networking.xpc\" \"${SCRIPT_OUTPUT_FILE_3}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH}/com.apple.WebKit.GPU.xpc\" \"${SCRIPT_OUTPUT_FILE_4}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH}/com.apple.WebKit.Model.xpc\" \"${SCRIPT_OUTPUT_FILE_5}\"\nln -sFhv \"${BUILT_PRODUCTS_DIR_RELATIVE_PATH}/libWebKitSwift.dylib\" \"${SCRIPT_OUTPUT_FILE_6}\"\n";
 		};
 		942DB245257EE6DF009BD80A /* Create /usr/local to work around XBS Bug <rdar://problem/20388650> */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
#### 58b61c2b391439afb6e58cf7fc9e20d5a0e82b3a
<pre>
[Xcode] Teach &quot;Create symlinks to XPC services&quot; build phase to also symlink libWebKitSwift.dylib
<a href="https://bugs.webkit.org/show_bug.cgi?id=269229">https://bugs.webkit.org/show_bug.cgi?id=269229</a>
<a href="https://rdar.apple.com/122825232">rdar://122825232</a>

Reviewed by Elliott Williams.

libWebKitSwift.dylib expects to be installed in WebKit.framework/Frameworks, but nothing in the
engineering build system places it in that location. While WebKitSwiftSoftLink.mm will find the
dylib in $BUILT_PRODUCTS_DIR on macOS, tools for creating roots from engineering built products
(e.g., `package-root`) do not know to include the dylib without at least a symlink to it in the
expected location. To fix this, extended WebKit&apos;s &quot;Create symlinks to XPC services&quot; build phase
to create a symlink to libWebKitSwift.dylib in the expected install location.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/274514@main">https://commits.webkit.org/274514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e939c7bf0790fb715710e324762054c0f11a6551

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35181 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15589 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13355 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13321 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43093 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39138 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37378 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15699 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8793 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->