### PR TITLE
[WebXR] Use linear RGBA format for back buffer

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -295,7 +295,7 @@ PlatformGLObject WebXROpaqueFramebuffer::allocateRenderbufferStorage(GraphicsCon
 
 PlatformGLObject WebXROpaqueFramebuffer::allocateColorStorage(GraphicsContextGL& gl, GCGLsizei samples, IntSize size)
 {
-    return allocateRenderbufferStorage(gl, samples, GL::SRGB8_ALPHA8, size);
+    return allocateRenderbufferStorage(gl, samples, GL::RGBA8, size);
 }
 
 PlatformGLObject WebXROpaqueFramebuffer::allocateDepthStencilStorage(GraphicsContextGL& gl, GCGLsizei samples, IntSize size)


### PR DESCRIPTION
#### 9390487621338e7d449be74b6c63078aecb33844
<pre>
[WebXR] Use linear RGBA format for back buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=269257">https://bugs.webkit.org/show_bug.cgi?id=269257</a>
<a href="https://rdar.apple.com/122842875">rdar://122842875</a>

Reviewed by Mike Wyrzykowski.

Use GL_RBGA8, instead of GL_SRGB8_ALPHA8 for WebXROpaqueFramebuffer color
buffers.

The CSS color spec defines the colorspace of content as sRGB. The sRGB
spec (<a href="https://en.wikipedia.org/wiki/SRGB)">https://en.wikipedia.org/wiki/SRGB)</a> defines two concepts:
1) The gamut (which is the &quot;color space&quot;), and
2) The &quot;gamma&quot; or &quot;transfer function&quot;

By default, when the browser interprets the content of a canvas, it treats 8-bpp
formats as in the sRGB colorspace encoded with the sRGB gamma transfer function.

In OpenGL and WebGL, the output of fragment shaders are considered to be
&quot;linear&quot;, (ie. 0.5 maps to floor(0.5 * 255)). The intention of specifying color
buffers with GL_SRGA8_ALPHA8 was to enable the sRGB transfer function to
fragment outputs, automatically ensuring the color buffer contained sRGB gamma
encoded values.

While automatic transfer from linear to sRGB gamma is the &quot;right thing to do&quot;,
this feature is a notoriously buggy and inconsitent in OpenGL
implementations. WebGL doesn&apos;t provide an API for controlling the enablement of
the sRGB transfer function, so using GL_SRGB8_ALPHA8 for WebXROpaqueFramebuffer
is the wrong thing to do. This makes the behavior of WebXROpaqueFramebuffer
consistent with standard WebGL color buffers.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::allocateColorStorage):

Canonical link: <a href="https://commits.webkit.org/274526@main">https://commits.webkit.org/274526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a35147ae41a90c412e84567d03a088caea56f33a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15652 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43156 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39165 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37407 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15762 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5157 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->