### PR TITLE
[iOS 17.4] Chrome crashes in -[WKSelectPicker resetContextMenuPresenter]

### DIFF
--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
@@ -94,7 +94,9 @@ CompactContextMenuPresenter::CompactContextMenuPresenter(UIView *rootView, id<UI
 
 CompactContextMenuPresenter::~CompactContextMenuPresenter()
 {
-    dismiss();
+    [UIView performWithoutAnimation:^{
+        dismiss();
+    }];
     [m_button removeFromSuperview];
 }
 


### PR DESCRIPTION
#### e12d22941da33206058b0f3077325bd23ed5b1d5
<pre>
[iOS 17.4] Chrome crashes in -[WKSelectPicker resetContextMenuPresenter]
<a href="https://bugs.webkit.org/show_bug.cgi?id=269222">https://bugs.webkit.org/show_bug.cgi?id=269222</a>
<a href="https://rdar.apple.com/122843112">rdar://122843112</a>

Reviewed by Aditya Keerthi.

Mitigate crashes in (`WKWebView`-based) Chrome on iOS while dismissing compact context menus under
`~CompactContextMenuPresenter`. Through means that are still unclear to me, Chrome prevents context
menus from being shown when their webpage translation feature is invoked. This prevents the targeted
preview container view from being added to the view hierarchy; the resulting context menu
interaction is still considered &quot;presented&quot; even though nothing is shown on screen.

In this state, if anything attempts to dismiss the menu with animation, we&apos;ll crash with an
exception as UIKit internally (and incorrectly) assumes that the targeted preview container must
still be in the view hierarchy from when it was presented, and attempts to create a preview target
with this unparented preview container view.

Since the call to `dismiss()` in this destructor is only here as a last resort to ensure that we
clean up context menu interactions and don&apos;t leave context menu views (or the hidden button view)
lingering around the view hierarchy, we can simply fix this by immediately dismissing the context
menu interaction without animation. This skips the UIKit code described above that crashes unless
the preview container view was parented, and allows us to keep this &quot;last resort&quot; cleanup logic
without otherwise affecting the dismissal animation.

* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm:
(WebKit::CompactContextMenuPresenter::~CompactContextMenuPresenter):

Canonical link: <a href="https://commits.webkit.org/274559@main">https://commits.webkit.org/274559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8b0c2bccc017b7f378fd6de057789823fed13d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35329 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13466 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43241 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39234 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37479 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15847 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8825 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->