### PR TITLE
[WebGPU] GPUTexture returned from GPUCanvasContext.getCurrentTexture() has the wrong size

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
@@ -33,10 +33,20 @@
 
 namespace WebCore {
 
-void GPUPresentationContext::configure(const GPUCanvasConfiguration& canvasConfiguration)
+void GPUPresentationContext::configure(const GPUCanvasConfiguration& canvasConfiguration, GPUIntegerCoordinate width, GPUIntegerCoordinate height)
 {
     m_device = canvasConfiguration.device;
     m_backing->configure(canvasConfiguration.convertToBacking());
+    m_textureDescriptor = GPUTextureDescriptor {
+        { "canvas backing"_s },
+        GPUExtent3DDict { width, height, 1 },
+        1,
+        1,
+        GPUTextureDimension::_2d,
+        GPUTextureFormat::Bgra8unorm,
+        canvasConfiguration.usage,
+        canvasConfiguration.viewFormats
+    };
 }
 
 void GPUPresentationContext::unconfigure()
@@ -48,9 +58,7 @@ RefPtr<GPUTexture> GPUPresentationContext::getCurrentTexture()
 {
     if (!m_currentTexture && m_device.get()) {
         if (auto currentTexture = m_backing->getCurrentTexture()) {
-            GPUTextureDescriptor textureDescriptor;
-            textureDescriptor.format = GPUTextureFormat::Bgra8unorm;
-            m_currentTexture = GPUTexture::create(*currentTexture, textureDescriptor, *m_device.get()).ptr();
+            m_currentTexture = GPUTexture::create(*currentTexture, m_textureDescriptor, *m_device.get()).ptr();
         }
     }
 

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "GPUTexture.h"
+#include "GPUTextureDescriptor.h"
 #include "WebGPUPresentationContext.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
@@ -48,7 +49,7 @@ public:
         return adoptRef(*new GPUPresentationContext(WTFMove(backing)));
     }
 
-    void configure(const GPUCanvasConfiguration&);
+    void configure(const GPUCanvasConfiguration&, GPUIntegerCoordinate, GPUIntegerCoordinate);
     void unconfigure();
 
     RefPtr<GPUTexture> getCurrentTexture();
@@ -66,6 +67,7 @@ private:
     Ref<WebGPU::PresentationContext> m_backing;
     RefPtr<GPUTexture> m_currentTexture;
     RefPtr<const GPUDevice> m_device;
+    GPUTextureDescriptor m_textureDescriptor;
 };
 
 }

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -107,8 +107,8 @@ private:
     Ref<GPUPresentationContext> m_presentationContext;
     RefPtr<GPUTexture> m_currentTexture;
 
-    int m_width { 0 };
-    int m_height { 0 };
+    GPUIntegerCoordinate m_width { 0 };
+    GPUIntegerCoordinate m_height { 0 };
     bool m_compositingResultsNeedsUpdating { false };
 };
 


### PR DESCRIPTION
#### 60b6c37529914986e681eece61f87a1c66080707
<pre>
[WebGPU] GPUTexture returned from GPUCanvasContext.getCurrentTexture() has the wrong size
<a href="https://bugs.webkit.org/show_bug.cgi?id=269262">https://bugs.webkit.org/show_bug.cgi?id=269262</a>
&lt;radar://122847972&gt;

Reviewed by Dan Glastonbury.

We were returning a GPUTexture instance that reported a
size of 1x1, which is incorrect.

* Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp:
(WebCore::GPUPresentationContext::configure):
(WebCore::GPUPresentationContext::getCurrentTexture):
* Source/WebCore/Modules/WebGPU/GPUPresentationContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::getCanvasWidth):
(WebCore::getCanvasHeight):
(WebCore::GPUCanvasContextCocoa::reshape):
(WebCore::GPUCanvasContextCocoa::configure):

Canonical link: <a href="https://commits.webkit.org/274571@main">https://commits.webkit.org/274571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3843b06b2807753059763413cf953eeb0dc9fc8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15755 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43259 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37496 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15865 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8829 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->