### PR TITLE
[WebGPU] Crash in Constraints.cpp:199 concretize

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -187,22 +187,22 @@ const Type* concretize(const Type* type, TypeStore& types)
             return type;
         },
         [&](const Function&) -> const Type* {
-            RELEASE_ASSERT_NOT_REACHED();
+            return nullptr;
         },
         [&](const Texture&) -> const Type* {
-            RELEASE_ASSERT_NOT_REACHED();
+            return nullptr;
         },
         [&](const TextureStorage&) -> const Type* {
-            RELEASE_ASSERT_NOT_REACHED();
+            return nullptr;
         },
         [&](const TextureDepth&) -> const Type* {
-            RELEASE_ASSERT_NOT_REACHED();
+            return nullptr;
         },
         [&](const Reference&) -> const Type* {
-            RELEASE_ASSERT_NOT_REACHED();
+            return nullptr;
         },
         [&](const TypeConstructor&) -> const Type* {
-            RELEASE_ASSERT_NOT_REACHED();
+            return nullptr;
         });
 }
 

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -310,7 +310,7 @@ ConversionRank OverloadResolver::calculateRank(const AbstractType& parameter, co
         ASSERT(resolvedType);
         if (variable->constraints) {
             resolvedType = satisfyOrPromote(resolvedType, variable->constraints, m_types);
-            ASSERT(resolvedType);
+            RELEASE_ASSERT(resolvedType);
         }
         return conversionRank(argumentType, resolvedType);
     }

--- a/Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl
@@ -38,3 +38,15 @@ fn testFunctionAsValue()
     // CHECK-L: cannot use function 'testI32Overflow' as value
     { const x: f32 = bitcast<f32>(testI32Overflow); }
 }
+
+@group(0) @binding(1) var s: sampler;
+@group(0) @binding(2) var t: texture_depth_2d;
+
+fn testTypeCannotBeConcretized()
+{
+    // CHECK-L: cannot bitcast from 'sampler' to 'i32'
+    let x = bitcast<i32>(s);
+
+    // CHECK-L: cannot bitcast from 'texture_depth_2d' to 'i32'
+    let x = bitcast<i32>(t);
+}


### PR DESCRIPTION
#### 28ce6649da175444470640ac88f29a7218024683
<pre>
[WebGPU] Crash in Constraints.cpp:199 concretize
<a href="https://bugs.webkit.org/show_bug.cgi?id=269114">https://bugs.webkit.org/show_bug.cgi?id=269114</a>
<a href="https://rdar.apple.com/122677724">rdar://122677724</a>

Reviewed by Mike Wyrzykowski.

Make concretize return nullptr instead of release asserting so it&apos;s safe to call
with any types.

* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::concretize):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::calculateRank):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::bitcast):
* Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl:

Canonical link: <a href="https://commits.webkit.org/274539@main">https://commits.webkit.org/274539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/682286cb6cf1f0da50165eb5ad3c7543d7811c98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35173 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32855 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13382 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43085 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37361 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15691 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8810 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->