### PR TITLE
Scope the UA override to www.apple.com/apple-events

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -72,7 +72,7 @@ static bool urlRequiresChromeBrowser(const String& domain, const String& baseDom
         return true;
 
     // https://webcompat.com/issues/123672
-    if (baseDomain == "apple.com"_s)
+    if (domain == "www.apple.com"_s)
         return true;
 
     return false;

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -88,7 +88,7 @@ TEST(UserAgentTest, Quirks)
     assertUserAgentForURLHasChromeBrowserQuirk("http://bankofamerica.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://soundcloud.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://youtube.com/");
-    assertUserAgentForURLHasChromeBrowserQuirk("http://apple.com/");
+    assertUserAgentForURLHasChromeBrowserQuirk("http://www.apple.com/");
 
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://bugzilla.redhat.com/");
 


### PR DESCRIPTION
#### 2d4541ef392983d779bcc4954110eb212eaca029
<pre>
Scope the UA override to www.apple.com/apple-events
<a href="https://bugs.webkit.org/show_bug.cgi?id=269211">https://bugs.webkit.org/show_bug.cgi?id=269211</a>

Reviewed by Michael Catanzaro.

A quirk has been introduced in 265206@main (e0b0d3b7983f) to use a
Chrome user-agent override for apple.com. Limit this to www.apple.com,
so that it does not apply to tv.apple.com (and its custom subdomains).

Otherwise, custom user-agents can not be used for Apple TV+ (<a href="https://rdar.apple.com/122408473">rdar://122408473</a>).

<a href="https://apple.com/apple-events/">https://apple.com/apple-events/</a> redirects to
<a href="https://www.apple.com/apple-events/">https://www.apple.com/apple-events/</a>, so the quirk will still apply to both.

* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
(WebCore::urlRequiresChromeBrowser):
* Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/274711@main">https://commits.webkit.org/274711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec5f55930aeb12c229b236cb97989ab6e517f08d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33068 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43421 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37625 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16027 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8929 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->