### PR TITLE
[UnifiedPDF] Context menu should have selection-activated items (copy link, lookup, search-the-web)

### DIFF
--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -515,11 +515,6 @@ String contextMenuItemPDFOpenWithPreview()
 {
     return WEB_UI_STRING("Open with Preview", "Open with Preview context menu item");
 }
-
-String contextMenuItemPDFCopy()
-{
-    return WEB_UI_STRING("Copy", "Copy context menu item");
-}
 #endif
 
 #if ENABLE(PDFJS) || ENABLE(UNIFIED_PDF)

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -66,7 +66,7 @@ namespace WebCore {
 #if ENABLE(CONTEXT_MENUS)
     WEBCORE_EXPORT String contextMenuItemTagOpenLinkInNewWindow();
     String contextMenuItemTagDownloadLinkToDisk();
-    String contextMenuItemTagCopyLinkToClipboard();
+    WEBCORE_EXPORT String contextMenuItemTagCopyLinkToClipboard();
     String contextMenuItemTagOpenImageInNewWindow();
     String contextMenuItemTagDownloadImageToDisk();
     String contextMenuItemTagCopyImageToClipboard();
@@ -74,7 +74,7 @@ namespace WebCore {
     String contextMenuItemTagCopyImageURLToClipboard();
 #endif
     String contextMenuItemTagOpenFrameInNewWindow();
-    String contextMenuItemTagCopy();
+    WEBCORE_EXPORT String contextMenuItemTagCopy();
     String contextMenuItemTagGoBack();
     String contextMenuItemTagGoForward();
     String contextMenuItemTagStop();
@@ -102,9 +102,9 @@ namespace WebCore {
     String contextMenuItemTagNoGuessesFound();
     String contextMenuItemTagIgnoreSpelling();
     String contextMenuItemTagLearnSpelling();
-    String contextMenuItemTagSearchWeb();
+    WEBCORE_EXPORT String contextMenuItemTagSearchWeb();
 #if PLATFORM(COCOA)
-    String contextMenuItemTagLookUpInDictionary(const String& selectedString);
+    WEBCORE_EXPORT String contextMenuItemTagLookUpInDictionary(const String& selectedString);
 #endif
     WEBCORE_EXPORT String contextMenuItemTagOpenLink();
     WEBCORE_EXPORT String contextMenuItemTagIgnoreGrammar();
@@ -179,7 +179,6 @@ namespace WebCore {
 #endif
 #if ENABLE(UNIFIED_PDF)
     WEBCORE_EXPORT String contextMenuItemPDFOpenWithPreview();
-    WEBCORE_EXPORT String contextMenuItemPDFCopy();
 #endif
 #if ENABLE(PDFJS) || ENABLE(UNIFIED_PDF)
     WEBCORE_EXPORT String contextMenuItemPDFSinglePage();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -43,6 +43,7 @@ enum class DelegatedScrollingMode : uint8_t;
 namespace WebKit {
 
 struct PDFContextMenu;
+struct PDFContextMenuItem;
 class PDFPluginPasswordField;
 class PDFPluginPasswordForm;
 class WebFrame;
@@ -191,9 +192,13 @@ private:
     [[maybe_unused]] bool performCopyEditingOperation() const;
 
     // Context Menu
+#if ENABLE(CONTEXT_MENUS)
     enum class ContextMenuItemTag : int8_t {
         Invalid = -1,
+        WebSearch,
+        DictionaryLookup,
         Copy,
+        CopyLink,
         OpenWithPreview,
         SinglePage,
         SinglePageContinuous,
@@ -205,8 +210,14 @@ private:
         Unknown,
     };
 
-#if PLATFORM(MAC)
-    PDFContextMenu createContextMenu(const WebCore::IntPoint& contextMenuPoint) const;
+    std::optional<PDFContextMenu> createContextMenu(const WebMouseEvent&) const;
+    PDFContextMenuItem contextMenuItem(ContextMenuItemTag) const;
+    String titleForContextMenuItemTag(ContextMenuItemTag) const;
+    bool isDisplayModeContextMenuItemTag(ContextMenuItemTag) const;
+    PDFContextMenuItem separatorContextMenuItem() const;
+    Vector<PDFContextMenuItem> selectionContextMenuItems(const WebCore::IntPoint& contextMenuPoint) const;
+    Vector<PDFContextMenuItem> displayModeContextMenuItems() const;
+    Vector<PDFContextMenuItem> scaleContextMenuItems() const;
     ContextMenuItemTag toContextMenuItemTag(int tagValue) const;
     void performContextMenuAction(ContextMenuItemTag);
 


### PR DESCRIPTION
#### 547b742836e50083101077f7002d57a24f0e92ea
<pre>
[UnifiedPDF] Context menu should have selection-activated items (copy link, lookup, search-the-web)
<a href="https://bugs.webkit.org/show_bug.cgi?id=269330">https://bugs.webkit.org/show_bug.cgi?id=269330</a>
<a href="https://rdar.apple.com/122918090">rdar://122918090</a>

Reviewed by Tim Horton.

We track text selections as of 274032@main, making it possible to perform
actions on said selections. This patch introduces the context menu items
that are modulated by the current selection context. Namely, we add
&quot;Copy Link&quot;, &quot;Dictionary Lookup&quot;, and &quot;Search the Web&quot;. The last of
these items has a concrete action courtesy of 274583@main, and the other
two will be implemented in upcoming commits.

In doing so, we slightly refactor how we construct the context menu by
breaking it up into sections corresponding to selections, scale
adjustment, and display mode.

* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemPDFOpenWithPreview):
(WebCore::contextMenuItemPDFCopy): Deleted.
Remove the redundant definition since contextMenuItemTagCopy() returns
the same data.

* Source/WebCore/platform/LocalizedStrings.h:
WEBCORE_EXPORT some more methods since they&apos;re being called from WebKit.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleContextMenuEvent):
(WebKit::UnifiedPDFPlugin::toContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::UnifiedPDFPlugin::isDisplayModeContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::titleForContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::contextMenuItem const):
(WebKit::UnifiedPDFPlugin::separatorContextMenuItem const):
(WebKit::UnifiedPDFPlugin::selectionContextMenuItems const):
(WebKit::UnifiedPDFPlugin::displayModeContextMenuItems const):
(WebKit::UnifiedPDFPlugin::scaleContextMenuItems const):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):

Canonical link: <a href="https://commits.webkit.org/274611@main">https://commits.webkit.org/274611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a4ff6d5ebd89f3049e57f31634b35865defc8a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42132 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15905 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13582 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43409 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35553 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11866 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16015 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8860 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16063 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->