### PR TITLE
Web Inspector: Timelines tab is unusable when inspector is docked bottom

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
@@ -25,25 +25,25 @@
 
 .timeline-overview {
     --timeline-sidebar-width: 197px;
+    --timeline-header-height: 23px;
+
+    display: grid;
+    grid-template-columns: [timelines-sidebar] var(--timeline-sidebar-width) [timelines-content] minmax(0, 1fr);
+    grid-template-rows: [timelines-header] var(--timeline-header-height) [timelines-content] 1fr;
 }
 
 .timeline-overview > :is(.navigation-bar.timelines, .tree-outline.timelines) {
     border-inline-end: 1px solid var(--border-color);
-    inset-inline-start: 0;
-}
-
-.timeline-overview:not(.frames) > :is(.scroll-container, .timeline-ruler, .graphs-container) {
-    inset-inline-start: var(--timeline-sidebar-width);
+    grid-column: timelines-sidebar;
 }
 
 .timeline-overview > .navigation-bar.timelines {
     box-sizing: border-box;
     justify-content: flex-start;
-    position: absolute;
-    top: 0;
+    grid-row: timelines-header;
     z-index: var(--z-index-header);
     width: var(--timeline-sidebar-width);
-    height: 23px;
+    height: var(--timeline-header-height);
     background-color: var(--background-color);
     border-bottom: 1px solid var(--border-color);
 }
@@ -70,15 +70,9 @@
 }
 
 .timeline-overview > .tree-outline.timelines {
-    position: absolute;
-    top: 23px;
     z-index: var(--z-index-header);
     width: var(--timeline-sidebar-width);
     background-color: var(--panel-background-color);
-}
-
-.timeline-overview.edit-instruments > .tree-outline.timelines {
-    bottom: 0;
 }
 
 .timeline-overview.edit-instruments > .tree-outline.timelines .item.selected {
@@ -121,6 +115,9 @@ body:not(.window-inactive, .window-docked-inactive) .timeline-overview:not(.edit
 }
 
 .timeline-overview > .scroll-container {
+    grid-column: timelines-content;
+    grid-row: timelines-content;
+
     position: absolute;
     right: 0;
     bottom: 0;
@@ -151,11 +148,9 @@ body:not(.window-inactive, .window-docked-inactive) .timeline-overview:not(.edit
 }
 
 .timeline-overview > .timeline-ruler {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    grid-column: timelines-content;
+    grid-row: timelines-header / -1;
+    width: 100%;
 }
 
 .timeline-overview.frames > .timeline-ruler {
@@ -186,11 +181,9 @@ body[dir=rtl] .timeline-overview.frames > .timeline-ruler:not(.both-handles-clam
 }
 
 .timeline-overview > .graphs-container {
-    position: absolute;
-    top: 23px;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    grid-column: timelines-content;
+    grid-row: timelines-content;
+    overflow-x: hidden;
 }
 
 body.mac-platform.legacy .timeline-overview > .graphs-container {
@@ -198,6 +191,7 @@ body.mac-platform.legacy .timeline-overview > .graphs-container {
 }
 
 .timeline-overview > .graphs-container > .timeline-overview-graph {
+    position: relative;
     height: 36px;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js
@@ -552,6 +552,11 @@ WI.TimelineOverview = class TimelineOverview extends WI.View
 
     _handleWheelEvent(event)
     {
+        // Ignore handling wheel events originating over the timelines tree outline to allow the timelines overview to be scrolled on small viewports.
+        // The result of compareDocumentPosition() is a bitwise mask: https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition#node.document_position_contains
+        if (event.target.compareDocumentPosition(this._timelinesTreeOutline.element) & Node.DOCUMENT_POSITION_CONTAINS)
+            return;
+
         // Ignore cloned events that come our way, we already handled the original.
         if (event.__cloned)
             return;
@@ -563,6 +568,9 @@ WI.TimelineOverview = class TimelineOverview extends WI.View
         // Require twice the vertical delta to overcome horizontal scrolling. This prevents most
         // cases of inadvertent zooming for slightly diagonal scrolls.
         if (Math.abs(event.deltaX) >= Math.abs(event.deltaY) * 0.5) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+
             // Clone the event to dispatch it on the scroll container. Mark it as cloned so we don't get into a loop.
             let newWheelEvent = new event.constructor(event.type, event);
             newWheelEvent.__cloned = true;

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.css
@@ -23,15 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+.content-view.timeline-recording {
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+
+    --timeline-content-browser-min-height: 250px;
+}
+
 .content-view.timeline-recording > .timeline-overview {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
+    position: relative;
+    flex: none;
 }
 
 .content-view.timeline-recording.edit-instruments > .timeline-overview {
-    bottom: 0;
+    flex: 1;
 }
 
 .content-view.timeline-recording.edit-instruments > .content-browser {
@@ -39,12 +45,8 @@
 }
 
 .content-view.timeline-recording > .content-browser {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    overflow: hidden;
-
+    flex: 1;
+    min-height: var(--timeline-content-browser-min-height);
     border-top: 1px solid var(--border-color);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js
@@ -338,7 +338,6 @@ WI.TimelineRecordingContentView = class TimelineRecordingContentView extends WI.
             newViewMode = WI.TimelineOverview.ViewMode.Timelines;
 
         this._timelineOverview.viewMode = newViewMode;
-        this._updateTimelineOverviewHeight();
         this._updateProgressView();
         this._updateFilterBar();
 
@@ -661,19 +660,6 @@ WI.TimelineRecordingContentView = class TimelineRecordingContentView extends WI.
         this._recording.reset();
     }
 
-    _updateTimelineOverviewHeight()
-    {
-        if (this._timelineOverview.editingInstruments)
-            this._timelineOverview.element.style.height = "";
-        else {
-            const rulerHeight = 23;
-
-            let styleValue = (rulerHeight + this._timelineOverview.height) + "px";
-            this._timelineOverview.element.style.height = styleValue;
-            this._timelineContentBrowser.element.style.top = styleValue;
-        }
-    }
-
     _instrumentAdded(instrumentOrEvent)
     {
         let instrument = instrumentOrEvent instanceof WI.Instrument ? instrumentOrEvent : instrumentOrEvent.data.instrument;
@@ -725,8 +711,6 @@ WI.TimelineRecordingContentView = class TimelineRecordingContentView extends WI.
 
             previousPathComponent = pathComponent;
         }
-
-        this._updateTimelineOverviewHeight();
     }
 
     _recordingReset(event)
@@ -885,8 +869,6 @@ WI.TimelineRecordingContentView = class TimelineRecordingContentView extends WI.
     {
         let editingInstruments = this._timelineOverview.editingInstruments;
         this.element.classList.toggle(WI.TimelineOverview.EditInstrumentsStyleClassName, editingInstruments);
-
-        this._updateTimelineOverviewHeight();
     }
 
     _filterDidChange()

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
@@ -26,6 +26,7 @@
 .timeline-ruler {
     position: relative;
     pointer-events: none;
+    overflow-x: hidden;
 
     --timeline-ruler-marker-translateX: -1px;
 }


### PR DESCRIPTION
#### 77a543efb462d5fbeb9f8d17d89add5399a487b0
<pre>
Web Inspector: Timelines tab is unusable when inspector is docked bottom
<a href="https://bugs.webkit.org/show_bug.cgi?id=167110">https://bugs.webkit.org/show_bug.cgi?id=167110</a>
<a href="https://rdar.apple.com/30054421">rdar://30054421</a>

Reviewed by NOBODY (OOPS!).

Allow scrolling the content of the Timelines tab when scrolling over the timelines tree outline.
The behavior to resize the timline resolution on scroll is kept when scrolling over the graphs.

This patch changes the absolute positioning layout of the timeline overview to CSS Grid layout.
This enables scrolling and removes the need to calculate offsets + dimensions with JavaScript.

* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css:
(.timeline-overview):
(.timeline-overview &gt; :is(.navigation-bar.timelines, .tree-outline.timelines)):
(.timeline-overview &gt; .navigation-bar.timelines):
(.timeline-overview &gt; .tree-outline.timelines):
(.timeline-overview &gt; .scroll-container):
(.timeline-overview &gt; .timeline-ruler):
(.timeline-overview &gt; .graphs-container):
(.timeline-overview &gt; .graphs-container &gt; .timeline-overview-graph):
(.timeline-overview:not(.frames) &gt; :is(.scroll-container, .timeline-ruler, .graphs-container)): Deleted.
(.timeline-overview.edit-instruments &gt; .tree-outline.timelines): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js:
(WI.TimelineOverview.prototype._handleWheelEvent):
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.css:
(.content-view.timeline-recording):
(.content-view.timeline-recording &gt; .timeline-overview):
(.content-view.timeline-recording.edit-instruments &gt; .timeline-overview):
(.content-view.timeline-recording &gt; .content-browser):
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js:
(WI.TimelineRecordingContentView.prototype._currentContentViewDidChange):
(WI.TimelineRecordingContentView.prototype._timelineCountChanged):
(WI.TimelineRecordingContentView.prototype._editingInstrumentsDidChange):
(WI.TimelineRecordingContentView.prototype._updateTimelineOverviewHeight): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css:
(.timeline-ruler):
</pre>