### PR TITLE
[UnifedPDF] Hook up accessibility for Unified PDF

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
@@ -116,6 +116,13 @@
 - (PDFDestination *)namedDestination:(NSString *)name;
 @end
 
+@interface PDFDocument ()
+- (NSArray *)accessibilityChildren:(id)parent;
+- (NSArray *)accessibilityVisibleChildren:(NSArray<PDFPage *>*)visiblePages;
+- (void)resetAccessibilityTree;
+- (NSArray *)accessibilityPageElements;
+@end
+
 @interface PDFPage (IPI)
 - (CGPDFPageLayoutRef) pageLayout;
 @end

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -180,7 +180,6 @@ private:
 
     id accessibilityHitTest(const WebCore::IntPoint&) const override;
     id accessibilityObject() const override;
-    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
 
     NSEvent *nsEventForWebMouseEvent(const WebMouseEvent&);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1594,17 +1594,6 @@ NSData *PDFPlugin::liveData() const
     return originalData();
 }
 
-id PDFPlugin::accessibilityAssociatedPluginParentForElement(WebCore::Element* element) const
-{
-    if (!m_activeAnnotation)
-        return nil;
-
-    if (m_activeAnnotation->element() != element)
-        return nil;
-
-    return [m_activeAnnotation->annotation() accessibilityNode];
-}
-
 id PDFPlugin::accessibilityHitTest(const WebCore::IntPoint& point) const
 {
     return [m_accessibilityObject accessibilityHitTestIntPoint:point];

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -47,6 +47,7 @@ OBJC_CLASS NSDictionary;
 OBJC_CLASS PDFAnnotation;
 OBJC_CLASS PDFDocument;
 OBJC_CLASS PDFSelection;
+OBJC_CLASS WKAccessibilityPDFDocumentObject;
 
 namespace WebCore {
 class FragmentedSharedBuffer;
@@ -117,7 +118,6 @@ public:
     bool isLocked() const;
 
     RetainPtr<PDFDocument> pdfDocument() const { return m_pdfDocument; }
-    RetainPtr<PDFDocument> pdfDocumentForPrinting() const { return m_pdfDocument; }
     WebCore::FloatSize pdfDocumentSizeForPrinting() const;
 
     virtual bool geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform);
@@ -158,7 +158,7 @@ public:
 
     virtual id accessibilityHitTest(const WebCore::IntPoint&) const = 0;
     virtual id accessibilityObject() const = 0;
-    virtual id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const = 0;
+    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const;
 
     bool isBeingDestroyed() const { return m_isBeingDestroyed; }
 
@@ -175,13 +175,19 @@ public:
     WebCore::IntPoint convertFromPluginToRootView(const WebCore::IntPoint&) const;
     WebCore::IntRect convertFromPluginToRootView(const WebCore::IntRect&) const;
     WebCore::IntRect boundsOnScreen() const;
+    WebCore::FloatRect convertFromPDFViewToScreenForAccessibility(const WebCore::FloatRect&) const;
+    WebCore::IntPoint convertFromPDFViewToRootView(const WebCore::IntPoint&) const;
+    WebCore::IntPoint convertFromRootViewToPDFView(const WebCore::IntPoint&) const;
+
+    bool showContextMenuAtPoint(const WebCore::IntPoint&);
+    WebCore::AXObjectCache* axObjectCache() const;
 
     WebCore::ScrollPosition scrollPositionForTesting() const { return scrollPosition(); }
     WebCore::Scrollbar* horizontalScrollbar() const override { return m_horizontalScrollbar.get(); }
     WebCore::Scrollbar* verticalScrollbar() const override { return m_verticalScrollbar.get(); }
+    void setScrollOffset(const WebCore::ScrollOffset&) final;
 
     virtual void didAttachScrollingNode() { }
-
     virtual void didChangeSettings() { }
 
     // HUD Actions.
@@ -196,6 +202,9 @@ public:
 
     WebCore::ScrollPosition scrollPosition() const final;
 
+#if PLATFORM(MAC)
+    PDFPluginAnnotation* activeAnnotation() const { return m_activeAnnotation.get(); }
+#endif
     virtual void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) = 0;
     void didMutatePDFDocument() { m_pdfDocumentWasMutated = true; }
 
@@ -271,7 +280,6 @@ protected:
     bool isScrollableOrRubberbandable() final { return true; }
     bool hasScrollableOrRubberbandableAncestor() final { return true; }
     WebCore::IntRect scrollableAreaBoundingBox(bool* = nullptr) const final;
-    void setScrollOffset(const WebCore::ScrollOffset&) final;
     bool isActive() const final;
     bool isScrollCornerVisible() const final { return false; }
     WebCore::ScrollPosition minimumScrollPosition() const final;
@@ -328,6 +336,7 @@ protected:
     uint64_t m_streamedBytes { 0 };
 
     RetainPtr<PDFDocument> m_pdfDocument;
+    RetainPtr<WKAccessibilityPDFDocumentObject> m_accessibilityDocumentObject;
 
     String m_suggestedFilename;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -275,7 +275,7 @@ private:
 
     id accessibilityHitTest(const WebCore::IntPoint&) const override;
     id accessibilityObject() const override;
-    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
+    id accessibilityHitTestIntPoint(const WebCore::IntPoint&) const;
 
     void paint(WebCore::GraphicsContext&, const WebCore::IntRect&) override;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2519,19 +2519,20 @@ LookupTextResult UnifiedPDFPlugin::lookupTextAtLocation(const FloatPoint& rootVi
     return { lookupText, m_currentSelection };
 }
 
-id UnifiedPDFPlugin::accessibilityHitTest(const IntPoint&) const
+id UnifiedPDFPlugin::accessibilityHitTestIntPoint(const WebCore::IntPoint& point) const
 {
-    return nil;
+    auto convertedPoint =  convertFromRootViewToPDFView(point);
+    return [m_accessibilityDocumentObject accessibilityHitTest:convertedPoint];
+}
+
+id UnifiedPDFPlugin::accessibilityHitTest(const WebCore::IntPoint& point) const
+{
+    return accessibilityHitTestIntPoint(point);
 }
 
 id UnifiedPDFPlugin::accessibilityObject() const
 {
-    return nil;
-}
-
-id UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement(Element*) const
-{
-    return nil;
+    return m_accessibilityDocumentObject.get();
 }
 
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -921,7 +921,7 @@ bool PluginView::isBeingDestroyed() const
 
 RetainPtr<PDFDocument> PluginView::pdfDocumentForPrinting() const
 {
-    return m_plugin->pdfDocumentForPrinting();
+    return m_plugin->pdfDocument();
 }
 
 WebCore::FloatSize PluginView::pdfDocumentSizeForPrinting() const


### PR DESCRIPTION
#### 1f1b259fc291228f8aa3a199626845e0529e44bc
<pre>
[UnifedPDF] Hook up accessibility for Unified PDF
Bug 269249 - ([UnifedPDF] Hook up accessibility for Unified PDF)
<a href="https://rdar.apple.com/118903435">rdar://118903435</a> ([UnifedPDF] Hook up accessibility for Unified PDF)

Reviewed by Simon Fraser.

This commit add support so that UnifiedPDF is accessible
This commit create WKAccessibilityPDFDocumentObject as a UnifedPDF accessibility wrapper, which is different from WKPDFPluginAccessibilityObject in that this object does not depends on any layer codes. Previously, the accessibility communication point between webkit and pdfkit is in LayerController. I move the communication point to pdfDocument for better code reuse and less dependency.
Some Todos:
    1. stop accessing the plugin on the accessibility thread
    2. move WKAccessibilityPDFDocumentObject to its own file
    3. resolve coordinate space for better visual experience

* Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::accessibilityAssociatedPluginParentForElement const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::pdfDocument const):
(WebKit::PDFPluginBase::didAttachScrollingNode):
(WebKit::PDFPluginBase::activeAnnotation const):
(WebKit::PDFPluginBase::pdfDocumentForPrinting const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(-[WKAccessibilityPDFDocumentObject initWithPDFDocument:andElement:]):
(-[WKAccessibilityPDFDocumentObject setPDFPlugin:]):
(-[WKAccessibilityPDFDocumentObject setPDFDocument:]):
(-[WKAccessibilityPDFDocumentObject isAccessibilityElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityFocusedUIElement]):
(-[WKAccessibilityPDFDocumentObject document]):
(-[WKAccessibilityPDFDocumentObject accessibilityVisibleChildren]):
(-[WKAccessibilityPDFDocumentObject parent]):
(-[WKAccessibilityPDFDocumentObject setParent:]):
(-[WKAccessibilityPDFDocumentObject accessibilityAttributeValue:]):
(-[WKAccessibilityPDFDocumentObject accessibilityAttributeNames]):
(-[WKAccessibilityPDFDocumentObject accessibilityShouldUseUniqueId]):
(-[WKAccessibilityPDFDocumentObject accessibilityArrayAttributeCount:]):
(-[WKAccessibilityPDFDocumentObject accessibilityChildren]):
(-[WKAccessibilityPDFDocumentObject accessibilityHitTest:]):
(-[WKAccessibilityPDFDocumentObject gotoDestination:]):
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::showContextMenuAtPoint):
(WebKit::PDFPluginBase::convertFromPDFViewToRootView const):
(WebKit::PDFPluginBase::convertFromPDFViewToScreenForAccessibility const):
(WebKit::PDFPluginBase::axObjectCache const):
(WebKit::PDFPluginBase::convertFromRootViewToPDFView const):
(WebKit::PDFPluginBase::accessibilityAssociatedPluginParentForElement const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::accessibilityHitTestIntPoint const):
(WebKit::UnifiedPDFPlugin::accessibilityHitTest const):
(WebKit::UnifiedPDFPlugin::accessibilityObject const):
(WebKit::UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement const): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::pdfDocumentForPrinting const):

Canonical link: <a href="https://commits.webkit.org/274775@main">https://commits.webkit.org/274775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/003261e269bb54df2abc87886d72d98a85a54e0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42485 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16282 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13820 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36260 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39581 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16375 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8967 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->