### PR TITLE
[UnifedPDF] Hook up accessibility for Unified PDF

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -181,7 +181,6 @@ private:
 
     id accessibilityHitTest(const WebCore::IntPoint&) const override;
     id accessibilityObject() const override;
-    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
 
     NSEvent *nsEventForWebMouseEvent(const WebMouseEvent&);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1606,17 +1606,6 @@ NSData *PDFPlugin::liveData() const
     return originalData();
 }
 
-id PDFPlugin::accessibilityAssociatedPluginParentForElement(WebCore::Element* element) const
-{
-    if (!m_activeAnnotation)
-        return nil;
-
-    if (m_activeAnnotation->element() != element)
-        return nil;
-
-    return [m_activeAnnotation->annotation() accessibilityNode];
-}
-
 id PDFPlugin::accessibilityHitTest(const WebCore::IntPoint& point) const
 {
     return [m_accessibilityObject accessibilityHitTestIntPoint:point];

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -47,6 +47,7 @@ OBJC_CLASS NSDictionary;
 OBJC_CLASS PDFAnnotation;
 OBJC_CLASS PDFDocument;
 OBJC_CLASS PDFSelection;
+OBJC_CLASS WKAccessibilityPDFDocumentObject;
 
 namespace WebCore {
 class FragmentedSharedBuffer;
@@ -153,7 +154,7 @@ public:
 
     virtual id accessibilityHitTest(const WebCore::IntPoint&) const = 0;
     virtual id accessibilityObject() const = 0;
-    virtual id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const = 0;
+    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const;
 
     bool isBeingDestroyed() const { return m_isBeingDestroyed; }
 
@@ -170,11 +171,19 @@ public:
     WebCore::IntPoint convertFromPluginToRootView(const WebCore::IntPoint&) const;
     WebCore::IntRect convertFromPluginToRootView(const WebCore::IntRect&) const;
     WebCore::IntRect boundsOnScreen() const;
-
+    WebCore::FloatRect convertFromPDFViewToScreen(const WebCore::FloatRect&) const;
+    WebCore::IntPoint convertFromPDFViewToRootView(const WebCore::IntPoint&) const;
+    bool showContextMenuAtPoint(const WebCore::IntPoint&);
+    WebCore::IntPoint convertFromRootViewToPDFView(const WebCore::IntPoint&) const;
+    WebCore::AXObjectCache* axObjectCache() const;
+    void setScrollOffset(const WebCore::ScrollOffset&) final;
+#if PLATFORM(MAC)
+    RefPtr<PDFPluginAnnotation> m_activeAnnotation;
+    PDFPluginAnnotation* activeAnnotation() const { return m_activeAnnotation.get(); }
+#endif
     WebCore::ScrollPosition scrollPositionForTesting() const { return scrollPosition(); }
     WebCore::Scrollbar* horizontalScrollbar() const override { return m_horizontalScrollbar.get(); }
     WebCore::Scrollbar* verticalScrollbar() const override { return m_verticalScrollbar.get(); }
-
     virtual void didChangeSettings() { }
 
     // HUD Actions.
@@ -262,7 +271,6 @@ protected:
     bool isScrollableOrRubberbandable() final { return true; }
     bool hasScrollableOrRubberbandableAncestor() final { return true; }
     WebCore::IntRect scrollableAreaBoundingBox(bool* = nullptr) const final;
-    void setScrollOffset(const WebCore::ScrollOffset&) final;
     bool isActive() const final;
     bool isScrollCornerVisible() const final { return false; }
     WebCore::ScrollPosition minimumScrollPosition() const final;
@@ -317,6 +325,7 @@ protected:
     uint64_t m_streamedBytes { 0 };
 
     RetainPtr<PDFDocument> m_pdfDocument;
+    RetainPtr<WKAccessibilityPDFDocumentObject> m_accessibilityObject;
 
     String m_suggestedFilename;
 
@@ -334,9 +343,6 @@ protected:
     std::atomic<bool> m_hasBeenDestroyed { false };
     bool m_didRunScripts { false };
 
-#if PLATFORM(MAC)
-    RefPtr<PDFPluginAnnotation> m_activeAnnotation;
-#endif
     RefPtr<WebCore::Element> m_annotationContainer;
     bool m_pdfDocumentWasMutated { false };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -227,7 +227,7 @@ private:
 
     id accessibilityHitTest(const WebCore::IntPoint&) const override;
     id accessibilityObject() const override;
-    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
+    id accessibilityHitTestIntPoint(const WebCore::IntPoint&) const;
 
     void paint(WebCore::GraphicsContext&, const WebCore::IntRect&) override;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1742,19 +1742,20 @@ std::tuple<String, PDFSelection *, NSDictionary *> UnifiedPDFPlugin::lookupTextA
     return { };
 }
 
-id UnifiedPDFPlugin::accessibilityHitTest(const IntPoint&) const
+id UnifiedPDFPlugin::accessibilityHitTestIntPoint(const WebCore::IntPoint& point) const
 {
-    return nil;
+    auto convertedPoint =  convertFromRootViewToPDFView(point);
+    return [m_accessibilityObject accessibilityHitTest:convertedPoint];
+}
+
+id UnifiedPDFPlugin::accessibilityHitTest(const WebCore::IntPoint& point) const
+{
+    return accessibilityHitTestIntPoint(point);
 }
 
 id UnifiedPDFPlugin::accessibilityObject() const
 {
-    return nil;
-}
-
-id UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement(Element*) const
-{
-    return nil;
+    return m_accessibilityObject.get();
 }
 
 #if ENABLE(PDF_HUD)


### PR DESCRIPTION
#### e752fc08a1c9e63e2a22ecc20982143a327c747d
Finish - navigation across and in the page

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::accessibilityAssociatedPluginParentForElement const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::activeAnnotation const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(-[WKAccessibilityPDFDocumentObject initWithPDFDocument:andElement:]):
(-[WKAccessibilityPDFDocumentObject setPDFPluginBase:]):
(-[WKAccessibilityPDFDocumentObject setPDFDocument:]):
(-[WKAccessibilityPDFDocumentObject isAccessibilityElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityFocusedUIElement]):
(-[WKAccessibilityPDFDocumentObject document]):
(-[WKAccessibilityPDFDocumentObject accessibilityVisibleChildren]):
(-[WKAccessibilityPDFDocumentObject parent]):
(-[WKAccessibilityPDFDocumentObject setParent:]):
(-[WKAccessibilityPDFDocumentObject accessibilityAttributeValue:]):
(-[WKAccessibilityPDFDocumentObject accessibilityAttributeNames]):
(-[WKAccessibilityPDFDocumentObject accessibilityShouldUseUniqueId]):
(-[WKAccessibilityPDFDocumentObject accessibilityArrayAttributeCount:]):
(-[WKAccessibilityPDFDocumentObject accessibilityChildren]):
(-[WKAccessibilityPDFDocumentObject accessibilityHitTest:]):
(-[WKAccessibilityPDFDocumentObject gotoDestination:]):
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::showContextMenuAtPoint):
(WebKit::PDFPluginBase::convertFromPDFViewToRootView const):
(WebKit::PDFPluginBase::convertFromPDFViewToScreen const):
(WebKit::PDFPluginBase::axObjectCache const):
(WebKit::PDFPluginBase::convertFromRootViewToPDFView const):
(WebKit::PDFPluginBase::accessibilityAssociatedPluginParentForElement const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::accessibilityHitTestIntPoint const):
(WebKit::UnifiedPDFPlugin::accessibilityHitTest const):
(WebKit::UnifiedPDFPlugin::accessibilityObject const):
(WebKit::UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e752fc08a1c9e63e2a22ecc20982143a327c747d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18264 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/41638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41819 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21122 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15593 "Hash e752fc08 for PR 24287 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39859 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/41638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/41638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43097 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/35671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/41638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/15593 "Hash e752fc08 for PR 24287 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/41638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->