### PR TITLE
Guard BackingStore with USE(CAIRO)

### DIFF
--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -48,7 +48,7 @@
 #include <wtf/glib/RunLoopSourcePriority.h>
 #endif
 
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
 #include "BackingStore.h"
 #endif
 
@@ -57,11 +57,11 @@ using namespace WebCore;
 
 DrawingAreaProxyCoordinatedGraphics::DrawingAreaProxyCoordinatedGraphics(WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::CoordinatedGraphics, webPageProxy, webProcessProxy)
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
     , m_discardBackingStoreTimer(RunLoop::current(), this, &DrawingAreaProxyCoordinatedGraphics::discardBackingStore)
 #endif
 {
-#if USE(GLIB_EVENT_LOOP) && !PLATFORM(WPE)
+#if USE(GLIB_EVENT_LOOP) && USE(CAIRO) && !PLATFORM(WPE)
     m_discardBackingStoreTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
 #endif
 }
@@ -73,7 +73,7 @@ DrawingAreaProxyCoordinatedGraphics::~DrawingAreaProxyCoordinatedGraphics()
         exitAcceleratedCompositingMode();
 }
 
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
 void DrawingAreaProxyCoordinatedGraphics::paint(cairo_t* cr, const IntRect& rect, Region& unpaintedRegion)
 {
     unpaintedRegion = rect;
@@ -166,7 +166,7 @@ void DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange()
 
 void DrawingAreaProxyCoordinatedGraphics::setBackingStoreIsDiscardable(bool isBackingStoreDiscardable)
 {
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
     if (m_isBackingStoreDiscardable == isBackingStoreDiscardable)
         return;
 
@@ -199,7 +199,7 @@ void DrawingAreaProxyCoordinatedGraphics::update(uint64_t, UpdateInfo&& updateIn
 
     // FIXME: Handle the case where the view is hidden.
 
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
     incorporateUpdate(WTFMove(updateInfo));
 #endif
 
@@ -215,7 +215,7 @@ void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(uint64
 void DrawingAreaProxyCoordinatedGraphics::exitAcceleratedCompositingMode(uint64_t, UpdateInfo&& updateInfo)
 {
     exitAcceleratedCompositingMode();
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
     incorporateUpdate(WTFMove(updateInfo));
 #endif
 }
@@ -233,7 +233,7 @@ bool DrawingAreaProxyCoordinatedGraphics::alwaysUseCompositing() const
 void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)
 {
     ASSERT(!isInAcceleratedCompositingMode());
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
     m_backingStore = nullptr;
 #endif
     m_layerTreeContext = layerTreeContext;
@@ -281,7 +281,7 @@ void DrawingAreaProxyCoordinatedGraphics::didUpdateGeometry()
         sendUpdateGeometry();
 }
 
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
 void DrawingAreaProxyCoordinatedGraphics::discardBackingStoreSoon()
 {
     if (!m_backingStore || !m_isBackingStoreDiscardable || m_discardBackingStoreTimer.isActive())

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -31,7 +31,7 @@
 #include "LayerTreeContext.h"
 #include <wtf/RunLoop.h>
 
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
 typedef struct _cairo cairo_t;
 #endif
 
@@ -48,7 +48,7 @@ public:
     DrawingAreaProxyCoordinatedGraphics(WebPageProxy&, WebProcessProxy&);
     virtual ~DrawingAreaProxyCoordinatedGraphics();
 
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
     void paint(cairo_t*, const WebCore::IntRect&, WebCore::Region& unpaintedRegion);
 #endif
 
@@ -88,7 +88,7 @@ private:
     void sendUpdateGeometry();
     void didUpdateGeometry();
 
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
     bool forceUpdateIfNeeded();
     void incorporateUpdate(UpdateInfo&&);
     void discardBackingStoreSoon();
@@ -120,7 +120,7 @@ private:
     WebCore::IntSize m_lastSentSize;
 
 
-#if !PLATFORM(WPE)
+#if USE(CAIRO) && !PLATFORM(WPE)
     bool m_isBackingStoreDiscardable { true };
     bool m_inForceUpdate { false };
     std::unique_ptr<BackingStore> m_backingStore;


### PR DESCRIPTION
#### 0bb4f2e6550c70d93fbd0a3b4e6c0967e3cadd7e
<pre>
Guard BackingStore with USE(CAIRO)
<a href="https://bugs.webkit.org/show_bug.cgi?id=269252">https://bugs.webkit.org/show_bug.cgi?id=269252</a>

Reviewed by Adrian Perez de Castro.

In `DrawingAreaProxyCoordinatedGraphics` the use of `BackingStore` was just
checking for `!PLATFORM(WPE)`. Compiling with `USE_CAIRO` to `OFF` would fail
so update the guard to also check for cairo.

* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:

Canonical link: <a href="https://commits.webkit.org/274541@main">https://commits.webkit.org/274541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/741b9639b98bc48484a5c7b70a4a4ab80af2fae7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41861 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35227 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41633 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32886 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13351 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39155 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37395 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15745 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8806 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->