### PR TITLE
Re-enable some now passing JSC wasm stress tests on arm

### DIFF
--- a/JSTests/wasm/stress/atomic-decrement.js
+++ b/JSTests/wasm/stress/atomic-decrement.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64" && !($architecture == "arm" && !$cloop)
 import * as assert from '../assert.js';
 
 const num = 3;

--- a/JSTests/wasm/stress/atomic-increment.js
+++ b/JSTests/wasm/stress/atomic-increment.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64" && !($architecture == "arm" && !$cloop)
 import * as assert from '../assert.js';
 
 const num = 3;

--- a/JSTests/wasm/stress/invalid-atomic-alignment.js
+++ b/JSTests/wasm/stress/invalid-atomic-alignment.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"  && !($architecture == "arm" && !$cloop)
 import * as assert from '../assert.js';
 import { instantiate } from "../wabt-wrapper.js";
 


### PR DESCRIPTION
#### 81f30c470c54a0f56a7eed13d02221a83ed7d780
<pre>
Re-enable some now passing JSC wasm stress tests on arm
<a href="https://bugs.webkit.org/show_bug.cgi?id=269297">https://bugs.webkit.org/show_bug.cgi?id=269297</a>

Unreviewed gardering.

* JSTests/wasm/stress/atomic-decrement.js:
* JSTests/wasm/stress/atomic-increment.js:
* JSTests/wasm/stress/invalid-atomic-alignment.js:

Canonical link: <a href="https://commits.webkit.org/274708@main">https://commits.webkit.org/274708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2181f2df31a70db1b31c7b68f1d45ea1c80c4e1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35336 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13451 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43248 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32889 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39239 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39062 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37493 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15854 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46068 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8925 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15902 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9524 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->