### PR TITLE
[WGSL] Cannot initialize variable with non-concrete type

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -88,6 +88,20 @@ static ASCIILiteral evaluationToString(Evaluation evaluation)
     }
 }
 
+static ASCIILiteral variableFlavorToString(AST::VariableFlavor flavor)
+{
+    switch (flavor) {
+    case AST::VariableFlavor::Var:
+        return "var"_s;
+    case AST::VariableFlavor::Let:
+        return "let"_s;
+    case AST::VariableFlavor::Const:
+        return "const"_s;
+    case AST::VariableFlavor::Override:
+        return "override"_s;
+    }
+}
+
 class TypeChecker : public AST::ScopedVisitor<Binding> {
     using Base  = AST::ScopedVisitor<Binding>;
     using Base::visit;
@@ -502,7 +516,8 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
                 result = initializerType;
             else {
                 result = concretize(initializerType, m_types);
-                RELEASE_ASSERT(result);
+                if (!result)
+                    return error("'", *initializerType, "' cannot be used as the type of a '", variableFlavorToString(variable.flavor()), "'");
                 variable.maybeInitializer()->m_inferredType = result;
             }
         } else if (unify(result, initializerType))


### PR DESCRIPTION
#### d01f00ff4efa7da5a686a4d41f612be6850057dc
<pre>
[WGSL] Cannot initialize variable with non-concrete type
<a href="https://bugs.webkit.org/show_bug.cgi?id=269304">https://bugs.webkit.org/show_bug.cgi?id=269304</a>
<a href="https://rdar.apple.com/122293570">rdar://122293570</a>

Reviewed by Mike Wyrzykowski.

Currently we release_assert, but it should be a type error instead.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::variableFlavorToString):
(WGSL::TypeChecker::visitVariable):

Canonical link: <a href="https://commits.webkit.org/274621@main">https://commits.webkit.org/274621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59de6c5184f929dfcc6304cddceb8de8b1e425e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32980 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13489 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13462 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43271 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39259 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37517 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15877 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8864 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->