### PR TITLE
Implement the `require-trusted-types-for` pre-navigation check

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-report-only-support.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-report-only-support.html
@@ -31,7 +31,7 @@
   // Navigate to the non-report-only version of the test. That has the same
   // event listening setup as this, but is a different target URI.
   const target_script = `location.href='${location.href.replace("-report-only", "") + "#continue"}';`;
-  const target = `javascript:"<script>${target_script}</scri${""}pt>"`;
+  const target = `javascript:${target_script}`;
 
   // Navigate the anchor, but only after the content is loaded (so that we
   // won't disturb delivery of that event to the opener.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-support.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-support.html
@@ -32,7 +32,7 @@
   // re-use the messageing mechanisms above. In order to not end up in a loop,
   // we'll only click if we don't find fragment in the current URL.
   const target_script = `location.href='${location.href}&continue';`;
-  const target = `javascript:"<script>${target_script}</scri${""}pt>"`;
+  const target = `javascript:${target_script}`;
 
   const anchor = document.getElementById("anchor");
   anchor.href = target;

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation-expected.txt
@@ -1,12 +1,20 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: The Content Security Policy 'require-trusted-types-for 'script';' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
+CONSOLE MESSAGE: [Report Only] This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: The Content Security Policy 'require-trusted-types-for 'script';' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: The Content Security Policy 'require-trusted-types-for 'script';' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
+CONSOLE MESSAGE: The Content Security Policy 'require-trusted-types-for 'script';' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
+CONSOLE MESSAGE: [Report Only] This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: The Content Security Policy 'require-trusted-types-for 'script';' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
+CONSOLE MESSAGE: The Content Security Policy 'require-trusted-types-for 'script';' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Navigate a window with javascript:-urls in enforcing mode. Test timed out
-NOTRUN Navigate a window with javascript:-urls w/ default policy in enforcing mode.
-NOTRUN Navigate a window with javascript:-urls in report-only mode.
-NOTRUN Navigate a window with javascript:-urls w/ default policy in report-only mode.
-NOTRUN Navigate a frame with javascript:-urls in enforcing mode.
-NOTRUN Navigate a frame with javascript:-urls w/ default policy in enforcing mode.
-NOTRUN Navigate a frame with javascript:-urls in report-only mode.
-NOTRUN Navigate a frame with javascript:-urls w/ default policy in report-only mode.
+PASS Navigate a window with javascript:-urls in enforcing mode.
+PASS Navigate a window with javascript:-urls w/ default policy in enforcing mode.
+PASS Navigate a window with javascript:-urls in report-only mode.
+PASS Navigate a window with javascript:-urls w/ default policy in report-only mode.
+PASS Navigate a frame with javascript:-urls in enforcing mode.
+PASS Navigate a frame with javascript:-urls w/ default policy in enforcing mode.
+PASS Navigate a frame with javascript:-urls in report-only mode.
+PASS Navigate a frame with javascript:-urls w/ default policy in report-only mode.
 

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -53,6 +53,7 @@
 #include "ScriptSourceCode.h"
 #include "ScriptableDocumentParser.h"
 #include "Settings.h"
+#include "TrustedType.h"
 #include "UserGestureIndicator.h"
 #include "WebCoreJITOperations.h"
 #include "WebCoreJSClientData.h"
@@ -824,16 +825,31 @@ void ScriptController::executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigi
     if (requesterSecurityOrigin && !requesterSecurityOrigin->isSameOriginDomain(ownerDocument->securityOrigin()))
         return;
 
-    if (!frame->page() || !ownerDocument->checkedContentSecurityPolicy()->allowJavaScriptURLs(ownerDocument->url().string(), eventHandlerPosition().m_line, url.string(), nullptr))
+    if (!frame->page())
         return;
 
-    const int javascriptSchemeLength = sizeof("javascript:") - 1;
-
     JSDOMGlobalObject* globalObject = jsWindowProxy(mainThreadNormalWorld()).window();
+
+    RefPtr scriptExecutionContext = globalObject->scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return;
+
+    auto preNavigationCheckHolder = requireTrustedTypesForPreNavigationCheckPasses(*scriptExecutionContext, url.string());
+    if (preNavigationCheckHolder.hasException())
+        return;
+
+    auto preNavigationCheckURLString = preNavigationCheckHolder.releaseReturnValue();
+    if (preNavigationCheckURLString.isNull())
+        return;
+
+    if (!ownerDocument->checkedContentSecurityPolicy()->allowJavaScriptURLs(ownerDocument->url().string(), eventHandlerPosition().m_line, preNavigationCheckURLString, nullptr))
+        return;
+
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    String decodedURL = PAL::decodeURLEscapeSequences(url.string());
+    const int javascriptSchemeLength = sizeof("javascript:") - 1;
+    String decodedURL = PAL::decodeURLEscapeSequences(preNavigationCheckURLString);
     // FIXME: This probably needs to figure out if the origin is considered tanited.
     auto result = executeScriptIgnoringException(decodedURL.substring(javascriptSchemeLength), JSC::SourceTaintedOrigin::Untainted);
     RELEASE_ASSERT(&vm == &jsWindowProxy(mainThreadNormalWorld()).window()->vm());

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -48,4 +48,6 @@ WEBCORE_EXPORT std::variant<std::monostate, Exception, Ref<TrustedHTML>, Ref<Tru
 
 WEBCORE_EXPORT ExceptionOr<String> trustedTypeCompliantString(TrustedType, ScriptExecutionContext&, const String& input, const String& sink);
 
+WEBCORE_EXPORT ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecutionContext&, const String& urlString);
+
 } // namespace WebCore


### PR DESCRIPTION
#### c28bce0ecd22a5a41b3b0f9c8958be13880e5f64
<pre>
Implement the `require-trusted-types-for` pre-navigation check
<a href="https://bugs.webkit.org/show_bug.cgi?id=267695">https://bugs.webkit.org/show_bug.cgi?id=267695</a>

Reviewed by Youenn Fablet.

When the &apos;require-trusted-types-for&apos; CSP directive is present javascript URLs are now passed through a default policy
or rejected if one doesn&apos;t exist.

Spec: <a href="https://w3c.github.io/trusted-types/dist/spec/#require-trusted-types-for-pre-navigation-check">https://w3c.github.io/trusted-types/dist/spec/#require-trusted-types-for-pre-navigation-check</a>

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-report-only-support.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/navigation-support.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation-expected.txt:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::requireTrustedTypesForPreNavigationCheckPasses):
* Source/WebCore/dom/TrustedType.h:

Canonical link: <a href="https://commits.webkit.org/275687@main">https://commits.webkit.org/275687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f19041a00b25339d59607d601d13d4d47a5faf0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45076 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35174 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16114 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40476 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18910 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9509 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->