### PR TITLE
Don't repaint renderers on teardown if they have never been painted

### DIFF
--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -54,6 +54,11 @@ enum class PaintPhase : uint16_t {
     Accessibility            = 1 << 13,
 };
 
+static constexpr bool isVisualPaintPhase(PaintPhase phase)
+{
+    return phase < PaintPhase::TextClip;
+}
+
 enum class PaintBehavior : uint32_t {
     Normal                              = 0,
     SelectionOnly                       = 1 << 0,

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1095,6 +1095,9 @@ void RenderBlock::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     if (visualContentIsClippedOut(paintInfo.rect))
         return;
 
+    if (isVisualPaintPhase(phase))
+        setHasPainted();
+
     bool pushedClip = pushContentsClip(paintInfo, adjustedPaintOffset);
     paintObject(paintInfo, adjustedPaintOffset);
     if (pushedClip)

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3976,12 +3976,14 @@ void RenderBlockFlow::invalidateLineLayoutPath()
         if (modernLineLayout()) {
             m_previousModernLineLayoutContentBoxLogicalHeight = modernLineLayout()->contentBoxLogicalHeight();
             // Since we eagerly remove the display content here, repaints issued between this invalidation (triggered by style change/content mutation) and the subsequent layout would produce empty rects.
-            repaint();
-            for (auto walker = InlineWalker(*this); !walker.atEnd(); walker.advance()) {
-                auto& renderer = *walker.current(); 
-                if (!renderer.isInFlow())
-                    renderer.repaint();
-                renderer.setPreferredLogicalWidthsDirty(true);
+            if (hasPainted()) {
+                repaint();
+                for (auto walker = InlineWalker(*this); !walker.atEnd(); walker.advance()) {
+                    auto& renderer = *walker.current();
+                    if (!renderer.isInFlow())
+                        renderer.repaint();
+                    renderer.setPreferredLogicalWidthsDirty(true);
+                }
             }
         }
         auto path = UndeterminedPath;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -136,6 +136,7 @@ inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument,
     , m_isRegisteredForVisibleInViewportCallback(false)
     , m_visibleInViewportState(static_cast<unsigned>(VisibleInViewportState::Unknown))
     , m_didContributeToVisuallyNonEmptyPixelCount(false)
+    , m_hasPainted(false)
     , m_style(WTFMove(style))
 {
     ASSERT(RenderObject::isRenderElement());

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -293,6 +293,8 @@ public:
 
     void clearNeedsLayoutForDescendants();
 
+    bool hasPainted() const { return m_hasPainted; }
+
 protected:
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
     RenderElement(Type, Document&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
@@ -336,6 +338,8 @@ protected:
 
     bool shouldApplyLayoutOrPaintContainment(bool) const;
     inline bool shouldApplySizeOrStyleContainment(bool) const;
+
+    void setHasPainted() { m_hasPainted = true; }
 
 private:
     RenderElement(Type, ContainerNode&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
@@ -406,6 +410,7 @@ private:
     unsigned m_isRegisteredForVisibleInViewportCallback : 1;
     unsigned m_visibleInViewportState : 2;
     unsigned m_didContributeToVisuallyNonEmptyPixelCount : 1;
+    unsigned m_hasPainted : 1;
 
     // 3 bits free.
 

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -235,6 +235,9 @@ bool RenderInline::mayAffectLayout() const
 
 void RenderInline::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     if (auto* lineLayout = LayoutIntegration::LineLayout::containing(*this)) {
         lineLayout->paint(paintInfo, paintOffset, this);
         return;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -188,6 +188,9 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
     if (markerRect.isEmpty())
         return;
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     GraphicsContext& context = paintInfo.context();
 
     if (isImage()) {

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -234,6 +234,9 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         return;
     }
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     SetLayoutNeededForbiddenScope scope(*this);
 
     GraphicsContextStateSaver savedGraphicsContext(paintInfo.context(), false);

--- a/Source/WebCore/rendering/RenderReplica.cpp
+++ b/Source/WebCore/rendering/RenderReplica.cpp
@@ -71,7 +71,10 @@ void RenderReplica::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
     if (paintInfo.phase != PaintPhase::Foreground && paintInfo.phase != PaintPhase::Mask)
         return;
- 
+
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     LayoutPoint adjustedPaintOffset = paintOffset + location();
 
     if (paintInfo.phase == PaintPhase::Foreground) {

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -727,6 +727,9 @@ void RenderTable::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
             return;
     }
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     bool pushedClip = pushContentsClip(paintInfo, adjustedPaintOffset);
     paintObject(paintInfo, adjustedPaintOffset);
     if (pushedClip)

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -229,6 +229,9 @@ void RenderTableRow::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
     ASSERT(hasSelfPaintingLayer());
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     paintOutlineForRowIfNeeded(paintInfo, paintOffset);
     for (RenderTableCell* cell = firstCell(); cell; cell = cell->nextCell()) {
         // Paint the row background behind the cell.

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -935,6 +935,9 @@ void RenderTableSection::paint(PaintInfo& paintInfo, const LayoutPoint& paintOff
     if (!totalRows || !totalCols)
         return;
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     LayoutPoint adjustedPaintOffset = paintOffset + location();
 
     PaintPhase phase = paintInfo.phase;

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -298,6 +298,9 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     if (paintInfo.context().detectingContentfulPaint())
         return;
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     LayoutPoint adjustedPaintOffset = paintOffset + location();
 
     if (hasVisibleBoxDecorations() && (paintInfo.phase == PaintPhase::Foreground || paintInfo.phase == PaintPhase::Selection))

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -150,6 +150,9 @@ void RenderSVGImage::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         return;
     }
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     ASSERT(paintInfo.phase == PaintPhase::Foreground);
     GraphicsContextStateSaver stateSaver(paintInfo.context());
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -290,6 +290,9 @@ void RenderSVGRoot::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
             return;
     }
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     bool pushedClip = pushContentsClip(paintInfo, adjustedPaintOffset);
     paintObject(paintInfo, adjustedPaintOffset);
     if (pushedClip)

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -249,6 +249,9 @@ void RenderSVGShape::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         return;
     }
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     ASSERT(paintInfo.phase == PaintPhase::Foreground);
     GraphicsContextStateSaver stateSaver(paintInfo.context());
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -110,6 +110,9 @@ void LegacyRenderSVGContainer::paint(PaintInfo& paintInfo, const LayoutPoint&)
     if (!SVGRenderSupport::paintInfoIntersectsRepaintRect(repaintRect, localToParentTransform(), paintInfo))
         return;
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     PaintInfo childPaintInfo(paintInfo);
     {
         GraphicsContextStateSaver stateSaver(childPaintInfo.context());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -83,6 +83,9 @@ void LegacyRenderSVGForeignObject::paint(PaintInfo& paintInfo, const LayoutPoint
         return;
     }
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     // Paint all phases of FO elements atomically, as though the FO element established its
     // own stacking context.
     childPaintInfo.phase = PaintPhase::BlockBackground;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -179,6 +179,9 @@ void LegacyRenderSVGImage::paint(PaintInfo& paintInfo, const LayoutPoint&)
     if (!SVGRenderSupport::paintInfoIntersectsRepaintRect(boundingBox, m_localTransform, paintInfo))
         return;
 
+    if (isVisualPaintPhase(paintInfo.phase))
+        setHasPainted();
+
     PaintInfo childPaintInfo(paintInfo);
     GraphicsContextStateSaver stateSaver(childPaintInfo.context());
     childPaintInfo.applyTransform(m_localTransform);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -947,11 +947,15 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
     // that a positioned child got yanked). We also repaint, so that the area exposed when the child
     // disappears gets repainted properly.
     if (!parent.renderTreeBeingDestroyed() && child.everHadLayout()) {
-        bool shouldNotRepaint = is<RenderMultiColumnSet>(child.previousSibling());
-        if (child.isBody() && !shouldNotRepaint)
-            parent.view().repaintRootContents();
-        else if (!shouldNotRepaint)
-            child.repaint();
+        auto& repaintElement = is<RenderElement>(child) ? downcast<RenderElement>(child) : parent;
+//        WTFLogAlways("hasPainted %d", repaintElement.hasPainted());
+        bool shouldRepaint = repaintElement.hasPainted() && !is<RenderMultiColumnSet>(child.previousSibling());
+        if (shouldRepaint) {
+            if (!child.isBody())
+                parent.view().repaintRootContents();
+            else
+                child.repaint();
+        }
         child.setNeedsLayoutAndPrefWidthsRecalc();
     }
 


### PR DESCRIPTION
#### 85c347853da98ee52b501cc0b16f78a8ece69aa7
<pre>
Don&apos;t repaint renderers on teardown if they have never been painted
<a href="https://bugs.webkit.org/show_bug.cgi?id=269289">https://bugs.webkit.org/show_bug.cgi?id=269289</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/rendering/PaintPhase.h:
(WebCore::isVisualPaintPhase):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paint):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::invalidateLineLayoutPath):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::hasPainted const):
(WebCore::RenderElement::setHasPainted):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::paint):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::paint):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderReplica.cpp:
(WebCore::RenderReplica::paint):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::paint):
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::paint):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::paint):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paint):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paint):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::paint):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::paint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::paint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
(WebCore::LegacyRenderSVGForeignObject::paint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::paint):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::detachFromRenderElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85c347853da98ee52b501cc0b16f78a8ece69aa7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35305 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15713 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32941 "Found 6 new test failures: fast/block/height-percentage-descendants-with-absolute-pos-containingblock.html, fast/box-shadow/negative-shadow-box-shrink.html, imported/mozilla/svg/suspend-03.svg, imported/mozilla/svg/suspend-07.svg, imported/w3c/web-platform-tests/css/css-backgrounds/document-canvas-remove-body.html, imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-repeat-dynamic-001.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39979 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15480 "Found 3 new test failures: fast/block/height-percentage-descendants-with-absolute-pos-containingblock.html, fast/box-shadow/negative-shadow-box-shrink.html, fast/repaint/placeholder-after-caps-lock-hidden.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13420 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35075 "Found 10 new test failures: fast/block/height-percentage-descendants-with-absolute-pos-containingblock.html, fast/box-shadow/negative-shadow-box-shrink.html, fast/repaint/box-shadow-top-left-repaint.html, fast/repaint/focus-ring-repaint.html, fast/repaint/full-repaint-on-content-change.html, fast/repaint/incorrect-repaint-when-container-changes-from-overflow-visible-to-hidden.html, fast/repaint/leftover-after-shrinking-content.html, fast/repaint/out-of-flow-inside-relative-inline.html, fast/repaint/overlapping-lines-with-ink-overflow.html, imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-repeat-dynamic-001.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35774 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35406 "Found 10 new test failures: fast/block/height-percentage-descendants-with-absolute-pos-containingblock.html, fast/box-shadow/negative-shadow-box-shrink.html, fast/repaint/box-shadow-top-left-repaint.html, fast/repaint/full-repaint-on-content-change.html, fast/repaint/incorrect-repaint-when-container-changes-from-overflow-visible-to-hidden.html, fast/repaint/out-of-flow-inside-relative-inline.html, fast/repaint/overlapping-lines-with-ink-overflow.html, fast/repaint/placeholder-after-caps-lock-hidden.html, fast/repaint/vertical-text-repaint.html, imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-repeat-dynamic-001.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39215 "Found 9 new test failures: fast/block/height-percentage-descendants-with-absolute-pos-containingblock.html, fast/box-shadow/negative-shadow-box-shrink.html, fast/repaint/box-shadow-top-left-repaint.html, fast/repaint/full-repaint-on-content-change.html, fast/repaint/incorrect-repaint-when-container-changes-from-overflow-visible-to-hidden.html, fast/repaint/out-of-flow-inside-relative-inline.html, fast/repaint/overlapping-lines-with-ink-overflow.html, fast/repaint/vertical-text-repaint.html, imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-repeat-dynamic-001.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14217 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11720 "Found 10 new test failures: fast/block/height-percentage-descendants-with-absolute-pos-containingblock.html, fast/box-shadow/negative-shadow-box-shrink.html, fast/repaint/box-shadow-top-left-repaint.html, fast/repaint/full-repaint-on-content-change.html, fast/repaint/incorrect-repaint-when-container-changes-from-overflow-visible-to-hidden.html, fast/repaint/out-of-flow-inside-relative-inline.html, fast/repaint/overlapping-lines-with-ink-overflow.html, fast/repaint/placeholder-after-caps-lock-hidden.html, fast/repaint/vertical-text-repaint.html, imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-repeat-dynamic-001.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37460 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15871 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->