### PR TITLE
Set DeletingAllowed for bmalloc::Heap::m_largeAllocated

### DIFF
--- a/Source/bmalloc/bmalloc/Heap.h
+++ b/Source/bmalloc/bmalloc/Heap.h
@@ -133,7 +133,7 @@ private:
     std::array<List<Chunk>, pageClassCount> m_freePages;
     std::array<List<Chunk>, pageClassCount> m_chunkCache;
 
-    Map<void*, size_t, LargeObjectHash> m_largeAllocated;
+    Map<void*, size_t, LargeObjectHash, AllowDeleting::DeletingAllowed> m_largeAllocated;
     LargeMap m_largeFree;
 
     ObjectTypeTable m_objectTypes;


### PR DESCRIPTION
#### 1da9e9d6ada35701cb3c9438c5305eeabfd7e53e
<pre>
Set DeletingAllowed for bmalloc::Heap::m_largeAllocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=269357">https://bugs.webkit.org/show_bug.cgi?id=269357</a>

Reviewed by Michael Saboff.

<a href="https://commits.webkit.org/274606@main">https://commits.webkit.org/274606@main</a> added an AllowDeleting parameter
to bmalloc::Map, which defaults to DeletingNotAllowed. However, this
default does not work for the Map in bmalloc/Heap.h, leading to massive
JSC breakage on platforms that haven&apos;t switched to libpas. Set it to
DeletingAllowed instead.

* Source/bmalloc/bmalloc/Heap.h:

Canonical link: <a href="https://commits.webkit.org/274644@main">https://commits.webkit.org/274644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/823f94bee0c376a6684e34717686292ca69c56d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35523 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33077 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43435 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33076 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39365 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39249 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37630 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16041 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46256 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8882 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16090 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9441 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->