### PR TITLE
Add SPI for taking snapshot with contents rect

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm
@@ -29,6 +29,7 @@
 @implementation WKSnapshotConfiguration {
 #if PLATFORM(MAC)
     BOOL _includesSelectionHighlighting;
+    BOOL _usesContentsRect;
 #endif
     BOOL _usesTransparentBackground;
 }
@@ -43,6 +44,7 @@
 
 #if PLATFORM(MAC)
     self._includesSelectionHighlighting = YES;
+    self._usesContentsRect = NO;
 #endif
 
     return self;
@@ -81,6 +83,17 @@
 {
     _includesSelectionHighlighting = includesSelectionHighlighting;
 }
+
+- (BOOL)_usesContentsRect
+{
+    return _usesContentsRect;
+}
+
+- (void)_setUsesContentsRect:(BOOL)usesContentsRect
+{
+    _usesContentsRect = usesContentsRect;
+}
+
 #endif // PLATFORM(MAC)
 
 - (BOOL)_usesTransparentBackground

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfigurationPrivate.h
@@ -35,6 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, setter=_setUsesTransparentBackground:) BOOL _usesTransparentBackground WK_API_AVAILABLE(macos(14.2), ios(17.2));
 
+#if !TARGET_OS_IPHONE
+@property (nonatomic, setter=_setUsesContentsRect:) BOOL _usesContentsRect WK_API_AVAILABLE(macos(WK_MAC_TBA));
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### b65d8845733c026d747f9f07a29a93828b983653
<pre>
Add SPI for taking snapshot with contents rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=269239">https://bugs.webkit.org/show_bug.cgi?id=269239</a>
<a href="https://rdar.apple.com/122830522">rdar://122830522</a>

Reviewed by Tim Horton.

API Test: WKWebView.SnapshotWithContentsRect

* Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm:
(-[WKSnapshotConfiguration init]):
(-[WKSnapshotConfiguration _usesContentsRect]):
(-[WKSnapshotConfiguration _setUsesContentsRect:]):
* Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView takeSnapshotWithConfiguration:completionHandler:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::takeSnapshot):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/274561@main">https://commits.webkit.org/274561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1be8dfce879a925106dd75e520b9ac60b3c4156

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32919 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13421 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37439 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15793 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8826 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15841 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->