### PR TITLE
HTMLMediaElement::player() shouldn't return a RefPtr

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -309,7 +309,7 @@ static void imageBytesForSource(const auto& source, const auto& destination, Ima
         return callback(nullptr, 0, 0);
     }, [&](const RefPtr<HTMLVideoElement> videoElement) -> ResultType {
 #if PLATFORM(COCOA)
-        if (auto player = videoElement->player(); player->isVideoPlayer())
+        if (RefPtr player = videoElement->player(); player->isVideoPlayer())
             return getImageBytesFromVideoFrame(player->videoFrameForCurrentTime(), WTFMove(callback));
 #endif
         UNUSED_PARAM(videoElement);

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
@@ -129,17 +129,17 @@ bool WebKitMediaKeys::isTypeSupported(const String& keySystem, const String& mim
 
 void WebKitMediaKeys::setMediaElement(HTMLMediaElement* element)
 {
-    if (m_mediaElement && m_mediaElement->player()) {
-        m_mediaElement->player()->setCDMSession(nullptr);
-        m_mediaElement->player()->setCDM(nullptr);
+    if (RefPtr player = m_mediaElement? m_mediaElement->player() : nullptr) {
+        player->setCDMSession(nullptr);
+        player->setCDM(nullptr);
     }
 
     m_mediaElement = element;
 
-    if (m_mediaElement && m_mediaElement->player()) {
-        m_mediaElement->player()->setCDM(m_cdm.get());
+    if (RefPtr player = m_mediaElement? m_mediaElement->player() : nullptr) {
+        player->setCDM(m_cdm.get());
         if (!m_sessions.isEmpty())
-            m_mediaElement->player()->setCDMSession(m_sessions.last()->session());
+            player->setCDMSession(m_sessions.last()->session());
     }
 }
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -288,7 +288,7 @@ String MediaControlsHost::externalDeviceDisplayName() const
     if (!m_mediaElement)
         return emptyString();
 
-    auto player = m_mediaElement->player();
+    RefPtr player = m_mediaElement->player();
     if (!player) {
         LOG(Media, "MediaControlsHost::externalDeviceDisplayName - returning \"\" because player is NULL");
         return emptyString();
@@ -310,7 +310,7 @@ auto MediaControlsHost::externalDeviceType() const -> DeviceType
     if (!m_mediaElement)
         return DeviceType::None;
 
-    auto player = m_mediaElement->player();
+    RefPtr player = m_mediaElement->player();
     if (!player) {
         LOG(Media, "MediaControlsHost::externalDeviceType - returning \"none\" because player is NULL");
         return DeviceType::None;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -199,7 +199,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
     },
 #if ENABLE(VIDEO)
     [&] (RefPtr<HTMLVideoElement>& video) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {
-        RefPtr<VideoFrame> videoFrame = video->player() ? video->player()->videoFrameForCurrentTime() : nullptr;
+        RefPtr videoFrame = video->player() ? video->player()->videoFrameForCurrentTime() : nullptr;
         if (!videoFrame)
             return Exception { ExceptionCode::InvalidStateError,  "Video element has no video frame"_s };
         return initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init), VideoFrame::ShouldCloneWithDifferentTimestamp::No);

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -167,7 +167,8 @@ public:
 
     HTMLMediaElementIdentifier identifier() const { return m_identifier; }
 
-    RefPtr<MediaPlayer> player() const { return m_player; }
+    MediaPlayer* player() const { return m_player.get(); }
+    RefPtr<MediaPlayer> protectedPlayer() const { return m_player; }
     WEBCORE_EXPORT std::optional<MediaPlayerIdentifier> playerIdentifier() const;
 
     bool supportsAcceleratedRendering() const { return m_player && m_player->supportsAcceleratedRendering(); }

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -754,7 +754,7 @@ bool MediaElementSession::wirelessVideoPlaybackDisabled() const
         return true;
     }
 
-    auto player = m_element.player();
+    RefPtr player = m_element.player();
     if (!player)
         return true;
 
@@ -771,7 +771,7 @@ void MediaElementSession::setWirelessVideoPlaybackDisabled(bool disabled)
     else
         removeBehaviorRestriction(WirelessVideoPlaybackDisabled);
 
-    auto player = m_element.player();
+    RefPtr player = m_element.player();
     if (!player)
         return;
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1452,7 +1452,7 @@ static inline FloatSize size(ImageBitmap& imageBitmap)
 
 static inline FloatSize size(HTMLVideoElement& video)
 {
-    auto player = video.player();
+    RefPtr player = video.player();
     if (!player)
         return { };
     return player->naturalSize();

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3394,7 +3394,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
     bool sourceImageRectIsDefault = inputSourceImageRect == sentinelEmptyRect() || inputSourceImageRect == IntRect(0, 0, source.videoWidth(), source.videoHeight());
 
 #if PLATFORM(COCOA) && !HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
-    if (auto player = source.player())
+    if (RefPtr player = source.player())
         player->willBeAskedToPaintGL();
 #endif
     // Go through the fast path doing a GPU-GPU textures copy without a readback to system memory if possible.
@@ -3405,7 +3405,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
         && (format == GraphicsContextGL::RGB || format == GraphicsContextGL::RGBA)
         && type == GraphicsContextGL::UNSIGNED_BYTE
         && !level) {
-        if (auto player = source.player()) {
+        if (RefPtr player = source.player()) {
             if (m_context->copyTextureFromMedia(*player, texture->object(), target, level, internalformat, format, type, m_unpackPremultiplyAlpha, m_unpackFlipY))
                 return { };
         }

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -352,7 +352,7 @@ int CaptionUserPreferences::textTrackSelectionScore(TextTrack* track, HTMLMediaE
         if (testingMode())
             audioTrackLanguage = primaryAudioTrackLanguageOverride();
         else
-            audioTrackLanguage = mediaElement->player()->languageOfPrimaryAudioTrack();
+            audioTrackLanguage = mediaElement->protectedPlayer()->languageOfPrimaryAudioTrack();
 
         if (audioTrackLanguage.isEmpty())
             return 0;

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -129,7 +129,7 @@ void VideoPresentationModelVideoElement::updateForEventName(const WTF::AtomStrin
             if (!m_videoElement)
                 return std::nullopt;
 
-            auto player = m_videoElement->player();
+            RefPtr player = m_videoElement->player();
             if (!player)
                 return std::nullopt;
 

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -67,7 +67,7 @@ void RenderVideo::willBeDestroyed()
 {
     visibleInViewportStateChanged();
 
-    if (auto player = videoElement().player())
+    if (RefPtr player = videoElement().player())
         player->renderVideoWillBeDestroyed();
 
     RenderMedia::willBeDestroyed();
@@ -127,7 +127,7 @@ LayoutSize RenderVideo::calculateIntrinsicSizeInternal()
     // The intrinsic height of a video element's playback area is the intrinsic height 
     // of the video resource, if that is available; otherwise it is the intrinsic 
     // height of the poster frame, if that is available; otherwise it is 150 CSS pixels.
-    auto player = videoElement().player();
+    RefPtr player = videoElement().player();
     if (player && videoElement().readyState() >= HTMLVideoElement::HAVE_METADATA) {
         LayoutSize size(player->naturalSize());
         if (!size.isEmpty())
@@ -179,7 +179,7 @@ void RenderVideo::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
 
 IntRect RenderVideo::videoBox() const
 {
-    auto mediaPlayer = videoElement().player();
+    RefPtr mediaPlayer = videoElement().player();
     if (mediaPlayer && mediaPlayer->shouldIgnoreIntrinsicSize())
         return snappedIntRect(contentBoxRect());
 
@@ -203,7 +203,7 @@ bool RenderVideo::failedToLoadPosterImage() const
 
 void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
-    auto mediaPlayer = videoElement().player();
+    RefPtr mediaPlayer = videoElement().player();
     bool displayingPoster = videoElement().shouldDisplayPosterImage();
 
     if (!displayingPoster && !mediaPlayer) {
@@ -297,7 +297,7 @@ void RenderVideo::updatePlayer()
     intrinsicSizeChanged = updateIntrinsicSize();
     ASSERT_UNUSED(intrinsicSizeChanged, !intrinsicSizeChanged || !view().frameView().layoutContext().isInRenderTreeLayout());
 
-    auto mediaPlayer = videoElement().player();
+    RefPtr mediaPlayer = videoElement().player();
     if (!mediaPlayer)
         return;
 
@@ -324,13 +324,13 @@ bool RenderVideo::supportsAcceleratedRendering() const
 
 void RenderVideo::acceleratedRenderingStateChanged()
 {
-    if (auto player = videoElement().player())
+    if (RefPtr player = videoElement().player())
         player->acceleratedRenderingStateChanged();
 }
 
 bool RenderVideo::requiresImmediateCompositing() const
 {
-    auto player = videoElement().player();
+    RefPtr player = videoElement().player();
     return player && player->requiresImmediateCompositing();
 }
 
@@ -342,7 +342,7 @@ bool RenderVideo::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect,
     if (!videoBox().contains(enclosingIntRect(localRect)))
         return false;
 
-    if (auto player = videoElement().player())
+    if (RefPtr player = videoElement().player())
         return player->hasAvailableVideoFrame();
 
     return false;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4297,7 +4297,7 @@ Vector<String> Internals::mediaResponseContentRanges(HTMLMediaElement& media)
 void Internals::simulateAudioInterruption(HTMLMediaElement& element)
 {
 #if USE(GSTREAMER)
-    element.player()->simulateAudioInterruption();
+    element.protectedPlayer()->simulateAudioInterruption();
 #else
     UNUSED_PARAM(element);
 #endif
@@ -4317,13 +4317,13 @@ ExceptionOr<bool> Internals::mediaElementHasCharacteristic(HTMLMediaElement& ele
 
 void Internals::beginSimulatedHDCPError(HTMLMediaElement& element)
 {
-    if (auto player = element.player())
+    if (RefPtr player = element.player())
         player->beginSimulatedHDCPError();
 }
 
 void Internals::endSimulatedHDCPError(HTMLMediaElement& element)
 {
-    if (auto player = element.player())
+    if (RefPtr player = element.player())
         player->endSimulatedHDCPError();
 }
 
@@ -4810,19 +4810,19 @@ bool Internals::elementIsBlockingDisplaySleep(const HTMLMediaElement& element) c
 
 bool Internals::isPlayerVisibleInViewport(const HTMLMediaElement& element) const
 {
-    auto player = element.player();
+    RefPtr player = element.player();
     return player && player->isVisibleInViewport();
 }
 
 bool Internals::isPlayerMuted(const HTMLMediaElement& element) const
 {
-    auto player = element.player();
+    RefPtr player = element.player();
     return player && player->muted();
 }
 
 bool Internals::isPlayerPaused(const HTMLMediaElement& element) const
 {
-    auto player = element.player();
+    RefPtr player = element.player();
     return player && player->paused();
 }
 

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -161,7 +161,7 @@ void Internals::setUsesOverlayScrollbars(bool enabled)
 #if ENABLE(VIDEO)
 double Internals::privatePlayerVolume(const HTMLMediaElement& element)
 {
-    auto corePlayer = element.player();
+    RefPtr corePlayer = element.player();
     if (!corePlayer)
         return 0;
     auto player = corePlayer->objCAVFoundationAVPlayer();
@@ -172,7 +172,7 @@ double Internals::privatePlayerVolume(const HTMLMediaElement& element)
 
 bool Internals::privatePlayerMuted(const HTMLMediaElement& element)
 {
-    auto corePlayer = element.player();
+    RefPtr corePlayer = element.player();
     if (!corePlayer)
         return false;
     auto player = corePlayer->objCAVFoundationAVPlayer();

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -389,7 +389,7 @@ void VideoPresentationManager::enterVideoFullscreenForVideoElement(HTMLVideoElem
             return;
         page->send(Messages::VideoPresentationManagerProxy::SetupFullscreenWithID(contextId, contextID, videoRect, initialSize, size, page->deviceScaleFactor(), fullscreenMode, allowsPictureInPicture, standby, videoElement->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk()));
 
-        if (auto player = videoElement->player()) {
+        if (RefPtr player = videoElement->player()) {
             if (auto identifier = player->identifier())
                 protectedThis->setPlayerIdentifier(contextId, identifier);
         }


### PR DESCRIPTION
#### 805716af78821a5f5946c1acd31d2466bfeed080
<pre>
HTMLMediaElement::player() shouldn&apos;t return a RefPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=269334">https://bugs.webkit.org/show_bug.cgi?id=269334</a>

Reviewed by Ryosuke Niwa.

HTMLMediaElement::player() shouldn&apos;t return a RefPtr as it causes unnecessary
ref-counting churn for call sites that don&apos;t need it. Instead, follow the usual
pattern:
1. Have HTMLMediaElement::player() return a raw pointer
2. Introduce a HTMLMediaElement::protectedPlayer() which returns a RefPtr for
   the call sites that need a RefPtr

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::imageBytesForSource):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp:
(WebCore::WebKitMediaKeys::setMediaElement):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::externalDeviceDisplayName const):
(WebCore::MediaControlsHost::externalDeviceType const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::player const):
(WebCore::HTMLMediaElement::protectedPlayer const):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::mediaPlayerFirstVideoFrameAvailable):
(WebCore::HTMLVideoElement::colorSpace const):
(WebCore::HTMLVideoElement::paintCurrentFrameInContext):
(WebCore::HTMLVideoElement::nativeImageForCurrentTime):
(WebCore::HTMLVideoElement::requestVideoFrameCallback):
(WebCore::HTMLVideoElement::cancelVideoFrameCallback):
(WebCore::HTMLVideoElement::serviceRequestVideoFrameCallbacks):
(WebCore::HTMLVideoElement::mediaPlayerEngineUpdated):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::wirelessVideoPlaybackDisabled const):
(WebCore::MediaElementSession::setWirelessVideoPlaybackDisabled):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::size):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource):
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::textTrackSelectionScore const):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::updateForEventName):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::willBeDestroyed):
(WebCore::RenderVideo::calculateIntrinsicSizeInternal):
(WebCore::RenderVideo::videoBox const):
(WebCore::RenderVideo::paintReplaced):
(WebCore::RenderVideo::updatePlayer):
(WebCore::RenderVideo::acceleratedRenderingStateChanged):
(WebCore::RenderVideo::requiresImmediateCompositing const):
(WebCore::RenderVideo::foregroundIsKnownToBeOpaqueInRect const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::simulateAudioInterruption):
(WebCore::Internals::beginSimulatedHDCPError):
(WebCore::Internals::endSimulatedHDCPError):
(WebCore::Internals::isPlayerVisibleInViewport const):
(WebCore::Internals::isPlayerMuted const):
(WebCore::Internals::isPlayerPaused const):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::privatePlayerVolume):
(WebCore::Internals::privatePlayerMuted):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):

Canonical link: <a href="https://commits.webkit.org/274601@main">https://commits.webkit.org/274601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ca1a98d109ad85bfea4a17e9f47495deda47d2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42096 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15870 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15620 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35529 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39188 "Build is in progress. Recent messages:") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11839 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15980 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5186 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->