### PR TITLE
Regression (Safari 17 vs 16.5, 261003@main): height collapsing on auto-height image when container-type set on parent

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-flex-fraction-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-flex-fraction-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Verify contain:inline-size effect on grid flex child</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<meta name="assert" content="Tests that contain:inline-size does not apply to flex child's block direction" />
+
+<div>
+    <img src="/css/support/60x60-green.png">
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-flex-fraction.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-flex-fraction.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Verify contain:inline-size effect on grid flex child</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<meta name="assert" content="Tests that contain:inline-size does not apply to flex child's block direction" />
+
+<style>
+.grid {
+  display: grid;
+  grid-template-rows: 1fr;
+  contain: inline-size;
+}
+
+.images {
+  display: flex;
+  overflow: auto;
+}
+</style>
+
+<div class="grid">
+  <div class="images">
+    <img src="/css/support/60x60-green.png">
+  </div>
+</div>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1149,7 +1149,7 @@ double IndefiniteSizeStrategy::findUsedFlexFraction(Vector<unsigned>& flexibleSi
     // If we are computing the flex fraction of the grid while under the "Sizing as if empty," phase,
     // then we should use the flex fraction computed up to this point since we do not want to avoid
     // taking into consideration the grid items.
-    if (!grid.hasGridItems() || (isComputingSizeOrInlineSizeContainment() && !m_algorithm.renderGrid()->explicitIntrinsicInnerLogicalSize(direction)))
+    if (!grid.hasGridItems() || (renderGrid()->shouldCheckExplicitIntrinsicInnerLogicalSize(direction) && !m_algorithm.renderGrid()->explicitIntrinsicInnerLogicalSize(direction)))
         return flexFraction;
 
     SingleThreadWeakHashSet<RenderBox> itemsSet;

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -129,6 +129,9 @@ public:
 
     LayoutUnit masonryContentSize() const;
     Vector<LayoutRect> gridItemsLayoutRects();
+
+    bool shouldCheckExplicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
+
 private:
     friend class GridTrackSizingAlgorithm;
     friend class GridMasonryLayout;
@@ -150,7 +153,6 @@ private:
     bool namedGridLinesDefinitionDidChange(const RenderStyle&) const;
     bool implicitGridLinesDefinitionDidChange(const RenderStyle&) const;
 
-    bool shouldCheckExplicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
     unsigned computeAutoRepeatTracksCount(GridTrackSizingDirection, std::optional<LayoutUnit> availableSize) const;
 
     unsigned clampAutoRepeatTracks(GridTrackSizingDirection, unsigned autoRepeatTracks) const;


### PR DESCRIPTION
#### dd25a04355e3584bf5615720b1e48f90796b6c1e
<pre>
Regression (Safari 17 vs 16.5, 261003@main): height collapsing on auto-height image when container-type set on parent
<a href="https://bugs.webkit.org/show_bug.cgi?id=268874">https://bugs.webkit.org/show_bug.cgi?id=268874</a>

Reviewed by Alan Baradlay.

In r261003 isComputingSizeOrInlineSizeContainment was used which did not consider grid track sizing direction. Fix that
by using shouldCheckExplicitIntrinsicInnerLogicalSize which will take the direction into account.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-flex-fraction-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-flex-fraction.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::IndefiniteSizeStrategy::findUsedFlexFraction const):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/275376@main">https://commits.webkit.org/275376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62c0813d016495354f52de692b07b09cd8bc672d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42167 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33083 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39372 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37638 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34535 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9342 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->