### PR TITLE
Adopt even more smart pointer under WebCore/page/

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -33,6 +33,7 @@
 #include "Event.h"
 #include "EventLoop.h"
 #include "FetchResponse.h"
+#include "HTMLFrameOwnerElement.h"
 #include "InspectorController.h"
 #include "JSDOMBindingSecurity.h"
 #include "JSDocument.h"

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -125,6 +125,11 @@ CSSStyleSheet* CSSImportRule::styleSheet() const
     return m_styleSheetCSSOMWrapper.get(); 
 }
 
+RefPtr<CSSStyleSheet> CSSImportRule::protectedStyleSheet() const
+{
+    return styleSheet();
+}
+
 void CSSImportRule::reattach(StyleRuleBase&)
 {
     // FIXME: Implement when enabling caching for stylesheets with import rules.

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -42,6 +42,7 @@ public:
     WEBCORE_EXPORT String href() const;
     WEBCORE_EXPORT MediaList& media() const;
     WEBCORE_EXPORT CSSStyleSheet* styleSheet() const;
+    RefPtr<CSSStyleSheet> protectedStyleSheet() const;
     String layerName() const;
     String supportsText() const;
 

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -153,8 +153,8 @@ bool CaptionUserPreferences::userPrefersTextDescriptions() const
     if (!page)
         return false;
 
-    auto& settings = page->settings();
-    return settings.shouldDisplayTextDescriptions() && (settings.audioDescriptionsEnabled() || settings.extendedAudioDescriptionsEnabled());
+    Ref settings = page->settings();
+    return settings->shouldDisplayTextDescriptions() && (settings->audioDescriptionsEnabled() || settings->extendedAudioDescriptionsEnabled());
 }
 
 void CaptionUserPreferences::setUserPrefersTextDescriptions(bool preference)

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -298,9 +298,9 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         return;
     }
 
-    auto& document = m_context.hitTestResult().innerNonSharedNode()->document();
+    Ref document = m_context.hitTestResult().innerNonSharedNode()->document();
 
-    RefPtr frame = document.frame();
+    RefPtr frame = document->frame();
     if (!frame)
         return;
 

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -77,7 +77,7 @@ bool DeviceController::hasDeviceEventListener(LocalDOMWindow& window) const
 void DeviceController::dispatchDeviceEvent(Event& event)
 {
     for (auto& listener : copyToVector(m_listeners.values())) {
-        auto document = listener->document();
+        RefPtr document = listener->document();
         if (document && !document->activeDOMObjectsAreSuspended() && !document->activeDOMObjectsAreStopped())
             listener->dispatchEvent(event);
     }

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -380,23 +380,23 @@ static bool isInShadowTreeOfEnabledColorInput(Node& node)
 // This can return null if an empty document is loaded.
 static Element* elementUnderMouse(Document& documentUnderMouse, const IntPoint& p)
 {
-    auto* frame = documentUnderMouse.frame();
+    RefPtr frame = documentUnderMouse.frame();
     float zoomFactor = frame ? frame->pageZoomFactor() : 1;
     LayoutPoint point(p.x() * zoomFactor, p.y() * zoomFactor);
 
     HitTestResult result(point);
     documentUnderMouse.hitTest(HitTestRequest(), result);
 
-    auto* node = result.innerNode();
+    RefPtr node = result.innerNode();
     if (!node)
         return nullptr;
 
     // FIXME: Use parentElementInComposedTree here.
-    auto* element = dynamicDowncast<Element>(*node);
+    RefPtr element = dynamicDowncast<Element>(*node);
     if (!element)
         element = node->parentElement();
     auto* host = element->shadowHost();
-    return host ? host : element;
+    return host ? host : element.get();
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -815,9 +815,9 @@ Element* DragController::draggableElement(const LocalFrame* sourceFrame, Element
     }
 #endif // ENABLE(ATTACHMENT_ELEMENT)
 
-    auto selectionDragElement = state.type.contains(DragSourceAction::Selection) && m_dragSourceAction.contains(DragSourceAction::Selection) ? startElement : nullptr;
+    RefPtr selectionDragElement = state.type.contains(DragSourceAction::Selection) && m_dragSourceAction.contains(DragSourceAction::Selection) ? startElement : nullptr;
     if (ImageOverlay::isOverlayText(startElement))
-        return selectionDragElement;
+        return selectionDragElement.get();
 
     for (auto* element = startElement; element; element = element->parentOrShadowHostElement()) {
         auto* renderer = element->renderer();
@@ -866,7 +866,7 @@ Element* DragController::draggableElement(const LocalFrame* sourceFrame, Element
     }
 
     // We either have nothing to drag or we have a selection and we're not over a draggable element.
-    return selectionDragElement;
+    return selectionDragElement.get();
 }
 
 static CachedImage* getCachedImage(Element& element)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -470,7 +470,7 @@ void EventHandler::clear()
 
 void EventHandler::nodeWillBeRemoved(Node& nodeToBeRemoved)
 {
-    if (nodeToBeRemoved.containsIncludingShadowDOM(m_clickNode.get()))
+    if (nodeToBeRemoved.containsIncludingShadowDOM(RefPtr { m_clickNode }.get()))
         m_clickNode = nullptr;
 }
 
@@ -2147,8 +2147,8 @@ HandleUserInputEventResult EventHandler::handleMouseMoveEvent(const PlatformMous
             m_offsetFromResizeCorner.setWidth(m_resizeLayer->offsetFromResizeCorner(localPoint).width());
         }
     } else {
-        Scrollbar* scrollbar = mouseEvent.scrollbar();
-        updateLastScrollbarUnderMouse(scrollbar, m_mousePressed ? SetOrClearLastScrollbar::Clear : SetOrClearLastScrollbar::Set);
+        RefPtr scrollbar = mouseEvent.scrollbar();
+        updateLastScrollbarUnderMouse(scrollbar.get(), m_mousePressed ? SetOrClearLastScrollbar::Clear : SetOrClearLastScrollbar::Set);
 
         // On iOS, our scrollbars are managed by UIKit.
 #if !PLATFORM(IOS_FAMILY)
@@ -2157,7 +2157,7 @@ HandleUserInputEventResult EventHandler::handleMouseMoveEvent(const PlatformMous
 #endif
         if (onlyUpdateScrollbars) {
             if (shouldSendMouseEventsToInactiveWindows())
-                updateMouseEventTargetNode(eventNames().mousemoveEvent, mouseEvent.targetNode(), platformMouseEvent, FireMouseOverOut::Yes);
+                updateMouseEventTargetNode(eventNames().mousemoveEvent, mouseEvent.protectedTargetNode().get(), platformMouseEvent, FireMouseOverOut::Yes);
 
             return true;
         }
@@ -2311,10 +2311,10 @@ HandleUserInputEventResult EventHandler::handleMouseReleaseEvent(const PlatformM
     if (localSubframe && passMouseReleaseEventToSubframe(mouseEvent, *localSubframe))
         return true;
 
-    bool swallowMouseUpEvent = !dispatchMouseEvent(eventNames().mouseupEvent, mouseEvent.targetNode(), m_clickCount, platformMouseEvent, FireMouseOverOut::No);
+    bool swallowMouseUpEvent = !dispatchMouseEvent(eventNames().mouseupEvent, mouseEvent.protectedTargetNode().get(), m_clickCount, platformMouseEvent, FireMouseOverOut::No);
     bool contextMenuEvent = platformMouseEvent.button() == MouseButton::Right;
 
-    auto nodeToClick = targetNodeForClickEvent(m_clickNode.get(), mouseEvent.targetNode());
+    auto nodeToClick = targetNodeForClickEvent(RefPtr { m_clickNode }.get(), mouseEvent.protectedTargetNode().get());
     bool swallowClickEvent = m_clickCount > 0 && !contextMenuEvent && nodeToClick && !dispatchMouseEvent(eventNames().clickEvent, nodeToClick.get(), m_clickCount, platformMouseEvent, FireMouseOverOut::Yes);
 
     if (m_resizeLayer) {

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -680,13 +680,13 @@ Element* FocusController::findFocusableElementAcrossFocusScope(FocusDirection di
     }
 
     // If there's no focusable node to advance to, move up the focus scopes until we find one.
-    Element* owner = scope.owner();
+    RefPtr owner = scope.owner();
     while (owner) {
         if (direction == FocusDirection::Backward && isFocusableScopeOwner(*owner, event))
-            return findFocusableElementDescendingIntoSubframes(direction, owner, event);
+            return findFocusableElementDescendingIntoSubframes(direction, owner.get(), event);
 
         auto outerScope = FocusNavigationScope::scopeOf(*owner);
-        if (Element* candidateInOuterScope = findFocusableElementWithinScope(direction, outerScope, owner, event))
+        if (Element* candidateInOuterScope = findFocusableElementWithinScope(direction, outerScope, owner.get(), event))
             return candidateInOuterScope;
         owner = outerScope.owner();
     }
@@ -696,42 +696,42 @@ Element* FocusController::findFocusableElementAcrossFocusScope(FocusDirection di
 Element* FocusController::findFocusableElementWithinScope(FocusDirection direction, const FocusNavigationScope& scope, Node* start, KeyboardEvent* event)
 {
     // Starting node is exclusive.
-    Element* candidate = direction == FocusDirection::Forward
+    RefPtr candidate = direction == FocusDirection::Forward
         ? nextFocusableElementWithinScope(scope, start, event)
         : previousFocusableElementWithinScope(scope, start, event);
-    return findFocusableElementDescendingIntoSubframes(direction, candidate, event);
+    return findFocusableElementDescendingIntoSubframes(direction, candidate.get(), event);
 }
 
 Element* FocusController::nextFocusableElementWithinScope(const FocusNavigationScope& scope, Node* start, KeyboardEvent* event)
 {
-    Element* found = nextFocusableElementOrScopeOwner(scope, start, event);
+    RefPtr found = nextFocusableElementOrScopeOwner(scope, start, event);
     if (!found)
         return nullptr;
     if (isNonFocusableScopeOwner(*found, event)) {
         if (Element* foundInInnerFocusScope = nextFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, event))
             return foundInInnerFocusScope;
-        return nextFocusableElementWithinScope(scope, found, event);
+        return nextFocusableElementWithinScope(scope, found.get(), event);
     }
-    return found;
+    return found.get();
 }
 
 Element* FocusController::previousFocusableElementWithinScope(const FocusNavigationScope& scope, Node* start, KeyboardEvent* event)
 {
-    Element* found = previousFocusableElementOrScopeOwner(scope, start, event);
+    RefPtr found = previousFocusableElementOrScopeOwner(scope, start, event);
     if (!found)
         return nullptr;
     if (isFocusableScopeOwner(*found, event)) {
         // Search an inner focusable element in the shadow tree from the end.
         if (Element* foundInInnerFocusScope = previousFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, event))
             return foundInInnerFocusScope;
-        return found;
+        return found.get();
     }
     if (isNonFocusableScopeOwner(*found, event)) {
         if (Element* foundInInnerFocusScope = previousFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, event))
             return foundInInnerFocusScope;
-        return previousFocusableElementWithinScope(scope, found, event);
+        return previousFocusableElementWithinScope(scope, found.get(), event);
     }
-    return found;
+    return found.get();
 }
 
 Element* FocusController::findFocusableElementOrScopeOwner(FocusDirection direction, const FocusNavigationScope& scope, Node* node, KeyboardEvent* event)
@@ -1183,9 +1183,9 @@ bool FocusController::advanceFocusDirectionallyInContainer(Node* container, cons
         }
         // Navigate into a new frame.
         LayoutRect rect;
-        Element* focusedElement = focusedOrMainFrame().document()->focusedElement();
-        if (focusedElement && !hasOffscreenRect(focusedElement))
-            rect = nodeRectInAbsoluteCoordinates(focusedElement, true /* ignore border */);
+        RefPtr focusedElement = focusedOrMainFrame().document()->focusedElement();
+        if (focusedElement && !hasOffscreenRect(focusedElement.get()))
+            rect = nodeRectInAbsoluteCoordinates(focusedElement.get(), true /* ignore border */);
         dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document()->updateLayoutIgnorePendingStylesheets();
         if (!advanceFocusDirectionallyInContainer(dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document(), rect, direction, event)) {
             // The new frame had nothing interesting, need to find another candidate.
@@ -1201,9 +1201,9 @@ bool FocusController::advanceFocusDirectionallyInContainer(Node* container, cons
         }
         // Navigate into a new scrollable container.
         LayoutRect startingRect;
-        Element* focusedElement = focusedOrMainFrame().document()->focusedElement();
-        if (focusedElement && !hasOffscreenRect(focusedElement))
-            startingRect = nodeRectInAbsoluteCoordinates(focusedElement, true);
+        RefPtr focusedElement = focusedOrMainFrame().document()->focusedElement();
+        if (focusedElement && !hasOffscreenRect(focusedElement.get()))
+            startingRect = nodeRectInAbsoluteCoordinates(focusedElement.get(), true);
         return advanceFocusDirectionallyInContainer(RefPtr { focusCandidate.visibleNode.get() }.get(), startingRect, direction, event);
     }
     if (focusCandidate.isOffscreenAfterScrolling) {

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -122,16 +122,14 @@ AtomString FrameTree::generateUniqueName() const
 
 static bool inScope(Frame& frame, TreeScope& scope)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
     if (!localFrame)
         return true;
-    Document* document = localFrame->document();
+    RefPtr document = localFrame->document();
     if (!document)
         return false;
-    HTMLFrameOwnerElement* owner = document->ownerElement();
-    if (!owner)
-        return false;
-    return &owner->treeScope() == &scope;
+    RefPtr owner = document->ownerElement();
+    return owner && &owner->treeScope() == &scope;
 }
 
 Frame* FrameTree::scopedChild(unsigned index, TreeScope* scope) const
@@ -289,7 +287,7 @@ inline Frame* FrameTree::find(const AtomString& name, const Function<const AtomS
     }
 
     // Search the entire tree of each of the other pages in this namespace.
-    Page* page = m_thisFrame.page();
+    RefPtr page = m_thisFrame.page();
     if (!page)
         return nullptr;
 

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -125,7 +125,7 @@ void FrameView::invalidateRect(const IntRect& rect)
         return;
     }
 
-    auto* renderer = frame->ownerRenderer();
+    CheckedPtr renderer = frame->ownerRenderer();
     if (!renderer)
         return;
 
@@ -142,7 +142,7 @@ bool FrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const
 
 IntRect FrameView::scrollableAreaBoundingBox(bool*) const
 {
-    RenderWidget* ownerRenderer = frame().ownerRenderer();
+    RefPtr ownerRenderer = frame().ownerRenderer();
     if (!ownerRenderer)
         return frameRect();
 

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -183,7 +183,8 @@ public:
 
     DOMSelection* getSelection();
 
-    Element* frameElement() const;
+    HTMLFrameOwnerElement* frameElement() const;
+    RefPtr<HTMLFrameOwnerElement> protectedFrameElement() const;
 
     WEBCORE_EXPORT void focus(bool allowFocus = false);
     void focus(LocalDOMWindow& incumbentWindow);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -918,8 +918,8 @@ void LocalFrameView::updateSnapOffsets()
     if (!m_frame->document())
         return;
 
-    auto* documentElement = m_frame->document()->documentElement();
-    auto* rootRenderer = documentElement ? documentElement->renderBox() : nullptr;
+    RefPtr documentElement = m_frame->document()->documentElement();
+    CheckedPtr rootRenderer = documentElement ? documentElement->renderBox() : nullptr;
 
     const RenderStyle* styleToUse = nullptr;
     if (rootRenderer && rootRenderer->style().scrollSnapType().strictness != ScrollSnapStrictness::None)
@@ -3278,7 +3278,7 @@ void LocalFrameView::adjustTiledBackingCoverage()
 
 static bool shouldEnableSpeculativeTilingDuringLoading(const LocalFrameView& view)
 {
-    auto* page = view.frame().page();
+    RefPtr page = view.frame().page();
     return page && view.isVisuallyNonEmpty() && !page->progress().isMainLoadProgressing();
 }
 
@@ -3585,23 +3585,23 @@ bool LocalFrameView::shouldUpdate() const
 
 bool LocalFrameView::safeToPropagateScrollToParent() const
 {
-    auto* document = m_frame->document();
+    RefPtr document = m_frame->document();
     if (!document)
         return false;
 
-    auto* parentFrame = m_frame->tree().parent();
+    RefPtr parentFrame = m_frame->tree().parent();
     if (!parentFrame)
         return false;
     
-    auto* localParent = dynamicDowncast<LocalFrame>(parentFrame);
+    RefPtr localParent = dynamicDowncast<LocalFrame>(parentFrame);
     if (!localParent)
         return false;
 
-    auto* parentDocument = localParent->document();
+    RefPtr parentDocument = localParent->document();
     if (!parentDocument)
         return false;
 
-    return document->securityOrigin().isSameOriginDomain(parentDocument->securityOrigin());
+    return document->protectedSecurityOrigin()->isSameOriginDomain(parentDocument->protectedSecurityOrigin());
 }
 
 void LocalFrameView::scheduleScrollToAnchorAndTextFragment()
@@ -4415,10 +4415,10 @@ void LocalFrameView::notifyScrollableAreasThatContentAreaWillPaint() const
 
 void LocalFrameView::updateScrollCorner()
 {
-    RenderElement* renderer = nullptr;
+    CheckedPtr<RenderElement> renderer;
     std::unique_ptr<RenderStyle> cornerStyle;
     IntRect cornerRect = scrollCornerRect();
-    Document* doc = m_frame->document();
+    RefPtr doc = m_frame->document();
 
     auto usesStandardScrollbarStyle = [](auto& doc) {
         if (!doc || !doc->documentElement())
@@ -4431,7 +4431,7 @@ void LocalFrameView::updateScrollCorner()
 
     if (!(usesStandardScrollbarStyle(doc) || cornerRect.isEmpty())) {
         // Try the <body> element first as a scroll corner source.
-        Element* body = doc ? doc->bodyOrFrameset() : nullptr;
+        RefPtr body = doc ? doc->bodyOrFrameset() : nullptr;
         if (body && body->renderer()) {
             renderer = body->renderer();
             cornerStyle = renderer->getUncachedPseudoStyle({ PseudoId::WebKitScrollbarCorner }, &renderer->style());
@@ -4439,7 +4439,7 @@ void LocalFrameView::updateScrollCorner()
         
         if (!cornerStyle) {
             // If the <body> didn't have a custom style, then the root element might.
-            Element* docElement = doc ? doc->documentElement() : nullptr;
+            RefPtr docElement = doc ? doc->documentElement() : nullptr;
             if (docElement && docElement->renderer()) {
                 renderer = docElement->renderer();
                 cornerStyle = renderer->getUncachedPseudoStyle({ PseudoId::WebKitScrollbarCorner }, &renderer->style());
@@ -4449,7 +4449,7 @@ void LocalFrameView::updateScrollCorner()
         if (!cornerStyle) {
             // If we have an owning iframe/frame element, then it can set the custom scrollbar also.
             // FIXME: Seems wrong to do this for cross-origin frames.
-            if (RenderWidget* renderer = m_frame->ownerRenderer())
+            if (RefPtr renderer = m_frame->ownerRenderer())
                 cornerStyle = renderer->getUncachedPseudoStyle({ PseudoId::WebKitScrollbarCorner }, &renderer->style());
         }
     }
@@ -4458,7 +4458,7 @@ void LocalFrameView::updateScrollCorner()
         m_scrollCorner = nullptr;
     else {
         if (!m_scrollCorner) {
-            m_scrollCorner = createRenderer<RenderScrollbarPart>(renderer->document(), WTFMove(*cornerStyle));
+            m_scrollCorner = createRenderer<RenderScrollbarPart>(renderer->protectedDocument(), WTFMove(*cornerStyle));
             m_scrollCorner->initializeStyle();
         } else
             m_scrollCorner->setStyle(WTFMove(*cornerStyle));
@@ -4927,7 +4927,7 @@ void LocalFrameView::updateLayoutAndStyleIfNeededRecursive(OptionSet<LayoutOptio
     auto needsStyleRecalc = [&] {
         DescendantsDeque deque;
         while (auto view = nextRenderedDescendant(deque)) {
-            auto* document = view->m_frame->document();
+            RefPtr document = view->m_frame->document();
             if (document && document->childNeedsStyleRecalc())
                 return true;
         }

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -293,7 +293,7 @@ ExceptionOr<void> Location::setLocation(LocalDOMWindow& incumbentWindow, LocalDO
     RefPtr frame = this->frame();
     ASSERT(frame);
 
-    auto* firstFrame = firstWindow.frame();
+    RefPtr firstFrame = firstWindow.frame();
     if (!firstFrame || !firstFrame->document())
         return { };
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3763,14 +3763,14 @@ void Page::effectiveAppearanceDidChange(bool useDarkAppearance, bool useElevated
 bool Page::useDarkAppearance() const
 {
 #if ENABLE(DARK_MODE_CSS)
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
-    auto* view = localMainFrame ? localMainFrame->view() : nullptr;
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    RefPtr view = localMainFrame ? localMainFrame->view() : nullptr;
     if (!view || view->mediaType() != screenAtom())
         return false;
     if (m_useDarkAppearanceOverride)
         return m_useDarkAppearanceOverride.value();
 
-    if (auto* documentLoader = localMainFrame->loader().documentLoader()) {
+    if (RefPtr documentLoader = localMainFrame->loader().documentLoader()) {
         auto colorSchemePreference = documentLoader->colorSchemePreference();
         if (colorSchemePreference != ColorSchemePreference::NoPreference)
             return colorSchemePreference == ColorSchemePreference::Dark;
@@ -3971,7 +3971,7 @@ bool Page::hasLocalDataForURL(const URL& url)
     if (url.protocolIsFile())
         return true;
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
     RefPtr documentLoader = localMainFrame ? localMainFrame->loader().documentLoader() : nullptr;
     if (documentLoader && documentLoader->subresource(MemoryCache::removeFragmentIdentifierIfNeeded(url)))
         return true;
@@ -4138,7 +4138,7 @@ void Page::configureLoggingChannel(const String& channelName, WTFLogChannelState
         channel->level = level;
 
 #if USE(LIBWEBRTC)
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
+        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
         if (channel == &LogWebRTC && localMainFrame && localMainFrame->document() && !sessionID().isEphemeral())
             webRTCProvider().setLoggingLevel(LogWebRTC.level);
 #endif
@@ -4264,7 +4264,7 @@ void Page::removeInjectedUserStyleSheet(UserStyleSheet& userStyleSheet)
     }
 
     if (userStyleSheet.injectedFrames() == UserContentInjectedFrames::InjectInTopFrameOnly) {
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
+        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
         if (RefPtr document = localMainFrame ? localMainFrame->document() : nullptr)
             document->checkedExtensionStyleSheets()->removePageSpecificUserStyleSheet(userStyleSheet);
     } else {
@@ -4582,7 +4582,7 @@ void Page::setMediaKeysStorageDirectory(const String& directory)
 
 void Page::reloadExecutionContextsForOrigin(const ClientOrigin& origin, std::optional<FrameIdentifier> triggeringFrame) const
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
     if (!localMainFrame || localMainFrame->document()->topOrigin().data() != origin.topOrigin)
         return;
 

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -118,7 +118,7 @@ static std::optional<Lab<float>> sampleColor(Document& document, IntPoint&& loca
     auto colorSpace = DestinationColorSpace::SRGB();
 
     ASSERT(document.view());
-    auto snapshot = snapshotFrameRect(document.view()->frame(), IntRect(location, IntSize(1, 1)), { { SnapshotFlags::ExcludeSelectionHighlighting, SnapshotFlags::PaintEverythingExcludingSelection }, PixelFormat::BGRA8, colorSpace });
+    auto snapshot = snapshotFrameRect(document.view()->protectedFrame(), IntRect(location, IntSize(1, 1)), { { SnapshotFlags::ExcludeSelectionHighlighting, SnapshotFlags::PaintEverythingExcludingSelection }, PixelFormat::BGRA8, colorSpace });
     if (!snapshot)
         return std::nullopt;
 

--- a/Source/WebCore/page/PageDebuggable.cpp
+++ b/Source/WebCore/page/PageDebuggable.cpp
@@ -49,7 +49,7 @@ String PageDebuggable::name() const
     if (!m_nameOverride.isNull())
         return m_nameOverride;
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
     if (!localMainFrame)
         return String();
 

--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -132,7 +132,7 @@ IntSize PageOverlay::viewToOverlayOffset() const
         return IntSize();
 
     case OverlayType::Document: {
-        auto* frameView = m_page->mainFrame().virtualView();
+        RefPtr frameView = m_page->mainFrame().virtualView();
         return frameView ? toIntSize(frameView->viewToContents(IntPoint())) : IntSize();
     }
     }

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -27,9 +27,9 @@
 
 #include "GraphicsLayerClient.h"
 #include "PageOverlay.h"
-#include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
@@ -71,7 +71,7 @@ public:
     void didChangeOverlayFrame(PageOverlay&);
     void didChangeOverlayBackgroundColor(PageOverlay&);
 
-    int overlayCount() const { return m_overlayGraphicsLayers.size(); }
+    int overlayCount() const { return m_overlayGraphicsLayers.computeSize(); }
 
     bool handleMouseEvent(const PlatformMouseEvent&);
 
@@ -106,7 +106,7 @@ private:
     RefPtr<GraphicsLayer> m_documentOverlayRootLayer;
     RefPtr<GraphicsLayer> m_viewOverlayRootLayer;
 
-    HashMap<PageOverlay*, Ref<GraphicsLayer>> m_overlayGraphicsLayers;
+    WeakHashMap<PageOverlay, Ref<GraphicsLayer>> m_overlayGraphicsLayers;
     Vector<RefPtr<PageOverlay>> m_pageOverlays;
     bool m_initialized { false };
 };

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -210,7 +210,7 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
             continue;
         // We have to process in-line style as it might contain some resources (typically background images).
         if (RefPtr styledElement = dynamicDowncast<StyledElement>(*element))
-            retrieveResourcesForProperties(styledElement->inlineStyle(), document);
+            retrieveResourcesForProperties(styledElement->protectedInlineStyle().get(), document);
 
         if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(*element)) {
             auto url = document->completeURL(imageElement->attributeWithoutSynchronization(HTMLNames::srcAttr));
@@ -253,7 +253,7 @@ void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL
             auto importURL = document->completeURL(importRule->href());
             if (m_resourceURLs.contains(importURL))
                 continue;
-            serializeCSSStyleSheet(importRule->styleSheet(), importURL);
+            serializeCSSStyleSheet(importRule->protectedStyleSheet().get(), importURL);
         } else if (is<CSSFontFaceRule>(*rule)) {
             // FIXME: Add support for font face rule. It is not clear to me at this point if the actual otf/eot file can
             // be retrieved from the CSSFontFaceRule object.
@@ -293,7 +293,7 @@ void PageSerializer::addImageToResources(CachedImage* image, RenderElement* imag
 
 void PageSerializer::retrieveResourcesForRule(StyleRule& rule, Document* document)
 {
-    retrieveResourcesForProperties(&rule.properties(), document);
+    retrieveResourcesForProperties(rule.protectedProperties().ptr(), document);
 }
 
 void PageSerializer::retrieveResourcesForProperties(const StyleProperties* styleDeclaration, Document* document)

--- a/Source/WebCore/page/PerformanceLogging.cpp
+++ b/Source/WebCore/page/PerformanceLogging.cpp
@@ -62,17 +62,17 @@ HashMap<const char*, size_t> PerformanceLogging::memoryUsageStatistics(ShouldInc
     stats.add("backforward_cache_page_count", BackForwardCache::singleton().pageCount());
     stats.add("document_count", Document::allDocuments().size());
 
-    auto& vm = commonVM();
+    Ref vm = commonVM();
     JSC::JSLockHolder locker(vm);
-    stats.add("javascript_gc_heap_capacity_mb", vm.heap.capacity() >> 20);
-    stats.add("javascript_gc_heap_extra_memory_size_mb", vm.heap.extraMemorySize() >> 20);
+    stats.add("javascript_gc_heap_capacity_mb", vm->heap.capacity() >> 20);
+    stats.add("javascript_gc_heap_extra_memory_size_mb", vm->heap.extraMemorySize() >> 20);
 
     if (includeExpensive == ShouldIncludeExpensiveComputations::Yes) {
-        stats.add("javascript_gc_heap_size_mb", vm.heap.size() >> 20);
-        stats.add("javascript_gc_object_count", vm.heap.objectCount());
-        stats.add("javascript_gc_protected_object_count", vm.heap.protectedObjectCount());
-        stats.add("javascript_gc_global_object_count", vm.heap.globalObjectCount());
-        stats.add("javascript_gc_protected_global_object_count", vm.heap.protectedGlobalObjectCount());
+        stats.add("javascript_gc_heap_size_mb", vm->heap.size() >> 20);
+        stats.add("javascript_gc_object_count", vm->heap.objectCount());
+        stats.add("javascript_gc_protected_object_count", vm->heap.protectedObjectCount());
+        stats.add("javascript_gc_global_object_count", vm->heap.globalObjectCount());
+        stats.add("javascript_gc_protected_global_object_count", vm->heap.protectedGlobalObjectCount());
     }
 
     getPlatformMemoryUsageStatistics(stats);

--- a/Source/WebCore/page/PerformanceNavigation.cpp
+++ b/Source/WebCore/page/PerformanceNavigation.cpp
@@ -66,11 +66,11 @@ unsigned short PerformanceNavigation::type() const
 
 unsigned short PerformanceNavigation::redirectCount() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
-    DocumentLoader* loader = frame->loader().documentLoader();
+    RefPtr loader = frame->loader().documentLoader();
     if (!loader)
         return 0;
 

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -124,7 +124,7 @@ bool PointerCaptureController::hasPointerCapture(Element* capturingTarget, Point
     if (!m_haveAnyCapturingElement)
         return false;
 
-    auto capturingData = m_activePointerIdsToCapturingData.get(pointerId);
+    RefPtr capturingData = m_activePointerIdsToCapturingData.get(pointerId);
     return capturingData && capturingData->pendingTargetOverride == capturingTarget;
 }
 
@@ -509,10 +509,10 @@ void PointerCaptureController::cancelPointer(PointerID pointerId, const IntPoint
         if (capturingData->targetOverride)
             return capturingData->targetOverride;
         constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
         if (!localMainFrame)
             return nullptr;
-        return Ref(*localMainFrame)->eventHandler().hitTestResultAtPoint(documentPoint, hitType).innerNonSharedElement();
+        return localMainFrame->checkedEventHandler()->hitTestResultAtPoint(documentPoint, hitType).innerNonSharedElement();
     }();
 
     if (!target)

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -119,6 +119,11 @@ FloatSize ResizeObservation::snappedContentBoxSize() const
     return m_lastObservationSizes.contentBoxLogicalSize; // FIXME: Need to pixel snap.
 }
 
+RefPtr<Element> ResizeObservation::protectedTarget() const
+{
+    return m_target.get();
+}
+
 std::optional<ResizeObservation::BoxSizes> ResizeObservation::elementSizeChanged() const
 {
     auto currentSizes = computeObservedSizes();

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -65,6 +65,7 @@ public:
     FloatSize snappedContentBoxSize() const;
 
     Element* target() const { return m_target.get(); }
+    RefPtr<Element> protectedTarget() const;
     ResizeObserverBoxOptions observedBox() const { return m_observedBox; }
     size_t targetElementDepth() const;
 

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -143,7 +143,7 @@ size_t ResizeObserver::gatherObservations(size_t deeperThan)
                 LOG_WITH_STREAM(ResizeObserver, stream << "ResizeObserver " << this << " gatherObservations - recording observation " << observation.get());
 
                 m_activeObservations.append(observation.get());
-                m_activeObservationTargets.append(*observation->target());
+                m_activeObservationTargets.append(*observation->protectedTarget());
                 minObservedDepth = std::min(depth, minObservedDepth);
             } else
                 m_hasSkippedObservations = true;
@@ -177,7 +177,7 @@ void ResizeObserver::deliverObservations()
     if (!jsCallback->hasCallback())
         return;
 
-    auto* context = jsCallback->scriptExecutionContext();
+    RefPtr context = jsCallback->scriptExecutionContext();
     if (!context)
         return;
 
@@ -212,7 +212,7 @@ bool ResizeObserver::removeTarget(Element& target)
 void ResizeObserver::removeAllTargets()
 {
     for (auto& observation : m_observations) {
-        bool removed = removeTarget(*observation->target());
+        bool removed = removeTarget(*observation->protectedTarget());
         ASSERT_UNUSED(removed, removed);
     }
     m_activeObservationTargets.clear();

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -331,18 +331,18 @@ void SettingsBase::setNeedsRelayoutAllFrames()
 
 void SettingsBase::mediaTypeOverrideChanged()
 {
-    if (!m_page)
+    RefPtr page = m_page.get();
+    if (!page)
         return;
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
     if (!localMainFrame)
         return;
 
-    auto* view = localMainFrame->view();
-    if (view)
-        view->setMediaType(AtomString(m_page->settings().mediaTypeOverride()));
+    if (RefPtr view = localMainFrame->view())
+        view->setMediaType(AtomString(page->settings().mediaTypeOverride()));
 
-    m_page->setNeedsRecalcStyleInAllFrames();
+    page->setNeedsRecalcStyleInAllFrames();
 }
 
 void SettingsBase::imagesEnabledChanged()

--- a/Source/WebCore/page/VisualViewport.cpp
+++ b/Source/WebCore/page/VisualViewport.cpp
@@ -52,10 +52,8 @@ EventTargetInterface VisualViewport::eventTargetInterface() const
 
 ScriptExecutionContext* VisualViewport::scriptExecutionContext() const
 {
-    auto window = this->window();
-    if (!window)
-        return nullptr;
-    return static_cast<ContextDestructionObserver*>(window)->scriptExecutionContext();
+    RefPtr window = this->window();
+    return window ? window->document() : nullptr;
 }
 
 bool VisualViewport::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -65,17 +65,17 @@ GPU* WorkerNavigator::gpu()
             if (!workerGlobalScope.graphicsClient())
                 return nullptr;
 
-            auto gpu = workerGlobalScope.graphicsClient()->createGPUForWebGPU();
+            RefPtr gpu = workerGlobalScope.graphicsClient()->createGPUForWebGPU();
             if (!gpu)
                 return nullptr;
 
             m_gpuForWebGPU = GPU::create(*gpu);
         } else if (scriptExecutionContext->isDocument()) {
-            auto& document = downcast<Document>(*scriptExecutionContext);
-            auto* page = document.page();
+            Ref document = downcast<Document>(*scriptExecutionContext);
+            RefPtr page = document->page();
             if (!page)
                 return nullptr;
-            auto gpu = page->chrome().createGPUForWebGPU();
+            RefPtr gpu = page->chrome().createGPUForWebGPU();
             if (!gpu)
                 return nullptr;
 

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -414,16 +414,16 @@ bool EventHandler::passSubframeEventToSubframe(MouseEventWithHitTestResults& eve
         return true;
         
     case NSEventTypeLeftMouseDown: {
-        Node* node = event.targetNode();
+        RefPtr node = event.targetNode();
         if (!node)
             return false;
-        auto* renderer = node->renderer();
-        if (!is<RenderWidget>(renderer))
+        WeakPtr renderer = node->renderer();
+        if (!is<RenderWidget>(renderer.get()))
             return false;
-        Widget* widget = downcast<RenderWidget>(*renderer).widget();
+        RefPtr widget = downcast<RenderWidget>(*renderer).widget();
         if (!widget || !widget->isLocalFrameView())
             return false;
-        if (!passWidgetMouseDownEventToWidget(downcast<RenderWidget>(renderer)))
+        if (!passWidgetMouseDownEventToWidget(downcast<RenderWidget>(renderer.get()))) // May destroy the renderer.
             return false;
         m_mouseDownWasInSubframe = true;
         return true;

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -247,6 +247,16 @@ GraphicsLayer* ScrollingCoordinator::footerLayerForFrameView(LocalFrameView& fra
 #endif
 }
 
+Page* ScrollingCoordinator::page() const
+{
+    return m_page.get();
+}
+
+RefPtr<Page> ScrollingCoordinator::protectedPage() const
+{
+    return m_page.get();
+}
+
 GraphicsLayer* ScrollingCoordinator::counterScrollingLayerForFrameView(LocalFrameView& frameView)
 {
     if (auto* renderView = frameView.frame().contentRenderer())

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -226,7 +226,8 @@ protected:
 
     virtual void willCommitTree() { }
 
-    SingleThreadWeakPtr<Page> m_page; // FIXME: ideally this would be a WeakRef but it gets nulled on async teardown.
+    WEBCORE_EXPORT Page* page() const;
+    RefPtr<Page> protectedPage() const;
 
 private:
     virtual bool hasVisibleSlowRepaintViewportConstrainedObjects(const LocalFrameView&) const;
@@ -237,6 +238,8 @@ private:
     EventTrackingRegions absoluteEventTrackingRegionsForFrame(const LocalFrame&) const;
 
     bool m_forceSynchronousScrollLayerPositionUpdates { false };
+    SingleThreadWeakPtr<Page> m_page; // FIXME: ideally this would be a WeakRef but it gets nulled on async teardown.
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
@@ -83,7 +83,7 @@ void ScrollingStateFixedNode::reconcileLayerPositionForViewportRect(const Layout
 {
     FloatPoint position = m_constraints.layerPositionForViewportRect(viewportRect);
     if (layer().representsGraphicsLayer()) {
-        auto* graphicsLayer = static_cast<GraphicsLayer*>(layer());
+        RefPtr graphicsLayer = static_cast<GraphicsLayer*>(layer());
 
         LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateFixedNode " << scrollingNodeID() <<" reconcileLayerPositionForViewportRect " << action << " position of layer " << graphicsLayer->primaryLayerID() << " to " << position);
         

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -71,7 +71,7 @@ void ThreadedScrollingCoordinator::commitTreeStateIfNeeded()
 WheelEventHandlingResult ThreadedScrollingCoordinator::handleWheelEventForScrolling(const PlatformWheelEvent& wheelEvent, ScrollingNodeID targetNodeID, std::optional<WheelScrollGestureState> gestureState)
 {
     ASSERT(isMainThread());
-    ASSERT(m_page);
+    ASSERT(page());
     ASSERT(scrollingTree());
 
     if (scrollingTree()->willWheelEventStartSwipeGesture(wheelEvent))
@@ -79,7 +79,7 @@ WheelEventHandlingResult ThreadedScrollingCoordinator::handleWheelEventForScroll
 
     LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::handleWheelEventForScrolling " << wheelEvent << " - sending event to scrolling thread, node " << targetNodeID << " gestureState " << gestureState);
 
-    auto deferrer = WheelEventTestMonitorCompletionDeferrer { m_page->wheelEventTestMonitor().get(), reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(targetNodeID), WheelEventTestMonitor::DeferReason::PostMainThreadWheelEventHandling };
+    auto deferrer = WheelEventTestMonitorCompletionDeferrer { page()->wheelEventTestMonitor().get(), reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(targetNodeID), WheelEventTestMonitor::DeferReason::PostMainThreadWheelEventHandling };
 
     RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
     ScrollingThread::dispatch([threadedScrollingTree, wheelEvent, targetNodeID, gestureState, deferrer = WTFMove(deferrer)] {
@@ -110,9 +110,9 @@ void ThreadedScrollingCoordinator::didScheduleRenderingUpdate()
 void ThreadedScrollingCoordinator::willStartRenderingUpdate()
 {
     ASSERT(isMainThread());
-    if (m_page)
-        m_page->layoutIfNeeded(LayoutOptions::UpdateCompositingLayers);
-    RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
+    if (RefPtr page = this->page())
+        page->layoutIfNeeded(LayoutOptions::UpdateCompositingLayers);
+    RefPtr threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
     threadedScrollingTree->willStartRenderingUpdate();
     commitTreeStateIfNeeded();
     synchronizeStateFromScrollingTree();

--- a/Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.mm
@@ -82,15 +82,15 @@ void ScrollingCoordinatorMac::didCompletePlatformRenderingUpdate()
 
 void ScrollingCoordinatorMac::updateTiledScrollingIndicator()
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page()->mainFrame());
     if (!localMainFrame)
         return;
 
-    auto* frameView = localMainFrame->view();
+    RefPtr frameView = localMainFrame->view();
     if (!frameView)
         return;
     
-    TiledBacking* tiledBacking = frameView->tiledBacking();
+    CheckedPtr tiledBacking = frameView->tiledBacking();
     if (!tiledBacking)
         return;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
@@ -25,6 +25,7 @@
 #include <WebCore/DOMException.h>
 #include <WebCore/Document.h>
 #include "GObjectEventListener.h"
+#include <WebCore/HTMLFrameOwnerElement.h>
 #include <WebCore/JSDOMGlobalObject.h>
 #include <WebCore/JSDOMPromiseDeferred.h>
 #include <WebCore/JSExecState.h>

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -167,19 +167,19 @@ void RemoteScrollingCoordinator::startMonitoringWheelEvents(bool clearLatchingSt
 
 void RemoteScrollingCoordinator::receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase)
 {
-    if (auto monitor = m_page->wheelEventTestMonitor())
+    if (auto monitor = page()->wheelEventTestMonitor())
         monitor->receivedWheelEventWithPhases(phase, momentumPhase);
 }
 
 void RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason)
 {
-    if (auto monitor = m_page->wheelEventTestMonitor())
+    if (auto monitor = page()->wheelEventTestMonitor())
         monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
 }
 
 void RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason)
 {
-    if (auto monitor = m_page->wheelEventTestMonitor())
+    if (auto monitor = page()->wheelEventTestMonitor())
         monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
 }
 


### PR DESCRIPTION
#### 46e0a788746340ea0cabd5006bdac3e9f3c965cc
<pre>
Adopt even more smart pointer under WebCore/page/
<a href="https://bugs.webkit.org/show_bug.cgi?id=269267">https://bugs.webkit.org/show_bug.cgi?id=269267</a>

Reviewed by Ryosuke Niwa.

Adopt even more smart pointer under WebCore/page/, as recommended by the static
analyzer.

* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::protectedStyleSheet const):
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::userPrefersTextDescriptions const):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
* Source/WebCore/page/DeviceController.cpp:
(WebCore::DeviceController::dispatchDeviceEvent):
* Source/WebCore/page/DragController.cpp:
(WebCore::elementUnderMouse):
(WebCore::DragController::draggableElement const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::nodeWillBeRemoved):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
(WebCore::FocusController::findFocusableElementWithinScope):
(WebCore::FocusController::nextFocusableElementWithinScope):
(WebCore::FocusController::previousFocusableElementWithinScope):
(WebCore::FocusController::advanceFocusDirectionallyInContainer):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::inScope):
(WebCore::FrameTree::find const):
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::invalidateRect):
(WebCore::FrameView::scrollableAreaBoundingBox const):
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::frameElement const):
(WebCore::LocalDOMWindow::protectedFrameElement const):
(WebCore::LocalDOMWindow::scrollTo const):
(WebCore::LocalDOMWindow::setLocation):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateSnapOffsets):
(WebCore::shouldEnableSpeculativeTilingDuringLoading):
(WebCore::LocalFrameView::safeToPropagateScrollToParent const):
(WebCore::LocalFrameView::updateScrollCorner):
(WebCore::LocalFrameView::updateLayoutAndStyleIfNeededRecursive):
* Source/WebCore/page/Location.cpp:
(WebCore::Location::setLocation):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::useDarkAppearance const):
(WebCore::Page::hasLocalDataForURL):
(WebCore::Page::configureLoggingChannel):
(WebCore::Page::removeInjectedUserStyleSheet):
(WebCore::Page::reloadExecutionContextsForOrigin const):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::sampleColor):
* Source/WebCore/page/PageDebuggable.cpp:
(WebCore::PageDebuggable::name const):
* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::viewToOverlayOffset const):
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::layerWithDocumentOverlays):
(WebCore::PageOverlayController::layerWithViewOverlays):
(WebCore::PageOverlayController::installPageOverlay):
(WebCore::PageOverlayController::uninstallPageOverlay):
(WebCore::PageOverlayController::setPageOverlayNeedsDisplay):
(WebCore::PageOverlayController::setPageOverlayOpacity):
(WebCore::PageOverlayController::clearPageOverlay):
(WebCore::PageOverlayController::layerForOverlay const):
(WebCore::PageOverlayController::didChangeViewSize):
(WebCore::PageOverlayController::didChangeDocumentSize):
(WebCore::PageOverlayController::didChangeSettings):
(WebCore::PageOverlayController::didChangeDeviceScaleFactor):
(WebCore::PageOverlayController::didScrollFrame):
(WebCore::PageOverlayController::paintContents):
(WebCore::PageOverlayController::didChangeOverlayFrame):
(WebCore::PageOverlayController::didChangeOverlayBackgroundColor):
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serializeFrame):
(WebCore::PageSerializer::serializeCSSStyleSheet):
(WebCore::PageSerializer::retrieveResourcesForRule):
* Source/WebCore/page/PerformanceLogging.cpp:
(WebCore::PerformanceLogging::memoryUsageStatistics):
* Source/WebCore/page/PerformanceNavigation.cpp:
(WebCore::PerformanceNavigation::redirectCount const):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::hasPointerCapture):
(WebCore::PointerCaptureController::cancelPointer):
* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::protectedTarget const):
* Source/WebCore/page/ResizeObservation.h:
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::gatherObservations):
(WebCore::ResizeObserver::deliverObservations):
(WebCore::ResizeObserver::removeAllTargets):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::mediaTypeOverrideChanged):
* Source/WebCore/page/VisualViewport.cpp:
(WebCore::VisualViewport::scriptExecutionContext const):
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::gpu):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passSubframeEventToSubframe):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::remainingTimeUntilHighlightShouldBeShown const):
(WebCore::ServicesOverlayController::buildPhoneNumberHighlights):
(WebCore::ServicesOverlayController::buildSelectionHighlight):
(WebCore::ServicesOverlayController::createOverlayIfNeeded):
(WebCore::ServicesOverlayController::telephoneNumberRangesForFocusedFrame):
(WebCore::ServicesOverlayController::handleClick):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::hysterisisTimerFired):
(WebCore::AsyncScrollingCoordinator::handleWheelEventPhase):
(WebCore::AsyncScrollingCoordinator::frameViewLayoutUpdated):
(WebCore::AsyncScrollingCoordinator::frameViewVisualViewportChanged):
(WebCore::AsyncScrollingCoordinator::frameViewWillBeDetached):
(WebCore::AsyncScrollingCoordinator::updateIsMonitoringWheelEventsForFrameView):
(WebCore::AsyncScrollingCoordinator::frameViewEventTrackingRegionsChanged):
(WebCore::AsyncScrollingCoordinator::frameViewRootLayerDidChange):
(WebCore::AsyncScrollingCoordinator::requestStartKeyboardScrollAnimation):
(WebCore::AsyncScrollingCoordinator::requestStopKeyboardScrollAnimation):
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
(WebCore::AsyncScrollingCoordinator::stopAnimatedScroll):
(WebCore::AsyncScrollingCoordinator::setMouseIsOverScrollbar):
(WebCore::AsyncScrollingCoordinator::setMouseIsOverContentArea):
(WebCore::AsyncScrollingCoordinator::setMouseMovedInContentArea):
(WebCore::AsyncScrollingCoordinator::setScrollbarEnabled):
(WebCore::AsyncScrollingCoordinator::scheduleRenderingUpdate):
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
(WebCore::AsyncScrollingCoordinator::animatedScrollWillStartForNode):
(WebCore::AsyncScrollingCoordinator::animatedScrollDidEndForNode):
(WebCore::AsyncScrollingCoordinator::wheelEventScrollWillStartForNode):
(WebCore::AsyncScrollingCoordinator::wheelEventScrollDidEndForNode):
(WebCore::AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll):
(WebCore::AsyncScrollingCoordinator::reconcileScrollingState):
(WebCore::AsyncScrollingCoordinator::scrollableAreaScrollbarLayerDidChange):
(WebCore::AsyncScrollingCoordinator::setNodeLayers):
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):
(WebCore::AsyncScrollingCoordinator::setViewportConstraintedNodeConstraints):
(WebCore::AsyncScrollingCoordinator::setPositionedNodeConstraints):
(WebCore::AsyncScrollingCoordinator::setRelatedOverflowScrollingNodes):
(WebCore::AsyncScrollingCoordinator::setSynchronousScrollingReasons):
(WebCore::AsyncScrollingCoordinator::synchronousScrollingReasons const):
(WebCore::AsyncScrollingCoordinator::scrollableContainerNodeID const):
(WebCore::AsyncScrollingCoordinator::setActiveScrollSnapIndices):
(WebCore::AsyncScrollingCoordinator::updateScrollSnapPropertiesWithFrameView):
(WebCore::AsyncScrollingCoordinator::reportExposedUnfilledArea):
(WebCore::AsyncScrollingCoordinator::reportSynchronousScrollingReasonsChanged):
(WebCore::AsyncScrollingCoordinator::scrollAnimatorEnabled const):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::protectedPage const):
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::page const):
* Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp:
(WebCore::ScrollingStateFixedNode::reconcileLayerPositionForViewportRect):
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp:
(WebCore::ThreadedScrollingCoordinator::handleWheelEventForScrolling):
(WebCore::ThreadedScrollingCoordinator::willStartRenderingUpdate):
* Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.mm:
(WebCore::ScrollingCoordinatorMac::updateTiledScrollingIndicator):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode):
(WebKit::RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode):

Canonical link: <a href="https://commits.webkit.org/274652@main">https://commits.webkit.org/274652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba74459396398e195ea46b9519522743743b9cf9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42067 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33028 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43345 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39314 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37574 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15951 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15999 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5208 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->