### PR TITLE
[WGSL] Fix wgslc tests

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -320,6 +320,9 @@ Packing RewriteGlobalVariables::pack(Packing expectedPacking, AST::Expression& e
         if (std::holds_alternative<Types::Struct>(*type))
             operation = packing & Packing::Packed ? "__unpack"_s : "__pack"_s;
         else if (std::holds_alternative<Types::Array>(*type)) {
+            // array of vec3 can be implicitly converted
+            if (packing & Packing::Vec3)
+                return expectedPacking;
             if (packing & Packing::Packed) {
                 operation = "__unpack"_s;
                 m_callGraph.ast().setUsesUnpackArray();

--- a/Source/WebGPU/WGSL/tests/invalid/const-assert.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/const-assert.wgsl
@@ -26,7 +26,7 @@ const_assert(x > y);
 
 var<private> z = 3;
 
-// CHECK-L: const assertion requires a const-expression
+// CHECK-L: cannot use runtime value in constant expression
 const_assert(x > z);
 
 fn f()
@@ -57,7 +57,7 @@ fn f()
 
     let z = 3;
 
-    // CHECK-L: const assertion requires a const-expression
+    // CHECK-L: cannot use runtime value in constant expression
     const_assert(x > z);
 }
 

--- a/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
@@ -57,7 +57,7 @@ fn main()
     // CHECK: function\d\(\)
     _ = g();
 
-    // CHECK: function\d\(global\d, global\d\)
+    // CHECK: function\d\(global\d, \(\d+\)\)
     _ = h();
 
     // CHECK: function\d\(global\d\)

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -4148,11 +4148,11 @@ fn testDerivativeFunctions()
 @group(0) @binding(21) var ts3d: texture_storage_3d<rgba32float, write>;
 @group(0) @binding(22) var te: texture_external;
 
-var td2d: texture_depth_2d;
-var td2da: texture_depth_2d_array;
-var tdc: texture_depth_cube;
-var tdca: texture_depth_cube_array;
-var tdms2d: texture_depth_multisampled_2d;
+@group(0) @binding(23) var td2d: texture_depth_2d;
+@group(0) @binding(24) var td2da: texture_depth_2d_array;
+@group(0) @binding(25) var tdc: texture_depth_cube;
+@group(0) @binding(26) var tdca: texture_depth_cube_array;
+@group(0) @binding(27) var tdms2d: texture_depth_multisampled_2d;
 
 // 16.7.1
 // RUN: %metal-compile testTextureDimensions


### PR DESCRIPTION
#### a11d9bd8350a97ad50c40b00eccae5b49937ed75
<pre>
[WGSL] Fix wgslc tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=269238">https://bugs.webkit.org/show_bug.cgi?id=269238</a>
<a href="https://rdar.apple.com/122829420">rdar://122829420</a>

Reviewed by Mike Wyrzykowski.

Some of the tests contained invalid code that started failing with validations
recently added. One was failing due to an unnecessary unpack call with arrays
of vec3, which can be implicitly converted.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
* Source/WebGPU/WGSL/tests/invalid/const-assert.wgsl:
* Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/274538@main">https://commits.webkit.org/274538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72c8acb409a9185982ff29b73fc068e31a34eb29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41811 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35177 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32866 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13322 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39129 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37368 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/39324 "Build is in progress. Recent messages:") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15695 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8809 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->