### PR TITLE
[UnifiedPDF] Annotation hover and interaction is broken in rotated pages

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -66,9 +66,12 @@ public:
     std::optional<unsigned> indexForPage(RetainPtr<PDFPage>) const;
 
     // This is not scaled by scale().
-    WebCore::FloatRect boundsForPageAtIndex(PageIndex) const;
+    WebCore::FloatRect layoutBoundsForPageAtIndex(PageIndex) const;
     // Returns 0, 90, 180, 270.
     WebCore::IntDegrees rotationForPageAtIndex(PageIndex) const;
+
+    WebCore::FloatPoint documentPointToPDFPagePoint(WebCore::FloatPoint documentPoint, PageIndex) const;
+    WebCore::FloatPoint pdfPagePointToDocumentPoint(WebCore::FloatPoint pagePoint, PageIndex) const;
 
     // This is the scale that scales the largest page or pair of pages up or down to fit the available width.
     float scale() const { return m_scale; }
@@ -86,9 +89,12 @@ private:
     void layoutTwoUpColumn(float availableWidth, float maxRowWidth);
 
     struct PageGeometry {
-        WebCore::FloatRect normalizedBounds;
+        WebCore::FloatRect cropBox;
+        WebCore::FloatRect layoutBounds;
         WebCore::IntDegrees rotation { 0 };
     };
+
+    WebCore::AffineTransform toPageTransform(const PageGeometry&) const;
 
     RetainPtr<PDFDocument> m_pdfDocument;
     Vector<PageGeometry> m_pageGeometry;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -334,10 +334,8 @@ private:
 
     WebCore::IntPoint convertFromDocumentToPage(const WebCore::IntPoint&, PDFDocumentLayout::PageIndex) const;
     WebCore::IntPoint convertFromPageToDocument(const WebCore::IntPoint&, PDFDocumentLayout::PageIndex) const;
-    WebCore::FloatRect convertFromPageToDocument(const WebCore::FloatRect&, PDFDocumentLayout::PageIndex) const;
 
     WebCore::IntPoint convertFromPageToContents(const WebCore::IntPoint&, PDFDocumentLayout::PageIndex) const;
-    WebCore::FloatRect convertFromPageToContents(const WebCore::FloatRect&, PDFDocumentLayout::PageIndex) const;
 
     std::optional<PDFDocumentLayout::PageIndex> pageIndexForDocumentPoint(const WebCore::IntPoint&) const;
 


### PR DESCRIPTION
#### 622b90f2c44db97d10326a6970b96588b7394705
<pre>
[UnifiedPDF] Annotation hover and interaction is broken in rotated pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=269344">https://bugs.webkit.org/show_bug.cgi?id=269344</a>
<a href="https://rdar.apple.com/122929753">rdar://122929753</a>

Reviewed by Tim Horton.

The transform math in `documentSpaceToPageSpaceTransform()` was wrong, resulting in hit-testing
of annotations in rotated pages being wrong.

The page bounds vended by PDFDocumentLayout are normalized, so we can&apos;t use them for coordinate
conversion. We need to go back to the original page crop boxes. Clarify this by renaming
`boundsForPageAtIndex()` to `layoutBoundsForPageAtIndex()` since it is normalized, and contains
the layout offset of the page.

Then have PDFDocumentLayout store the original crop box per page. Internally, it computes
an AffineTransform from page rotation and crop box, and we use that and some coordinate flipping
to convert points.

Remove the FloatRect conversion functions on UnifiedPDFPlugin that I just added, because
they were wrong, and unused.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::layoutTwoUpColumn):
(WebKit::PDFDocumentLayout::layoutBoundsForPageAtIndex const):
(WebKit::PDFDocumentLayout::toPageTransform const):
(WebKit::PDFDocumentLayout::documentPointToPDFPagePoint const):
(WebKit::PDFDocumentLayout::pdfPagePointToDocumentPoint const):
(WebKit::PDFDocumentLayout::boundsForPageAtIndex const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updatePageBackgroundLayers):
(WebKit::UnifiedPDFPlugin::pageCoverageForRect const):
(WebKit::UnifiedPDFPlugin::scaleForActualSize const):
(WebKit::UnifiedPDFPlugin::heightForPage const):
(WebKit::UnifiedPDFPlugin::pageIndexForDocumentPoint const):
(WebKit::UnifiedPDFPlugin::convertFromDocumentToPage const):
(WebKit::UnifiedPDFPlugin::convertFromPageToDocument const):
(WebKit::documentSpaceToPageSpaceTransform): Deleted.

Canonical link: <a href="https://commits.webkit.org/274625@main">https://commits.webkit.org/274625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a05e1af110666a68a3dbb72dad797c6e6eadc57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35490 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33056 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13577 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43402 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33043 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39338 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37602 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16008 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8872 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->