### PR TITLE
[UnifiedPDF] Choose a good initial scale, and fix various scaling issues

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -29,6 +29,7 @@
 #if ENABLE(UNIFIED_PDF)
 
 #import "Logging.h"
+#import <WebCore/AffineTransform.h>
 #import <wtf/text/TextStream.h>
 
 #import "PDFKitSoftLink.h"

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -126,6 +126,8 @@ private:
     void installPDFDocument() override;
 
     float scaleForActualSize() const;
+    float initialScale() const;
+    float scaleForFitToView() const;
 
     CGFloat scaleFactor() const override;
     CGSize contentSizeRespectingZoom() const final;
@@ -159,7 +161,11 @@ private:
 
     void scheduleRenderingUpdate();
 
-    void updateLayout();
+    enum class AdjustScaleAfterLayout : bool {
+        No,
+        Yes
+    };
+    void updateLayout(AdjustScaleAfterLayout = AdjustScaleAfterLayout::No);
 
     WebCore::IntRect availableContentsRect() const;
 
@@ -314,7 +320,7 @@ private:
     bool requestStartKeyboardScrollAnimation(const WebCore::KeyboardScroll& scrollData) override;
     bool requestStopKeyboardScrollAnimation(bool immediate) override;
 
-    float sidePaddingWidth() const;
+    WebCore::FloatSize centeringOffset() const;
 
     // HUD Actions.
 #if ENABLE(PDF_HUD)


### PR DESCRIPTION
#### 201d691c2124b002de6280430852e50e0f9f997e
<pre>
[UnifiedPDF] Choose a good initial scale, and fix various scaling issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=269333">https://bugs.webkit.org/show_bug.cgi?id=269333</a>
<a href="https://rdar.apple.com/122907238">rdar://122907238</a>

Reviewed by Tim Horton.

Fix various scaling issues with PDFs:
1. On first load, try to display at actual size, as long as that doesn&apos;t cause it to
   zoom in. Otherwise try to fix the entire height in the view. Implemented via the
   `AdjustScaleAfterLayout` argument to `updateLayout()`.

2. When changing layout modes, rescale using the same logic as first load.

3. When the PDF content is shorter than the view, vertically center it. Implemented
   by renaming and changing `sidePaddingWidth()` to return a FloatSize. It also now
   always computes padding, even when scaled above 1.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::attemptToUnlockPDF):
(WebKit::UnifiedPDFPlugin::updatePageBackgroundLayers):
(WebKit::UnifiedPDFPlugin::scaleForFitToView const):
(WebKit::UnifiedPDFPlugin::initialScale const):
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
(WebKit::UnifiedPDFPlugin::updateLayout):
(WebKit::UnifiedPDFPlugin::centeringOffset const):
(WebKit::UnifiedPDFPlugin::convertFromPluginToDocument const):
(WebKit::UnifiedPDFPlugin::convertFromDocumentToPlugin const):
(WebKit::UnifiedPDFPlugin::convertFromPageToContents const):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):
(WebKit::UnifiedPDFPlugin::sidePaddingWidth const): Deleted.

Canonical link: <a href="https://commits.webkit.org/274627@main">https://commits.webkit.org/274627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c5500e7be69978513a8b2fd159ad6ca161b6574

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42170 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35535 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15943 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13602 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39378 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37644 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16053 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8875 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->