### PR TITLE
[JSC] Adjust PerfLog mechanism a bit

### DIFF
--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -42,13 +42,14 @@ class PerfLog {
     friend class LazyNeverDestroyed<PerfLog>;
 public:
     static void log(CString&&, const uint8_t* executableAddress, size_t);
+    static void flush();
 
 private:
     PerfLog();
     static PerfLog& singleton();
 
-    void write(const void*, size_t) WTF_REQUIRES_LOCK(m_lock);
-    void flush() WTF_REQUIRES_LOCK(m_lock);
+    void write(const AbstractLocker&, const void*, size_t) WTF_REQUIRES_LOCK(m_lock);
+    void flush(const AbstractLocker&) WTF_REQUIRES_LOCK(m_lock);
 
     FILE* m_file { nullptr };
     void* m_marker { nullptr };


### PR DESCRIPTION
#### e47ea0079d3efadc839401a38a86d99a247d3144
<pre>
[JSC] Adjust PerfLog mechanism a bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=269336">https://bugs.webkit.org/show_bug.cgi?id=269336</a>
<a href="https://rdar.apple.com/problem/122924560">rdar://problem/122924560</a>

Reviewed by Justin Michaud.

This patch improves PerfLog.cpp a bit,

1. We use `./jit-%d.dump` format since some of tools are particularly caring about &quot;./&quot;
2. Stop doing flush for every call of logging, it is too slow. This patch adds flush function separately.

* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::PerfLog):
(JSC::PerfLog::write):
(JSC::PerfLog::flush):
(JSC::PerfLog::log):
* Source/JavaScriptCore/assembler/PerfLog.h:

Canonical link: <a href="https://commits.webkit.org/274597@main">https://commits.webkit.org/274597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56145d4b0e2f156a4e6482c449f459ea0fd3e7c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39569 "Failed to checkout and rebase branch from PR 24388") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18548 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/41925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42104 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15877 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40143 "Failed to checkout and rebase branch from PR 24388") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15628 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/41925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/41925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43381 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/33022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35918 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/41925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/39195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11844 "Build is in progress. Recent messages:") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/41925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46201 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/9422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5184 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->