### PR TITLE
Remove code skipping some JSC tests on mips

### DIFF
--- a/JSTests/microbenchmarks/array-from-derived-object-func.js
+++ b/JSTests/microbenchmarks/array-from-derived-object-func.js
@@ -1,4 +1,4 @@
-//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
+//@ $skipModes << :lockdown if ($buildType == "debug")
 //@ skip if $architecture == "arm" and !$cloop
 
 function shouldBe(actual, expected) {

--- a/JSTests/microbenchmarks/delete-property-allocation-sinking.js
+++ b/JSTests/microbenchmarks/delete-property-allocation-sinking.js
@@ -1,5 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3"
-//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
+//@ $skipModes << :lockdown if ($buildType == "debug")
 
 function assert(condition) {
     if (!condition)

--- a/JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js
+++ b/JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js
@@ -1,5 +1,5 @@
 //@ skip if $model =~ /^Apple Watch/
-//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
+//@ $skipModes << :lockdown if ($buildType == "debug")
 
 function assert(b) {
     if (!b)

--- a/JSTests/microbenchmarks/large-empty-array-join-resolve-rope.js
+++ b/JSTests/microbenchmarks/large-empty-array-join-resolve-rope.js
@@ -1,5 +1,4 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
-//@ $skipModes << :lockdown if $architecture == "mips"
 
 const array = [];
 for (let i = 0; i < 100; ++i)

--- a/JSTests/microbenchmarks/large-empty-array-join.js
+++ b/JSTests/microbenchmarks/large-empty-array-join.js
@@ -1,5 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
-//@ $skipModes << :lockdown if $memoryLimited or $architecture == "mips"
+//@ $skipModes << :lockdown if $memoryLimited
 const array = [];
 for (let i = 0; i < 100; ++i)
     array.push(new Array(1e6).join('—' + i));

--- a/JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js
+++ b/JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js
@@ -1,5 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
-//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
+//@ $skipModes << :lockdown if ($buildType == "debug")
 
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;

--- a/JSTests/microbenchmarks/u16-string-index-of-1000001-404.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-1000001-404.js
@@ -1,5 +1,3 @@
-//@ $skipModes << :lockdown if $architecture == "mips"
-
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-1000001-beg.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-1000001-beg.js
@@ -1,5 +1,3 @@
-//@ $skipModes << :lockdown if $architecture == "mips"
-
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-1000001-end.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-1000001-end.js
@@ -1,5 +1,3 @@
-//@ $skipModes << :lockdown if $architecture == "mips"
-
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-1000001-mid.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-1000001-mid.js
@@ -1,5 +1,3 @@
-//@ $skipModes << :lockdown if $architecture == "mips"
-
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/stress/call-apply-exponential-bytecode-size.js
+++ b/JSTests/stress/call-apply-exponential-bytecode-size.js
@@ -1,5 +1,3 @@
-// Currently flaky on mips.
-//@ skip if $architecture == "mips"
 // This test seems to require 64 MB for the executable memory pool, but only
 // arm64 and x86_64 have that much by default.
 //@ requireOptions("--jitMemoryReservationSize=67108864") if !["arm64", "x86_64"].include?($architecture)

--- a/JSTests/stress/check-stack-overflow-before-value-profiling-arguments.js
+++ b/JSTests/stress/check-stack-overflow-before-value-profiling-arguments.js
@@ -1,5 +1,5 @@
 //@ skip if $memoryLimited
-//@ requireOptions("-e", "let arraysize=0x100000") if ["arm", "mips"].include?($architecture)
+//@ requireOptions("-e", "let arraysize=0x100000") if ["arm"].include?($architecture)
 //@ runDefault("--useConcurrentJIT=0", "--thresholdForJITAfterWarmUp=10", "--slowPathAllocsBetweenGCs=10", "--useConcurrentGC=0")
 
 arraysize = typeof(arraysize) === 'undefined' ? 0x1000000 : arraysize;

--- a/JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js
+++ b/JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js
@@ -1,4 +1,4 @@
-//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
+//@ $skipModes << :lockdown if ($buildType == "debug")
 
 function empty() {}
 function empty2() {}

--- a/JSTests/stress/elidable-new-object-roflcopter-then-exit.js
+++ b/JSTests/stress/elidable-new-object-roflcopter-then-exit.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" and $architecture != "x86_64" and $architecture != "mips" and $architecture != "arm"
+//@ skip if $architecture != "arm64" and $architecture != "x86_64" and $architecture != "arm"
 //@ $skipModes << :lockdown if ($buildType == "debug")
 
 function sumOfArithSeries(limit) {

--- a/JSTests/stress/generator-cell-with-type.js
+++ b/JSTests/stress/generator-cell-with-type.js
@@ -1,6 +1,3 @@
-// This test takes too long on mips devices.
-//@ requireOptions("-e", "let iterations=1e5") if ["mips"].include?($architecture)
-
 iterations = typeof(iterations) === 'undefined' ? 1e6 : iterations;
 
 function shouldBe(actual, expected) {

--- a/JSTests/stress/hash-deleted-value-cell-32.js
+++ b/JSTests/stress/hash-deleted-value-cell-32.js
@@ -1,4 +1,4 @@
-//@ skip if $buildType != "debug" or ($architecture != "arm" and $architecture != "mips")
+//@ skip if $buildType != "debug" or ($architecture != "arm")
 function __getProperties(obj) {
   properties = []
   for (name of Object.getOwnPropertyNames(obj)) properties.push(name)

--- a/JSTests/stress/incremental-marking-should-not-dead-lock-in-new-property-transition.js
+++ b/JSTests/stress/incremental-marking-should-not-dead-lock-in-new-property-transition.js
@@ -1,4 +1,4 @@
-//@ skip if $hostOS == "playstation" || ($memoryLimited and not ["mips", "arm"].include?($architecture))
+//@ skip if $hostOS == "playstation" || ($memoryLimited and not ["arm"].include?($architecture))
 //@ runDefault("--gcIncrementScale=100", "--gcIncrementBytes=10", "--numberOfGCMarkers=1")
 
 let a = [];

--- a/JSTests/stress/materialize-regexp-cyclic-regexp.js
+++ b/JSTests/stress/materialize-regexp-cyclic-regexp.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" and $architecture != "x86_64" and $architecture != "arm" and $architecture != "mips"
+//@ skip if $architecture != "arm64" and $architecture != "x86_64" and $architecture != "arm"
 
 function shouldBe(actual, expected)
 {

--- a/JSTests/stress/materialized-regexp-has-correct-last-index-set-by-match.js
+++ b/JSTests/stress/materialized-regexp-has-correct-last-index-set-by-match.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" and $architecture != "x86_64" and $architecture != "arm" and $architecture != "mips"
+//@ skip if $architecture != "arm64" and $architecture != "x86_64" and $architecture != "arm"
 
 function shouldBe(actual, expected)
 {

--- a/JSTests/stress/new-largeish-contiguous-array-with-size.js
+++ b/JSTests/stress/new-largeish-contiguous-array-with-size.js
@@ -1,6 +1,5 @@
 // We only need one run of this with any GC or JIT strategy. This test is not particularly fast.
 // Unfortunately, it needs to run for a while to test the thing it's testing.
-//@ requireOptions("-e", "let leakFactor=3") if $architecture == "mips"
 //@ runWithRAMSize(10000000)
 //@ slow!
 

--- a/JSTests/stress/sampling-profiler-wasm-name-section.js
+++ b/JSTests/stress/sampling-profiler-wasm-name-section.js
@@ -1,7 +1,7 @@
 // This test is statistical, and without optimizing Wasm tiers the likelihood
 // of hitting the deepest expected stack trace is very low, so disable.
 // FIXME: remove when 32-bit platforms support optimizing Wasm tiers
-//@ skip if ["arm", "mips"].include?($architecture)
+//@ skip if ["arm"].include?($architecture)
 //
 //@ runDefault
 

--- a/JSTests/typeProfiler/deltablue-for-of.js
+++ b/JSTests/typeProfiler/deltablue-for-of.js
@@ -1,6 +1,6 @@
 //@ if $buildType == "debug" then skip else runTypeProfiler end
-//@ requireOptions("-e", "let iterations=15") if $architecture =~ /(^arm$)|mips/
-//@ requireOptions("-e", "let numConstraints=30") if $architecture =~ /(^arm$)|mips/
+//@ requireOptions("-e", "let iterations=15") if $architecture =~ /^arm$/
+//@ requireOptions("-e", "let numConstraints=30") if $architecture =~ /^arm$/
 
 iterations = typeof(iterations) === 'undefined' ? 30 : iterations;
 numConstraints = typeof(numConstraints) === 'undefined' ? 50 : numConstraints;

--- a/JSTests/typeProfiler/getter-richards.js
+++ b/JSTests/typeProfiler/getter-richards.js
@@ -1,4 +1,3 @@
-//@ requireOptions("-e", "let iterations=50") if ["mips"].include?($architecture)
 //@ if $buildType == "debug" or not $jitTests then skip else runTypeProfiler end
 
 iterations = typeof(iterations) === 'undefined' ? 150 : iterations;

--- a/PerformanceTests/SunSpider/with-baseline-code-sharing.yaml
+++ b/PerformanceTests/SunSpider/with-baseline-code-sharing.yaml
@@ -27,7 +27,7 @@
 
 - path: tests/sunspider-1.0
   cmd: |
-      if ($architecture == "arm" || $architecture == "mips")
+      if $architecture == "arm"
           requireOptions("--useBaselineJITCodeSharing=true")
           defaultRun
       else


### PR DESCRIPTION
#### 905eb824d6179f9d185f583e3d562751eb543096
<pre>
Remove code skipping some JSC tests on mips
<a href="https://bugs.webkit.org/show_bug.cgi?id=269294">https://bugs.webkit.org/show_bug.cgi?id=269294</a>

Unreviewed.

JSC no longer explicitly supports MIPS, no need to make accommodations
for it any more.

* JSTests/microbenchmarks/array-from-derived-object-func.js:
* JSTests/microbenchmarks/delete-property-allocation-sinking.js:
* JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js:
* JSTests/microbenchmarks/large-empty-array-join-resolve-rope.js:
* JSTests/microbenchmarks/large-empty-array-join.js:
* JSTests/microbenchmarks/let-const-tdz-environment-parsing-and-hash-consing-speed.js:
* JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js:
* JSTests/microbenchmarks/u16-string-index-of-1000001-404.js:
* JSTests/microbenchmarks/u16-string-index-of-1000001-beg.js:
* JSTests/microbenchmarks/u16-string-index-of-1000001-end.js:
* JSTests/microbenchmarks/u16-string-index-of-1000001-mid.js:
* JSTests/stress/call-apply-exponential-bytecode-size.js:
* JSTests/stress/check-stack-overflow-before-value-profiling-arguments.js:
* JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js:
* JSTests/stress/elidable-new-object-roflcopter-then-exit.js:
* JSTests/stress/generator-cell-with-type.js:
* JSTests/stress/hash-deleted-value-cell-32.js:
* JSTests/stress/incremental-marking-should-not-dead-lock-in-new-property-transition.js:
* JSTests/stress/materialize-regexp-cyclic-regexp.js:
* JSTests/stress/materialized-regexp-has-correct-last-index-set-by-match.js:
* JSTests/stress/new-largeish-contiguous-array-with-size.js:
* JSTests/stress/sampling-profiler-wasm-name-section.js:
* JSTests/typeProfiler/deltablue-for-of.js:
* JSTests/typeProfiler/getter-richards.js:
* PerformanceTests/SunSpider/with-baseline-code-sharing.yaml:

Canonical link: <a href="https://commits.webkit.org/274577@main">https://commits.webkit.org/274577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b50a50ad4688f921841a1c70687ce52b6678f332

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35317 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13434 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43229 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32870 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39225 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39043 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37471 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15835 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46049 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8837 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15883 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9388 "Passed tests") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->