### PR TITLE
[UnifiedPDF] Introduce AsyncPDFRenderer

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -85,6 +85,7 @@ extern "C" {
     M(NetworkSession) \
     M(Notifications) \
     M(PDF) \
+    M(PDFAsyncRendering) \
     M(PerformanceLogging) \
     M(Plugins) \
     M(Printing) \

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -693,8 +693,9 @@ WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
 WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
 WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
-WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 
 WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
 WebProcess/WebCoreSupport/WebValidationMessageClient.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -3205,6 +3205,8 @@
 		0F174AA2142A4CB60039250F /* APIGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIGeometry.h; sourceTree = "<group>"; };
 		0F174AA6142AAC610039250F /* WKGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKGeometry.cpp; sourceTree = "<group>"; };
 		0F189CAB24749F2F00E58D81 /* DisplayLinkObserverID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisplayLinkObserverID.h; sourceTree = "<group>"; };
+		0F23ADDE2B7D240B00E6199B /* AsyncPDFRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncPDFRenderer.h; sourceTree = "<group>"; };
+		0F23ADDF2B7D240C00E6199B /* AsyncPDFRenderer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AsyncPDFRenderer.mm; sourceTree = "<group>"; };
 		0F25C49F29A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteLayerTreeEventDispatcher.cpp; sourceTree = "<group>"; };
 		0F25C4A029A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteLayerTreeEventDispatcher.h; sourceTree = "<group>"; };
 		0F2E0DF628F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteScrollingCoordinatorProxyMac.mm; sourceTree = "<group>"; };
@@ -8600,6 +8602,8 @@
 		0FFACF022AC2453300ED8DB6 /* UnifiedPDF */ = {
 			isa = PBXGroup;
 			children = (
+				0F23ADDE2B7D240B00E6199B /* AsyncPDFRenderer.h */,
+				0F23ADDF2B7D240C00E6199B /* AsyncPDFRenderer.mm */,
 				0F3D56732AC651390086D64E /* PDFDocumentLayout.h */,
 				0F3D56722AC651390086D64E /* PDFDocumentLayout.mm */,
 				0FFACF042AC2453300ED8DB6 /* UnifiedPDFPlugin.h */,
@@ -19577,9 +19581,7 @@
 		};
 		5C400E6A29DB8AB500446F6F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
 			targetProxy = 5C400E6929DB8AB500446F6F /* PBXContainerItemProxy */;
 		};
@@ -19595,25 +19597,19 @@
 		};
 		5CE4B60729CEBB760038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
 			targetProxy = 5CE4B60629CEBB760038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62329CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
 			targetProxy = 5CE4B62229CF880B0038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62529CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
 			targetProxy = 5CE4B62429CF880B0038F565 /* PBXContainerItemProxy */;
 		};

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -115,6 +115,7 @@ public:
 
     bool isLocked() const;
 
+    RetainPtr<PDFDocument> pdfDocument() const { return m_pdfDocument; }
     RetainPtr<PDFDocument> pdfDocumentForPrinting() const { return m_pdfDocument; }
     WebCore::FloatSize pdfDocumentSizeForPrinting() const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_PDF)
+
+#include <WebCore/FloatRect.h>
+#include <WebCore/GraphicsLayer.h>
+#include <WebCore/IntPoint.h>
+#include <WebCore/TiledBacking.h>
+#include <wtf/HashMap.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WorkQueue.h>
+
+OBJC_CLASS PDFDocument;
+
+namespace WebKit {
+
+struct TileForGrid {
+    WebCore::TileGridIndex gridIndex { 0 };
+    WebCore::TileIndex tileIndex;
+
+    bool operator==(const TileForGrid&) const = default;
+};
+
+} // namespace WebKit
+
+namespace WTF {
+
+struct TileForGridHash {
+    static unsigned hash(const WebKit::TileForGrid& key)
+    {
+        return pairIntHash(key.gridIndex, DefaultHash<WebCore::IntPoint>::hash(key.tileIndex));
+    }
+    static bool equal(const WebKit::TileForGrid& a, const WebKit::TileForGrid& b)
+    {
+        return a.gridIndex == b.gridIndex && DefaultHash<WebCore::IntPoint>::equal(a.tileIndex, b.tileIndex);
+
+    }
+    static const bool safeToCompareToEmptyOrDeleted = true;
+};
+
+template<> struct HashTraits<WebKit::TileForGrid> : GenericHashTraits<WebKit::TileForGrid> {
+    static const bool emptyValueIsZero = false;
+    static WebKit::TileForGrid emptyValue()  { return { std::numeric_limits<unsigned>::max(), { -1, -1 } }; }
+    static WebKit::TileForGrid deletedValue() { return { 0, { -1, -1 } }; }
+    static void constructDeletedValue(WebKit::TileForGrid& tileForGrid) { tileForGrid = deletedValue(); }
+    static bool isDeletedValue(const WebKit::TileForGrid& tileForGrid) { return tileForGrid == deletedValue(); }
+};
+template<> struct DefaultHash<WebKit::TileForGrid> : TileForGridHash { };
+
+} // namespace WTF
+
+
+
+namespace WebKit {
+
+class UnifiedPDFPlugin;
+struct PDFPageCoverage;
+
+class AsyncPDFRenderer : public WebCore::TiledBackingClient,
+    public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AsyncPDFRenderer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(AsyncPDFRenderer);
+public:
+    static Ref<AsyncPDFRenderer> create(UnifiedPDFPlugin&);
+
+    virtual ~AsyncPDFRenderer();
+
+    void setupWithLayer(WebCore::GraphicsLayer&);
+    bool paintTileForClip(WebCore::GraphicsContext&, const WebCore::FloatRect& clip);
+    void clearCachedTiles();
+
+private:
+    AsyncPDFRenderer(UnifiedPDFPlugin&);
+
+    // TiledBackingClient
+    void willRepaintTile(WebCore::TileGridIndex, WebCore::TileIndex, const WebCore::FloatRect& tileRect, const WebCore::FloatRect& tileDirtyRect) final;
+    void willRemoveTile(WebCore::TileGridIndex, WebCore::TileIndex) final;
+    void willRepaintAllTiles(WebCore::TileGridIndex) final;
+
+    void enqueuePaintWithClip(const TileForGrid&, const WebCore::FloatRect& tileRect);
+    void paintTileOnWorkQueue(RetainPtr<PDFDocument>&&, const TileForGrid&, const WebCore::FloatRect& tileRect, const PDFPageCoverage&);
+    void paintPDFIntoBuffer(RetainPtr<PDFDocument>&&, Ref<WebCore::ImageBuffer>, const TileForGrid&, const WebCore::FloatRect& tileRect, const PDFPageCoverage&);
+    void transferBufferToMainThread(RefPtr<WebCore::ImageBuffer>&&, const TileForGrid&, const WebCore::FloatRect& tileRect);
+
+    Ref<WorkQueue> paintingWorkQueue() const { return m_paintingWorkQueue; }
+
+    ThreadSafeWeakPtr<UnifiedPDFPlugin> m_plugin;
+    RefPtr<WebCore::GraphicsLayer> m_pdfContentsLayer;
+    Ref<WorkQueue> m_paintingWorkQueue;
+
+    HashMap<TileForGrid, PDFPageCoverage> m_enqueuedTileRenders;
+
+    struct BufferAndClip {
+        RefPtr<WebCore::ImageBuffer> buffer;
+        WebCore::FloatRect tileClip;
+    };
+    HashMap<TileForGrid, BufferAndClip> m_rendereredTiles;
+};
+
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AsyncPDFRenderer.h"
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "Logging.h"
+#include "UnifiedPDFPlugin.h"
+#include <CoreGraphics/CoreGraphics.h>
+#include <PDFKit/PDFKit.h>
+#include <WebCore/GraphicsContext.h>
+#include <WebCore/ImageBuffer.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<AsyncPDFRenderer> AsyncPDFRenderer::create(UnifiedPDFPlugin& plugin)
+{
+    return adoptRef(*new AsyncPDFRenderer(plugin));
+}
+
+AsyncPDFRenderer::AsyncPDFRenderer(UnifiedPDFPlugin& plugin)
+    : m_plugin(plugin)
+    , m_paintingWorkQueue(WorkQueue::create("WebKit: PDF Painting Work Queue"_s, WorkQueue::QOS::UserInteractive)) // Maybe make this concurrent?
+{
+}
+
+AsyncPDFRenderer::~AsyncPDFRenderer()
+{
+    if (auto* tiledBacking = m_pdfContentsLayer->tiledBacking())
+        tiledBacking->setClient(nullptr);
+}
+
+void AsyncPDFRenderer::setupWithLayer(GraphicsLayer& layer)
+{
+    m_pdfContentsLayer = &layer;
+
+    if (auto* tiledBacking = m_pdfContentsLayer->tiledBacking())
+        tiledBacking->setClient(this);
+}
+
+void AsyncPDFRenderer::willRepaintTile(TileGridIndex gridIndex, TileIndex tileIndex, const FloatRect& tileRect, const FloatRect& tileDirtyRect)
+{
+    auto tileInfo = TileForGrid { gridIndex, tileIndex };
+
+    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::willRepaintTile " << tileIndex << " " << tileRect << " (dirty rect " << tileDirtyRect << ") - already queued " << m_enqueuedTileRenders.contains(tileInfo) << " have cached tile " << m_rendereredTiles.contains(tileInfo));
+    // Currently we always do full tile paints.
+    UNUSED_PARAM(tileDirtyRect);
+
+    if (m_enqueuedTileRenders.contains(tileInfo))
+        return;
+
+    // If we have a tile, we can just paint it.
+    if (m_rendereredTiles.contains(tileInfo))
+        return;
+
+    enqueuePaintWithClip(tileInfo, tileRect);
+}
+
+void AsyncPDFRenderer::willRemoveTile(TileGridIndex gridIndex, TileIndex tileIndex)
+{
+    auto tileInfo = TileForGrid { gridIndex, tileIndex };
+
+    m_enqueuedTileRenders.remove(tileInfo);
+    m_rendereredTiles.remove(tileInfo);
+}
+
+void AsyncPDFRenderer::willRepaintAllTiles(TileGridIndex)
+{
+    // FIXME: Could remove per-grid, when we use more than one grid.
+    m_enqueuedTileRenders.clear();
+    m_rendereredTiles.clear();
+}
+
+void AsyncPDFRenderer::clearCachedTiles()
+{
+    m_enqueuedTileRenders.clear();
+    m_rendereredTiles.clear();
+}
+
+void AsyncPDFRenderer::enqueuePaintWithClip(const TileForGrid& tileInfo, const FloatRect& tileRect)
+{
+    ASSERT(isMainRunLoop());
+
+    RefPtr plugin = m_plugin.get();
+    if (!plugin)
+        return;
+
+    auto pdfDocument = plugin->pdfDocument();
+    if (!pdfDocument) {
+        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::enqueueLayerPaint - document is null, bailing");
+        return;
+    }
+
+    auto pageCoverage = plugin->pageCoverageForRect(tileRect);
+    if (pageCoverage.pages.isEmpty())
+        return;
+
+    m_enqueuedTileRenders.add(tileInfo, pageCoverage);
+
+    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::enqueuePaintWithClip for tile at " << tileInfo.tileIndex);
+
+    m_paintingWorkQueue->dispatch([protectedThis = Ref { *this }, pdfDocument = WTFMove(pdfDocument), tileInfo, tileRect, pageCoverage]() mutable {
+        protectedThis->paintTileOnWorkQueue(WTFMove(pdfDocument), tileInfo, tileRect, pageCoverage);
+    });
+}
+
+void AsyncPDFRenderer::paintTileOnWorkQueue(RetainPtr<PDFDocument>&& pdfDocument, const TileForGrid& tileInfo, const FloatRect& tileRect, const PDFPageCoverage& pageCoverage)
+{
+    assertIsCurrent(m_paintingWorkQueue);
+
+    auto tileBuffer = ImageBuffer::create(tileRect.size(), RenderingPurpose::Unspecified, pageCoverage.deviceScaleFactor, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    if (!tileBuffer)
+        return;
+
+    // transform the origin
+
+    paintPDFIntoBuffer(WTFMove(pdfDocument), *tileBuffer, tileInfo, tileRect, pageCoverage);
+
+    // This is really a no-op (but only works if there's just one ref).
+    auto bufferCopy = ImageBuffer::sinkIntoBufferForDifferentThread(WTFMove(tileBuffer));
+    ASSERT(bufferCopy);
+
+    transferBufferToMainThread(WTFMove(bufferCopy), tileInfo, tileRect);
+}
+
+void AsyncPDFRenderer::paintPDFIntoBuffer(RetainPtr<PDFDocument>&& pdfDocument, Ref<ImageBuffer> imageBuffer, const TileForGrid& tileInfo, const FloatRect& tileRect, const PDFPageCoverage& pageCoverage)
+{
+    assertIsCurrent(m_paintingWorkQueue);
+
+    auto& context = imageBuffer->context();
+
+    auto stateSaver = GraphicsContextStateSaver(context);
+
+    context.translate(FloatPoint { -tileRect.location() });
+    context.scale(pageCoverage.documentScale);
+
+    for (auto& pageInfo : pageCoverage.pages) {
+        RetainPtr pdfPage = [pdfDocument pageAtIndex:pageInfo.pageIndex];
+        if (!pdfPage)
+            continue;
+
+        auto destinationRect = pageInfo.pageBounds;
+
+        auto pageStateSaver = GraphicsContextStateSaver(context);
+        context.clip(destinationRect);
+        context.fillRect(destinationRect, Color::white);
+
+        // Translate the context to the bottom of pageBounds and flip, so that PDFKit operates
+        // from this page's drawing origin.
+        context.translate(destinationRect.minXMaxYCorner());
+        context.scale({ 1, -1 });
+
+        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer: painting PDF page " << pageInfo.pageIndex << " into rect " << destinationRect << " with clip " << tileRect);
+        [pdfPage drawWithBox:kPDFDisplayBoxCropBox toContext:context.platformContext()];
+    }
+}
+
+void AsyncPDFRenderer::transferBufferToMainThread(RefPtr<ImageBuffer>&& imageBuffer, const TileForGrid& tileInfo, const FloatRect& tileRect)
+{
+    assertIsCurrent(m_paintingWorkQueue);
+
+    callOnMainRunLoop([weakThis = ThreadSafeWeakPtr { *this }, imageBuffer = WTFMove(imageBuffer), tileInfo, tileRect]() {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        if (!protectedThis->m_pdfContentsLayer)
+            return;
+
+        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::transferBufferToMainThread - got results for tile at " << tileInfo.tileIndex << " (" << protectedThis->m_rendereredTiles.size() << " tiles in cache)");
+
+        // If the request for this tile has been revoked, don't cache it.
+        if (!protectedThis->m_enqueuedTileRenders.contains(tileInfo))
+            return;
+
+        auto bufferAndClip = BufferAndClip { WTFMove(imageBuffer), tileRect };
+        protectedThis->m_rendereredTiles.add(tileInfo, WTFMove(bufferAndClip));
+
+        protectedThis->m_pdfContentsLayer->setNeedsDisplayInRect(tileRect);
+    });
+}
+
+bool AsyncPDFRenderer::paintTileForClip(GraphicsContext& context, const FloatRect& clip)
+{
+    ASSERT(isMainRunLoop());
+
+    bool paintedATile = false;
+
+    for (auto& keyValuePair : m_rendereredTiles) {
+        auto& tileInfo = keyValuePair.key;
+        auto& bufferAndClip = keyValuePair.value;
+
+        if (!clip.intersects(bufferAndClip.tileClip))
+            continue;
+
+        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::paintTileForClip - painting tile for " << tileInfo.tileIndex << " with clip " << bufferAndClip.tileClip);
+
+        auto stateSaver = GraphicsContextStateSaver(context);
+
+        context.drawImageBuffer(*bufferAndClip.buffer, bufferAndClip.tileClip.location());
+        paintedATile = true;
+
+        m_enqueuedTileRenders.remove(tileInfo);
+    }
+
+    // FIXME: Ideally return true if we covered the entire dirty rect.
+    return paintedATile;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -82,6 +82,7 @@ struct PDFPageCoverage {
 };
 
 class UnifiedPDFPlugin final : public PDFPluginBase, public WebCore::GraphicsLayerClient {
+    friend class AsyncPDFRenderer;
 public:
     static Ref<UnifiedPDFPlugin> create(WebCore::HTMLPlugInElement&);
 


### PR DESCRIPTION
#### 98c763e246170ff480978642d91f27ff6bff79e8
<pre>
[UnifiedPDF] Introduce AsyncPDFRenderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=269368">https://bugs.webkit.org/show_bug.cgi?id=269368</a>
<a href="https://rdar.apple.com/122950491">rdar://122950491</a>

Reviewed by Tim Horton.

This is the first step to rendering PDF content off the main thread.

AsyncPDFRenderer is a TiledBackingClient, so gets notified when the TileBacking needs
to repaint a tile. This causes it to enqueue a request to render a tile (identified by
a grid index/tile index pair in `TileForGrid`) on a workqueue (currently serial, but likely
concurrent in future). The tile rendering request includes a `PDFPageCoverage`, which
describes the set of PDF pages and their geometry which will go into this tile.

Rendering a tile on the work queue involves allocating an in-process ImageBuffer, calling
PDFDocument for the PDFPages for this tile, and drawing them (without selection). That
ImageBuffer is then transferred back to the main thread, and put into a cache, again
keyed by `TileForGrid`.

When a tile render is complete, we need to trigger a repaint so we can paint the tile
in the normal painting code path. There&apos;s a little trickiness to avoid continual repaints,
which is handled by `AsyncPDFRenderer::willRepaintTile()`.

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::pdfDocument const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h: Added.
(WTF::TileForGridHash::hash):
(WTF::TileForGridHash::equal):
(WTF::HashTraits&lt;WebKit::TileForGrid&gt;::emptyValue):
(WTF::HashTraits&lt;WebKit::TileForGrid&gt;::deletedValue):
(WTF::HashTraits&lt;WebKit::TileForGrid&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebKit::TileForGrid&gt;::isDeletedValue):
(WebKit::AsyncPDFRenderer::paintingWorkQueue const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm: Added.
(WebKit::AsyncPDFRenderer::create):
(WebKit::AsyncPDFRenderer::AsyncPDFRenderer):
(WebKit::AsyncPDFRenderer::~AsyncPDFRenderer):
(WebKit::AsyncPDFRenderer::setupWithLayer):
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::willRemoveTile):
(WebKit::AsyncPDFRenderer::willRepaintAllTiles):
(WebKit::AsyncPDFRenderer::clearCachedTiles):
(WebKit::AsyncPDFRenderer::enqueuePaintWithClip):
(WebKit::AsyncPDFRenderer::paintTileOnWorkQueue):
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer):
(WebKit::AsyncPDFRenderer::transferBufferToMainThread):
(WebKit::AsyncPDFRenderer::paintTileForClip):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:

Canonical link: <a href="https://commits.webkit.org/274659@main">https://commits.webkit.org/274659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/212eba5a140bdfd81954536dca4334c23ca1f78c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42208 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35573 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15981 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33114 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40247 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13642 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43485 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39402 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11930 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16091 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8890 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->