### PR TITLE
[WPE][Skia] Implement support for canvas toDataURL

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -3,6 +3,7 @@ set_property(DIRECTORY . PROPERTY FOLDER "skia")
 # Skia dependencies not used directly in WebKit.
 find_package(Freetype 2.9.0 REQUIRED)
 find_package(Fontconfig 2.13.0 REQUIRED)
+find_package(WebP REQUIRED COMPONENTS mux)
 
 #
 # SKIA_ROOT_DIR may point to a checkout from the upstream Skia repository,
@@ -86,8 +87,10 @@ if (DEVELOPER_MODE AND (SKIA_ROOT_DIR OR NOT "$ENV{SKIA_ROOT_DIR}" STREQUAL ""))
     target_link_libraries(Skia INTERFACE
         Fontconfig::Fontconfig
         Freetype::Freetype
+        JPEG::JPEG
         OpenGL::GLES
         PNG::PNG
+        WebP::mux
         ${EGL_LIBRARIES}
     )
 
@@ -640,7 +643,10 @@ add_library(Skia STATIC
 
     src/encode/SkEncoder.cpp
     src/encode/SkICC.cpp
+    src/encode/SkJPEGWriteUtility.cpp
+    src/encode/SkJpegEncoderImpl.cpp
     src/encode/SkPngEncoderImpl.cpp
+    src/encode/SkWebpEncoderImpl.cpp
 
     src/pathops/SkAddIntersections.cpp
     src/pathops/SkDConicLineIntersection.cpp
@@ -860,7 +866,9 @@ target_link_libraries(Skia PRIVATE
     Epoxy::Epoxy
     Fontconfig::Fontconfig
     Freetype::Freetype
+    JPEG::JPEG
     PNG::PNG
+    WebP::mux
 )
 
 WEBKIT_ADD_TARGET_CXX_FLAGS(Skia

--- a/Source/WebCore/platform/ImageDecoders.cmake
+++ b/Source/WebCore/platform/ImageDecoders.cmake
@@ -38,7 +38,6 @@ list(APPEND WebCore_LIBRARIES
     JPEG::JPEG
     PNG::PNG
     WebP::demux
-    WebP::libwebp
 )
 
 if (USE_JPEGXL)

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -478,6 +478,11 @@ std::unique_ptr<MIMETypeRegistryThreadGlobalData> MIMETypeRegistry::createMIMETy
         "image/ico"_s,
 #elif USE(CAIRO)
         "image/png"_s,
+#elif USE(SKIA)
+        "image/png"_s,
+        "image/jpeg"_s,
+        "image/jpg"_s,
+        "image/webp"_s,
 #endif
     };
 #endif

--- a/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
@@ -27,15 +27,106 @@
 #include "ImageBufferUtilitiesSkia.h"
 
 #if USE(SKIA)
-#include "NotImplemented.h"
+#include "GLContext.h"
+#include "MIMETypeRegistry.h"
+#include "PlatformDisplay.h"
+#include <skia/core/SkData.h>
 #include <skia/core/SkImage.h>
+#include <skia/core/SkStream.h>
+#include <skia/encode/SkJpegEncoder.h>
+#include <skia/encode/SkPngEncoder.h>
+#include <skia/encode/SkWebpEncoder.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-Vector<uint8_t> encodeData(SkImage*, const String& /*mimeType*/, std::optional<double>)
+class VectorSkiaWritableStream final : public SkWStream {
+public:
+    explicit VectorSkiaWritableStream(Vector<uint8_t>& vector)
+        : m_vector(vector)
+    {
+    }
+
+    bool write(const void* data, size_t length) override
+    {
+        m_vector.append(static_cast<const uint8_t*>(data), length);
+        return true;
+    }
+
+    void flush() override { }
+
+    size_t bytesWritten() const override { return m_vector.size(); }
+
+private:
+    Vector<uint8_t>& m_vector;
+};
+
+static sk_sp<SkData> encodeAcceleratedImage(SkImage* image, const String& mimeType, std::optional<double> quality)
 {
-    notImplemented();
-    return { };
+    GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+    auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
+    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+
+    if (MIMETypeRegistry::isJPEGMIMEType(mimeType)) {
+        SkJpegEncoder::Options options;
+        if (quality && *quality >= 0.0 && *quality <= 1.0)
+            options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);
+        return SkJpegEncoder::Encode(grContext, image, options);
+    }
+
+    if (equalLettersIgnoringASCIICase(mimeType, "image/webp"_s)) {
+        SkWebpEncoder::Options options;
+        if (quality && *quality >= 0.0 && *quality <= 1.0)
+            options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);
+        return SkWebpEncoder::Encode(grContext, image, options);
+    }
+
+    if (equalLettersIgnoringASCIICase(mimeType, "image/png"_s))
+        return SkPngEncoder::Encode(grContext, image, { });
+
+    return nullptr;
+}
+
+static Vector<uint8_t> encodeUnacceleratedImage(const SkPixmap& pixmap, const String& mimeType, std::optional<double> quality)
+{
+    Vector<uint8_t> result;
+    VectorSkiaWritableStream stream(result);
+
+    if (MIMETypeRegistry::isJPEGMIMEType(mimeType)) {
+        SkJpegEncoder::Options options;
+        if (quality && *quality >= 0.0 && *quality <= 1.0)
+            options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);
+        if (!SkJpegEncoder::Encode(&stream, pixmap, options))
+            return { };
+    } else if (equalLettersIgnoringASCIICase(mimeType, "image/webp"_s)) {
+        SkWebpEncoder::Options options;
+        if (quality && *quality >= 0.0 && *quality <= 1.0)
+            options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);
+        if (!SkWebpEncoder::Encode(&stream, pixmap, options))
+            return { };
+    } else if (equalLettersIgnoringASCIICase(mimeType, "image/png"_s)) {
+        if (!SkPngEncoder::Encode(&stream, pixmap, { }))
+            return { };
+    }
+
+    return result;
+}
+
+Vector<uint8_t> encodeData(SkImage* image, const String& mimeType, std::optional<double> quality)
+{
+    if (image->isTextureBacked()) {
+        auto data = encodeAcceleratedImage(image, mimeType, quality);
+        if (!data)
+            return { };
+
+        return { reinterpret_cast<const uint8_t*>(data->data()), data->size() };
+    }
+
+    SkPixmap pixmap;
+    if (!image->peekPixels(&pixmap))
+        return { };
+
+    return encodeUnacceleratedImage(pixmap, mimeType, quality);
 }
 
 } // namespace WebCore

--- a/Source/cmake/FindWebP.cmake
+++ b/Source/cmake/FindWebP.cmake
@@ -38,6 +38,9 @@ Imported Targets
 ``WebP::demux``
   The WebP demux library, if found.
 
+``WebP::mux``
+  The WebP mux library, if found.
+
 Result Variables
 ^^^^^^^^^^^^^^^^
 
@@ -114,6 +117,28 @@ if ("demux" IN_LIST WebP_FIND_COMPONENTS)
     endif ()
 endif ()
 
+if ("mux" IN_LIST WebP_FIND_COMPONENTS)
+    find_library(WebP_MUX_LIBRARY
+        NAMES ${WebP_MUX_NAMES} webpmux libwebpmux
+        HINTS ${PC_WEBP_LIBDIR} ${PC_WEBP_LIBRARY_DIRS}
+    )
+
+    if (WebP_MUX_LIBRARY)
+        if (WebP_FIND_REQUIRED_mux)
+            list(APPEND WebP_LIBS_FOUND "mux (required): ${WebP_MUX_LIBRARY}")
+        else ()
+           list(APPEND WebP_LIBS_FOUND "mux (optional): ${WebP_MUX_LIBRARY}")
+        endif ()
+    else ()
+        if (WebP_FIND_REQUIRED_mux)
+           set(_WebP_REQUIRED_LIBS_FOUND OFF)
+           list(APPEND WebP_LIBS_NOT_FOUND "mux (required)")
+        else ()
+           list(APPEND WebP_LIBS_NOT_FOUND "mux (optional)")
+        endif ()
+    endif ()
+endif ()
+
 if (NOT WebP_FIND_QUIETLY)
     if (WebP_LIBS_FOUND)
         message(STATUS "Found the following WebP libraries:")
@@ -152,15 +177,27 @@ if (WebP_DEMUX_LIBRARY AND NOT TARGET WebP::demux)
         INTERFACE_COMPILE_OPTIONS "${WebP_COMPILE_OPTIONS}"
         INTERFACE_INCLUDE_DIRECTORIES "${WebP_INCLUDE_DIR}"
     )
+    target_link_libraries(WebP::demux INTERFACE WebP::libwebp)
+endif ()
+
+if (WebP_MUX_LIBRARY AND NOT TARGET WebP::mux)
+    add_library(WebP::mux UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(WebP::mux PROPERTIES
+        IMPORTED_LOCATION "${WebP_MUX_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${WebP_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${WebP_INCLUDE_DIR}"
+    )
+    target_link_libraries(WebP::mux INTERFACE WebP::libwebp)
 endif ()
 
 mark_as_advanced(
     WebP_INCLUDE_DIR
     WebP_LIBRARY
     WebP_DEMUX_LIBRARY
+    WebP_MUX_LIBRARY
 )
 
 if (WebP_FOUND)
-    set(WebP_LIBRARIES ${WebP_LIBRARY} ${WebP_DEMUX_LIBRARY})
+    set(WebP_LIBRARIES ${WebP_LIBRARY} ${WebP_DEMUX_LIBRARY} ${WebP_MUX_LIBRARY})
     set(WebP_INCLUDE_DIRS ${WebP_INCLUDE_DIR})
 endif ()


### PR DESCRIPTION
#### 56d0998a1ebb77d9b7e3f6948de2336de044d6a0
<pre>
[WPE][Skia] Implement support for canvas toDataURL
<a href="https://bugs.webkit.org/show_bug.cgi?id=269362">https://bugs.webkit.org/show_bug.cgi?id=269362</a>

Reviewed by Adrian Perez de Castro.

Implement encodeData().

* Source/ThirdParty/skia/CMakeLists.txt: Add JPEG and WebP encoder files.
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::createMIMETypeRegistryThreadGlobalData): Mark JPEG,
PNG and WebP as formats support for encoding when building with Skia.
* Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp:
(WebCore::encodeAcceleratedImage):
(WebCore::encodeUnacceleratedImage):
(WebCore::encodeData):
* Source/cmake/FindWebP.cmake: Also look for mux library if requested as component

Canonical link: <a href="https://commits.webkit.org/274723@main">https://commits.webkit.org/274723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bfdf6002211e1bf7b7da72518ba87e1716ae6ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16185 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34449 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43667 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33297 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35741 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39470 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12057 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16278 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46478 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16326 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9558 "Found 4 new JSC stress test failures: stress/sampling-profiler-microtasks.js.default, stress/sampling-profiler-microtasks.js.dfg-eager, stress/sampling-profiler-microtasks.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-microtasks.js.no-llint (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5245 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->