### PR TITLE
[JSC] re-enable some no-longer-failing tests on armv7

### DIFF
--- a/JSTests/stress/sampling-profiler-microtasks.js
+++ b/JSTests/stress/sampling-profiler-microtasks.js
@@ -1,4 +1,3 @@
-//@ skip if $architecture == "arm"
 
 var abort = $vm.abort;
 

--- a/JSTests/wasm/function-tests/trap-load-shared.js
+++ b/JSTests/wasm/function-tests/trap-load-shared.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64" && $architecture != "arm"
 
 import Builder from '../Builder.js'
 import * as assert from '../assert.js'

--- a/JSTests/wasm/stress/simple-inline-stacktrace-with-catch.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-with-catch.js
@@ -1,4 +1,3 @@
-//@ skip if $architecture == 'arm'
 var wasm_code = read('simple-inline-stacktrace-with-catch.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);
 let throwCounter = 0

--- a/JSTests/wasm/stress/simple-inline-stacktrace.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace.js
@@ -1,4 +1,3 @@
-//@ skip if $architecture == "arm"
 
 var wasm_code = read('simple-inline-stacktrace.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);

--- a/PerformanceTests/SunSpider/shadow-chicken.yaml
+++ b/PerformanceTests/SunSpider/shadow-chicken.yaml
@@ -30,5 +30,5 @@
   cmd: runShadowChicken
 
 - path: tests/v8-v6
-  cmd: if 'arm' == $architecture; skip; else runShadowChicken; end
+  cmd: runShadowChicken
 


### PR DESCRIPTION
#### 138b7cceac1666bad280084efc76a57ad8e8465b
<pre>
[JSC] re-enable some no-longer-failing tests on armv7
Test gardening.

Unreviewed test gardening.

These tests now pass on armv7.

* JSTests/stress/sampling-profiler-microtasks.js:
* JSTests/wasm/function-tests/trap-load-shared.js:
* JSTests/wasm/stress/simple-inline-stacktrace-with-catch.js:
* JSTests/wasm/stress/simple-inline-stacktrace.js:
* PerformanceTests/SunSpider/shadow-chicken.yaml:

Canonical link: <a href="https://commits.webkit.org/274604@main">https://commits.webkit.org/274604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/437440197d77dc48ec0d86def1dd277365697c4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35391 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33002 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13486 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43303 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32944 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39289 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39117 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37543 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15909 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46123 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8853 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15957 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9402 "Found 5 new JSC stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.default, stress/sampling-profiler-microtasks.js.dfg-eager, stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.mini-mode (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->