### PR TITLE
[UnifiedPDF] PDFPluginBase should forward Spotlight/Web search queries to the web page

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -99,8 +99,6 @@ public:
     void clickedLink(NSURL *);
 
     void showDefinitionForAttributedString(NSAttributedString *, CGPoint);
-    void performWebSearch(NSString *);
-    void performSpotlightSearch(NSString *);
 
     CGRect pluginBoundsForAnnotation(RetainPtr<PDFAnnotation>&) const final;
     void focusNextAnnotation() final;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -433,12 +433,12 @@ static WebCore::Cursor::Type toWebCoreCursorType(PDFLayerControllerCursorType cu
 
 - (void)performWebSearch:(NSString *)string
 {
-    _pdfPlugin->performWebSearch(string);
+    _pdfPlugin->performWebSearch({ string });
 }
 
 - (void)performSpotlightSearch:(NSString *)string
 {
-    _pdfPlugin->performSpotlightSearch(string);
+    _pdfPlugin->performSpotlightSearch({ string });
 }
 
 - (void)openWithNativeApplication
@@ -1538,20 +1538,6 @@ CGSize PDFPlugin::contentSizeRespectingZoom() const
 CGFloat PDFPlugin::scaleFactor() const
 {
     return [m_pdfLayerController contentScaleFactor];
-}
-
-void PDFPlugin::performWebSearch(NSString *string)
-{
-    if (!m_frame || !m_frame->page())
-        return;
-    m_frame->page()->send(Messages::WebPageProxy::SearchTheWeb(string));
-}
-
-void PDFPlugin::performSpotlightSearch(NSString *string)
-{
-    if (!m_frame || !m_frame->page())
-        return;
-    m_frame->page()->send(Messages::WebPageProxy::SearchWithSpotlight(string));
 }
 
 bool PDFPlugin::handleWheelEvent(const WebWheelEvent& event)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -149,6 +149,8 @@ public:
     virtual bool findString(const String& target, WebCore::FindOptions, unsigned maxMatchCount) = 0;
 
     virtual bool performDictionaryLookupAtLocation(const WebCore::FloatPoint&) = 0;
+    void performSpotlightSearch(const String& query);
+    void performWebSearch(const String& query);
     virtual std::pair<String, PDFSelection *> lookupTextAtLocation(const WebCore::FloatPoint&, WebHitTestResultData&) const = 0;
 
     virtual id accessibilityHitTest(const WebCore::IntPoint&) const = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -420,6 +420,28 @@ void PDFPluginBase::receivedNonLinearizedPDFSentinel()
 
 #endif // HAVE(INCREMENTAL_PDF_APIS)
 
+void PDFPluginBase::performSpotlightSearch(const String& query)
+{
+    if (!m_frame || !m_frame->page())
+        return;
+
+    if (!query || !query.trim(isASCIIWhitespace) || query.utf8().isNull())
+        return;
+
+    m_frame->protectedPage()->send(Messages::WebPageProxy::SearchWithSpotlight(query));
+}
+
+void PDFPluginBase::performWebSearch(const String& query)
+{
+    if (!m_frame || !m_frame->page())
+        return;
+
+    if (!query)
+        return;
+
+    m_frame->protectedPage()->send(Messages::WebPageProxy::SearchTheWeb(query));
+}
+
 void PDFPluginBase::addArchiveResource()
 {
     // FIXME: It's a hack to force add a resource to DocumentLoader. PDF documents should just be fetched as CachedResources.


### PR DESCRIPTION
#### d7c4292b37659eeb541526ced9c8db8ed054042d
<pre>
[UnifiedPDF] PDFPluginBase should forward Spotlight/Web search queries to the web page
<a href="https://bugs.webkit.org/show_bug.cgi?id=269316">https://bugs.webkit.org/show_bug.cgi?id=269316</a>
<a href="https://rdar.apple.com/122906584">rdar://122906584</a>

Reviewed by Simon Fraser.

In preparation of Spotlight/Web search context menu items, this patch
moves the (implementation-agnostic) logic to forward search queries into
PDFPluginBase.

We are also a little more defensive in forwarding our queries -
particularly for Spotlight search - to prevent bugs like <a href="https://rdar.apple.com/40300615">rdar://40300615</a>.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFLayerControllerDelegate performWebSearch:]):
(-[WKPDFLayerControllerDelegate performSpotlightSearch:]):
(WebKit::PDFPlugin::scaleFactor const):
(WebKit::PDFPlugin::performWebSearch): Deleted.
(WebKit::PDFPlugin::performSpotlightSearch): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::performSpotlightSearch):
(WebKit::PDFPluginBase::performWebSearch):

Canonical link: <a href="https://commits.webkit.org/274583@main">https://commits.webkit.org/274583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/088be2df0824e3cfd1ca19092d2517d9afa09520

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42028 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15802 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34197 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35858 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11790 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15912 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8840 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->