### PR TITLE
[threaded-animation-resolution] webanimations/transform-accelerated-animation-finishes-before-removal.html is a failure

### DIFF
--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -35,6 +35,7 @@
 #include "RenderStyleInlines.h"
 #include "RotateTransformOperation.h"
 #include "ScaleTransformOperation.h"
+#include "Settings.h"
 #include "TransformOperations.h"
 #include "TranslateTransformOperation.h"
 #include "WebAnimation.h"
@@ -291,6 +292,21 @@ void KeyframeEffectStack::applyPendingAcceleratedActions() const
         else
             effect->applyPendingAcceleratedActions();
     }
+}
+
+bool KeyframeEffectStack::hasAcceleratedEffects(const Settings& settings) const
+{
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    if (settings.threadedAnimationResolutionEnabled())
+        return !m_acceleratedEffects.isEmptyIgnoringNullReferences();
+#else
+    UNUSED_PARAM(settings);
+#endif
+    for (auto& effect : m_effects) {
+        if (effect->isRunningAccelerated())
+            return true;
+    }
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -31,11 +31,20 @@
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include <wtf/WeakListHashSet.h>
+#endif
+
 namespace WebCore {
 
 class Document;
 class KeyframeEffect;
 class RenderStyle;
+class Settings;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class AcceleratedEffect;
+#endif
 
 namespace Style {
 struct ResolutionContext;
@@ -75,6 +84,11 @@ public:
 
     void applyPendingAcceleratedActions() const;
 
+    bool hasAcceleratedEffects(const Settings&) const;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void setAcceleratedEffects(WeakListHashSet<AcceleratedEffect>&& acceleratedEffects) { m_acceleratedEffects = WTFMove(acceleratedEffects); }
+#endif
+
 private:
     void ensureEffectsAreSorted();
     bool hasMatchingEffect(const Function<bool(const KeyframeEffect&)>&) const;
@@ -82,6 +96,9 @@ private:
     void stopAcceleratedAnimations();
 
     Vector<WeakPtr<KeyframeEffect>> m_effects;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    WeakListHashSet<AcceleratedEffect> m_acceleratedEffects;
+#endif
     HashSet<String> m_invalidCSSAnimationNames;
     HashSet<AnimatableCSSProperty> m_acceleratedPropertiesOverriddenByCascade;
     RefPtr<const AnimationList> m_cssAnimationList;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -941,7 +941,7 @@ void RenderBoxModelObject::mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode>
 bool RenderBoxModelObject::hasRunningAcceleratedAnimations() const
 {
     if (auto styleable = Styleable::fromRenderer(*this))
-        return styleable->runningAnimationsAreAllAccelerated();
+        return styleable->hasRunningAcceleratedAnimations();
     return false;
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -101,6 +101,7 @@
 #include "AcceleratedEffectValues.h"
 #include "KeyframeEffect.h"
 #include "KeyframeEffectStack.h"
+#include <wtf/WeakListHashSet.h>
 #endif
 
 namespace WebCore {
@@ -4079,6 +4080,7 @@ bool RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()
     }();
 
     AcceleratedEffects acceleratedEffects;
+    WeakListHashSet<AcceleratedEffect> weakAcceleratedEffects;
     if (auto* effectStack = target->keyframeEffectStack()) {
         auto animatesWidth = effectStack->containsProperty(CSSPropertyWidth);
         auto animatesHeight = effectStack->containsProperty(CSSPropertyHeight);
@@ -4096,8 +4098,10 @@ bool RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()
             if (!hasInterpolatingEffect && effect->isRunningAccelerated())
                 hasInterpolatingEffect = true;
             effect->setAcceleratedRepresentation(acceleratedEffect.get());
+            weakAcceleratedEffects.add(*acceleratedEffect);
             acceleratedEffects.append(acceleratedEffect.releaseNonNull());
         }
+        effectStack->setAcceleratedEffects(WTFMove(weakAcceleratedEffects));
     }
 
     // If all of the effects in the stack are either idle, paused or filling, then the

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3403,6 +3403,8 @@ bool RenderLayerCompositor::requiresCompositingForAnimation(RenderLayerModelObje
         return false;
 
     if (auto styleable = Styleable::fromRenderer(renderer)) {
+        if (styleable->hasRunningAcceleratedAnimations())
+            return true;
         if (auto* effectsStack = styleable->keyframeEffectStack()) {
             return (effectsStack->isCurrentlyAffectingProperty(CSSPropertyOpacity)
                 && (usesCompositing() || (m_compositingTriggers & ChromeClient::AnimatedOpacityTrigger)))

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -245,18 +245,11 @@ bool Styleable::isRunningAcceleratedTransformAnimation() const
     return false;
 }
 
-bool Styleable::runningAnimationsAreAllAccelerated() const
+bool Styleable::hasRunningAcceleratedAnimations() const
 {
-    auto* effectStack = keyframeEffectStack();
-    if (!effectStack || !effectStack->hasEffects())
-        return false;
-
-    for (const auto& effect : effectStack->sortedEffects()) {
-        if (!effect->isRunningAccelerated())
-            return false;
-    }
-
-    return true;
+    if (auto* effectStack = keyframeEffectStack())
+        return effectStack->hasAcceleratedEffects(element.document().settings());
+    return false;
 }
 
 void Styleable::animationWasAdded(WebAnimation& animation) const

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -78,7 +78,7 @@ struct Styleable {
 
     bool isRunningAcceleratedTransformAnimation() const;
 
-    bool runningAnimationsAreAllAccelerated() const;
+    bool hasRunningAcceleratedAnimations() const;
 
     KeyframeEffectStack* keyframeEffectStack() const
     {


### PR DESCRIPTION
#### c409399155163c223f7bb1bca5d54e71a8724b99
<pre>
[threaded-animation-resolution] webanimations/transform-accelerated-animation-finishes-before-removal.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=269278">https://bugs.webkit.org/show_bug.cgi?id=269278</a>
<a href="https://rdar.apple.com/122856408">rdar://122856408</a>

Reviewed by Dean Jackson.

We need to ensure keyframe effects that are accelerated using threaded animation resolution cause the target element
to remain on a layer until the effect has completed. In the case of threaded animation resolution, because accelerated
effects run in the UIProcess, we cannot simply rely on whether the keyframe effect stack has a running effect indicating
it is accelerated, because it will no longer be &quot;running&quot; as soon as timing in the WebProcess resolves to such a state.

What we want is to ensure the target element remains on a layer until after that state has been propagated to the UIProcess.
To do so, we now set a list of all accelerated effects on the `KeyframeEffectStack` when we compute the latest accelerated
effect stack in RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(). Then the keyframe effect stack can be queried
for the presence of at least one accelerated effect using `KeyframeEffectStack::hasAcceleratedEffects()`. We call this new
function in two spots:

    1. `RenderLayerCompositor::requiresCompositingForAnimation()`
    2. `Styleable::hasRunningAcceleratedAnimations()`

The latter was formerly called `Styleable::runningAnimationsAreAllAccelerated()` which, while named accurately, was not
doing what was required, which was to identify whether at least one animation was being run with acceleration. This method
is called under `RenderBox::requiresLayer()` and `RenderInline::requiresLayer()`.

This addresses the test regression with threaded animation resolution enabled.

* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::hasAcceleratedEffects const):
* Source/WebCore/animation/KeyframeEffectStack.h:
(WebCore::KeyframeEffectStack::setAcceleratedEffects):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::hasRunningAcceleratedAnimations const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForAnimation const):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::hasRunningAcceleratedAnimations const):
(WebCore::Styleable::runningAnimationsAreAllAccelerated const): Deleted.
* Source/WebCore/style/Styleable.h:

Canonical link: <a href="https://commits.webkit.org/275178@main">https://commits.webkit.org/275178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aeb283c8ededf43f0119ea402e2e405fc123c14e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16717 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33488 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44199 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39840 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38113 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16810 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9227 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->