### PR TITLE
[WebXR] Remove texture size from createAndBindEGLImage result

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -46,7 +46,7 @@ namespace WebCore {
 using GL = GraphicsContextGL;
 
 #if PLATFORM(COCOA)
-static std::optional<GL::EGLImageAttachResult> createAndBindCompositorTexture(GL& gl, GCGLenum target, GCGLOwnedTexture& texture, GL::EGLImageSource source)
+static GCEGLImage createAndBindCompositorTexture(GL& gl, GCGLenum target, GCGLOwnedTexture& texture, GL::EGLImageSource source)
 {
     auto object = gl.createTexture();
     if (!object)
@@ -58,16 +58,14 @@ static std::optional<GL::EGLImageAttachResult> createAndBindCompositorTexture(GL
     gl.texParameteri(target, GL::TEXTURE_WRAP_S, GL::CLAMP_TO_EDGE);
     gl.texParameteri(target, GL::TEXTURE_WRAP_T, GL::CLAMP_TO_EDGE);
 
-    auto attachResult = gl.createAndBindEGLImage(target, source);
-    if (!attachResult || !std::get<GCEGLImage>(*attachResult) || std::get<IntSize>(*attachResult).isEmpty()) {
+    auto image = gl.createAndBindEGLImage(target, source);
+    if (!image)
         texture.release(gl);
-        return std::nullopt;
-    }
 
-    return attachResult;
+    return image;
 }
 
-static std::optional<GL::EGLImageAttachResult> createAndBindCompositorBuffer(GL& gl, GCGLOwnedRenderbuffer& buffer, GL::EGLImageSource source)
+static GCEGLImage createAndBindCompositorBuffer(GL& gl, GCGLOwnedRenderbuffer& buffer, GL::EGLImageSource source)
 {
     auto object = gl.createRenderbuffer();
     if (!object)
@@ -75,13 +73,11 @@ static std::optional<GL::EGLImageAttachResult> createAndBindCompositorBuffer(GL&
     buffer.adopt(gl, object);
     gl.bindRenderbuffer(GL::RENDERBUFFER, buffer);
 
-    auto attachResult = gl.createAndBindEGLImage(GL::RENDERBUFFER, source);
-    if (!attachResult || !std::get<GCEGLImage>(*attachResult) || std::get<IntSize>(*attachResult).isEmpty()) {
+    auto image = gl.createAndBindEGLImage(GL::RENDERBUFFER, source);
+    if (!image)
         buffer.release(gl);
-        return std::nullopt;
-    }
 
-    return attachResult;
+    return image;
 }
 
 static GL::EGLImageSource makeEGLImageSource(const std::tuple<WTF::MachSendRight, bool>& imageSource)
@@ -153,23 +149,17 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& 
 
 #if PLATFORM(COCOA)
     auto colorTextureSource = makeEGLImageSource(data.colorTexture);
-    auto colorTextureAttachment = createAndBindCompositorTexture(*gl, textureTarget, m_colorTexture, colorTextureSource);
-
-    if (!colorTextureAttachment)
+    m_colorImage = createAndBindCompositorTexture(*gl, textureTarget, m_colorTexture, colorTextureSource);
+    if (!m_colorImage)
         return;
 
     auto depthStencilBufferSource = makeEGLImageSource(data.depthStencilBuffer);
-    auto depthStencilBufferAttachment = createAndBindCompositorBuffer(*gl, m_depthStencilBuffer, depthStencilBufferSource);
-
-    IntSize bufferSize;
-    std::tie(m_colorImage, bufferSize) = colorTextureAttachment.value();
-    if (depthStencilBufferAttachment)
-        std::tie(m_depthStencilImage, std::ignore) = depthStencilBufferAttachment.value();
+    m_depthStencilImage = createAndBindCompositorBuffer(*gl, m_depthStencilBuffer, depthStencilBufferSource);
 
     // The drawing target can change size at any point during the session. If this happens, we need
     // to recreate the framebuffer.
-    if (m_framebufferSize != bufferSize) {
-        m_framebufferSize = bufferSize;
+    if (m_framebufferSize != data.framebufferSize) {
+        m_framebufferSize = data.framebufferSize;
         if (!setupFramebuffer())
             return;
     }

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1506,8 +1506,7 @@ public:
 #else
     using EGLImageSource = int;
 #endif
-    using EGLImageAttachResult = std::tuple<GCEGLImage, IntSize>;
-    virtual std::optional<EGLImageAttachResult> createAndBindEGLImage(GCGLenum, EGLImageSource) = 0;
+    virtual GCEGLImage createAndBindEGLImage(GCGLenum, EGLImageSource) = 0;
     virtual void destroyEGLImage(GCEGLImage) = 0;
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2859,10 +2859,10 @@ void GraphicsContextGLANGLE::getActiveUniformBlockiv(GCGLuint program, GCGLuint 
     GL_GetActiveUniformBlockivRobustANGLE(program, uniformBlockIndex, pname, params.size(), nullptr, params.data());
 }
 
-std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLANGLE::createAndBindEGLImage(GCGLenum, EGLImageSource)
+GCEGLImage GraphicsContextGLANGLE::createAndBindEGLImage(GCGLenum, EGLImageSource)
 {
     notImplemented();
-    return std::nullopt;
+    return nullptr;
 }
 
 void GraphicsContextGLANGLE::destroyEGLImage(GCEGLImage handle)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -289,7 +289,7 @@ public:
     String getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) final;
     void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) final;
     void getActiveUniformBlockiv(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
-    std::optional<EGLImageAttachResult> createAndBindEGLImage(GCGLenum, EGLImageSource) override;
+    GCEGLImage createAndBindEGLImage(GCGLenum, EGLImageSource) override;
     void destroyEGLImage(GCEGLImage) final;
     GCEGLSync createEGLSync(ExternalEGLSyncEvent) override;
     bool destroyEGLSync(GCEGLSync) final;

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -68,7 +68,7 @@ public:
     void* createPbufferAndAttachIOSurface(GCGLenum target, PbufferAttachmentUsage, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLenum type, IOSurfaceRef, GCGLuint plane);
     void destroyPbufferAndDetachIOSurface(void* handle);
 
-    std::optional<EGLImageAttachResult> createAndBindEGLImage(GCGLenum, EGLImageSource) final;
+    GCEGLImage createAndBindEGLImage(GCGLenum, EGLImageSource) final;
 
     RetainPtr<id> newSharedEventWithMachPort(mach_port_t);
     GCEGLSync createEGLSync(ExternalEGLSyncEvent) final;

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -246,6 +246,7 @@ struct FrameData {
 
     struct LayerData {
 #if PLATFORM(COCOA)
+        WebCore::IntSize framebufferSize;
         std::tuple<MachSendRight, bool> colorTexture = { MachSendRight(), false };
         std::tuple<MachSendRight, bool> depthStencilBuffer = { MachSendRight(), false };
         std::tuple<MachSendRight, uint64_t> completionSyncEvent;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -165,12 +165,11 @@ void RemoteGraphicsContextGL::forceContextLost()
     send(Messages::RemoteGraphicsContextGLProxy::WasLost());
 }
 
-void RemoteGraphicsContextGL::createAndBindEGLImage(GCGLenum target, WebCore::GraphicsContextGL::EGLImageSource source, CompletionHandler<void(uint64_t handle, WebCore::IntSize size)>&& completionHandler)
+void RemoteGraphicsContextGL::createAndBindEGLImage(GCGLenum target, WebCore::GraphicsContextGL::EGLImageSource source, CompletionHandler<void(uint64_t handle)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    auto attachment = m_context->createAndBindEGLImage(target, WTFMove(source));
-    auto [handle, size] = attachment.value_or(std::make_tuple(nullptr, IntSize { }));
-    completionHandler(static_cast<uint64_t>(reinterpret_cast<intptr_t>(handle)), size);
+    auto handle = m_context->createAndBindEGLImage(target, WTFMove(source));
+    completionHandler(static_cast<uint64_t>(reinterpret_cast<intptr_t>(handle)));
 }
 
 void RemoteGraphicsContextGL::reshape(int32_t width, int32_t height)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -108,7 +108,7 @@ protected:
 
     // Messages to be received.
     void ensureExtensionEnabled(String&&);
-    void createAndBindEGLImage(GCGLenum, WebCore::GraphicsContextGL::EGLImageSource, CompletionHandler<void(uint64_t, WebCore::IntSize)>&&);
+    void createAndBindEGLImage(GCGLenum, WebCore::GraphicsContextGL::EGLImageSource, CompletionHandler<void(uint64_t)>&&);
     void reshape(int32_t width, int32_t height);
 #if PLATFORM(COCOA)
     virtual void prepareForDisplay(IPC::Semaphore&&, CompletionHandler<void(WTF::MachSendRight&&)>&&) = 0;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -59,7 +59,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void MultiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t> firstsCountsInstanceCountsAndBaseInstances)
     void MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type)
 #if PLATFORM(COCOA)
-    void CreateAndBindEGLImage(GCGLenum target, WebCore::GraphicsContextGL::EGLImageSource source) -> (uint64_t handle, WebCore::IntSize size) Synchronous NotStreamEncodable NotStreamEncodableReply
+    void CreateAndBindEGLImage(GCGLenum target, WebCore::GraphicsContextGL::EGLImageSource source) -> (uint64_t handle) Synchronous NotStreamEncodable NotStreamEncodableReply
     void CreateEGLSync(MachSendRight syncEvent, uint64_t signalValue) -> (uint64_t sync) Synchronous NotStreamEncodable NotStreamEncodableReply
 #endif
 

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -97,6 +97,7 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
 
 [Nested, RValue] struct PlatformXR::FrameData::LayerData {
 #if PLATFORM(COCOA)
+    WebCore::IntSize framebufferSize;
     std::tuple<MachSendRight, bool> colorTexture;
     std::tuple<MachSendRight, bool> depthStencilBuffer;
     std::tuple<MachSendRight, uint64_t> completionSyncEvent;

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -282,7 +282,8 @@ void ARKitCoordinator::renderLoop(Box<RenderState> active)
                     PlatformXRPose(frame.camera.projectionMatrix).toColumnMajorFloatArray()
                 },
             });
-            auto colorTexture = makeMachSendRight(presentationSession.colorTexture);
+            id<MTLTexture> colorTexture = presentationSession.colorTexture;
+            auto colorTextureSendRight = makeMachSendRight(colorTexture);
             auto renderingFrameIndex = presentationSession.renderingFrameIndex;
             // FIXME: Send this event once at setup time, not every frame.
             id<MTLSharedEvent> completionEvent = presentationSession.completionEvent;
@@ -291,7 +292,8 @@ void ARKitCoordinator::renderLoop(Box<RenderState> active)
 
             // FIXME: rdar://77858090 (Need to transmit color space information)
             frameData.layers.set(defaultLayerHandle(), PlatformXR::FrameData::LayerData {
-                .colorTexture = WTFMove(colorTexture),
+                .framebufferSize = IntSize(colorTexture.width, colorTexture.height),
+                .colorTexture = WTFMove(colorTextureSendRight),
                 .completionSyncEvent = { MachSendRight(completionPort), renderingFrameIndex }
             });
             frameData.shouldRender = true;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -165,7 +165,7 @@ void RemoteGraphicsContextGLProxy::initialize(const RemoteGraphicsContextGLIniti
     m_externalImageBindingQuery = initializationState.externalImageBindingQuery;
 }
 
-std::optional<GraphicsContextGL::EGLImageAttachResult> RemoteGraphicsContextGLProxy::createAndBindEGLImage(GCGLenum, GraphicsContextGL::EGLImageSource)
+GCEGLImage RemoteGraphicsContextGLProxy::createAndBindEGLImage(GCGLenum, GraphicsContextGL::EGLImageSource)
 {
     notImplemented();
     return { };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -71,7 +71,7 @@ public:
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) final { }
 
     // WebCore::GraphicsContextGL overrides.
-    std::optional<WebCore::GraphicsContextGL::EGLImageAttachResult> createAndBindEGLImage(GCGLenum, WebCore::GraphicsContextGL::EGLImageSource) override;
+    GCEGLImage createAndBindEGLImage(GCGLenum, WebCore::GraphicsContextGL::EGLImageSource) override;
     GCEGLSync createEGLSync(ExternalEGLSyncEvent) override;
     std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint() final;
     void reshape(int width, int height) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -132,7 +132,7 @@ private:
 class RemoteGraphicsContextGLProxyCocoa final : public RemoteGraphicsContextGLProxy {
 public:
     // GraphicsContextGL override.
-    std::optional<WebCore::GraphicsContextGL::EGLImageAttachResult> createAndBindEGLImage(GCGLenum, WebCore::GraphicsContextGL::EGLImageSource) final;
+    GCEGLImage createAndBindEGLImage(GCGLenum, WebCore::GraphicsContextGL::EGLImageSource) final;
     GCEGLSync createEGLSync(ExternalEGLSyncEvent) final;
 
     // RemoteGraphicsContextGLProxy overrides.
@@ -157,19 +157,17 @@ private:
     friend class RemoteGraphicsContextGLProxy;
 };
 
-std::optional<WebCore::GraphicsContextGL::EGLImageAttachResult> RemoteGraphicsContextGLProxyCocoa::createAndBindEGLImage(GCGLenum target, WebCore::GraphicsContextGL::EGLImageSource source)
+GCEGLImage RemoteGraphicsContextGLProxyCocoa::createAndBindEGLImage(GCGLenum target, WebCore::GraphicsContextGL::EGLImageSource source)
 {
     if (isContextLost())
-        return std::nullopt;
+        return nullptr;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateAndBindEGLImage(target, WTFMove(source)));
     if (!sendResult.succeeded()) {
         markContextLost();
-        return std::nullopt;
+        return nullptr;
     }
-    auto [handle, size] = sendResult.takeReply();
-    if (!handle)
-        return std::nullopt;
-    return std::make_tuple(reinterpret_cast<GCEGLImage>(static_cast<intptr_t>(handle)), size);
+    auto& [returnValue] = sendResult.reply();
+    return reinterpret_cast<GCEGLImage>(static_cast<intptr_t>(returnValue));
 }
 
 GCEGLSync RemoteGraphicsContextGLProxyCocoa::createEGLSync(ExternalEGLSyncEvent syncEvent)


### PR DESCRIPTION
#### cf4012b2fc39b2fd05e6b2011ffb5a5eae22df0d
<pre>
[WebXR] Remove texture size from createAndBindEGLImage result
<a href="https://bugs.webkit.org/show_bug.cgi?id=269280">https://bugs.webkit.org/show_bug.cgi?id=269280</a>
<a href="https://rdar.apple.com/122857763">rdar://122857763</a>

Reviewed by Mike Wyrzykowski.

Don&apos;t return the size of external image from createAndBindEGLImage. The size of
the framebuffer and external images are already known by the calling code.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::createAndBindCompositorTexture):
(WebCore::createAndBindCompositorBuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::createAndBindEGLImage):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::createAndBindEGLImage):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::createAndBindEGLImage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::createAndBindEGLImage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/274682@main">https://commits.webkit.org/274682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20ccd4343d47e2e590d530d524ae98d3494be985

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35468 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15876 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15626 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39324 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37586 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15986 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8901 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15643 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->