### PR TITLE
Unreviewed, reverting 274152@main

### DIFF
--- a/Source/WebKit/Shared/API/APIFrameHandle.h
+++ b/Source/WebKit/Shared/API/APIFrameHandle.h
@@ -37,12 +37,10 @@ public:
     {
         return adoptRef(*new FrameHandle(frameID, false));
     }
-
     static Ref<FrameHandle> createAutoconverting(WebCore::FrameIdentifier frameID)
     {
         return adoptRef(*new FrameHandle(frameID, true));
     }
-
     static Ref<FrameHandle> create(WebCore::FrameIdentifier frameID, bool autoconverting)
     {
         return adoptRef(*new FrameHandle(frameID, autoconverting));
@@ -52,7 +50,6 @@ public:
         : m_frameID(frameID)
         , m_isAutoconverting(isAutoconverting)
     {
-        ASSERT(m_frameID.object().isValid());
     }
 
     WebCore::FrameIdentifier frameID() const { return m_frameID; }

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
@@ -41,10 +41,7 @@ Ref<FrameInfo> FrameInfo::create(WebKit::FrameInfoData&& frameInfoData, RefPtr<W
 
 FrameInfo::FrameInfo(WebKit::FrameInfoData&& data, RefPtr<WebKit::WebPageProxy>&& page)
     : m_data(WTFMove(data))
-    , m_page(WTFMove(page))
-{
-    ASSERT(m_data.frameID.object().isValid());
-}
+    , m_page(WTFMove(page)) { }
 
 FrameInfo::~FrameInfo() = default;
 

--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
@@ -48,10 +48,7 @@ public:
 private:
     FrameTreeNode(WebKit::FrameTreeNodeData&& data, WebKit::WebPageProxy& page)
         : m_data(WTFMove(data))
-        , m_page(page)
-    {
-        ASSERT(m_data.info.frameID.object().isValid());
-    }
+        , m_page(page) { }
 
     const WebKit::FrameTreeNodeData m_data;
     Ref<WebKit::WebPageProxy> m_page;


### PR DESCRIPTION
#### 7dbe9729bdea12ceedf761fc194371c1066bfd86
<pre>
Unreviewed, reverting 274152@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=269240">https://bugs.webkit.org/show_bug.cgi?id=269240</a>
<a href="https://rdar.apple.com/122831039">rdar://122831039</a>

make 20 API tests fail with assert

Reverted change:

ASSERT traversing frames under WebExtensionContext::webNavigationTraverseFrameTreeForFrame.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268775">https://bugs.webkit.org/show_bug.cgi?id=268775</a>
<a href="https://rdar.apple.com/122331877">rdar://122331877</a>
<a href="https://commits.webkit.org/274152@main">https://commits.webkit.org/274152@main</a>

Canonical link: <a href="https://commits.webkit.org/274564@main">https://commits.webkit.org/274564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9060e5b8aabc23fb8515860f92e0fe6a6a09e49a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41995 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15769 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15532 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13492 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43273 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35826 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37507 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5168 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->