### PR TITLE
[JSC] Skip some tests specifically for $memoryLimited and $isSIMDPlatform

### DIFF
--- a/JSTests/microbenchmarks/get-private-name.js
+++ b/JSTests/microbenchmarks/get-private-name.js
@@ -1,5 +1,5 @@
 //@ $skipModes << :lockdown if $buildType == "debug"
-//@ skip if $architecture == "arm" and !$cloop
+//@ skip if $memoryLimited
 
 function assert(b, m = "Assertion failed") {
     if (!b)

--- a/JSTests/stress/bigdecimal-identifiers-fail-on-oom.js
+++ b/JSTests/stress/bigdecimal-identifiers-fail-on-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture == "arm" or $memoryLimited
+//@ skip if $memoryLimited
 
 function foo() {
     let m = new WebAssembly.Memory({initial: 1000});

--- a/JSTests/stress/sampling-profiler-richards.js
+++ b/JSTests/stress/sampling-profiler-richards.js
@@ -1,6 +1,6 @@
 //@ skip if not $jitTests
 //@ skip if $architecture == "x86"
-//@ skip if $architecture == "arm"
+//@ skip if $memoryLimited
 //@ runDefault("--collectContinuously=1", "--useSamplingProfiler=1", "--collectExtraSamplingProfilerData=1")
 
 "use strict";

--- a/JSTests/wasm/function-tests/trap-store-shared.js
+++ b/JSTests/wasm/function-tests/trap-store-shared.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64" && $architecture != "arm"
 import Builder from '../Builder.js'
 import * as assert from '../assert.js'
 

--- a/JSTests/wasm/v8/liftoff-simd-params.js
+++ b/JSTests/wasm/v8/liftoff-simd-params.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/multi-value-simd.js
+++ b/JSTests/wasm/v8/multi-value-simd.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/simd-call.js
+++ b/JSTests/wasm/v8/simd-call.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/simd-errors.js
+++ b/JSTests/wasm/v8/simd-errors.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/simd-globals.js
+++ b/JSTests/wasm/v8/simd-globals.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/simd-i64x2-mul.js
+++ b/JSTests/wasm/v8/simd-i64x2-mul.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.


### PR DESCRIPTION
#### d0613703b5c65bc567095253d9496c1af49b7283
<pre>
[JSC] Skip some tests specifically for $memoryLimited and $isSIMDPlatform
<a href="https://bugs.webkit.org/show_bug.cgi?id=269730">https://bugs.webkit.org/show_bug.cgi?id=269730</a>

Unreviewed test gardening.

We want some tests to be skipped for $memoryLimited and $isSIMDPlatform
specifically (as opposed to for ARM) for classification reasons.

Also unskips JSTests/wasm/function-tests/trap-store-shared.js for
armv7 (no longer failing).

Also skips JSTests/stress/sampling-profiler-microtasks.js again
on armv7 because it fails in non-debug builds.

* JSTests/microbenchmarks/get-private-name.js:
* JSTests/stress/bigdecimal-identifiers-fail-on-oom.js:
* JSTests/stress/sampling-profiler-microtasks.js:
* JSTests/stress/sampling-profiler-richards.js:
* JSTests/wasm/function-tests/trap-store-shared.js:
* JSTests/wasm/v8/liftoff-simd-params.js:
* JSTests/wasm/v8/multi-value-simd.js:
* JSTests/wasm/v8/simd-call.js:
* JSTests/wasm/v8/simd-errors.js:
* JSTests/wasm/v8/simd-globals.js:
* JSTests/wasm/v8/simd-i64x2-mul.js:

Canonical link: <a href="https://commits.webkit.org/274989@main">https://commits.webkit.org/274989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c93889e5ac1e5c08c34bb64a94463c765098759

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43152 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36688 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16943 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14269 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44425 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34052 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36813 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40040 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40225 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38374 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17033 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47235 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9092 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17084 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9708 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->