### PR TITLE
Element::userAgentShadowRoot() shouldn't return a RefPtr

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2990,10 +2990,15 @@ RefPtr<ShadowRoot> Element::shadowRootForBindings(JSC::JSGlobalObject& lexicalGl
     return nullptr;
 }
 
-RefPtr<ShadowRoot> Element::userAgentShadowRoot() const
+ShadowRoot* Element::userAgentShadowRoot() const
 {
     ASSERT(!shadowRoot() || shadowRoot()->mode() == ShadowRootMode::UserAgent);
     return shadowRoot();
+}
+
+RefPtr<ShadowRoot> Element::protectedUserAgentShadowRoot() const
+{
+    return userAgentShadowRoot();
 }
 
 ShadowRoot& Element::ensureUserAgentShadowRoot()

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -364,7 +364,8 @@ public:
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&);
     ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, bool delegatesFocus);
 
-    RefPtr<ShadowRoot> userAgentShadowRoot() const;
+    ShadowRoot* userAgentShadowRoot() const;
+    RefPtr<ShadowRoot> protectedUserAgentShadowRoot() const;
     WEBCORE_EXPORT ShadowRoot& ensureUserAgentShadowRoot();
     WEBCORE_EXPORT ShadowRoot& createUserAgentShadowRoot();
 

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -170,7 +170,7 @@ bool isInsideOverlay(const SimpleRange& range)
 bool isInsideOverlay(const Node& node)
 {
     RefPtr host = imageOverlayHost(node);
-    return host && host->userAgentShadowRoot()->contains(node);
+    return host && host->protectedUserAgentShadowRoot()->contains(node);
 }
 
 bool isOverlayText(const Node* node)
@@ -184,7 +184,7 @@ bool isOverlayText(const Node& node)
     if (!host)
         return false;
 
-    if (RefPtr overlay = host->userAgentShadowRoot()->getElementById(imageOverlayElementIdentifier()))
+    if (RefPtr overlay = host->protectedUserAgentShadowRoot()->getElementById(imageOverlayElementIdentifier()))
         return node.isDescendantOf(*overlay);
 
     return false;
@@ -195,7 +195,7 @@ void removeOverlaySoonIfNeeded(HTMLElement& element)
     if (!hasOverlay(element))
         return;
 
-    element.protectedDocument()->eventLoop().queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
+    element.protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
         RefPtr element = weakElement.get();
         if (!element)
             return;

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -97,7 +97,7 @@ bool isInsideImageControls(const Node& node)
     if (!host)
         return false;
 
-    return host->userAgentShadowRoot()->contains(node);
+    return host->protectedUserAgentShadowRoot()->contains(node);
 }
 
 void createImageControls(HTMLElement& element)

--- a/Source/WebCore/html/AttachmentAssociatedElement.cpp
+++ b/Source/WebCore/html/AttachmentAssociatedElement.cpp
@@ -47,7 +47,7 @@ void AttachmentAssociatedElement::setAttachmentElement(Ref<HTMLAttachmentElement
 
 RefPtr<HTMLAttachmentElement> AttachmentAssociatedElement::attachmentElement() const
 {
-    if (auto shadowRoot = asHTMLElement().userAgentShadowRoot())
+    if (RefPtr shadowRoot = asHTMLElement().userAgentShadowRoot())
         return childrenOfType<HTMLAttachmentElement>(*shadowRoot).first();
 
     return nullptr;

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -330,17 +330,19 @@ void BaseDateAndTimeInputType::createShadowSubtree()
     ASSERT(needsShadowSubtree());
     ASSERT(element());
 
-    auto& element = *this->element();
-    auto& document = element.document();
+    Ref element = *this->element();
+    Ref document = element->document();
 
-    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element.userAgentShadowRoot() };
+    Ref shadowRoot = *element->userAgentShadowRoot();
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
 
-    if (document.settings().dateTimeInputsEditableComponentsEnabled()) {
-        m_dateTimeEditElement = DateTimeEditElement::create(document, *this);
-        element.userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, *m_dateTimeEditElement);
+    if (document->settings().dateTimeInputsEditableComponentsEnabled()) {
+        Ref dateTimeEditElement = DateTimeEditElement::create(document, *this);
+        m_dateTimeEditElement = dateTimeEditElement.copyRef();
+        shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, dateTimeEditElement);
     } else {
-        auto valueContainer = HTMLDivElement::create(document);
-        element.userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, valueContainer);
+        Ref valueContainer = HTMLDivElement::create(document);
+        shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, valueContainer);
         valueContainer->setUserAgentPart(UserAgentParts::webkitDateAndTimeValue());
     }
     updateInnerTextValue();
@@ -511,8 +513,8 @@ void BaseDateAndTimeInputType::didChangeValueFromControl()
     if (!valueChanged)
         return;
 
-    Ref<HTMLInputElement> input(*element());
-    if (input->userAgentShadowRoot()->containsFocusedElement())
+    Ref input = *element();
+    if (input->protectedUserAgentShadowRoot()->containsFocusedElement())
         input->dispatchFormControlInputEvent();
     else
         input->dispatchFormControlChangeEvent();

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -82,15 +82,16 @@ void CheckboxInputType::createShadowSubtree()
     ASSERT(element());
     ASSERT(element()->userAgentShadowRoot());
 
-    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
+    Ref shadowRoot = *element()->userAgentShadowRoot();
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
 
     Ref document = element()->document();
-    auto track = HTMLDivElement::create(document);
+    Ref track = HTMLDivElement::create(document);
     track->setUserAgentPart(UserAgentParts::track());
-    element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, track);
-    auto thumb = HTMLDivElement::create(document);
+    shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, track);
+    Ref thumb = HTMLDivElement::create(document);
     thumb->setUserAgentPart(UserAgentParts::thumb());
-    element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, thumb);
+    shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, thumb);
 }
 
 void CheckboxInputType::handleKeyupEvent(KeyboardEvent& event)

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -144,12 +144,13 @@ void ColorInputType::createShadowSubtree()
     ASSERT(element());
     ASSERT(element()->shadowRoot());
 
-    Document& document = element()->document();
-    auto wrapperElement = HTMLDivElement::create(document);
-    auto colorSwatch = HTMLDivElement::create(document);
+    Ref document = element()->document();
+    Ref wrapperElement = HTMLDivElement::create(document);
+    Ref colorSwatch = HTMLDivElement::create(document);
 
-    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
-    element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, wrapperElement);
+    Ref shadowRoot = *element()->userAgentShadowRoot();
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
+    shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, wrapperElement);
 
     wrapperElement->appendChild(ContainerNode::ChildChange::Source::Parser, colorSwatch);
     wrapperElement->setUserAgentPart(UserAgentParts::webkitColorSwatchWrapper());
@@ -282,11 +283,11 @@ void ColorInputType::updateColorSwatch()
 HTMLElement* ColorInputType::shadowColorSwatch() const
 {
     ASSERT(element());
-    RefPtr<ShadowRoot> shadow = element()->userAgentShadowRoot();
+    RefPtr shadow = element()->userAgentShadowRoot();
     if (!shadow)
         return nullptr;
 
-    auto wrapper = childrenOfType<HTMLDivElement>(*shadow).first();
+    RefPtr wrapper = childrenOfType<HTMLDivElement>(*shadow).first();
     if (!wrapper)
         return nullptr;
 

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -224,15 +224,16 @@ void FileInputType::createShadowSubtree()
     ASSERT(element());
     ASSERT(element()->shadowRoot());
 
-    auto button = HTMLInputElement::create(inputTag, element()->document(), nullptr, false);
+    Ref button = HTMLInputElement::create(inputTag, element()->protectedDocument(), nullptr, false);
     {
         ScriptDisallowedScope::EventAllowedScope eventAllowedScopeBeforeAppend { button };
         button->setType(InputTypeNames::button());
         button->setUserAgentPart(UserAgentParts::fileSelectorButton());
         button->setValue(element()->multiple() ? fileButtonChooseMultipleFilesLabel() : fileButtonChooseFileLabel());
     }
-    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
-    element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, button);
+    Ref shadowRoot = *element()->userAgentShadowRoot();
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
+    shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, button);
     disabledStateChanged();
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5079,11 +5079,11 @@ void HTMLMediaElement::updateCaptionContainer()
 void HTMLMediaElement::layoutSizeChanged()
 {
     auto task = [this] {
-        if (auto root = userAgentShadowRoot())
+        if (RefPtr root = userAgentShadowRoot())
             root->dispatchEvent(Event::create(eventNames().resizeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
-        if (m_mediaControlsHost)
-            m_mediaControlsHost->updateCaptionDisplaySizes();
+        if (RefPtr mediaControlsHost = m_mediaControlsHost)
+            mediaControlsHost->updateCaptionDisplaySizes();
     };
     queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, WTFMove(task));
 

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -254,7 +254,7 @@ void HTMLPlugInElement::swapRendererTimerFired()
     
     // Create a shadow root, which will trigger the code to add a snapshot container
     // and reattach, thus making a new Renderer.
-    Ref<HTMLPlugInElement> protectedThis(*this);
+    Ref protectedThis { *this };
     ensureUserAgentShadowRoot();
 }
 

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -74,7 +74,7 @@ RenderProgress* HTMLProgressElement::renderProgress() const
 {
     if (auto* renderProgress = dynamicDowncast<RenderProgress>(renderer()))
         return renderProgress;
-    return downcast<RenderProgress>(descendantsOfType<Element>(*userAgentShadowRoot()).first()->renderer());
+    return downcast<RenderProgress>(descendantsOfType<Element>(*protectedUserAgentShadowRoot()).first()->renderer());
 }
 
 void HTMLProgressElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -315,9 +315,7 @@ String HTMLTextAreaElement::sanitizeUserInputValue(const String& proposedValue, 
 RefPtr<TextControlInnerTextElement> HTMLTextAreaElement::innerTextElement() const
 {
     RefPtr root = userAgentShadowRoot();
-    if (!root)
-        return nullptr;
-    return childrenOfType<TextControlInnerTextElement>(*root).first();
+    return root ? childrenOfType<TextControlInnerTextElement>(*root).first() : nullptr;
 }
 
 RefPtr<TextControlInnerTextElement> HTMLTextAreaElement::innerTextElementCreatingShadowSubtreeIfNeeded()
@@ -518,17 +516,22 @@ void HTMLTextAreaElement::updatePlaceholderText()
 {
     auto& placeholderText = attributeWithoutSynchronization(placeholderAttr);
     if (placeholderText.isEmpty()) {
-        if (m_placeholder) {
-            userAgentShadowRoot()->removeChild(*m_placeholder);
+        if (RefPtr placeholder = m_placeholder) {
+            protectedUserAgentShadowRoot()->removeChild(*placeholder);
             m_placeholder = nullptr;
         }
         return;
     }
     if (!m_placeholder) {
         m_placeholder = TextControlPlaceholderElement::create(document());
-        userAgentShadowRoot()->insertBefore(*m_placeholder, innerTextElement()->protectedNextSibling());
+        protectedUserAgentShadowRoot()->insertBefore(*protectedPlaceholderElement(), innerTextElement()->protectedNextSibling());
     }
-    m_placeholder->setInnerText(String { placeholderText });
+    protectedPlaceholderElement()->setInnerText(String { placeholderText });
+}
+
+RefPtr<HTMLElement> HTMLTextAreaElement::protectedPlaceholderElement() const
+{
+    return m_placeholder;
 }
 
 RenderStyle HTMLTextAreaElement::createInnerTextStyle(const RenderStyle& style)

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -72,6 +72,7 @@ private:
 
     bool supportsPlaceholder() const final { return true; }
     HTMLElement* placeholderElement() const final { return m_placeholder.get(); }
+    RefPtr<HTMLElement> protectedPlaceholderElement() const;
     void updatePlaceholderText() final;
     bool isEmptyValue() const final { return value().isEmpty(); }
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -681,7 +681,7 @@ void HTMLTextFormControlElement::setInnerTextValue(String&& value)
 
         {
             // Events dispatched on the inner text element cannot execute arbitrary author scripts.
-            ScriptDisallowedScope::EventAllowedScope allowedScope(*userAgentShadowRoot());
+            ScriptDisallowedScope::EventAllowedScope allowedScope(*protectedUserAgentShadowRoot());
 
             bool endsWithNewLine = value.endsWith('\n') || value.endsWith('\r');
             innerText->setInnerText(WTFMove(value));

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -655,7 +655,7 @@ void InputType::createShadowSubtree()
 void InputType::removeShadowSubtree()
 {
     ASSERT(element());
-    RefPtr<ShadowRoot> root = element()->userAgentShadowRoot();
+    RefPtr root = element()->userAgentShadowRoot();
     if (!root)
         return;
 

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -137,17 +137,17 @@ void RangeInputType::handleMouseDownEvent(MouseEvent& event)
     if (element()->isDisabledFormControl())
         return;
 
-    auto* targetNode = dynamicDowncast<Node>(event.target());
+    RefPtr targetNode = dynamicDowncast<Node>(event.target());
     if (!targetNode)
         return;
 
     ASSERT(element()->shadowRoot());
-    if (targetNode != element() && !targetNode->isDescendantOf(element()->userAgentShadowRoot().get()))
+    if (targetNode != element() && !targetNode->isDescendantOf(element()->protectedUserAgentShadowRoot().get()))
         return;
-    auto& thumb = typedSliderThumbElement();
-    if (targetNode == &thumb)
+    Ref thumb = typedSliderThumbElement();
+    if (targetNode == thumb.ptr())
         return;
-    thumb.dragFrom(event.absoluteLocation());
+    thumb->dragFrom(event.absoluteLocation());
 }
 
 #if ENABLE(TOUCH_EVENTS)
@@ -246,13 +246,14 @@ void RangeInputType::createShadowSubtree()
     ASSERT(element());
     ASSERT(element()->userAgentShadowRoot());
 
-    Document& document = element()->document();
+    Ref document = element()->document();
 
-    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
+    Ref shadowRoot = *element()->userAgentShadowRoot();
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
 
-    auto track = HTMLDivElement::create(document);
-    auto container = SliderContainerElement::create(document);
-    element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, container);
+    Ref track = HTMLDivElement::create(document);
+    Ref container = SliderContainerElement::create(document);
+    shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, container);
     container->appendChild(ContainerNode::ChildChange::Source::Parser, track);
 
     track->setUserAgentPart(UserAgentParts::webkitSliderRunnableTrack());
@@ -266,16 +267,16 @@ HTMLElement* RangeInputType::sliderTrackElement() const
     if (!hasCreatedShadowSubtree())
         return nullptr;
 
-    ASSERT(element()->userAgentShadowRoot());
-    ASSERT(element()->userAgentShadowRoot()->firstChild()); // container
-    ASSERT(element()->userAgentShadowRoot()->firstChild()->isHTMLElement());
-    ASSERT(element()->userAgentShadowRoot()->firstChild()->firstChild()); // track
+    RefPtr root = element()->userAgentShadowRoot();
+    ASSERT(root);
+    ASSERT(root->firstChild()); // container
+    ASSERT(root->firstChild()->isHTMLElement());
+    ASSERT(root->firstChild()->firstChild()); // track
 
-    RefPtr<ShadowRoot> root = element()->userAgentShadowRoot();
     if (!root)
         return nullptr;
     
-    auto* container = childrenOfType<SliderContainerElement>(*root).first();
+    RefPtr container = childrenOfType<SliderContainerElement>(*root).first();
     if (!container)
         return nullptr;
 

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -338,7 +338,7 @@ void TextFieldInputType::createShadowSubtree()
     ASSERT(!m_capsLockIndicator);
     ASSERT(!m_autoFillButton);
 
-    Document& document = element()->document();
+    Ref document = element()->document();
     bool shouldHaveSpinButton = this->shouldHaveSpinButton();
     bool shouldHaveCapsLockIndicator = this->shouldHaveCapsLockIndicator();
     bool shouldDrawAutoFillButton = this->shouldDrawAutoFillButton();
@@ -351,11 +351,13 @@ void TextFieldInputType::createShadowSubtree()
 #endif
         || needsContainer();
 
-    m_innerText = TextControlInnerTextElement::create(document, element()->isInnerTextElementEditable());
+    Ref innerText = TextControlInnerTextElement::create(document, element()->isInnerTextElementEditable());
+    m_innerText = innerText.copyRef();
 
-    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
+    Ref shadowRoot = *element()->userAgentShadowRoot();
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
     if (!createsContainer) {
-        element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, *m_innerText);
+        shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, innerText);
         updatePlaceholderText();
         updateInnerTextValue();
         return;
@@ -366,18 +368,20 @@ void TextFieldInputType::createShadowSubtree()
     updateInnerTextValue();
 
     if (shouldHaveSpinButton) {
-        m_innerSpinButton = SpinButtonElement::create(document, *this);
-        m_container->appendChild(ContainerNode::ChildChange::Source::Parser, *m_innerSpinButton);
+        Ref innerSpinButton = SpinButtonElement::create(document, *this);
+        m_innerSpinButton = innerSpinButton.copyRef();
+        RefPtr { m_container }->appendChild(ContainerNode::ChildChange::Source::Parser, innerSpinButton);
     }
 
     if (shouldHaveCapsLockIndicator) {
-        m_capsLockIndicator = HTMLDivElement::create(document);
-        m_container->appendChild(ContainerNode::ChildChange::Source::Parser, *m_capsLockIndicator);
+        Ref capsLockIndicator = HTMLDivElement::create(document);
+        m_capsLockIndicator = capsLockIndicator.copyRef();
+        RefPtr { m_container }->appendChild(ContainerNode::ChildChange::Source::Parser, capsLockIndicator);
 
-        m_capsLockIndicator->setUserAgentPart(UserAgentParts::webkitCapsLockIndicator());
+        capsLockIndicator->setUserAgentPart(UserAgentParts::webkitCapsLockIndicator());
 
         bool shouldDrawCapsLockIndicator = this->shouldDrawCapsLockIndicator();
-        m_capsLockIndicator->setInlineStyleProperty(CSSPropertyDisplay, shouldDrawCapsLockIndicator ? CSSValueBlock : CSSValueNone, true);
+        capsLockIndicator->setInlineStyleProperty(CSSPropertyDisplay, shouldDrawCapsLockIndicator ? CSSValueBlock : CSSValueNone, true);
     }
 
     updateAutoFillButton();
@@ -651,20 +655,19 @@ void TextFieldInputType::updatePlaceholderText()
 
     String placeholderText = element()->placeholder();
     if (placeholderText.isEmpty()) {
-        if (m_placeholder) {
-            m_placeholder->parentNode()->removeChild(*m_placeholder);
-            m_placeholder = nullptr;
-        }
+        if (RefPtr placeholder = std::exchange(m_placeholder, nullptr))
+            placeholder->remove();
         return;
     }
     if (!m_placeholder) {
-        m_placeholder = TextControlPlaceholderElement::create(element()->document());
-        if (m_container)
-            element()->userAgentShadowRoot()->insertBefore(*m_placeholder, m_container.copyRef());
+        Ref placeholder = TextControlPlaceholderElement::create(element()->protectedDocument());
+        m_placeholder = placeholder.copyRef();
+        if (RefPtr container = m_container)
+            element()->protectedUserAgentShadowRoot()->insertBefore(placeholder, container);
         else
-            element()->userAgentShadowRoot()->insertBefore(*m_placeholder, innerTextElement());
+            element()->protectedUserAgentShadowRoot()->insertBefore(placeholder, innerTextElement());
     }
-    m_placeholder->setInnerText(WTFMove(placeholderText));
+    RefPtr { m_placeholder }->setInnerText(WTFMove(placeholderText));
 }
 
 bool TextFieldInputType::appendFormData(DOMFormData& formData) const
@@ -818,23 +821,27 @@ void TextFieldInputType::createContainer(PreserveSelectionRange preserveSelectio
 
     static MainThreadNeverDestroyed<const AtomString> webkitTextfieldDecorationContainerName("-webkit-textfield-decoration-container"_s);
 
-    ScriptDisallowedScope::EventAllowedScope allowedScope(*element()->userAgentShadowRoot());
+    Ref shadowRoot = *element()->userAgentShadowRoot();
+    ScriptDisallowedScope::EventAllowedScope allowedScope(shadowRoot);
 
+    Ref document = element()->document();
     // FIXME: <https://webkit.org/b/245977> Suppress selectionchange events during subtree modification.
     std::optional<std::tuple<unsigned, unsigned, TextFieldSelectionDirection>> selectionState;
-    if (preserveSelection == PreserveSelectionRange::Yes && enclosingTextFormControl(element()->document().selection().selection().start()) == element())
+    if (preserveSelection == PreserveSelectionRange::Yes && enclosingTextFormControl(document->selection().selection().start()) == element())
         selectionState = { element()->selectionStart(), element()->selectionEnd(), element()->computeSelectionDirection() };
 
-    m_container = TextControlInnerContainer::create(element()->document());
-    element()->userAgentShadowRoot()->appendChild(*m_container);
-    m_container->setUserAgentPart(UserAgentParts::webkitTextfieldDecorationContainer());
+    Ref container = TextControlInnerContainer::create(document);
+    m_container = container.copyRef();
+    shadowRoot->appendChild(container);
+    container->setUserAgentPart(UserAgentParts::webkitTextfieldDecorationContainer());
 
-    m_innerBlock = TextControlInnerElement::create(element()->document());
-    m_container->appendChild(*m_innerBlock);
-    m_innerBlock->appendChild(*m_innerText);
+    Ref innerBlock = TextControlInnerElement::create(document);
+    m_innerBlock = innerBlock.copyRef();
+    m_container->appendChild(innerBlock);
+    innerBlock->appendChild(*m_innerText.copyRef());
 
     if (selectionState) {
-        element()->document().eventLoop().queueTask(TaskSource::DOMManipulation, [selectionState = *selectionState, element = WeakPtr { element() }] {
+        document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [selectionState = *selectionState, element = WeakPtr { element() }] {
             if (!element || !element->focused())
                 return;
 

--- a/Source/WebCore/html/ValidationMessage.cpp
+++ b/Source/WebCore/html/ValidationMessage.cpp
@@ -255,11 +255,12 @@ bool ValidationMessage::shadowTreeContains(const Node& node) const
 void ValidationMessage::deleteBubbleTree()
 {
     ASSERT(!validationMessageClient());
-    if (m_bubble) {
-        ScriptDisallowedScope::EventAllowedScope allowedScope(*m_element->userAgentShadowRoot());
+    if (RefPtr bubble = m_bubble) {
+        Ref shadowRoot = *m_element->userAgentShadowRoot();
+        ScriptDisallowedScope::EventAllowedScope allowedScope(shadowRoot);
         m_messageHeading = nullptr;
         m_messageBody = nullptr;
-        m_element->userAgentShadowRoot()->removeChild(*m_bubble);
+        shadowRoot->removeChild(*bubble);
         m_bubble = nullptr;
     }
     m_message = String();

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -58,7 +58,7 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
     }
 
     Vector<Ref<HTMLElement>> dataDetectorResultElements;
-    for (auto& child : descendantsOfType<HTMLElement>(*overlayHost.userAgentShadowRoot())) {
+    for (auto& child : descendantsOfType<HTMLElement>(*overlayHost.protectedUserAgentShadowRoot())) {
         if (ImageOverlay::isDataDetectorResult(child) && child.renderer())
             dataDetectorResultElements.append(child);
     }

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -294,9 +294,7 @@ void SVGUseElement::updateUserAgentShadowTree()
 RefPtr<SVGElement> SVGUseElement::targetClone() const
 {
     RefPtr root = userAgentShadowRoot();
-    if (!root)
-        return nullptr;
-    return childrenOfType<SVGElement>(*root).first();
+    return root ? childrenOfType<SVGElement>(*root).first() : nullptr;
 }
 
 RenderPtr<RenderElement> SVGUseElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
@@ -510,7 +508,7 @@ static void cloneDataAndChildren(SVGElement& replacementClone, SVGElement& origi
 
 void SVGUseElement::expandUseElementsInShadowTree() const
 {
-    auto descendants = descendantsOfType<SVGUseElement>(*userAgentShadowRoot());
+    auto descendants = descendantsOfType<SVGUseElement>(*protectedUserAgentShadowRoot());
     for (auto it = descendants.begin(); it; ) {
         Ref originalClone = *it;
         it.dropAssertions();
@@ -544,7 +542,7 @@ void SVGUseElement::expandUseElementsInShadowTree() const
 
 void SVGUseElement::expandSymbolElementsInShadowTree() const
 {
-    auto descendants = descendantsOfType<SVGSymbolElement>(*userAgentShadowRoot());
+    auto descendants = descendantsOfType<SVGSymbolElement>(*protectedUserAgentShadowRoot());
     for (auto it = descendants.begin(); it; ) {
         Ref originalClone = *it;
         it.dropAssertions();
@@ -571,7 +569,7 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
 void SVGUseElement::transferEventListenersToShadowTree() const
 {
     // FIXME: Don't directly add event listeners on each descendant. Copy event listeners on the use element instead.
-    for (Ref descendant : descendantsOfType<SVGElement>(*userAgentShadowRoot())) {
+    for (Ref descendant : descendantsOfType<SVGElement>(*protectedUserAgentShadowRoot())) {
         if (EventTargetData* data = descendant->correspondingElement()->eventTargetData())
             data->eventListenerMap.copyEventListenersNotCreatedFromMarkupToTarget(descendant.ptr());
     }


### PR DESCRIPTION
#### 9951fe460428c043d54ceb41d050680c1bb40d01
<pre>
Element::userAgentShadowRoot() shouldn&apos;t return a RefPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=269331">https://bugs.webkit.org/show_bug.cgi?id=269331</a>

Reviewed by Ryosuke Niwa.

Element::userAgentShadowRoot() shouldn&apos;t return a RefPtr. It causes unnecessary
ref-counting churn for caller that don&apos;t need it. Have it return a raw pointer
instead and add a `protectedUserAgentShadowRoot()` getter for the callers that
actually want a RefPtr.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::userAgentShadowRoot const):
(WebCore::Element::protectedUserAgentShadowRoot const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::isInsideOverlay):
(WebCore::ImageOverlay::isOverlayText):
(WebCore::ImageOverlay::removeOverlaySoonIfNeeded):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::isInsideImageControls):
* Source/WebCore/html/AttachmentAssociatedElement.cpp:
(WebCore::AttachmentAssociatedElement::attachmentElement const):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::createShadowSubtree):
(WebCore::BaseDateAndTimeInputType::didChangeValueFromControl):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::createShadowSubtree):
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::createShadowSubtree):
(WebCore::ColorInputType::shadowColorSwatch const):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::createShadowSubtree):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::layoutSizeChanged):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::swapRendererTimerFired):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::renderProgress const):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::innerTextElement const):
(WebCore::HTMLTextAreaElement::updatePlaceholderText):
(WebCore::HTMLTextAreaElement::protectedPlaceholderElement const):
* Source/WebCore/html/HTMLTextAreaElement.h:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setInnerTextValue):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::removeShadowSubtree):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::handleMouseDownEvent):
(WebCore::RangeInputType::createShadowSubtree):
(WebCore::RangeInputType::sliderTrackElement const):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createShadowSubtree):
(WebCore::TextFieldInputType::updatePlaceholderText):
(WebCore::TextFieldInputType::createContainer):
* Source/WebCore/html/ValidationMessage.cpp:
(WebCore::ValidationMessage::deleteBubbleTree):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::updateDataDetectorHighlights):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::targetClone const):
(WebCore::SVGUseElement::expandUseElementsInShadowTree const):
(WebCore::SVGUseElement::expandSymbolElementsInShadowTree const):
(WebCore::SVGUseElement::transferEventListenersToShadowTree const):

Canonical link: <a href="https://commits.webkit.org/274602@main">https://commits.webkit.org/274602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58aa1b94b4eab2291e922185f9710fd1b168e52e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42098 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15872 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15622 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13536 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43376 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35527 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11840 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15982 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5185 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->