### PR TITLE
[WebGPU] RemoteBuffer::getMappedRange may fail on invalid buffers

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
@@ -102,7 +102,7 @@ ExceptionOr<Ref<GPUTextureView>> GPUTexture::createView(const std::optional<GPUT
 {
     if (textureViewDescriptor.has_value() && textureViewDescriptor->format.has_value()) {
         if (!m_device->isSupportedFormat(*textureViewDescriptor->format))
-            return Exception { ExceptionCode::TypeError, "Unsupported texture format."_s };
+            return Exception { ExceptionCode::TypeError, "GPUTexture.createView: Unsupported texture format."_s };
     }
     return GPUTextureView::create(m_backing->createView(convertToBacking(textureViewDescriptor)));
 }

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -201,7 +201,7 @@ ExceptionOr<void> GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& conf
         return { };
 
     if (!configuration.device->isSupportedFormat(configuration.format))
-        return Exception { ExceptionCode::TypeError, "Unsupported texture format."_s };
+        return Exception { ExceptionCode::TypeError, "GPUCanvasContextCocoa.configure: Unsupported texture format."_s };
 
     for (auto viewFormat : configuration.viewFormats) {
         if (!configuration.device->isSupportedFormat(viewFormat))

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -112,7 +112,6 @@ private:
     using MappedRanges = RangeSet<Range<size_t>>;
     MappedRanges m_mappedRanges;
     WGPUMapModeFlags m_mapMode { WGPUMapMode_None };
-    Vector<uint8_t> m_emptyBuffer;
 
     const Ref<Device> m_device;
     mutable WeakPtr<CommandEncoder> m_commandEncoder;

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -222,10 +222,8 @@ static size_t computeRangeSize(uint64_t size, size_t offset)
 void* Buffer::getMappedRange(size_t offset, size_t size)
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange
-    if (!isValid()) {
-        m_emptyBuffer.resize(std::max<size_t>(size, 1));
-        return &m_emptyBuffer[0];
-    }
+    if (!isValid())
+        return nullptr;
 
     auto rangeSize = size;
     if (size == WGPU_WHOLE_MAP_SIZE)
@@ -359,7 +357,7 @@ void Buffer::setLabel(String&& label)
 
 uint64_t Buffer::size() const
 {
-    return m_emptyBuffer.size() ?: m_size;
+    return m_size;
 }
 
 bool Buffer::isValid() const


### PR DESCRIPTION
#### 436df12fad2091d6859324000ad00dd8714835dc
<pre>
[WebGPU] RemoteBuffer::getMappedRange may fail on invalid buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=269275">https://bugs.webkit.org/show_bug.cgi?id=269275</a>
&lt;radar://122399176&gt;

Reviewed by Tadeu Zagallo.

Buffer::getMappedRange returns nullptr if validation failed,
but previously returned an empty buffer for invalid buffers.

This leads to incorrect behaviors as offset is not validated
and may be outside the range of the buffer. Furthermore, creating
an empty buffer of an arbitrary size is unnecessary.

Address this by matching the behavior of returning nullptr which
is handled correctly at the one call site of Buffer::getMappedRange.

All api,operation,buffer,* and api,validation,buffers,* CTS
test pass after this change.

* Source/WebCore/Modules/WebGPU/GPUTexture.cpp:
(WebCore::GPUTexture::createView const):
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::configure):
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::getMappedRange):
(WebGPU::Buffer::size const):

Canonical link: <a href="https://commits.webkit.org/274591@main">https://commits.webkit.org/274591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/540370ec9a79213bc954d59f47dd5b9df0aa0832

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35277 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32920 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43189 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39190 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37434 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15795 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8844 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->