### PR TITLE
[WebXR] Allow audio and media sessions to continue uninterrupted when starting immersive WebXR sessions

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -592,6 +592,11 @@ void WebXRSystem::sessionEnded(WebXRSession& session)
     m_inlineSessions.remove(session);
 }
 
+bool WebXRSystem::hasActiveImmersiveSession() const
+{
+    return !!m_activeImmersiveSession;
+}
+
 class InlineRequestAnimationFrameCallback final: public RequestAnimationFrameCallback {
 public:
     static Ref<InlineRequestAnimationFrameCallback> create(ScriptExecutionContext& scriptExecutionContext, Function<void()>&& callback)

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -73,8 +73,9 @@ public:
 
     // This is also needed by WebGLRenderingContextBase::makeXRCompatible() and HTMLCanvasElement::createContextWebGL().
     void ensureImmersiveXRDeviceIsSelected(CompletionHandler<void()>&&);
-    bool hasActiveImmersiveXRDevice() { return !!m_activeImmersiveDevice.get(); }
+    bool hasActiveImmersiveXRDevice() const { return !!m_activeImmersiveDevice.get(); }
 
+    bool hasActiveImmersiveSession() const;
     void sessionEnded(WebXRSession&);
 
     // For testing purpouses only.

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8570,6 +8570,14 @@ bool HTMLMediaElement::shouldOverrideBackgroundPlaybackRestriction(PlatformMedia
             return true;
         }
 #endif
+#if PLATFORM(VISION) && ENABLE(WEBXR)
+        if (RefPtr page = document().page()) {
+            if (page->hasActiveImmersiveSession()) {
+                INFO_LOG(LOGIDENTIFIER, "returning true due to active immersive session");
+                return true;
+            }
+        }
+#endif
 #if ENABLE(MEDIA_STREAM)
         if (hasMediaStreamSrcObject() && mediaState().containsAny(MediaProducerMediaState::IsPlayingAudio) && document().mediaState().containsAny(MediaProducerMediaState::HasActiveAudioCaptureDevice)) {
             INFO_LOG(LOGIDENTIFIER, "returning true because playing an audio MediaStreamTrack");

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -210,6 +210,11 @@
 #include "AccessibilityRootAtspi.h"
 #endif
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(WEBXR)
+#include "NavigatorWebXR.h"
+#include "WebXRSystem.h"
+#endif
+
 namespace WebCore {
 
 static HashSet<SingleThreadWeakRef<Page>>& allPages()
@@ -4669,5 +4674,25 @@ void Page::setAccessibilityRootObject(AccessibilityRootAtspi* rootObject)
     m_accessibilityRootObject = rootObject;
 }
 #endif // USE(ATSPI)
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(WEBXR)
+bool Page::hasActiveImmersiveSession() const
+{
+    for (RefPtr frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
+        RefPtr window = localFrame ? localFrame->window() : nullptr;
+        if (!window)
+            continue;
+
+        RefPtr navigator = window->optionalNavigator();
+        if (!navigator)
+            continue;
+
+        if (NavigatorWebXR::xr(*navigator).hasActiveImmersiveSession())
+            return true;
+    }
+    return false;
+}
+#endif // PLATFORM(IOS_FAMILY) && ENABLE(WEBXR)
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1087,6 +1087,10 @@ public:
     std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting() const;
     WEBCORE_EXPORT void setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(WEBXR)
+    WEBCORE_EXPORT bool hasActiveImmersiveSession() const;
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3221,14 +3221,26 @@ void WebPage::updateDrawingAreaLayerTreeFreezeState()
     if (!m_drawingArea)
         return;
 
+    if (m_layerTreeFreezeReasons.hasExactlyOneBitSet() && m_layerTreeFreezeReasons.contains(LayerTreeFreezeReason::BackgroundApplication)) {
+        // When the browser is in the background, we should not freeze the layer tree
+        // if the page has a video playing in picture-in-picture or if the page is in an
+        // active immersive session.
+        bool shouldSkipFreezingLayerTreeOnBackgrounding = false;
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    // When the browser is in the background, we should not freeze the layer tree
-    // if the page has a video playing in picture-in-picture.
-    if (m_videoPresentationManager && m_videoPresentationManager->hasVideoPlayingInPictureInPicture() && m_layerTreeFreezeReasons.hasExactlyOneBitSet() && m_layerTreeFreezeReasons.contains(LayerTreeFreezeReason::BackgroundApplication)) {
-        m_drawingArea->setLayerTreeStateIsFrozen(false);
-        return;
-    }
+        if (m_videoPresentationManager && m_videoPresentationManager->hasVideoPlayingInPictureInPicture())
+            shouldSkipFreezingLayerTreeOnBackgrounding = true;
 #endif
+#if PLATFORM(VISION) && ENABLE(WEBXR)
+        if (RefPtr page = m_page) {
+            if (page->hasActiveImmersiveSession())
+                shouldSkipFreezingLayerTreeOnBackgrounding = true;
+        }
+#endif
+        if (shouldSkipFreezingLayerTreeOnBackgrounding) {
+            m_drawingArea->setLayerTreeStateIsFrozen(false);
+            return;
+        }
+    }
 
     m_drawingArea->setLayerTreeStateIsFrozen(!!m_layerTreeFreezeReasons);
 }


### PR DESCRIPTION
#### 76e52d168312e91a83bd2f9db3535f6921b3cd87
<pre>
[WebXR] Allow audio and media sessions to continue uninterrupted when starting immersive WebXR sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=269332">https://bugs.webkit.org/show_bug.cgi?id=269332</a>
<a href="https://rdar.apple.com/102391109">rdar://102391109</a>

Reviewed by Eric Carlson.

The original Safari window gets backgrounded when we start an immersive WebXR
session. We need to allow audio/media to continue playback when we get a
backgrounding notification for this scenario, similar to how we handle this
for picture-in-picture.

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::shouldOverrideBackgroundPlaybackRestriction const):
Return true if the page has an active WebXR immersive session.
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::hasActiveImmersiveSession const):
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::shouldOverrideBackgroundPlaybackRestriction const):
Return true if the page has an active WebXR immersive session.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::hasActiveImmersiveSession const):
Walk the frame tree and return true if any frame&apos;s window has an active
WebXR immersive session.
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateDrawingAreaLayerTreeFreezeState):
Similar to picture-in-picture, skip freezing the layer tree state if
the window gets backgrounded due to an active immersive session.

Canonical link: <a href="https://commits.webkit.org/274742@main">https://commits.webkit.org/274742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/624e28fce057a2fde114920acae1c2f9b33eec9a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42129 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35494 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33059 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13580 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43406 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37610 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16012 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8951 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->