### PR TITLE
[Skia] Building with USE_SKIA=ON still uses Cairo for ImageDiff

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -140,6 +140,14 @@ add_library(Skia STATIC
     src/base/SkUTF.cpp
     src/base/SkUtils.cpp
 
+    src/codec/SkCodec.cpp
+    src/codec/SkColorPalette.cpp
+    src/codec/SkEncodedInfo.cpp
+    src/codec/SkPixmapUtils.cpp
+    src/codec/SkPngCodec.cpp
+    src/codec/SkSampler.cpp
+    src/codec/SkSwizzler.cpp
+
     src/core/SkAAClip.cpp
     src/core/SkATrace.cpp
     src/core/SkAlphaRuns.cpp
@@ -890,6 +898,8 @@ target_include_directories(Skia INTERFACE
 
 target_compile_definitions(Skia PRIVATE
     SKIA_IMPLEMENTATION=1
+
+    SK_CODEC_DECODES_PNG
 
     SK_GAMMA_APPLY_TO_A8
 )

--- a/Tools/ImageDiff/Cairo.cmake
+++ b/Tools/ImageDiff/Cairo.cmake
@@ -2,10 +2,6 @@ list(APPEND ImageDiff_SOURCES
     cairo/PlatformImageCairo.cpp
 )
 
-if (NOT TARGET Cairo::Cairo)
-    find_package(Cairo REQUIRED)
-endif ()
-
 list(APPEND ImageDiff_LIBRARIES
     Cairo::Cairo
 )

--- a/Tools/ImageDiff/PlatformImage.h
+++ b/Tools/ImageDiff/PlatformImage.h
@@ -29,7 +29,7 @@
 #if defined(USE_CAIRO) && USE_CAIRO
 typedef struct _cairo_surface cairo_surface_t;
 #elif defined(USE_SKIA) && USE_SKIA
-class SkBitmap;
+#include <skia/core/SkImage.h>
 #else
 typedef struct CGImage *CGImageRef;
 #endif
@@ -45,7 +45,7 @@ public:
 #if defined(USE_CAIRO) && USE_CAIRO
     PlatformImage(cairo_surface_t*);
 #elif defined(USE_SKIA) && USE_SKIA
-    PlatformImage(SkBitmap*);
+    explicit PlatformImage(sk_sp<SkImage>&&);
 #else
     PlatformImage(CGImageRef, double scaleFactor = 1);
 #endif
@@ -74,6 +74,8 @@ public:
 private:
 #if defined(USE_CAIRO) && USE_CAIRO
     cairo_surface_t* m_image;
+#elif defined(USE_SKIA) && USE_SKIA
+    sk_sp<SkImage> m_image;
 #else
     CGImageRef m_image;
     mutable void* m_buffer { nullptr };

--- a/Tools/ImageDiff/PlatformWPE.cmake
+++ b/Tools/ImageDiff/PlatformWPE.cmake
@@ -1,1 +1,5 @@
-include(Cairo.cmake)
+if (USE_CAIRO)
+    include(Cairo.cmake)
+elseif (USE_SKIA)
+    include(Skia.cmake)
+endif ()

--- a/Tools/ImageDiff/Skia.cmake
+++ b/Tools/ImageDiff/Skia.cmake
@@ -1,0 +1,9 @@
+list(APPEND ImageDiff_SOURCES
+    skia/PlatformImageSkia.cpp
+)
+
+list(APPEND ImageDiff_LIBRARIES
+    Skia
+)
+
+list(APPEND ImageDiff_PRIVATE_DEFINITIONS USE_SKIA=1)

--- a/Tools/ImageDiff/skia/PlatformImageSkia.cpp
+++ b/Tools/ImageDiff/skia/PlatformImageSkia.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "PlatformImage.h"
+
+#include <cstdio>
+#include <skia/codec/SkPngDecoder.h>
+#include <skia/core/SkImage.h>
+#include <skia/core/SkPixmap.h>
+#include <skia/core/SkStream.h>
+#include <skia/encode/SkPngEncoder.h>
+
+namespace ImageDiff {
+
+static std::unique_ptr<PlatformImage> createFromStream(std::unique_ptr<SkStream>&& stream)
+{
+    if (!stream)
+        return nullptr;
+
+    SkCodec::Result decodeResult;
+    auto codec = SkPngDecoder::Decode(std::move(stream), &decodeResult, nullptr);
+    if (decodeResult != SkCodec::Result::kSuccess) {
+        fprintf(stderr, "ImageDiff failed to decode PNG: %s\n", SkCodec::ResultToString(decodeResult));
+        return nullptr;
+    }
+
+    auto [image, result] = codec->getImage();
+    if (result != SkCodec::Result::kSuccess) {
+        fprintf(stderr, "ImageDiff failed to decode PNG: %s\n", SkCodec::ResultToString(result));
+        return nullptr;
+    }
+
+    return std::make_unique<PlatformImage>(std::move(image));
+}
+
+std::unique_ptr<PlatformImage> PlatformImage::createFromFile(const char* filename)
+{
+    return createFromStream(SkStream::MakeFromFile(filename));
+}
+
+std::unique_ptr<PlatformImage> PlatformImage::createFromStdin(size_t imageSize)
+{
+    SkDynamicMemoryWStream stream;
+    unsigned char buffer[2048];
+    size_t bytesRemaining = imageSize;
+    while (bytesRemaining > 0) {
+        size_t bytesToRead = std::min<size_t>(bytesRemaining, 2048);
+        size_t bytesRead = fread(buffer, 1, bytesToRead, stdin);
+        stream.write(buffer, bytesRead);
+        bytesRemaining -= static_cast<int>(bytesRead);
+    }
+    return createFromStream(stream.detachAsStream());
+}
+
+std::unique_ptr<PlatformImage> PlatformImage::createFromDiffData(void* data, size_t width, size_t height)
+{
+    auto imageInfo = SkImageInfo::Make(width, height, SkColorType::kGray_8_SkColorType, SkAlphaType::kOpaque_SkAlphaType);
+    SkPixmap pixmap(imageInfo, data, imageInfo.minRowBytes());
+    auto image = SkImages::RasterFromPixmap(pixmap, [](const void* pixels, void*) {
+        free(const_cast<void*>(pixels));
+    }, nullptr);
+    if (!image)
+        return nullptr;
+    return std::make_unique<PlatformImage>(std::move(image));
+}
+
+PlatformImage::PlatformImage(sk_sp<SkImage>&& image)
+    : m_image(std::move(image))
+{
+}
+
+PlatformImage::~PlatformImage() = default;
+
+size_t PlatformImage::width() const
+{
+    return m_image->width();
+}
+
+size_t PlatformImage::height() const
+{
+    return m_image->height();
+}
+
+size_t PlatformImage::rowBytes() const
+{
+    return m_image->imageInfo().minRowBytes();
+}
+
+bool PlatformImage::hasAlpha() const
+{
+    return !m_image->imageInfo().isOpaque();
+}
+
+unsigned char* PlatformImage::pixels() const
+{
+    SkPixmap pixmap;
+    if (m_image->peekPixels(&pixmap))
+        return static_cast<unsigned char*>(pixmap.writable_addr());
+    return nullptr;
+}
+
+void PlatformImage::writeAsPNGToStdout()
+{
+    auto data = SkPngEncoder::Encode(nullptr, m_image.get(), { });
+    if (!data)
+        return;
+
+    fprintf(stdout, "Content-Length: %lu\n", data->size());
+    fwrite(data->data(), 1, data->size(), stdout);
+}
+
+} // namespace ImageDiff


### PR DESCRIPTION
#### 0e6f0245ab8d06d0bfa36cb19d3054d86b8ed798
<pre>
[Skia] Building with USE_SKIA=ON still uses Cairo for ImageDiff
<a href="https://bugs.webkit.org/show_bug.cgi?id=269190">https://bugs.webkit.org/show_bug.cgi?id=269190</a>

Reviewed by Alejandro G. Castro and Nikolas Zimmermann.

Add ImageDiff implementation for Skia.

* Source/ThirdParty/skia/CMakeLists.txt:
* Tools/ImageDiff/Cairo.cmake:
* Tools/ImageDiff/PlatformImage.h:
* Tools/ImageDiff/PlatformWPE.cmake:
* Tools/ImageDiff/Skia.cmake: Added.
* Tools/ImageDiff/skia/PlatformImageSkia.cpp: Added.
(ImageDiff::createFromStream):
(ImageDiff::PlatformImage::createFromFile):
(ImageDiff::PlatformImage::createFromStdin):
(ImageDiff::PlatformImage::createFromDiffData):
(ImageDiff::PlatformImage::PlatformImage):
(ImageDiff::PlatformImage::~PlatformImage):
(ImageDiff::PlatformImage::width const):
(ImageDiff::PlatformImage::height const):
(ImageDiff::PlatformImage::rowBytes const):
(ImageDiff::PlatformImage::hasAlpha const):
(ImageDiff::PlatformImage::pixels const):
(ImageDiff::PlatformImage::writeAsPNGToStdout):

Canonical link: <a href="https://commits.webkit.org/274544@main">https://commits.webkit.org/274544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fbc5d01255a92701eb1d10ca1b4827a07aa77fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39406 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15714 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39980 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13447 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43218 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35404 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14218 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15824 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5163 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->