### PR TITLE
[WGSL] Global sort does not check max expression depth in parameters

### DIFF
--- a/Source/WebGPU/WGSL/GlobalSorting.cpp
+++ b/Source/WebGPU/WGSL/GlobalSorting.cpp
@@ -213,7 +213,7 @@ GraphBuilder::GraphBuilder(Graph& graph, Graph::Node& node)
 void GraphBuilder::visit(AST::Parameter& parameter)
 {
     introduceVariable(parameter.name());
-    Base::visit(parameter.typeName());
+    Base::visit(parameter);
 }
 
 void GraphBuilder::visit(AST::VariableStatement& variable)


### PR DESCRIPTION
#### 2d31dba1a971959a98ff0a87c4d243cf905e3908
<pre>
[WGSL] Global sort does not check max expression depth in parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=269305">https://bugs.webkit.org/show_bug.cgi?id=269305</a>
<a href="https://rdar.apple.com/122293551">rdar://122293551</a>

Reviewed by Mike Wyrzykowski.

We check for maximum expression depth in GlobalSorting, but while visiting parameters
we visit further the parameter type, which allows for expressions that exceed the max
depth to occur in the parameter&apos;s attributes.

* Source/WebGPU/WGSL/GlobalSorting.cpp:
(WGSL::GraphBuilder::visit):

Canonical link: <a href="https://commits.webkit.org/274618@main">https://commits.webkit.org/274618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a5bcfe9cf9bf93bff6ab9cbf6f584d8d4055860

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41997 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35363 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32984 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13466 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39258 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11771 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37509 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15881 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8865 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->