### PR TITLE
[CMake] Support USE(SKIA) build on PlayStation

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -1,9 +1,14 @@
-include(platform/Cairo.cmake)
 include(platform/Curl.cmake)
-include(platform/FreeType.cmake)
 include(platform/ImageDecoders.cmake)
 include(platform/OpenSSL.cmake)
 include(platform/TextureMapper.cmake)
+
+if (USE_CAIRO)
+    include(platform/Cairo.cmake)
+    include(platform/FreeType.cmake)
+elseif (USE_SKIA)
+    include(platform/Skia.cmake)
+endif ()
 
 list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     ${WEBCORE_DIR}/platform
@@ -127,7 +132,6 @@ endif ()
 set(WebCore_MODULES
     Brotli
     CURL
-    Cairo
     EGL
     Fontconfig
     Freetype
@@ -142,6 +146,10 @@ set(WebCore_MODULES
     WebKitRequirements
     WebP
 )
+
+if (USE_CAIRO)
+    list(APPEND WebCore_MODULES Cairo)
+endif ()
 
 if (USE_LCMS)
     list(APPEND WebCore_MODULES LCMS2)

--- a/Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
+++ b/Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
@@ -44,7 +44,9 @@ static void loadLibraryOrExit(const char* name)
 int main(int argc, char** argv)
 {
     loadLibraryOrExit(WebKitRequirements_LOAD_AT);
+#if USE(CAIRO) && defined(Cairo_LOAD_AT)
     loadLibraryOrExit(Cairo_LOAD_AT);
+#endif
     loadLibraryOrExit("libWebKit");
     // load backend libraries as needed here
 

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -59,15 +59,11 @@ list(APPEND WebKit_SOURCES
     Platform/unix/LoggingUnix.cpp
     Platform/unix/ModuleUnix.cpp
 
-    Shared/API/c/cairo/WKImageCairo.cpp
-
     Shared/API/c/curl/WKCertificateInfoCurl.cpp
 
     Shared/API/c/playstation/WKEventPlayStation.cpp
 
     Shared/curl/WebCoreArgumentCodersCurl.cpp
-
-    Shared/freetype/WebCoreArgumentCodersFreeType.cpp
 
     Shared/libwpe/NativeWebKeyboardEventLibWPE.cpp
     Shared/libwpe/NativeWebMouseEventLibWPE.cpp
@@ -94,8 +90,6 @@ list(APPEND WebKit_SOURCES
     UIProcess/API/C/playstation/WKRunloop.cpp
     UIProcess/API/C/playstation/WKView.cpp
 
-    UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
-
     UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 
     UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp
@@ -103,8 +97,6 @@ list(APPEND WebKit_SOURCES
     UIProcess/WebsiteData/curl/WebsiteDataStoreCurl.cpp
 
     UIProcess/WebsiteData/playstation/WebsiteDataStorePlayStation.cpp
-
-    UIProcess/cairo/BackingStore.cpp
 
     UIProcess/libwpe/WebPasteboardProxyLibWPE.cpp
 
@@ -140,13 +132,11 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics"
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics/threadedcompositor"
     "${WEBKIT_DIR}/Shared/libwpe"
-    "${WEBKIT_DIR}/UIProcess/API/C/cairo"
     "${WEBKIT_DIR}/UIProcess/API/C/curl"
     "${WEBKIT_DIR}/UIProcess/API/C/playstation"
     "${WEBKIT_DIR}/UIProcess/API/libwpe"
     "${WEBKIT_DIR}/UIProcess/API/playstation"
     "${WEBKIT_DIR}/UIProcess/CoordinatedGraphics"
-    "${WEBKIT_DIR}/UIProcess/cairo"
     "${WEBKIT_DIR}/UIProcess/playstation"
     "${WEBKIT_DIR}/WebProcess/WebCoreSupport/curl"
     "${WEBKIT_DIR}/WebProcess/WebPage/CoordinatedGraphics"
@@ -162,6 +152,40 @@ endif ()
 if (ENABLE_WEBDRIVER AND USE_WPE_BACKEND_PLAYSTATION)
     list(APPEND WebKit_SOURCES
         UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
+    )
+endif ()
+
+if (USE_CAIRO)
+    list(APPEND WebKit_SOURCES
+        Shared/API/c/cairo/WKImageCairo.cpp
+
+        Shared/freetype/WebCoreArgumentCodersFreeType.cpp
+
+        UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
+
+        UIProcess/cairo/BackingStore.cpp
+    )
+
+    list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBKIT_DIR}/UIProcess/API/C/cairo"
+        "${WEBKIT_DIR}/UIProcess/cairo"
+    )
+
+    list(APPEND WebKit_LIBRARIES
+        Cairo::Cairo
+        Freetype::Freetype
+    )
+
+    list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
+        Shared/API/c/cairo/WKImageCairo.h
+    )
+elseif (USE_SKIA)
+    list(APPEND WebKit_SOURCES
+        Shared/skia/WebCoreArgumentCodersSkia.cpp
+    )
+
+    list(APPEND WebKit_LIBRARIES
+        Skia
     )
 endif ()
 
@@ -195,8 +219,6 @@ endif ()
 
 # PlayStation specific
 list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
-    Shared/API/c/cairo/WKImageCairo.h
-
     Shared/API/c/curl/WKCertificateInfoCurl.h
 
     Shared/API/c/playstation/WKBasePlayStation.h

--- a/Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
@@ -35,13 +35,17 @@
 #include "WebEventFactory.h"
 #include "WebPageProxy.h"
 #include <WebCore/Region.h>
-#include <cairo.h>
 #include <wpe/wpe.h>
+
+#if USE(CAIRO)
+#include <cairo.h>
+#endif
 
 #if USE(GRAPHICS_LAYER_WC)
 #include "DrawingAreaProxyWC.h"
 #endif
 
+#if USE(CAIRO)
 static void drawPageBackground(cairo_t* ctx, const std::optional<WebCore::Color>& backgroundColor, const WebCore::IntRect& rect)
 {
     if (!backgroundColor || backgroundColor.value().isVisible())
@@ -54,6 +58,7 @@ static void drawPageBackground(cairo_t* ctx, const std::optional<WebCore::Color>
     cairo_set_operator(ctx, CAIRO_OPERATOR_OVER);
     cairo_fill(ctx);
 }
+#endif
 
 void WKPageHandleKeyboardEvent(WKPageRef pageRef, WKKeyboardEvent event)
 {
@@ -161,6 +166,7 @@ void WKPageHandleWheelEvent(WKPageRef pageRef, WKWheelEvent event)
 
 void WKPagePaint(WKPageRef pageRef, unsigned char* surfaceData, WKSize wkSurfaceSize, WKRect wkPaintRect)
 {
+#if USE(CAIRO)
     auto surfaceSize = WebKit::toIntSize(wkSurfaceSize);
     auto paintRect = WebKit::toIntRect(wkPaintRect);
     if (!surfaceData || surfaceSize.isEmpty())
@@ -193,4 +199,7 @@ void WKPagePaint(WKPageRef pageRef, unsigned char* surfaceData, WKSize wkSurface
 
     cairo_destroy(ctx);
     cairo_surface_destroy(surface);
+#else
+    // FIXME
+#endif
 }

--- a/Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp
+++ b/Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp
@@ -67,7 +67,9 @@ int main(int argc, char** argv)
     loadLibraryOrExit(Freetype_LOAD_AT);
     loadLibraryOrExit(Fontconfig_LOAD_AT);
     loadLibraryOrExit(HarfBuzz_LOAD_AT);
+#if USE(CAIRO) && defined(Cairo_LOAD_AT)
     loadLibraryOrExit(Cairo_LOAD_AT);
+#endif
 #if defined(LibPSL_LOAD_AT)
     loadLibraryOrExit(LibPSL_LOAD_AT);
 #endif

--- a/Source/cmake/OptionsPlayStation.cmake
+++ b/Source/cmake/OptionsPlayStation.cmake
@@ -102,7 +102,6 @@ if (ENABLE_WEBCORE)
 
     find_package(Brotli OPTIONAL_COMPONENTS dec)
     find_package(CURL 7.85.0 REQUIRED)
-    find_package(Cairo REQUIRED)
     find_package(EGL REQUIRED)
     find_package(Fontconfig REQUIRED)
     find_package(Freetype REQUIRED)
@@ -114,7 +113,6 @@ if (ENABLE_WEBCORE)
     list(APPEND PlayStationModule_TARGETS
         Brotli::dec
         CURL::libcurl
-        Cairo::Cairo
         Fontconfig::Fontconfig
         Freetype::Freetype
         HarfBuzz::HarfBuzz
@@ -264,12 +262,18 @@ SET_AND_EXPOSE_TO_BUILD(USE_INSPECTOR_SOCKET_SERVER ${ENABLE_REMOTE_INSPECTOR})
 SET_AND_EXPOSE_TO_BUILD(USE_UNIX_DOMAIN_SOCKETS ON)
 
 if (ENABLE_WEBCORE)
-    SET_AND_EXPOSE_TO_BUILD(USE_CAIRO ON)
     SET_AND_EXPOSE_TO_BUILD(USE_CURL ON)
-    SET_AND_EXPOSE_TO_BUILD(USE_FREETYPE ON)
     SET_AND_EXPOSE_TO_BUILD(USE_HARFBUZZ ON)
     SET_AND_EXPOSE_TO_BUILD(USE_LIBWPE ON)
     SET_AND_EXPOSE_TO_BUILD(USE_OPENSSL ON)
+
+    if (NOT USE_SKIA)
+        find_package(Cairo REQUIRED)
+        list(APPEND PlayStationModule_TARGETS Cairo::Cairo)
+
+        SET_AND_EXPOSE_TO_BUILD(USE_CAIRO ON)
+        SET_AND_EXPOSE_TO_BUILD(USE_FREETYPE ON)
+    endif ()
 
     if (USE_LCMS)
         set(LCMS2_NAMES SceVshLCMS2)
@@ -330,6 +334,12 @@ if (ENABLE_MINIBROWSER)
     find_library(TOOLKIT_LIBRARY ToolKitten)
     if (NOT TOOLKIT_LIBRARY)
         message(FATAL_ERROR "ToolKit library required to run MiniBrowser")
+    endif ()
+
+    # ToolKitten has a dependency on Cairo so find it here but don't turn on Cairo
+    if (USE_SKIA)
+        find_package(Cairo REQUIRED)
+        list(APPEND PlayStationModule_TARGETS Cairo::Cairo)
     endif ()
 endif ()
 

--- a/Tools/MiniBrowser/playstation/CMakeLists.txt
+++ b/Tools/MiniBrowser/playstation/CMakeLists.txt
@@ -1,5 +1,4 @@
-find_library(TOOLKIT_LIBRARY ToolKitten)
-set(MiniBrowser_DEPENDENCIES ToolKitten_CopyModule)
+set(MiniBrowser_DEPENDENCIES Cairo_CopyModule ToolKitten_CopyModule)
 
 set(MiniBrowser_PRIVATE_INCLUDE_DIRECTORIES
     ${CMAKE_BINARY_DIR}
@@ -22,8 +21,12 @@ set(MiniBrowser_LIBRARIES
 )
 set(MiniBrowser_FRAMEWORKS WebKit)
 
+# Currently Cairo is required for MiniBrowser on PlayStation
+list(APPEND MiniBrowser_DEFINITIONS USE_CAIRO=1)
+list(APPEND MiniBrowser_LIBRARIES Cairo::Cairo)
+
 if (USE_WPE_BACKEND_PLAYSTATION)
-    set(MiniBrowser_DEFINITIONS USE_WPE_BACKEND_PLAYSTATION)
+    list(APPEND MiniBrowser_DEFINITIONS USE_WPE_BACKEND_PLAYSTATION)
     list(APPEND MiniBrowser_LIBRARIES WebKit::WPEToolingBackends)
 endif ()
 

--- a/Tools/MiniBrowser/playstation/WebViewWindow.cpp
+++ b/Tools/MiniBrowser/playstation/WebViewWindow.cpp
@@ -34,11 +34,14 @@
 #include <WebKit/WKPreferencesRef.h>
 #include <WebKit/WKPreferencesRefPrivate.h>
 #include <WebKit/WKURL.h>
-#include <cairo.h>
 #include <map>
 #include <toolkitten/Application.h>
 #include <toolkitten/Cursor.h>
 #include <toolkitten/MessageDialog.h>
+
+#if defined(USE_CAIRO) && USE_CAIRO
+#include <cairo.h>
+#endif
 
 #if defined(USE_WPE_BACKEND_PLAYSTATION) && USE_WPE_BACKEND_PLAYSTATION
 #include <WPEToolingBackends/HeadlessViewBackend.h>
@@ -278,9 +281,11 @@ void WebViewWindow::setSize(toolkitten::IntSize size)
     Widget::setSize(size);
     WKViewSetSize(m_view.get(), toWKSize(size));
 
+#if defined(USE_CAIRO) && USE_CAIRO
     size_t surfaceSize = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, this->m_size.w) * this->m_size.h;
     m_surface = std::make_unique<unsigned char[]>(surfaceSize);
     memset(m_surface.get(), 0xff, surfaceSize);
+#endif
 }
 
 bool WebViewWindow::onKeyUp(int32_t virtualKeyCode)
@@ -368,6 +373,7 @@ bool WebViewWindow::onWheelMove(toolkitten::IntPoint point, toolkitten::IntPoint
 void WebViewWindow::paintSelf(IntPoint position)
 {
     if (!dirtyRects().empty()) {
+#if defined(USE_CAIRO) && USE_CAIRO
         cairo_surface_t* wkviewSurface = cairo_image_surface_create_for_data(m_surface.get(), CAIRO_FORMAT_ARGB32, this->m_size.w, this->m_size.h, cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, this->m_size.w));
         std::list<toolkitten::IntRect>::const_iterator it = dirtyRects().begin();
         toolkitten::IntRect unionRect = *it;
@@ -385,6 +391,7 @@ void WebViewWindow::paintSelf(IntPoint position)
             cairo_destroy(cr);
             cairo_surface_destroy(wkviewSurface);
         }
+#endif
     }
     if (m_active)
         Widget::paintSelf(position);

--- a/Tools/MiniBrowser/playstation/main.cpp
+++ b/Tools/MiniBrowser/playstation/main.cpp
@@ -63,7 +63,9 @@ static void initialize()
     loadLibraryOrExit(Fontconfig_LOAD_AT);
     loadLibraryOrExit(Freetype_LOAD_AT);
     loadLibraryOrExit(HarfBuzz_LOAD_AT);
+#if defined(USE_CAIRO) && USE_CAIRO && defined(Cairo_LOAD_AT)
     loadLibraryOrExit(Cairo_LOAD_AT);
+#endif
     loadLibraryOrExit(ToolKitten_LOAD_AT);
     loadLibraryOrExit(WebKitRequirements_LOAD_AT);
 #if defined(LibPSL_LOAD_AT)

--- a/Tools/TestWebKitAPI/playstation/main.cpp
+++ b/Tools/TestWebKitAPI/playstation/main.cpp
@@ -59,7 +59,9 @@ int main(int argc, char** argv)
     loadLibraryOrExit(Fontconfig_LOAD_AT);
     loadLibraryOrExit(Freetype_LOAD_AT);
     loadLibraryOrExit(HarfBuzz_LOAD_AT);
+#if USE(CAIRO) && defined(Cairo_LOAD_AT)
     loadLibraryOrExit(Cairo_LOAD_AT);
+#endif
     loadLibraryOrExit(WebKitRequirements_LOAD_AT);
 #endif
 #if defined(BUILDING_TestWebCore) || defined(BUILDING_TestWebKit) || defined(BUILDING_TestJavaScriptCore)

--- a/Tools/WebKitTestRunner/PlatformPlayStation.cmake
+++ b/Tools/WebKitTestRunner/PlatformPlayStation.cmake
@@ -1,6 +1,4 @@
 list(APPEND WebKitTestRunner_SOURCES
-    cairo/TestInvocationCairo.cpp
-
     libwpe/EventSenderProxyClientLibWPE.cpp
     libwpe/EventSenderProxyLibWPE.cpp
     libwpe/PlatformWebViewClientLibWPE.cpp
@@ -17,9 +15,16 @@ list(APPEND WebKitTestRunner_INCLUDE_DIRECTORIES
 )
 
 list(APPEND WebKitTestRunner_PRIVATE_LIBRARIES
-    Cairo::Cairo
     WebKit::WPEToolingBackends
 )
+
+if (USE_CAIRO)
+    list(APPEND WebKitTestRunner_SOURCES cairo/TestInvocationCairo.cpp)
+    list(APPEND WebKitTestRunner_PRIVATE_LIBRARIES Cairo::Cairo)
+elseif (USE_SKIA)
+    list(APPEND WebKitTestRunner_SOURCES skia/TestInvocationSkia.cpp)
+    list(APPEND WebKitTestRunner_PRIVATE_LIBRARIES Skia)
+endif ()
 
 list(APPEND TestRunnerInjectedBundle_SOURCES
     InjectedBundle/playstation/AccessibilityControllerPlayStation.cpp


### PR DESCRIPTION
#### b2384277ae56839abfca022f4c70fdf6f9b38cc3
<pre>
[CMake] Support USE(SKIA) build on PlayStation
<a href="https://bugs.webkit.org/show_bug.cgi?id=269250">https://bugs.webkit.org/show_bug.cgi?id=269250</a>

Reviewed by Fujii Hironori.

Handle the `USE(SKIA)` case within the PlayStation build of WebKit. Modify the
build to handle both `USE(CAIRO)` and `USE(SKIA)`. Guard more code with
`USE(CAIRO)`.

Cairo has to be used when building the MiniBrowser at this time so also support
that.

Building Skia itself in a cross platform way will be in separate patches.

* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp:
(main):
* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp:
(WKPagePaint):
* Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp:
(main):
* Source/cmake/OptionsPlayStation.cmake:
* Tools/MiniBrowser/playstation/CMakeLists.txt:
* Tools/MiniBrowser/playstation/WebViewWindow.cpp:
(WebViewWindow::setSize):
(WebViewWindow::paintSelf):
* Tools/MiniBrowser/playstation/main.cpp:
(initialize):
* Tools/TestWebKitAPI/playstation/main.cpp:
(main):
* Tools/WebKitTestRunner/PlatformPlayStation.cmake:

Canonical link: <a href="https://commits.webkit.org/274675@main">https://commits.webkit.org/274675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd7058403a1d2928eb71128b6c2e3300adf9be51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18731 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42059 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/21637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16060 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40326 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/21637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/21637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/33205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/21637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39378 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46386 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/9538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5221 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->