### PR TITLE
Fix PlayStation WPE build of WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityControllerPlayStation.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityControllerPlayStation.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AccessibilityController.h"
+
+#include "AccessibilityUIElement.h"
+#include <WebCore/NotImplemented.h>
+
+namespace WTR {
+
+void AccessibilityController::resetToConsistentState()
+{
+    notImplemented();
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityController::accessibleElementById(JSStringRef id)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityController::platformName()
+{
+    notImplemented();
+    return nullptr;
+}
+
+void AccessibilityController::injectAccessibilityPreference(JSStringRef domain, JSStringRef key, JSStringRef value)
+{
+    notImplemented();
+}
+
+Ref<AccessibilityUIElement> AccessibilityController::rootElement()
+{
+    notImplemented();
+    return AccessibilityUIElement::create(nullptr);
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityController::focusedElement()
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityController::addNotificationListener(JSValueRef)
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityController::removeNotificationListener()
+{
+    notImplemented();
+    return false;
+}
+
+void AccessibilityController::overrideClient(JSStringRef)
+{
+}
+
+} // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Tools/WebKitTestRunner/PlatformPlayStation.cmake
+++ b/Tools/WebKitTestRunner/PlatformPlayStation.cmake
@@ -1,7 +1,9 @@
 list(APPEND WebKitTestRunner_SOURCES
     cairo/TestInvocationCairo.cpp
 
+    libwpe/EventSenderProxyClientLibWPE.cpp
     libwpe/EventSenderProxyLibWPE.cpp
+    libwpe/PlatformWebViewClientLibWPE.cpp
     libwpe/PlatformWebViewLibWPE.cpp
 
     playstation/TestControllerPlayStation.cpp
@@ -10,6 +12,7 @@ list(APPEND WebKitTestRunner_SOURCES
 )
 
 list(APPEND WebKitTestRunner_INCLUDE_DIRECTORIES
+    ${WebKitTestRunner_DIR}/libwpe
     ${WebKitTestRunner_DIR}/playstation
 )
 
@@ -19,6 +22,8 @@ list(APPEND WebKitTestRunner_PRIVATE_LIBRARIES
 )
 
 list(APPEND TestRunnerInjectedBundle_SOURCES
+    InjectedBundle/playstation/AccessibilityControllerPlayStation.cpp
+    InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
     InjectedBundle/playstation/ActivateFontsPlayStation.cpp
     InjectedBundle/playstation/InjectedBundlePlayStation.cpp
     InjectedBundle/playstation/TestRunnerPlayStation.cpp

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -27,10 +27,13 @@
 #include "EventSenderProxy.h"
 
 #include "EventSenderProxyClientLibWPE.h"
-#include "EventSenderProxyClientWPE.h"
 #include "TestController.h"
 #include <WebCore/NotImplemented.h>
 #include <wtf/MonotonicTime.h>
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#include "EventSenderProxyClientWPE.h"
+#endif
 
 namespace WTR {
 

--- a/Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp
@@ -27,11 +27,14 @@
 #include "PlatformWebView.h"
 
 #include "PlatformWebViewClientLibWPE.h"
-#include "PlatformWebViewClientWPE.h"
 #include "TestController.h"
 #include <cstdio>
 #include <wtf/RunLoop.h>
 #include <wtf/text/WTFString.h>
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#include "PlatformWebViewClientWPE.h"
+#endif
 
 namespace WTR {
 


### PR DESCRIPTION
#### 2cc8f74ab704eb21c09d89ffce90367aee307f03
<pre>
Fix PlayStation WPE build of WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=269247">https://bugs.webkit.org/show_bug.cgi?id=269247</a>

Reviewed by Fujii Hironori.

Add stubs for the accessibility within the InjectedBundle for PlayStation. Fix
a typo in `AccessibilityUIElementWin.cpp` while there.

Include additional libWPE files to the build and guard `ENABLE(WPE_PLATFORM)`.

* Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityControllerPlayStation.cpp: Added.
* Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp: Copied from Tools\WebKitTestRunner\InjectedBundle\win\AccessibilityUIElementWin.cpp.
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp:
* Tools/WebKitTestRunner/PlatformPlayStation.cmake:
* Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp:
* Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp:

Canonical link: <a href="https://commits.webkit.org/274509@main">https://commits.webkit.org/274509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4319ff6bd7eb5c549f1677a2d4cf99b3e290851

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41847 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15621 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15387 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13371 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43125 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35682 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5147 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->