### PR TITLE
Skip some tests on memoryLimited instead of on non-watch arm

### DIFF
--- a/JSTests/microbenchmarks/array-from-derived-object-func.js
+++ b/JSTests/microbenchmarks/array-from-derived-object-func.js
@@ -1,5 +1,5 @@
 //@ $skipModes << :lockdown if ($buildType == "debug")
-//@ skip if $architecture == "arm" and !$cloop
+//@ skip if $memoryLimited
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/slowMicrobenchmarks/map-constant-key.js
+++ b/JSTests/slowMicrobenchmarks/map-constant-key.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture == "arm" and !$cloop
+//@ skip if $memoryLimited
 
 function assert(b) {
     if (!b)

--- a/LayoutTests/js/script-tests/regress-139548.js
+++ b/LayoutTests/js/script-tests/regress-139548.js
@@ -1,5 +1,5 @@
 //@ skip if not $jitTests
-//@ skip if $architecture == "arm"
+//@ skip if $memoryLimited
 //@ slow!
 //@ noEagerNoNoLLIntTestsRunLayoutTest
 


### PR DESCRIPTION
#### 5d14ae63de064ea4ff5f8e298e441f868696b327
<pre>
Skip some tests on memoryLimited instead of on non-watch arm
<a href="https://bugs.webkit.org/show_bug.cgi?id=269298">https://bugs.webkit.org/show_bug.cgi?id=269298</a>

Unreviewed gardening.

Use semantically correct skip condition.

* JSTests/microbenchmarks/array-from-derived-object-func.js:
* JSTests/slowMicrobenchmarks/map-constant-key.js:
* LayoutTests/js/script-tests/regress-139548.js:

Canonical link: <a href="https://commits.webkit.org/274725@main">https://commits.webkit.org/274725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/826a52df06538eb8b03882fefde492d8c4192e49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42055 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35421 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33018 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43333 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32974 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39302 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39147 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37588 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15939 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46153 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8940 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15987 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9411 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->