### PR TITLE
Give TiledBacking a TiledBackingClient that allows a client more knowledge of tile painting

### DIFF
--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include "IntPoint.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -57,9 +59,25 @@ enum class TiledBackingScrollability : uint8_t {
     VerticallyScrollable    = 1 << 1
 };
 
+using TileIndex = IntPoint;
+using TileGridIndex = unsigned;
+
+class TiledBackingClient : public CanMakeWeakPtr<TiledBackingClient> {
+public:
+    virtual ~TiledBackingClient() = default;
+
+    // paintDirtyRect is in the same coordinate system as tileClip.
+    virtual void willRepaintTile(TileGridIndex, TileIndex, const FloatRect& tileClip, const FloatRect& paintDirtyRect) = 0;
+    virtual void willRemoveTile(TileGridIndex, TileIndex) = 0;
+    virtual void willRepaintAllTiles(TileGridIndex) = 0;
+};
+
+
 class TiledBacking : public CanMakeCheckedPtr {
 public:
     virtual ~TiledBacking() = default;
+
+    virtual void setClient(TiledBackingClient*) = 0;
 
     virtual void setVisibleRect(const FloatRect&) = 0;
     virtual FloatRect visibleRect() const = 0;

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -83,6 +83,17 @@ TileController::~TileController()
 #endif
 }
 
+
+void TileController::setClient(TiledBackingClient* client)
+{
+    if (client) {
+        m_client = *client;
+        return;
+    }
+
+    m_client = nullptr;
+}
+
 void TileController::tileCacheLayerBoundsChanged()
 {
     ASSERT(owningGraphicsLayer()->isCommittingChanges());
@@ -526,6 +537,33 @@ void TileController::didEndLiveResize()
 {
     m_inLiveResize = false;
     m_tileSizeLocked = false; // Let the end of a live resize update the tiles.
+}
+
+void TileController::willRepaintTile(TileGrid& tileGrid, TileIndex tileIndex, const FloatRect& tileClip, const FloatRect& paintDirtyRect)
+{
+    if (!m_client)
+        return;
+
+    unsigned gridIndex = &tileGrid == m_tileGrid.get() ? 0 : 1;
+    m_client->willRepaintTile(gridIndex, tileIndex, tileClip, paintDirtyRect);
+}
+
+void TileController::willRemoveTile(TileGrid& tileGrid, TileIndex tileIndex)
+{
+    if (!m_client)
+        return;
+
+    unsigned gridIndex = &tileGrid == m_tileGrid.get() ? 0 : 1;
+    m_client->willRemoveTile(gridIndex, tileIndex);
+}
+
+void TileController::willRepaintAllTiles(TileGrid& tileGrid)
+{
+    if (!m_client)
+        return;
+
+    unsigned gridIndex = &tileGrid == m_tileGrid.get() ? 0 : 1;
+    m_client->willRepaintAllTiles(gridIndex);
 }
 
 void TileController::notePendingTileSizeChange()

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -153,6 +153,7 @@ private:
     float topContentInset() const { return m_topContentInset; }
 
     // TiledBacking member functions.
+    void setClient(TiledBackingClient*) final;
     void setVisibleRect(const FloatRect&) final;
     void setLayoutViewportRect(std::optional<FloatRect>) final;
     void setCoverageRect(const FloatRect&) final;
@@ -189,6 +190,10 @@ private:
     void notePendingTileSizeChange();
     void tileSizeChangeTimerFired();
 
+    void willRepaintTile(TileGrid&, TileIndex, const FloatRect& tileClip, const FloatRect& paintDirtyRect);
+    void willRemoveTile(TileGrid&, TileIndex);
+    void willRepaintAllTiles(TileGrid&);
+
 #if !PLATFORM(IOS_FAMILY)
     FloatRect adjustTileCoverageForDesktopPageScrolling(const FloatRect& coverageRect, const FloatSize& newSize, const FloatRect& previousVisibleRect, const FloatRect& visibleRect) const;
 #endif
@@ -200,6 +205,8 @@ private:
     PlatformCALayerClient* owningGraphicsLayer() const { return m_tileCacheLayer->owner(); }
 
     PlatformCALayer* m_tileCacheLayer;
+
+    WeakPtr<TiledBackingClient> m_client;
 
     float m_zoomedOutContentsScale { 0 };
     float m_deviceScaleFactor;

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -97,17 +97,21 @@ void TileGrid::setScale(float scale)
 
     for (auto& tile : m_tiles.values())
         tile.layer->setContentsScale(m_controller.deviceScaleFactor());
+
+    m_controller.willRepaintAllTiles(*this);
 }
 
 void TileGrid::setNeedsDisplay()
 {
     for (auto& entry : m_tiles) {
+        TileIndex tileIndex = entry.key;
         TileInfo& tileInfo = entry.value;
-        IntRect tileRect = rectForTileIndex(entry.key);
+        IntRect tileRect = rectForTileIndex(tileIndex);
 
-        if (tileRect.intersects(m_primaryTileCoverageRect) && tileInfo.layer->superlayer())
+        if (tileRect.intersects(m_primaryTileCoverageRect) && tileInfo.layer->superlayer()) {
             tileInfo.layer->setNeedsDisplay();
-        else
+            m_controller.willRepaintTile(*this, tileIndex, tileRect, tileRect);
+        } else
             tileInfo.hasStaleContent = true;
     }
 }
@@ -173,12 +177,14 @@ void TileGrid::setTileNeedsDisplayInRect(const TileIndex& tileIndex, TileInfo& t
     if (tileRepaintRect.isEmpty())
         return;
 
-    tileRepaintRect.moveBy(-tileRect.location());
+    auto tileLocalRepaintRect = tileRepaintRect;
+    tileLocalRepaintRect.moveBy(-tileRect.location());
     
     // We could test for intersection with the visible rect. This would reduce painting yet more,
     // but may make scrolling stale tiles into view more frequent.
     if (tileRect.intersects(coverageRectInTileCoords) && tileLayer->superlayer()) {
-        tileLayer->setNeedsDisplayInRect(tileRepaintRect);
+        tileLayer->setNeedsDisplayInRect(tileLocalRepaintRect);
+        m_controller.willRepaintTile(*this, tileIndex, tileRect, tileRepaintRect);
 
         if (m_controller.rootLayer().owner()->platformCALayerShowRepaintCounter(0)) {
             FloatRect indicatorRect(0, 0, 52, 27);
@@ -288,13 +294,15 @@ unsigned TileGrid::blankPixelCount() const
     return TileController::blankPixelCountForTiles(tiles, m_controller.visibleRect(), IntPoint(0, 0));
 }
 
-void TileGrid::removeTiles(const Vector<TileGrid::TileIndex>& toRemove)
+void TileGrid::removeTiles(const Vector<TileIndex>& toRemove)
 {
     for (size_t i = 0; i < toRemove.size(); ++i) {
-        TileInfo tileInfo = m_tiles.take(toRemove[i]);
+        auto tileIndex = toRemove[i];
+        TileInfo tileInfo = m_tiles.take(tileIndex);
         tileInfo.layer->removeFromSuperlayer();
         m_tileRepaintCounts.removeAll(tileInfo.layer.get());
         tileInfo.layer->moveToLayerPool();
+        m_controller.willRemoveTile(*this, tileIndex);
     }
 }
 
@@ -368,6 +376,7 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
             if (tileInfo.hasStaleContent) {
                 // FIXME: store a dirty region per layer?
                 tileLayer->setNeedsDisplay();
+                m_controller.willRepaintTile(*this, tileIndex, tileRect, tileRect);
                 tileInfo.hasStaleContent = false;
             }
         } else {
@@ -375,6 +384,7 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
             if (tileInfo.cohort == visibleTileCohort) {
                 tileInfo.cohort = currCohort;
                 ++tilesInCohort;
+                m_controller.willRemoveTile(*this, tileIndex);
                 tileLayer->removeFromSuperlayer();
             } else if (m_controller.shouldAggressivelyRetainTiles() && tileLayer->superlayer()) {
                 // Aggressive tile retention means we'll never remove cohorts, but we need to make sure they're unparented.
@@ -387,8 +397,10 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
                     if (timeUntilCohortExpires > 0_s) {
                         minimumRevalidationTimerDuration = std::min(minimumRevalidationTimerDuration, timeUntilCohortExpires);
                         needsTileRevalidation = true;
-                    } else
+                    } else {
+                        m_controller.willRemoveTile(*this, tileIndex);
                         tileLayer->removeFromSuperlayer();
+                    }
                     break;
                 }
             }
@@ -416,8 +428,10 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
     }
 
     if (validationPolicy & UnparentAllTiles) {
-        for (auto& tile : m_tiles.values())
-            tile.layer->removeFromSuperlayer();
+        for (auto& entry : m_tiles) {
+            m_controller.willRemoveTile(*this, entry.key);
+            entry.value.layer->removeFromSuperlayer();
+        }
     }
 
     auto boundsAtLastRevalidate = m_controller.boundsAtLastRevalidate();
@@ -565,6 +579,7 @@ IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, CoverageType newTile
 
             if (!tileInfo.layer) {
                 tileInfo.layer = m_controller.createTileLayer(tileRect, *this);
+                m_controller.willRepaintTile(*this, tileIndex, tileRect, tileRect);
                 ASSERT(!m_tileRepaintCounts.contains(tileInfo.layer.get()));
             } else {
                 // We already have a layer for this tile. Ensure that its size is correct.
@@ -575,6 +590,7 @@ IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, CoverageType newTile
                     tileInfo.layer->setBounds(FloatRect(FloatPoint(), tileRect.size()));
                     tileInfo.layer->setPosition(tileRect.location());
                     tileInfo.layer->setNeedsDisplay();
+                    m_controller.willRepaintTile(*this, tileIndex, tileRect, tileRect);
                 }
             }
 

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -44,6 +44,8 @@ class GraphicsContext;
 class PlatformCALayer;
 class TileController;
 
+using TileIndex = IntPoint;
+
 class TileGrid : public PlatformCALayerClient {
     WTF_MAKE_NONCOPYABLE(TileGrid);
     WTF_MAKE_FAST_ALLOCATED;
@@ -93,8 +95,6 @@ public:
     void removeUnparentedTilesNow();
 #endif
 
-    using TileIndex = IntPoint;
-
     using TileCohort = unsigned;
     static constexpr TileCohort visibleTileCohort = std::numeric_limits<TileCohort>::max();
 
@@ -135,7 +135,7 @@ private:
     TileCohort newestTileCohort() const;
     TileCohort oldestTileCohort() const;
 
-    void removeTiles(const Vector<TileGrid::TileIndex>& toRemove);
+    void removeTiles(const Vector<TileIndex>& toRemove);
 
     // PlatformCALayerClient
     void platformCALayerPaintContents(PlatformCALayer*, GraphicsContext&, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>) override;

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -89,6 +89,7 @@ public:
     TiledBacking* tiledBacking() const { return const_cast<WCTiledBacking*>(this); };
 
     // TiledBacking override
+    void setClient(TiledBackingClient*) final { }
     void setVisibleRect(const FloatRect&) final { }
     FloatRect visibleRect() const final { return { }; };
     void setLayoutViewportRect(std::optional<FloatRect>) final { }


### PR DESCRIPTION
#### 3f6d7f5ff24f92cb8327e9d67a87755d6d3d47a4
<pre>
Give TiledBacking a TiledBackingClient that allows a client more knowledge of tile painting
<a href="https://bugs.webkit.org/show_bug.cgi?id=269268">https://bugs.webkit.org/show_bug.cgi?id=269268</a>
<a href="https://rdar.apple.com/122850594">rdar://122850594</a>

Reviewed by Tim Horton.

Introduce TiledBackingClient, a weakly held client of TiledBacking that gets informed
when a tile is repainted or removed, and when all tiles are invalidate.

UnifiedPDFPlugin will use this as a basis for caching.

The client is informed about events per tile using TileGridIndex and TileIndex to
identify tiles; TileGridIndex is 0 for the main tile grid, and 1 for the optional zoomed-out
tile grid.

* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setClient):
(WebCore::TileController::willRepaintTile):
(WebCore::TileController::willRemoveTile):
(WebCore::TileController::willRepaintAllTiles):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::setScale):
(WebCore::TileGrid::setNeedsDisplay):
(WebCore::TileGrid::setTileNeedsDisplayInRect):
(WebCore::TileGrid::removeTiles):
(WebCore::TileGrid::revalidateTiles):
(WebCore::TileGrid::ensureTilesForRect):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:

Canonical link: <a href="https://commits.webkit.org/274574@main">https://commits.webkit.org/274574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcf0357f8dada045db1825569dbf19decc37934d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35350 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15758 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39254 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37505 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15868 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8834 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15916 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->