### PR TITLE
UnifiedPDF: Support for unlocking locked PDFs

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -644,7 +644,8 @@ void PDFPlugin::installPDFDocument()
 
     notifyScrollPositionChanged(IntPoint([m_pdfLayerController scrollPosition]));
 
-    updatePDFHUDLocation();
+    updateHUDVisibility();
+    updateHUDLocation();
     updateScrollbars();
 
     tryRunScriptsInPDFDocument();
@@ -673,7 +674,8 @@ void PDFPlugin::attemptToUnlockPDF(const String& password)
     if (!isLocked()) {
         m_passwordField = nullptr;
 
-        updatePDFHUDLocation();
+        updateHUDVisibility();
+        updateHUDLocation();
         updateScrollbars();
     }
 }
@@ -809,7 +811,7 @@ bool PDFPlugin::geometryDidChange(const IntSize& pluginSize, const AffineTransfo
     CATransform3D transform = CATransform3DMakeScale(1, -1, 1);
     transform = CATransform3DTranslate(transform, 0, -pluginSize.height(), 0);
     
-    updatePDFHUDLocation();
+    updateHUDLocation();
     updateScrollbars();
 
     if (m_activeAnnotation)
@@ -1218,13 +1220,13 @@ void PDFPlugin::notifyContentScaleFactorChanged(CGFloat scaleFactor)
     if (handlesPageScaleFactor())
         m_view->setPageScaleFactor(scaleFactor, std::nullopt);
 
-    updatePDFHUDLocation();
+    updateHUDLocation();
     updateScrollbars();
 }
 
 void PDFPlugin::notifyDisplayModeChanged(int)
 {
-    updatePDFHUDLocation();
+    updateHUDLocation();
     updateScrollbars();
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -299,9 +299,11 @@ protected:
     virtual void destroyScrollbar(WebCore::ScrollbarOrientation);
 
 #if ENABLE(PDF_HUD)
-    void updatePDFHUDLocation();
+    void updateHUDLocation();
     WebCore::IntRect frameForHUDInRootViewCoordinates() const;
     bool hudEnabled() const;
+    bool shouldShowHUD() const;
+    void updateHUDVisibility();
 #endif
 
 #if !LOG_DISABLED

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -42,6 +42,7 @@ enum class DelegatedScrollingMode : uint8_t;
 namespace WebKit {
 
 struct PDFContextMenu;
+class PDFPluginPasswordField;
 class WebFrame;
 class WebMouseEvent;
 enum class WebEventType : uint8_t;
@@ -140,7 +141,6 @@ private:
     WebCore::IntSize contentsSize() const override;
     unsigned firstPageHeight() const override;
     unsigned heightForPage(PDFDocumentLayout::PageIndex) const;
-
 
     void scheduleRenderingUpdate();
 
@@ -310,6 +310,8 @@ private:
 
     bool isTaggedPDF() const;
 
+    void createPasswordEntryForm();
+
     PDFDocumentLayout m_documentLayout;
     RefPtr<WebCore::GraphicsLayer> m_rootLayer;
     RefPtr<WebCore::GraphicsLayer> m_scrollContainerLayer;
@@ -347,6 +349,8 @@ private:
     RetainPtr<PDFSelection> m_currentSelection;
 
     RetainPtr<WKPDFFormMutationObserver> m_pdfMutationObserver;
+
+    RefPtr<PDFPluginPasswordField> m_passwordField;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 56db500c6ff59a3ce287cdbce3a2a1dbc23f3db9
<pre>
UnifiedPDF: Support for unlocking locked PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=269260">https://bugs.webkit.org/show_bug.cgi?id=269260</a>
<a href="https://rdar.apple.com/118551131">rdar://118551131</a>

Reviewed by Simon Fraser.

Add support for unlocking PDFs. Right now the UI is just a lone text field,
a future patch will add more appropriate instructions.

Also fix a bug where we&apos;d show the HUD on top of a locked PDF.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::installPDFDocument):
(WebKit::PDFPlugin::attemptToUnlockPDF):
(WebKit::PDFPlugin::geometryDidChange):
(WebKit::PDFPlugin::notifyContentScaleFactorChanged):
(WebKit::PDFPlugin::notifyDisplayModeChanged):
Update visibility of the HUD when unlocking a PDF.
Also, rename &quot;PDFHUD&quot; to &quot;HUD&quot; in the context of PDFPlugin classes.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::geometryDidChange):
(WebKit::PDFPluginBase::shouldShowHUD const):
(WebKit::PDFPluginBase::updateHUDVisibility):
(WebKit::PDFPluginBase::visibilityDidChange):
(WebKit::PDFPluginBase::updateHUDLocation):
(WebKit::PDFPluginBase::updatePDFHUDLocation): Deleted.
Make HUD visibility a &quot;pull&quot; thing, with an update method that we can call
from anywhere.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
Hide the HUD once we get a PDFDocument and find out it&apos;s locked.
Also create a password field in the same case.

(WebKit::UnifiedPDFPlugin::createPasswordEntryForm):
(WebKit::UnifiedPDFPlugin::attemptToUnlockPDF):
Roughly borrowed from PDFPlugin; try unlocking the PDF, and rebuild the world
if it works out.

(WebKit::UnifiedPDFPlugin::updatePageBackgroundLayers):
Don&apos;t paint any page backgrounds if we are locked. The grey is better.

(WebKit::UnifiedPDFPlugin::scrollToFragmentIfNeeded):
Wait for the document to be unlocked before scrolling to the fragment.

Canonical link: <a href="https://commits.webkit.org/274519@main">https://commits.webkit.org/274519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f8b6382cb8cb5f00a161ce092e1bb8cdc135e15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41883 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15657 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13399 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43161 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35343 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37412 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8796 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->