### PR TITLE
[UnifiedPDF] Prepare for sharing some PDF page painting data with async rendering

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -48,6 +48,7 @@ class WebFrame;
 class WebMouseEvent;
 enum class WebEventType : uint8_t;
 enum class WebMouseEventButton : int8_t;
+enum class WebEventModifier : uint8_t;
 
 class AnnotationTrackingState {
 public:
@@ -62,12 +63,22 @@ private:
     bool m_isBeingHovered { false };
 };
 
-enum class WebEventModifier : uint8_t;
-
 enum class AnnotationSearchDirection : bool {
     Forward,
     Backward
 };
+
+struct PerPageInfo {
+    PDFDocumentLayout::PageIndex pageIndex { 0 };
+    WebCore::FloatRect pageBounds;
+};
+
+struct PDFPageCoverage {
+    Vector<PerPageInfo> pages;
+    float deviceScaleFactor { 1 };
+    float documentScale { 1 };
+};
+
 class UnifiedPDFPlugin final : public PDFPluginBase, public WebCore::GraphicsLayerClient {
 public:
     static Ref<UnifiedPDFPlugin> create(WebCore::HTMLPlugInElement&);
@@ -247,8 +258,11 @@ private:
     float pageScaleFactor() const override { return scaleFactor(); }
     bool layerNeedsPlatformContext(const WebCore::GraphicsLayer*) const override { return true; }
 
+    // Package up the data needed to paint a set of pages for the given clip, for use by UnifiedPDFPlugin::paintPDFContent and async rendering.
+    PDFPageCoverage pageCoverageForRect(const WebCore::FloatRect& clipRect) const;
+
     void paintPDFContent(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect);
-    void paintPDFOverlays(WebCore::GraphicsContext&);
+    void paintPDFOverlays(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect);
 
     void ensureLayers();
     void updatePageBackgroundLayers();


### PR DESCRIPTION
#### 6c12bd338a35f85ab2f42e906e2dfc985c745e7b
<pre>
[UnifiedPDF] Prepare for sharing some PDF page painting data with async rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=269270">https://bugs.webkit.org/show_bug.cgi?id=269270</a>
<a href="https://rdar.apple.com/122851341">rdar://122851341</a>

Reviewed by Tim Horton.

Async PDF painting will need to be able to paint the set of pages that intersect
with a given clipRect (corresponding to a tile) in m_contentLayer coordinates,
in a way that does not use the thread-unsafe PDFDocumentLayout.

So make a little data structure, `PDFPageCoverage` to hold enough information about
the set of pages that intersect the given rect, and their geometry.

`UnifiedPDFPlugin::pageCoverageForRect()` computes this data, and  `UnifiedPDFPlugin::paintPDFContent()`
is updated to use it.

Also pass a clipRect to `UnifiedPDFPlugin::paintPDFOverlays()` to avoid filling a rect outside the clip,
and make the code easier to read.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::pageCoverageForRect const):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::paintPDFOverlays):

Canonical link: <a href="https://commits.webkit.org/274552@main">https://commits.webkit.org/274552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5e92c27a37ba986e20116166ee079b2fda04ce0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35267 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32912 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13413 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13387 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43179 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35733 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39181 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37425 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15785 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8818 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->