### PR TITLE
VAPI for register_script_message_handler of webkitgtk-6.0 is wrong

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -478,7 +478,7 @@ void webkit_user_content_manager_unregister_script_message_handler(WebKitUserCon
  * webkit_user_content_manager_register_script_message_handler_with_reply:
  * @manager: A #WebKitUserContentManager
  * @name: Name of the script message channel
- * @world_name (nullable): the name of a #WebKitScriptWorld
+ * @world_name: (nullable): the name of a #WebKitScriptWorld
  *
  * Registers a new user script message handler in script world with name @world_name.
  *


### PR DESCRIPTION
#### 5d528e1cafcaa30bc59e66c78e5691830fdd0378
<pre>
VAPI for register_script_message_handler of webkitgtk-6.0 is wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=269358">https://bugs.webkit.org/show_bug.cgi?id=269358</a>

Reviewed by Adrian Perez de Castro.

Too bad we don&apos;t get a warning when we typo the colon here.

* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:

Canonical link: <a href="https://commits.webkit.org/274653@main">https://commits.webkit.org/274653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec46ef2956822103f0c6852aeb4d156118e70fb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33098 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13625 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13611 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39386 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11910 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37654 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/save, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16062 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8887 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->