### PR TITLE
[WPE] REGRESSION(274544@main): Build fails due to Clang -Wcast-align errors

### DIFF
--- a/Tools/ImageDiff/skia/PlatformImageSkia.cpp
+++ b/Tools/ImageDiff/skia/PlatformImageSkia.cpp
@@ -26,7 +26,12 @@
 #include "PlatformImage.h"
 
 #include <cstdio>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-align"
 #include <skia/codec/SkPngDecoder.h>
+#pragma clang diagnostic pop
+
 #include <skia/core/SkImage.h>
 #include <skia/core/SkPixmap.h>
 #include <skia/core/SkStream.h>

--- a/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
+++ b/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
@@ -36,7 +36,10 @@
 #endif
 
 #if defined(USE_SKIA) && USE_SKIA
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-align"
 #include <skia/core/SkPixmap.h>
+#pragma clang diagnostic pop
 #endif
 
 namespace WPEToolingBackends {


### PR DESCRIPTION
#### 36d87a9c88b9400cbb24387dfecda318e92a6ba6
<pre>
[WPE] REGRESSION(274544@main): Build fails due to Clang -Wcast-align errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=269360">https://bugs.webkit.org/show_bug.cgi?id=269360</a>

Unreviewed build fix.

Use &quot;pragma clang diagnostic&quot; to silence -Wcast-align warnings being
treated as errors. The IGNORE_CLANG_WARNINGS_{BEGIN,END} macros are not
used in this instance because none of the affected sources are supposed
to use WTF. No additional guards are needed to use the pragmas, because
compilers are expected to ignore an unknown #pragma.

* Tools/ImageDiff/skia/PlatformImageSkia.cpp:
* Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp:

Canonical link: <a href="https://commits.webkit.org/274624@main">https://commits.webkit.org/274624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43b7c1925a19f92082d32b340bc49cbe613ee72f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42163 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15936 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13607 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13591 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43440 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39367 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11891 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37633 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/save, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16046 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8871 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->