### PR TITLE
Devirtualize Event::eventInterface

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(GPUUncapturedErrorEvent);
 
 GPUUncapturedErrorEvent::GPUUncapturedErrorEvent(const AtomString& type, GPUUncapturedErrorEventInit&& uncapturedErrorEventInit)
-    : Event(type, uncapturedErrorEventInit, IsTrusted::Yes)
+    : Event(EventInterfaceType::GPUUncapturedErrorEvent, type, uncapturedErrorEventInit, IsTrusted::Yes)
     , m_uncapturedErrorEventInit(WTFMove(uncapturedErrorEventInit))
 {
 }

--- a/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.cpp
+++ b/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.cpp
@@ -44,13 +44,13 @@ static const AtomString& stringForPlaybackTargetAvailability(bool available)
 }
 
 WebKitPlaybackTargetAvailabilityEvent::WebKitPlaybackTargetAvailabilityEvent(const AtomString& eventType, bool available)
-    : Event(eventType, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::WebKitPlaybackTargetAvailabilityEvent, eventType, CanBubble::No, IsCancelable::No)
     , m_availability(stringForPlaybackTargetAvailability(available))
 {
 }
 
 WebKitPlaybackTargetAvailabilityEvent::WebKitPlaybackTargetAvailabilityEvent(const AtomString& eventType, const Init& initializer, IsTrusted isTrusted)
-    : Event(eventType, initializer, isTrusted)
+    : Event(EventInterfaceType::WebKitPlaybackTargetAvailabilityEvent, eventType, initializer, isTrusted)
     , m_availability(initializer.availability)
 {
 }

--- a/Source/WebCore/Modules/applepay/ApplePayCancelEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayCancelEvent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ApplePayCancelEvent);
 
 ApplePayCancelEvent::ApplePayCancelEvent(const AtomString& type, PaymentSessionError&& sessionError)
-    : Event { type, CanBubble::No, IsCancelable::No }
+    : Event { EventInterfaceType::ApplePayCancelEvent, type, CanBubble::No, IsCancelable::No }
     , m_sessionError { WTFMove(sessionError) }
 {
 }

--- a/Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ApplePayCouponCodeChangedEvent);
 
 ApplePayCouponCodeChangedEvent::ApplePayCouponCodeChangedEvent(const AtomString& type, String&& couponCode)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::ApplePayCouponCodeChangedEvent, type, CanBubble::No, IsCancelable::No)
     , m_couponCode(WTFMove(couponCode))
 {
 }

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ApplePayPaymentAuthorizedEvent);
 
 ApplePayPaymentAuthorizedEvent::ApplePayPaymentAuthorizedEvent(const AtomString& type, unsigned version, const Payment& payment)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::ApplePayPaymentAuthorizedEvent, type, CanBubble::No, IsCancelable::No)
     , m_payment(payment.toApplePayPayment(version))
 {
 }

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ApplePayPaymentMethodSelectedEvent);
 
 ApplePayPaymentMethodSelectedEvent::ApplePayPaymentMethodSelectedEvent(const AtomString& type, const PaymentMethod& paymentMethod)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::ApplePayPaymentMethodSelectedEvent, type, CanBubble::No, IsCancelable::No)
     , m_paymentMethod(paymentMethod.toApplePayPaymentMethod())
 {
 }

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ApplePayShippingContactSelectedEvent);
 
 ApplePayShippingContactSelectedEvent::ApplePayShippingContactSelectedEvent(const AtomString& type, unsigned version, const PaymentContact& shippingContact)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::ApplePayShippingContactSelectedEvent, type, CanBubble::No, IsCancelable::No)
     , m_shippingContact(shippingContact.toApplePayPaymentContact(version))
 {
 }

--- a/Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ApplePayShippingMethodSelectedEvent);
 
 ApplePayShippingMethodSelectedEvent::ApplePayShippingMethodSelectedEvent(const AtomString& type, const ApplePayShippingMethod& shippingMethod)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::ApplePayShippingMethodSelectedEvent, type, CanBubble::No, IsCancelable::No)
     , m_shippingMethod(shippingMethod)
 {
 }

--- a/Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ApplePayValidateMerchantEvent);
 
 ApplePayValidateMerchantEvent::ApplePayValidateMerchantEvent(const AtomString& type, URL&& validationURL)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::ApplePayValidateMerchantEvent, type, CanBubble::No, IsCancelable::No)
     , m_validationURL(WTFMove(validationURL))
 {
 }

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp
@@ -42,7 +42,7 @@ Ref<CookieChangeEvent> CookieChangeEvent::create(const AtomString& type, CookieC
 }
 
 CookieChangeEvent::CookieChangeEvent(const AtomString& type, CookieChangeEventInit&& eventInitDict, IsTrusted isTrusted)
-    : Event(type, eventInitDict, isTrusted)
+    : Event(EventInterfaceType::CookieChangeEvent, type, eventInitDict, isTrusted)
     , m_changed(WTFMove(eventInitDict.changed))
     , m_deleted(WTFMove(eventInitDict.deleted))
 { }

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp
@@ -42,7 +42,7 @@ Ref<ExtendableCookieChangeEvent> ExtendableCookieChangeEvent::create(const AtomS
 }
 
 ExtendableCookieChangeEvent::ExtendableCookieChangeEvent(const AtomString& type, ExtendableCookieChangeEventInit&& eventInitDict, IsTrusted isTrusted)
-    : ExtendableEvent(type, eventInitDict, isTrusted)
+    : ExtendableEvent(EventInterfaceType::ExtendableCookieChangeEvent, type, eventInitDict, isTrusted)
     , m_changed(WTFMove(eventInitDict.changed))
     , m_deleted(WTFMove(eventInitDict.deleted))
 { }

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(MediaKeyMessageEvent);
 
 MediaKeyMessageEvent::MediaKeyMessageEvent(const AtomString& type, const MediaKeyMessageEvent::Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::MediaKeyMessageEvent, type, initializer, isTrusted)
     , m_messageType(initializer.messageType)
     , m_message(initializer.message)
 {

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebKitMediaKeyMessageEvent);
 
 WebKitMediaKeyMessageEvent::WebKitMediaKeyMessageEvent(const AtomString& type, Uint8Array* message, const String& destinationURL)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::WebKitMediaKeyMessageEvent, type, CanBubble::No, IsCancelable::No)
     , m_message(message)
     , m_destinationURL(destinationURL)
 {
@@ -44,7 +44,7 @@ WebKitMediaKeyMessageEvent::WebKitMediaKeyMessageEvent(const AtomString& type, U
 
 
 WebKitMediaKeyMessageEvent::WebKitMediaKeyMessageEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::WebKitMediaKeyMessageEvent, type, initializer, isTrusted)
     , m_message(initializer.message)
     , m_destinationURL(initializer.destinationURL)
 {

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp
@@ -36,13 +36,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebKitMediaKeyNeededEvent);
 
 WebKitMediaKeyNeededEvent::WebKitMediaKeyNeededEvent(const AtomString& type, Uint8Array* initData)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::WebKitMediaKeyNeededEvent, type, CanBubble::No, IsCancelable::No)
     , m_initData(initData)
 {
 }
 
 WebKitMediaKeyNeededEvent::WebKitMediaKeyNeededEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::WebKitMediaKeyNeededEvent, type, initializer, isTrusted)
     , m_initData(initializer.initData)
 {
 }

--- a/Source/WebCore/Modules/gamepad/GamepadEvent.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadEvent.cpp
@@ -34,13 +34,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(GamepadEvent);
 
 GamepadEvent::GamepadEvent(const AtomString& eventType, Gamepad& gamepad)
-    : Event(eventType, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::GamepadEvent, eventType, CanBubble::No, IsCancelable::No)
     , m_gamepad(&gamepad)
 {
 }
 
 GamepadEvent::GamepadEvent(const AtomString& eventType, const Init& initializer, IsTrusted isTrusted)
-    : Event(eventType, initializer, isTrusted)
+    : Event(EventInterfaceType::GamepadEvent, eventType, initializer, isTrusted)
     , m_gamepad(initializer.gamepad)
 {
 }

--- a/Source/WebCore/Modules/indexeddb/IDBRequestCompletionEvent.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequestCompletionEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(IDBRequestCompletionEvent);
 
 IDBRequestCompletionEvent::IDBRequestCompletionEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, IDBRequest& request)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::Event, type, canBubble, cancelable)
     , m_request(request)
 {
 }

--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(IDBVersionChangeEvent);
 
 IDBVersionChangeEvent::IDBVersionChangeEvent(const IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion, const AtomString& name)
-    : Event(name, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::IDBVersionChangeEvent, name, CanBubble::No, IsCancelable::No)
     , m_requestIdentifier(requestIdentifier)
     , m_oldVersion(oldVersion)
 {
@@ -44,7 +44,7 @@ IDBVersionChangeEvent::IDBVersionChangeEvent(const IDBResourceIdentifier& reques
 }
 
 IDBVersionChangeEvent::IDBVersionChangeEvent(const AtomString& name, const Init& init, IsTrusted isTrusted)
-    : Event(name, init, isTrusted)
+    : Event(EventInterfaceType::IDBVersionChangeEvent, name, init, isTrusted)
     , m_oldVersion(init.oldVersion)
     , m_newVersion(init.newVersion)
 {

--- a/Source/WebCore/Modules/mediarecorder/BlobEvent.cpp
+++ b/Source/WebCore/Modules/mediarecorder/BlobEvent.cpp
@@ -41,7 +41,7 @@ Ref<BlobEvent> BlobEvent::create(const AtomString& type, Init&& init, IsTrusted 
 }
 
 BlobEvent::BlobEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
-    : Event(type, init, isTrusted)
+    : Event(EventInterfaceType::BlobEvent, type, init, isTrusted)
     , m_blob(init.data.releaseNonNull())
     , m_timecode(init.timecode)
 {

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp
@@ -47,13 +47,13 @@ Ref<MediaRecorderErrorEvent> MediaRecorderErrorEvent::create(const AtomString& t
 }
 
 MediaRecorderErrorEvent::MediaRecorderErrorEvent(const AtomString& type, Init&& init, Ref<DOMException>&& exception, IsTrusted isTrusted)
-    : Event(type, WTFMove(init), isTrusted)
+    : Event(EventInterfaceType::MediaRecorderErrorEvent, type, WTFMove(init), isTrusted)
     , m_domError(WTFMove(exception))
 {
 }
 
 MediaRecorderErrorEvent::MediaRecorderErrorEvent(const AtomString& type, Exception&& exception)
-    : Event(type, Event::CanBubble::No, Event::IsCancelable::No)
+    : Event(EventInterfaceType::MediaRecorderErrorEvent, type, Event::CanBubble::No, Event::IsCancelable::No)
     , m_domError(DOMException::create(exception))
 {
 }

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp
@@ -38,14 +38,14 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(BufferedChangeEvent);
 
 BufferedChangeEvent::BufferedChangeEvent(RefPtr<TimeRanges>&& added, RefPtr<TimeRanges>&& removed)
-    : Event(eventNames().bufferedchangeEvent, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::BufferedChangeEvent, eventNames().bufferedchangeEvent, CanBubble::No, IsCancelable::No)
     , m_added(WTFMove(added))
     , m_removed(WTFMove(removed))
 {
 }
 
 BufferedChangeEvent::BufferedChangeEvent(const AtomString& type, Init&& init)
-    : Event(type, init, IsTrusted::No)
+    : Event(EventInterfaceType::BufferedChangeEvent, type, init, IsTrusted::No)
     , m_added(WTFMove(init.addedRanges))
     , m_removed(WTFMove(init.removedRanges))
 {

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp
@@ -45,13 +45,13 @@ Ref<MediaStreamTrackEvent> MediaStreamTrackEvent::create(const AtomString& type,
 }
 
 MediaStreamTrackEvent::MediaStreamTrackEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, RefPtr<MediaStreamTrack>&& track)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::MediaStreamTrackEvent, type, canBubble, cancelable)
     , m_track(WTFMove(track))
 {
 }
 
 MediaStreamTrackEvent::MediaStreamTrackEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::MediaStreamTrackEvent, type, initializer, isTrusted)
     , m_track(initializer.track)
 {
 }

--- a/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.h
@@ -60,12 +60,12 @@ public:
 
 private:
     explicit OverconstrainedErrorEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, OverconstrainedError* error)
-        : Event(type, canBubble, cancelable)
+        : Event(EventInterfaceType::OverconstrainedErrorEvent, type, canBubble, cancelable)
         , m_error(error)
     {
     }
     OverconstrainedErrorEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-        : Event(type, initializer, isTrusted)
+        : Event(EventInterfaceType::OverconstrainedErrorEvent, type, initializer, isTrusted)
         , m_error(initializer.error)
     {
     }

--- a/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp
@@ -46,13 +46,13 @@ Ref<RTCDTMFToneChangeEvent> RTCDTMFToneChangeEvent::create(const AtomString& typ
 }
 
 RTCDTMFToneChangeEvent::RTCDTMFToneChangeEvent(const String& tone)
-    : Event(eventNames().tonechangeEvent, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::RTCDTMFToneChangeEvent, eventNames().tonechangeEvent, CanBubble::No, IsCancelable::No)
     , m_tone(tone)
 {
 }
 
 RTCDTMFToneChangeEvent::RTCDTMFToneChangeEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::RTCDTMFToneChangeEvent, type, initializer, isTrusted)
     , m_tone(initializer.tone)
 {
 }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp
@@ -46,13 +46,13 @@ Ref<RTCDataChannelEvent> RTCDataChannelEvent::create(const AtomString& type, Ini
 }
 
 RTCDataChannelEvent::RTCDataChannelEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, Ref<RTCDataChannel>&& channel)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::RTCDataChannelEvent, type, canBubble, cancelable)
     , m_channel(WTFMove(channel))
 {
 }
 
 RTCDataChannelEvent::RTCDataChannelEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::RTCDataChannelEvent, type, initializer, isTrusted)
     , m_channel(initializer.channel.releaseNonNull())
 {
 }

--- a/Source/WebCore/Modules/mediastream/RTCErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCErrorEvent.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RTCErrorEvent);
 
 RTCErrorEvent::RTCErrorEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::RTCErrorEvent, type, initializer, isTrusted)
     , m_error(initializer.error.releaseNonNull())
 {
 }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.cpp
@@ -47,7 +47,7 @@ Ref<RTCPeerConnectionIceErrorEvent> RTCPeerConnectionIceErrorEvent::create(const
 }
 
 RTCPeerConnectionIceErrorEvent::RTCPeerConnectionIceErrorEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, String&& address, std::optional<uint16_t> port, String&& url, uint16_t errorCode, String&& errorText)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::RTCPeerConnectionIceErrorEvent, type, canBubble, cancelable)
     , m_address(WTFMove(address))
     , m_port(port)
     , m_url(WTFMove(url))

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp
@@ -47,7 +47,7 @@ Ref<RTCPeerConnectionIceEvent> RTCPeerConnectionIceEvent::create(const AtomStrin
 }
 
 RTCPeerConnectionIceEvent::RTCPeerConnectionIceEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, RefPtr<RTCIceCandidate>&& candidate, String&& serverURL)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::RTCPeerConnectionIceEvent, type, canBubble, cancelable)
     , m_candidate(WTFMove(candidate))
     , m_url(WTFMove(serverURL))
 {

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.cpp
@@ -47,7 +47,7 @@ Ref<RTCRtpSFrameTransformErrorEvent> RTCRtpSFrameTransformErrorEvent::create(con
 }
 
 RTCRtpSFrameTransformErrorEvent::RTCRtpSFrameTransformErrorEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, Type errorType)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::RTCRtpSFrameTransformErrorEvent, type, canBubble, cancelable)
     , m_errorType(errorType)
 {
 }

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp
@@ -53,7 +53,7 @@ Ref<RTCTrackEvent> RTCTrackEvent::create(const AtomString& type, const Init& ini
 }
 
 RTCTrackEvent::RTCTrackEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, RefPtr<RTCRtpReceiver>&& receiver, RefPtr<MediaStreamTrack>&& track, Vector<RefPtr<MediaStream>>&& streams, RefPtr<RTCRtpTransceiver>&& transceiver)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::RTCTrackEvent, type, canBubble, cancelable)
     , m_receiver(WTFMove(receiver))
     , m_track(WTFMove(track))
     , m_streams(WTFMove(streams))
@@ -62,7 +62,7 @@ RTCTrackEvent::RTCTrackEvent(const AtomString& type, CanBubble canBubble, IsCanc
 }
 
 RTCTrackEvent::RTCTrackEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::RTCTrackEvent, type, initializer, isTrusted)
     , m_receiver(initializer.receiver)
     , m_track(initializer.track)
     , m_streams(initializer.streams)

--- a/Source/WebCore/Modules/mediastream/RTCTransformEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCTransformEvent.cpp
@@ -39,7 +39,7 @@ Ref<RTCTransformEvent> RTCTransformEvent::create(const AtomString& type, Ref<RTC
 }
 
 RTCTransformEvent::RTCTransformEvent(const AtomString& type, Ref<RTCRtpScriptTransformer>&& transformer, IsTrusted isTrusted)
-    : Event(type, { }, isTrusted)
+    : Event(EventInterfaceType::RTCTransformEvent, type, { }, isTrusted)
     , m_transformer(WTFMove(transformer))
 {
 }

--- a/Source/WebCore/Modules/notifications/NotificationEvent.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.cpp
@@ -48,7 +48,7 @@ Ref<NotificationEvent> NotificationEvent::create(const AtomString& type, Notific
 }
 
 NotificationEvent::NotificationEvent(const AtomString& type, NotificationEventInit&& eventInit, Notification* notification, const String& action, IsTrusted isTrusted)
-    : ExtendableEvent(type, WTFMove(eventInit), isTrusted)
+    : ExtendableEvent(EventInterfaceType::NotificationEvent, type, WTFMove(eventInit), isTrusted)
     , m_notification(notification)
     , m_action(action)
 {

--- a/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp
@@ -58,7 +58,7 @@ ExceptionOr<Ref<MerchantValidationEvent>> MerchantValidationEvent::create(Docume
 }
 
 MerchantValidationEvent::MerchantValidationEvent(const AtomString& type, const String& methodName, URL&& validationURL)
-    : Event { type, Event::CanBubble::No, Event::IsCancelable::No }
+    : Event { EventInterfaceType::MerchantValidationEvent, type, Event::CanBubble::No, Event::IsCancelable::No }
     , m_methodName { methodName }
     , m_validationURL { WTFMove(validationURL) }
 {
@@ -67,7 +67,7 @@ MerchantValidationEvent::MerchantValidationEvent(const AtomString& type, const S
 }
 
 MerchantValidationEvent::MerchantValidationEvent(const AtomString& type, String&& methodName, URL&& validationURL, Init&& eventInit)
-    : Event { type, WTFMove(eventInit), IsTrusted::No }
+    : Event { EventInterfaceType::MerchantValidationEvent, type, WTFMove(eventInit), IsTrusted::No }
     , m_methodName { WTFMove(methodName) }
     , m_validationURL { WTFMove(validationURL) }
 {

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
@@ -40,14 +40,14 @@ EventInterface PaymentMethodChangeEvent::eventInterface() const
 }
 
 PaymentMethodChangeEvent::PaymentMethodChangeEvent(const AtomString& type, Init&& eventInit)
-    : PaymentRequestUpdateEvent { type, eventInit }
+    : PaymentRequestUpdateEvent { EventInterfaceType::PaymentMethodChangeEvent, type, eventInit }
     , m_methodName { WTFMove(eventInit.methodName) }
     , m_methodDetails { std::in_place_type_t<JSValueInWrappedObject>(), eventInit.methodDetails.get() }
 {
 }
 
 PaymentMethodChangeEvent::PaymentMethodChangeEvent(const AtomString& type, const String& methodName, MethodDetailsFunction&& methodDetailsFunction)
-    : PaymentRequestUpdateEvent { type }
+    : PaymentRequestUpdateEvent { EventInterfaceType::PaymentMethodChangeEvent, type }
     , m_methodName { methodName }
     , m_methodDetails { std::in_place_type_t<MethodDetailsFunction>(), WTFMove(methodDetailsFunction) }
 {

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp
@@ -36,14 +36,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(PaymentRequestUpdateEvent);
 
-PaymentRequestUpdateEvent::PaymentRequestUpdateEvent(const AtomString& type, const PaymentRequestUpdateEventInit& eventInit)
-    : Event { type, eventInit, IsTrusted::No }
+PaymentRequestUpdateEvent::PaymentRequestUpdateEvent(enum EventInterfaceType eventInterface, const AtomString& type, const PaymentRequestUpdateEventInit& eventInit)
+    : Event { eventInterface, type, eventInit, IsTrusted::No }
 {
     ASSERT(!isTrusted());
 }
 
-PaymentRequestUpdateEvent::PaymentRequestUpdateEvent(const AtomString& type)
-    : Event { type, CanBubble::No, IsCancelable::No }
+PaymentRequestUpdateEvent::PaymentRequestUpdateEvent(enum EventInterfaceType eventInterface, const AtomString& type)
+    : Event { eventInterface, type, CanBubble::No, IsCancelable::No }
 {
     ASSERT(isTrusted());
 }

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h
@@ -40,7 +40,7 @@ class PaymentRequestUpdateEvent : public Event {
 public:
     template <typename... Args> static Ref<PaymentRequestUpdateEvent> create(Args&&... args)
     {
-        return adoptRef(*new PaymentRequestUpdateEvent(std::forward<Args>(args)...));
+        return adoptRef(*new PaymentRequestUpdateEvent(EventInterfaceType::PaymentRequestUpdateEvent, std::forward<Args>(args)...));
     }
     ~PaymentRequestUpdateEvent();
     ExceptionOr<void> updateWith(Ref<DOMPromise>&&);
@@ -48,8 +48,8 @@ public:
     bool didCallUpdateWith() const { return m_waitForUpdate; }
 
 protected:
-    explicit PaymentRequestUpdateEvent(const AtomString& type);
-    PaymentRequestUpdateEvent(const AtomString& type, const PaymentRequestUpdateEventInit&);
+    explicit PaymentRequestUpdateEvent(enum EventInterfaceType, const AtomString& type);
+    PaymentRequestUpdateEvent(enum EventInterfaceType, const AtomString& type, const PaymentRequestUpdateEventInit&);
 
     // Event
     EventInterface eventInterface() const override;

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.cpp
@@ -42,7 +42,7 @@ Ref<PictureInPictureEvent> PictureInPictureEvent::create(const AtomString& type,
 }
 
 PictureInPictureEvent::PictureInPictureEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
-    : Event(type, init, isTrusted)
+    : Event(EventInterfaceType::PictureInPictureEvent, type, init, isTrusted)
     , m_pictureInPictureWindow(init.pictureInPictureWindow.releaseNonNull())
 {
 }

--- a/Source/WebCore/Modules/push-api/PushEvent.cpp
+++ b/Source/WebCore/Modules/push-api/PushEvent.cpp
@@ -73,7 +73,7 @@ static inline RefPtr<PushMessageData> pushMessageDataFromOptionalVector(std::opt
 }
 
 PushEvent::PushEvent(const AtomString& type, ExtendableEventInit&& eventInit, std::optional<Vector<uint8_t>>&& data, IsTrusted isTrusted)
-    : ExtendableEvent(type, WTFMove(eventInit), isTrusted)
+    : ExtendableEvent(EventInterfaceType::PushEvent, type, WTFMove(eventInit), isTrusted)
     , m_data(pushMessageDataFromOptionalVector(WTFMove(data)))
 {
 }

--- a/Source/WebCore/Modules/push-api/PushNotificationEvent.cpp
+++ b/Source/WebCore/Modules/push-api/PushNotificationEvent.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(PushNotificationEvent);
 
 PushNotificationEvent::PushNotificationEvent(const AtomString& type, ExtendableEventInit&& eventInit, Notification* proposedNotification, std::optional<uint64_t> proposedAppBadge, IsTrusted isTrusted)
-    : ExtendableEvent(type, WTFMove(eventInit), isTrusted)
+    : ExtendableEvent(EventInterfaceType::PushNotificationEvent, type, WTFMove(eventInit), isTrusted)
     , m_proposedNotification(proposedNotification)
     , m_proposedAppBadge(proposedAppBadge)
 {

--- a/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.cpp
@@ -46,7 +46,7 @@ Ref<PushSubscriptionChangeEvent> PushSubscriptionChangeEvent::create(const AtomS
 }
 
 PushSubscriptionChangeEvent::PushSubscriptionChangeEvent(const AtomString& type, ExtendableEventInit&& eventInit, RefPtr<PushSubscription>&& newSubscription, RefPtr<PushSubscription>&& oldSubscription, IsTrusted isTrusted)
-    : ExtendableEvent(type, WTFMove(eventInit), isTrusted)
+    : ExtendableEvent(EventInterfaceType::PushSubscriptionChangeEvent, type, WTFMove(eventInit), isTrusted)
     , m_newSubscription(WTFMove(newSubscription))
     , m_oldSubscription(WTFMove(oldSubscription))
 {

--- a/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp
@@ -44,14 +44,14 @@ Ref<SpeechRecognitionErrorEvent> SpeechRecognitionErrorEvent::create(const AtomS
 }
 
 SpeechRecognitionErrorEvent::SpeechRecognitionErrorEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
-    : Event(type, init, isTrusted)
+    : Event(EventInterfaceType::SpeechRecognitionErrorEvent, type, init, isTrusted)
     , m_error(init.error)
     , m_message(WTFMove(init.message))
 {
 }
 
 SpeechRecognitionErrorEvent::SpeechRecognitionErrorEvent(const AtomString& type, SpeechRecognitionErrorCode error, const String& message)
-    : Event(type, Event::CanBubble::No, Event::IsCancelable::No)
+    : Event(EventInterfaceType::SpeechRecognitionErrorEvent, type, Event::CanBubble::No, Event::IsCancelable::No)
     , m_error(error)
     , m_message(message)
 {

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp
@@ -44,14 +44,14 @@ Ref<SpeechRecognitionEvent> SpeechRecognitionEvent::create(const AtomString& typ
 }
 
 SpeechRecognitionEvent::SpeechRecognitionEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
-    : Event(type, init, isTrusted)
+    : Event(EventInterfaceType::SpeechRecognitionEvent, type, init, isTrusted)
     , m_resultIndex(init.resultIndex)
     , m_results(WTFMove(init.results))
 {
 }
 
 SpeechRecognitionEvent::SpeechRecognitionEvent(const AtomString& type, uint64_t resultIndex, RefPtr<SpeechRecognitionResultList>&& results)
-    : Event(type, Event::CanBubble::No, Event::IsCancelable::No)
+    : Event(EventInterfaceType::SpeechRecognitionEvent, type, Event::CanBubble::No, Event::IsCancelable::No)
     , m_resultIndex(resultIndex)
     , m_results(WTFMove(results))
 {

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp
@@ -41,7 +41,7 @@ Ref<SpeechSynthesisErrorEvent> SpeechSynthesisErrorEvent::create(const AtomStrin
 }
 
 SpeechSynthesisErrorEvent::SpeechSynthesisErrorEvent(const AtomString& type, const SpeechSynthesisErrorEventInit& initializer)
-    : SpeechSynthesisEvent(type, initializer)
+    : SpeechSynthesisEvent(EventInterfaceType::SpeechSynthesisErrorEvent, type, initializer)
     , m_error(initializer.error)
 {
 }

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp
@@ -37,11 +37,11 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SpeechSynthesisEvent);
 
 Ref<SpeechSynthesisEvent> SpeechSynthesisEvent::create(const AtomString& type, const SpeechSynthesisEventInit& initializer)
 {
-    return adoptRef(*new SpeechSynthesisEvent(type, initializer));
+    return adoptRef(*new SpeechSynthesisEvent(EventInterfaceType::SpeechSynthesisEvent, type, initializer));
 }
 
-SpeechSynthesisEvent::SpeechSynthesisEvent(const AtomString& type, const SpeechSynthesisEventInit& initializer)
-    : Event(type, CanBubble::No, IsCancelable::No)
+SpeechSynthesisEvent::SpeechSynthesisEvent(enum EventInterfaceType eventInterface, const AtomString& type, const SpeechSynthesisEventInit& initializer)
+    : Event(eventInterface, type, CanBubble::No, IsCancelable::No)
     , m_utterance(initializer.utterance)
     , m_charIndex(initializer.charIndex)
     , m_charLength(initializer.charLength)

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.h
@@ -48,7 +48,7 @@ public:
     virtual EventInterface eventInterface() const { return SpeechSynthesisEventInterfaceType; }
 
 protected:
-    SpeechSynthesisEvent(const AtomString& type, const SpeechSynthesisEventInit&);
+    SpeechSynthesisEvent(enum EventInterfaceType, const AtomString& type, const SpeechSynthesisEventInit&);
 
 private:
     RefPtr<SpeechSynthesisUtterance> m_utterance;

--- a/Source/WebCore/Modules/webaudio/AudioProcessingEvent.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioProcessingEvent.cpp
@@ -47,7 +47,7 @@ Ref<AudioProcessingEvent> AudioProcessingEvent::create(const AtomString& eventTy
 }
 
 AudioProcessingEvent::AudioProcessingEvent(RefPtr<AudioBuffer>&& inputBuffer, RefPtr<AudioBuffer>&& outputBuffer, double playbackTime)
-    : Event(eventNames().audioprocessEvent, CanBubble::Yes, IsCancelable::No)
+    : Event(EventInterfaceType::AudioProcessingEvent, eventNames().audioprocessEvent, CanBubble::Yes, IsCancelable::No)
     , m_inputBuffer(WTFMove(inputBuffer))
     , m_outputBuffer(WTFMove(outputBuffer))
     , m_playbackTime(playbackTime)
@@ -55,7 +55,7 @@ AudioProcessingEvent::AudioProcessingEvent(RefPtr<AudioBuffer>&& inputBuffer, Re
 }
 
 AudioProcessingEvent::AudioProcessingEvent(const AtomString& eventType, AudioProcessingEventInit&& eventInitDict)
-    : Event(eventType, eventInitDict, IsTrusted::No)
+    : Event(EventInterfaceType::AudioProcessingEvent, eventType, eventInitDict, IsTrusted::No)
     , m_inputBuffer(eventInitDict.inputBuffer.releaseNonNull())
     , m_outputBuffer(eventInitDict.outputBuffer.releaseNonNull())
     , m_playbackTime(eventInitDict.playbackTime)

--- a/Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.cpp
@@ -51,13 +51,13 @@ Ref<OfflineAudioCompletionEvent> OfflineAudioCompletionEvent::create(const AtomS
 }
 
 OfflineAudioCompletionEvent::OfflineAudioCompletionEvent(Ref<AudioBuffer>&& renderedBuffer)
-    : Event(eventNames().completeEvent, CanBubble::Yes, IsCancelable::No)
+    : Event(EventInterfaceType::OfflineAudioCompletionEvent, eventNames().completeEvent, CanBubble::Yes, IsCancelable::No)
     , m_renderedBuffer(WTFMove(renderedBuffer))
 {
 }
 
 OfflineAudioCompletionEvent::OfflineAudioCompletionEvent(const AtomString& eventType, OfflineAudioCompletionEventInit&& init)
-    : Event(eventType, init, IsTrusted::No)
+    : Event(EventInterfaceType::OfflineAudioCompletionEvent, eventType, init, IsTrusted::No)
     , m_renderedBuffer(init.renderedBuffer.releaseNonNull())
 {
 }

--- a/Source/WebCore/Modules/websockets/CloseEvent.h
+++ b/Source/WebCore/Modules/websockets/CloseEvent.h
@@ -63,7 +63,7 @@ public:
 
 private:
     CloseEvent(bool wasClean, int code, const String& reason)
-        : Event(eventNames().closeEvent, CanBubble::No, IsCancelable::No)
+        : Event(EventInterfaceType::CloseEvent, eventNames().closeEvent, CanBubble::No, IsCancelable::No)
         , m_wasClean(wasClean)
         , m_code(code)
         , m_reason(reason)
@@ -71,7 +71,7 @@ private:
     }
 
     CloseEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-        : Event(type, initializer, isTrusted)
+        : Event(EventInterfaceType::CloseEvent, type, initializer, isTrusted)
         , m_wasClean(initializer.wasClean)
         , m_code(initializer.code)
         , m_reason(initializer.reason)

--- a/Source/WebCore/Modules/webxr/XRInputSourceEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRInputSourceEvent.cpp
@@ -42,7 +42,7 @@ Ref<XRInputSourceEvent> XRInputSourceEvent::create(const AtomString& type, const
 }
 
 XRInputSourceEvent::XRInputSourceEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::XRInputSourceEvent, type, initializer, isTrusted)
     , m_frame(initializer.frame)
     , m_inputSource(initializer.inputSource)
 {

--- a/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.cpp
@@ -42,7 +42,7 @@ Ref<XRInputSourcesChangeEvent> XRInputSourcesChangeEvent::create(const AtomStrin
 }
 
 XRInputSourcesChangeEvent::XRInputSourcesChangeEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::XRInputSourcesChangeEvent, type, initializer, isTrusted)
     , m_session(*initializer.session)
     , m_added(initializer.added)
     , m_removed(initializer.removed)

--- a/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.cpp
@@ -42,7 +42,7 @@ Ref<XRReferenceSpaceEvent> XRReferenceSpaceEvent::create(const AtomString& type,
 }
 
 XRReferenceSpaceEvent::XRReferenceSpaceEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::XRReferenceSpaceEvent, type, initializer, isTrusted)
     , m_referenceSpace(initializer.referenceSpace)
     , m_transform(initializer.transform)
 {

--- a/Source/WebCore/Modules/webxr/XRSessionEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRSessionEvent.cpp
@@ -41,7 +41,7 @@ Ref<XRSessionEvent> XRSessionEvent::create(const AtomString& type, const Init& i
 }
 
 XRSessionEvent::XRSessionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::XRSessionEvent, type, initializer, isTrusted)
     , m_session(initializer.session)
 {
     ASSERT(m_session);

--- a/Source/WebCore/animation/AnimationEventBase.cpp
+++ b/Source/WebCore/animation/AnimationEventBase.cpp
@@ -35,15 +35,15 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(AnimationEventBase);
 
-AnimationEventBase::AnimationEventBase(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime)
-    : Event(type, CanBubble::Yes, IsCancelable::No)
+AnimationEventBase::AnimationEventBase(enum EventInterfaceType eventInterface, const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime)
+    : Event(eventInterface, type, CanBubble::Yes, IsCancelable::No)
     , m_animation(animation)
     , m_scheduledTime(scheduledTime)
 {
 }
 
-AnimationEventBase::AnimationEventBase(const AtomString& type, const EventInit& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+AnimationEventBase::AnimationEventBase(enum EventInterfaceType eventInterface, const AtomString& type, const EventInit& initializer, IsTrusted isTrusted)
+    : Event(eventInterface, type, initializer, isTrusted)
 {
 }
 

--- a/Source/WebCore/animation/AnimationEventBase.h
+++ b/Source/WebCore/animation/AnimationEventBase.h
@@ -45,8 +45,8 @@ public:
     std::optional<Seconds> scheduledTime() const { return m_scheduledTime; }
 
 protected:
-    AnimationEventBase(const AtomString&, WebAnimation*, std::optional<Seconds> scheduledTime);
-    AnimationEventBase(const AtomString&, const EventInit&, IsTrusted);
+    AnimationEventBase(enum EventInterfaceType, const AtomString&, WebAnimation*, std::optional<Seconds> scheduledTime);
+    AnimationEventBase(enum EventInterfaceType, const AtomString&, const EventInit&, IsTrusted);
 
 private:
     RefPtr<WebAnimation> m_animation;

--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(AnimationPlaybackEvent);
 
 AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, const AnimationPlaybackEventInit& initializer, IsTrusted isTrusted)
-    : AnimationEventBase(type, initializer, isTrusted)
+    : AnimationEventBase(EventInterfaceType::AnimationPlaybackEvent, type, initializer, isTrusted)
 {
     if (initializer.currentTime)
         m_currentTime = Seconds::fromMilliseconds(*initializer.currentTime);
@@ -48,7 +48,7 @@ AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, const Ani
 }
 
 AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, std::optional<Seconds> timelineTime, std::optional<Seconds> currentTime)
-    : AnimationEventBase(type, animation, scheduledTime)
+    : AnimationEventBase(EventInterfaceType::AnimationPlaybackEvent, type, animation, scheduledTime)
     , m_timelineTime(timelineTime)
     , m_currentTime(currentTime)
 {

--- a/Source/WebCore/animation/CSSAnimationEvent.cpp
+++ b/Source/WebCore/animation/CSSAnimationEvent.cpp
@@ -33,13 +33,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSAnimationEvent);
 
 CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : StyleOriginatedAnimationEvent(type, initializer, isTrusted, initializer.elapsedTime, initializer.pseudoElement)
+    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSAnimationEvent, type, initializer, isTrusted, initializer.elapsedTime, initializer.pseudoElement)
     , m_animationName(initializer.animationName)
 {
 }
 
 CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String& animationName)
-    : StyleOriginatedAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElementIdentifier)
+    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSAnimationEvent, type, animation, scheduledTime, elapsedTime, pseudoElementIdentifier)
     , m_animationName(animationName)
 {
 }

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -34,13 +34,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSTransitionEvent);
 
 CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const String propertyName)
-    : StyleOriginatedAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElementIdentifier)
+    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSTransitionEvent, type, animation, scheduledTime, elapsedTime, pseudoElementIdentifier)
     , m_propertyName(propertyName)
 {
 }
 
 CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : StyleOriginatedAnimationEvent(type, initializer, isTrusted, initializer.elapsedTime, initializer.pseudoElement)
+    : StyleOriginatedAnimationEvent(EventInterfaceType::CSSTransitionEvent, type, initializer, isTrusted, initializer.elapsedTime, initializer.pseudoElement)
     , m_propertyName(initializer.propertyName)
 {
 }

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
@@ -34,15 +34,15 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(StyleOriginatedAnimationEvent);
 
-StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
-    : AnimationEventBase(type, animation, scheduledTime)
+StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterfaceType eventInterface, const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+    : AnimationEventBase(eventInterface, type, animation, scheduledTime)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElementIdentifier(pseudoElementIdentifier)
 {
 }
 
-StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(const AtomString& type, const EventInit& init, IsTrusted isTrusted, double elapsedTime, const String& pseudoElement)
-    : AnimationEventBase(type, init, isTrusted)
+StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterfaceType eventInterface, const AtomString& type, const EventInit& init, IsTrusted isTrusted, double elapsedTime, const String& pseudoElement)
+    : AnimationEventBase(eventInterface, type, init, isTrusted)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)
 {

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
@@ -40,8 +40,8 @@ public:
     const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier() const { return m_pseudoElementIdentifier; }
 
 protected:
-    StyleOriginatedAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, const std::optional<Style::PseudoElementIdentifier>&);
-    StyleOriginatedAnimationEvent(const AtomString&, const EventInit&, IsTrusted, double, const String&);
+    StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, const std::optional<Style::PseudoElementIdentifier>&);
+    StyleOriginatedAnimationEvent(enum EventInterfaceType, const AtomString&, const EventInit&, IsTrusted, double, const String&);
 
 private:
     double m_elapsedTime;

--- a/Source/WebCore/bindings/scripts/InFilesCompiler.pm
+++ b/Source/WebCore/bindings/scripts/InFilesCompiler.pm
@@ -224,14 +224,42 @@ sub generateInterfacesHeader()
 
     print F "namespace WebCore {\n";
     print F "\n";
-    print F "enum ${namespace}Interface {\n";
+    print F "enum class ${namespace}InterfaceType {\n";
 
     my $suffix = "InterfaceType";
     if ($useNamespaceAsSuffix eq "true") {
         $suffix = $namespace . $suffix;
     }
 
+    print F "    Invalid = 0,\n";
+
     my $count = 1;
+    for my $conditional (sort keys %interfacesByConditional) {
+        my $preferredConditional = $object->preferredConditional($conditional);
+        print F "#if " . $object->conditionalStringFromAttributeValue($conditional) . "\n";
+        for my $interface (sort keys %{ $interfacesByConditional{$conditional} }) {
+            next if defined($unconditionalInterfaces{$interface});
+            print F "    ${interface} = $count,\n";
+            $count++;
+        }
+        print F "#endif\n";
+    }
+
+    if ($namespace eq "EventTarget") {
+        print F "    ${suffix} = $count,\n";
+        $count++;
+    }
+
+    for my $interface (sort keys %unconditionalInterfaces) {
+        print F "    ${interface} = $count,\n";
+        $count++;
+    }
+
+    print F "};\n";
+    print F "\n";
+    print F "enum ${namespace}Interface {\n";
+
+    $count = 1;
     for my $conditional (sort keys %interfacesByConditional) {
         my $preferredConditional = $object->preferredConditional($conditional);
         print F "#if " . $object->conditionalStringFromAttributeValue($conditional) . "\n";

--- a/Source/WebCore/css/MediaQueryListEvent.cpp
+++ b/Source/WebCore/css/MediaQueryListEvent.cpp
@@ -33,14 +33,14 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(MediaQueryListEvent);
 
 MediaQueryListEvent::MediaQueryListEvent(const AtomString& type, const String& media, bool matches)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::MediaQueryListEvent, type, CanBubble::No, IsCancelable::No)
     , m_media(media)
     , m_matches(matches)
 {
 }
 
 MediaQueryListEvent::MediaQueryListEvent(const AtomString& type, const Init& init, IsTrusted isTrusted)
-    : Event(type, init, isTrusted)
+    : Event(EventInterfaceType::MediaQueryListEvent, type, init, isTrusted)
     , m_media(init.media)
     , m_matches(init.matches)
 {

--- a/Source/WebCore/dom/BeforeTextInsertedEvent.cpp
+++ b/Source/WebCore/dom/BeforeTextInsertedEvent.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(BeforeTextInsertedEvent);
 
 BeforeTextInsertedEvent::BeforeTextInsertedEvent(const String& text)
-    : Event(eventNames().webkitBeforeTextInsertedEvent, CanBubble::No, IsCancelable::Yes), m_text(text)
+    : Event(EventInterfaceType::Event, eventNames().webkitBeforeTextInsertedEvent, CanBubble::No, IsCancelable::Yes), m_text(text)
 {
 }
 

--- a/Source/WebCore/dom/BeforeUnloadEvent.cpp
+++ b/Source/WebCore/dom/BeforeUnloadEvent.cpp
@@ -31,11 +31,12 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(BeforeUnloadEvent);
 
 BeforeUnloadEvent::BeforeUnloadEvent()
-    : Event(eventNames().beforeunloadEvent, CanBubble::No, IsCancelable::Yes)
+    : Event(EventInterfaceType::BeforeUnloadEvent, eventNames().beforeunloadEvent, CanBubble::No, IsCancelable::Yes)
 {
 }
 
 BeforeUnloadEvent::BeforeUnloadEvent(ForBindingsFlag)
+    : Event(EventInterfaceType::BeforeUnloadEvent)
 {
 }
 

--- a/Source/WebCore/dom/ClipboardEvent.cpp
+++ b/Source/WebCore/dom/ClipboardEvent.cpp
@@ -31,13 +31,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ClipboardEvent);
 
 ClipboardEvent::ClipboardEvent(const AtomString& type, Ref<DataTransfer>&& dataTransfer)
-    : Event(type, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes)
+    : Event(EventInterfaceType::ClipboardEvent, type, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes)
     , m_clipboardData(WTFMove(dataTransfer))
 {
 }
 
 ClipboardEvent::ClipboardEvent(const AtomString& type, const Init& init)
-    : Event(type, init, IsTrusted::No)
+    : Event(EventInterfaceType::ClipboardEvent, type, init, IsTrusted::No)
     , m_clipboardData(init.clipboardData)
 {
 }

--- a/Source/WebCore/dom/CompositionEvent.cpp
+++ b/Source/WebCore/dom/CompositionEvent.cpp
@@ -33,16 +33,19 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CompositionEvent);
 
-CompositionEvent::CompositionEvent() = default;
+CompositionEvent::CompositionEvent()
+    : UIEvent(EventInterfaceType::CompositionEvent)
+{
+}
 
 CompositionEvent::CompositionEvent(const AtomString& type, RefPtr<WindowProxy>&& view, const String& data)
-    : UIEvent(type, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
+    : UIEvent(EventInterfaceType::CompositionEvent, type, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
     , m_data(data)
 {
 }
 
 CompositionEvent::CompositionEvent(const AtomString& type, const Init& initializer)
-    : UIEvent(type, initializer)
+    : UIEvent(EventInterfaceType::CompositionEvent, type, initializer)
     , m_data(initializer.data)
 {
 }

--- a/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.cpp
+++ b/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ContentVisibilityAutoStateChangeEvent);
 
 ContentVisibilityAutoStateChangeEvent::ContentVisibilityAutoStateChangeEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::ContentVisibilityAutoStateChangeEvent, type, initializer, isTrusted)
     , m_skipped(initializer.skipped)
 {
 }

--- a/Source/WebCore/dom/CustomEvent.cpp
+++ b/Source/WebCore/dom/CustomEvent.cpp
@@ -35,12 +35,12 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(CustomEvent);
 
 inline CustomEvent::CustomEvent(IsTrusted isTrusted)
-    : Event(isTrusted)
+    : Event(EventInterfaceType::CustomEvent, isTrusted)
 {
 }
 
 inline CustomEvent::CustomEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::CustomEvent, type, initializer, isTrusted)
     , m_detail(initializer.detail)
 {
 }

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -38,12 +38,27 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(DeviceMotionEvent);
 DeviceMotionEvent::~DeviceMotionEvent() = default;
 
 DeviceMotionEvent::DeviceMotionEvent()
-    : m_deviceMotionData(DeviceMotionData::create())
+#if ENABLE(DEVICE_ORIENTATION)
+    : Event(EventInterfaceType::DeviceMotionEvent)
+#else
+    // FIXME: ENABLE(DEVICE_ORIENTATION) seems to be in a strange state where
+    // it is half-guarded by #ifdefs. DeviceMotionEvent.idl is guarded
+    // but DeviceMotionEvent.cpp itself is required by unguarded code.
+    : Event(EventInterfaceType::Event)
+#endif
+    , m_deviceMotionData(DeviceMotionData::create())
 {
 }
 
 DeviceMotionEvent::DeviceMotionEvent(const AtomString& eventType, DeviceMotionData* deviceMotionData)
-    : Event(eventType, CanBubble::No, IsCancelable::No)
+#if ENABLE(DEVICE_ORIENTATION)
+    : Event(EventInterfaceType::DeviceMotionEvent, eventType, CanBubble::No, IsCancelable::No)
+#else
+    // FIXME: ENABLE(DEVICE_ORIENTATION) seems to be in a strange state where
+    // it is half-guarded by #ifdefs. DeviceMotionEvent.idl is guarded
+    // but DeviceMotionEvent.cpp itself is required by unguarded code.
+    : Event(EventInterfaceType::Event, eventType, CanBubble::No, IsCancelable::No)
+#endif
     , m_deviceMotionData(deviceMotionData)
 {
 }

--- a/Source/WebCore/dom/DeviceOrientationEvent.cpp
+++ b/Source/WebCore/dom/DeviceOrientationEvent.cpp
@@ -40,12 +40,27 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(DeviceOrientationEvent);
 DeviceOrientationEvent::~DeviceOrientationEvent() = default;
 
 DeviceOrientationEvent::DeviceOrientationEvent()
-    : m_orientation(DeviceOrientationData::create())
+#if ENABLE(DEVICE_ORIENTATION)
+    : Event(EventInterfaceType::DeviceOrientationEvent)
+#else
+    // FIXME: ENABLE(DEVICE_ORIENTATION) seems to be in a strange state where
+    // it is half-guarded by #ifdefs. DeviceOrientationEvent.idl is guarded
+    // but DeviceOrientationEvent.cpp itself is required by unguarded code.
+    : Event(EventInterfaceType::Event)
+#endif
+    , m_orientation(DeviceOrientationData::create())
 {
 }
 
 DeviceOrientationEvent::DeviceOrientationEvent(const AtomString& eventType, DeviceOrientationData* orientation)
-    : Event(eventType, CanBubble::No, IsCancelable::No)
+#if ENABLE(DEVICE_ORIENTATION)
+    : Event(EventInterfaceType::DeviceOrientationEvent, eventType, CanBubble::No, IsCancelable::No)
+#else
+    // FIXME: ENABLE(DEVICE_ORIENTATION) seems to be in a strange state where
+    // it is half-guarded by #ifdefs. DeviceOrientationEvent.idl is guarded
+    // but DeviceOrientationEvent.cpp itself is required by unguarded code.
+    : Event(EventInterfaceType::Event, eventType, CanBubble::No, IsCancelable::No)
+#endif
     , m_orientation(orientation)
 {
 }

--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -53,7 +53,7 @@ Ref<DragEvent> DragEvent::create(const AtomString& type, CanBubble canBubble, Is
 }
 
 DragEvent::DragEvent(const AtomString& eventType, DragEventInit&& init)
-    : MouseEvent(eventType, init)
+    : MouseEvent(EventInterfaceType::DragEvent, eventType, init)
     , m_dataTransfer(WTFMove(init.dataTransfer))
 {
 }
@@ -62,12 +62,15 @@ DragEvent::DragEvent(const AtomString& eventType, CanBubble canBubble, IsCancela
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
     const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, DataTransfer* dataTransfer, IsSimulated isSimulated, IsTrusted isTrusted)
-    : MouseEvent(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, isSimulated, isTrusted)
+    : MouseEvent(EventInterfaceType::DragEvent, eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, isSimulated, isTrusted)
     , m_dataTransfer(dataTransfer)
 {
 }
 
-DragEvent::DragEvent() = default;
+DragEvent::DragEvent()
+    : MouseEvent(EventInterfaceType::DragEvent)
+{
+}
 
 EventInterface DragEvent::eventInterface() const
 {

--- a/Source/WebCore/dom/ErrorEvent.cpp
+++ b/Source/WebCore/dom/ErrorEvent.cpp
@@ -44,7 +44,7 @@ using namespace JSC;
 WTF_MAKE_ISO_ALLOCATED_IMPL(ErrorEvent);
 
 ErrorEvent::ErrorEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::ErrorEvent, type, initializer, isTrusted)
     , m_message(initializer.message)
     , m_fileName(initializer.filename)
     , m_lineNumber(initializer.lineno)
@@ -54,7 +54,7 @@ ErrorEvent::ErrorEvent(const AtomString& type, const Init& initializer, IsTruste
 }
 
 ErrorEvent::ErrorEvent(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
-    : Event(type, CanBubble::No, IsCancelable::Yes)
+    : Event(EventInterfaceType::ErrorEvent, type, CanBubble::No, IsCancelable::Yes)
     , m_message(message)
     , m_fileName(fileName)
     , m_lineNumber(lineNumber)

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(Event);
 
-ALWAYS_INLINE Event::Event(MonotonicTime createTime, const AtomString& type, IsTrusted isTrusted, CanBubble canBubble, IsCancelable cancelable, IsComposed composed)
+ALWAYS_INLINE Event::Event(MonotonicTime createTime, enum EventInterfaceType eventInterface, const AtomString& type, IsTrusted isTrusted, CanBubble canBubble, IsCancelable cancelable, IsComposed composed)
     : m_isInitialized { !type.isNull() }
     , m_canBubble { canBubble == CanBubble::Yes }
     , m_cancelable { cancelable == IsCancelable::Yes }
@@ -55,30 +55,31 @@ ALWAYS_INLINE Event::Event(MonotonicTime createTime, const AtomString& type, IsT
     , m_isExecutingPassiveEventListener { false }
     , m_currentTargetIsInShadowTree { false }
     , m_eventPhase { NONE }
+    , m_eventInterface(enumToUnderlyingType(eventInterface))
     , m_type { type }
     , m_createTime { createTime }
 {
+    ASSERT(m_eventInterface == enumToUnderlyingType(eventInterface));
 }
 
-Event::Event(IsTrusted isTrusted)
-    : Event { MonotonicTime::now(), { }, isTrusted, CanBubble::No, IsCancelable::No, IsComposed::No }
+Event::Event(enum EventInterfaceType eventInterface, IsTrusted isTrusted)
+    : Event { MonotonicTime::now(), eventInterface, { }, isTrusted, CanBubble::No, IsCancelable::No, IsComposed::No }
 {
 }
 
-Event::Event(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed)
-    : Event { MonotonicTime::now(), eventType, IsTrusted::Yes, canBubble, isCancelable, isComposed }
-{
-    ASSERT(!eventType.isNull());
-}
-
-Event::Event(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, IsTrusted isTrusted)
-    : Event { timestamp, eventType, isTrusted, canBubble, isCancelable, isComposed }
+Event::Event(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed)
+    : Event { MonotonicTime::now(), eventInterface, eventType, IsTrusted::Yes, canBubble, isCancelable, isComposed }
 {
     ASSERT(!eventType.isNull());
 }
 
-Event::Event(const AtomString& eventType, const EventInit& initializer, IsTrusted isTrusted)
-    : Event { MonotonicTime::now(), eventType, isTrusted,
+Event::Event(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable cancelable, IsComposed composed, MonotonicTime timestamp, IsTrusted isTrusted)
+    : Event(timestamp, eventInterface, eventType, isTrusted, canBubble, cancelable, composed)
+{
+}
+
+Event::Event(enum EventInterfaceType eventInterface, const AtomString& eventType, const EventInit& initializer, IsTrusted isTrusted)
+    : Event { MonotonicTime::now(), eventInterface, eventType, isTrusted,
         initializer.bubbles ? CanBubble::Yes : CanBubble::No,
         initializer.cancelable ? IsCancelable::Yes : IsCancelable::No,
         initializer.composed ? IsComposed::Yes : IsComposed::No }
@@ -91,17 +92,17 @@ Event::~Event() = default;
 
 Ref<Event> Event::create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed)
 {
-    return adoptRef(*new Event(type, canBubble, isCancelable, isComposed));
+    return adoptRef(*new Event(EventInterfaceType::Event, type, canBubble, isCancelable, isComposed));
 }
 
 Ref<Event> Event::createForBindings()
 {
-    return adoptRef(*new Event);
+    return adoptRef(*new Event(EventInterfaceType::Event));
 }
 
 Ref<Event> Event::create(const AtomString& type, const EventInit& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new Event(type, initializer, isTrusted));
+    return adoptRef(*new Event(EventInterfaceType::Event, type, initializer, isTrusted));
 }
 
 void Event::initEvent(const AtomString& eventTypeArg, bool canBubbleArg, bool cancelableArg)

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -72,6 +72,8 @@ public:
     const AtomString& type() const { return m_type; }
     void setType(const AtomString& type) { m_type = type; }
 
+    enum EventInterfaceType interfaceType() const { return m_eventInterface ? static_cast<enum EventInterfaceType>(m_eventInterface) : static_cast<enum EventInterfaceType>(eventInterface()); }
+
     EventTarget* target() const { return m_target.get(); }
     void setTarget(RefPtr<EventTarget>&&);
 
@@ -155,17 +157,17 @@ public:
     virtual String debugDescription() const;
 
 protected:
-    explicit Event(IsTrusted = IsTrusted::No);
-    Event(const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
-    Event(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, IsTrusted isTrusted = IsTrusted::Yes);
-    Event(const AtomString& type, const EventInit&, IsTrusted);
+    explicit Event(enum EventInterfaceType, IsTrusted = IsTrusted::No);
+    Event(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
+    Event(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, IsTrusted isTrusted = IsTrusted::Yes);
+    Event(enum EventInterfaceType, const AtomString& type, const EventInit&, IsTrusted);
 
     virtual void receivedTarget() { }
 
     bool isConstructedFromInitializer() const { return m_isConstructedFromInitializer; }
 
 private:
-    explicit Event(MonotonicTime createTime, const AtomString& type, IsTrusted, CanBubble, IsCancelable, IsComposed);
+    explicit Event(MonotonicTime createTime, enum EventInterfaceType, const AtomString& type, IsTrusted, CanBubble, IsCancelable, IsComposed);
 
     void setCanceledFlagIfPossible();
 
@@ -188,6 +190,10 @@ private:
     // We consult this flag since the EventInit dictionary takes priority in initializing event attribute values.
     // See step 4 of https://dom.spec.whatwg.org/#inner-event-creation-steps
     unsigned m_isConstructedFromInitializer : 1 { false };
+
+    unsigned m_eventInterface : 7 { 0 };
+
+    // 10-bits left.
 
     AtomString m_type;
 

--- a/Source/WebCore/dom/FocusEvent.cpp
+++ b/Source/WebCore/dom/FocusEvent.cpp
@@ -43,14 +43,19 @@ bool FocusEvent::isFocusEvent() const
     return true;
 }
 
+FocusEvent::FocusEvent()
+    : UIEvent(EventInterfaceType::FocusEvent)
+{
+}
+
 FocusEvent::FocusEvent(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, RefPtr<WindowProxy>&& view, int detail, RefPtr<EventTarget>&& relatedTarget)
-    : UIEvent(type, canBubble, isCancelable, IsComposed::Yes, WTFMove(view), detail)
+    : UIEvent(EventInterfaceType::FocusEvent, type, canBubble, isCancelable, IsComposed::Yes, WTFMove(view), detail)
     , m_relatedTarget(WTFMove(relatedTarget))
 {
 }
 
 FocusEvent::FocusEvent(const AtomString& type, const Init& initializer)
-    : UIEvent(type, initializer)
+    : UIEvent(EventInterfaceType::FocusEvent, type, initializer)
     , m_relatedTarget(initializer.relatedTarget)
 {
 }

--- a/Source/WebCore/dom/FocusEvent.h
+++ b/Source/WebCore/dom/FocusEvent.h
@@ -58,7 +58,7 @@ public:
     EventTarget* relatedTarget() const final { return m_relatedTarget.get(); }
 
 private:
-    FocusEvent() = default;
+    FocusEvent();
     FocusEvent(const AtomString& type, CanBubble, IsCancelable, RefPtr<WindowProxy>&&, int, RefPtr<EventTarget>&&);
     FocusEvent(const AtomString& type, const Init&);
 

--- a/Source/WebCore/dom/FormDataEvent.cpp
+++ b/Source/WebCore/dom/FormDataEvent.cpp
@@ -44,13 +44,13 @@ Ref<FormDataEvent> FormDataEvent::create(const AtomString& eventType, CanBubble 
 }
 
 FormDataEvent::FormDataEvent(const AtomString& eventType, Init&& init)
-    : Event(eventType, init, IsTrusted::No)
+    : Event(EventInterfaceType::FormDataEvent, eventType, init, IsTrusted::No)
     , m_formData(init.formData.releaseNonNull())
 {
 }
 
 FormDataEvent::FormDataEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, Ref<DOMFormData>&& formData)
-    : Event(eventType, canBubble, isCancelable, isComposed)
+    : Event(EventInterfaceType::FormDataEvent, eventType, canBubble, isCancelable, isComposed)
     , m_formData(WTFMove(formData))
 {
 }

--- a/Source/WebCore/dom/HashChangeEvent.h
+++ b/Source/WebCore/dom/HashChangeEvent.h
@@ -66,18 +66,19 @@ public:
 
 private:
     HashChangeEvent()
+        : Event(EventInterfaceType::HashChangeEvent)
     {
     }
 
     HashChangeEvent(const String& oldURL, const String& newURL)
-        : Event(eventNames().hashchangeEvent, CanBubble::No, IsCancelable::No)
+        : Event(EventInterfaceType::HashChangeEvent, eventNames().hashchangeEvent, CanBubble::No, IsCancelable::No)
         , m_oldURL(oldURL)
         , m_newURL(newURL)
     {
     }
 
     HashChangeEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-        : Event(type, initializer, isTrusted)
+        : Event(EventInterfaceType::HashChangeEvent, type, initializer, isTrusted)
         , m_oldURL(initializer.oldURL)
         , m_newURL(initializer.newURL)
     {

--- a/Source/WebCore/dom/InputEvent.cpp
+++ b/Source/WebCore/dom/InputEvent.cpp
@@ -44,7 +44,7 @@ Ref<InputEvent> InputEvent::create(const AtomString& eventType, const String& in
 
 InputEvent::InputEvent(const AtomString& eventType, const String& inputType, IsCancelable cancelable, RefPtr<WindowProxy>&& view,
     const String& data, RefPtr<DataTransfer>&& dataTransfer, const Vector<RefPtr<StaticRange>>& targetRanges, int detail, IsInputMethodComposing isInputMethodComposing)
-    : UIEvent(eventType, CanBubble::Yes, cancelable, IsComposed::Yes, WTFMove(view), detail)
+    : UIEvent(EventInterfaceType::InputEvent, eventType, CanBubble::Yes, cancelable, IsComposed::Yes, WTFMove(view), detail)
     , m_inputType(inputType)
     , m_data(data)
     , m_dataTransfer(dataTransfer)
@@ -54,7 +54,7 @@ InputEvent::InputEvent(const AtomString& eventType, const String& inputType, IsC
 }
 
 InputEvent::InputEvent(const AtomString& eventType, const Init& initializer)
-    : UIEvent(eventType, initializer)
+    : UIEvent(EventInterfaceType::InputEvent, eventType, initializer)
     , m_inputType(initializer.inputType)
     , m_data(initializer.data)
     , m_isInputMethodComposing(initializer.isComposing)

--- a/Source/WebCore/dom/InvokeEvent.cpp
+++ b/Source/WebCore/dom/InvokeEvent.cpp
@@ -34,8 +34,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(InvokeEvent);
 
+InvokeEvent::InvokeEvent()
+    : Event(EventInterfaceType::InvokeEvent)
+{
+}
+
 InvokeEvent::InvokeEvent(const AtomString& type, const InvokeEvent::Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::InvokeEvent, type, initializer, isTrusted)
     , m_invoker(initializer.invoker)
     , m_action(initializer.action)
 {

--- a/Source/WebCore/dom/InvokeEvent.h
+++ b/Source/WebCore/dom/InvokeEvent.h
@@ -51,7 +51,7 @@ public:
     String action() const { return m_action; }
 
 private:
-    InvokeEvent() = default;
+    InvokeEvent();
     InvokeEvent(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
 
     EventInterface eventInterface() const final;

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -101,7 +101,10 @@ static inline KeyboardEvent::KeyLocationCode keyLocationCode(const PlatformKeybo
     }
 }
 
-inline KeyboardEvent::KeyboardEvent() = default;
+inline KeyboardEvent::KeyboardEvent()
+     : UIEventWithKeyState(EventInterfaceType::KeyboardEvent)
+{
+}
 
 static bool viewIsCompositing(WindowProxy* view)
 {
@@ -112,7 +115,7 @@ static bool viewIsCompositing(WindowProxy* view)
 }
 
 inline KeyboardEvent::KeyboardEvent(const PlatformKeyboardEvent& key, RefPtr<WindowProxy>&& view)
-    : UIEventWithKeyState(eventTypeForKeyboardEventType(key.type()), CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes,
+    : UIEventWithKeyState(EventInterfaceType::KeyboardEvent, eventTypeForKeyboardEventType(key.type()), CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes,
         key.timestamp().approximateMonotonicTime(), view.copyRef(), 0, key.modifiers(), IsTrusted::Yes)
     , m_underlyingPlatformEvent(makeUnique<PlatformKeyboardEvent>(key))
     , m_key(key.key())
@@ -131,7 +134,7 @@ inline KeyboardEvent::KeyboardEvent(const PlatformKeyboardEvent& key, RefPtr<Win
 }
 
 inline KeyboardEvent::KeyboardEvent(const AtomString& eventType, const Init& initializer, IsTrusted isTrusted)
-    : UIEventWithKeyState(eventType, initializer, isTrusted)
+    : UIEventWithKeyState(EventInterfaceType::KeyboardEvent, eventType, initializer, isTrusted)
     , m_key(initializer.key)
     , m_code(initializer.code)
     , m_keyIdentifier(initializer.keyIdentifier)

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -40,10 +40,13 @@ using namespace JSC;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(MessageEvent);
 
-MessageEvent::MessageEvent() = default;
+MessageEvent::MessageEvent()
+    : Event(EventInterfaceType::MessageEvent)
+{
+}
 
 inline MessageEvent::MessageEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::MessageEvent, type, initializer, isTrusted)
     , m_data(JSValueTag { })
     , m_origin(initializer.origin)
     , m_lastEventId(initializer.lastEventId)
@@ -54,7 +57,7 @@ inline MessageEvent::MessageEvent(const AtomString& type, Init&& initializer, Is
 }
 
 inline MessageEvent::MessageEvent(const AtomString& type, DataType&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<RefPtr<MessagePort>>&& ports)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::MessageEvent, type, CanBubble::No, IsCancelable::No)
     , m_data(WTFMove(data))
     , m_origin(origin)
     , m_lastEventId(lastEventId)

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MouseEvent);
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& type, const MouseEventInit& initializer)
 {
-    return adoptRef(*new MouseEvent(type, initializer));
+    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, type, initializer));
 }
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowProxy>&& view, const PlatformMouseEvent& event, int detail, Node* relatedTarget)
@@ -63,7 +63,7 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& type, CanBubble canBubble, 
     const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, IsSimulated isSimulated, IsTrusted isTrusted)
 {
-    return adoptRef(*new MouseEvent(type, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail,
+    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, type, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail,
         screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, isSimulated, isTrusted));
 }
 
@@ -71,16 +71,25 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, CanBubble canBub
     int screenX, int screenY, int clientX, int clientY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     SyntheticClickType syntheticClickType, EventTarget* relatedTarget)
 {
-    return adoptRef(*new MouseEvent(eventType, canBubble, isCancelable, isComposed, WTFMove(view), detail, { screenX, screenY }, { clientX, clientY }, 0, 0, modifiers, button, buttons, syntheticClickType, relatedTarget));
+    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, eventType, canBubble, isCancelable, isComposed, WTFMove(view), detail, { screenX, screenY }, { clientX, clientY }, 0, 0, modifiers, button, buttons, syntheticClickType, relatedTarget));
 }
 
-MouseEvent::MouseEvent() = default;
 
-MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
+Ref<MouseEvent> MouseEvent::createForBindings()
+{
+    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent));
+}
+
+MouseEvent::MouseEvent(enum EventInterfaceType eventInterface)
+    : MouseRelatedEvent(eventInterface)
+{
+}
+
+MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
     const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, IsSimulated isSimulated, IsTrusted isTrusted)
-    : MouseRelatedEvent(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, isSimulated, isTrusted)
+    : MouseRelatedEvent(eventInterface, eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, isSimulated, isTrusted)
     , m_button(enumToUnderlyingType(button == MouseButton::None ? MouseButton::Left : button))
     , m_buttons(buttons)
     , m_syntheticClickType(button == MouseButton::None ? SyntheticClickType::NoTap : syntheticClickType)
@@ -90,10 +99,10 @@ MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCance
 {
 }
 
-MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
+MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     RefPtr<WindowProxy>&& view, int detail, const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY,
     OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons, SyntheticClickType syntheticClickType, EventTarget* relatedTarget)
-    : MouseRelatedEvent(eventType, canBubble, isCancelable, isComposed, MonotonicTime::now(), WTFMove(view), detail, screenLocation, { }, movementX, movementY, modifiers, IsSimulated::No)
+    : MouseRelatedEvent(eventInterface, eventType, canBubble, isCancelable, isComposed, MonotonicTime::now(), WTFMove(view), detail, screenLocation, { }, movementX, movementY, modifiers, IsSimulated::No)
     , m_button(enumToUnderlyingType(button == MouseButton::None ? MouseButton::Left : button))
     , m_buttons(buttons)
     , m_syntheticClickType(button == MouseButton::None ? SyntheticClickType::NoTap : syntheticClickType)
@@ -103,8 +112,8 @@ MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCance
     initCoordinates(clientLocation);
 }
 
-MouseEvent::MouseEvent(const AtomString& eventType, const MouseEventInit& initializer)
-    : MouseRelatedEvent(eventType, initializer)
+MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const MouseEventInit& initializer)
+    : MouseRelatedEvent(eventInterface, eventType, initializer)
     , m_button(initializer.button == enumToUnderlyingType(MouseButton::None) ? enumToUnderlyingType(MouseButton::Left) : initializer.button)
     , m_buttons(initializer.buttons)
     , m_buttonDown(initializer.button != enumToUnderlyingType(MouseButton::None))

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -58,7 +58,7 @@ public:
         int screenX, int screenY, int clientX, int clientY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         SyntheticClickType, EventTarget* relatedTarget);
 
-    static Ref<MouseEvent> createForBindings() { return adoptRef(*new MouseEvent); }
+    static Ref<MouseEvent> createForBindings();
 
     static Ref<MouseEvent> create(const AtomString& eventType, const MouseEventInit&);
 
@@ -89,17 +89,17 @@ public:
     unsigned which() const final;
 
 protected:
-    MouseEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
+    MouseEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
         const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         EventTarget* relatedTarget, double force, SyntheticClickType, IsSimulated, IsTrusted);
 
-    MouseEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, RefPtr<WindowProxy>&&, int detail,
+    MouseEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, RefPtr<WindowProxy>&&, int detail,
         const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         SyntheticClickType, EventTarget* relatedTarget);
 
-    MouseEvent(const AtomString& type, const MouseEventInit&);
+    MouseEvent(enum EventInterfaceType, const AtomString& type, const MouseEventInit&);
 
-    MouseEvent();
+    MouseEvent(enum EventInterfaceType);
 
 private:
     bool isMouseEvent() const final;

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -38,10 +38,21 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(MouseRelatedEvent);
 
-MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
+// FIXME: Remove this variant.
+MouseRelatedEvent::MouseRelatedEvent()
+    : UIEventWithKeyState(EventInterfaceType::Invalid)
+{
+}
+
+MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface)
+    : UIEventWithKeyState(eventInterface)
+{
+}
+
+MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
     const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, IsSimulated isSimulated, IsTrusted isTrusted)
-    : UIEventWithKeyState(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, modifiers, isTrusted)
+    : UIEventWithKeyState(eventInterface, eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, modifiers, isTrusted)
     , m_screenLocation(screenLocation)
     , m_movementX(movementX)
     , m_movementY(movementY)
@@ -50,20 +61,42 @@ MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, CanBubble canB
     init(m_isSimulated, windowLocation);
 }
 
-MouseRelatedEvent::MouseRelatedEvent(const AtomString& type, IsCancelable isCancelable, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, const IntPoint& globalLocation, OptionSet<Modifier> modifiers)
-    : MouseRelatedEvent(type, CanBubble::Yes, isCancelable, IsComposed::Yes, timestamp,
+// FIXME: Remove this variant.
+MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
+    MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, IsSimulated isSimulated, IsTrusted isTrusted)
+    : MouseRelatedEvent(EventInterfaceType::Invalid, eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation,
+        movementX, movementY, modifiers, isSimulated, isTrusted)
+{
+}
+
+MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, const AtomString& type, IsCancelable isCancelable, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, const IntPoint& globalLocation, OptionSet<Modifier> modifiers)
+    : MouseRelatedEvent(eventInterface, type, CanBubble::Yes, isCancelable, IsComposed::Yes, timestamp,
         WTFMove(view), 0, globalLocation, globalLocation /* Converted in init */, 0, 0, modifiers, IsSimulated::No)
 {
 }
 
-MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, const MouseRelatedEventInit& initializer, IsTrusted isTrusted)
-    : UIEventWithKeyState(eventType, initializer)
+// FIXME: Remove this variant.
+MouseRelatedEvent::MouseRelatedEvent(const AtomString& type, IsCancelable isCancelable, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, const IntPoint& globalLocation, OptionSet<Modifier> modifiers)
+    : MouseRelatedEvent(EventInterfaceType::Invalid, type, CanBubble::Yes, isCancelable, IsComposed::Yes, timestamp,
+        WTFMove(view), 0, globalLocation, globalLocation /* Converted in init */, 0, 0, modifiers, IsSimulated::No)
+{
+}
+
+MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const MouseRelatedEventInit& initializer, IsTrusted isTrusted)
+    : UIEventWithKeyState(eventInterface, eventType, initializer)
     , m_screenLocation(IntPoint(initializer.screenX, initializer.screenY))
     , m_movementX(initializer.movementX)
     , m_movementY(initializer.movementY)
 {
     ASSERT_UNUSED(isTrusted, isTrusted == IsTrusted::No);
     init(false, IntPoint(0, 0));
+}
+
+// FIXME: Remove this variant.
+MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, const MouseRelatedEventInit& initializer, IsTrusted isTrusted)
+    : MouseRelatedEvent(EventInterfaceType::Invalid, eventType, initializer, isTrusted)
+{
 }
 
 static inline bool isMoveEventType(const AtomString& eventType)

--- a/Source/WebCore/dom/MouseRelatedEvent.h
+++ b/Source/WebCore/dom/MouseRelatedEvent.h
@@ -75,11 +75,17 @@ public:
     static LayoutPoint pagePointToAbsolutePoint(LayoutPoint pagePoint, LocalFrameView*);
 
 protected:
-    MouseRelatedEvent() = default;
+    MouseRelatedEvent(enum EventInterfaceType);
+    MouseRelatedEvent();
+    MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime, RefPtr<WindowProxy>&&, int detail,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers,
+        IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
     MouseRelatedEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime, RefPtr<WindowProxy>&&, int detail,
         const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers,
         IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
     MouseRelatedEvent(const AtomString& type, IsCancelable, MonotonicTime, RefPtr<WindowProxy>&&, const IntPoint& globalLocation, OptionSet<Modifier>);
+    MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, IsCancelable, MonotonicTime, RefPtr<WindowProxy>&&, const IntPoint& globalLocation, OptionSet<Modifier>);
+    MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, const MouseRelatedEventInit&, IsTrusted = IsTrusted::No);
     MouseRelatedEvent(const AtomString& type, const MouseRelatedEventInit&, IsTrusted = IsTrusted::No);
 
     void initCoordinates();

--- a/Source/WebCore/dom/MutationEvent.cpp
+++ b/Source/WebCore/dom/MutationEvent.cpp
@@ -29,8 +29,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(MutationEvent);
 
+MutationEvent::MutationEvent()
+    : Event(EventInterfaceType::MutationEvent)
+{
+}
+
 MutationEvent::MutationEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, Node* relatedNode, const String& prevValue, const String& newValue)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::MutationEvent, type, canBubble, cancelable)
     , m_relatedNode(relatedNode)
     , m_prevValue(prevValue)
     , m_newValue(newValue)

--- a/Source/WebCore/dom/MutationEvent.h
+++ b/Source/WebCore/dom/MutationEvent.h
@@ -56,7 +56,7 @@ public:
     unsigned short attrChange() const { return m_attrChange; }
 
 private:
-    MutationEvent() = default;
+    MutationEvent();
     MutationEvent(const AtomString& type, CanBubble, IsCancelable, Node* relatedNode, const String& prevValue, const String& newValue);
 
     EventInterface eventInterface() const final;

--- a/Source/WebCore/dom/OverflowEvent.cpp
+++ b/Source/WebCore/dom/OverflowEvent.cpp
@@ -34,14 +34,15 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(OverflowEvent);
 
 OverflowEvent::OverflowEvent()
-    : m_orient(VERTICAL)
+    : Event(EventInterfaceType::OverflowEvent)
+    , m_orient(VERTICAL)
     , m_horizontalOverflow(false)
     , m_verticalOverflow(false)
 {
 }
 
 OverflowEvent::OverflowEvent(bool horizontalOverflowChanged, bool horizontalOverflow, bool verticalOverflowChanged, bool verticalOverflow)
-    : Event(eventNames().overflowchangedEvent, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::OverflowEvent, eventNames().overflowchangedEvent, CanBubble::No, IsCancelable::No)
     , m_horizontalOverflow(horizontalOverflow)
     , m_verticalOverflow(verticalOverflow)
 {
@@ -56,7 +57,7 @@ OverflowEvent::OverflowEvent(bool horizontalOverflowChanged, bool horizontalOver
 }
 
 OverflowEvent::OverflowEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::OverflowEvent, type, initializer, isTrusted)
     , m_orient(initializer.orient)
     , m_horizontalOverflow(initializer.horizontalOverflow)
     , m_verticalOverflow(initializer.verticalOverflow)

--- a/Source/WebCore/dom/PageTransitionEvent.cpp
+++ b/Source/WebCore/dom/PageTransitionEvent.cpp
@@ -33,13 +33,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(PageTransitionEvent);
 
 PageTransitionEvent::PageTransitionEvent(const AtomString& type, bool persisted)
-    : Event(type, CanBubble::Yes, IsCancelable::Yes)
+    : Event(EventInterfaceType::PageTransitionEvent, type, CanBubble::Yes, IsCancelable::Yes)
     , m_persisted(persisted)
 {
 }
 
 PageTransitionEvent::PageTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::PageTransitionEvent, type, initializer, isTrusted)
     , m_persisted(initializer.persisted)
 {
 }

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -76,10 +76,13 @@ Ref<PointerEvent> PointerEvent::create(const AtomString& type, PointerID pointer
     return adoptRef(*new PointerEvent(type, pointerId, pointerType, isPrimary));
 }
 
-PointerEvent::PointerEvent() = default;
+PointerEvent::PointerEvent()
+    : MouseEvent(EventInterfaceType::PointerEvent)
+{
+}
 
 PointerEvent::PointerEvent(const AtomString& type, Init&& initializer)
-    : MouseEvent(type, initializer)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, initializer)
     , m_pointerId(initializer.pointerId)
     , m_width(initializer.width)
     , m_height(initializer.height)
@@ -94,7 +97,7 @@ PointerEvent::PointerEvent(const AtomString& type, Init&& initializer)
 }
 
 PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
-    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), mouseEvent.view(), mouseEvent.detail(), mouseEvent.screenLocation(),
+    : MouseEvent(EventInterfaceType::PointerEvent, type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), mouseEvent.view(), mouseEvent.detail(), mouseEvent.screenLocation(),
         { mouseEvent.clientX(), mouseEvent.clientY() }, mouseEvent.movementX(), mouseEvent.movementY(), mouseEvent.modifierKeys(), button, mouseEvent.buttons(),
         mouseEvent.syntheticClickType(), mouseEvent.relatedTarget())
     , m_pointerId(pointerId)
@@ -107,7 +110,7 @@ PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const Mou
 }
 
 PointerEvent::PointerEvent(const AtomString& type, PointerID pointerId, const String& pointerType, IsPrimary isPrimary)
-    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, 0, 0, { }, buttonForType(type), buttonsForType(type), SyntheticClickType::NoTap, nullptr)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, 0, 0, { }, buttonForType(type), buttonsForType(type), SyntheticClickType::NoTap, nullptr)
     , m_pointerId(pointerId)
     // FIXME: This may be wrong because we can create an event from a pressure sensitive device.
     // We don't have a backing MouseEvent to consult pressure/force information from, though, so let's do the next best thing.

--- a/Source/WebCore/dom/PopStateEvent.cpp
+++ b/Source/WebCore/dom/PopStateEvent.cpp
@@ -36,15 +36,20 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(PopStateEvent);
 
+PopStateEvent::PopStateEvent()
+    : Event(EventInterfaceType::PopStateEvent)
+{
+}
+
 PopStateEvent::PopStateEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::PopStateEvent, type, initializer, isTrusted)
     , m_state(initializer.state)
     , m_hasUAVisualTransition(initializer.hasUAVisualTransition)
 {
 }
 
 PopStateEvent::PopStateEvent(RefPtr<SerializedScriptValue>&& serializedState, History* history)
-    : Event(eventNames().popstateEvent, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::PopStateEvent, eventNames().popstateEvent, CanBubble::No, IsCancelable::No)
     , m_serializedState(WTFMove(serializedState))
     , m_history(history)
 {

--- a/Source/WebCore/dom/PopStateEvent.h
+++ b/Source/WebCore/dom/PopStateEvent.h
@@ -59,7 +59,7 @@ public:
     bool hasUAVisualTransition() const { return m_hasUAVisualTransition; }
 
 private:
-    PopStateEvent() = default;
+    PopStateEvent();
     PopStateEvent(const AtomString&, const Init&, IsTrusted);
     PopStateEvent(RefPtr<SerializedScriptValue>&&, History*);
 

--- a/Source/WebCore/dom/ProgressEvent.cpp
+++ b/Source/WebCore/dom/ProgressEvent.cpp
@@ -32,16 +32,16 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ProgressEvent);
 
-ProgressEvent::ProgressEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+ProgressEvent::ProgressEvent(enum EventInterfaceType eventInterface, const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+    : Event(eventInterface, type, initializer, isTrusted)
     , m_lengthComputable(initializer.lengthComputable)
     , m_loaded(initializer.loaded)
     , m_total(initializer.total)
 {
 }
 
-ProgressEvent::ProgressEvent(const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total)
-    : Event(type, CanBubble::No, IsCancelable::No)
+ProgressEvent::ProgressEvent(enum EventInterfaceType eventInterface, const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total)
+    : Event(eventInterface, type, CanBubble::No, IsCancelable::No)
     , m_lengthComputable(lengthComputable)
     , m_loaded(loaded)
     , m_total(total)

--- a/Source/WebCore/dom/ProgressEvent.h
+++ b/Source/WebCore/dom/ProgressEvent.h
@@ -34,7 +34,7 @@ class ProgressEvent : public Event {
 public:
     static Ref<ProgressEvent> create(const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total)
     {
-        return adoptRef(*new ProgressEvent(type, lengthComputable, loaded, total));
+        return adoptRef(*new ProgressEvent(EventInterfaceType::ProgressEvent, type, lengthComputable, loaded, total));
     }
 
     struct Init : EventInit {
@@ -45,7 +45,7 @@ public:
 
     static Ref<ProgressEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new ProgressEvent(type, initializer, isTrusted));
+        return adoptRef(*new ProgressEvent(EventInterfaceType::ProgressEvent, type, initializer, isTrusted));
     }
 
     bool lengthComputable() const { return m_lengthComputable; }
@@ -55,8 +55,8 @@ public:
     EventInterface eventInterface() const override;
 
 protected:
-    ProgressEvent(const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total);
-    ProgressEvent(const AtomString&, const Init&, IsTrusted);
+    ProgressEvent(enum EventInterfaceType, const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total);
+    ProgressEvent(enum EventInterfaceType, const AtomString&, const Init&, IsTrusted);
 
 private:
     bool m_lengthComputable;

--- a/Source/WebCore/dom/PromiseRejectionEvent.cpp
+++ b/Source/WebCore/dom/PromiseRejectionEvent.cpp
@@ -38,7 +38,7 @@ using namespace JSC;
 WTF_MAKE_ISO_ALLOCATED_IMPL(PromiseRejectionEvent);
 
 PromiseRejectionEvent::PromiseRejectionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::PromiseRejectionEvent, type, initializer, isTrusted)
     , m_promise(*(initializer.promise))
     , m_reason(initializer.reason)
 {

--- a/Source/WebCore/dom/ScopedEventQueue.cpp
+++ b/Source/WebCore/dom/ScopedEventQueue.cpp
@@ -56,7 +56,7 @@ void ScopedEventQueue::enqueueEvent(Ref<Event>&& event)
 
 void ScopedEventQueue::dispatchEvent(const ScopedEvent& event) const
 {
-    if (event.event->eventInterface() == MutationEventInterfaceType && event.target->isInShadowTree())
+    if (event.event->interfaceType() == EventInterfaceType::MutationEvent && event.target->isInShadowTree())
         return;
     Ref { event.target.get() }->dispatchEvent(event.event);
 }

--- a/Source/WebCore/dom/SecurityPolicyViolationEvent.h
+++ b/Source/WebCore/dom/SecurityPolicyViolationEvent.h
@@ -76,11 +76,12 @@ public:
 
 private:
     SecurityPolicyViolationEvent()
+        : Event(EventInterfaceType::SecurityPolicyViolationEvent)
     {
     }
 
     SecurityPolicyViolationEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-        : Event(type, initializer, isTrusted)
+        : Event(EventInterfaceType::SecurityPolicyViolationEvent, type, initializer, isTrusted)
         , m_documentURI(initializer.documentURI)
         , m_referrer(initializer.referrer)
         , m_blockedURI(initializer.blockedURI)

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -48,7 +48,7 @@ public:
 
 private:
     SimulatedMouseEvent(const AtomString& eventType, RefPtr<WindowProxy>&& view, RefPtr<Event>&& underlyingEvent, Element& target, SimulatedClickSource source)
-        : MouseEvent(eventType, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes,
+        : MouseEvent(EventInterfaceType::MouseEvent, eventType, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes,
             underlyingEvent ? underlyingEvent->timeStamp() : MonotonicTime::now(), WTFMove(view), /* detail */ 0,
             { }, { }, 0, 0, modifiersFromUnderlyingEvent(underlyingEvent), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::Yes,
             source == SimulatedClickSource::UserAgent ? IsTrusted::Yes : IsTrusted::No)

--- a/Source/WebCore/dom/TextEvent.cpp
+++ b/Source/WebCore/dom/TextEvent.cpp
@@ -67,7 +67,7 @@ Ref<TextEvent> TextEvent::createForDictation(RefPtr<WindowProxy>&& view, const S
 }
 
 TextEvent::TextEvent()
-    : m_inputType(TextEventInputKeyboard)
+    : UIEvent(EventInterfaceType::TextEvent)
     , m_shouldSmartReplace(false)
     , m_shouldMatchStyle(false)
     , m_mailBlockquoteHandling(MailBlockquoteHandling::RespectBlockquote)
@@ -75,7 +75,7 @@ TextEvent::TextEvent()
 }
 
 TextEvent::TextEvent(RefPtr<WindowProxy>&& view, const String& data, TextEventInputType inputType)
-    : UIEvent(eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
+    : UIEvent(EventInterfaceType::TextEvent, eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
     , m_inputType(inputType)
     , m_data(data)
     , m_shouldSmartReplace(false)
@@ -85,7 +85,7 @@ TextEvent::TextEvent(RefPtr<WindowProxy>&& view, const String& data, TextEventIn
 }
 
 TextEvent::TextEvent(RefPtr<WindowProxy>&& view, const String& data, RefPtr<DocumentFragment>&& pastingFragment, TextEventInputType inputType, bool shouldSmartReplace, bool shouldMatchStyle, MailBlockquoteHandling mailBlockquoteHandling)
-    : UIEvent(eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
+    : UIEvent(EventInterfaceType::TextEvent, eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
     , m_inputType(inputType)
     , m_data(data)
     , m_pastingFragment(WTFMove(pastingFragment))
@@ -96,7 +96,7 @@ TextEvent::TextEvent(RefPtr<WindowProxy>&& view, const String& data, RefPtr<Docu
 }
 
 TextEvent::TextEvent(RefPtr<WindowProxy>&& view, const String& data, const Vector<DictationAlternative>& dictationAlternatives)
-    : UIEvent(eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
+    : UIEvent(EventInterfaceType::TextEvent, eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
     , m_inputType(TextEventInputDictation)
     , m_data(data)
     , m_shouldSmartReplace(false)

--- a/Source/WebCore/dom/ToggleEvent.cpp
+++ b/Source/WebCore/dom/ToggleEvent.cpp
@@ -32,15 +32,20 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ToggleEvent);
 
+ToggleEvent::ToggleEvent()
+    : Event(EventInterfaceType::ToggleEvent)
+{
+}
+
 ToggleEvent::ToggleEvent(const AtomString& type, const ToggleEvent::Init& initializer, Event::IsCancelable cancelable)
-    : Event(type, Event::CanBubble::No, cancelable, Event::IsComposed::No)
+    : Event(EventInterfaceType::ToggleEvent, type, Event::CanBubble::No, cancelable, Event::IsComposed::No)
     , m_oldState(initializer.oldState)
     , m_newState(initializer.newState)
 {
 }
 
 ToggleEvent::ToggleEvent(const AtomString& type, const ToggleEvent::Init& initializer)
-    : Event(type, initializer, IsTrusted::No)
+    : Event(EventInterfaceType::ToggleEvent, type, initializer, IsTrusted::No)
     , m_oldState(initializer.oldState)
     , m_newState(initializer.newState)
 {

--- a/Source/WebCore/dom/ToggleEvent.h
+++ b/Source/WebCore/dom/ToggleEvent.h
@@ -46,7 +46,7 @@ public:
     String newState() const { return m_newState; }
 
 private:
-    ToggleEvent() = default;
+    ToggleEvent();
     ToggleEvent(const AtomString&, const Init&, Event::IsCancelable);
     ToggleEvent(const AtomString&, const Init&);
 

--- a/Source/WebCore/dom/UIEvent.cpp
+++ b/Source/WebCore/dom/UIEvent.cpp
@@ -31,27 +31,28 @@ namespace WebCore {
     
 WTF_MAKE_ISO_ALLOCATED_IMPL(UIEvent);
 
-UIEvent::UIEvent()
-    : m_detail(0)
+UIEvent::UIEvent(enum EventInterfaceType eventInterface)
+    : Event(eventInterface)
+    , m_detail(0)
 {
 }
 
-UIEvent::UIEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, RefPtr<WindowProxy>&& viewArg, int detailArg)
-    : Event(eventType, canBubble, isCancelable, isComposed)
+UIEvent::UIEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, RefPtr<WindowProxy>&& viewArg, int detailArg)
+    : Event(eventInterface, eventType, canBubble, isCancelable, isComposed)
     , m_view(WTFMove(viewArg))
     , m_detail(detailArg)
 {
 }
 
-UIEvent::UIEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& viewArg, int detailArg, IsTrusted isTrusted)
-    : Event(eventType, canBubble, isCancelable, isComposed, timestamp, isTrusted)
+UIEvent::UIEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& viewArg, int detailArg, IsTrusted isTrusted)
+    : Event(eventInterface, eventType, canBubble, isCancelable, isComposed, timestamp, isTrusted)
     , m_view(WTFMove(viewArg))
     , m_detail(detailArg)
 {
 }
 
-UIEvent::UIEvent(const AtomString& eventType, const UIEventInit& initializer, IsTrusted isTrusted)
-    : Event(eventType, initializer, isTrusted)
+UIEvent::UIEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const UIEventInit& initializer, IsTrusted isTrusted)
+    : Event(eventInterface, eventType, initializer, isTrusted)
     , m_view(initializer.view.get())
     , m_detail(initializer.detail)
 {

--- a/Source/WebCore/dom/UIEvent.h
+++ b/Source/WebCore/dom/UIEvent.h
@@ -38,15 +38,15 @@ class UIEvent : public Event {
 public:
     static Ref<UIEvent> create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, RefPtr<WindowProxy>&& view, int detail)
     {
-        return adoptRef(*new UIEvent(type, canBubble, isCancelable, isComposed, WTFMove(view), detail));
+        return adoptRef(*new UIEvent(EventInterfaceType::UIEvent, type, canBubble, isCancelable, isComposed, WTFMove(view), detail));
     }
     static Ref<UIEvent> createForBindings()
     {
-        return adoptRef(*new UIEvent);
+        return adoptRef(*new UIEvent(EventInterfaceType::UIEvent));
     }
     static Ref<UIEvent> create(const AtomString& type, const UIEventInit& initializer, IsTrusted = IsTrusted::No)
     {
-        return adoptRef(*new UIEvent(type, initializer));
+        return adoptRef(*new UIEvent(EventInterfaceType::UIEvent, type, initializer));
     }
     virtual ~UIEvent();
 
@@ -66,11 +66,11 @@ public:
     virtual unsigned which() const;
 
 protected:
-    UIEvent();
+    UIEvent(enum EventInterfaceType);
 
-    UIEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, RefPtr<WindowProxy>&&, int detail);
-    UIEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail, IsTrusted = IsTrusted::Yes);
-    UIEvent(const AtomString&, const UIEventInit&, IsTrusted = IsTrusted::No);
+    UIEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, RefPtr<WindowProxy>&&, int detail);
+    UIEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail, IsTrusted = IsTrusted::Yes);
+    UIEvent(enum EventInterfaceType, const AtomString&, const UIEventInit&, IsTrusted = IsTrusted::No);
 
 private:
     bool isUIEvent() const final;

--- a/Source/WebCore/dom/UIEventWithKeyState.h
+++ b/Source/WebCore/dom/UIEventWithKeyState.h
@@ -45,24 +45,27 @@ public:
     WEBCORE_EXPORT bool getModifierState(const String& keyIdentifier) const;
 
 protected:
-    UIEventWithKeyState() = default;
+    UIEventWithKeyState(enum EventInterfaceType eventInterface)
+        : UIEvent(eventInterface)
+    {
+    }
 
-    UIEventWithKeyState(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, IsComposed isComposed,
+    UIEventWithKeyState(enum EventInterfaceType eventInterface, const AtomString& type, CanBubble canBubble, IsCancelable cancelable, IsComposed isComposed,
         RefPtr<WindowProxy>&& view, int detail, OptionSet<Modifier> modifiers)
-        : UIEvent(type, canBubble, cancelable, isComposed, WTFMove(view), detail)
+        : UIEvent(eventInterface, type, canBubble, cancelable, isComposed, WTFMove(view), detail)
         , m_modifiers(modifiers)
     {
     }
 
-    UIEventWithKeyState(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, IsComposed isComposed,
+    UIEventWithKeyState(enum EventInterfaceType eventInterface, const AtomString& type, CanBubble canBubble, IsCancelable cancelable, IsComposed isComposed,
         MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail, OptionSet<Modifier> modifiers, IsTrusted isTrusted)
-        : UIEvent(type, canBubble, cancelable, isComposed, timestamp, WTFMove(view), detail, isTrusted)
+        : UIEvent(eventInterface, type, canBubble, cancelable, isComposed, timestamp, WTFMove(view), detail, isTrusted)
         , m_modifiers(modifiers)
     {
     }
 
-    UIEventWithKeyState(const AtomString& type, const EventModifierInit& initializer, IsTrusted isTrusted = IsTrusted::No)
-        : UIEvent(type, initializer, isTrusted)
+    UIEventWithKeyState(enum EventInterfaceType eventInterface, const AtomString& type, const EventModifierInit& initializer, IsTrusted isTrusted = IsTrusted::No)
+        : UIEvent(eventInterface, type, initializer, isTrusted)
         , m_modifiers(modifiersFromInitializer(initializer))
     {
     }

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -48,10 +48,13 @@ static double wheelDeltaToDelta(int wheelDelta)
     return -static_cast<double>(wheelDelta);
 }
 
-inline WheelEvent::WheelEvent() = default;
+inline WheelEvent::WheelEvent()
+    : MouseEvent(EventInterfaceType::WheelEvent)
+{
+}
 
 inline WheelEvent::WheelEvent(const AtomString& type, const Init& initializer)
-    : MouseEvent(type, initializer)
+    : MouseEvent(EventInterfaceType::WheelEvent, type, initializer)
     , m_wheelDelta(initializer.wheelDeltaX ? initializer.wheelDeltaX : clampTo<int>(-initializer.deltaX), initializer.wheelDeltaY ? initializer.wheelDeltaY : clampTo<int>(-initializer.deltaY))
     , m_deltaX(initializer.deltaX ? initializer.deltaX : wheelDeltaToDelta(initializer.wheelDeltaX))
     , m_deltaY(initializer.deltaY ? initializer.deltaY : wheelDeltaToDelta(initializer.wheelDeltaY))
@@ -61,7 +64,7 @@ inline WheelEvent::WheelEvent(const AtomString& type, const Init& initializer)
 }
 
 inline WheelEvent::WheelEvent(const PlatformWheelEvent& event, RefPtr<WindowProxy>&& view, IsCancelable isCancelable)
-    : MouseEvent(eventNames().wheelEvent, CanBubble::Yes, isCancelable, IsComposed::Yes, event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
+    : MouseEvent(EventInterfaceType::WheelEvent, eventNames().wheelEvent, CanBubble::Yes, isCancelable, IsComposed::Yes, event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
         event.globalPosition(), event.position() , 0, 0, event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes)
     , m_wheelDelta(event.wheelTicksX() * TickMultiplier, event.wheelTicksY() * TickMultiplier)
     , m_deltaX(-event.deltaX())

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -51,7 +51,7 @@ static AtomString mouseEventType(PlatformTouchPoint::TouchPhaseType phase)
 
 Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned index, Ref<WindowProxy>&& view, IsCancelable cancelable)
 {
-    return adoptRef(*new MouseEvent(mouseEventType(event.touchPhaseAtIndex(index)), CanBubble::Yes, cancelable, IsComposed::Yes,
+    return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, mouseEventType(event.touchPhaseAtIndex(index)), CanBubble::Yes, cancelable, IsComposed::Yes,
         event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), 0, 0,
         event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes));
 }

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -63,7 +63,7 @@ Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTou
 }
 
 PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
-    : MouseEvent(type, typeCanBubble(type), isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
+    : MouseEvent(EventInterfaceType::PointerEvent, type, typeCanBubble(type), isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
         event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchIdentifierAtIndex(index))
     , m_width(2 * event.radiusXAtIndex(index))

--- a/Source/WebCore/dom/make_event_factory.pl
+++ b/Source/WebCore/dom/make_event_factory.pl
@@ -98,7 +98,10 @@ sub generateImplementation()
     if ($factoryFunction eq "toNewlyCreated") {
         print F "JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<${namespace}>&& impl)\n";
         print F "{\n";
-        print F "    switch (impl->${interfaceMethodName}()) {\n";
+        print F "    switch (impl->interfaceType()) {\n";
+        print F "    case EventInterfaceType::Invalid:\n";
+        print F "        ASSERT_NOT_REACHED();\n";
+        print F "        break;\n";
     } else {
         print F "JSC::JSValue toJS(JSC::JSGlobalObject* state, JSDOMGlobalObject* globalObject, ${namespace}& impl)\n";
         print F "{\n";
@@ -125,10 +128,11 @@ sub generateImplementation()
             my $conditionals = "#if ENABLE(" . join(") || ENABLE(", split("\\|", $conditional)) . ")";
             print F "$conditionals\n";
         }
-        print F "    case ${interfaceName}${suffix}InterfaceType:\n";
         if ($factoryFunction eq "toNewlyCreated") {
+            print F "    case EventInterfaceType::${interfaceName}:\n";
             print F "        return createWrapper<$interfaceName$suffix>(globalObject, WTFMove(impl));\n";
         } else {
+            print F "    case ${interfaceName}${suffix}InterfaceType:\n";
             print F "        return toJS(state, globalObject, static_cast<$interfaceName&>(impl));\n";
         }
         print F "#endif\n" if $conditional;

--- a/Source/WebCore/dom/wpe/PointerEventWPE.cpp
+++ b/Source/WebCore/dom/wpe/PointerEventWPE.cpp
@@ -66,7 +66,7 @@ Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTou
 }
 
 PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
-    : MouseEvent(type, typeCanBubble(type), isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, typeCanBubble(type), isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchPoints().at(index).id())
     , m_width(2 * event.touchPoints().at(index).radiusX())
     , m_height(2 * event.touchPoints().at(index).radiusY())

--- a/Source/WebCore/html/MediaEncryptedEvent.cpp
+++ b/Source/WebCore/html/MediaEncryptedEvent.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(MediaEncryptedEvent);
 
 MediaEncryptedEvent::MediaEncryptedEvent(const AtomString& type, const MediaEncryptedEventInit& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::MediaEncryptedEvent, type, initializer, isTrusted)
     , m_initDataType(initializer.initDataType)
     , m_initData(initializer.initData)
 {

--- a/Source/WebCore/html/SubmitEvent.cpp
+++ b/Source/WebCore/html/SubmitEvent.cpp
@@ -45,12 +45,12 @@ Ref<SubmitEvent> SubmitEvent::create(RefPtr<HTMLElement>&& submitter)
 }
 
 SubmitEvent::SubmitEvent(const AtomString& type, Init&& init)
-    : Event(type, init, IsTrusted::No)
+    : Event(EventInterfaceType::SubmitEvent, type, init, IsTrusted::No)
     , m_submitter(WTFMove(init.submitter))
 { }
 
 SubmitEvent::SubmitEvent(RefPtr<HTMLElement>&& submitter)
-    : Event(eventNames().submitEvent, CanBubble::Yes, IsCancelable::Yes)
+    : Event(EventInterfaceType::SubmitEvent, eventNames().submitEvent, CanBubble::Yes, IsCancelable::Yes)
     , m_submitter(WTFMove(submitter))
 { }
 

--- a/Source/WebCore/html/canvas/WebGLContextEvent.cpp
+++ b/Source/WebCore/html/canvas/WebGLContextEvent.cpp
@@ -35,13 +35,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLContextEvent);
 
 WebGLContextEvent::WebGLContextEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, const String& statusMessage)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::WebGLContextEvent, type, canBubble, cancelable)
     , m_statusMessage(statusMessage)
 {
 }
 
 WebGLContextEvent::WebGLContextEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::WebGLContextEvent, type, initializer, isTrusted)
     , m_statusMessage(initializer.statusMessage)
 {
 }

--- a/Source/WebCore/html/track/TrackEvent.cpp
+++ b/Source/WebCore/html/track/TrackEvent.cpp
@@ -52,13 +52,13 @@ static inline std::optional<TrackEvent::TrackEventTrack> convertToTrackEventTrac
 }
 
 TrackEvent::TrackEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, Ref<TrackBase>&& track)
-    : Event(type, canBubble, cancelable)
+    : Event(EventInterfaceType::TrackEvent, type, canBubble, cancelable)
     , m_track(convertToTrackEventTrack(WTFMove(track)))
 {
 }
 
 TrackEvent::TrackEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::TrackEvent, type, initializer, isTrusted)
     , m_track(WTFMove(initializer.track))
 {
 }

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigateEvent);
 
 NavigateEvent::NavigateEvent(const AtomString& type, const NavigateEvent::Init& init)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::NavigateEvent, type, CanBubble::No, IsCancelable::No)
     , m_navigationType(init.navigationType)
     , m_destination(init.destination)
     , m_signal(init.signal)

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationCurrentEntryChangeEvent);
 
 NavigationCurrentEntryChangeEvent::NavigationCurrentEntryChangeEvent(const AtomString& type, const NavigationCurrentEntryChangeEvent::Init& init)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::NavigationCurrentEntryChangeEvent, type, CanBubble::No, IsCancelable::No)
     , m_navigationType(init.navigationType)
     , m_from(init.from)
 {

--- a/Source/WebCore/storage/StorageEvent.cpp
+++ b/Source/WebCore/storage/StorageEvent.cpp
@@ -38,8 +38,6 @@ Ref<StorageEvent> StorageEvent::createForBindings()
     return adoptRef(*new StorageEvent);
 }
 
-StorageEvent::StorageEvent() = default;
-
 StorageEvent::~StorageEvent() = default;
 
 Ref<StorageEvent> StorageEvent::create(const AtomString& type, const String& key, const String& oldValue, const String& newValue, const String& url, Storage* storageArea)
@@ -52,8 +50,13 @@ Ref<StorageEvent> StorageEvent::create(const AtomString& type, const Init& initi
     return adoptRef(*new StorageEvent(type, initializer, isTrusted));
 }
 
+StorageEvent::StorageEvent()
+    : Event(EventInterfaceType::StorageEvent)
+{
+}
+
 StorageEvent::StorageEvent(const AtomString& type, const String& key, const String& oldValue, const String& newValue, const String& url, Storage* storageArea)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(EventInterfaceType::StorageEvent, type, CanBubble::No, IsCancelable::No)
     , m_key(key)
     , m_oldValue(oldValue)
     , m_newValue(newValue)
@@ -63,7 +66,7 @@ StorageEvent::StorageEvent(const AtomString& type, const String& key, const Stri
 }
 
 StorageEvent::StorageEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(EventInterfaceType::StorageEvent, type, initializer, isTrusted)
     , m_key(initializer.key)
     , m_oldValue(initializer.oldValue)
     , m_newValue(initializer.newValue)

--- a/Source/WebCore/workers/service/ExtendableEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableEvent.cpp
@@ -36,13 +36,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ExtendableEvent);
 
-ExtendableEvent::ExtendableEvent(const AtomString& type, const ExtendableEventInit& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+ExtendableEvent::ExtendableEvent(enum EventInterfaceType eventInterface, const AtomString& type, const ExtendableEventInit& initializer, IsTrusted isTrusted)
+    : Event(eventInterface, type, initializer, isTrusted)
 {
 }
 
-ExtendableEvent::ExtendableEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable)
-    : Event(type, canBubble, cancelable)
+ExtendableEvent::ExtendableEvent(enum EventInterfaceType eventInterface, const AtomString& type, CanBubble canBubble, IsCancelable cancelable)
+    : Event(eventInterface, type, canBubble, cancelable)
 {
 }
 

--- a/Source/WebCore/workers/service/ExtendableEvent.h
+++ b/Source/WebCore/workers/service/ExtendableEvent.h
@@ -38,7 +38,7 @@ class ExtendableEvent : public Event, public CanMakeWeakPtr<ExtendableEvent> {
 public:
     static Ref<ExtendableEvent> create(const AtomString& type, const ExtendableEventInit& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new ExtendableEvent(type, initializer, isTrusted));
+        return adoptRef(*new ExtendableEvent(EventInterfaceType::ExtendableEvent, type, initializer, isTrusted));
     }
 
     ~ExtendableEvent();
@@ -51,8 +51,8 @@ public:
     WEBCORE_EXPORT void whenAllExtendLifetimePromisesAreSettled(Function<void(HashSet<Ref<DOMPromise>>&&)>&&);
 
 protected:
-    WEBCORE_EXPORT ExtendableEvent(const AtomString&, const ExtendableEventInit&, IsTrusted);
-    ExtendableEvent(const AtomString&, CanBubble, IsCancelable);
+    WEBCORE_EXPORT ExtendableEvent(enum EventInterfaceType, const AtomString&, const ExtendableEventInit&, IsTrusted);
+    ExtendableEvent(enum EventInterfaceType, const AtomString&, CanBubble, IsCancelable);
 
     void addExtendLifetimePromise(Ref<DOMPromise>&&);
 

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
@@ -40,7 +40,7 @@ Ref<ExtendableMessageEvent> ExtendableMessageEvent::create(Vector<RefPtr<Message
 }
 
 ExtendableMessageEvent::ExtendableMessageEvent(JSC::JSGlobalObject& state, const AtomString& type, const Init& init, IsTrusted isTrusted)
-    : ExtendableEvent(type, init, isTrusted)
+    : ExtendableEvent(EventInterfaceType::ExtendableMessageEvent, type, init, isTrusted)
     , m_data(SerializedScriptValue::create(state, init.data, SerializationForStorage::No, SerializationErrorMode::NonThrowing))
     , m_origin(init.origin)
     , m_lastEventId(init.lastEventId)
@@ -50,7 +50,7 @@ ExtendableMessageEvent::ExtendableMessageEvent(JSC::JSGlobalObject& state, const
 }
 
 ExtendableMessageEvent::ExtendableMessageEvent(RefPtr<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<ExtendableMessageEventSource>&& source, Vector<RefPtr<MessagePort>>&& ports)
-    : ExtendableEvent(eventNames().messageEvent, CanBubble::No, IsCancelable::No)
+    : ExtendableEvent(EventInterfaceType::ExtendableMessageEvent, eventNames().messageEvent, CanBubble::No, IsCancelable::No)
     , m_data(WTFMove(data))
     , m_origin(origin)
     , m_lastEventId(lastEventId)

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -59,7 +59,7 @@ static inline Ref<DOMPromise> retrieveHandledPromise(JSC::JSGlobalObject& global
 }
 
 FetchEvent::FetchEvent(JSC::JSGlobalObject& globalObject, const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : ExtendableEvent(type, initializer, isTrusted)
+    : ExtendableEvent(EventInterfaceType::FetchEvent, type, initializer, isTrusted)
     , m_request(initializer.request.releaseNonNull())
     , m_clientId(WTFMove(initializer.clientId))
     , m_resultingClientId(WTFMove(initializer.resultingClientId))

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.cpp
@@ -35,11 +35,11 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(BackgroundFetchEvent);
 Ref<BackgroundFetchEvent> BackgroundFetchEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
     auto registration = init.registration;
-    return adoptRef(*new BackgroundFetchEvent(type, WTFMove(init), WTFMove(registration), isTrusted));
+    return adoptRef(*new BackgroundFetchEvent(EventInterfaceType::BackgroundFetchEvent, type, WTFMove(init), WTFMove(registration), isTrusted));
 }
 
-BackgroundFetchEvent::BackgroundFetchEvent(const AtomString& type, ExtendableEventInit&& eventInit, RefPtr<BackgroundFetchRegistration>&& registration, IsTrusted isTrusted)
-    : ExtendableEvent(type, WTFMove(eventInit), isTrusted)
+BackgroundFetchEvent::BackgroundFetchEvent(enum EventInterfaceType eventInterface, const AtomString& type, ExtendableEventInit&& eventInit, RefPtr<BackgroundFetchRegistration>&& registration, IsTrusted isTrusted)
+    : ExtendableEvent(eventInterface, type, WTFMove(eventInit), isTrusted)
     , m_registration(WTFMove(registration))
 {
 }

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h
@@ -43,7 +43,7 @@ public:
     RefPtr<BackgroundFetchRegistration> registration() const;
 
 protected:
-    BackgroundFetchEvent(const AtomString&, ExtendableEventInit&&, RefPtr<BackgroundFetchRegistration>&&, IsTrusted);
+    BackgroundFetchEvent(enum EventInterfaceType, const AtomString&, ExtendableEventInit&&, RefPtr<BackgroundFetchRegistration>&&, IsTrusted);
 
 private:
     RefPtr<BackgroundFetchRegistration> m_registration;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp
@@ -40,7 +40,7 @@ Ref<BackgroundFetchUpdateUIEvent> BackgroundFetchUpdateUIEvent::create(const Ato
 }
 
 BackgroundFetchUpdateUIEvent::BackgroundFetchUpdateUIEvent(const AtomString& type, ExtendableEventInit&& eventInit, RefPtr<BackgroundFetchRegistration>&& registration, IsTrusted isTrusted)
-    : BackgroundFetchEvent(type, WTFMove(eventInit), WTFMove(registration), isTrusted)
+    : BackgroundFetchEvent(EventInterfaceType::BackgroundFetchUpdateUIEvent, type, WTFMove(eventInit), WTFMove(registration), isTrusted)
 {
 }
 

--- a/Source/WebCore/xml/XMLHttpRequestProgressEvent.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEvent.h
@@ -45,7 +45,7 @@ public:
 
 private:
     XMLHttpRequestProgressEvent(const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total)
-        : ProgressEvent(type, lengthComputable, loaded, total)
+        : ProgressEvent(EventInterfaceType::XMLHttpRequestProgressEvent, type, lengthComputable, loaded, total)
     {
     }
 };

--- a/Source/WebKitLegacy/mac/DOM/DOMEvents.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMEvents.mm
@@ -41,21 +41,21 @@ using WebCore::eventNames;
 
 Class kitClass(WebCore::Event* impl)
 {
-    switch (impl->eventInterface()) {
-    case WebCore::KeyboardEventInterfaceType:
+    switch (impl->interfaceType()) {
+    case WebCore::EventInterfaceType::KeyboardEvent:
         return [DOMKeyboardEvent class];
-    case WebCore::MouseEventInterfaceType:
+    case WebCore::EventInterfaceType::MouseEvent:
         return [DOMMouseEvent class];
-    case WebCore::MutationEventInterfaceType:
+    case WebCore::EventInterfaceType::MutationEvent:
         return [DOMMutationEvent class];
-    case WebCore::OverflowEventInterfaceType:
+    case WebCore::EventInterfaceType::OverflowEvent:
         return [DOMOverflowEvent class];
-    case WebCore::ProgressEventInterfaceType:
-    case WebCore::XMLHttpRequestProgressEventInterfaceType:
+    case WebCore::EventInterfaceType::ProgressEvent:
+    case WebCore::EventInterfaceType::XMLHttpRequestProgressEvent:
         return [DOMProgressEvent class];
-    case WebCore::TextEventInterfaceType:
+    case WebCore::EventInterfaceType::TextEvent:
         return [DOMTextEvent class];
-    case WebCore::WheelEventInterfaceType:
+    case WebCore::EventInterfaceType::WheelEvent:
         return [DOMWheelEvent class];
     default:
         if (impl->isUIEvent())


### PR DESCRIPTION
#### bd2795436d8c4c389d30444f2e927919e2520cb8
<pre>
Devirtualize Event::eventInterface
<a href="https://bugs.webkit.org/show_bug.cgi?id=269338">https://bugs.webkit.org/show_bug.cgi?id=269338</a>

Reviewed by Chris Dumez and Yusuke Suzuki.

This PR replaces Event::eventInterface, which is a virtual function, with Event::interfaceType,
which is an inline non-virtual function that reads the value off of m_eventInterface set forth
in the Event constructor. WebKitAdditions&apos; files need to be migrated once this PR lands so they
currently fallback to calling Event::eventInterface (m_eventInterface is set to 0 in this case).

This PR also replaces EventInterface enum with EventInterfaceType enum class. Because one of
the valid values of EventInterface enum is EventInterfaceType (for Event class), we need to
explicitly write `enum EventInterfaceType` for now. The plan is to remove EventInterface once
the code in WebKitAdditions has migrated to use the new code path.

* Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp:
(WebCore::GPUUncapturedErrorEvent::GPUUncapturedErrorEvent):
* Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.cpp:
(WebCore::WebKitPlaybackTargetAvailabilityEvent::WebKitPlaybackTargetAvailabilityEvent):
* Source/WebCore/Modules/applepay/ApplePayCancelEvent.cpp:
(WebCore::ApplePayCancelEvent::ApplePayCancelEvent):
* Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.cpp:
(WebCore::ApplePayCouponCodeChangedEvent::ApplePayCouponCodeChangedEvent):
* Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.cpp:
(WebCore::ApplePayPaymentAuthorizedEvent::ApplePayPaymentAuthorizedEvent):
* Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.cpp:
(WebCore::ApplePayPaymentMethodSelectedEvent::ApplePayPaymentMethodSelectedEvent):
* Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp:
(WebCore::ApplePayShippingContactSelectedEvent::ApplePayShippingContactSelectedEvent):
* Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.cpp:
(WebCore::ApplePayShippingMethodSelectedEvent::ApplePayShippingMethodSelectedEvent):
* Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.cpp:
(WebCore::ApplePayValidateMerchantEvent::ApplePayValidateMerchantEvent):
* Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp:
(WebCore::CookieChangeEvent::CookieChangeEvent):
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp:
(WebCore::ExtendableCookieChangeEvent::ExtendableCookieChangeEvent):
* Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.cpp:
(WebCore::MediaKeyMessageEvent::MediaKeyMessageEvent):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp:
(WebCore::WebKitMediaKeyMessageEvent::WebKitMediaKeyMessageEvent):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp:
(WebCore::WebKitMediaKeyNeededEvent::WebKitMediaKeyNeededEvent):
* Source/WebCore/Modules/gamepad/GamepadEvent.cpp:
(WebCore::GamepadEvent::GamepadEvent):
* Source/WebCore/Modules/indexeddb/IDBRequestCompletionEvent.cpp:
(WebCore::IDBRequestCompletionEvent::IDBRequestCompletionEvent):
* Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.cpp:
(WebCore::IDBVersionChangeEvent::IDBVersionChangeEvent):
* Source/WebCore/Modules/mediarecorder/BlobEvent.cpp:
(WebCore::BlobEvent::BlobEvent):
* Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp:
(WebCore::MediaRecorderErrorEvent::MediaRecorderErrorEvent):
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp:
(WebCore::BufferedChangeEvent::BufferedChangeEvent):
* Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp:
(WebCore::MediaStreamTrackEvent::MediaStreamTrackEvent):
* Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.h:
* Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp:
(WebCore::RTCDTMFToneChangeEvent::RTCDTMFToneChangeEvent):
* Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp:
(WebCore::RTCDataChannelEvent::RTCDataChannelEvent):
* Source/WebCore/Modules/mediastream/RTCErrorEvent.cpp:
(WebCore::RTCErrorEvent::RTCErrorEvent):
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.cpp:
(WebCore::RTCPeerConnectionIceErrorEvent::RTCPeerConnectionIceErrorEvent):
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp:
(WebCore::RTCPeerConnectionIceEvent::RTCPeerConnectionIceEvent):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.cpp:
(WebCore::RTCRtpSFrameTransformErrorEvent::RTCRtpSFrameTransformErrorEvent):
* Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp:
(WebCore::RTCTrackEvent::RTCTrackEvent):
* Source/WebCore/Modules/mediastream/RTCTransformEvent.cpp:
(WebCore::RTCTransformEvent::RTCTransformEvent):
* Source/WebCore/Modules/notifications/NotificationEvent.cpp:
(WebCore::NotificationEvent::NotificationEvent):
* Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp:
(WebCore::MerchantValidationEvent::MerchantValidationEvent):
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp:
(WebCore::PaymentMethodChangeEvent::PaymentMethodChangeEvent):
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp:
(WebCore::PaymentRequestUpdateEvent::PaymentRequestUpdateEvent):
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h:
(WebCore::PaymentRequestUpdateEvent::create):
* Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.cpp:
(WebCore::PictureInPictureEvent::PictureInPictureEvent):
* Source/WebCore/Modules/push-api/PushEvent.cpp:
(WebCore::PushEvent::PushEvent):
* Source/WebCore/Modules/push-api/PushNotificationEvent.cpp:
(WebCore::PushNotificationEvent::PushNotificationEvent):
* Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.cpp:
(WebCore::PushSubscriptionChangeEvent::PushSubscriptionChangeEvent):
* Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp:
(WebCore::SpeechRecognitionErrorEvent::SpeechRecognitionErrorEvent):
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp:
(WebCore::SpeechRecognitionEvent::SpeechRecognitionEvent):
* Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp:
(WebCore::SpeechSynthesisErrorEvent::SpeechSynthesisErrorEvent):
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp:
(WebCore::SpeechSynthesisEvent::create):
(WebCore::SpeechSynthesisEvent::SpeechSynthesisEvent):
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.h:
* Source/WebCore/Modules/webaudio/AudioProcessingEvent.cpp:
(WebCore::AudioProcessingEvent::AudioProcessingEvent):
* Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.cpp:
(WebCore::OfflineAudioCompletionEvent::OfflineAudioCompletionEvent):
* Source/WebCore/Modules/websockets/CloseEvent.h:
* Source/WebCore/Modules/webxr/XRInputSourceEvent.cpp:
(WebCore::XRInputSourceEvent::XRInputSourceEvent):
* Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.cpp:
(WebCore::XRInputSourcesChangeEvent::XRInputSourcesChangeEvent):
* Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.cpp:
(WebCore::XRReferenceSpaceEvent::XRReferenceSpaceEvent):
* Source/WebCore/Modules/webxr/XRSessionEvent.cpp:
(WebCore::XRSessionEvent::XRSessionEvent):
* Source/WebCore/animation/AnimationEventBase.cpp:
(WebCore::AnimationEventBase::AnimationEventBase):
* Source/WebCore/animation/AnimationEventBase.h:
* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
(WebCore::AnimationPlaybackEvent::AnimationPlaybackEvent):
* Source/WebCore/animation/CSSAnimationEvent.cpp:
(WebCore::CSSAnimationEvent::CSSAnimationEvent):
* Source/WebCore/animation/CSSTransitionEvent.cpp:
(WebCore::CSSTransitionEvent::CSSTransitionEvent):
* Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp:
(WebCore::StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent):
* Source/WebCore/animation/StyleOriginatedAnimationEvent.h:
* Source/WebCore/bindings/scripts/InFilesCompiler.pm:
(generateInterfacesHeader):
* Source/WebCore/css/MediaQueryListEvent.cpp:
(WebCore::MediaQueryListEvent::MediaQueryListEvent):
* Source/WebCore/dom/BeforeTextInsertedEvent.cpp:
(WebCore::BeforeTextInsertedEvent::BeforeTextInsertedEvent):
* Source/WebCore/dom/BeforeUnloadEvent.cpp:
(WebCore::BeforeUnloadEvent::BeforeUnloadEvent):
* Source/WebCore/dom/ClipboardEvent.cpp:
(WebCore::ClipboardEvent::ClipboardEvent):
* Source/WebCore/dom/CompositionEvent.cpp:
(WebCore::CompositionEvent::CompositionEvent):
* Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.cpp:
(WebCore::ContentVisibilityAutoStateChangeEvent::ContentVisibilityAutoStateChangeEvent):
* Source/WebCore/dom/CustomEvent.cpp:
(WebCore::CustomEvent::CustomEvent):
* Source/WebCore/dom/DeviceMotionEvent.cpp:
(WebCore::DeviceMotionEvent::DeviceMotionEvent):
* Source/WebCore/dom/DeviceOrientationEvent.cpp:
(WebCore::DeviceOrientationEvent::DeviceOrientationEvent):
* Source/WebCore/dom/DragEvent.cpp:
(WebCore::DragEvent::DragEvent):
* Source/WebCore/dom/ErrorEvent.cpp:
(WebCore::ErrorEvent::ErrorEvent):
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::Event):
(WebCore::Event::create):
(WebCore::Event::createForBindings):
* Source/WebCore/dom/Event.h:
(WebCore::Event::interfaceType):
* Source/WebCore/dom/FocusEvent.cpp:
(WebCore::FocusEvent::FocusEvent):
* Source/WebCore/dom/FocusEvent.h:
* Source/WebCore/dom/FormDataEvent.cpp:
(WebCore::FormDataEvent::FormDataEvent):
* Source/WebCore/dom/HashChangeEvent.h:
* Source/WebCore/dom/InputEvent.cpp:
(WebCore::InputEvent::InputEvent):
* Source/WebCore/dom/InvokeEvent.cpp:
(WebCore::InvokeEvent::InvokeEvent):
* Source/WebCore/dom/InvokeEvent.h:
* Source/WebCore/dom/KeyboardEvent.cpp:
(WebCore::KeyboardEvent::KeyboardEvent):
* Source/WebCore/dom/MessageEvent.cpp:
(WebCore::MessageEvent::MessageEvent):
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::create):
(WebCore::MouseEvent::createForBindings):
(WebCore::MouseEvent::MouseEvent):
* Source/WebCore/dom/MouseEvent.h:
(WebCore::MouseEvent::createForBindings): Deleted.
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::MouseRelatedEvent):
* Source/WebCore/dom/MouseRelatedEvent.h:
* Source/WebCore/dom/MutationEvent.cpp:
(WebCore::MutationEvent::MutationEvent):
* Source/WebCore/dom/MutationEvent.h:
* Source/WebCore/dom/OverflowEvent.cpp:
(WebCore::OverflowEvent::OverflowEvent):
* Source/WebCore/dom/PageTransitionEvent.cpp:
(WebCore::PageTransitionEvent::PageTransitionEvent):
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/PopStateEvent.cpp:
(WebCore::PopStateEvent::PopStateEvent):
* Source/WebCore/dom/PopStateEvent.h:
* Source/WebCore/dom/ProgressEvent.cpp:
(WebCore::ProgressEvent::ProgressEvent):
* Source/WebCore/dom/ProgressEvent.h:
(WebCore::ProgressEvent::create):
* Source/WebCore/dom/PromiseRejectionEvent.cpp:
(WebCore::PromiseRejectionEvent::PromiseRejectionEvent):
* Source/WebCore/dom/ScopedEventQueue.cpp:
(WebCore::ScopedEventQueue::dispatchEvent const):
* Source/WebCore/dom/SecurityPolicyViolationEvent.h:
* Source/WebCore/dom/SimulatedClick.cpp:
* Source/WebCore/dom/TextEvent.cpp:
(WebCore::TextEvent::TextEvent):
* Source/WebCore/dom/ToggleEvent.cpp:
(WebCore::ToggleEvent::ToggleEvent):
* Source/WebCore/dom/ToggleEvent.h:
* Source/WebCore/dom/UIEvent.cpp:
(WebCore::UIEvent::UIEvent):
* Source/WebCore/dom/UIEvent.h:
(WebCore::UIEvent::create):
(WebCore::UIEvent::createForBindings):
* Source/WebCore/dom/UIEventWithKeyState.h:
(WebCore::UIEventWithKeyState::UIEventWithKeyState):
* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::WheelEvent::WheelEvent):
* Source/WebCore/dom/ios/MouseEventIOS.cpp:
(WebCore::MouseEvent::create):
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/make_event_factory.pl:
(generateImplementation):
* Source/WebCore/html/MediaEncryptedEvent.cpp:
(WebCore::MediaEncryptedEvent::MediaEncryptedEvent):
* Source/WebCore/html/SubmitEvent.cpp:
(WebCore::SubmitEvent::SubmitEvent):
* Source/WebCore/html/canvas/WebGLContextEvent.cpp:
(WebCore::WebGLContextEvent::WebGLContextEvent):
* Source/WebCore/html/track/TrackEvent.cpp:
(WebCore::TrackEvent::TrackEvent):
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::NavigateEvent):
* Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp:
(WebCore::NavigationCurrentEntryChangeEvent::NavigationCurrentEntryChangeEvent):
* Source/WebCore/storage/StorageEvent.cpp:
(WebCore::StorageEvent::StorageEvent):
* Source/WebCore/workers/service/ExtendableEvent.cpp:
(WebCore::ExtendableEvent::ExtendableEvent):
* Source/WebCore/workers/service/ExtendableEvent.h:
(WebCore::ExtendableEvent::create):
* Source/WebCore/workers/service/ExtendableMessageEvent.cpp:
(WebCore::ExtendableMessageEvent::ExtendableMessageEvent):
* Source/WebCore/workers/service/FetchEvent.cpp:
(WebCore::FetchEvent::FetchEvent):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.cpp:
(WebCore::BackgroundFetchEvent::create):
(WebCore::BackgroundFetchEvent::BackgroundFetchEvent):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp:
(WebCore::BackgroundFetchUpdateUIEvent::BackgroundFetchUpdateUIEvent):
* Source/WebCore/xml/XMLHttpRequestProgressEvent.h:
* Source/WebKitLegacy/mac/DOM/DOMEvents.mm:
(kitClass):

Canonical link: <a href="https://commits.webkit.org/274913@main">https://commits.webkit.org/274913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e23caa07ac0dbda2a10678d659103713eb2b3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40116 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42661 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36205 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33376 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13933 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39693 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37987 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16550 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9056 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->