### PR TITLE
[Unified Text Replacement] Support unified text replacement on macOS

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -133,6 +133,10 @@ class EmptyContextMenuClient final : public ContextMenuClient {
     void handleTranslation(const TranslationContextMenuInfo&) final { }
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    void handleSwapCharacters(IntRect) final { };
+#endif
+
 #if PLATFORM(GTK)
     void insertEmoji(LocalFrame&) final { }
 #endif

--- a/Source/WebCore/page/ContextMenuClient.h
+++ b/Source/WebCore/page/ContextMenuClient.h
@@ -62,6 +62,10 @@ public:
     virtual void handleTranslation(const TranslationContextMenuInfo&) = 0;
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    virtual void handleSwapCharacters(IntRect selectionBoundsInRootView) = 0;
+#endif
+
 #if PLATFORM(COCOA)
     virtual void searchWithSpotlight() = 0;
 #endif

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -641,6 +641,14 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         }
 #endif
         break;
+
+    case ContextMenuItemTagSwapCharacters:
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+        if (RefPtr view = frame->view())
+            m_client->handleSwapCharacters(view->contentsToRootView(enclosingIntRect(frame->selection().selectionBounds())));
+#endif
+        break;
+
 #if ENABLE(PDFJS)
     case ContextMenuItemPDFAutoSize:
         performPDFJSAction(*frame, "context-menu-auto-size"_s);
@@ -1031,6 +1039,11 @@ void ContextMenuController::populate()
 #if HAVE(TRANSLATION_UI_SERVICES)
         ContextMenuItem translateItem(ContextMenuItemType::Action, ContextMenuItemTagTranslate, contextMenuItemTagTranslate(selectedText));
         appendItem(translateItem, m_contextMenu.get());
+#endif
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+        ContextMenuItem swapCharactersItem(ContextMenuItemType::Action, ContextMenuItemTagSwapCharacters, contextMenuItemTagSwapCharacters());
+        appendItem(swapCharactersItem, m_contextMenu.get());
 #endif
 
 #if !PLATFORM(GTK)
@@ -1760,6 +1773,7 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
             break;
         case ContextMenuItemTagLookUpImage:
         case ContextMenuItemTagTranslate:
+        case ContextMenuItemTagSwapCharacters:
             break;
     }
 

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -265,6 +265,7 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagToggleVideoEnhancedFullscreen:
     case ContextMenuAction::ContextMenuItemTagLookUpImage:
     case ContextMenuAction::ContextMenuItemTagTranslate:
+    case ContextMenuAction::ContextMenuItemTagSwapCharacters:
     case ContextMenuAction::ContextMenuItemBaseCustomTag:
     case ContextMenuAction::ContextMenuItemLastCustomTag:
     case ContextMenuAction::ContextMenuItemBaseApplicationTag:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -153,6 +153,7 @@ enum ContextMenuAction {
     ContextMenuItemTagAddHighlightToNewQuickNote,
     ContextMenuItemTagLookUpImage,
     ContextMenuItemTagTranslate,
+    ContextMenuItemTagSwapCharacters,
     ContextMenuItemTagCopySubject,
     ContextMenuItemPDFSinglePageContinuous,
     ContextMenuItemPDFTwoPages,

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -503,6 +503,13 @@ String contextMenuItemTagTranslate(const String& selectedString)
 }
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+String contextMenuItemTagSwapCharacters()
+{
+    return WEB_UI_STRING("Swap characters", "Swap characters context menu item");
+}
+#endif
+
 #if ENABLE(UNIFIED_PDF)
 String contextMenuItemPDFOpenWithPreview()
 {

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -174,6 +174,9 @@ namespace WebCore {
 #if HAVE(TRANSLATION_UI_SERVICES)
     String contextMenuItemTagTranslate(const String& selectedString);
 #endif
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    String contextMenuItemTagSwapCharacters();
+#endif
 #if ENABLE(UNIFIED_PDF)
     WEBCORE_EXPORT String contextMenuItemPDFOpenWithPreview();
     WEBCORE_EXPORT String contextMenuItemPDFCopy();

--- a/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
@@ -132,6 +132,7 @@ enum {
     kWKContextMenuItemTagRevealImage,
     kWKContextMenuItemTagTranslate,
     kWKContextMenuItemTagCopyCroppedImage,
+    kWKContextMenuItemTagSwapCharacters,
     kWKContextMenuItemBaseApplicationTag = 10000
 };
 typedef uint32_t WKContextMenuItemTag;

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -581,6 +581,8 @@ inline WKContextMenuItemTag toAPI(WebCore::ContextMenuAction action)
         return kWKContextMenuItemTagRevealImage;
     case WebCore::ContextMenuItemTagTranslate:
         return kWKContextMenuItemTagTranslate;
+    case WebCore::ContextMenuItemTagSwapCharacters:
+        return kWKContextMenuItemTagSwapCharacters;
     case WebCore::ContextMenuItemTagCopySubject:
         return kWKContextMenuItemTagCopyCroppedImage;
     default:
@@ -795,6 +797,8 @@ inline WebCore::ContextMenuAction toImpl(WKContextMenuItemTag tag)
         return WebCore::ContextMenuItemTagLookUpImage;
     case kWKContextMenuItemTagTranslate:
         return WebCore::ContextMenuItemTagTranslate;
+    case kWKContextMenuItemTagSwapCharacters:
+        return WebCore::ContextMenuItemTagSwapCharacters;
     case kWKContextMenuItemTagCopyCroppedImage:
         return WebCore::ContextMenuItemTagCopySubject;
     case kWKContextMenuItemTagOpenLinkInThisWindow:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
@@ -58,6 +58,7 @@ NSString * const _WKMenuItemIdentifierShareMenu = @"WKMenuItemIdentifierShareMen
 NSString * const _WKMenuItemIdentifierSpeechMenu = @"WKMenuItemIdentifierSpeechMenu";
 
 NSString * const _WKMenuItemIdentifierTranslate = @"WKMenuItemIdentifierTranslate";
+NSString * const _WKMenuItemIdentifierSwapCharacters = @"WKMenuItemIdentifierSwapCharacters";
 NSString * const _WKMenuItemIdentifierCopySubject = @"WKMenuItemIdentifierCopySubject";
 
 NSString * const _WKMenuItemIdentifierSpellingMenu = @"WKMenuItemIdentifierSpellingMenu";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
@@ -59,6 +59,7 @@ WK_EXTERN NSString * const _WKMenuItemIdentifierAddHighlightToCurrentQuickNote W
 WK_EXTERN NSString * const _WKMenuItemIdentifierAddHighlightToNewQuickNote WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
 WK_EXTERN NSString * const _WKMenuItemIdentifierTranslate WK_API_AVAILABLE(macos(12.0), ios(15.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSwapCharacters WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 WK_EXTERN NSString * const _WKMenuItemIdentifierCopySubject WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 WK_EXTERN NSString * const _WKMenuItemIdentifierSpellingMenu WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -36,12 +36,18 @@
 #import "WebFrameProxy.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
+#import "WebTextReplacementData.h"
+#import "WebUnifiedTextReplacementContextData.h"
 #import "WebViewImpl.h"
 #import "_WKFrameHandleInternal.h"
 #import "_WKHitTestResultInternal.h"
 #import <pal/spi/mac/NSTextFinderSPI.h>
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/UnifiedTextReplacementAdditions.h>
+#endif
 
 _WKOverlayScrollbarStyle toAPIScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle> coreScrollbarStyle)
 {

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -845,6 +845,15 @@ void WebPageProxy::requestActiveNowPlayingSessionInfo(CompletionHandler<void(boo
     sendWithAsyncReply(Messages::WebPage::RequestActiveNowPlayingSessionInfo(), WTFMove(callback));
 }
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
+
+void WebPageProxy::handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView)
+{
+    protectedPageClient()->handleContextMenuSwapCharacters(selectionBoundsInRootView);
+}
+
+#endif
+
 void WebPageProxy::setLastNavigationWasAppInitiated(ResourceRequest& request)
 {
 #if ENABLE(APP_PRIVACY_REPORT)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -695,6 +695,10 @@ public:
     virtual void handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo&) = 0;
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
+    virtual void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView) = 0;
+#endif
+
 #if ENABLE(DATA_DETECTION)
     virtual void handleClickForDataDetectionResult(const WebCore::DataDetectorElementInfo&, const WebCore::IntPoint&) { }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2212,6 +2212,10 @@ public:
     void handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo&);
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView);
+#endif
+
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
     void createMediaSessionCoordinator(Ref<MediaSessionCoordinatorProxyPrivate>&&, CompletionHandler<void(bool)>&&);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -232,6 +232,10 @@ messages -> WebPageProxy {
     HandleContextMenuTranslation(struct WebCore::TranslationContextMenuInfo info)
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
+    HandleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView)
+#endif
+
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     ShowMediaControlsContextMenu(WebCore::FloatRect targetFrame, Vector<WebCore::MediaControlsContextMenuItem> items) -> (WebCore::MediaControlsContextMenuItem::ID selectedItemID)
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -302,6 +302,10 @@ private:
     void handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo&) override;
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
+    void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView) override;
+#endif
+
 #if ENABLE(DATA_DETECTION)
     void handleClickForDataDetectionResult(const WebCore::DataDetectorElementInfo&, const WebCore::IntPoint&) final;
 #endif

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1081,6 +1081,13 @@ void PageClientImpl::handleContextMenuTranslation(const TranslationContextMenuIn
 
 #endif // HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
+void PageClientImpl::handleContextMenuSwapCharacters(IntRect selectionBoundsInRootView)
+{
+    m_impl->handleContextMenuSwapCharacters(selectionBoundsInRootView);
+}
+#endif
+
 #if ENABLE(DATA_DETECTION)
 
 void PageClientImpl::handleClickForDataDetectionResult(const DataDetectorElementInfo& info, const IntPoint& clickLocation)

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -623,6 +623,9 @@ static NSString *menuItemIdentifier(const WebCore::ContextMenuAction action)
     case ContextMenuItemTagTranslate:
         return _WKMenuItemIdentifierTranslate;
 
+    case ContextMenuItemTagSwapCharacters:
+        return _WKMenuItemIdentifierSwapCharacters;
+
     case ContextMenuItemTagCopySubject:
         return _WKMenuItemIdentifierCopySubject;
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -689,6 +689,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     void handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo&);
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
+    void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView);
+#endif
+
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
     MediaSessionCoordinatorProxyPrivate* mediaSessionCoordinatorForTesting() { return m_coordinatorForTesting.get(); }
     void setMediaSessionCoordinatorForTesting(MediaSessionCoordinatorProxyPrivate*);
@@ -708,6 +712,22 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(INLINE_PREDICTIONS)
     void setInlinePredictionsEnabled(bool enabled) { m_inlinePredictionsEnabled = enabled; }
     bool inlinePredictionsEnabled() const { return m_inlinePredictionsEnabled; }
+#endif
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    void willBeginTextReplacementSession(const WTF::UUID&, CompletionHandler<void(const Vector<WebUnifiedTextReplacementContextData>&)>&&);
+
+    void didBeginTextReplacementSession(const WTF::UUID&, const Vector<WebUnifiedTextReplacementContextData>&);
+
+    void textReplacementSessionDidReceiveReplacements(const WTF::UUID&, const Vector<WebTextReplacementData>&, const WebUnifiedTextReplacementContextData&, bool finished);
+
+    void textReplacementSessionDidUpdateStateForReplacement(const WTF::UUID&, WebTextReplacementDataState, const WebTextReplacementData&, const WebUnifiedTextReplacementContextData&);
+
+    void didEndTextReplacementSession(const WTF::UUID&, bool accepted);
+
+    void textReplacementSessionDidReceiveTextWithReplacementRange(const WTF::UUID&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebUnifiedTextReplacementContextData&);
+
+    void textReplacementSessionDidReceiveEditAction(const WTF::UUID&, WebTextReplacementDataEditAction);
 #endif
 
 private:
@@ -805,6 +825,8 @@ private:
 #endif
 
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
+
+    Ref<WebPageProxy> protectedPage() const;
 
     WeakObjCPtr<NSView<WebViewImplDelegate>> m_view;
     std::unique_ptr<PageClient> m_pageClient;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -65,6 +65,10 @@ private:
     void handleTranslation(const WebCore::TranslationContextMenuInfo&) final;
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    void handleSwapCharacters(WebCore::IntRect selectionBoundsInRootView) final;
+#endif
+
 #if PLATFORM(GTK)
     void insertEmoji(WebCore::LocalFrame&) override;
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -109,6 +109,18 @@ void WebContextMenuClient::handleTranslation(const WebCore::TranslationContextMe
 
 #endif // HAVE(TRANSLATION_UI_SERVICES)
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+
+void WebContextMenuClient::handleSwapCharacters(WebCore::IntRect selectionBoundsInRootView)
+{
+    if (!m_page)
+        return;
+
+    m_page->send(Messages::WebPageProxy::HandleContextMenuSwapCharacters(selectionBoundsInRootView));
+}
+
+#endif
+
 } // namespace WebKit
 
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -879,8 +879,6 @@ std::optional<SimpleRange> WebPage::autocorrectionContextRange()
 {
     Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
 
-    VisiblePosition contextStartPosition;
-
     VisiblePosition startPosition = frame->selection().selection().start();
     VisiblePosition endPosition = frame->selection().selection().end();
 
@@ -888,8 +886,9 @@ std::optional<SimpleRange> WebPage::autocorrectionContextRange()
     constexpr unsigned maxContextLength = 100;
 
     auto firstPositionInEditableContent = startOfEditableContent(startPosition);
+
     if (startPosition != firstPositionInEditableContent) {
-        contextStartPosition = startPosition;
+        VisiblePosition contextStartPosition = startPosition;
         unsigned totalContextLength = 0;
 
         for (unsigned i = 0; i < minContextWordCount; ++i) {
@@ -911,7 +910,7 @@ std::optional<SimpleRange> WebPage::autocorrectionContextRange()
 
         VisiblePosition sentenceContextStartPosition = startOfSentence(startPosition);
         if (sentenceContextStartPosition.isNotNull() && sentenceContextStartPosition < contextStartPosition)
-            contextStartPosition = sentenceContextStartPosition;
+            startPosition = sentenceContextStartPosition;
     }
 
     if (endPosition != endOfEditableContent(endPosition)) {
@@ -920,7 +919,7 @@ std::optional<SimpleRange> WebPage::autocorrectionContextRange()
             endPosition = nextPosition;
     }
 
-    return makeSimpleRange(contextStartPosition, endPosition);
+    return makeSimpleRange(startPosition, endPosition);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8806,6 +8806,13 @@ void WebPage::handleContextMenuTranslation(const TranslationContextMenuInfo& inf
 }
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
+void WebPage::handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView)
+{
+    send(Messages::WebPageProxy::HandleContextMenuSwapCharacters(selectionBoundsInRootView));
+}
+#endif
+
 void WebPage::scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint&)
 {
     RefPtr frameView = localMainFrameView();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1573,6 +1573,10 @@ public:
     void handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo&);
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
+    void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView);
+#endif
+
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&);
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
@@ -77,6 +77,10 @@ public:
     void handleTranslation(const WebCore::TranslationContextMenuInfo&) final;
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    void handleSwapCharacters(WebCore::IntRect selectionBoundsInRootView) final;
+#endif
+
 private:
     NSMenu *contextMenuForEvent(NSEvent *, NSView *, bool& isServicesMenu);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -151,6 +151,14 @@ void WebContextMenuClient::handleTranslation(const TranslationContextMenuInfo& i
 
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+
+void WebContextMenuClient::handleSwapCharacters(IntRect selectionBoundsInRootView)
+{
+}
+
+#endif
+
 #if ENABLE(SERVICE_CONTROLS)
 
 void WebContextMenuClient::sharingServicePickerWillBeDestroyed(WebSharingServicePickerController &)

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -411,6 +411,8 @@ static std::optional<WebCore::ContextMenuAction> toAction(NSInteger tag)
         return ContextMenuItemTagDictationAlternative;
     case WebMenuItemTagTranslate:
         return ContextMenuItemTagTranslate;
+    case WebMenuItemTagSwapCharacters:
+        return ContextMenuItemTagSwapCharacters;
     }
     return std::nullopt;
 }
@@ -593,6 +595,8 @@ static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
         return WebMenuItemTagToggleVideoEnhancedFullscreen;
     case ContextMenuItemTagTranslate:
         return WebMenuItemTagTranslate;
+    case ContextMenuItemTagSwapCharacters:
+        return WebMenuItemTagSwapCharacters;
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     case ContextMenuItemTagPlayAllAnimations:
         return WebMenuItemTagPlayAllAnimations;

--- a/Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h
@@ -110,6 +110,7 @@ enum {
     WebMenuItemTagPauseAllAnimations,
     WebMenuItemTagPlayAnimation,
     WebMenuItemTagPauseAnimation,
+    WebMenuItemTagSwapCharacters,
 };
 
 // Deprecated; remove when there are no more clients.


### PR DESCRIPTION
#### c3c08a7f5d2e662d020d454f5ca51e4f0aa168bf
<pre>
[Unified Text Replacement] Support unified text replacement on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=269261">https://bugs.webkit.org/show_bug.cgi?id=269261</a>
<a href="https://rdar.apple.com/122324339">rdar://122324339</a>

Reviewed by Wenson Hsieh.

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/ContextMenuClient.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemTagSwapCharacters):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h:
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::handleContextMenuSwapCharacters):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::handleContextMenuSwapCharacters):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::menuItemIdentifier):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::handleContextMenuSwapCharacters):
(WebKit::WebViewImpl::willBeginTextReplacementSession):
(WebKit::WebViewImpl::didBeginTextReplacementSession):
(WebKit::WebViewImpl::textReplacementSessionDidReceiveReplacements):
(WebKit::WebViewImpl::textReplacementSessionDidUpdateStateForReplacement):
(WebKit::WebViewImpl::didEndTextReplacementSession):
(WebKit::WebViewImpl::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebKit::WebViewImpl::textReplacementSessionDidReceiveEditAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::handleSwapCharacters):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::autocorrectionContextRange):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::handleContextMenuSwapCharacters):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
(WebContextMenuClient::handleSwapCharacters):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(toAction):
(toTag):
* Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h:

Canonical link: <a href="https://commits.webkit.org/274568@main">https://commits.webkit.org/274568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3188380a91005749c6e783aca09ecd8e150aba6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42004 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15778 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15543 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43282 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35837 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5169 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->