### PR TITLE
Add memory footprint notification callbacks

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -91,6 +91,7 @@ public:
 
     WTF_EXPORT_PRIVATE void install();
 
+    WTF_EXPORT_PRIVATE void setMemoryFootprintPollIntervalForTesting(Seconds);
     WTF_EXPORT_PRIVATE void setShouldUsePeriodicMemoryMonitor(bool);
 
 #if OS(LINUX) || OS(FREEBSD) || OS(QNX)
@@ -209,6 +210,10 @@ public:
 
     void setShouldLogMemoryMemoryPressureEvents(bool shouldLog) { m_shouldLogMemoryMemoryPressureEvents = shouldLog; }
 
+    // Runs the provided callback the first time that this process's footprint exceeds any of the given thresholds.
+    // Only works in processes that use PeriodicMemoryMonitor.
+    WTF_EXPORT_PRIVATE void setMemoryFootprintNotificationThresholds(Vector<size_t>&& thresholds, WTF::Function<void(size_t)>&&);
+
 private:
     std::optional<size_t> thresholdForMemoryKill();
     size_t thresholdForPolicy(MemoryUsagePolicy);
@@ -247,6 +252,8 @@ private:
     WTF::Function<void()> m_memoryKillCallback;
     WTF::Function<void(MemoryPressureStatus)> m_memoryPressureStatusChangedCallback;
     LowMemoryHandler m_lowMemoryHandler;
+    Vector<size_t> m_memoryFootprintNotificationThresholds;
+    WTF::Function<void(size_t)> m_memoryFootprintNotificationHandler;
 
     Configuration m_configuration;
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -278,6 +278,9 @@ struct WebProcessCreationParameters {
 
     HashMap<WebCore::RegistrableDomain, String> storageAccessUserAgentStringQuirksData;
     HashSet<WebCore::RegistrableDomain> storageAccessPromptQuirksDomains;
+
+    Seconds memoryFootprintPollIntervalForTesting;
+    Vector<size_t> memoryFootprintNotificationThresholds;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -226,4 +226,7 @@
 
     HashMap<WebCore::RegistrableDomain, String> storageAccessUserAgentStringQuirksData;
     HashSet<WebCore::RegistrableDomain> storageAccessPromptQuirksDomains;
+
+    Seconds memoryFootprintPollIntervalForTesting;
+    Vector<size_t> memoryFootprintNotificationThresholds;
 };

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
@@ -82,6 +82,8 @@ Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::copy()
     copy->m_presentingApplicationProcessToken = this->m_presentingApplicationProcessToken;
 #endif
     copy->m_timeZoneOverride = this->m_timeZoneOverride;
+    copy->m_memoryFootprintPollIntervalForTesting = this->m_memoryFootprintPollIntervalForTesting;
+    copy->m_memoryFootprintNotificationThresholds = this->m_memoryFootprintNotificationThresholds;
     return copy;
 }
 

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
@@ -158,6 +158,12 @@ public:
     void setTimeZoneOverride(const WTF::String& timeZoneOverride) { m_timeZoneOverride = timeZoneOverride; }
     const WTF::String& timeZoneOverride() const { return m_timeZoneOverride; }
 
+    void setMemoryFootprintPollIntervalForTesting(Seconds interval) { m_memoryFootprintPollIntervalForTesting = interval; }
+    Seconds memoryFootprintPollIntervalForTesting() const { return m_memoryFootprintPollIntervalForTesting; }
+
+    void setMemoryFootprintNotificationThresholds(Vector<size_t>&& thresholds) { m_memoryFootprintNotificationThresholds = WTFMove(thresholds); }
+    const Vector<size_t>& memoryFootprintNotificationThresholds() const { return m_memoryFootprintNotificationThresholds; }
+
 private:
     WTF::String m_injectedBundlePath;
     Vector<WTF::String> m_cachePartitionedURLSchemes;
@@ -198,6 +204,8 @@ private:
     std::optional<audit_token_t> m_presentingApplicationProcessToken;
 #endif
     WTF::String m_timeZoneOverride;
+    Seconds m_memoryFootprintPollIntervalForTesting;
+    Vector<size_t> m_memoryFootprintNotificationThresholds;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h
@@ -122,4 +122,6 @@ static const WKNavigationResponsePolicy _WKNavigationResponsePolicyBecomeDownloa
 - (void)_webView:(WKWebView *)webView willGoToBackForwardListItem:(WKBackForwardListItem *)item inPageCache:(BOOL)inPageCache WK_API_AVAILABLE(macos(10.13.4), ios(14.0));
 - (void)_webView:(WKWebView *)webView decidePolicyForSOAuthorizationLoadWithCurrentPolicy:(_WKSOAuthorizationLoadPolicy)policy forExtension:(NSString *)extension completionHandler:(void (^)(_WKSOAuthorizationLoadPolicy policy))completionHandler WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
+- (void)_webView:(WKWebView *)webView didExceedMemoryFootprintThresholdWithFootprint:(size_t)footprint WK_API_AVAILABLE(macos(WK_MAC_TBA));
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -81,6 +81,7 @@ public:
         , m_hasNotifyBackgroundFetchChangeSelector([m_delegate.get() respondsToSelector:@selector(notifyBackgroundFetchChange:change:)])
         , m_hasWindowProxyPropertyAccessSelector([m_delegate.get() respondsToSelector:@selector(websiteDataStore:domain:didOpenDomainViaWindowOpen:withProperty:directly:)])
         , m_hasDidAllowPrivateTokenUsageByThirdPartyForTestingSelector([m_delegate.get() respondsToSelector:@selector(websiteDataStore:didAllowPrivateTokenUsageByThirdPartyForTesting:forResourceURL:)])
+        , m_hasDidExceedMemoryFootprintThresholdSelector([m_delegate.get() respondsToSelector:@selector(websiteDataStore:domain:didExceedMemoryFootprintThreshold:withPageCount:processLifetime:inForeground:)])
     {
     }
 
@@ -300,6 +301,14 @@ private:
         [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() didAllowPrivateTokenUsageByThirdPartyForTesting:wasAllowed forResourceURL:resourceURL];
     }
 
+    void didExceedMemoryFootprintThreshold(size_t footprint, const String& domain, unsigned pageCount, Seconds processLifetime, bool inForeground)
+    {
+        if (!m_hasDidExceedMemoryFootprintThresholdSelector)
+            return;
+
+        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() domain:(NSString *)domain didExceedMemoryFootprintThreshold:footprint withPageCount:pageCount processLifetime:processLifetime.seconds() inForeground:inForeground];
+    }
+
     WeakObjCPtr<WKWebsiteDataStore> m_dataStore;
     WeakObjCPtr<id <_WKWebsiteDataStoreDelegate> > m_delegate;
     bool m_hasRequestStorageSpaceSelector { false };
@@ -314,6 +323,7 @@ private:
     bool m_hasNotifyBackgroundFetchChangeSelector { false };
     bool m_hasWindowProxyPropertyAccessSelector { false };
     bool m_hasDidAllowPrivateTokenUsageByThirdPartyForTestingSelector { false };
+    bool m_hasDidExceedMemoryFootprintThresholdSelector { false };
 };
 
 @implementation WKWebsiteDataStore {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
@@ -78,6 +78,9 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 
 @property (nonatomic, nullable, copy) NSString *timeZoneOverride WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
+@property (nonatomic) NSTimeInterval memoryFootprintPollIntervalForTesting;
+@property (nonatomic, copy) NSArray<NSNumber *> *memoryFootprintNotificationThresholds WK_API_AVAILABLE(macos(WK_MAC_TBA));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
@@ -377,6 +377,34 @@
     _processPoolConfiguration->setTimeZoneOverride(timeZone);
 }
 
+- (void)setMemoryFootprintPollIntervalForTesting:(NSTimeInterval)pollInterval
+{
+    _processPoolConfiguration->setMemoryFootprintPollIntervalForTesting(Seconds { pollInterval });
+}
+
+- (NSTimeInterval)memoryFootprintPollIntervalForTesting
+{
+    return _processPoolConfiguration->memoryFootprintPollIntervalForTesting().seconds();
+}
+
+- (NSArray<NSNumber *> *)memoryFootprintNotificationThresholds
+{
+    const auto& thresholds = _processPoolConfiguration->memoryFootprintNotificationThresholds();
+    RetainPtr result = adoptNS([[NSMutableArray alloc] initWithCapacity: thresholds.size()]);
+    for (auto& threshold : thresholds)
+        [result addObject:@(threshold)];
+    return result.autorelease();
+}
+
+- (void)setMemoryFootprintNotificationThresholds:(NSArray<NSNumber *> *)thresholds
+{
+    Vector<size_t> sizes;
+    sizes.reserveCapacity(thresholds.count);
+    for (NSNumber *threshold in thresholds)
+        sizes.append(static_cast<size_t>(threshold.unsignedLongLongValue));
+    _processPoolConfiguration->setMemoryFootprintNotificationThresholds(WTFMove(sizes));
+}
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
@@ -71,4 +71,5 @@ WK_API_AVAILABLE(macos(10.15), ios(13.0))
 - (void)notifyBackgroundFetchChange:(NSString *)backgroundFetchIdentifier change:(WKBackgroundFetchChange)change;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore domain:(NSString *)registrableDomain didOpenDomainViaWindowOpen:(NSString *)openedRegistrableDomain withProperty:(WKWindowProxyProperty)property directly:(BOOL)directly;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore didAllowPrivateTokenUsageByThirdPartyForTesting:(BOOL)wasAllowed forResourceURL:(NSURL *)resourceURL;
+- (void)websiteDataStore:(WKWebsiteDataStore *)dataStore domain:(NSString *)registrableDomain didExceedMemoryFootprintThreshold:(size_t)footprint withPageCount:(NSUInteger)pageCount processLifetime:(NSTimeInterval)processLifetime inForeground:(BOOL)inForeground;
 @end

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1003,6 +1003,10 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
 
     parameters.timeZoneOverride = m_configuration->timeZoneOverride();
 
+    parameters.memoryFootprintPollIntervalForTesting = m_configuration->memoryFootprintPollIntervalForTesting();
+
+    parameters.memoryFootprintNotificationThresholds = m_configuration->memoryFootprintNotificationThresholds();
+
     // Add any platform specific parameters
     platformInitializeWebProcess(process, parameters);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -320,6 +320,7 @@ public:
     void didExceedCPULimit();
     void didExceedActiveMemoryLimit();
     void didExceedInactiveMemoryLimit();
+    void didExceedMemoryFootprintThreshold(size_t);
 
     void didCommitProvisionalLoad() { m_hasCommittedAnyProvisionalLoads = true; }
     bool hasCommittedAnyProvisionalLoads() const { return m_hasCommittedAnyProvisionalLoads; }

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -45,6 +45,7 @@ messages -> WebProcessProxy LegacyReceiver {
 
     DidExceedActiveMemoryLimit()
     DidExceedInactiveMemoryLimit()
+    DidExceedMemoryFootprintThreshold(size_t footprint)
     DidExceedCPULimit()
 
     StopResponsivenessTimer()

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -31,6 +31,7 @@
 #include "BackgroundFetchChange.h"
 #include <WebCore/NotificationData.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Seconds.h>
 
 namespace WebCore {
 enum class WindowProxyProperty : uint8_t;
@@ -113,6 +114,10 @@ public:
     }
 
     virtual void didAllowPrivateTokenUsageByThirdPartyForTesting(bool, URL&&)
+    {
+    }
+
+    virtual void didExceedMemoryFootprintThreshold(size_t footprint, const String& domain, unsigned pageCount, Seconds processLifetime, bool inForeground)
     {
     }
 };

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -244,6 +244,9 @@ public:
     void setWebPushMachServiceName(String&& name) { m_webPushMachServiceName = WTFMove(name); }
     const String& webPushMachServiceName() const { return m_webPushMachServiceName; }
 
+    void setMemoryFootprintNotificationThresholds(Vector<size_t>&& thresholds) { m_memoryFootprintNotificationThresholds = WTFMove(thresholds); }
+    const Vector<size_t>& memoryFootprintNotificationThresholds() { return m_memoryFootprintNotificationThresholds; }
+
 private:
     WebsiteDataStoreConfiguration(const String& baseCacheDirectory, const String& baseDataDirectory);
     static Ref<WebsiteDataStoreConfiguration> create(IsPersistent isPersistent, ShouldInitializePaths shouldInitializePaths) { return adoptRef(*new WebsiteDataStoreConfiguration(isPersistent, shouldInitializePaths)); }
@@ -322,6 +325,7 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<CFDictionaryRef> m_proxyConfiguration;
 #endif
+    Vector<size_t> m_memoryFootprintNotificationThresholds;
 };
 
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -461,6 +461,8 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
                 page->releaseMemory(critical);
         });
 #if ENABLE(PERIODIC_MEMORY_MONITOR)
+        if (auto pollInterval = parameters.memoryFootprintPollIntervalForTesting)
+            memoryPressureHandler.setMemoryFootprintPollIntervalForTesting(pollInterval);
         memoryPressureHandler.setShouldUsePeriodicMemoryMonitor(true);
         memoryPressureHandler.setMemoryKillCallback([this] () {
             WebCore::logMemoryStatistics(LogMemoryStatisticsReason::OutOfMemoryDeath);
@@ -468,6 +470,9 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
                 parentProcessConnection()->send(Messages::WebProcessProxy::DidExceedActiveMemoryLimit(), 0);
             else
                 parentProcessConnection()->send(Messages::WebProcessProxy::DidExceedInactiveMemoryLimit(), 0);
+        });
+        memoryPressureHandler.setMemoryFootprintNotificationThresholds(WTFMove(parameters.memoryFootprintNotificationThresholds), [this](size_t footprint) {
+            parentProcessConnection()->send(Messages::WebProcessProxy::DidExceedMemoryFootprintThreshold(footprint), 0);
         });
 #endif
         memoryPressureHandler.setMemoryPressureStatusChangedCallback([this](WTF::MemoryPressureStatus memoryPressureStatus) {

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -171,6 +171,7 @@ Tests/WebKitCocoa/MediaLoading.mm
 Tests/WebKitCocoa/MediaMutedState.mm
 Tests/WebKitCocoa/MediaSession.mm
 Tests/WebKitCocoa/MediaType.mm
+Tests/WebKitCocoa/MemoryFootprintThreshold.mm
 Tests/WebKitCocoa/MessagePortProviders.mm
 Tests/WebKitCocoa/ModalAlerts.mm
 Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3464,6 +3464,7 @@
 		EB4D320827C045440081A8E4 /* TestNotificationProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestNotificationProvider.h; sourceTree = "<group>"; };
 		EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PushDatabase.cpp; sourceTree = "<group>"; };
 		EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PushMessageCrypto.cpp; sourceTree = "<group>"; };
+		EBCD30F72B7C075F00268DA5 /* MemoryFootprintThreshold.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryFootprintThreshold.mm; sourceTree = "<group>"; };
 		EC79F168BE454E579E417B05 /* Markable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Markable.cpp; sourceTree = "<group>"; };
 		ECA680CD1E68CC0900731D20 /* StringUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = StringUtilities.mm; sourceTree = "<group>"; };
 		F3CEF6B82808F2D3001E23A5 /* TimeZoneOverride.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TimeZoneOverride.mm; sourceTree = "<group>"; };
@@ -4123,6 +4124,7 @@
 				07EF76D42540FC060053ED53 /* MediaMutedState.mm */,
 				0794740C25CA0BDE00C597EB /* MediaSession.mm */,
 				51BE9E652376089500B4E117 /* MediaType.mm */,
+				EBCD30F72B7C075F00268DA5 /* MemoryFootprintThreshold.mm */,
 				5165FE03201EE617009F7EC3 /* MessagePortProviders.mm */,
 				51CD1C6A1B38CE3600142CA5 /* ModalAlerts.mm */,
 				1ABC3DED1899BE6D004F0626 /* Navigation.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MemoryFootprintThreshold.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MemoryFootprintThreshold.mm
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(PERIODIC_MEMORY_MONITOR)
+
+#import "DeprecatedGlobalValues.h"
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestURLSchemeHandler.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+#import <WebKit/_WKWebsiteDataStoreDelegate.h>
+#import <wtf/HexNumber.h>
+#import <wtf/Vector.h>
+
+static constexpr auto memoryFootprintBytes = R"HTML(
+<script>
+function touchBytes(len)
+{
+    const array = new Uint8Array(len);
+    for (let i = 0; i < len; i += 4096)
+        array[i] = Math.random() * 256;
+    return array.reduce((accumulator, element) => accumulator + element, 0);
+}
+</script>
+)HTML"_s;
+
+@interface MemoryFootprintDelegate : NSObject<_WKWebsiteDataStoreDelegate> {
+@package
+    bool _done;
+    NSInteger _expectedCallbackCount;
+    Vector<size_t> _footprints;
+}
+@end
+
+@implementation MemoryFootprintDelegate
+
+- (void)websiteDataStore:(WKWebsiteDataStore *)dataStore domain:(NSString *)registrableDomain didExceedMemoryFootprintThreshold:(size_t)footprint withPageCount:(NSUInteger)pageCount processLifetime:(NSTimeInterval)processLifetime inForeground:(BOOL)inForeground
+{
+    _footprints.append(footprint);
+
+    if (_expectedCallbackCount-- == 1)
+        _done = YES;
+}
+
+@end
+
+TEST(MemoryFootprintThreshold, TestDelegateMethod)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { memoryFootprintBytes } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr delegate = adoptNS([MemoryFootprintDelegate new]);
+    configuration.get().websiteDataStore._delegate = delegate.get();
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    [processPoolConfiguration setMemoryFootprintPollIntervalForTesting:0.25];
+    [processPoolConfiguration setMemoryFootprintNotificationThresholds:@[@(25 << 20), @(50 << 20), @(100 << 20)]];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() processPoolConfiguration:processPoolConfiguration.get()]);
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    delegate->_expectedCallbackCount = 3;
+    [webView evaluateJavaScript:@"touchBytes(100 << 20)" completionHandler:nil];
+    TestWebKitAPI::Util::run(&delegate->_done);
+
+    EXPECT_EQ(delegate->_footprints.size(), 3u);
+    EXPECT_GT(delegate->_footprints[0], 25u << 20);
+    EXPECT_GT(delegate->_footprints[1], 50u << 20);
+    EXPECT_GT(delegate->_footprints[2], 100u << 20);
+}
+
+#endif // ENABLE(PERIODIC_MEMORY_MONITOR)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SnapshotStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SnapshotStore.mm
@@ -36,8 +36,10 @@
 #import <WebKit/WKBackForwardListItemPrivate.h>
 #import <WebKit/WKPage.h>
 #import <WebKit/WKPagePrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/_WKFeature.h>
 #import <wtf/RetainPtr.h>
 
 static bool didForceRepaint;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
@@ -28,6 +28,7 @@
 #import "PlatformUtilities.h"
 #import "PlatformWebView.h"
 #import "Test.h"
+#import "TestWKWebView.h"
 #import <JavaScriptCore/JavaScriptCore.h>
 #import <WebKit/WKPagePrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>


### PR DESCRIPTION
#### 0951ebda6a7aa5edba8cfb11e83d4aa1c6a893ce
<pre>
Add memory footprint notification callbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=269317">https://bugs.webkit.org/show_bug.cgi?id=269317</a>
<a href="https://rdar.apple.com/problem/122908959">rdar://problem/122908959</a>

Reviewed by Brady Eidson.

We want to observe when sites in the field exceed various key memory footprint thresholds (e.g. 2GB,
4GB, etc.). To do this, we let the embedder specify those thresholds in _WKProcessPoolConfiguration.
We also add a _WKWebsiteDataStore delegate method that is called when WebContent&apos;s footprint exceeds
those thresholds.

Theis notification only works on the Mac, since they require the use of the periodic memory monitor
(which is only enabled on Mac).

* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::setMemoryFootprintPollIntervalForTesting):
(WTF::MemoryPressureHandler::setMemoryFootprintNotificationThresholds):
(WTF::MemoryPressureHandler::measurementTimerFired):
* Source/WTF/wtf/MemoryPressureHandler.h:
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp:
(API::ProcessPoolConfiguration::copy):
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm:
(-[_WKProcessPoolConfiguration setMemoryFootprintPollIntervalForTesting:]):
(-[_WKProcessPoolConfiguration memoryFootprintPollIntervalForTesting]):
(-[_WKProcessPoolConfiguration memoryFootprintNotificationThresholds]):
(-[_WKProcessPoolConfiguration setMemoryFootprintNotificationThresholds:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::initializeNewWebProcess):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didExceedMemoryFootprintThreshold):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::didExceedMemoryFootprintThreshold):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::setMemoryFootprintNotificationThresholds):
(WebKit::WebsiteDataStoreConfiguration::memoryFootprintNotificationThresholds):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MemoryFootprintThreshold.mm: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm:

Canonical link: <a href="https://commits.webkit.org/274733@main">https://commits.webkit.org/274733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e27c557f87ae8d5a2fe3b2af906d5a69a119cb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39804 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42348 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33190 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43627 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33257 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39484 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39430 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12026 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16238 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46438 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8943 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16286 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9563 "Found 6 new JSC stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.default, stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.mini-mode, stress/sampling-profiler-microtasks.js.no-llint, wasm.yaml/wasm/js-api/export-arity.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->