### PR TITLE
[GStreamer] webrtc/video-lowercase-media-subtype.html times out

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1915,8 +1915,6 @@ webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]
 
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]
 
-webkit.org/b/261099 webrtc/video-lowercase-media-subtype.html [ Skip ]
-
 fast/mediastream/getDisplayMedia-max-constraints4.html [ Skip ]
 
 # DataChannel GstWebRTC implementation incomplete, missing stats support.
@@ -1966,7 +1964,8 @@ imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpTransceiver-headerExtens
 # GStreamerRtpReceiverBackend::getSynchronizationSources() unimplemented and also hitting srtpenc errors.
 webkit.org/b/235885 webrtc/video-addTransceiver.html [ Skip ]
 
-# GstWebRTC doesn't support transceiver direction changes.
+# GstWebRTC (< 1.24) doesn't support transceiver direction changes.
+webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html [ Failure ]
 webkit.org/b/193641 webkit.org/b/235885 webrtc/video-setDirection.html [ Skip ]
 webkit.org/b/235885 webrtc/direction-change.html [ Skip ]
 # This test calls pc.removeTrack() which implies a transceiver direction change.

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
@@ -20,17 +20,8 @@ a=mid:{mid:OK}
 a=setup:active
 a=rtpmap:96 OPUS/48000/2
 a=rtcp-fb:96 transport-cc
-a=rtcp-mux
-a=rtcp-rsize
-a=rtcp-fb:8 transport-cc
-a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fingerprint:sha-256 {fingerprint:OK}
-a=rtcp-mux-only
-a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-a=extmap:3 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=fmtp:96 minptime=10;useinbandfec=1
-a=sendrecv
+a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}
 ===
 
@@ -60,7 +51,7 @@ a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=fmtp:96 minptime=10;useinbandfec=1
-a=sendrecv
+a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}
 m=video 9 UDP/TLS/RTP/SAVPF 97
 c=IN IP4 0.0.0.0
@@ -73,20 +64,8 @@ a=rtpmap:97 H264/90000
 a=rtcp-fb:97 nack pli
 a=rtcp-fb:97 ccm fir
 a=rtcp-fb:97 transport-cc
-a=rtcp-mux
-a=rtcp-rsize
-a=rtcp-fb:109 transport-cc
-a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=ssrc-group:{semantics:OK} {ssrc-id:OK}
-a=fingerprint:sha-256 {fingerprint:OK}
-a=rtcp-mux-only
-a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
-a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/color-space
-a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
-a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
-a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
 a=fmtp:97 packetization-mode=1;level-asymmetry-allowed=1
-a=sendrecv
+a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}
 ===
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -498,11 +498,11 @@ void GStreamerMediaEndpoint::doSetRemoteDescription(const RTCSessionDescription&
 
             GRefPtr<GstWebRTCRTPTransceiver> rtcTransceiver;
             g_signal_emit_by_name(m_webrtcBin.get(), "get-transceiver", i, &rtcTransceiver.outPtr());
+            if (!rtcTransceiver)
+                continue;
+
             auto caps = capsFromSDPMedia(media);
-            if (rtcTransceiver)
-                g_object_set(rtcTransceiver.get(), "direction", direction, "codec-preferences", caps.get(), nullptr);
-            else
-                g_signal_emit_by_name(m_webrtcBin.get(), "add-transceiver", direction, caps.get(), &rtcTransceiver.outPtr());
+            g_object_set(rtcTransceiver.get(), "codec-preferences", caps.get(), nullptr);
         }
     }, [protectedThis = Ref(*this), this, initialSDP = WTFMove(initialSDP), localDescriptionSdp = WTFMove(localDescriptionSdp), localDescriptionSdpType = WTFMove(localDescriptionSdpType)](const GstSDPMessage& message) {
         if (protectedThis->isStopped())

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -220,7 +220,7 @@ public:
         }
 
         if (!clientId) {
-            GST_DEBUG_OBJECT(m_src.get(), "Incoming track registration failed, track likely not ready yet.");
+            GST_WARNING_OBJECT(m_src.get(), "Incoming track registration failed, track likely not ready yet.");
             return;
         }
 


### PR DESCRIPTION
#### 9a071fa681c3a373aea334d132f529ef1e02c90e
<pre>
[GStreamer] webrtc/video-lowercase-media-subtype.html times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=269354">https://bugs.webkit.org/show_bug.cgi?id=269354</a>

Reviewed by Xabier Rodriguez-Calvar.

The last issue with that test was that the transceiver direction (recvonly) of the receiver was
copied over to the sending PeerConnection, thus breaking negotiation, preventing the sender to start
streaming.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::doSetRemoteDescription):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:

Canonical link: <a href="https://commits.webkit.org/274706@main">https://commits.webkit.org/274706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9ffcb84e137382b94a6d7513e2c190defd676b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33075 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13601 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39361 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37631 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16037 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8923 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->