### PR TITLE
Ensure abandonned LocalFrame is not root after didCommitLoadInAnotherProcess

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -231,8 +231,10 @@ LocalFrame::~LocalFrame()
         localMainFrame->selfOnlyDeref();
 
     if (isRootFrame()) {
-        if (auto* page = this->page())
-            page->removeRootFrame(*this);
+        if (auto* page = this->page()) {
+            if (page->rootFrames().contains(this))
+                page->removeRootFrame(*this);
+        }
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -393,6 +393,9 @@ void WebFrame::didCommitLoadInAnotherProcess(std::optional<WebCore::LayerHosting
 
     if (ownerElement)
         ownerElement->scheduleInvalidateStyleAndLayerComposition();
+
+    if (localFrame->isRootFrame())
+        corePage->removeRootFrame(*localFrame);
 }
 
 void WebFrame::removeFromTree()


### PR DESCRIPTION
#### c612ffc1a951f0c5231d380ca6ca2376297acf1b
<pre>
Ensure abandonned LocalFrame is not root after didCommitLoadInAnotherProcess
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

In WebFrame::didCommitLoadInAnotherProcess, the core LocalFrame is effectively replaced
by a RemoteFrame. In most cases, the final strong reference to the LocalFrame is
dropped at the end of the function.

However in some cases, that LocalFrame survives and is still a root frame, which is
considered during rendering, but by that time the frame has no more frame view, so the
final layout steps do not get handled as expected, causing an assertion to trigger, as
experienced in the cross-origin-opener.html test.

So now at the end of didCommitLoadInAnotherProcess, if the local frame is still a root
frame, it is forcibly removed from its page&apos;s list of root frames.

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::didCommitLoadInAnotherProcess):

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::~LocalFrame):
Since a root frame may have already been removed from the page&apos;s list of root frames,
we need to test to avoid a double remove that could trigger an assertion.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c612ffc1a951f0c5231d380ca6ca2376297acf1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35516 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33073 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13599 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43428 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39359 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37623 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16034 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->