### PR TITLE
run-javascriptcore-tests: Allow a cap on the effective timeout

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -61,6 +61,7 @@ my $root;
 my $showHelp;
 my @extraTests = ();
 my $childProcesses;
+my $maxTimeout;
 my $shellRunner;
 my $makeRunner;
 my $rubyRunner;
@@ -279,6 +280,7 @@ Usage: $programName [options] [options to pass to build system]
   --device-os                   Speicifc OS version for the remote device
   --extra-tests=                Path to a file containing extra tests
   --child-processes=            Specify the number of child processes.
+  --max-timeout                 Specify a cap for the effective timeout.
   --shell-runner                Uses the shell-based test runner instead of the default make-based runner.
                                 In general the shell runner is slower than the make runner.
   --make-runner                 Uses the faster make-based runner.
@@ -361,6 +363,7 @@ GetOptions(
     'device-os=s' => \$deviceOS,
     'remote-config-file=s' => \$remoteConfigFile,
     'child-processes=s' => \$childProcesses,
+    'max-timeout=s' => \$maxTimeout,
     'shell-runner' => \$shellRunner,
     'make-runner' => \$makeRunner,
     'ruby-runner' => \$rubyRunner,
@@ -889,6 +892,11 @@ sub runJSCStressTests
     if ($childProcesses) {
         push(@jscStressDriverCmd, "--child-processes");
         push(@jscStressDriverCmd, $childProcesses);
+    }
+
+    if ($maxTimeout) {
+        push(@jscStressDriverCmd, "--max-timeout");
+        push(@jscStressDriverCmd, $maxTimeout);
     }
 
     if ($shellRunner) {

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -171,6 +171,7 @@ $reportExecutionTime = false
 $ldd = nil
 $artifact_exec_wrapper = nil
 $numChildProcessesSetByUser = false
+$maxTimeout = nil
 $runUniqueId = Random.new.bytes(16).unpack("H*")[0]
 $gnuParallelChunkSize = 1
 $testsDebugStream = nil # set to $stderr for debugging
@@ -212,6 +213,7 @@ def usage
     puts "--remote-config-file        Specify a remote host on which to run tests from JSON file."
     puts "--report-execution-time     Print execution time for each test."
     puts "--child-processes    (-c)   Specify the number of child processes."
+    puts "--max-timeout               Specify a cap for the effective timeout"
     puts "--filter                    Only run tests whose name matches the given regular expression."
     puts "--help               (-h)   Print this message."
     puts "--env-vars                  Add a list of environment variables to set before running jsc."
@@ -257,6 +259,7 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
                ['--report-execution-time', GetoptLong::NO_ARGUMENT],
                ['--model', GetoptLong::REQUIRED_ARGUMENT],
                ['--child-processes', '-c', GetoptLong::REQUIRED_ARGUMENT],
+               ['--max-timeout', GetoptLong::REQUIRED_ARGUMENT],
                ['--filter', GetoptLong::REQUIRED_ARGUMENT],
                ['--verbose', '-v', GetoptLong::NO_ARGUMENT],
                ['--env-vars', GetoptLong::REQUIRED_ARGUMENT],
@@ -343,6 +346,8 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
     when '--child-processes'
         $numChildProcesses = arg.to_i
         $numChildProcessesSetByUser = true
+    when '--max-timeout'
+        $maxTimeout = arg.to_i
     when '--filter'
         $filter = Regexp.new(arg)
     when '--arch'
@@ -3023,6 +3028,15 @@ if ENV["JSCTEST_timeout"]
     # In the worst case, the processors just interfere with each other.
     # Increase the timeout proportionally to the number of processors.
     ENV["JSCTEST_timeout"] = (ENV["JSCTEST_timeout"].to_i.to_f * Math.sqrt($numChildProcesses)).to_i.to_s
+    if not $maxTimeout.nil?
+        # The above adjustment can push the effective timeout over the timeout
+        # enforced by buildbot's ShellCommand. Tests that hang would then result
+        # in the whole run getting killed. Allow the user to cap the effective
+        # timeout.
+        if $maxTimeout < ENV["JSCTEST_timeout"].to_i
+            ENV["JSCTEST_timeout"] = $maxTimeout.to_s
+        end
+    end
 end
 
 # We do not adjust hardTimeout. If we are not producing any results during 1200 seconds, buildbot terminates the tests. So we should terminate hung tests.


### PR DESCRIPTION
#### 36543ae6e0e96340bd5071a9e3c6018fd1b6549e
<pre>
run-javascriptcore-tests: Allow a cap on the effective timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=269318">https://bugs.webkit.org/show_bug.cgi?id=269318</a>

Reviewed by Justin Michaud.

run-jsc-stress-tests scales up JSC_timeout by the number of cores. On
high core count machines, this would push the value above the 1200
seconds after which buildbot will kill the running command if it hasn&apos;t
seen any output. This means that when a single JSC stress test would
hang, the whole test run would ends up wasted and the user&apos;d only get a
cryptic

    command timed out: 1200 seconds without output running

message that gives no information as to which test got stuck.

Add a --max-timeout parameter, which the CI environment can use to cap
the effective per-stress-test timeout to something less than the
buildbot timeout.

* Tools/Scripts/run-javascriptcore-tests:
(runJSCStressTests):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/274620@main">https://commits.webkit.org/274620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f09307d32a0bdbe08bd1f9008cdf1d14e55e989a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33008 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13520 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43309 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32950 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39282 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39123 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37535 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15915 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46129 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8868 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15963 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9429 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->