### PR TITLE
Add support for the devtools.inspectedWindow Web Extension APIs.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/WebInspectorExtensionController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/WebInspectorExtensionController.js
@@ -139,6 +139,7 @@ WI.WebInspectorExtensionController = class WebInspectorExtensionController exten
             return WI.WebInspectorExtension.ErrorCode.InvalidRequest;
         }
 
+        // FIXME: <https://webkit.org/b/269349> Implement `contextSecurityOrigin` and `useContentScriptContext` options for `devtools.inspectedWindow.eval` command
         if (contextSecurityOrigin) {
             WI.reportInternalError("evaluateScriptForExtension: the 'contextSecurityOrigin' option is not yet implemented.");
             return WI.WebInspectorExtension.ErrorCode.NotImplemented;
@@ -179,7 +180,7 @@ WI.WebInspectorExtensionController = class WebInspectorExtensionController exten
             return WI.WebInspectorExtension.ErrorCode.InvalidRequest;
         }
 
-        // FIXME: <webkit.org/b/222328> Implement `userAgent` and `injectedScript` options for `devtools.inspectedWindow.reload` command
+        // FIXME: <https://webkit.org/b/222328> Implement `userAgent` and `injectedScript` options for `devtools.inspectedWindow.reload` command
         if (userAgent) {
             WI.reportInternalError("reloadForExtension: the 'userAgent' option is not yet implemented.");
             return WI.WebInspectorExtension.ErrorCode.NotImplemented;

--- a/Source/WebKit/Shared/InspectorExtensionTypes.h
+++ b/Source/WebKit/Shared/InspectorExtensionTypes.h
@@ -42,7 +42,8 @@ enum class ExtensionError : uint8_t;
 
 using ExtensionTabID = WTF::String;
 using ExtensionID = WTF::String;
-using ExtensionEvaluationResult = Expected<Expected<RefPtr<API::SerializedScriptValue>, WebCore::ExceptionDetails>, ExtensionError>;
+using ExtensionVoidResult = Expected<void, ExtensionError>;
+using ExtensionEvaluationResult = Expected<Expected<Ref<API::SerializedScriptValue>, WebCore::ExceptionDetails>, ExtensionError>;
 
 enum class ExtensionError : uint8_t {
     ContextDestroyed,

--- a/Source/WebKit/UIProcess/API/APIInspectorExtension.cpp
+++ b/Source/WebKit/UIProcess/API/APIInspectorExtension.cpp
@@ -82,7 +82,7 @@ void InspectorExtension::navigateTab(const Inspector::ExtensionTabID& extensionT
     m_extensionControllerProxy->navigateTabForExtension(extensionTabID, sourceURL, WTFMove(completionHandler));
 }
 
-void InspectorExtension::reloadIgnoringCache(const std::optional<bool>& ignoreCache, const std::optional<WTF::String>& userAgent, const std::optional<WTF::String>& injectedScript,  WTF::CompletionHandler<void(Inspector::ExtensionEvaluationResult)>&& completionHandler)
+void InspectorExtension::reloadIgnoringCache(const std::optional<bool>& ignoreCache, const std::optional<WTF::String>& userAgent, const std::optional<WTF::String>& injectedScript,  WTF::CompletionHandler<void(Inspector::ExtensionVoidResult)>&& completionHandler)
 {
     if (!m_extensionControllerProxy) {
         completionHandler(makeUnexpected(Inspector::ExtensionError::ContextDestroyed));

--- a/Source/WebKit/UIProcess/API/APIInspectorExtension.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorExtension.h
@@ -50,7 +50,7 @@ public:
     void createTab(const WTF::String& tabName, const WTF::URL& tabIconURL, const WTF::URL& sourceURL, WTF::CompletionHandler<void(Expected<Inspector::ExtensionTabID, Inspector::ExtensionError>)>&&);
     void evaluateScript(const WTF::String& scriptSource, const std::optional<WTF::URL>& frameURL, const std::optional<WTF::URL>& contextSecurityOrigin, const std::optional<bool>& useContentScriptContext, WTF::CompletionHandler<void(Inspector::ExtensionEvaluationResult)>&&);
     void navigateTab(const Inspector::ExtensionTabID&, const WTF::URL& sourceURL, WTF::CompletionHandler<void(const std::optional<Inspector::ExtensionError>)>&&);
-    void reloadIgnoringCache(const std::optional<bool>& ignoreCache, const std::optional<WTF::String>& userAgent, const std::optional<WTF::String>& injectedScript, WTF::CompletionHandler<void(Inspector::ExtensionEvaluationResult)>&&);
+    void reloadIgnoringCache(const std::optional<bool>& ignoreCache, const std::optional<WTF::String>& userAgent, const std::optional<WTF::String>& injectedScript, WTF::CompletionHandler<void(Inspector::ExtensionVoidResult)>&&);
 
     // For testing.
     void evaluateScriptInExtensionTab(const Inspector::ExtensionTabID&, const WTF::String& scriptSource, WTF::CompletionHandler<void(Inspector::ExtensionEvaluationResult)>&&);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
@@ -138,15 +138,9 @@
 {
     std::optional<String> optionalUserAgent = userAgent ? std::make_optional(String(userAgent)) : std::nullopt;
     std::optional<String> optionalInjectedScript = injectedScript ? std::make_optional(String(injectedScript)) : std::nullopt;
-    _extension->reloadIgnoringCache(ignoreCache, optionalUserAgent, optionalInjectedScript, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTFMove(completionHandler))] (Inspector::ExtensionEvaluationResult&& result) mutable {
+    _extension->reloadIgnoringCache(ignoreCache, optionalUserAgent, optionalInjectedScript, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTFMove(completionHandler))] (Inspector::ExtensionVoidResult&& result) mutable {
         if (!result) {
             capturedBlock([NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()) }]);
-            return;
-        }
-        
-        auto valueOrException = result.value();
-        if (!valueOrException) {
-            capturedBlock(nsErrorFromExceptionDetails(valueOrException.error()).get());
             return;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -653,6 +653,8 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // DevTools APIs
     void devToolsPanelsCreate(WebPageProxyIdentifier, const String& title, const String& iconPath, const String& pagePath, CompletionHandler<void(Expected<Inspector::ExtensionTabID, String>)>&&);
+    void devToolsInspectedWindowEval(WebPageProxyIdentifier, const String& scriptSource, const std::optional<URL>& frameURL, CompletionHandler<void(Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, String>)>&&);
+    void devToolsInspectedWindowReload(WebPageProxyIdentifier, const std::optional<bool>& ignoreCache);
 #endif
 
     // Event APIs

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -69,6 +69,8 @@ messages -> WebExtensionContext {
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // DevTools APIs
     DevToolsPanelsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String title, String iconPath, String pagePath) -> (Expected<Inspector::ExtensionTabID, String> result);
+    DevToolsInspectedWindowEval(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String scriptSource, std::optional<URL> frameURL) -> (Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, String> result);
+    DevToolsInspectedWindowReload(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<bool> ignoreCache);
 #endif
 
     // Event APIs

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -174,16 +174,17 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension(const In
             }
 
             if (details) {
-                Expected<RefPtr<API::SerializedScriptValue>, WebCore::ExceptionDetails> returnedValue = makeUnexpected(details.value());
-                return completionHandler({ returnedValue });
+                Expected<Ref<API::SerializedScriptValue>, WebCore::ExceptionDetails> returnedValue = makeUnexpected(details.value());
+                completionHandler({ returnedValue });
+                return;
             }
 
-            completionHandler({ { API::SerializedScriptValue::createFromWireBytes(Vector { dataReference.data(), dataReference.size() }).ptr() } });
+            completionHandler({ API::SerializedScriptValue::createFromWireBytes(dataReference) });
         });
     });
 }
 
-void WebInspectorUIExtensionControllerProxy::reloadForExtension(const Inspector::ExtensionID& extensionID, const std::optional<bool>& ignoreCache, const std::optional<String>& userAgent, const std::optional<String>& injectedScript, WTF::CompletionHandler<void(Inspector::ExtensionEvaluationResult)>&& completionHandler)
+void WebInspectorUIExtensionControllerProxy::reloadForExtension(const Inspector::ExtensionID& extensionID, const std::optional<bool>& ignoreCache, const std::optional<String>& userAgent, const std::optional<String>& injectedScript, WTF::CompletionHandler<void(Expected<void, Inspector::ExtensionError>)>&& completionHandler)
 {
     whenFrontendHasLoaded([weakThis = WeakPtr { *this }, extensionID, ignoreCache, userAgent, injectedScript, completionHandler = WTFMove(completionHandler)] () mutable {
         if (!weakThis || !weakThis->m_inspectorPage) {
@@ -243,11 +244,12 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab(const 
             }
 
             if (details) {
-                Expected<RefPtr<API::SerializedScriptValue>, WebCore::ExceptionDetails> returnedValue = makeUnexpected(details.value());
-                return completionHandler({ returnedValue });
+                Expected<Ref<API::SerializedScriptValue>, WebCore::ExceptionDetails> returnedValue = makeUnexpected(details.value());
+                completionHandler({ returnedValue });
+                return;
             }
 
-            completionHandler({ { API::SerializedScriptValue::createFromWireBytes({ dataReference.data(), dataReference.size() }).ptr() } });
+            completionHandler({ API::SerializedScriptValue::createFromWireBytes(dataReference) });
         });
     });
 }

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
@@ -60,7 +60,7 @@ public:
     void unregisterExtension(const Inspector::ExtensionID&, WTF::CompletionHandler<void(Expected<void, Inspector::ExtensionError>)>&&);
     void createTabForExtension(const Inspector::ExtensionID&, const String& tabName, const URL& tabIconURL, const URL& sourceURL, WTF::CompletionHandler<void(Expected<Inspector::ExtensionTabID, Inspector::ExtensionError>)>&&);
     void evaluateScriptForExtension(const Inspector::ExtensionID&, const String& scriptSource, const std::optional<URL>& frameURL, const std::optional<URL>& contextSecurityOrigin, const std::optional<bool>& useContentScriptContext, WTF::CompletionHandler<void(Inspector::ExtensionEvaluationResult)>&&);
-    void reloadForExtension(const Inspector::ExtensionID&, const std::optional<bool>& ignoreCache, const std::optional<String>& userAgent, const std::optional<String>& injectedScript, WTF::CompletionHandler<void(Inspector::ExtensionEvaluationResult)>&&);
+    void reloadForExtension(const Inspector::ExtensionID&, const std::optional<bool>& ignoreCache, const std::optional<String>& userAgent, const std::optional<String>& injectedScript, WTF::CompletionHandler<void(Inspector::ExtensionVoidResult)>&&);
     void showExtensionTab(const Inspector::ExtensionTabID&, CompletionHandler<void(Expected<void, Inspector::ExtensionError>)>&&);
     void navigateTabForExtension(const Inspector::ExtensionTabID&, const URL& sourceURL, CompletionHandler<void(const std::optional<Inspector::ExtensionError>)>&&);
     // API for testing.

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C62900D28EE2CD300C26B60 /* CoreSVGSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C62900C28EE2CD300C26B60 /* CoreSVGSPI.h */; };
 		1C62900F28EF4A1D00C26B60 /* FoundationSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C62900E28EF4A1D00C26B60 /* FoundationSPI.h */; };
+		1C66A8EF2B7C1D6D00BCF58D /* WebExtensionContextAPIDevToolsInspectedWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C66A8EE2B7C1D6D00BCF58D /* WebExtensionContextAPIDevToolsInspectedWindow.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C66BDDA2A8ADB8A009D4452 /* WebExtensionTabIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */; };
 		1C66BDDB2A8ADB8A009D4452 /* WebExtensionWindowIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C66BDD92A8ADB8A009D4452 /* WebExtensionWindowIdentifier.h */; };
 		1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C66BDD72A8AD957009D4452 /* WebExtensionTab.h */; };
@@ -3876,6 +3877,7 @@
 		1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaHelpers.mm; sourceTree = "<group>"; };
 		1C62900C28EE2CD300C26B60 /* CoreSVGSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreSVGSPI.h; sourceTree = "<group>"; };
 		1C62900E28EF4A1D00C26B60 /* FoundationSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FoundationSPI.h; sourceTree = "<group>"; };
+		1C66A8EE2B7C1D6D00BCF58D /* WebExtensionContextAPIDevToolsInspectedWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIDevToolsInspectedWindow.mm; sourceTree = "<group>"; };
 		1C66BDD72A8AD957009D4452 /* WebExtensionTab.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionTab.h; sourceTree = "<group>"; };
 		1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionTabIdentifier.h; sourceTree = "<group>"; };
 		1C66BDD92A8ADB8A009D4452 /* WebExtensionWindowIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionWindowIdentifier.h; sourceTree = "<group>"; };
@@ -9489,6 +9491,7 @@
 				1C8ECFEB2AFC8033007BAA62 /* WebExtensionContextAPICommandsCocoa.mm */,
 				1C7308812B33580D00B341DE /* WebExtensionContextAPICookiesCocoa.mm */,
 				331102462B17CFE300B21C8C /* WebExtensionContextAPIDeclarativeNetRequestCocoa.mm */,
+				1C66A8EE2B7C1D6D00BCF58D /* WebExtensionContextAPIDevToolsInspectedWindow.mm */,
 				1CD69BC72B7ADD1E00FDC9A7 /* WebExtensionContextAPIDevToolsPanels.mm */,
 				B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */,
 				1C78656D2AD1FD4F00EF3082 /* WebExtensionContextAPIExtensionCocoa.mm */,
@@ -19343,6 +19346,7 @@
 				1C8ECFEC2AFC8033007BAA62 /* WebExtensionContextAPICommandsCocoa.mm in Sources */,
 				1C7308822B33580D00B341DE /* WebExtensionContextAPICookiesCocoa.mm in Sources */,
 				331102472B17CFE300B21C8C /* WebExtensionContextAPIDeclarativeNetRequestCocoa.mm in Sources */,
+				1C66A8EF2B7C1D6D00BCF58D /* WebExtensionContextAPIDevToolsInspectedWindow.mm in Sources */,
 				1CD69BC82B7ADD1E00FDC9A7 /* WebExtensionContextAPIDevToolsPanels.mm in Sources */,
 				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,
 				1C78656E2AD1FD4F00EF3082 /* WebExtensionContextAPIExtensionCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
@@ -33,13 +33,15 @@
 
 namespace WebKit {
 
+class WebPage;
+
 class WebExtensionAPIDevToolsInspectedWindow : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsInspectedWindow, devToolsInspectedWindow);
 
 public:
 #if PLATFORM(COCOA)
-    void eval(NSString *expression, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void reload(NSDictionary *options, NSString **outExceptionString);
+    void eval(WebPage&, NSString *expression, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void reload(WebPage&, NSDictionary *options, NSString **outExceptionString);
 
     double tabId(WebPage&);
 #endif

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl
@@ -28,8 +28,8 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIDevToolsInspectedWindow {
 
-    [RaisesException] void eval(DOMString expression, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    [RaisesException] void reload([Optional, NSDictionary] any options);
+    [RaisesException, NeedsPage] void eval([CannotBeEmpty] DOMString expression, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void reload([Optional, NSDictionary] any options);
 
     [NeedsPage] readonly attribute double tabId;
 


### PR DESCRIPTION
#### bbc211140430e58da5821a8e87d1f6736a984929
<pre>
Add support for the devtools.inspectedWindow Web Extension APIs.
<a href="https://webkit.org/bug/246485">https://webkit.org/bug/246485</a>
<a href="https://rdar.apple.com/problem/114823326">rdar://problem/114823326</a>

Reviewed by Jeff Miller and BJ Burg.

Adds support for the eval() and reload() functions on devtools.inspectedWindow.
This is primarily implemented by API::InspectorExtension and Inspector code.

This implementation of eval() properly returns the result as an array of two values,
the result and error, like Chrome and Firefox. The Safari implementation just returned
the result and never provided the exception details.

Also removed the plumbing for reload to return a evaluation result. This was never the
case, and the Web Extension spec does not provide a result.

* Source/WebInspectorUI/UserInterface/Controllers/WebInspectorExtensionController.js:
(WI.WebInspectorExtensionController.prototype.async evaluateScriptForExtension):
(WI.WebInspectorExtensionController.prototype.reloadForExtension): Don&apos;t use an eval result
since reload does not provide a result to Web Extensions.
* Source/WebKit/Shared/InspectorExtensionTypes.h: Use Ref instead of RefPtr.
* Source/WebKit/UIProcess/API/APIInspectorExtension.cpp:
(API::InspectorExtension::reloadIgnoringCache):
* Source/WebKit/UIProcess/API/APIInspectorExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm:
(-[_WKInspectorExtension reloadIgnoringCache:userAgent:injectedScript:completionHandler:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm: Added.
(WebKit::WebExtensionContext::devToolsInspectedWindowEval):
(WebKit::WebExtensionContext::devToolsInspectedWindowReload):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm:
(WebKit::WebExtensionContext::devToolsPanelsCreate):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::reloadForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
(WebKit::WebExtensionAPIDevToolsInspectedWindow::reload):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm:
(TEST(WKWebExtensionAPIDevTools, InspectedWindowEval)): Added.
(TEST(WKWebExtensionAPIDevTools, InspectedWindowReload)): Added.
(TEST(WKWebExtensionAPIDevTools, InspectedWindowReloadIgnoringCache)): Added.

Canonical link: <a href="https://commits.webkit.org/274645@main">https://commits.webkit.org/274645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5cb921813f1030b7215cb7d1eea467dd13e412d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42192 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15965 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13632 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39393 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11918 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37665 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/save, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16124 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5202 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->