### PR TITLE
[threaded-animation-resolution] add support for blending `filter` values

### DIFF
--- a/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
@@ -32,9 +32,18 @@
 
 OBJC_CLASS NSValue;
 
+#if PLATFORM(MAC)
+OBJC_CLASS CAPresentationModifier;
+OBJC_CLASS CAPresentationModifierGroup;
+#endif
+
 namespace WebCore {
 
 class PlatformCALayer;
+
+#if PLATFORM(MAC)
+using TypedFilterPresentationModifier = std::pair<FilterOperation::Type, RetainPtr<CAPresentationModifier>>;
+#endif
 
 class PlatformCAFilters {
 public:
@@ -48,6 +57,12 @@ public:
 
     // A null operation indicates that we should make a "no-op" filter of the given type.
     static RetainPtr<NSValue> colorMatrixValueForFilter(FilterOperation::Type, const FilterOperation*);
+
+#if PLATFORM(MAC)
+    WEBCORE_EXPORT static void presentationModifiers(const FilterOperations& initialFilters, const FilterOperations* canonicalFilters, Vector<TypedFilterPresentationModifier>& presentationModifiers, RetainPtr<CAPresentationModifierGroup>&);
+    WEBCORE_EXPORT static void updatePresentationModifiers(const FilterOperations& filters, const Vector<TypedFilterPresentationModifier>& presentationModifiers);
+    WEBCORE_EXPORT static size_t presentationModifierCount(const FilterOperations&);
+#endif
 };
 
 }

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -37,6 +37,189 @@
 
 namespace WebCore {
 
+#if PLATFORM(MAC)
+static unsigned keyValueCountForFilter(const FilterOperation& filterOperation)
+{
+    switch (filterOperation.type()) {
+    case FilterOperation::Type::Default:
+    case FilterOperation::Type::Reference:
+    case FilterOperation::Type::None:
+        ASSERT_NOT_REACHED();
+        return 0;
+    case FilterOperation::Type::DropShadow:
+        return 3;
+    case FilterOperation::Type::Sepia:
+    case FilterOperation::Type::Saturate:
+    case FilterOperation::Type::HueRotate:
+    case FilterOperation::Type::Invert:
+    case FilterOperation::Type::Opacity:
+    case FilterOperation::Type::Brightness:
+    case FilterOperation::Type::Contrast:
+    case FilterOperation::Type::Grayscale:
+    case FilterOperation::Type::Blur:
+        return 1;
+    case FilterOperation::Type::AppleInvertLightness:
+        ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
+        break;
+    case FilterOperation::Type::Passthrough:
+        return 0;
+    }
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+size_t PlatformCAFilters::presentationModifierCount(const FilterOperations& filters)
+{
+    size_t count = 0;
+    for (const auto& filter : filters.operations())
+        count += keyValueCountForFilter(*filter.get());
+    return count;
+}
+
+static const FilterOperation& passthroughFilter(const FilterOperation::Type typeToMatch)
+{
+    switch (typeToMatch) {
+    case FilterOperation::Type::DropShadow:
+        static NeverDestroyed<Ref<DropShadowFilterOperation>> passthroughDropShadowFilter = DropShadowFilterOperation::create({ }, 0, { });
+        return passthroughDropShadowFilter.get();
+    case FilterOperation::Type::Grayscale:
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughGrayscaleFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
+        return passthroughGrayscaleFilter.get();
+    case FilterOperation::Type::Sepia:
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughSepiaFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
+        return passthroughSepiaFilter.get();
+    case FilterOperation::Type::Saturate:
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughSaturateFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
+        return passthroughSaturateFilter.get();
+    case FilterOperation::Type::HueRotate:
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughHueRotateFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
+        return passthroughHueRotateFilter.get();
+    case FilterOperation::Type::Invert:
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughInvertFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
+        return passthroughInvertFilter.get();
+    case FilterOperation::Type::Opacity:
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughOpacityFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
+        return passthroughOpacityFilter.get();
+    case FilterOperation::Type::Brightness:
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughBrightnessFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
+        return passthroughBrightnessFilter.get();
+    case FilterOperation::Type::Contrast:
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughContrastFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
+        return passthroughContrastFilter.get();
+    case FilterOperation::Type::Blur:
+        static NeverDestroyed<Ref<BlurFilterOperation>> passthroughBlurFilter = BlurFilterOperation::create({ 0, LengthType::Fixed });
+        return passthroughBlurFilter.get();
+    default:
+        ASSERT_NOT_REACHED();
+        static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughDefaultFilter = BasicColorMatrixFilterOperation::create(0, FilterOperation::Type::Grayscale);
+        return passthroughDefaultFilter.get();
+    }
+}
+
+void PlatformCAFilters::presentationModifiers(const FilterOperations& initialFilters, const FilterOperations* canonicalFilters, Vector<TypedFilterPresentationModifier>& presentationModifiers, RetainPtr<CAPresentationModifierGroup>& group)
+{
+    if (!canonicalFilters || canonicalFilters->isEmpty())
+        return;
+
+    ASSERT(canonicalFilters->size() >= initialFilters.size());
+    ASSERT(presentationModifierCount(*canonicalFilters));
+
+    auto& canonicalFilterOperations = canonicalFilters->operations();
+    auto& initialFilterOperations = initialFilters.operations();
+    auto numberOfInitialFilters = initialFilterOperations.size();
+    for (size_t i = 0; i < canonicalFilterOperations.size(); ++i) {
+        auto& canonicalFilterOperation = *canonicalFilterOperations[i];
+        auto& initialFilterOperation = i < numberOfInitialFilters ? *initialFilterOperations[i] : passthroughFilter(canonicalFilterOperation.type());
+        ASSERT(canonicalFilterOperation.type() == initialFilterOperation.type());
+        auto filterName = makeString("filter_", i);
+        auto type = initialFilterOperation.type();
+        switch (type) {
+        case FilterOperation::Type::Default:
+        case FilterOperation::Type::Reference:
+        case FilterOperation::Type::None:
+            ASSERT_NOT_REACHED();
+            break;
+        case FilterOperation::Type::DropShadow: {
+            const auto& dropShadowOperation = downcast<DropShadowFilterOperation>(initialFilterOperation);
+            auto size = CGSizeMake(dropShadowOperation.x(), dropShadowOperation.y());
+            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"shadowOffset" initialValue:[NSValue value:&size withObjCType:@encode(CGSize)] additive:NO group:group.get()]) });
+            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"shadowColor" initialValue:(id) cachedCGColor(dropShadowOperation.color()).autorelease() additive:NO group:group.get()]) });
+            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"shadowRadius" initialValue:@(dropShadowOperation.stdDeviation()) additive:NO group:group.get()]) });
+            continue;
+        }
+        case FilterOperation::Type::Grayscale:
+        case FilterOperation::Type::Sepia:
+        case FilterOperation::Type::Saturate:
+        case FilterOperation::Type::HueRotate:
+        case FilterOperation::Type::Invert:
+        case FilterOperation::Type::Opacity:
+        case FilterOperation::Type::Brightness:
+        case FilterOperation::Type::Contrast:
+        case FilterOperation::Type::Blur: {
+            auto keyValueName = makeString("filters.", filterName, ".", animatedFilterPropertyName(initialFilterOperation.type()));
+            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:keyValueName initialValue:filterValueForOperation(&initialFilterOperation).get() additive:NO group:group.get()]) });
+            continue;
+        }
+        case FilterOperation::Type::AppleInvertLightness:
+            ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
+            break;
+        case FilterOperation::Type::Passthrough:
+            continue;
+        }
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    ASSERT(presentationModifierCount(*canonicalFilters) == presentationModifiers.size());
+}
+
+void PlatformCAFilters::updatePresentationModifiers(const FilterOperations& filters, const Vector<TypedFilterPresentationModifier>& presentationModifiers)
+{
+    ASSERT(presentationModifierCount(filters) <= presentationModifiers.size());
+
+    size_t filterIndex = 0;
+    auto numberOfFilters = filters.size();
+    for (size_t i = 0; i < presentationModifiers.size(); ++i) {
+        auto& filterOperation = filterIndex < numberOfFilters ? *filters.at(filterIndex) : passthroughFilter(presentationModifiers[i].first);
+        ++filterIndex;
+        switch (filterOperation.type()) {
+        case FilterOperation::Type::Default:
+        case FilterOperation::Type::Reference:
+        case FilterOperation::Type::None:
+            ASSERT_NOT_REACHED();
+            return;
+        case FilterOperation::Type::DropShadow: {
+            const auto& dropShadowOperation = downcast<DropShadowFilterOperation>(filterOperation);
+            auto size = CGSizeMake(dropShadowOperation.x(), dropShadowOperation.y());
+            [presentationModifiers[i].second.get() setValue:[NSValue value:&size withObjCType:@encode(CGSize)]];
+            [presentationModifiers[i++].second.get() setValue:(id) cachedCGColor(dropShadowOperation.color()).autorelease()];
+            [presentationModifiers[i++].second.get() setValue:@(dropShadowOperation.stdDeviation())];
+            continue;
+        }
+        case FilterOperation::Type::Grayscale:
+        case FilterOperation::Type::Sepia:
+        case FilterOperation::Type::Saturate:
+        case FilterOperation::Type::HueRotate:
+        case FilterOperation::Type::Invert:
+        case FilterOperation::Type::Opacity:
+        case FilterOperation::Type::Brightness:
+        case FilterOperation::Type::Contrast:
+        case FilterOperation::Type::Blur: {
+            [presentationModifiers[i].second.get() setValue:filterValueForOperation(&filterOperation).get()];
+            continue;
+        }
+        case FilterOperation::Type::AppleInvertLightness:
+            ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
+            return;
+        case FilterOperation::Type::Passthrough:
+            continue;
+        }
+        ASSERT_NOT_REACHED();
+        return;
+    }
+}
+#endif // PLATFORM(MAC)
+
 void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOperations& filters)
 {
     if (!filters.size()) {
@@ -101,7 +284,6 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
             const auto& colorMatrixOperation = downcast<BasicColorMatrixFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorHueRotate];
             [filter setValue:[NSNumber numberWithFloat:deg2rad(colorMatrixOperation.amount())] forKey:@"inputAngle"];
-            [filter setName:@"hueRotate"];
             [filter setName:filterName];
             return filter;
         }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
@@ -30,7 +30,9 @@
 #include <WebCore/AcceleratedEffect.h>
 #include <WebCore/AcceleratedEffectStack.h>
 #include <WebCore/AcceleratedEffectValues.h>
+#include <WebCore/PlatformCAFilters.h>
 #include <WebCore/PlatformLayer.h>
+#include <wtf/OptionSet.h>
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS CAPresentationModifierGroup;
@@ -59,9 +61,14 @@ private:
 
     WebCore::AcceleratedEffectValues computeValues(MonotonicTime now) const;
 
+#if PLATFORM(MAC)
+    const WebCore::FilterOperations* longestFilterList() const;
+#endif
+
     enum class LayerProperty : uint8_t {
         Opacity = 1 << 1,
-        Transform = 1 << 2
+        Transform = 1 << 2,
+        Filter = 1 << 3
     };
 
     OptionSet<LayerProperty> m_affectedLayerProperties;
@@ -69,9 +76,12 @@ private:
     WebCore::FloatRect m_bounds;
     Seconds m_acceleratedTimelineTimeOrigin;
 
+#if PLATFORM(MAC)
     RetainPtr<CAPresentationModifierGroup> m_presentationModifierGroup;
     RetainPtr<CAPresentationModifier> m_opacityPresentationModifier;
     RetainPtr<CAPresentationModifier> m_transformPresentationModifier;
+    Vector<WebCore::TypedFilterPresentationModifier> m_filterPresentationModifiers;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
@@ -50,17 +50,23 @@ void RemoteAcceleratedEffectStack::setEffects(AcceleratedEffects&& effects)
 {
     AcceleratedEffectStack::setEffects(WTFMove(effects));
 
+    bool affectsFilter = false;
     bool affectsOpacity = false;
     bool affectsTransform = false;
 
-    for (auto& effect : m_primaryLayerEffects) {
+    for (auto& effect : m_backdropLayerEffects.isEmpty() ? m_primaryLayerEffects : m_backdropLayerEffects) {
         auto& properties = effect->animatedProperties();
+        affectsFilter = affectsFilter || properties.containsAny({ AcceleratedEffectProperty::Filter, AcceleratedEffectProperty::BackdropFilter });
         affectsOpacity = affectsOpacity || properties.contains(AcceleratedEffectProperty::Opacity);
         affectsTransform = affectsTransform || properties.containsAny(transformRelatedAcceleratedProperties);
-        if (affectsOpacity && affectsTransform)
+        if (affectsFilter && affectsOpacity && affectsTransform)
             break;
     }
 
+    ASSERT(affectsFilter || affectsOpacity || affectsTransform);
+
+    if (affectsFilter)
+        m_affectedLayerProperties.add(LayerProperty::Filter);
     if (affectsOpacity)
         m_affectedLayerProperties.add(LayerProperty::Opacity);
     if (affectsTransform)
@@ -68,19 +74,68 @@ void RemoteAcceleratedEffectStack::setEffects(AcceleratedEffects&& effects)
 }
 
 #if PLATFORM(MAC)
+const WebCore::FilterOperations* RemoteAcceleratedEffectStack::longestFilterList() const
+{
+    if (!m_affectedLayerProperties.contains(LayerProperty::Filter))
+        return nullptr;
+
+    auto isBackdrop = !m_backdropLayerEffects.isEmpty();
+    auto filterProperty = isBackdrop ? AcceleratedEffectProperty::BackdropFilter : AcceleratedEffectProperty::Filter;
+    auto& effects = isBackdrop ? m_backdropLayerEffects : m_primaryLayerEffects;
+
+    const WebCore::FilterOperations* longestFilterList = nullptr;
+    for (auto& effect : effects) {
+        if (!effect->animatedProperties().contains(filterProperty))
+            continue;
+        for (auto& keyframe : effect->keyframes()) {
+            if (!keyframe.animatedProperties().contains(filterProperty))
+                continue;
+            auto& filter = isBackdrop ? keyframe.values().backdropFilter : keyframe.values().filter;
+            if (!longestFilterList || longestFilterList->size() < filter.size())
+                longestFilterList = &filter;
+        }
+    }
+
+    if (longestFilterList) {
+        auto& baseFilter = isBackdrop ? m_baseValues.backdropFilter : m_baseValues.filter;
+        if (longestFilterList->size() < baseFilter.size())
+            longestFilterList = &baseFilter;
+    }
+
+    return longestFilterList && !longestFilterList->isEmpty() ? longestFilterList : nullptr;
+}
+
 void RemoteAcceleratedEffectStack::initEffectsFromMainThread(PlatformLayer *layer, MonotonicTime now)
 {
+    ASSERT(m_filterPresentationModifiers.isEmpty());
     ASSERT(!m_opacityPresentationModifier);
     ASSERT(!m_transformPresentationModifier);
     ASSERT(!m_presentationModifierGroup);
 
-    if (!m_affectedLayerProperties.containsAny({ LayerProperty::Opacity, LayerProperty::Transform }))
-        return;
-
     auto computedValues = computeValues(now);
 
-    auto numberOfPresentationModifiers = m_affectedLayerProperties.containsAll({ LayerProperty::Opacity, LayerProperty::Transform }) ? 2 : 1;
+    auto* canonicalFilters = longestFilterList();
+
+    auto numberOfPresentationModifiers = [&]() {
+        size_t count = 0;
+        if (m_affectedLayerProperties.contains(LayerProperty::Filter)) {
+            ASSERT(canonicalFilters);
+            count += PlatformCAFilters::presentationModifierCount(*canonicalFilters);
+        }
+        if (m_affectedLayerProperties.contains(LayerProperty::Opacity))
+            count++;
+        if (m_affectedLayerProperties.contains(LayerProperty::Transform))
+            count++;
+        return count;
+    }();
+
     m_presentationModifierGroup = [CAPresentationModifierGroup groupWithCapacity:numberOfPresentationModifiers];
+
+    if (m_affectedLayerProperties.contains(LayerProperty::Filter)) {
+        PlatformCAFilters::presentationModifiers(computedValues.filter, longestFilterList(), m_filterPresentationModifiers, m_presentationModifierGroup);
+        for (auto& filterPresentationModifier : m_filterPresentationModifiers)
+            [layer addPresentationModifier:filterPresentationModifier.second.get()];
+    }
 
     if (m_affectedLayerProperties.contains(LayerProperty::Opacity)) {
         auto *opacity = @(computedValues.opacity);
@@ -100,13 +155,12 @@ void RemoteAcceleratedEffectStack::initEffectsFromMainThread(PlatformLayer *laye
 
 void RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread(MonotonicTime now) const
 {
-    if (!m_affectedLayerProperties.containsAny({ LayerProperty::Opacity, LayerProperty::Transform }))
-        return;
-
-    ASSERT(m_opacityPresentationModifier || m_transformPresentationModifier);
     ASSERT(m_presentationModifierGroup);
 
     auto computedValues = computeValues(now);
+
+    if (!m_filterPresentationModifiers.isEmpty())
+        PlatformCAFilters::updatePresentationModifiers(computedValues.filter, m_filterPresentationModifiers);
 
     if (m_opacityPresentationModifier) {
         auto *opacity = @(computedValues.opacity);
@@ -125,10 +179,10 @@ void RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread(MonotonicTime
 
 void RemoteAcceleratedEffectStack::applyEffectsFromMainThread(PlatformLayer *layer, MonotonicTime now) const
 {
-    if (!m_affectedLayerProperties.containsAny({ LayerProperty::Opacity, LayerProperty::Transform }))
-        return;
-
     auto computedValues = computeValues(now);
+
+    if (m_affectedLayerProperties.contains(LayerProperty::Filter))
+        PlatformCAFilters::setFiltersOnLayer(layer, computedValues.filter);
 
     if (m_affectedLayerProperties.contains(LayerProperty::Opacity))
         [layer setOpacity:computedValues.opacity];
@@ -143,20 +197,18 @@ AcceleratedEffectValues RemoteAcceleratedEffectStack::computeValues(MonotonicTim
 {
     auto values = m_baseValues;
     auto currentTime = now.secondsSinceEpoch() - m_acceleratedTimelineTimeOrigin;
-    for (auto& effect : m_primaryLayerEffects)
+    for (auto& effect : m_backdropLayerEffects.isEmpty() ? m_primaryLayerEffects : m_backdropLayerEffects)
         effect->apply(currentTime, values, m_bounds);
     return values;
 }
 
 void RemoteAcceleratedEffectStack::clear(PlatformLayer *layer)
 {
-    if (!m_presentationModifierGroup) {
-        ASSERT(!m_opacityPresentationModifier && !m_transformPresentationModifier);
-        return;
-    }
+#if PLATFORM(MAC)
+    ASSERT(m_presentationModifierGroup);
 
-    ASSERT(m_opacityPresentationModifier || m_transformPresentationModifier);
-
+    for (auto& filterPresentationModifier : m_filterPresentationModifiers)
+        [layer removePresentationModifier:filterPresentationModifier.second.get()];
     if (m_opacityPresentationModifier)
         [layer removePresentationModifier:m_opacityPresentationModifier.get()];
     if (m_transformPresentationModifier)
@@ -164,9 +216,11 @@ void RemoteAcceleratedEffectStack::clear(PlatformLayer *layer)
 
     [m_presentationModifierGroup flushWithTransaction];
 
+    m_filterPresentationModifiers.clear();
     m_opacityPresentationModifier = nil;
     m_transformPresentationModifier = nil;
     m_presentationModifierGroup = nil;
+#endif
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 7591a3073e2887f58afca2dc56e6a3878e7e9c32
<pre>
[threaded-animation-resolution] add support for blending `filter` values
<a href="https://bugs.webkit.org/show_bug.cgi?id=269236">https://bugs.webkit.org/show_bug.cgi?id=269236</a>
<a href="https://rdar.apple.com/122842684">rdar://122842684</a>

Reviewed by Simon Fraser.

We&apos;ve added support for blending `opacity` with 274102@main and `transform`
with 274487@main. The last group of properties to support is those affecting
in the `CALayer.filters` property. This requires a bit more work than the
other properties since:

- the `drop-shadow()` property maps to separate `CALayer` properties,
- we cannot just compute a single `filters` value for all the other CSS
filter functions.

To that end we use a dedicated `CAPresentationModifier` per animated filter
function. An upcoming patch will ensure that only filter lists that support
interpolation (in other words, not discrete) make it up to the UIProcess,
thus guaranteeing a shared list of primitives. The canonical list of filter
functions can thus be obtained by looking at the longest list of operations
in the provided keyframes or the base value in the case where the 0% or 100%
keyframe is not explicitly provided.

That upcoming patch will also ensure that `drop-shadow()` is the last function
used in a filter list since otherwise the order in which the `CALayer.filters`
property and the properties used to reflect the `drop-shadow()` function won&apos;t
match.

This patch was co-authored with Matt Woodrow.

* Source/WebCore/platform/graphics/ca/PlatformCAFilters.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::keyValueCountForFilter):
(WebCore::PlatformCAFilters::presentationModifierCount):
(WebCore::passthroughFilter):
(WebCore::PlatformCAFilters::presentationModifiers):
(WebCore::PlatformCAFilters::updatePresentationModifiers):
(WebCore::PlatformCAFilters::setFiltersOnLayer):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm:
(WebKit::RemoteAcceleratedEffectStack::setEffects):
(WebKit::RemoteAcceleratedEffectStack::longestFilterList const):
(WebKit::RemoteAcceleratedEffectStack::initEffectsFromMainThread):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread const):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromMainThread const):
(WebKit::RemoteAcceleratedEffectStack::computeValues const):
(WebKit::RemoteAcceleratedEffectStack::clear):

Canonical link: <a href="https://commits.webkit.org/274587@main">https://commits.webkit.org/274587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d3201a221ae7ce42864b8af41e7f65bfa280227

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32969 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37491 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15857 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8843 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15905 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->