### PR TITLE
[Nicosia] Add support for translate/rotate/scale animations

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1761,7 +1761,6 @@ webkit.org/b/132995 transitions/cancel-transition.html [ Failure Pass ]
 
 webkit.org/b/211948 webanimations/accelerated-animation-playback-rate.html [ ImageOnlyFailure ]
 webkit.org/b/212020 webanimations/accelerated-animation-single-keyframe.html [ Skip ]
-webkit.org/b/213783 webanimations/accelerated-animation-with-easing.html [ ImageOnlyFailure ]
 
 webkit.org/b/215945 webanimations/accelerated-css-animation-with-easing.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1568,7 +1568,6 @@ webkit.org/b/264680 svg/css/svg-resource-fragment-identifier-img-src.html [ Imag
 webkit.org/b/264680 tables/mozilla_expected_failures/bugs/bug2479-5.html [ Failure Missing Pass ]
 
 fast/history/page-cache-execute-script-during-restore.html [ Timeout ]
-webanimations/animation-page-cache.html [ Timeout ]
 
 imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-and-nested-clip-path.svg [ Failure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-nested-clip-path-006.svg [ Failure ]

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h
@@ -49,8 +49,9 @@ public:
     Animation(Animation&&) = default;
     Animation& operator=(Animation&&) = default;
 
-    void apply(ApplicationResult&, MonotonicTime);
-    void applyKeepingInternalState(ApplicationResult&, MonotonicTime);
+    enum class KeepInternalState { Yes, No };
+    void apply(ApplicationResult&, MonotonicTime, KeepInternalState);
+
     void pause(Seconds);
     void resume();
 
@@ -82,6 +83,11 @@ class Animations {
 public:
     Animations() = default;
 
+    void setTranslate(WebCore::TransformationMatrix transform) { m_translate = transform; }
+    void setRotate(WebCore::TransformationMatrix transform) { m_rotate = transform; }
+    void setScale(WebCore::TransformationMatrix transform) { m_scale = transform; }
+    void setTransform(WebCore::TransformationMatrix transform) { m_transform = transform; }
+
     void add(const Animation&);
     void remove(const String& name);
     void remove(const String& name, WebCore::AnimatedProperty);
@@ -89,18 +95,24 @@ public:
     void suspend(MonotonicTime);
     void resume();
 
-    void apply(Animation::ApplicationResult&, MonotonicTime);
-    void applyKeepingInternalState(Animation::ApplicationResult&, MonotonicTime);
+    void apply(Animation::ApplicationResult&, MonotonicTime, Animation::KeepInternalState = Animation::KeepInternalState::No);
 
     bool isEmpty() const { return m_animations.isEmpty(); }
     size_t size() const { return m_animations.size(); }
     const Vector<Animation>& animations() const { return m_animations; }
     Vector<Animation>& animations() { return m_animations; }
 
-    bool hasRunningAnimations() const;
     bool hasActiveAnimationsOfType(WebCore::AnimatedProperty type) const;
 
+    bool hasRunningAnimations() const;
+    bool hasRunningTransformAnimations() const;
+
 private:
+    WebCore::TransformationMatrix m_translate;
+    WebCore::TransformationMatrix m_rotate;
+    WebCore::TransformationMatrix m_scale;
+    WebCore::TransformationMatrix m_transform;
+
     Vector<Animation> m_animations;
 };
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -1043,7 +1043,7 @@ bool TextureMapperLayer::syncAnimations(MonotonicTime time)
 #if USE(COORDINATED_GRAPHICS)
     // Calculate localTransform 50ms in the future.
     Nicosia::Animation::ApplicationResult futureApplicationResults;
-    m_animations.applyKeepingInternalState(futureApplicationResults, time + 50_ms);
+    m_animations.apply(futureApplicationResults, time + 50_ms, Nicosia::Animation::KeepInternalState::Yes);
     m_layerTransforms.futureLocalTransform = futureApplicationResults.transform.value_or(m_layerTransforms.localTransform);
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -74,6 +74,11 @@ void CoordinatedGraphicsLayer::notifyFlushRequired()
 
 void CoordinatedGraphicsLayer::didChangeAnimations()
 {
+    m_animations.setTranslate(client().transformMatrixForProperty(AnimatedProperty::Translate));
+    m_animations.setRotate(client().transformMatrixForProperty(AnimatedProperty::Rotate));
+    m_animations.setScale(client().transformMatrixForProperty(AnimatedProperty::Scale));
+    m_animations.setTransform(client().transformMatrixForProperty(AnimatedProperty::Transform));
+
     m_nicosia.delta.animationsChanged = true;
     notifyFlushRequired();
 }
@@ -1418,6 +1423,9 @@ bool CoordinatedGraphicsLayer::addAnimation(const KeyframeValueList& valueList, 
         break;
     }
     case AnimatedProperty::Opacity:
+    case AnimatedProperty::Translate:
+    case AnimatedProperty::Rotate:
+    case AnimatedProperty::Scale:
     case AnimatedProperty::Transform:
         break;
     default:
@@ -1453,6 +1461,12 @@ void CoordinatedGraphicsLayer::resumeAnimations()
 {
     m_animations.resume();
     didChangeAnimations();
+}
+
+void CoordinatedGraphicsLayer::transformRelatedPropertyDidChange()
+{
+    if (m_animations.hasRunningTransformAnimations())
+        didChangeAnimations();
 }
 
 void CoordinatedGraphicsLayer::animationStartedTimerFired()

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -131,6 +131,7 @@ public:
     void removeAnimation(const String&, std::optional<AnimatedProperty>) override;
     void suspendAnimations(MonotonicTime) override;
     void resumeAnimations() override;
+    void transformRelatedPropertyDidChange() override;
     bool usesContentsLayer() const override;
     void dumpAdditionalProperties(WTF::TextStream&, OptionSet<LayerTreeAsTextOptions>) const override;
 


### PR DESCRIPTION
#### 9f21b9e439f93986a5e4f7dc52b14b156d0f6677
<pre>
[Nicosia] Add support for translate/rotate/scale animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=269288">https://bugs.webkit.org/show_bug.cgi?id=269288</a>

Reviewed by Nikolas Zimmermann.

Nicosia already supports accelerated transform animations.
This patch implements translate, rotate, and scale animations.

It also ensures that when multiple animations are applied,
they run in the correct order required the spec [1]:
- translate
- rotate
- scale
- transform

[1] <a href="https://drafts.csswg.org/css-transforms-2/#ctm">https://drafts.csswg.org/css-transforms-2/#ctm</a>

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp:
(Nicosia::Animation::apply):
(Nicosia::Animation::applyInternal):
(Nicosia::Animations::apply):
(Nicosia::Animations::hasRunningTransformAnimations const):
(Nicosia::Animation::applyKeepingInternalState): Deleted.
(Nicosia::Animations::applyKeepingInternalState): Deleted.
* Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h:
(Nicosia::Animations::setTranslate):
(Nicosia::Animations::setRotate):
(Nicosia::Animations::setScale):
(Nicosia::Animations::setTransform):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::syncAnimations):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::didChangeAnimations):
(WebCore::CoordinatedGraphicsLayer::addAnimation):
(WebCore::CoordinatedGraphicsLayer::transformRelatedPropertyDidChange):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:

Canonical link: <a href="https://commits.webkit.org/275168@main">https://commits.webkit.org/275168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e86904efd18fa7b90f9c2a15c0ef01170242cdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33893 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14516 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44748 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36551 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40301 "Found 1 new test failure: webanimations/accelerated-animation-with-easing.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38669 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17329 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9221 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->