### PR TITLE
[WIP] Introduce BigInt Public C API in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/API/JSValue.h
+++ b/Source/JavaScriptCore/API/JSValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -170,6 +170,43 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @result The JSValue representing a unique JavaScript value with type symbol.
 */
 + (JSValue *)valueWithNewSymbolFromDescription:(NSString *)description inContext:(JSContext *)context JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+
+/*!
+@method
+@abstract Create a new, unique, bigint object.
+@param string The string representation of the bigint object being created.
+@param context The JSContext to which the resulting JSValue belongs.
+@result The JSValue representing a unique JavaScript value with type bigint.
+*/
++ (JSValue *)valueWithNewBigIntFromString:(NSString *)string inContext:(JSContext *)context JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Create a new, unique, bigint object.
+@param int64 The signed 64-bit integer of the bigint object being created.
+@param context The JSContext to which the resulting JSValue belongs.
+@result The JSValue representing a unique JavaScript value with type bigint.
+*/
++ (JSValue *)valueWithNewBigIntFromInt64:(int64_t)int64 inContext:(JSContext *)context JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Create a new, unique, bigint object.
+@param uint64 The unsigned 64-bit integer of the bigint object being created.
+@param context The JSContext to which the resulting JSValue belongs.
+@result The JSValue representing a unique JavaScript value with type bigint.
+*/
++ (JSValue *)valueWithNewBigIntFromUInt64:(uint64_t)uint64 inContext:(JSContext *)context JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Create a new, unique, bigint object.
+@param number The number of the bigint object being created.
+@param context The JSContext to which the resulting JSValue belongs.
+@result The JSValue representing a unique JavaScript value with type bigint.
+@discussion If number is not an integer an exception will be thrown.
+*/
++ (JSValue *)valueWithNewBigIntFromNumber:(double)number inContext:(JSContext *)context JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 /*!
 @method
@@ -401,6 +438,12 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
  @abstract Check if a JSValue is a symbol.
  */
 @property (readonly) BOOL isSymbol JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+
+/*!
+@property
+@abstract Check if a JSValue is a bigint.
+*/
+@property (readonly) BOOL isBigInt JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 /*!
 @method

--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -157,6 +157,50 @@ NSString * const JSPropertyDescriptorSetKey = @"set";
 {
     auto string = OpaqueJSString::tryCreate(description);
     return [JSValue valueWithJSValueRef:JSValueMakeSymbol([context JSGlobalContextRef], string.get()) inContext:context];
+}
+
++ (JSValue *)valueWithNewBigIntFromString:(NSString *)string inContext:(JSContext *)context
+{
+    JSValueRef exception = nullptr;
+    JSValueRef bigInt = JSBigIntCreateWithString([context JSGlobalContextRef], OpaqueJSString::tryCreate(string).get(), &exception);
+    if (exception) {
+        [context notifyException:exception];
+        return [JSValue valueWithUndefinedInContext:context];
+    }
+    return [JSValue valueWithJSValueRef:bigInt inContext:context];
+}
+
++ (JSValue *)valueWithNewBigIntFromInt64:(int64_t)int64 inContext:(JSContext *)context
+{
+    JSValueRef exception = nullptr;
+    JSValueRef bigInt = JSBigIntCreateWithInt64([context JSGlobalContextRef], int64, &exception);
+    if (exception) {
+        [context notifyException:exception];
+        return [JSValue valueWithUndefinedInContext:context];
+    }
+    return [JSValue valueWithJSValueRef:bigInt inContext:context];
+}
+
++ (JSValue *)valueWithNewBigIntFromUInt64:(uint64_t)uint64 inContext:(JSContext *)context
+{
+    JSValueRef exception = nullptr;
+    JSValueRef bigInt = JSBigIntCreateWithUInt64([context JSGlobalContextRef], uint64, &exception);
+    if (exception) {
+        [context notifyException:exception];
+        return [JSValue valueWithUndefinedInContext:context];
+    }
+    return [JSValue valueWithJSValueRef:bigInt inContext:context];
+}
+
++ (JSValue *)valueWithNewBigIntFromNumber:(double)number inContext:(JSContext *)context
+{
+    JSValueRef exception = nullptr;
+    JSValueRef bigInt = JSBigIntCreateWithNumber([context JSGlobalContextRef], number, &exception);
+    if (exception) {
+        [context notifyException:exception];
+        return [JSValue valueWithUndefinedInContext:context];
+    }
+    return [JSValue valueWithJSValueRef:bigInt inContext:context];
 }
 
 + (JSValue *)valueWithNewPromiseInContext:(JSContext *)context fromExecutor:(void (^)(JSValue *, JSValue *))executor
@@ -460,6 +504,15 @@ inline Expected<Result, JSValueRef> performPropertyOperation(NSStringFunction st
     return JSValueIsSymbol([_context JSGlobalContextRef], m_value);
 #else
     return toJS(m_value).isSymbol();
+#endif
+}
+
+- (BOOL)isBigInt
+{
+#if !CPU(ADDRESS64)
+    return JSValueIsBigInt([_context JSGlobalContextRef], m_value);
+#else
+    return toJS(m_value).isBigInt();
 #endif
 }
 

--- a/Source/JavaScriptCore/API/JSValueRef.h
+++ b/Source/JavaScriptCore/API/JSValueRef.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2019 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,8 @@ typedef enum {
     kJSTypeNumber,
     kJSTypeString,
     kJSTypeObject,
-    kJSTypeSymbol JSC_API_AVAILABLE(macos(10.15), ios(13.0))
+    kJSTypeSymbol JSC_API_AVAILABLE(macos(10.15), ios(13.0)),
+    kJSTypeBigInt JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA))
 } JSType;
 
 /*!
@@ -154,6 +155,15 @@ JS_EXPORT bool JSValueIsString(JSContextRef ctx, JSValueRef value);
 @result         true if value's type is the symbol type, otherwise false.
 */
 JS_EXPORT bool JSValueIsSymbol(JSContextRef ctx, JSValueRef value) JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+
+/*!
+@function
+@abstract       Tests whether a JavaScript value's type is the bigint type.
+@param ctx      The execution context to use.
+@param value    The JSValue to test.
+@result         true if value's type is the bigint type, otherwise false.
+*/
+JS_EXPORT bool JSValueIsBigInt(JSContextRef ctx, JSValueRef value) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 /*!
 @function
@@ -291,6 +301,81 @@ JS_EXPORT JSValueRef JSValueMakeString(JSContextRef ctx, JSStringRef string);
  @result              A unique JSValue of the symbol type, whose description matches the one provided.
  */
 JS_EXPORT JSValueRef JSValueMakeSymbol(JSContextRef ctx, JSStringRef description) JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+
+/*!
+    @function
+    @abstract         Creates a JavaScript bigint with a number.
+    @param ctx        The execution context to use.
+    @param number     The number to copy into the new bigint JSValue.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+    @result           A bigint JSValue of the number, or NULL if an exception is thrown.
+    @discussion       If number is not an integer this function will return an exception.
+*/
+JS_EXPORT JSValueRef JSBigIntCreateWithNumber(JSContextRef ctx, const double number, JSValueRef* exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Creates a JavaScript bigint with a 64-bit unsigned integer.
+    @param ctx        The execution context to use.
+    @param integer    The 64-bit unsigned integer to copy into the new bigint JSValue.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+    @result           A bigint JSValue of the integer, or NULL if an exception is thrown.
+*/
+JS_EXPORT JSValueRef JSBigIntCreateWithUInt64(JSContextRef ctx, const uint64_t integer, JSValueRef* exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Creates a JavaScript bigint with a 64-bit signed integer.
+    @param ctx        The execution context to use.
+    @param integer    The 64-bit signed integer to copy into the new bigint JSValue.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+    @result           A bigint JSValue of the integer, or NULL if an exception is thrown.
+*/
+JS_EXPORT JSValueRef JSBigIntCreateWithInt64(JSContextRef ctx, const int64_t integer, JSValueRef* exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Creates a JavaScript bigint with an integer represented in string.
+    @param ctx        The execution context to use.
+    @param string     The JSString representation of an integer.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+    @result           A bigint JSValue of the string, or NULL if an exception is thrown.
+*/
+JS_EXPORT JSValueRef JSBigIntCreateWithString(JSContextRef ctx, JSStringRef string, JSValueRef* exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Truncates a JavaScript bigint to an unsigned 64-bit integer and returns the resulting integer.
+    @param ctx        The execution context to use.
+    @param value      The bigint JSValue to Truncate.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+    @result           A 64-bit unsigned integer representing the bigint JSValue value.
+    @discussion       If value is not an bigint this function will return an exception.
+*/
+JS_EXPORT uint64_t JSBigIntToUInt64(JSContextRef ctx, JSValueRef value, JSValueRef* exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Truncates a JavaScript bigint to a singed 64-bit integer and returns the resulting integer.
+    @param ctx        The execution context to use.
+    @param value      The bigint JSValue to Truncate.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+    @result           A 64-bit signed integer representing the bigint JSValue value.
+    @discussion       If value is not an bigint this function will return an exception.
+*/
+JS_EXPORT int64_t JSBigIntToInt64(JSContextRef ctx, JSValueRef value, JSValueRef* exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Convert a bigint JSValue to JSString.
+    @param ctx        The execution context to use.
+    @param value      The bigint JSValue to Truncate.
+    @param radix      The integer in the range from 2 to 36 as the base for representing the bigint JSValue value.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+    @result           A JSString representing the bigint JSValue value, or NULL if an exception is thrown.
+    @discussion       If value is not an bigint this function will return an exception.
+*/
+JS_EXPORT JSStringRef JSBigIntToString(JSContextRef ctx, JSValueRef value, const size_t radix, JSValueRef* exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 /* Converting to and from JSON formatted strings */
 

--- a/Source/JavaScriptCore/API/tests/testapi.mm
+++ b/Source/JavaScriptCore/API/tests/testapi.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -648,6 +648,38 @@ static void testObjectiveCAPIMain()
         JSContext *context = [[JSContext alloc] init];
         JSValue *symbol = [JSValue valueWithNewSymbolFromDescription:@"dope" inContext:context];
         checkResult(@"Should be a created from Obj-C", symbol.isSymbol);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [context evaluateScript:@"BigInt('42');"];
+        JSValue *notBigInt = [context evaluateScript:@"'42'"];
+        checkResult(@"Should be a bigint value", bigInt.isBigInt);
+        checkResult(@"Should not be a bigint value", !notBigInt.isBigInt);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromString:@"42" inContext:context];
+        checkResult(@"Should be a created from Obj-C", bigInt.isBigInt);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromInt64:(int64_t)42 inContext:context];
+        checkResult(@"Should be a created from Obj-C", bigInt.isBigInt);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromUInt64:(uint64_t)42 inContext:context];
+        checkResult(@"Should be a created from Obj-C", bigInt.isBigInt);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromNumber:(double)42.0 inContext:context];
+        checkResult(@"Should be a created from Obj-C", bigInt.isBigInt);
     }
 
 // FIXME: These tests fail on tvOS and watchOS

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -288,6 +288,7 @@ public:
     JSValue toNumeric(JSGlobalObject*) const;
     JSValue toBigIntOrInt32(JSGlobalObject*) const;
     JSBigInt* asHeapBigInt() const;
+    JSBigInt* asBigInt(JSGlobalObject*) const;
 
     // toNumber conversion if it can be done without side effects.
     std::optional<double> toNumberFromPrimitive() const;

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -605,6 +605,22 @@ ALWAYS_INLINE JSBigInt* JSValue::asHeapBigInt() const
 }
 
 #endif // USE(JSVALUE64)
+
+ALWAYS_INLINE JSBigInt* JSValue::asBigInt(JSGlobalObject* globalObject) const
+{
+    ASSERT(isBigInt());
+
+#if USE(BIGINT32)
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (isBigInt32())
+        RELEASE_AND_RETURN(scope, JSBigInt::createFrom(globalObject, bigInt32AsInt32()));
+#endif
+
+    UNUSED_PARAM(globalObject);
+    ASSERT(isHeapBigInt());
+    return asHeapBigInt();
+}
 
 #if USE(BIGINT32)
 inline JSValue::JSValue(EncodeAsBigInt32Tag, int32_t value)


### PR DESCRIPTION
#### 20b3579ba20bed255dc974af5c41a9a59f9d818e
<pre>
[WIP] Introduce BigInt Public C API in JavaScriptCore

Reviewed by NOBODY (OOPS!).

JavaScriptCore framework provides the ability to evaluate
JavaScript programs within applications developed using
Swift and Object-C. While JavaScriptCore APIs support all
JavaScript primitive types except for BigInt type. This patch
introduces BigInt public C APIs for type verification,
type access, value creation, and value conversion.

* Source/JavaScriptCore/API/APICast.h:
(toRef):
(toBigIntRef):
* Source/JavaScriptCore/API/JSBase.h:
* Source/JavaScriptCore/API/JSBigIntRef.cpp: Added.
(JSBigIntCreateWithNumber):
(JSBigIntCreateWithString):
(JSBigIntToString):
* Source/JavaScriptCore/API/JSBigIntRef.h: Added.
* Source/JavaScriptCore/API/JSValue.h:
* Source/JavaScriptCore/API/JSValue.mm:
(-[JSValue isBigInt]):
* Source/JavaScriptCore/API/JSValueRef.cpp:
(JSValueGetType):
(JSValueIsBigInt):
(JSValueMakeBigInt):
(JSValueToBigInt):
* Source/JavaScriptCore/API/JSValueRef.h:
* Source/JavaScriptCore/API/JavaScript.h:
* Source/JavaScriptCore/API/tests/testapi.cpp:
(TestAPI::checkIsBigIntType):
(TestAPI::testBigInt):
(testCAPIViaCpp):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::stringToBigInt):
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::asBigInt const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12c86af63d5b091c9a140592b9517dee54f59d7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39311 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41664 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41845 "Hash 12c86af6 for PR 24294 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15619 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/41845 "Hash 12c86af6 for PR 24294 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39885 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/41845 "Hash 12c86af6 for PR 24294 does not build (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43123 "Hash 12c86af6 for PR 24294 does not build (failure)") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/32764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/35688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/43123 "Hash 12c86af6 for PR 24294 does not build (failure)") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/38937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/43123 "Hash 12c86af6 for PR 24294 does not build (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45943 "Hash 12c86af6 for PR 24294 does not build (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/45943 "Hash 12c86af6 for PR 24294 does not build (failure)") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->