### PR TITLE
[WebXR] Remove ensure() method from GCGLOwned

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -48,7 +48,10 @@ using GL = GraphicsContextGL;
 #if PLATFORM(COCOA)
 static std::optional<GL::EGLImageAttachResult> createAndBindCompositorTexture(GL& gl, GCGLenum target, GCGLOwnedTexture& texture, GL::EGLImageSource source)
 {
-    texture.ensure(gl);
+    auto object = gl.createTexture();
+    if (!object)
+        return { };
+    texture.adopt(gl, object);
     gl.bindTexture(target, texture);
     gl.texParameteri(target, GL::TEXTURE_MAG_FILTER, GL::LINEAR);
     gl.texParameteri(target, GL::TEXTURE_MIN_FILTER, GL::LINEAR);
@@ -66,7 +69,10 @@ static std::optional<GL::EGLImageAttachResult> createAndBindCompositorTexture(GL
 
 static std::optional<GL::EGLImageAttachResult> createAndBindCompositorBuffer(GL& gl, GCGLOwnedRenderbuffer& buffer, GL::EGLImageSource source)
 {
-    buffer.ensure(gl);
+    auto object = gl.createRenderbuffer();
+    if (!object)
+        return { };
+    buffer.adopt(gl, object);
     gl.bindRenderbuffer(GL::RENDERBUFFER, buffer);
 
     auto attachResult = gl.createAndBindEGLImage(GL::RENDERBUFFER, source);
@@ -262,7 +268,10 @@ bool WebXROpaqueFramebuffer::setupFramebuffer()
     auto sampleCount = m_attributes.antialias ? std::min(4, m_context.maxSamples()) : 0;
 
     if (m_attributes.antialias) {
-        m_resolvedFBO.ensure(*gl);
+        auto fbo = gl->createFramebuffer();
+        if (!fbo)
+            return false;
+        m_resolvedFBO.adopt(*gl, fbo);
 
         auto colorBuffer = allocateColorStorage(*gl, sampleCount, m_framebufferSize);
         bindColorBuffer(*gl, colorBuffer);

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1696,7 +1696,7 @@ private:
 
 WEBCORE_EXPORT RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes&, SerialFunctionDispatcher* = nullptr);
 
-template<PlatformGLObject(GraphicsContextGL::*createFunc)(), void(GraphicsContextGL::*destroyFunc)(PlatformGLObject)>
+template<void(GraphicsContextGL::*destroyFunc)(PlatformGLObject)>
 class GCGLOwned {
     WTF_MAKE_NONCOPYABLE(GCGLOwned);
 
@@ -1724,21 +1724,14 @@ public:
         m_object = object;
     }
 
-    void ensure(GraphicsContextGL& gl)
-    {
-        if (m_object)
-            return;
-        m_object = (gl.*createFunc)();
-    }
-
     void release(GraphicsContextGL& gl) { adopt(gl, 0); }
 private:
     PlatformGLObject m_object { 0 };
 };
 
-using GCGLOwnedFramebuffer = GCGLOwned<&GraphicsContextGL::createFramebuffer, &GraphicsContextGL::deleteFramebuffer>;
-using GCGLOwnedRenderbuffer = GCGLOwned<&GraphicsContextGL::createRenderbuffer, &GraphicsContextGL::deleteRenderbuffer>;
-using GCGLOwnedTexture = GCGLOwned<&GraphicsContextGL::createTexture, &GraphicsContextGL::deleteTexture>;
+using GCGLOwnedFramebuffer = GCGLOwned<&GraphicsContextGL::deleteFramebuffer>;
+using GCGLOwnedRenderbuffer = GCGLOwned<&GraphicsContextGL::deleteRenderbuffer>;
+using GCGLOwnedTexture = GCGLOwned<&GraphicsContextGL::deleteTexture>;
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 758d8904919d17134c2b00877f4b82dbc8d2f494
<pre>
[WebXR] Remove ensure() method from GCGLOwned
<a href="https://bugs.webkit.org/show_bug.cgi?id=269283">https://bugs.webkit.org/show_bug.cgi?id=269283</a>
<a href="https://rdar.apple.com/122860406">rdar://122860406</a>

Reviewed by Kimmo Kinnunen.

This method was only used in three places where allocation of an OpenGL object
was known to be taking place. Replace the ensure() calls with explicit
allocation and adopt() the results.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::createAndBindCompositorTexture):
(WebCore::createAndBindCompositorBuffer):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
(WebCore::destroyFunc):

Canonical link: <a href="https://commits.webkit.org/274596@main">https://commits.webkit.org/274596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3206e9093929da856ccea389b87a4056bc610d78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42065 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15839 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15594 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43343 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35504 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11820 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15949 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8850 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->