### PR TITLE
[threaded-animation-resolution] webanimations/seeking-by-changing-delay-accelerated.html is a failure

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -252,10 +252,9 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
 {
     ASSERT(isUIThread());
 
-    if (m_effectStack) {
+    if (m_effectStack)
         m_effectStack->clear(layer());
-        host.animationsWereRemovedFromNode(*this);
-    }
+    host.animationsWereRemovedFromNode(*this);
 
     if (effects.isEmpty())
         return;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -598,7 +598,8 @@ void RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode(RemoteLayerTr
 {
     ASSERT(isMainRunLoop());
     assertIsHeld(m_effectStacksLock);
-    m_effectStacks.remove(node.layerID());
+    if (auto effectStack = m_effectStacks.take(node.layerID()))
+        effectStack->clear(node.layer());
 }
 
 void RemoteLayerTreeEventDispatcher::updateAnimations()


### PR DESCRIPTION
#### 7f0ea2560ba1232e6f32da91332921f655652296
<pre>
[threaded-animation-resolution] webanimations/seeking-by-changing-delay-accelerated.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=269279">https://bugs.webkit.org/show_bug.cgi?id=269279</a>
<a href="https://rdar.apple.com/122856750">rdar://122856750</a>

Reviewed by Simon Fraser.

On macOS, the `RemoteAcceleratedStack` ownership is transferred from the target `RemoteLayerTreeNode` to the
`RemoteLayerTreeEventDispatcher`. So when we set new effects, including the case where we remove them
altogether, we cannot rely on `RemoteLayerTreeNode::m_effectStack` being set because the effect stack would
have been transferred. So we need to call `animationsWereRemovedFromNode()` on the host through to the dispatcher
and call `RemoteAcceleratedStack::clear()` from there.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode):

Canonical link: <a href="https://commits.webkit.org/274549@main">https://commits.webkit.org/274549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49d21c97a1fd23cf136a5294d96f4bb3087cf82a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35284 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32926 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13404 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43196 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35753 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39200 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37447 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15802 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8817 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->