### PR TITLE
[resutlsdb] Add reset button for ConfigurationSelectors

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js
@@ -292,7 +292,10 @@ function ConfigurationSelectors(callback) {
         {'query': 'architecture', 'name': 'Architecture'},
         {'query': 'flavor', 'name': 'Flavor'},
     ];
-    return elements.map(details => {
+    const resetButtonRef = REF.createRef({});
+    const resetEventStream = resetButtonRef.fromEvent('click');
+
+    return `${elements.map(details => {
         const modifier = new QueryModifier(details.query);
 
         let ref = REF.createRef({
@@ -328,9 +331,25 @@ function ConfigurationSelectors(callback) {
                                     return;
                                 child.style.display = isExpanded ? 'block' : 'none';
                             });
+                            resetEventStream.action(resetSwitch);
                         }
-                    }
+                    },
+                    onElementUnmount: () => {
+                        resetEventStream.stopAction(resetSwitch);
+                    },
                 });
+
+                const resetSwitch = () => {
+                    Object.keys(switches).forEach(key => {
+                        if (key === 'All')
+                            switches[key].checked = true;
+                        else
+                            switches[key].checked = false;
+                    });
+                    modifier.remove();
+                    callback();
+                };
+
 
                 DOM.inject(element, `<a class="link-button text medium" ref="${expander}">+</a>
                     ${details.name} <br>
@@ -341,6 +360,7 @@ function ConfigurationSelectors(callback) {
                         else if (option !== 'All' && modifier.current().indexOf(option) >= 0)
                             isChecked = true;
 
+                        
                         let swtch = REF.createRef({
                             onElementMount: (element) => {
                                 switches[option] = element;
@@ -364,8 +384,9 @@ function ConfigurationSelectors(callback) {
                                     }
                                     callback();
                                 };
-                            },
+                            }
                         });
+
 
                         return `<div class="input" ${isExpanded ? '' : `style="display: none;"`}>
                                 <label>${escapeHTML(option)}</label>
@@ -382,7 +403,9 @@ function ConfigurationSelectors(callback) {
         });
 
         return `<div style="font-size: var(--smallSize);" ref="${ref}"></div>`;
-    }).join('')
+    }).join('')}
+    <button class="button" ref="${resetButtonRef}">Reset</button>
+    `;
 }
 
 function CommitRepresentation(callback) {


### PR DESCRIPTION
#### ec2d9753bb2acef535cf5584a73b4c00b0ad560f
<pre>
[resutlsdb] Add reset button for ConfigurationSelectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=269312">https://bugs.webkit.org/show_bug.cgi?id=269312</a>
<a href="https://rdar.apple.com/122889620">rdar://122889620</a>

Reviewed by Jonathan Bedard.

Add a reset button for user to easily reset all config filters

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js:

Canonical link: <a href="https://commits.webkit.org/274688@main">https://commits.webkit.org/274688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acaf8132c6f0d3270b271e2a9bcd9c3a16e71256

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16048 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33151 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15793 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13681 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/39607 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13689 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43552 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39445 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11983 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/39787 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16158 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8914 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16227 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->