### PR TITLE
Adopt more smart pointers in WebCore/bindings

### DIFF
--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -1781,7 +1781,7 @@ JS_EXPORT_PRIVATE NEVER_INLINE bool ordinarySetWithOwnDescriptor(JSGlobalObject*
         vm, globalObject, makeIdentifier(vm, (jsName)), (generatorName)(vm), (attributes))
 
 #define JSC_TO_STRING_TAG_WITHOUT_TRANSITION() \
-    putDirectWithoutTransition(vm, vm.propertyNames->toStringTagSymbol, \
+    putDirectWithoutTransition(vm, WTF::getPtr(vm)->propertyNames->toStringTagSymbol, \
         jsNontrivialString(vm, info()->className), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly)
 
 // Helper for defining native getters on properties.

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -70,11 +70,11 @@ HashSet<WebAnimation*>& WebAnimation::instances()
     return instances;
 }
 
-Ref<WebAnimation> WebAnimation::create(Document& document, AnimationEffect* effect)
+Ref<WebAnimation> WebAnimation::create(Document& document, RefPtr<AnimationEffect>&& effect)
 {
     auto result = adoptRef(*new WebAnimation(document));
     result->initialize();
-    result->setEffect(effect);
+    result->setEffect(WTFMove(effect));
     result->setTimeline(&document.timeline());
 
     InspectorInstrumentation::didCreateWebAnimation(result.get());
@@ -82,11 +82,11 @@ Ref<WebAnimation> WebAnimation::create(Document& document, AnimationEffect* effe
     return result;
 }
 
-Ref<WebAnimation> WebAnimation::create(Document& document, AnimationEffect* effect, AnimationTimeline* timeline)
+Ref<WebAnimation> WebAnimation::create(Document& document, RefPtr<AnimationEffect>&& effect, AnimationTimeline* timeline)
 {
     auto result = adoptRef(*new WebAnimation(document));
     result->initialize();
-    result->setEffect(effect);
+    result->setEffect(WTFMove(effect));
     if (timeline)
         result->setTimeline(timeline);
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -59,8 +59,8 @@ struct ResolutionContext;
 class WebAnimation : public RefCounted<WebAnimation>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(WebAnimation);
 public:
-    static Ref<WebAnimation> create(Document&, AnimationEffect*);
-    static Ref<WebAnimation> create(Document&, AnimationEffect*, AnimationTimeline*);
+    static Ref<WebAnimation> create(Document&, RefPtr<AnimationEffect>&&);
+    static Ref<WebAnimation> create(Document&, RefPtr<AnimationEffect>&&, AnimationTimeline*);
     ~WebAnimation();
 
     WEBCORE_EXPORT static HashSet<WebAnimation*>& instances();

--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -40,7 +40,7 @@ public:
 
     virtual ~CachedScriptSourceProvider()
     {
-        m_cachedScript->removeClient(*this);
+        protectedScript()->removeClient(*this);
     }
 
     unsigned hash() const override;
@@ -51,8 +51,10 @@ private:
         : SourceProvider(JSC::SourceOrigin { cachedScript->response().url(), WTFMove(scriptFetcher) }, String(cachedScript->response().url().string()), cachedScript->response().isRedirected() ? String(cachedScript->url().string()) : String(), JSC::SourceTaintedOrigin::Untainted, TextPosition(), sourceType)
         , m_cachedScript(cachedScript)
     {
-        m_cachedScript->addClient(*this);
+        protectedScript()->addClient(*this);
     }
+
+    CachedResourceHandle<CachedScript> protectedScript() const { return m_cachedScript; }
 
     CachedResourceHandle<CachedScript> m_cachedScript;
 };
@@ -62,8 +64,8 @@ inline unsigned CachedScriptSourceProvider::hash() const
     // Modules should always be decoded as UTF-8.
     // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
     if (sourceType() == JSC::SourceProviderSourceType::Module)
-        return m_cachedScript->scriptHash(CachedScript::ShouldDecodeAsUTF8Only::Yes);
-    return m_cachedScript->scriptHash();
+        return protectedScript()->scriptHash(CachedScript::ShouldDecodeAsUTF8Only::Yes);
+    return protectedScript()->scriptHash();
 }
 
 inline StringView CachedScriptSourceProvider::source() const
@@ -71,8 +73,8 @@ inline StringView CachedScriptSourceProvider::source() const
     // Modules should always be decoded as UTF-8.
     // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
     if (sourceType() == JSC::SourceProviderSourceType::Module)
-        return m_cachedScript->script(CachedScript::ShouldDecodeAsUTF8Only::Yes);
-    return m_cachedScript->script();
+        return protectedScript()->script(CachedScript::ShouldDecodeAsUTF8Only::Yes);
+    return protectedScript()->script();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/CommonVM.cpp
+++ b/Source/WebCore/bindings/js/CommonVM.cpp
@@ -59,12 +59,12 @@ JSC::VM& commonVMSlow()
     ScriptController::initializeMainThread();
 
 #if PLATFORM(IOS_FAMILY)
-    RunLoop* runLoop = RunLoop::webIfExists();
+    RefPtr runLoop = RunLoop::webIfExists();
 #else
-    RunLoop* runLoop = nullptr;
+    RefPtr<RunLoop> runLoop;
 #endif
 
-    auto& vm = JSC::VM::create(JSC::HeapType::Large, runLoop).leakRef();
+    auto& vm = JSC::VM::create(JSC::HeapType::Large, runLoop.get()).leakRef();
 #if !PLATFORM(IOS_FAMILY)
     vm.heap.setFullActivityCallback(OpportunisticTaskScheduler::FullGCActivityCallback::create(vm.heap));
     vm.heap.setEdenActivityCallback(OpportunisticTaskScheduler::EdenGCActivityCallback::create(vm.heap));
@@ -101,7 +101,12 @@ LocalFrame* lexicalFrameFromCommonVM()
 
 void addImpureProperty(const AtomString& propertyName)
 {
-    commonVM().addImpureProperty(propertyName.impl());
+    protectedCommonVM()->addImpureProperty(propertyName.impl());
+}
+
+Ref<JSC::VM> protectedCommonVM()
+{
+    return commonVM();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/CommonVM.h
+++ b/Source/WebCore/bindings/js/CommonVM.h
@@ -52,6 +52,8 @@ inline JSC::VM& commonVM()
     return commonVMSlow();
 }
 
+Ref<JSC::VM> protectedCommonVM();
+
 void addImpureProperty(const AtomString&);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.h
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.h
@@ -48,8 +48,8 @@ protected:
 private:
     template<typename Visitor> void executeImplImpl(Visitor&);
 
-    JSC::VM& m_vm;
-    JSHeapData& m_heapData;
+    JSC::VM& m_vm; // FIXME: This should use a smart pointer.
+    JSHeapData& m_heapData; // FIXME: This should use a smart pointer.
     uint64_t m_lastExecutionVersion;
 };
 

--- a/Source/WebCore/bindings/js/DOMPromiseProxy.h
+++ b/Source/WebCore/bindings/js/DOMPromiseProxy.h
@@ -123,7 +123,7 @@ inline JSC::JSValue DOMPromiseProxy<IDLType>::resolvePromise(JSC::JSGlobalObject
     }
 
     // DeferredPromise can fail construction during worker abrupt termination.
-    auto deferredPromise = DeferredPromise::create(globalObject, DeferredPromise::Mode::RetainPromiseOnResolve);
+    RefPtr deferredPromise = DeferredPromise::create(globalObject, DeferredPromise::Mode::RetainPromiseOnResolve);
     if (!deferredPromise)
         return JSC::jsUndefined();
 
@@ -229,7 +229,7 @@ inline JSC::JSValue DOMPromiseProxy<IDLUndefined>::promise(JSC::JSGlobalObject& 
     }
 
     // DeferredPromise can fail construction during worker abrupt termination.
-    auto deferredPromise = DeferredPromise::create(globalObject, DeferredPromise::Mode::RetainPromiseOnResolve);
+    RefPtr deferredPromise = DeferredPromise::create(globalObject, DeferredPromise::Mode::RetainPromiseOnResolve);
     if (!deferredPromise)
         return JSC::jsUndefined();
 
@@ -301,7 +301,7 @@ inline JSC::JSValue DOMPromiseProxyWithResolveCallback<IDLType>::promise(JSC::JS
     }
 
     // DeferredPromise can fail construction during worker abrupt termination.
-    auto deferredPromise = DeferredPromise::create(globalObject, DeferredPromise::Mode::RetainPromiseOnResolve);
+    RefPtr deferredPromise = DeferredPromise::create(globalObject, DeferredPromise::Mode::RetainPromiseOnResolve);
     if (!deferredPromise)
         return JSC::jsUndefined();
 

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -49,7 +49,7 @@ DOMWrapperWorld::~DOMWrapperWorld()
 
     // These items are created lazily.
     while (!m_jsWindowProxies.isEmpty())
-        (*m_jsWindowProxies.begin())->destroyJSWindowProxy(*this);
+        Ref { (*m_jsWindowProxies.begin()).get() }->destroyJSWindowProxy(*this);
 }
 
 void DOMWrapperWorld::clearWrappers()
@@ -58,7 +58,17 @@ void DOMWrapperWorld::clearWrappers()
 
     // These items are created lazily.
     while (!m_jsWindowProxies.isEmpty())
-        (*m_jsWindowProxies.begin())->destroyJSWindowProxy(*this);
+        Ref { (*m_jsWindowProxies.begin()).get() }->destroyJSWindowProxy(*this);
+}
+
+void DOMWrapperWorld::didCreateWindowProxy(WindowProxy& controller)
+{
+    m_jsWindowProxies.add(controller);
+}
+
+void DOMWrapperWorld::didDestroyWindowProxy(WindowProxy& controller)
+{
+    m_jsWindowProxies.remove(controller);
 }
 
 DOMWrapperWorld& normalWorld(JSC::VM& vm)

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -48,8 +48,8 @@ public:
     // Free as much memory held onto by this world as possible.
     WEBCORE_EXPORT void clearWrappers();
 
-    void didCreateWindowProxy(WindowProxy* controller) { m_jsWindowProxies.add(controller); }
-    void didDestroyWindowProxy(WindowProxy* controller) { m_jsWindowProxies.remove(controller); }
+    void didCreateWindowProxy(WindowProxy&);
+    void didDestroyWindowProxy(WindowProxy&);
 
     void setShadowRootIsAlwaysOpen() { m_shadowRootIsAlwaysOpen = true; }
     bool shadowRootIsAlwaysOpen() const { return m_shadowRootIsAlwaysOpen; }
@@ -72,7 +72,7 @@ protected:
 
 private:
     JSC::VM& m_vm;
-    HashSet<WindowProxy*> m_jsWindowProxies;
+    HashSet<SingleThreadWeakRef<WindowProxy>> m_jsWindowProxies;
     DOMObjectWrapperMap m_wrappers;
 
     String m_name;

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -111,7 +111,7 @@ void GCController::garbageCollectNowIfNotDoneRecently()
 
 void GCController::garbageCollectOnAlternateThreadForDebugging(bool waitUntilDone)
 {
-    auto thread = Thread::create("WebCore: GCController", &collect, ThreadType::GarbageCollection);
+    Ref thread = Thread::create("WebCore: GCController", &collect, ThreadType::GarbageCollection);
 
     if (waitUntilDone) {
         thread->waitForCompletion();
@@ -128,14 +128,16 @@ void GCController::setJavaScriptGarbageCollectorTimerEnabled(bool enable)
 
 void GCController::deleteAllCode(DeleteAllCodeEffort effort)
 {
-    JSLockHolder lock(commonVM());
-    commonVM().deleteAllCode(effort);
+    Ref vm = commonVM();
+    JSLockHolder lock(vm);
+    vm->deleteAllCode(effort);
 }
 
 void GCController::deleteAllLinkedCode(DeleteAllCodeEffort effort)
 {
-    JSLockHolder lock(commonVM());
-    commonVM().deleteAllLinkedCode(effort);
+    Ref vm = commonVM();
+    JSLockHolder lock(vm);
+    vm->deleteAllLinkedCode(effort);
 }
 
 void GCController::dumpHeap()
@@ -147,7 +149,7 @@ void GCController::dumpHeap()
         return;
     }
 
-    VM& vm = commonVM();
+    Ref vm = commonVM();
     JSLockHolder lock(vm);
 
     sanitizeStackForVM(vm);
@@ -156,7 +158,7 @@ void GCController::dumpHeap()
     {
         DeferGCForAWhile deferGC(vm); // Prevent concurrent GC from interfering with the full GC that the snapshot does.
 
-        HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler(), HeapSnapshotBuilder::SnapshotType::GCDebuggingSnapshot);
+        HeapSnapshotBuilder snapshotBuilder(vm->ensureHeapProfiler(), HeapSnapshotBuilder::SnapshotType::GCDebuggingSnapshot);
         snapshotBuilder.buildSnapshot();
 
         jsonData = snapshotBuilder.json();

--- a/Source/WebCore/bindings/js/InternalReadableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStream.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 static ExceptionOr<JSC::JSValue> invokeReadableStreamFunction(JSC::JSGlobalObject& globalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
 {
-    JSC::VM& vm = globalObject.vm();
+    Ref vm = globalObject.vm();
     JSC::JSLockHolder lock(vm);
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
@@ -84,9 +84,10 @@ bool InternalReadableStream::isLocked() const
     if (!globalObject)
         return false;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().isReadableStreamLockedPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -106,9 +107,10 @@ bool InternalReadableStream::isDisturbed() const
     if (!globalObject)
         return false;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().isReadableStreamDisturbedPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -128,8 +130,9 @@ void InternalReadableStream::cancel(Exception&& exception)
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
-    JSC::JSLockHolder lock(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    JSC::JSLockHolder lock(vm);
     cancel(*globalObject, toJSNewlyCreated(globalObject, JSC::jsCast<JSDOMGlobalObject*>(globalObject), DOMException::create(WTFMove(exception))), Use::Private);
     if (UNLIKELY(scope.exception()))
         scope.clearException();
@@ -141,9 +144,10 @@ void InternalReadableStream::lock()
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().acquireReadableStreamDefaultReaderPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -161,10 +165,11 @@ void InternalReadableStream::pipeTo(ReadableStreamSink& sink)
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
-    JSC::JSLockHolder lock(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    JSC::JSLockHolder lock(vm);
 
-    auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamPipeToPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -183,7 +188,8 @@ ExceptionOr<std::pair<Ref<InternalReadableStream>, Ref<InternalReadableStream>>>
     if (!globalObject)
         return Exception { ExceptionCode::InvalidStateError };
 
-    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto result = tee(*globalObject, shouldClone);
     if (UNLIKELY(scope.exception()))
         return Exception { ExceptionCode::ExistingExceptionError };
@@ -197,7 +203,8 @@ ExceptionOr<std::pair<Ref<InternalReadableStream>, Ref<InternalReadableStream>>>
 
 JSC::JSValue InternalReadableStream::cancel(JSC::JSGlobalObject& globalObject, JSC::JSValue reason, Use use)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& names = clientData->builtinFunctions().readableStreamInternalsBuiltins();
     auto& privateName = use == Use::Bindings ? names.readableStreamCancelForBindingsPrivateName() : names.readableStreamCancelPrivateName();
 
@@ -215,7 +222,8 @@ JSC::JSValue InternalReadableStream::cancel(JSC::JSGlobalObject& globalObject, J
 
 JSC::JSValue InternalReadableStream::getReader(JSC::JSGlobalObject& globalObject, JSC::JSValue options)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamGetReaderForBindingsPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -232,7 +240,8 @@ JSC::JSValue InternalReadableStream::getReader(JSC::JSGlobalObject& globalObject
 
 JSC::JSValue InternalReadableStream::pipeTo(JSC::JSGlobalObject& globalObject, JSC::JSValue streams, JSC::JSValue options)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamPipeToForBindingsPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -250,7 +259,8 @@ JSC::JSValue InternalReadableStream::pipeTo(JSC::JSGlobalObject& globalObject, J
 
 JSC::JSValue InternalReadableStream::pipeThrough(JSC::JSGlobalObject& globalObject, JSC::JSValue dest, JSC::JSValue options)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamPipeThroughForBindingsPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -268,7 +278,8 @@ JSC::JSValue InternalReadableStream::pipeThrough(JSC::JSGlobalObject& globalObje
 
 JSC::JSValue InternalReadableStream::tee(JSC::JSGlobalObject& globalObject, bool shouldClone)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamTeePrivateName();
 
     JSC::MarkedArgumentBuffer arguments;

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 static ExceptionOr<JSC::JSValue> invokeWritableStreamFunction(JSC::JSGlobalObject& globalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
 {
-    JSC::VM& vm = globalObject.vm();
+    Ref vm = globalObject.vm();
     JSC::JSLockHolder lock(vm);
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
@@ -54,7 +54,8 @@ static ExceptionOr<JSC::JSValue> invokeWritableStreamFunction(JSC::JSGlobalObjec
 
 ExceptionOr<Ref<InternalWritableStream>> InternalWritableStream::createFromUnderlyingSink(JSDOMGlobalObject& globalObject, JSC::JSValue underlyingSink, JSC::JSValue strategy)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().createInternalWritableStreamFromUnderlyingSinkPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -81,9 +82,10 @@ bool InternalWritableStream::locked() const
     if (!globalObject)
         return false;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().isWritableStreamLockedPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -103,9 +105,10 @@ void InternalWritableStream::lock()
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().acquireWritableStreamDefaultWriterPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -119,7 +122,8 @@ void InternalWritableStream::lock()
 
 JSC::JSValue InternalWritableStream::abortForBindings(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamAbortForBindingsPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -136,7 +140,8 @@ JSC::JSValue InternalWritableStream::abortForBindings(JSC::JSGlobalObject& globa
 
 JSC::JSValue InternalWritableStream::closeForBindings(JSC::JSGlobalObject& globalObject)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamCloseForBindingsPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -156,9 +161,10 @@ void InternalWritableStream::closeIfPossible()
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamCloseIfPossiblePrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
@@ -172,7 +178,8 @@ void InternalWritableStream::closeIfPossible()
 
 JSC::JSValue InternalWritableStream::getWriter(JSC::JSGlobalObject& globalObject)
 {
-    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    Ref vm = globalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().acquireWritableStreamDefaultWriterPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -44,7 +44,7 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
     ASSERT(callback);
 
     JSGlobalObject* lexicalGlobalObject = &globalObject;
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
@@ -81,17 +81,17 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
     ASSERT(!function.isEmpty());
     ASSERT(callData.type != CallData::Type::None);
 
-    ScriptExecutionContext* context = globalObject.scriptExecutionContext();
+    RefPtr context = globalObject.scriptExecutionContext();
     // We will fail to get the context if the frame has been detached.
     if (!context)
         return JSValue();
 
-    JSExecState::instrumentFunction(context, callData);
+    JSExecState::instrumentFunction(context.get(), callData);
 
     returnedException = nullptr;
     JSValue result = JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Other, function, callData, thisValue, args, returnedException);
 
-    InspectorInstrumentation::didCallFunction(context);
+    InspectorInstrumentation::didCallFunction(context.get());
 
     return result;
 }

--- a/Source/WebCore/bindings/js/JSCustomEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCustomEventCustom.cpp
@@ -36,7 +36,8 @@ namespace WebCore {
 
 JSC::JSValue JSCustomEvent::detail(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    Ref vm = lexicalGlobalObject.vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedDetail(), [this](JSC::ThrowScope&) {
         return wrapped().detail().getValue(JSC::jsNull());
     });

--- a/Source/WebCore/bindings/js/JSDOMAbstractOperations.h
+++ b/Source/WebCore/bindings/js/JSDOMAbstractOperations.h
@@ -50,10 +50,10 @@ static bool isVisibleNamedProperty(JSC::JSGlobalObject& lexicalGlobalObject, JSC
     if (propertyName.isSymbol())
         return false;
 
-    auto& impl = thisObject.wrapped();
+    Ref impl = thisObject.wrapped();
 
     // 1. If P is not a supported property name of O, then return false.
-    if (!impl.isSupportedPropertyName(propertyNameToString(propertyName)))
+    if (!impl->isSupportedPropertyName(propertyNameToString(propertyName)))
         return false;
     
     // 2. If O has an own property named P, then return false.

--- a/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
@@ -208,7 +208,7 @@ JSC::JSValue JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::next(JSC::JSGlob
 template<typename JSWrapper, typename IteratorTraits>
 JSC::JSPromise* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::runNextSteps(JSC::JSGlobalObject& globalObject)
 {
-    JSC::VM& vm = globalObject.vm();
+    Ref vm = globalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto nextPromiseCapability = JSC::JSPromise::createNewPromiseCapability(&globalObject, globalObject.promiseConstructor());
@@ -240,10 +240,10 @@ JSC::JSPromise* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::runNextSteps(
 template<typename JSWrapper, typename IteratorTraits>
 JSC::JSPromise* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::getNextIterationResult(JSC::JSGlobalObject& globalObject)
 {
-    JSC::VM& vm = JSC::getVM(&globalObject);
+    Ref vm = JSC::getVM(&globalObject);
 
     auto* promise = JSC::JSPromise::create(vm, globalObject.promiseStructure());
-    auto deferred = DeferredPromise::create(*this->globalObject(), *promise);
+    RefPtr deferred = DeferredPromise::create(*this->globalObject(), *promise);
     if (!m_iterator) {
         deferred->resolve();
         return promise;
@@ -276,7 +276,7 @@ JSC::EncodedJSValue JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::settle(JS
 template<typename JSWrapper, typename IteratorTraits>
 JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::onPromiseSettled(JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto castedThis = JSC::jsDynamicCast<JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>*>(callFrame->thisValue());
     if (!castedThis)
@@ -288,7 +288,7 @@ JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, I
 template<typename JSWrapper, typename IteratorTraits>
 JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnSettledFunction(JSC::JSGlobalObject* globalObject)
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto onSettled = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseSettled, ImplementationVisibility::Public);
     return JSC::JSBoundFunction::create(vm, globalObject, onSettled, this, { }, 1, jsEmptyString(vm));
 }
@@ -308,7 +308,7 @@ JSC::EncodedJSValue JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::fulfill(J
 template<typename JSWrapper, typename IteratorTraits>
 JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::onPromiseFulFilled(JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto castedThis = JSC::jsDynamicCast<JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>*>(callFrame->thisValue());
     if (!castedThis)
@@ -320,7 +320,7 @@ JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, I
 template<typename JSWrapper, typename IteratorTraits>
 JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnFulfilledFunction(JSC::JSGlobalObject* globalObject)
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto onFulFilled = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseFulFilled, ImplementationVisibility::Public);
     return JSC::JSBoundFunction::create(vm, globalObject, onFulFilled, this, { }, 1, jsEmptyString(vm));
 }
@@ -331,7 +331,7 @@ JSC::EncodedJSValue JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::reject(JS
     m_ongoingPromise = nullptr;
     m_iterator = nullptr;
 
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     return throwVMError(globalObject, scope, reason);
 }
@@ -339,7 +339,7 @@ JSC::EncodedJSValue JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::reject(JS
 template<typename JSWrapper, typename IteratorTraits>
 JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::onPromiseRejected(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto castedThis = JSC::jsDynamicCast<JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>*>(callFrame->thisValue());
     if (!castedThis)
@@ -351,7 +351,7 @@ JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorBase<JSWrapper, I
 template<typename JSWrapper, typename IteratorTraits>
 JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnRejectedFunction(JSC::JSGlobalObject* globalObject)
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto onRejected = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseRejected, ImplementationVisibility::Public);
     return JSC::JSBoundFunction::create(vm, globalObject, onRejected, this, { }, 1, jsEmptyString(vm));
 }
@@ -359,7 +359,7 @@ JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnReje
 template<typename JSWrapper, typename IteratorTraits>
 JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMAsyncIteratorPrototype<JSWrapper, IteratorTraits>::next(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto iterator = JSC::jsDynamicCast<JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>*>(callFrame->thisValue());

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurityInlines.h
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurityInlines.h
@@ -35,7 +35,7 @@ inline bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject* lexicalGlobalObjec
 {
     if (LIKELY(lexicalGlobalObject == &target))
         return true;
-    return shouldAllowAccessToDOMWindow(lexicalGlobalObject, target.wrapped(), reportingOption);
+    return shouldAllowAccessToDOMWindow(lexicalGlobalObject, target.protectedWrapped(), reportingOption);
 }
 
 } // namespace BindingSecurity

--- a/Source/WebCore/bindings/js/JSDOMBuiltinConstructor.h
+++ b/Source/WebCore/bindings/js/JSDOMBuiltinConstructor.h
@@ -79,7 +79,7 @@ template<typename JSClass> inline void JSDOMBuiltinConstructor<JSClass>::finishC
 
 template<typename JSClass> inline JSC::Structure* JSDOMBuiltinConstructor<JSClass>::getDOMStructureForJSObject(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* newTarget)
 {
-    auto& vm = JSC::getVM(lexicalGlobalObject);
+    Ref vm = JSC::getVM(lexicalGlobalObject);
 
     if (LIKELY(newTarget == this))
         return getDOMStructure<JSClass>(vm, *globalObject());

--- a/Source/WebCore/bindings/js/JSDOMCastThisValue.h
+++ b/Source/WebCore/bindings/js/JSDOMCastThisValue.h
@@ -44,10 +44,10 @@ enum class CastedThisErrorBehavior : uint8_t {
 template<class JSClass>
 JSClass* castThisValue(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue thisValue)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    if constexpr (std::is_base_of_v<JSDOMGlobalObject, JSClass>)
+    if constexpr (std::is_base_of_v<JSDOMGlobalObject, JSClass>) {
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
         return toJSDOMGlobalObject<JSClass>(vm, thisValue.isUndefinedOrNull() ? JSC::JSValue(&lexicalGlobalObject) : thisValue);
-    else
+    } else
         return JSC::jsDynamicCast<JSClass*>(thisValue);
 }
 

--- a/Source/WebCore/bindings/js/JSDOMConstructorBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConstructorBase.cpp
@@ -32,7 +32,7 @@ STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSDOMConstructorBase);
 
 JSC_DEFINE_HOST_FUNCTION(callThrowTypeErrorForJSDOMConstructor, (JSGlobalObject* globalObject, CallFrame*))
 {
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     throwTypeError(globalObject, scope, "Constructor requires 'new' operator"_s);
     return JSValue::encode(jsNull());
@@ -40,7 +40,7 @@ JSC_DEFINE_HOST_FUNCTION(callThrowTypeErrorForJSDOMConstructor, (JSGlobalObject*
 
 JSC_DEFINE_HOST_FUNCTION(callThrowTypeErrorForJSDOMConstructorNotConstructable, (JSC::JSGlobalObject* globalObject, JSC::CallFrame*))
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::throwTypeError(globalObject, scope, "Illegal constructor"_s);
     return JSC::JSValue::encode(JSC::jsNull());

--- a/Source/WebCore/bindings/js/JSDOMConvertAny.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertAny.h
@@ -72,7 +72,7 @@ template<> struct VariadicConverter<IDLAny> {
 
     static std::optional<Item> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
     {
-        auto& vm = JSC::getVM(&lexicalGlobalObject);
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         auto result = Converter<IDLAny>::convert(lexicalGlobalObject, value);

--- a/Source/WebCore/bindings/js/JSDOMConvertBufferSource.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertBufferSource.h
@@ -125,7 +125,7 @@ struct BufferSourceConverter {
     template<typename ExceptionThrower = DefaultExceptionThrower>
     static ReturnType convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, ExceptionThrower&& exceptionThrower = ExceptionThrower())
     {
-        auto& vm = JSC::getVM(&lexicalGlobalObject);
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
         ReturnType object { };
         if constexpr (mode == BufferSourceConverterAllowSharedMode::Allow)

--- a/Source/WebCore/bindings/js/JSDOMConvertCallbacks.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertCallbacks.h
@@ -38,7 +38,7 @@ template<typename T> struct Converter<IDLCallbackFunction<T>> : DefaultConverter
     template<typename ExceptionThrower = DefaultExceptionThrower>
     static RefPtr<T> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, ExceptionThrower&& exceptionThrower = ExceptionThrower())
     {
-        JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         if (!value.isCallable()) {
@@ -72,7 +72,7 @@ template<typename T> struct Converter<IDLCallbackInterface<T>> : DefaultConverte
     template<typename ExceptionThrower = DefaultExceptionThrower>
     static RefPtr<T> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, ExceptionThrower&& exceptionThrower = ExceptionThrower())
     {
-        JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         if (!value.isObject()) {

--- a/Source/WebCore/bindings/js/JSDOMConvertDate.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertDate.cpp
@@ -39,13 +39,13 @@ WallTime valueToDate(JSC::JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
     double milliseconds = std::numeric_limits<double>::quiet_NaN();
 
-    auto& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     if (value.inherits<DateInstance>())
         milliseconds = jsCast<DateInstance*>(value)->internalNumber();
     else if (value.isNumber())
         milliseconds = value.asNumber();
     else if (value.isString())
-        milliseconds = vm.dateCache.parseDate(&lexicalGlobalObject, vm, value.getString(&lexicalGlobalObject));
+        milliseconds = vm->dateCache.parseDate(&lexicalGlobalObject, vm, value.getString(&lexicalGlobalObject));
 
     return WallTime::fromRawSeconds(Seconds::fromMilliseconds(milliseconds).value());
 }

--- a/Source/WebCore/bindings/js/JSDOMConvertEnumeration.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertEnumeration.h
@@ -44,7 +44,7 @@ template<typename T> struct Converter<IDLEnumeration<T>> : DefaultConverter<IDLE
     template<typename ExceptionThrower = DefaultExceptionThrower>
     static T convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, ExceptionThrower&& exceptionThrower = ExceptionThrower())
     {
-        auto& vm = JSC::getVM(&lexicalGlobalObject);
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
         auto throwScope = DECLARE_THROW_SCOPE(vm);
 
         auto result = parseEnumeration<T>(lexicalGlobalObject, value);

--- a/Source/WebCore/bindings/js/JSDOMConvertEventListener.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertEventListener.h
@@ -36,7 +36,8 @@ template<typename T> struct Converter<IDLEventListener<T>> : DefaultConverter<ID
     template<typename ExceptionThrower = DefaultExceptionThrower>
     static ReturnType convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSC::JSObject& thisObject, ExceptionThrower&& exceptionThrower = ExceptionThrower())
     {
-        auto scope = DECLARE_THROW_SCOPE(JSC::getVM(&lexicalGlobalObject));
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
 
         if (UNLIKELY(!value.isObject())) {
             exceptionThrower(lexicalGlobalObject, scope);

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -126,7 +126,7 @@ JSC_DEFINE_HOST_FUNCTION(makeThisTypeErrorForBuiltins, (JSGlobalObject* globalOb
 {
     ASSERT(callFrame);
     ASSERT(callFrame->argumentCount() == 2);
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     DeferTermination deferScope(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
@@ -141,7 +141,7 @@ JSC_DEFINE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins, (JSGlobalObject* global
 {
     ASSERT(callFrame);
     ASSERT(callFrame->argumentCount() == 2);
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     DeferTermination deferScope(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
@@ -160,7 +160,7 @@ JSC_DEFINE_HOST_FUNCTION(makeDOMExceptionForBuiltins, (JSGlobalObject* globalObj
     ASSERT(callFrame);
     ASSERT(callFrame->argumentCount() == 2);
 
-    auto& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     DeferTermination deferScope(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
@@ -175,7 +175,7 @@ JSC_DEFINE_HOST_FUNCTION(makeDOMExceptionForBuiltins, (JSGlobalObject* globalObj
         code = ExceptionCode::AbortError;
     auto value = createDOMException(globalObject, code, message);
 
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    EXCEPTION_ASSERT(!scope.exception() || vm->hasPendingTerminationException());
 
     return JSValue::encode(value);
 }
@@ -233,7 +233,7 @@ JSC_DEFINE_HOST_FUNCTION(addAbortAlgorithmToSignal, (JSGlobalObject* globalObjec
         return JSValue::encode(JSValue(JSC::JSValue::JSFalse));
 
     auto* jsDOMGlobalObject = JSC::jsCast<JSDOMGlobalObject*>(globalObject);
-    Ref<AbortAlgorithm> abortAlgorithm = JSAbortAlgorithm::create(callFrame->uncheckedArgument(1).getObject(), jsDOMGlobalObject);
+    Ref abortAlgorithm = JSAbortAlgorithm::create(callFrame->uncheckedArgument(1).getObject(), jsDOMGlobalObject);
 
     auto algorithmIdentifier = AbortSignal::addAbortAlgorithmToSignal(abortSignal->protectedWrapped().get(), WTFMove(abortAlgorithm));
     return JSValue::encode(JSC::jsNumber(algorithmIdentifier));
@@ -374,6 +374,11 @@ ScriptExecutionContext* JSDOMGlobalObject::scriptExecutionContext() const
     return nullptr;
 }
 
+RefPtr<ScriptExecutionContext> JSDOMGlobalObject::protectedScriptExecutionContext() const
+{
+    return scriptExecutionContext();
+}
+
 template<typename Visitor>
 void JSDOMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
@@ -405,11 +410,11 @@ void JSDOMGlobalObject::promiseRejectionTracker(JSGlobalObject* jsGlobalObject, 
     // https://html.spec.whatwg.org/multipage/webappapis.html#the-hostpromiserejectiontracker-implementation
 
     auto& globalObject = *JSC::jsCast<JSDOMGlobalObject*>(jsGlobalObject);
-    auto* context = globalObject.scriptExecutionContext();
+    RefPtr context = globalObject.scriptExecutionContext();
     if (!context)
         return;
 
-    auto rejectedPromiseTracker = context->ensureRejectedPromiseTracker();
+    CheckedPtr rejectedPromiseTracker = context->ensureRejectedPromiseTracker();
     if (!rejectedPromiseTracker)
         return;
 
@@ -443,7 +448,7 @@ void JSDOMGlobalObject::clearDOMGuardedObjects() const
 
 JSFunction* JSDOMGlobalObject::createCrossOriginFunction(JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, NativeFunction nativeFunction, unsigned length)
 {
-    auto& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     CrossOriginMapKey key = std::make_pair(lexicalGlobalObject, nativeFunction.taggedPtr());
 
     // WeakGCMap::ensureValue's functor must not invoke GC since GC can modify WeakGCMap in the middle of HashMap::ensure.
@@ -457,7 +462,7 @@ JSFunction* JSDOMGlobalObject::createCrossOriginFunction(JSGlobalObject* lexical
 GetterSetter* JSDOMGlobalObject::createCrossOriginGetterSetter(JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, GetValueFunc getter, PutValueFunc setter)
 {
     ASSERT(getter || setter);
-    auto& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     CrossOriginMapKey key = std::make_pair(lexicalGlobalObject, getter ? getter.taggedPtr() : setter.taggedPtr());
 
     // WeakGCMap::ensureValue's functor must not invoke GC since GC can modify WeakGCMap in the middle of HashMap::ensure.
@@ -474,12 +479,12 @@ GetterSetter* JSDOMGlobalObject::createCrossOriginGetterSetter(JSGlobalObject* l
 // https://webassembly.github.io/spec/web-api/index.html#compile-a-potential-webassembly-response
 static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* globalObject, JSC::JSValue source, JSC::Wasm::CompilerMode compilerMode, JSC::JSObject* importObject)
 {
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     JSLockHolder lock(vm);
 
-    auto deferred = DeferredPromise::create(*jsCast<JSDOMGlobalObject*>(globalObject), DeferredPromise::Mode::RetainPromiseOnResolve);
+    RefPtr deferred = DeferredPromise::create(*jsCast<JSDOMGlobalObject*>(globalObject), DeferredPromise::Mode::RetainPromiseOnResolve);
 
-    auto inputResponse = JSFetchResponse::toWrapped(vm, source);
+    RefPtr inputResponse = JSFetchResponse::toWrapped(vm, source);
     if (!inputResponse) {
         deferred->reject(ExceptionCode::TypeError, "first argument must be an Response or Promise for Response"_s);
         return jsCast<JSC::JSPromise*>(deferred->promise());
@@ -528,7 +533,7 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
 
     if (inputResponse->isBodyReceivedByChunk()) {
         inputResponse->consumeBodyReceivedByChunk([globalObject, compiler = WTFMove(compiler)](auto&& result) mutable {
-            VM& vm = globalObject->vm();
+            Ref vm = globalObject->vm();
             JSLockHolder lock(vm);
 
             if (result.hasException()) {
@@ -548,7 +553,7 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
                 auto scope = DECLARE_THROW_SCOPE(vm);
                 auto error = createDOMException(*globalObject, WTFMove(exception));
                 if (UNLIKELY(scope.exception())) {
-                    ASSERT(vm.hasPendingTerminationException());
+                    ASSERT(vm->hasPendingTerminationException());
                     compiler->cancel();
                     return;
                 }
@@ -624,7 +629,7 @@ JSC::Identifier JSDOMGlobalObject::moduleLoaderResolve(JSC::JSGlobalObject* glob
 
 JSC::JSInternalPromise* JSDOMGlobalObject::moduleLoaderFetch(JSC::JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSValue moduleKey, JSC::JSValue parameters, JSC::JSValue scriptFetcher)
 {
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSDOMGlobalObject* thisObject = JSC::jsCast<JSDOMGlobalObject*>(globalObject);
     if (auto* loader = scriptModuleLoader(thisObject))
@@ -645,7 +650,7 @@ JSC::JSValue JSDOMGlobalObject::moduleLoaderEvaluate(JSC::JSGlobalObject* global
 
 JSC::JSInternalPromise* JSDOMGlobalObject::moduleLoaderImportModule(JSC::JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, JSC::JSValue parameters, const JSC::SourceOrigin& sourceOrigin)
 {
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSDOMGlobalObject* thisObject = JSC::jsCast<JSDOMGlobalObject*>(globalObject);
     if (auto* loader = scriptModuleLoader(thisObject))
@@ -666,11 +671,11 @@ JSC::JSObject* JSDOMGlobalObject::moduleLoaderCreateImportMetaProperties(JSC::JS
 
 JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlobalObject* globalObject)
 {
-    auto& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
 
     auto domGlobalObject = jsCast<JSDOMGlobalObject*>(globalObject);
-    auto context = domGlobalObject->scriptExecutionContext();
-    if (auto* document = dynamicDowncast<Document>(context)) {
+    RefPtr context = domGlobalObject->scriptExecutionContext();
+    if (auto* document = dynamicDowncast<Document>(context.get())) {
         // Same-origin iframes present a difficult circumstance because the
         // shadow realm global object cannot retain the incubating realm's
         // global object (that would be a refcount loop); but, same-origin
@@ -688,7 +693,7 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
         while (!document->isTopDocument()) {
             auto candidateDocument = document->parentDocument();
 
-            if (!candidateDocument->securityOrigin().isSameOriginDomain(originalOrigin))
+            if (!candidateDocument->protectedSecurityOrigin()->isSameOriginDomain(originalOrigin))
                 break;
 
             document = candidateDocument;
@@ -727,10 +732,15 @@ String JSDOMGlobalObject::agentClusterID() const
     return defaultAgentClusterID();
 }
 
+Ref<DOMWrapperWorld> JSDOMGlobalObject::protectedWorld()
+{
+    return m_world;
+}
+
 JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext& context, DOMWrapperWorld& world)
 {
     if (auto* document = dynamicDowncast<Document>(context))
-        return toJSLocalDOMWindow(document->frame(), world);
+        return toJSLocalDOMWindow(document->protectedFrame().get(), world);
 
     if (auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(context))
         return globalScope->script()->globalScopeWrapper();
@@ -741,7 +751,7 @@ JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext& context, DOMWrapp
 
 static JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame* callFrame, bool skipFirstFrame, bool lookUpFromVMEntryScope)
 {
-    VM& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     if (callFrame) {
         class GetCallerGlobalObjectFunctor {
         public:
@@ -789,8 +799,8 @@ static JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalO
     // Since we put JSGlobalObject to VMEntryScope, we can retrieve the right globalObject from that.
     // For callerGlobalObject, we do not check vm.entryScope to keep it the old behavior.
     if (lookUpFromVMEntryScope) {
-        if (vm.entryScope) {
-            if (auto* result = vm.entryScope->globalObject())
+        if (vm->entryScope) {
+            if (auto* result = vm->entryScope->globalObject())
                 return *jsCast<JSDOMGlobalObject*>(result);
         }
     }

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -78,6 +78,7 @@ public:
     inline DOMGuardedObjectSet& guardedObjects(NoLockingNecessaryTag);
 
     ScriptExecutionContext* scriptExecutionContext() const;
+    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
     // https://tc39.es/ecma262/#sec-agent-clusters
     String agentClusterID() const;
@@ -89,6 +90,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     DOMWrapperWorld& world() { return m_world.get(); }
+    Ref<DOMWrapperWorld> protectedWorld();
     bool worldIsNormal() const { return m_worldIsNormal; }
     static ptrdiff_t offsetOfWorldIsNormal() { return OBJECT_OFFSETOF(JSDOMGlobalObject, m_worldIsNormal); }
 

--- a/Source/WebCore/bindings/js/JSDOMGuardedObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGuardedObject.cpp
@@ -36,12 +36,13 @@ DOMGuardedObject::DOMGuardedObject(JSDOMGlobalObject& globalObject, JSCell& guar
     , m_guarded(&guarded)
     , m_globalObject(&globalObject)
 {
-    if (globalObject.vm().heap.mutatorShouldBeFenced()) {
+    Ref vm = globalObject.vm();
+    if (vm->heap.mutatorShouldBeFenced()) {
         Locker locker { globalObject.gcLock() };
         globalObject.guardedObjects().add(this);
     } else
         globalObject.guardedObjects(NoLockingNecessary).add(this);
-    globalObject.vm().writeBarrier(&globalObject, &guarded);
+    vm->writeBarrier(&globalObject, &guarded);
 }
 
 DOMGuardedObject::~DOMGuardedObject()

--- a/Source/WebCore/bindings/js/JSDOMIterator.cpp
+++ b/Source/WebCore/bindings/js/JSDOMIterator.cpp
@@ -38,7 +38,7 @@ void addValueIterableMethods(JSC::JSGlobalObject& globalObject, JSC::JSObject& p
 
     JSC::JSGlobalObject* lexicalGlobalObject = &globalObject;
     ASSERT(lexicalGlobalObject);
-    JSC::VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
 
     auto copyProperty = [&] (const JSC::Identifier& arrayIdentifier, const JSC::Identifier& otherIdentifier, unsigned attributes = 0) {
         JSC::JSValue value = arrayPrototype->getDirect(vm, arrayIdentifier);
@@ -46,10 +46,10 @@ void addValueIterableMethods(JSC::JSGlobalObject& globalObject, JSC::JSObject& p
         prototype.putDirect(vm, otherIdentifier, value, attributes);
     };
 
-    copyProperty(vm.propertyNames->builtinNames().entriesPrivateName(), vm.propertyNames->builtinNames().entriesPublicName());
-    copyProperty(vm.propertyNames->builtinNames().forEachPrivateName(), vm.propertyNames->builtinNames().forEachPublicName());
-    copyProperty(vm.propertyNames->builtinNames().keysPrivateName(), vm.propertyNames->builtinNames().keysPublicName());
-    copyProperty(vm.propertyNames->builtinNames().valuesPrivateName(), vm.propertyNames->builtinNames().valuesPublicName());
+    copyProperty(vm->propertyNames->builtinNames().entriesPrivateName(), vm->propertyNames->builtinNames().entriesPublicName());
+    copyProperty(vm->propertyNames->builtinNames().forEachPrivateName(), vm->propertyNames->builtinNames().forEachPublicName());
+    copyProperty(vm->propertyNames->builtinNames().keysPrivateName(), vm->propertyNames->builtinNames().keysPublicName());
+    copyProperty(vm->propertyNames->builtinNames().valuesPrivateName(), vm->propertyNames->builtinNames().valuesPublicName());
 }
 
 }

--- a/Source/WebCore/bindings/js/JSDOMIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMIterator.h
@@ -203,7 +203,7 @@ template<typename JSIterator, typename IteratorValue> EnableIfSet<typename JSIte
 
 template<typename JSIterator> JSC::JSValue iteratorForEach(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, typename JSIterator::Wrapper& thisObject)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSValue callback = callFrame.argument(0);
     JSC::JSValue thisValue = callFrame.argument(1);
@@ -250,7 +250,7 @@ JSC::JSValue JSDOMIteratorBase<JSWrapper, IteratorTraits>::next(JSC::JSGlobalObj
 template<typename JSWrapper, typename IteratorTraits>
 JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMIteratorPrototype<JSWrapper, IteratorTraits>::next(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto iterator = JSC::jsDynamicCast<JSDOMIteratorBase<JSWrapper, IteratorTraits>*>(callFrame->thisValue());

--- a/Source/WebCore/bindings/js/JSDOMMapLike.h
+++ b/Source/WebCore/bindings/js/JSDOMMapLike.h
@@ -91,33 +91,33 @@ template<typename WrapperClass> JSC::JSObject& getAndInitializeBackingMap(JSC::J
 
 template<typename WrapperClass> JSC::JSValue forwardSizeToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, WrapperClass& mapLike)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardAttributeGetterToBackingMap(lexicalGlobalObject, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm.propertyNames->builtinNames().sizePrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardAttributeGetterToBackingMap(lexicalGlobalObject, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm->propertyNames->builtinNames().sizePrivateName());
 }
 
 template<typename WrapperClass> JSC::JSValue forwardEntriesToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm.propertyNames->builtinNames().entriesPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm->propertyNames->builtinNames().entriesPrivateName());
 }
 
 template<typename WrapperClass> JSC::JSValue forwardKeysToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm.propertyNames->builtinNames().keysPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm->propertyNames->builtinNames().keysPrivateName());
 }
 
 template<typename WrapperClass> JSC::JSValue forwardValuesToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm.propertyNames->builtinNames().valuesPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm->propertyNames->builtinNames().valuesPrivateName());
 }
 
 template<typename WrapperClass> JSC::JSValue forwardClearToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike)
 {
-    mapLike.wrapped().clear();
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm.propertyNames->builtinNames().clearPrivateName());
+    mapLike.protectedWrapped()->clear();
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm->propertyNames->builtinNames().clearPrivateName());
 }
 
 template<typename WrapperClass, typename Callback> JSC::JSValue forwardForEachToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike, Callback&&)
@@ -128,33 +128,33 @@ template<typename WrapperClass, typename Callback> JSC::JSValue forwardForEachTo
 
 template<typename WrapperClass, typename ItemType> JSC::JSValue forwardGetToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike, ItemType&&)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm.propertyNames->builtinNames().getPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm->propertyNames->builtinNames().getPrivateName());
 }
 
 template<typename WrapperClass, typename ItemType> JSC::JSValue forwardHasToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike, ItemType&&)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm.propertyNames->builtinNames().hasPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm->propertyNames->builtinNames().hasPrivateName());
 }
 
 template<typename WrapperClass, typename KeyType, typename ValueType> JSC::JSValue forwardSetToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike, KeyType&& key, ValueType&& value)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    mapLike.wrapped().setFromMapLike(std::forward<KeyType>(key), std::forward<ValueType>(value));
-    forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm.propertyNames->builtinNames().setPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    mapLike.protectedWrapped()->setFromMapLike(std::forward<KeyType>(key), std::forward<ValueType>(value));
+    forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, getAndInitializeBackingMap(lexicalGlobalObject, mapLike), vm->propertyNames->builtinNames().setPrivateName());
     return &mapLike;
 }
 
 template<typename WrapperClass, typename ItemType> JSC::JSValue forwardDeleteToMapLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& mapLike, ItemType&& item)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
     auto& backingMap = getAndInitializeBackingMap(lexicalGlobalObject, mapLike);
 
-    auto isDeleted = mapLike.wrapped().remove(std::forward<ItemType>(item));
+    auto isDeleted = mapLike.protectedWrapped()->remove(std::forward<ItemType>(item));
     UNUSED_PARAM(isDeleted);
 
-    auto result = forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, backingMap, vm.propertyNames->builtinNames().deletePrivateName());
+    auto result = forwardFunctionCallToBackingMap(lexicalGlobalObject, callFrame, backingMap, vm->propertyNames->builtinNames().deletePrivateName());
 
     ASSERT_UNUSED(result, result.asBoolean() == isDeleted);
     return result;

--- a/Source/WebCore/bindings/js/JSDOMMicrotask.cpp
+++ b/Source/WebCore/bindings/js/JSDOMMicrotask.cpp
@@ -58,14 +58,14 @@ Ref<Microtask> createJSDOMMicrotask(VM& vm, JSObject* job)
 
 void JSDOMMicrotask::run(JSGlobalObject* globalObject)
 {
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     JSObject* job = m_job.get();
 
 
     auto* lexicalGlobalObject = job->globalObject();
-    auto* context = jsCast<JSDOMGlobalObject*>(lexicalGlobalObject)->scriptExecutionContext();
+    RefPtr context = jsCast<JSDOMGlobalObject*>(lexicalGlobalObject)->scriptExecutionContext();
     if (!context || context->activeDOMObjectsAreSuspended() || context->activeDOMObjectsAreStopped())
         return;
 
@@ -84,7 +84,7 @@ void JSDOMMicrotask::run(JSGlobalObject* globalObject)
     }
 
     NakedPtr<JSC::Exception> returnedException = nullptr;
-    if (LIKELY(!vm.hasPendingTerminationException())) {
+    if (LIKELY(!vm->hasPendingTerminationException())) {
         JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Microtask, job, callData, jsUndefined(), ArgList(), returnedException);
         if (returnedException)
             reportException(lexicalGlobalObject, returnedException);

--- a/Source/WebCore/bindings/js/JSDOMOperation.h
+++ b/Source/WebCore/bindings/js/JSDOMOperation.h
@@ -48,7 +48,8 @@ public:
     template<Operation operation, CastedThisErrorBehavior shouldThrow = CastedThisErrorBehavior::Throw>
     static JSC::EncodedJSValue call(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, const char* operationName)
     {
-        auto throwScope = DECLARE_THROW_SCOPE(JSC::getVM(&lexicalGlobalObject));
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
         
         auto* thisObject = cast(lexicalGlobalObject, callFrame);
         if constexpr (shouldThrow != CastedThisErrorBehavior::Assert) {

--- a/Source/WebCore/bindings/js/JSDOMPromise.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromise.cpp
@@ -46,7 +46,7 @@ auto DOMPromise::whenSettled(std::function<void()>&& callback) -> IsCallbackRegi
 auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSObject* promise, Function<void()>&& callback) -> IsCallbackRegistered
 {
     auto& lexicalGlobalObject = *globalObject;
-    auto& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     JSLockHolder lock(vm);
     auto* handler = JSC::JSNativeStdFunction::create(vm, globalObject, 1, String { }, [callback = WTFMove(callback)] (JSGlobalObject*, CallFrame*) mutable {
         callback();
@@ -54,10 +54,10 @@ auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSOb
     });
 
     auto scope = DECLARE_THROW_SCOPE(vm);
-    const JSC::Identifier& privateName = vm.propertyNames->builtinNames().thenPrivateName();
+    const JSC::Identifier& privateName = vm->propertyNames->builtinNames().thenPrivateName();
     auto thenFunction = promise->get(&lexicalGlobalObject, privateName);
 
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    EXCEPTION_ASSERT(!scope.exception() || vm->hasPendingTerminationException());
     if (scope.exception())
         return IsCallbackRegistered::No;
 
@@ -72,7 +72,7 @@ auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSOb
     ASSERT(callData.type != JSC::CallData::Type::None);
     call(&lexicalGlobalObject, thenFunction, callData, promise, arguments);
 
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    EXCEPTION_ASSERT(!scope.exception() || vm->hasPendingTerminationException());
     return scope.exception() ? IsCallbackRegistered::No : IsCallbackRegistered::Yes;
 }
 

--- a/Source/WebCore/bindings/js/JSDOMSetLike.cpp
+++ b/Source/WebCore/bindings/js/JSDOMSetLike.cpp
@@ -42,10 +42,9 @@ void DOMSetAdapter::clear()
 
 std::pair<bool, std::reference_wrapper<JSC::JSObject>> getBackingSet(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSObject& setLike)
 {
-    auto& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     auto backingSet = setLike.getDirect(vm, builtinNames(vm).backingSetPrivateName());
     if (!backingSet) {
-        auto& vm = lexicalGlobalObject.vm();
         backingSet = JSC::JSSet::create(vm, lexicalGlobalObject.setStructure());
         setLike.putDirect(vm, builtinNames(vm).backingSetPrivateName(), backingSet, enumToUnderlyingType(JSC::PropertyAttribute::DontEnum));
         return { true, *JSC::asObject(backingSet) };
@@ -55,8 +54,8 @@ std::pair<bool, std::reference_wrapper<JSC::JSObject>> getBackingSet(JSC::JSGlob
 
 void clearBackingSet(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSObject& backingSet)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    auto function = lexicalGlobalObject.jsSetPrototype()->getDirect(vm, vm.propertyNames->builtinNames().clearPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    auto function = lexicalGlobalObject.jsSetPrototype()->getDirect(vm, vm->propertyNames->builtinNames().clearPrivateName());
     ASSERT(function);
 
     auto callData = JSC::getCallData(function);
@@ -67,8 +66,8 @@ void clearBackingSet(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSObject& ba
 
 void addToBackingSet(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSObject& backingSet, JSC::JSValue item)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    auto function = lexicalGlobalObject.jsSetPrototype()->getDirect(vm, vm.propertyNames->builtinNames().addPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    auto function = lexicalGlobalObject.jsSetPrototype()->getDirect(vm, vm->propertyNames->builtinNames().addPrivateName());
     ASSERT(function);
 
     auto callData = JSC::getCallData(function);
@@ -86,7 +85,7 @@ JSC::JSValue forwardAttributeGetterToBackingSet(JSC::JSGlobalObject& lexicalGlob
 
 JSC::JSValue forwardFunctionCallToBackingSet(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, JSC::JSObject& backingSet, const JSC::Identifier& functionName)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
     auto function = lexicalGlobalObject.jsSetPrototype()->getDirect(vm, functionName);
     ASSERT(function);
 

--- a/Source/WebCore/bindings/js/JSDOMSetLike.h
+++ b/Source/WebCore/bindings/js/JSDOMSetLike.h
@@ -86,7 +86,7 @@ JSC::JSObject& getAndInitializeBackingSet(JSC::JSGlobalObject& lexicalGlobalObje
     auto pair = getBackingSet(lexicalGlobalObject, setLike);
     if (pair.first) {
         DOMSetAdapter adapter { lexicalGlobalObject, pair.second.get() };
-        setLike.wrapped().initializeSetLike(adapter);
+        setLike.protectedWrapped()->initializeSetLike(adapter);
     }
     return pair.second.get();
 }
@@ -94,29 +94,29 @@ JSC::JSObject& getAndInitializeBackingSet(JSC::JSGlobalObject& lexicalGlobalObje
 template<typename WrapperClass>
 JSC::JSValue forwardSizeToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, WrapperClass& setLike)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardAttributeGetterToBackingSet(lexicalGlobalObject, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm.propertyNames->builtinNames().sizePrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardAttributeGetterToBackingSet(lexicalGlobalObject, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm->propertyNames->builtinNames().sizePrivateName());
 }
 
 template<typename WrapperClass>
 JSC::JSValue forwardEntriesToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& setLike)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm.propertyNames->builtinNames().entriesPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm->propertyNames->builtinNames().entriesPrivateName());
 }
 
 template<typename WrapperClass>
 JSC::JSValue forwardKeysToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& setLike)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm.propertyNames->builtinNames().keysPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm->propertyNames->builtinNames().keysPrivateName());
 }
 
 template<typename WrapperClass>
 JSC::JSValue forwardValuesToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& setLike)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm.propertyNames->builtinNames().valuesPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm->propertyNames->builtinNames().valuesPrivateName());
 }
 
 template<typename WrapperClass, typename Callback>
@@ -129,26 +129,26 @@ JSC::JSValue forwardForEachToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, J
 template<typename WrapperClass>
 JSC::JSValue forwardClearToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& setLike)
 {
-    setLike.wrapped().clearFromSetLike();
+    setLike.protectedWrapped()->clearFromSetLike();
 
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm.propertyNames->builtinNames().clearPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm->propertyNames->builtinNames().clearPrivateName());
 }
 
 template<typename WrapperClass, typename ItemType>
 JSC::JSValue forwardHasToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& setLike, ItemType&&)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm.propertyNames->builtinNames().hasPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    return forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm->propertyNames->builtinNames().hasPrivateName());
 }
 
 template<typename WrapperClass, typename ItemType>
 JSC::JSValue forwardAddToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& setLike, ItemType&& item)
 {
-    setLike.wrapped().addToSetLike(std::forward<ItemType>(item));
+    setLike.protectedWrapped()->addToSetLike(std::forward<ItemType>(item));
 
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm.propertyNames->builtinNames().addPrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm->propertyNames->builtinNames().addPrivateName());
     return &setLike;
 }
 
@@ -158,11 +158,11 @@ JSC::JSValue forwardDeleteToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JS
     // Initialize backingSet before removing value so assertion below actually holds.
     auto& backingSet = getAndInitializeBackingSet(lexicalGlobalObject, setLike);
 
-    auto isDeleted = setLike.wrapped().removeFromSetLike(std::forward<ItemType>(item));
+    auto isDeleted = setLike.protectedWrapped()->removeFromSetLike(std::forward<ItemType>(item));
     UNUSED_PARAM(isDeleted);
 
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    auto result = forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, backingSet, vm.propertyNames->builtinNames().deletePrivateName());
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
+    auto result = forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, backingSet, vm->propertyNames->builtinNames().deletePrivateName());
     ASSERT_UNUSED(result, result.asBoolean() == isDeleted);
     return result;
 }

--- a/Source/WebCore/bindings/js/JSDOMWrapper.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.cpp
@@ -49,7 +49,7 @@ JSC::JSValue cloneAcrossWorlds(JSC::JSGlobalObject& lexicalGlobalObject, const J
     if (isWorldCompatible(lexicalGlobalObject, value))
         return value;
     // FIXME: Is it best to handle errors by returning null rather than throwing an exception?
-    auto serializedValue = SerializedScriptValue::create(lexicalGlobalObject, value, SerializationForStorage::No, SerializationErrorMode::NonThrowing, SerializationContext::CloneAcrossWorlds);
+    RefPtr serializedValue = SerializedScriptValue::create(lexicalGlobalObject, value, SerializationForStorage::No, SerializationErrorMode::NonThrowing, SerializationContext::CloneAcrossWorlds);
     if (!serializedValue)
         return JSC::jsNull();
     // FIXME: Why is owner->globalObject() better than lexicalGlobalObject.lexicalGlobalObject() here?

--- a/Source/WebCore/bindings/js/JSDOMWrapperCache.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapperCache.h
@@ -209,7 +209,7 @@ template<typename DOMClass> inline void setSubclassStructureIfNeeded(JSC::JSGlob
 
     using WrapperClass = typename JSDOMWrapperConverterTraits<DOMClass>::WrapperClass;
 
-    JSC::VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* functionGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);

--- a/Source/WebCore/bindings/js/JSDocumentCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDocumentCustom.cpp
@@ -56,11 +56,11 @@ JSObject* cachedDocumentWrapper(JSGlobalObject& lexicalGlobalObject, JSDOMGlobal
     if (auto* wrapper = getCachedWrapper(globalObject.world(), document))
         return wrapper;
 
-    auto* window = document.domWindow();
+    RefPtr window = document.domWindow();
     if (!window)
         return nullptr;
 
-    auto* documentGlobalObject = toJSDOMGlobalObject<JSLocalDOMWindow>(lexicalGlobalObject.vm(), toJS(&lexicalGlobalObject, *window));
+    auto* documentGlobalObject = toJSDOMGlobalObject<JSLocalDOMWindow>(Ref { lexicalGlobalObject.vm() }, toJS(&lexicalGlobalObject, *window));
     if (!documentGlobalObject)
         return nullptr;
 
@@ -74,14 +74,14 @@ void reportMemoryForDocumentIfFrameless(JSGlobalObject& lexicalGlobalObject, Doc
     if (document.frame())
         return;
 
-    VM& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     size_t memoryCost = 0;
     for (Node* node = &document; node; node = NodeTraversal::next(*node))
         memoryCost += node->approximateMemoryCost();
 
     // FIXME: Adopt reportExtraMemoryVisited, and switch to reportExtraMemoryAllocated.
     // https://bugs.webkit.org/show_bug.cgi?id=142595
-    vm.heap.deprecatedReportExtraMemory(memoryCost);
+    vm->heap.deprecatedReportExtraMemory(memoryCost);
 }
 
 JSValue toJSNewlyCreated(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<Document>&& document)
@@ -98,7 +98,7 @@ JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObjec
 
 void setAdoptedStyleSheetsOnTreeScope(TreeScope& treeScope, JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto nativeValue = convert<IDLFrozenArray<IDLInterface<CSSStyleSheet>>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, void());
@@ -109,7 +109,7 @@ void setAdoptedStyleSheetsOnTreeScope(TreeScope& treeScope, JSC::JSGlobalObject&
 
 void JSDocument::setAdoptedStyleSheets(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
 {
-    setAdoptedStyleSheetsOnTreeScope(wrapped(), lexicalGlobalObject, value);
+    setAdoptedStyleSheetsOnTreeScope(protectedWrapped(), lexicalGlobalObject, value);
 }
 
 template<typename Visitor>

--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -68,7 +68,7 @@ static JSValue createNewElementWrapper(JSDOMGlobalObject* globalObject, Ref<Elem
 
 JSValue toJS(JSGlobalObject*, JSDOMGlobalObject* globalObject, Element& element)
 {
-    if (auto* wrapper = getCachedWrapper(globalObject->world(), element))
+    if (auto* wrapper = getCachedWrapper(globalObject->protectedWorld(), element))
         return wrapper;
     return createNewElementWrapper(globalObject, element);
 }
@@ -76,18 +76,18 @@ JSValue toJS(JSGlobalObject*, JSDOMGlobalObject* globalObject, Element& element)
 JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<Element>&& element)
 {
     if (element->isDefinedCustomElement()) {
-        JSValue result = getCachedWrapper(globalObject->world(), element);
+        JSValue result = getCachedWrapper(globalObject->protectedWorld(), element);
         if (result)
             return result;
         ASSERT(!globalObject->vm().exceptionForInspection());
     }
-    ASSERT(!getCachedWrapper(globalObject->world(), element));
+    ASSERT(!getCachedWrapper(globalObject->protectedWorld(), element));
     return createNewElementWrapper(globalObject, WTFMove(element));
 }
 
 static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, const JSElement& thisObject, const QualifiedName& attributeName)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* cachedObject = nullptr;

--- a/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
@@ -45,7 +45,7 @@ JSValue JSElementInternals::setFormValue(JSGlobalObject& lexicalGlobalObject, Ca
 {
     using JSCustomElementFormValue = IDLUnion<IDLNull, IDLInterface<File>, IDLUSVString, IDLInterface<DOMFormData>>;
 
-    auto& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     if (UNLIKELY(callFrame.argumentCount() < 1)) {
         throwException(&lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(&lexicalGlobalObject));
@@ -63,7 +63,7 @@ JSValue JSElementInternals::setFormValue(JSGlobalObject& lexicalGlobalObject, Ca
         RETURN_IF_EXCEPTION(throwScope, { });
     }
 
-    auto result = wrapped().setFormValue(WTFMove(value), WTFMove(state));
+    auto result = protectedWrapped()->setFormValue(WTFMove(value), WTFMove(state));
     if (UNLIKELY(result.hasException())) {
         propagateException(lexicalGlobalObject, throwScope, result.releaseException());
         return { };
@@ -74,7 +74,7 @@ JSValue JSElementInternals::setFormValue(JSGlobalObject& lexicalGlobalObject, Ca
 
 static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, const JSElementInternals& thisObject, const QualifiedName& attributeName)
 {
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    Ref vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* cachedObject = nullptr;
@@ -86,7 +86,7 @@ static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, co
         const_cast<JSElementInternals&>(thisObject).putDirect(vm, builtinNames(vm).cachedAttrAssociatedElementsPrivateName(), cachedObject);
     }
 
-    std::optional<Vector<RefPtr<Element>>> elements = thisObject.wrapped().getElementsArrayAttribute(attributeName);
+    std::optional<Vector<RefPtr<Element>>> elements = thisObject.protectedWrapped()->getElementsArrayAttribute(attributeName);
     auto propertyName = PropertyName(Identifier::fromString(vm, attributeName.toString()));
     JSValue cachedValue = cachedObject->getDirect(vm, propertyName);
     if (!cachedValue.isEmpty()) {

--- a/Source/WebCore/bindings/js/JSErrorHandler.cpp
+++ b/Source/WebCore/bindings/js/JSErrorHandler.cpp
@@ -66,14 +66,14 @@ void JSErrorHandler::handleEvent(ScriptExecutionContext& scriptExecutionContext,
     if (!errorEvent)
         return JSEventListener::handleEvent(scriptExecutionContext, event);
 
-    VM& vm = scriptExecutionContext.vm();
+    Ref vm = scriptExecutionContext.vm();
     JSLockHolder lock(vm);
 
     JSObject* jsFunction = this->ensureJSFunction(scriptExecutionContext);
     if (!jsFunction)
         return;
 
-    auto* isolatedWorld = this->isolatedWorld();
+    RefPtr isolatedWorld = this->isolatedWorld();
     if (UNLIKELY(!isolatedWorld))
         return;
 
@@ -103,8 +103,8 @@ void JSErrorHandler::handleEvent(ScriptExecutionContext& scriptExecutionContext,
         args.append(errorEvent->error(*globalObject));
         ASSERT(!args.hasOverflowed());
 
-        VM& vm = globalObject->vm();
-        VMEntryScope entryScope(vm, vm.entryScope ? vm.entryScope->globalObject() : globalObject);
+        Ref vm = globalObject->vm();
+        VMEntryScope entryScope(vm, vm->entryScope ? vm->entryScope->globalObject() : globalObject);
 
         JSExecState::instrumentFunction(&scriptExecutionContext, callData);
 

--- a/Source/WebCore/bindings/js/JSEventListener.h
+++ b/Source/WebCore/bindings/js/JSEventListener.h
@@ -112,7 +112,7 @@ inline JSC::JSValue windowEventHandlerAttribute(LocalDOMWindow& window, const At
 
 inline JSC::JSValue windowEventHandlerAttribute(HTMLElement& element, const AtomString& eventType, DOMWrapperWorld& isolatedWorld)
 {
-    if (auto* domWindow = element.document().domWindow())
+    if (RefPtr domWindow = element.document().domWindow())
         return eventHandlerAttribute(*domWindow, eventType, isolatedWorld);
     return JSC::jsNull();
 }
@@ -126,7 +126,7 @@ inline void setWindowEventHandlerAttribute(LocalDOMWindow& window, const AtomStr
 template<typename JSMaybeErrorEventListener>
 inline void setWindowEventHandlerAttribute(HTMLElement& element, const AtomString& eventType, JSC::JSValue listener, JSC::JSObject& jsEventTarget)
 {
-    if (auto* domWindow = element.document().domWindow())
+    if (RefPtr domWindow = element.document().domWindow())
         domWindow->setAttributeEventListener<JSMaybeErrorEventListener>(eventType, listener, *jsEventTarget.globalObject());
 }
 
@@ -137,8 +137,8 @@ inline JSC::JSObject* JSEventListener::ensureJSFunction(ScriptExecutionContext& 
     if (UNLIKELY(!m_isolatedWorld))
         return nullptr;
 
-    JSC::VM& vm = m_isolatedWorld->vm();
-    Ref protect = const_cast<JSEventListener&>(*this);
+    Ref vm = m_isolatedWorld->vm();
+    Ref protectedThis { *this };
     JSC::EnsureStillAliveScope protectedWrapper(m_wrapper.get());
 
     if (!m_isInitialized) {
@@ -148,7 +148,7 @@ inline JSC::JSObject* JSEventListener::ensureJSFunction(ScriptExecutionContext& 
             m_jsFunction = JSC::Weak<JSC::JSObject>(function);
             // When JSFunction is initialized, initializeJSFunction must ensure that m_wrapper should be initialized too.
             ASSERT(m_wrapper);
-            vm.writeBarrier(m_wrapper.get(), function);
+            vm->writeBarrier(m_wrapper.get(), function);
             m_isInitialized = true;
         }
     }

--- a/Source/WebCore/bindings/js/JSExecState.cpp
+++ b/Source/WebCore/bindings/js/JSExecState.cpp
@@ -35,10 +35,10 @@ namespace WebCore {
 
 void JSExecState::didLeaveScriptContext(JSC::JSGlobalObject* lexicalGlobalObject)
 {
-    auto context = executionContext(lexicalGlobalObject);
+    RefPtr context = executionContext(lexicalGlobalObject);
     if (!context)
         return;
-    context->eventLoop().performMicrotaskCheckpoint();
+    context->checkedEventLoop()->performMicrotaskCheckpoint();
 }
 
 JSC::JSValue functionCallHandlerFromAnyThread(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue functionObject, const JSC::CallData& callData, JSC::JSValue thisValue, const JSC::ArgList& args, NakedPtr<JSC::Exception>& returnedException)

--- a/Source/WebCore/bindings/js/JSExecState.h
+++ b/Source/WebCore/bindings/js/JSExecState.h
@@ -51,7 +51,7 @@ public:
     
     static JSC::JSValue call(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue functionObject, const JSC::CallData& callData, JSC::JSValue thisValue, const JSC::ArgList& args, NakedPtr<JSC::Exception>& returnedException)
     {
-        JSC::VM& vm = JSC::getVM(lexicalGlobalObject);
+        Ref vm = JSC::getVM(lexicalGlobalObject);
         auto scope = DECLARE_CATCH_SCOPE(vm);
         JSC::JSValue returnValue;
         {
@@ -64,7 +64,7 @@ public:
 
     static JSC::JSValue evaluate(JSC::JSGlobalObject* lexicalGlobalObject, const JSC::SourceCode& source, JSC::JSValue thisValue, NakedPtr<JSC::Exception>& returnedException)
     {
-        JSC::VM& vm = JSC::getVM(lexicalGlobalObject);
+        Ref vm = JSC::getVM(lexicalGlobalObject);
         auto scope = DECLARE_CATCH_SCOPE(vm);
         JSC::JSValue returnValue;
         {
@@ -83,7 +83,7 @@ public:
 
     static JSC::JSValue profiledCall(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ProfilingReason reason, JSC::JSValue functionObject, const JSC::CallData& callData, JSC::JSValue thisValue, const JSC::ArgList& args, NakedPtr<JSC::Exception>& returnedException)
     {
-        JSC::VM& vm = JSC::getVM(lexicalGlobalObject);
+        Ref vm = JSC::getVM(lexicalGlobalObject);
         auto scope = DECLARE_CATCH_SCOPE(vm);
         JSC::JSValue returnValue;
         {
@@ -96,7 +96,7 @@ public:
 
     static JSC::JSValue profiledEvaluate(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ProfilingReason reason, const JSC::SourceCode& source, JSC::JSValue thisValue, NakedPtr<JSC::Exception>& returnedException)
     {
-        JSC::VM& vm = JSC::getVM(lexicalGlobalObject);
+        Ref vm = JSC::getVM(lexicalGlobalObject);
         auto scope = DECLARE_CATCH_SCOPE(vm);
         JSC::JSValue returnValue;
         {
@@ -133,7 +133,7 @@ public:
 
     static JSC::JSValue linkAndEvaluateModule(JSC::JSGlobalObject& lexicalGlobalObject, const JSC::Identifier& moduleKey, JSC::JSValue scriptFetcher, NakedPtr<JSC::Exception>& returnedException)
     {
-        JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
+        Ref vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_CATCH_SCOPE(vm);
         JSC::JSValue returnValue;
         {
@@ -141,7 +141,7 @@ public:
             returnValue = JSC::linkAndEvaluateModule(&lexicalGlobalObject, moduleKey, scriptFetcher);
             if (UNLIKELY(scope.exception())) {
                 returnedException = scope.exception();
-                if (!vm.hasPendingTerminationException())
+                if (!vm->hasPendingTerminationException())
                     scope.clearException();
                 return JSC::jsUndefined();
             }
@@ -162,7 +162,7 @@ private:
 
     ~JSExecState()
     {
-        JSC::VM& vm = currentState()->vm();
+        Ref vm = currentState()->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
         scope.assertNoExceptionExceptTermination();
 
@@ -174,7 +174,7 @@ private:
         if (didExitJavaScript) {
             didLeaveScriptContext(lexicalGlobalObject);
             // We need to clear any exceptions from microtask drain.
-            if (!vm.hasPendingTerminationException())
+            if (!vm->hasPendingTerminationException())
                 scope.clearException();
         }
     }

--- a/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
@@ -37,7 +37,7 @@ using namespace JSC;
 
 JSC::EncodedJSValue constructJSExtendableMessageEvent(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame& callFrame)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     UNUSED_PARAM(throwScope);
 
@@ -81,7 +81,7 @@ JSValue JSExtendableMessageEvent::data(JSGlobalObject& lexicalGlobalObject) cons
         result = jsNull();
 
     // Save the result so we don't have to deserialize the value again.
-    m_data.set(lexicalGlobalObject.vm(), this, result);
+    m_data.set(Ref { lexicalGlobalObject.vm() }, this, result);
     return result;
 }
 

--- a/Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp
@@ -43,18 +43,19 @@ static JSC_DECLARE_HOST_FUNCTION(callJSHTMLAllCollection);
 // https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#HTMLAllCollection-call
 JSC_DEFINE_HOST_FUNCTION(callJSHTMLAllCollection, (JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame))
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* castedThis = jsCast<JSHTMLAllCollection*>(callFrame->jsCallee());
     ASSERT(castedThis);
-    auto& impl = castedThis->wrapped();
     if (callFrame->argument(0).isUndefined())
         return JSValue::encode(jsNull());
 
     AtomString nameOrIndex = callFrame->uncheckedArgument(0).toString(lexicalGlobalObject)->toAtomString(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, { });
-    RELEASE_AND_RETURN(scope, JSValue::encode(toJS<IDLNullable<IDLUnion<IDLInterface<HTMLCollection>, IDLInterface<Element>>>>(*lexicalGlobalObject, *castedThis->globalObject(), impl.namedOrIndexedItemOrItems(WTFMove(nameOrIndex)))));
+
+    Ref impl = castedThis->wrapped();
+    RELEASE_AND_RETURN(scope, JSValue::encode(toJS<IDLNullable<IDLUnion<IDLInterface<HTMLCollection>, IDLInterface<Element>>>>(*lexicalGlobalObject, *castedThis->globalObject(), impl->namedOrIndexedItemOrItems(WTFMove(nameOrIndex)))));
 }
 
 CallData JSHTMLAllCollection::getCallData(JSCell*)

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -52,7 +52,7 @@ EncodedJSValue constructJSHTMLElement(JSGlobalObject* lexicalGlobalObject, CallF
     auto* jsConstructor = jsCast<JSDOMConstructorBase*>(callFrame.jsCallee());
     ASSERT(jsConstructor);
 
-    auto* context = jsConstructor->scriptExecutionContext();
+    RefPtr context = jsConstructor->scriptExecutionContext();
     if (!context)
         return throwConstructorScriptExecutionContextUnavailableError(*lexicalGlobalObject, scope, "HTMLElement");
     ASSERT(context->isDocument());
@@ -114,19 +114,19 @@ EncodedJSValue constructJSHTMLElement(JSGlobalObject* lexicalGlobalObject, CallF
 
 JSScope* JSHTMLElement::pushEventHandlerScope(JSGlobalObject* lexicalGlobalObject, JSScope* scope) const
 {
-    HTMLElement& element = wrapped();
+    Ref element = wrapped();
 
     // The document is put on first, fall back to searching it only after the element and form.
     // FIXME: This probably may use the wrong global object. If this is called from a native
     // function, then it would be correct but not optimal since the native function would *know*
     // the global object. But, it may be that globalObject() is more correct.
     // https://bugs.webkit.org/show_bug.cgi?id=134932
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     
-    scope = JSWithScope::create(vm, lexicalGlobalObject, scope, asObject(toJS(lexicalGlobalObject, globalObject(), element.document())));
+    scope = JSWithScope::create(vm, lexicalGlobalObject, scope, asObject(toJS(lexicalGlobalObject, globalObject(), element->document())));
 
     // The form is next, searched before the document, but after the element itself.
-    if (auto* formAssociated = element.asFormAssociatedElement()) {
+    if (auto* formAssociated = element->asFormAssociatedElement()) {
         if (RefPtr form = formAssociated->form())
             scope = JSWithScope::create(vm, lexicalGlobalObject, scope, asObject(toJS(lexicalGlobalObject, globalObject(), *form)));
     }

--- a/Source/WebCore/bindings/js/JSHistoryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHistoryCustom.cpp
@@ -38,7 +38,8 @@ using namespace JSC;
 
 JSValue JSHistory::state(JSGlobalObject& lexicalGlobalObject) const
 {
-    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    Ref vm = lexicalGlobalObject.vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedState(), [this, &throwScope, &lexicalGlobalObject](JSC::ThrowScope&) {
         if (UNLIKELY(wrapped().state().hasException())) {
             propagateException(lexicalGlobalObject, throwScope, wrapped().state().releaseException());

--- a/Source/WebCore/bindings/js/JSImageDataCustom.cpp
+++ b/Source/WebCore/bindings/js/JSImageDataCustom.cpp
@@ -39,14 +39,14 @@ using namespace JSC;
 
 JSValue toJSNewlyCreated(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<ImageData>&& imageData)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto& data = imageData->data();
     auto* wrapper = createWrapper<ImageData>(globalObject, WTFMove(imageData));
     Identifier dataName = Identifier::fromString(vm, "data"_s);
     wrapper->putDirect(vm, dataName, toJS(lexicalGlobalObject, globalObject, data), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     // FIXME: Adopt reportExtraMemoryVisited, and switch to reportExtraMemoryAllocated.
     // https://bugs.webkit.org/show_bug.cgi?id=142595
-    vm.heap.deprecatedReportExtraMemory(data.length());
+    vm->heap.deprecatedReportExtraMemory(data.length());
     
     return wrapper;
 }

--- a/Source/WebCore/bindings/js/JSKeyframeEffectCustom.cpp
+++ b/Source/WebCore/bindings/js/JSKeyframeEffectCustom.cpp
@@ -41,7 +41,7 @@ JSValue JSKeyframeEffect::getKeyframes(JSGlobalObject& lexicalGlobalObject, Call
 {
     auto lock = JSLockHolder { &lexicalGlobalObject };
 
-    auto* context = jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->scriptExecutionContext();
+    RefPtr context = jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->scriptExecutionContext();
     if (UNLIKELY(!context))
         return jsUndefined();
 

--- a/Source/WebCore/bindings/js/JSLocationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocationCustom.cpp
@@ -37,10 +37,10 @@ using namespace JSC;
 
 static bool getOwnPropertySlotCommon(JSLocation& thisObject, JSGlobalObject& lexicalGlobalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    VM& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* window = thisObject.wrapped().window();
+    RefPtr window = thisObject.wrapped().window();
 
     // When accessing Location cross-domain, functions are always the native built-in ones.
     // See JSLocalDOMWindow::getOwnPropertySlotDelegate for additional details.
@@ -48,13 +48,13 @@ static bool getOwnPropertySlotCommon(JSLocation& thisObject, JSGlobalObject& lex
     // Our custom code is only needed to implement the Window cross-domain scheme, so if access is
     // allowed, return false so the normal lookup will take place.
     String message;
-    if (BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, window, message))
+    if (BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, window.get(), message))
         return false;
 
     // https://html.spec.whatwg.org/#crossorigingetownpropertyhelper-(-o,-p-)
 
     // We only allow access to Location.replace() cross origin.
-    if (propertyName == vm.propertyNames->replace) {
+    if (propertyName == vm->propertyNames->replace) {
         auto* entry = JSLocation::info()->staticPropHashTable->entry(propertyName);
         auto* jsFunction = thisObject.globalObject()->createCrossOriginFunction(&lexicalGlobalObject, propertyName, entry->function(), entry->functionLength());
         slot.setValue(&thisObject, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum, jsFunction);
@@ -80,7 +80,7 @@ static bool getOwnPropertySlotCommon(JSLocation& thisObject, JSGlobalObject& lex
 
 bool JSLocation::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = jsCast<JSLocation*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
@@ -95,7 +95,7 @@ bool JSLocation::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGlo
 
 bool JSLocation::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* lexicalGlobalObject, unsigned index, PropertySlot& slot)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = jsCast<JSLocation*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
@@ -110,7 +110,7 @@ bool JSLocation::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* lex
 
 bool JSLocation::put(JSCell* cell, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, JSValue value, PutPropertySlot& putPropertySlot)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = jsCast<JSLocation*>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
@@ -119,7 +119,7 @@ bool JSLocation::put(JSCell* cell, JSGlobalObject* lexicalGlobalObject, Property
     // However, allowing assigning of pieces might inadvertently disclose parts of the original location.
     // So fall through to the access check for those.
     String errorMessage;
-    if (!BindingSecurity::shouldAllowAccessToDOMWindow(*lexicalGlobalObject, thisObject->wrapped().window(), errorMessage)) {
+    if (!BindingSecurity::shouldAllowAccessToDOMWindow(*lexicalGlobalObject, thisObject->wrapped().protectedWindow().get(), errorMessage)) {
         if (propertyName == builtinNames(vm).hrefPublicName()) {
             auto setter = s_info.staticPropHashTable->entry(propertyName)->propertyPutter();
             scope.release();
@@ -139,7 +139,7 @@ bool JSLocation::putByIndex(JSCell* cell, JSGlobalObject* lexicalGlobalObject, u
     auto* thisObject = jsCast<JSLocation*>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
-    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().window(), ThrowSecurityError))
+    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().protectedWindow().get(), ThrowSecurityError))
         return false;
 
     return JSObject::putByIndex(cell, lexicalGlobalObject, index, value, shouldThrow);
@@ -149,7 +149,7 @@ bool JSLocation::deleteProperty(JSCell* cell, JSGlobalObject* lexicalGlobalObjec
 {
     JSLocation* thisObject = jsCast<JSLocation*>(cell);
     // Only allow deleting by frames in the same origin.
-    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().window(), ThrowSecurityError))
+    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().protectedWindow().get(), ThrowSecurityError))
         return false;
     return Base::deleteProperty(thisObject, lexicalGlobalObject, propertyName, slot);
 }
@@ -158,7 +158,7 @@ bool JSLocation::deletePropertyByIndex(JSCell* cell, JSGlobalObject* lexicalGlob
 {
     JSLocation* thisObject = jsCast<JSLocation*>(cell);
     // Only allow deleting by frames in the same origin.
-    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().window(), ThrowSecurityError))
+    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().protectedWindow().get(), ThrowSecurityError))
         return false;
     return Base::deletePropertyByIndex(thisObject, lexicalGlobalObject, propertyName);
 }
@@ -166,7 +166,7 @@ bool JSLocation::deletePropertyByIndex(JSCell* cell, JSGlobalObject* lexicalGlob
 void JSLocation::getOwnPropertyNames(JSObject* object, JSGlobalObject* lexicalGlobalObject, PropertyNameArray& propertyNames, DontEnumPropertiesMode mode)
 {
     JSLocation* thisObject = jsCast<JSLocation*>(object);
-    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().window(), DoNotReportSecurityError)) {
+    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().protectedWindow().get(), DoNotReportSecurityError)) {
         if (mode == DontEnumPropertiesMode::Include)
             addCrossOriginOwnPropertyNames<CrossOriginObject::Location>(*lexicalGlobalObject, propertyNames);
         return;
@@ -177,7 +177,7 @@ void JSLocation::getOwnPropertyNames(JSObject* object, JSGlobalObject* lexicalGl
 bool JSLocation::defineOwnProperty(JSObject* object, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool throwException)
 {
     JSLocation* thisObject = jsCast<JSLocation*>(object);
-    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().window(), ThrowSecurityError))
+    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().protectedWindow().get(), ThrowSecurityError))
         return false;
 
     return Base::defineOwnProperty(object, lexicalGlobalObject, propertyName, descriptor, throwException);
@@ -186,7 +186,7 @@ bool JSLocation::defineOwnProperty(JSObject* object, JSGlobalObject* lexicalGlob
 JSValue JSLocation::getPrototype(JSObject* object, JSGlobalObject* lexicalGlobalObject)
 {
     JSLocation* thisObject = jsCast<JSLocation*>(object);
-    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().window(), DoNotReportSecurityError))
+    if (!BindingSecurity::shouldAllowAccessToDOMWindow(lexicalGlobalObject, thisObject->wrapped().protectedWindow().get(), DoNotReportSecurityError))
         return jsNull();
 
     return Base::getPrototype(object, lexicalGlobalObject);

--- a/Source/WebCore/bindings/js/JSMicrotaskCallback.h
+++ b/Source/WebCore/bindings/js/JSMicrotaskCallback.h
@@ -41,7 +41,7 @@ public:
     void call()
     {
         auto protectedThis { Ref { *this } };
-        JSC::VM& vm = m_globalObject->vm();
+        Ref vm = m_globalObject->vm();
         JSC::JSLockHolder lock(vm);
         JSExecState::runTask(m_globalObject.get(), m_task);
     }

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -169,7 +169,7 @@ JSC::JSObject* getOutOfLineCachedWrapper(JSDOMGlobalObject* globalObject, Node& 
 
 void willCreatePossiblyOrphanedTreeByRemovalSlowCase(Node& root)
 {
-    auto frame = root.document().frame();
+    RefPtr frame = root.document().frame();
     if (!frame)
         return;
 

--- a/Source/WebCore/bindings/js/JSObservableArray.cpp
+++ b/Source/WebCore/bindings/js/JSObservableArray.cpp
@@ -80,7 +80,7 @@ void JSObservableArray::destroy(JSCell* cell)
 
 JSC_DEFINE_CUSTOM_GETTER(arrayLengthGetter, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName))
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObservableArray* thisObject = jsDynamicCast<JSObservableArray*>(JSValue::decode(thisValue));
@@ -91,23 +91,23 @@ JSC_DEFINE_CUSTOM_GETTER(arrayLengthGetter, (JSGlobalObject* lexicalGlobalObject
 
 void JSObservableArray::getOwnPropertyNames(JSObject* object, JSGlobalObject* lexicalGlobalObject, PropertyNameArray& propertyNames, DontEnumPropertiesMode mode)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     JSObservableArray* thisObject = jsCast<JSObservableArray*>(object);
     unsigned length = thisObject->length();
     for (unsigned i = 0; i < length; ++i)
         propertyNames.add(Identifier::from(vm, i));
 
     if (mode == DontEnumPropertiesMode::Include)
-        propertyNames.add(vm.propertyNames->length);
+        propertyNames.add(vm->propertyNames->length);
 
     thisObject->getOwnNonIndexPropertyNames(lexicalGlobalObject, propertyNames, mode);
 }
 
 bool JSObservableArray::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     JSObservableArray* thisObject = jsCast<JSObservableArray*>(object);
-    if (propertyName == vm.propertyNames->length) {
+    if (propertyName == vm->propertyNames->length) {
         slot.setCacheableCustom(thisObject, PropertyAttribute::DontDelete | PropertyAttribute::DontEnum, arrayLengthGetter);
         return true;
     }
@@ -136,11 +136,11 @@ bool JSObservableArray::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObje
 
 bool JSObservableArray::put(JSCell* cell, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* thisObject = jsCast<JSObservableArray*>(cell);
-    if (propertyName == vm.propertyNames->length)
+    if (propertyName == vm->propertyNames->length)
         return observableArraySetLength(thisObject, lexicalGlobalObject, scope, value);
 
     if (auto index = parseIndex(propertyName))
@@ -162,10 +162,10 @@ bool JSObservableArray::putByIndex(JSCell* cell, JSGlobalObject* lexicalGlobalOb
 // https://webidl.spec.whatwg.org/#es-observable-array-deleteProperty
 bool JSObservableArray::deleteProperty(JSCell* cell, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (propertyName == vm.propertyNames->length)
+    if (propertyName == vm->propertyNames->length)
         return false;
 
     if (auto index = parseIndex(propertyName))
@@ -189,11 +189,11 @@ bool JSObservableArray::deletePropertyByIndex(JSCell* cell, JSGlobalObject*, uns
 // https://webidl.spec.whatwg.org/#es-observable-array-defineProperty
 bool JSObservableArray::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool throwException)
 {
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObservableArray* thisObject = jsCast<JSObservableArray*>(object);
-    if (propertyName == vm.propertyNames->length) {
+    if (propertyName == vm->propertyNames->length) {
         if (descriptor.isAccessorDescriptor())
             return typeError(globalObject, scope, throwException, "Not allowed to change access mechanism for 'length' property"_s);
         if (descriptor.configurablePresent() && descriptor.configurable())

--- a/Source/WebCore/bindings/js/JSObservableArray.h
+++ b/Source/WebCore/bindings/js/JSObservableArray.h
@@ -55,7 +55,7 @@ public:
 
     static JSObservableArray* create(JSGlobalObject* lexicalGlobalObject, Ref<ObservableArray>&& array)
     {
-        VM& vm = lexicalGlobalObject->vm();
+        Ref vm = lexicalGlobalObject->vm();
         // FIXME: deprecatedGetDOMStructure uses the prototype off of the wrong global object
         // We need to pass in the right global object for "array".
         Structure* domStructure = WebCore::deprecatedGetDOMStructure<JSObservableArray>(lexicalGlobalObject);

--- a/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
@@ -55,14 +55,14 @@ JSValue JSPopStateEvent::state(JSGlobalObject& lexicalGlobalObject) const
         return eventState;
     };
 
-    PopStateEvent& event = wrapped();
+    Ref event = wrapped();
 
-    if (event.state()) {
-        JSC::JSValue eventState = event.state().getValue();
+    if (event->state()) {
+        JSC::JSValue eventState = event->state().getValue();
         // We need to make sure a PopStateEvent does not leak objects in its lexicalGlobalObject property across isolated DOM worlds.
         // Ideally, we would check that the worlds have different privileges but that's not possible yet.
         if (!isWorldCompatible(lexicalGlobalObject, eventState)) {
-            if (auto serializedValue = event.trySerializeState(lexicalGlobalObject))
+            if (auto serializedValue = event->trySerializeState(lexicalGlobalObject))
                 eventState = serializedValue->deserialize(lexicalGlobalObject, globalObject());
             else
                 eventState = jsNull();
@@ -70,8 +70,8 @@ JSValue JSPopStateEvent::state(JSGlobalObject& lexicalGlobalObject) const
         return cacheState(eventState);
     }
     
-    History* history = event.history();
-    if (!history || !event.serializedState())
+    RefPtr history = event->history();
+    if (!history || !event->serializedState())
         return cacheState(jsNull());
 
     // There's no cached value from a previous invocation, nor a lexicalGlobalObject value was provided by the
@@ -80,14 +80,14 @@ JSValue JSPopStateEvent::state(JSGlobalObject& lexicalGlobalObject) const
     // The current history lexicalGlobalObject object might've changed in the meantime, so we need to take care
     // of using the correct one, and always share the same deserialization with history.lexicalGlobalObject.
 
-    bool isSameState = history->isSameAsCurrentState(event.serializedState());
+    bool isSameState = history->isSameAsCurrentState(event->serializedState());
     JSValue result;
 
     if (isSameState) {
         JSHistory* jsHistory = jsCast<JSHistory*>(toJS(&lexicalGlobalObject, globalObject(), *history).asCell());
         result = jsHistory->state(lexicalGlobalObject);
     } else
-        result = event.serializedState()->deserialize(lexicalGlobalObject, globalObject());
+        result = event->serializedState()->deserialize(lexicalGlobalObject, globalObject());
 
     return cacheState(result);
 }

--- a/Source/WebCore/bindings/js/JSRTCRtpSFrameTransformCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRTCRtpSFrameTransformCustom.cpp
@@ -37,7 +37,7 @@ using namespace JSC;
 
 JSValue JSRTCRtpSFrameTransform::setEncryptionKey(JSGlobalObject& lexicalGlobalObject, CallFrame& callFrame, Ref<DeferredPromise>&& promise)
 {
-    auto& vm = getVM(&lexicalGlobalObject);
+    Ref vm = getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     if (UNLIKELY(callFrame.argumentCount() < 1)) {
@@ -66,7 +66,7 @@ JSValue JSRTCRtpSFrameTransform::setEncryptionKey(JSGlobalObject& lexicalGlobalO
     RETURN_IF_EXCEPTION(throwScope, jsUndefined());
     throwScope.release();
 
-    wrapped().setEncryptionKey(*key, keyID, WTFMove(promise));
+    protectedWrapped()->setEncryptionKey(*key, keyID, WTFMove(promise));
     return jsUndefined();
 }
 

--- a/Source/WebCore/bindings/js/JSReadableStreamSourceCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReadableStreamSourceCustom.cpp
@@ -36,7 +36,7 @@ using namespace JSC;
 
 JSValue JSReadableStreamSource::start(JSGlobalObject& lexicalGlobalObject, CallFrame& callFrame, Ref<DeferredPromise>&& promise)
 {
-    VM& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     
     // FIXME: Why is it ok to ASSERT the argument count here?
     ASSERT(callFrame.argumentCount());
@@ -45,14 +45,14 @@ JSValue JSReadableStreamSource::start(JSGlobalObject& lexicalGlobalObject, CallF
 
     m_controller.set(vm, this, controller);
 
-    wrapped().start(ReadableStreamDefaultController(controller), WTFMove(promise));
+    protectedWrapped()->start(ReadableStreamDefaultController(controller), WTFMove(promise));
 
     return jsUndefined();
 }
 
 JSValue JSReadableStreamSource::pull(JSGlobalObject&, CallFrame&, Ref<DeferredPromise>&& promise)
 {
-    wrapped().pull(WTFMove(promise));
+    protectedWrapped()->pull(WTFMove(promise));
     return jsUndefined();
 }
 

--- a/Source/WebCore/bindings/js/JSRemoteDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSRemoteDOMWindowBase.cpp
@@ -72,6 +72,11 @@ void JSRemoteDOMWindowBase::destroy(JSCell* cell)
     static_cast<JSRemoteDOMWindowBase*>(cell)->JSRemoteDOMWindowBase::~JSRemoteDOMWindowBase();
 }
 
+Ref<RemoteDOMWindow> JSRemoteDOMWindowBase::protectedWrapped() const
+{
+    return *m_wrapped;
+}
+
 RuntimeFlags JSRemoteDOMWindowBase::javaScriptRuntimeFlags(const JSGlobalObject*)
 {
     return RuntimeFlags { };

--- a/Source/WebCore/bindings/js/JSRemoteDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSRemoteDOMWindowBase.h
@@ -43,6 +43,7 @@ public:
     static void subspaceFor(JSC::VM&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     RemoteDOMWindow& wrapped() const { return *m_wrapped; }
+    Ref<RemoteDOMWindow> protectedWrapped() const;
 
     DECLARE_INFO;
 

--- a/Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp
@@ -48,10 +48,10 @@ bool JSRemoteDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lex
 
 bool JSRemoteDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* lexicalGlobalObject, unsigned index, PropertySlot& slot)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto* thisObject = jsCast<JSRemoteDOMWindow*>(object);
-    auto& window = thisObject->wrapped();
-    auto* frame = window.frame();
+    Ref window = thisObject->wrapped();
+    RefPtr frame = window->frame();
 
     // Indexed getters take precendence over regular properties, so caching would be invalid.
     slot.disableCaching();
@@ -60,7 +60,7 @@ bool JSRemoteDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObje
     if (frame && index < frame->tree().childCount()) {
         // FIXME: <rdar://118263337> This should work also if it's a RemoteFrame, it should just return a RemoteDOMWindow.
         // JSLocalDOMWindow::getOwnPropertySlotByIndex uses scopedChild. Investigate the difference.
-        if (auto* child = dynamicDowncast<LocalFrame>(frame->tree().child(index))) {
+        if (RefPtr child = dynamicDowncast<LocalFrame>(frame->tree().child(index))) {
             slot.setValue(thisObject, enumToUnderlyingType(JSC::PropertyAttribute::ReadOnly), toJS(lexicalGlobalObject, child->document()->domWindow()));
             return true;
         }
@@ -69,12 +69,12 @@ bool JSRemoteDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObje
     // FIXME: <rdar://118263337> Make this more like JSLocalDOMWindow::getOwnPropertySlotByIndex and share code when possible.
     // There is some missing functionality here, and it is likely important.
 
-    return jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess<DOMWindowType::Remote>(thisObject, thisObject->wrapped(), *lexicalGlobalObject, Identifier::from(vm, index), slot, String());
+    return jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess<DOMWindowType::Remote>(thisObject, thisObject->protectedWrapped(), *lexicalGlobalObject, Identifier::from(vm, index), slot, String());
 }
 
 bool JSRemoteDOMWindow::put(JSCell* cell, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* thisObject = jsCast<JSRemoteDOMWindow*>(cell);
@@ -102,7 +102,7 @@ bool JSRemoteDOMWindow::putByIndex(JSCell*, JSGlobalObject*, unsigned, JSValue, 
 
 bool JSRemoteDOMWindow::deleteProperty(JSCell*, JSGlobalObject* lexicalGlobalObject, PropertyName, DeletePropertySlot&)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     throwSecurityError(*lexicalGlobalObject, scope, String());
@@ -111,7 +111,7 @@ bool JSRemoteDOMWindow::deleteProperty(JSCell*, JSGlobalObject* lexicalGlobalObj
 
 bool JSRemoteDOMWindow::deletePropertyByIndex(JSCell*, JSGlobalObject* lexicalGlobalObject, unsigned)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     throwSecurityError(*lexicalGlobalObject, scope, String());
@@ -128,7 +128,7 @@ void JSRemoteDOMWindow::getOwnPropertyNames(JSObject*, JSGlobalObject* lexicalGl
 
 bool JSRemoteDOMWindow::defineOwnProperty(JSC::JSObject*, JSC::JSGlobalObject* lexicalGlobalObject, JSC::PropertyName, const JSC::PropertyDescriptor&, bool)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     throwSecurityError(*lexicalGlobalObject, scope, String());

--- a/Source/WebCore/bindings/js/JSShadowRootCustom.cpp
+++ b/Source/WebCore/bindings/js/JSShadowRootCustom.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 void JSShadowRoot::setAdoptedStyleSheets(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
 {
-    setAdoptedStyleSheetsOnTreeScope(wrapped(), lexicalGlobalObject, value);
+    setAdoptedStyleSheetsOnTreeScope(protectedWrapped(), lexicalGlobalObject, value);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSWebAnimationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebAnimationCustom.cpp
@@ -54,22 +54,22 @@ JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObjec
 
 EncodedJSValue constructJSWebAnimation(JSGlobalObject* lexicalGlobalObject, CallFrame& callFrame)
 {
-    VM& vm = lexicalGlobalObject->vm();
+    Ref vm = lexicalGlobalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     UNUSED_PARAM(throwScope);
     auto* jsConstructor = jsCast<JSDOMConstructorBase*>(callFrame.jsCallee());
     ASSERT(jsConstructor);
-    auto* context = jsConstructor->scriptExecutionContext();
+    RefPtr context = jsConstructor->scriptExecutionContext();
     if (UNLIKELY(!context))
         return throwConstructorScriptExecutionContextUnavailableError(*lexicalGlobalObject, throwScope, "Animation");
     auto& document = downcast<Document>(*context);
-    auto effect = convert<IDLNullable<IDLInterface<AnimationEffect>>>(*lexicalGlobalObject, callFrame.argument(0), [](JSGlobalObject& lexicalGlobalObject, ThrowScope& scope) {
+    RefPtr effect = convert<IDLNullable<IDLInterface<AnimationEffect>>>(*lexicalGlobalObject, callFrame.argument(0), [](JSGlobalObject& lexicalGlobalObject, ThrowScope& scope) {
         throwArgumentTypeError(lexicalGlobalObject, scope, 0, "effect", "Animation", nullptr, "AnimationEffect");
     });
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
     if (callFrame.argument(1).isUndefined()) {
-        auto object = WebAnimation::create(document, WTFMove(effect));
+        Ref object = WebAnimation::create(document, WTFMove(effect));
         return JSValue::encode(toJSNewlyCreated<IDLInterface<WebAnimation>>(*lexicalGlobalObject, *jsConstructor->globalObject(), WTFMove(object)));
     }
 
@@ -77,7 +77,7 @@ EncodedJSValue constructJSWebAnimation(JSGlobalObject* lexicalGlobalObject, Call
         throwArgumentTypeError(lexicalGlobalObject, scope, 1, "timeline", "Animation", nullptr, "AnimationTimeline");
     });
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    auto object = WebAnimation::create(document, WTFMove(effect), WTFMove(timeline));
+    Ref object = WebAnimation::create(document, WTFMove(effect), WTFMove(timeline));
     return JSValue::encode(toJSNewlyCreated<IDLInterface<WebAnimation>>(*lexicalGlobalObject, *jsConstructor->globalObject(), WTFMove(object)));
 }
 

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -97,7 +97,7 @@ void JSWindowProxy::setWindow(DOMWindow& domWindow)
 
     auto* localWindow = dynamicDowncast<LocalDOMWindow>(domWindow);
 
-    VM& vm = commonVM();
+    Ref vm = commonVM();
     auto& prototypeStructure = localWindow ? *JSLocalDOMWindowPrototype::createStructure(vm, nullptr, jsNull()) : *JSRemoteDOMWindowPrototype::createStructure(vm, nullptr, jsNull());
 
     // Explicitly protect the prototype so it isn't collected when we allocate the global object.

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -149,8 +149,8 @@ void JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, 
     JSWorkerGlobalScopeBase& thisObject = static_cast<JSWorkerGlobalScopeBase&>(object);
 
     auto callback = JSMicrotaskCallback::create(thisObject, WTFMove(task));
-    auto& context = thisObject.wrapped();
-    context.eventLoop().queueMicrotask([callback = WTFMove(callback)]() mutable {
+    Ref context = thisObject.wrapped();
+    context->checkedEventLoop()->queueMicrotask([callback = WTFMove(callback)]() mutable {
         callback->call();
     });
 }

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
@@ -57,7 +57,7 @@ DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWorkerGlobalScope);
 
 JSValue JSWorkerGlobalScope::queueMicrotask(JSGlobalObject& lexicalGlobalObject, CallFrame& callFrame)
 {
-    VM& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (UNLIKELY(callFrame.argumentCount() < 1))

--- a/Source/WebCore/bindings/js/ModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/ModuleScriptLoader.h
@@ -49,14 +49,14 @@ public:
 
 protected:
     ModuleScriptLoader(ModuleScriptLoaderClient& client, DeferredPromise& promise, JSC::ScriptFetcher& scriptFetcher, RefPtr<JSC::ScriptFetchParameters>&& parameters)
-        : m_client(&client)
+        : m_client(client)
         , m_promise(&promise)
         , m_scriptFetcher(scriptFetcher)
         , m_parameters(WTFMove(parameters))
     {
     }
 
-    ModuleScriptLoaderClient* m_client;
+    WeakPtr<ModuleScriptLoaderClient> m_client;
     RefPtr<DeferredPromise> m_promise;
     Ref<JSC::ScriptFetcher> m_scriptFetcher;
     RefPtr<JSC::ScriptFetchParameters> m_parameters;

--- a/Source/WebCore/bindings/js/ModuleScriptLoaderClient.h
+++ b/Source/WebCore/bindings/js/ModuleScriptLoaderClient.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include <wtf/WeakPtr.h>
+
 namespace WebCore {
 
 class ModuleScriptLoader;
 class DeferredPromise;
 
-class ModuleScriptLoaderClient {
+class ModuleScriptLoaderClient : public CanMakeWeakPtr<ModuleScriptLoaderClient> {
 public:
     virtual ~ModuleScriptLoaderClient() = default;
 

--- a/Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp
+++ b/Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp
@@ -41,20 +41,20 @@ namespace WebCore {
 
 static bool invokeReadableStreamDefaultControllerFunction(JSC::JSGlobalObject& lexicalGlobalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
 {
-    JSC::VM& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     JSC::JSLockHolder lock(vm);
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
     auto function = lexicalGlobalObject.get(&lexicalGlobalObject, identifier);
 
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    EXCEPTION_ASSERT(!scope.exception() || vm->hasPendingTerminationException());
     RETURN_IF_EXCEPTION(scope, false);
 
     ASSERT(function.isCallable());
 
     auto callData = JSC::getCallData(function);
     call(&lexicalGlobalObject, function, callData, JSC::jsUndefined(), arguments);
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    EXCEPTION_ASSERT(!scope.exception() || vm->hasPendingTerminationException());
     return !scope.exception();
 }
 
@@ -74,13 +74,13 @@ void ReadableStreamDefaultController::close()
 void ReadableStreamDefaultController::error(const Exception& exception)
 {
     JSC::JSGlobalObject& lexicalGlobalObject = this->globalObject();
-    auto& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     JSC::JSLockHolder lock(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
     auto value = createDOMException(&lexicalGlobalObject, exception.code(), exception.message());
 
     if (UNLIKELY(scope.exception())) {
-        ASSERT(vm.hasPendingTerminationException());
+        ASSERT(vm->hasPendingTerminationException());
         return;
     }
 
@@ -89,7 +89,7 @@ void ReadableStreamDefaultController::error(const Exception& exception)
     arguments.append(value);
     ASSERT(!arguments.hasOverflowed());
 
-    auto* clientData = static_cast<JSVMClientData*>(vm.clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamDefaultControllerErrorPrivateName();
 
     invokeReadableStreamDefaultControllerFunction(globalObject(), privateName, arguments);
@@ -98,7 +98,7 @@ void ReadableStreamDefaultController::error(const Exception& exception)
 bool ReadableStreamDefaultController::enqueue(JSC::JSValue value)
 {
     JSC::JSGlobalObject& lexicalGlobalObject = this->globalObject();
-    auto& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     JSC::JSLockHolder lock(vm);
 
     JSC::MarkedArgumentBuffer arguments;
@@ -106,7 +106,7 @@ bool ReadableStreamDefaultController::enqueue(JSC::JSValue value)
     arguments.append(value);
     ASSERT(!arguments.hasOverflowed());
 
-    auto* clientData = static_cast<JSVMClientData*>(lexicalGlobalObject.vm().clientData);
+    auto* clientData = static_cast<JSVMClientData*>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamDefaultControllerEnqueuePrivateName();
 
     return invokeReadableStreamDefaultControllerFunction(globalObject(), privateName, arguments);
@@ -120,14 +120,14 @@ bool ReadableStreamDefaultController::enqueue(RefPtr<JSC::ArrayBuffer>&& buffer)
     }
 
     JSC::JSGlobalObject& lexicalGlobalObject = this->globalObject();
-    auto& vm = lexicalGlobalObject.vm();
+    Ref vm = lexicalGlobalObject.vm();
     JSC::JSLockHolder lock(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
     auto length = buffer->byteLength();
     auto chunk = JSC::Uint8Array::create(WTFMove(buffer), 0, length);
     auto value = toJS(&lexicalGlobalObject, &lexicalGlobalObject, chunk.get());
 
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    EXCEPTION_ASSERT(!scope.exception() || vm->hasPendingTerminationException());
     RETURN_IF_EXCEPTION(scope, false);
 
     return enqueue(value);

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -95,7 +95,7 @@ void ScheduledAction::execute(ScriptExecutionContext& context)
 void ScheduledAction::executeFunctionInContext(JSGlobalObject* globalObject, JSValue thisValue, ScriptExecutionContext& context)
 {
     ASSERT(m_function);
-    VM& vm = context.vm();
+    Ref vm = context.vm();
     JSLockHolder lock(vm);
     auto catchScope = DECLARE_CATCH_SCOPE(vm);
 
@@ -142,7 +142,7 @@ void ScheduledAction::execute(Document& document)
     if (m_function)
         executeFunctionInContext(window, &window->proxy(), document);
     else
-        frame->script().executeScriptInWorldIgnoringException(m_isolatedWorld, m_code, m_sourceTaintedOrigin);
+        frame->checkedScript()->executeScriptInWorldIgnoringException(m_isolatedWorld, m_code, m_sourceTaintedOrigin);
 }
 
 void ScheduledAction::execute(WorkerGlobalScope& workerGlobalScope)
@@ -150,7 +150,7 @@ void ScheduledAction::execute(WorkerGlobalScope& workerGlobalScope)
     // In a Worker, the execution should always happen on a worker thread.
     ASSERT(workerGlobalScope.thread().thread() == &Thread::current());
 
-    auto* scriptController = workerGlobalScope.script();
+    CheckedPtr scriptController = workerGlobalScope.script();
 
     if (m_function) {
         auto* contextWrapper = scriptController->globalScopeWrapper();

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -189,8 +189,8 @@ private:
 
     Ref<LocalFrame> protectedFrame() const;
 
-    LocalFrame& m_frame;
-    const URL* m_sourceURL { nullptr };
+    WeakRef<LocalFrame> m_frame;
+    const URL* m_sourceURL { nullptr }; // FIXME: We shouldn't use a raw pointer here.
 
     bool m_paused;
     bool m_willReplaceWithResultOfExecutingJavascriptURL { false };

--- a/Source/WebCore/bindings/js/ScriptControllerMac.mm
+++ b/Source/WebCore/bindings/js/ScriptControllerMac.mm
@@ -109,8 +109,8 @@ void ScriptController::updatePlatformScriptObjects()
 
 void ScriptController::disconnectPlatformScriptObjects()
 {
-    if (m_windowScriptObject)
-        disconnectWindowWrapper(m_windowScriptObject.get());
+    if (RetainPtr windowScriptObject = m_windowScriptObject)
+        disconnectWindowWrapper(windowScriptObject.get());
 }
 
 }

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -100,7 +100,7 @@ static Expected<URL, String> resolveModuleSpecifier(ScriptExecutionContext& cont
 
 JSC::Identifier ScriptModuleLoader::resolve(JSC::JSGlobalObject* jsGlobalObject, JSC::JSModuleLoader*, JSC::JSValue moduleNameValue, JSC::JSValue importerModuleKey, JSC::JSValue)
 {
-    JSC::VM& vm = jsGlobalObject->vm();
+    Ref vm = jsGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // We use a Symbol as a special purpose; It means this module is an inline module.
@@ -139,10 +139,10 @@ JSC::Identifier ScriptModuleLoader::resolve(JSC::JSGlobalObject* jsGlobalObject,
 
 static void rejectToPropagateNetworkError(ScriptExecutionContext& context, Ref<DeferredPromise>&& deferred, ModuleFetchFailureKind failureKind, ASCIILiteral message)
 {
-    context.eventLoop().queueTask(TaskSource::Networking, [deferred = WTFMove(deferred), failureKind, message]() {
+    context.checkedEventLoop()->queueTask(TaskSource::Networking, [deferred = WTFMove(deferred), failureKind, message]() {
         deferred->rejectWithCallback([&] (JSDOMGlobalObject& jsGlobalObject) {
             // We annotate exception with special private symbol. It allows us to distinguish these errors from the user thrown ones.
-            JSC::VM& vm = jsGlobalObject.vm();
+            Ref vm = jsGlobalObject.vm();
             // FIXME: Propagate more descriptive error.
             // https://bugs.webkit.org/show_bug.cgi?id=167553
             auto* error = JSC::createTypeError(&jsGlobalObject, message);
@@ -156,9 +156,9 @@ static void rejectToPropagateNetworkError(ScriptExecutionContext& context, Ref<D
 static void rejectWithFetchError(ScriptExecutionContext& context, Ref<DeferredPromise>&& deferred, ExceptionCode ec, String&& message)
 {
     // Used to signal to the promise client that the failure was from a fetch, but not one that was propagated from another context.
-    context.eventLoop().queueTask(TaskSource::Networking, [deferred = WTFMove(deferred), ec, message = WTFMove(message)]() {
+    context.checkedEventLoop()->queueTask(TaskSource::Networking, [deferred = WTFMove(deferred), ec, message = WTFMove(message)]() {
         deferred->rejectWithCallback([&] (JSDOMGlobalObject& jsGlobalObject) {
-            JSC::VM& vm = jsGlobalObject.vm();
+            Ref vm = jsGlobalObject.vm();
             JSC::JSObject* error = JSC::jsCast<JSC::JSObject*>(createDOMException(&jsGlobalObject, ec, message));
             ASSERT(error);
             error->putDirect(vm, builtinNames(vm).failureKindPrivateName(), JSC::jsNumber(enumToUnderlyingType(ModuleFetchFailureKind::WasFetchError)));
@@ -169,7 +169,7 @@ static void rejectWithFetchError(ScriptExecutionContext& context, Ref<DeferredPr
 
 JSC::JSInternalPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalObject, JSC::JSModuleLoader*, JSC::JSValue moduleKeyValue, JSC::JSValue parametersValue, JSC::JSValue scriptFetcher)
 {
-    JSC::VM& vm = jsGlobalObject->vm();
+    Ref vm = jsGlobalObject->vm();
     ASSERT(JSC::jsDynamicCast<JSC::JSScriptFetcher*>(scriptFetcher));
 
     auto& globalObject = *JSC::jsCast<JSDOMGlobalObject*>(jsGlobalObject);
@@ -178,7 +178,7 @@ JSC::JSInternalPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalO
     if (!m_context)
         return jsPromise;
 
-    auto deferred = DeferredPromise::create(globalObject, *jsPromise);
+    Ref deferred = DeferredPromise::create(globalObject, *jsPromise);
     if (moduleKeyValue.isSymbol()) {
         rejectWithFetchError(*m_context, WTFMove(deferred), ExceptionCode::TypeError, "Symbol module key should be already fulfilled with the inlined resource."_s);
         return jsPromise;
@@ -202,18 +202,19 @@ JSC::JSInternalPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalO
         parameters = &scriptFetchParameters->parameters();
 
     if (m_ownerType == OwnerType::Document) {
-        auto loader = CachedModuleScriptLoader::create(*this, deferred.get(), *static_cast<CachedScriptFetcher*>(JSC::jsCast<JSC::JSScriptFetcher*>(scriptFetcher)->fetcher()), WTFMove(parameters));
+        Ref loader = CachedModuleScriptLoader::create(*this, deferred.get(), *static_cast<CachedScriptFetcher*>(JSC::jsCast<JSC::JSScriptFetcher*>(scriptFetcher)->fetcher()), WTFMove(parameters));
         m_loaders.add(loader.copyRef());
-        if (!loader->load(downcast<Document>(*m_context), WTFMove(completedURL))) {
+        Ref document = downcast<Document>(*m_context);
+        if (!loader->load(document, WTFMove(completedURL))) {
             loader->clearClient();
             m_loaders.remove(WTFMove(loader));
-            rejectToPropagateNetworkError(*m_context, WTFMove(deferred), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
+            rejectToPropagateNetworkError(document, WTFMove(deferred), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
             return jsPromise;
         }
     } else {
         auto loader = WorkerModuleScriptLoader::create(*this, deferred.get(), *static_cast<WorkerScriptFetcher*>(JSC::jsCast<JSC::JSScriptFetcher*>(scriptFetcher)->fetcher()), WTFMove(parameters));
         m_loaders.add(loader.copyRef());
-        loader->load(*m_context, WTFMove(completedURL));
+        loader->load(Ref { *m_context }, WTFMove(completedURL));
     }
 
     return jsPromise;
@@ -230,7 +231,7 @@ URL ScriptModuleLoader::moduleURL(JSC::JSGlobalObject& jsGlobalObject, JSC::JSVa
 
 URL ScriptModuleLoader::responseURLFromRequestURL(JSC::JSGlobalObject& jsGlobalObject, JSC::JSValue moduleKeyValue)
 {
-    JSC::VM& vm = jsGlobalObject.vm();
+    Ref vm = jsGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (isRootModule(moduleKeyValue)) {
@@ -257,7 +258,7 @@ URL ScriptModuleLoader::responseURLFromRequestURL(JSC::JSGlobalObject& jsGlobalO
 
 JSC::JSValue ScriptModuleLoader::evaluate(JSC::JSGlobalObject* jsGlobalObject, JSC::JSModuleLoader*, JSC::JSValue moduleKeyValue, JSC::JSValue moduleRecordValue, JSC::JSValue, JSC::JSValue awaitedValue, JSC::JSValue resumeMode)
 {
-    JSC::VM& vm = jsGlobalObject->vm();
+    Ref vm = jsGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // FIXME: Currently, we only support JSModuleRecord and WebAssemblyModuleRecord.
@@ -280,7 +281,7 @@ JSC::JSValue ScriptModuleLoader::evaluate(JSC::JSGlobalObject* jsGlobalObject, J
         if (RefPtr frame = downcast<Document>(*m_context).frame())
             RELEASE_AND_RETURN(scope, frame->script().evaluateModule(sourceURL, *moduleRecord, awaitedValue, resumeMode));
     } else {
-        if (auto* script = downcast<WorkerOrWorkletGlobalScope>(*m_context).script())
+        if (CheckedPtr script = downcast<WorkerOrWorkletGlobalScope>(*m_context).script())
             RELEASE_AND_RETURN(scope, script->evaluateModule(*moduleRecord, awaitedValue, resumeMode));
     }
     return JSC::jsUndefined();
@@ -296,7 +297,7 @@ static JSC::JSInternalPromise* rejectPromise(ScriptExecutionContext& context, JS
 
 JSC::JSInternalPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* jsGlobalObject, JSC::JSModuleLoader*, JSC::JSString* moduleName, JSC::JSValue parametersValue, const JSC::SourceOrigin& sourceOrigin)
 {
-    JSC::VM& vm = jsGlobalObject->vm();
+    Ref vm = jsGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto& globalObject = *JSC::jsCast<JSDOMGlobalObject*>(jsGlobalObject);
 
@@ -307,7 +308,7 @@ JSC::JSInternalPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* js
     // If settings object's global object implements WorkletGlobalScope or ServiceWorkerGlobalScope, then:
     if (is<WorkletGlobalScope>(*m_context) || is<ServiceWorkerGlobalScope>(*m_context)) {
         scope.release();
-        return rejectPromise(*m_context, globalObject, ExceptionCode::TypeError, "Dynamic-import is not available in Worklets or ServiceWorkers"_s);
+        return rejectPromise(Ref { *m_context }, globalObject, ExceptionCode::TypeError, "Dynamic-import is not available in Worklets or ServiceWorkers"_s);
     }
 
     auto reject = [&](auto& scope) {
@@ -318,7 +319,7 @@ JSC::JSInternalPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* js
     auto getTypeFromAssertions = [&]() -> JSC::ScriptFetchParameters::Type {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        auto assertions = JSC::retrieveImportAttributesFromDynamicImportOptions(&globalObject, parametersValue, { vm.propertyNames->type.impl() });
+        auto assertions = JSC::retrieveImportAttributesFromDynamicImportOptions(&globalObject, parametersValue, { vm->propertyNames->type.impl() });
         RETURN_IF_EXCEPTION(scope, { });
 
         auto type = JSC::retrieveTypeImportAttribute(&globalObject, assertions);
@@ -356,7 +357,7 @@ JSC::JSInternalPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* js
         baseURL = URL { sourceOrigin.string() };
         if (!baseURL.isValid()) {
             scope.release();
-            return rejectPromise(*m_context, globalObject, ExceptionCode::TypeError, "Importer module key is not a Symbol or a String."_s);
+            return rejectPromise(Ref { *m_context }, globalObject, ExceptionCode::TypeError, "Importer module key is not a Symbol or a String."_s);
         }
 
         auto type = getTypeFromAssertions();
@@ -394,7 +395,7 @@ JSC::JSObject* ScriptModuleLoader::createImportMetaProperties(JSC::JSGlobalObjec
 {
     // https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties
 
-    auto& vm = jsGlobalObject->vm();
+    Ref vm = jsGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* metaProperties = JSC::constructEmptyObject(vm, jsGlobalObject->nullPrototypeObjectStructure());
@@ -409,7 +410,7 @@ JSC::JSObject* ScriptModuleLoader::createImportMetaProperties(JSC::JSGlobalObjec
     String resolveName = "resolve"_s;
     OwnerType ownerType = m_ownerType;
     auto* function = JSC::JSNativeStdFunction::create(vm, jsGlobalObject, 1, resolveName, [ownerType, responseURL](JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame) -> JSC::EncodedJSValue {
-        JSC::VM& vm = globalObject->vm();
+        Ref vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         auto specifier = callFrame->argument(0).toWTFString(globalObject);
@@ -419,7 +420,7 @@ JSC::JSObject* ScriptModuleLoader::createImportMetaProperties(JSC::JSGlobalObjec
         if (UNLIKELY(!domGlobalObject))
             return JSC::throwVMTypeError(globalObject, scope);
 
-        auto* context = domGlobalObject->scriptExecutionContext();
+        RefPtr context = domGlobalObject->scriptExecutionContext();
         if (UNLIKELY(!context))
             return JSC::throwVMTypeError(globalObject, scope);
 
@@ -463,17 +464,17 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
         auto& cachedScript = *loader.cachedScript();
 
         if (cachedScript.resourceError().isAccessControl()) {
-            rejectToPropagateNetworkError(*m_context, WTFMove(promise), ModuleFetchFailureKind::WasPropagatedError, "Cross-origin script load denied by Cross-Origin Resource Sharing policy."_s);
+            rejectToPropagateNetworkError(Ref { *m_context }, WTFMove(promise), ModuleFetchFailureKind::WasPropagatedError, "Cross-origin script load denied by Cross-Origin Resource Sharing policy."_s);
             return;
         }
 
         if (cachedScript.errorOccurred()) {
-            rejectToPropagateNetworkError(*m_context, WTFMove(promise), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
+            rejectToPropagateNetworkError(Ref { *m_context }, WTFMove(promise), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
             return;
         }
 
         if (cachedScript.wasCanceled()) {
-            rejectToPropagateNetworkError(*m_context, WTFMove(promise), ModuleFetchFailureKind::WasCanceled, "Importing a module script is canceled."_s);
+            rejectToPropagateNetworkError(Ref { *m_context }, WTFMove(promise), ModuleFetchFailureKind::WasCanceled, "Importing a module script is canceled."_s);
             return;
         }
 
@@ -491,7 +492,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
             // The result of extracting a MIME type from response's header list (ignoring parameters) is not a JavaScript MIME type.
             // For historical reasons, fetching a classic script does not include MIME type checking. In contrast, module scripts will fail to load if they are not of a correct MIME type.
-            rejectWithFetchError(*m_context, WTFMove(promise), ExceptionCode::TypeError, makeString("'", cachedScript.response().mimeType(), "' is not a valid JavaScript MIME type."));
+            rejectWithFetchError(Ref { *m_context }, WTFMove(promise), ExceptionCode::TypeError, makeString("'", cachedScript.response().mimeType(), "' is not a valid JavaScript MIME type."));
             return;
         }
 
@@ -499,8 +500,9 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             String integrity = parameters->integrity();
             if (!integrity.isEmpty()) {
                 if (!matchIntegrityMetadata(cachedScript, integrity)) {
-                    m_context->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load script ", integrityMismatchDescription(cachedScript, integrity)));
-                    rejectWithFetchError(*m_context, WTFMove(promise), ExceptionCode::TypeError, "Cannot load script due to integrity mismatch"_s);
+                    RefPtr context = m_context.get();
+                    context->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load script ", integrityMismatchDescription(cachedScript, integrity)));
+                    rejectWithFetchError(*context, WTFMove(promise), ExceptionCode::TypeError, "Cannot load script due to integrity mismatch"_s);
                     return;
                 }
             }
@@ -531,16 +533,16 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             auto& workerScriptLoader = loader.scriptLoader();
             ASSERT(workerScriptLoader.failed());
             if (workerScriptLoader.error().isAccessControl()) {
-                rejectToPropagateNetworkError(*m_context, WTFMove(promise), ModuleFetchFailureKind::WasPropagatedError, "Cross-origin script load denied by Cross-Origin Resource Sharing policy."_s);
+                rejectToPropagateNetworkError(Ref { *m_context }, WTFMove(promise), ModuleFetchFailureKind::WasPropagatedError, "Cross-origin script load denied by Cross-Origin Resource Sharing policy."_s);
                 return;
             }
 
             if (workerScriptLoader.error().isCancellation()) {
-                rejectToPropagateNetworkError(*m_context, WTFMove(promise), ModuleFetchFailureKind::WasCanceled, "Importing a module script is canceled."_s);
+                rejectToPropagateNetworkError(Ref { *m_context }, WTFMove(promise), ModuleFetchFailureKind::WasCanceled, "Importing a module script is canceled."_s);
                 return;
             }
 
-            rejectToPropagateNetworkError(*m_context, WTFMove(promise), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
+            rejectToPropagateNetworkError(Ref { *m_context }, WTFMove(promise), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
             return;
         }
 
@@ -558,7 +560,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
             // The result of extracting a MIME type from response's header list (ignoring parameters) is not a JavaScript MIME type.
             // For historical reasons, fetching a classic script does not include MIME type checking. In contrast, module scripts will fail to load if they are not of a correct MIME type.
-            rejectWithFetchError(*m_context, WTFMove(promise), ExceptionCode::TypeError, makeString("'", loader.responseMIMEType(), "' is not a valid JavaScript MIME type."));
+            rejectWithFetchError(Ref { *m_context }, WTFMove(promise), ExceptionCode::TypeError, makeString("'", loader.responseMIMEType(), "' is not a valid JavaScript MIME type."));
             return;
         }
 
@@ -571,7 +573,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
                     static_cast<WorkerScriptFetcher&>(loader.scriptFetcher()).setReferrerPolicy(loader.referrerPolicy());
             }
             responseURL = canonicalizeAndRegisterResponseURL(responseURL, workerScriptLoader.isRedirected(), workerScriptLoader.responseSource());
-            if (auto* globalScope = dynamicDowncast<ServiceWorkerGlobalScope>(*m_context))
+            if (RefPtr globalScope = dynamicDowncast<ServiceWorkerGlobalScope>(*m_context))
                 globalScope->setScriptResource(sourceURL, ServiceWorkerContextData::ImportedScript { loader.script(), responseURL, loader.responseMIMEType() });
         }
         m_requestURLToResponseURLMap.add(sourceURL.string(), responseURL);
@@ -593,7 +595,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
         }
     }
 
-    m_context->eventLoop().queueTask(TaskSource::Networking, [promise = WTFMove(promise), sourceCode = WTFMove(sourceCode)]() {
+    Ref { *m_context }->checkedEventLoop()->queueTask(TaskSource::Networking, [promise = WTFMove(promise), sourceCode = WTFMove(sourceCode)]() {
         promise->resolveWithCallback([&, sourceCode](JSDOMGlobalObject& jsGlobalObject) {
             return JSC::JSSourceCode::create(jsGlobalObject.vm(), JSC::SourceCode { sourceCode });
         });

--- a/Source/WebCore/bindings/js/StructuredClone.cpp
+++ b/Source/WebCore/bindings/js/StructuredClone.cpp
@@ -73,7 +73,7 @@ JSC_DEFINE_HOST_FUNCTION(structuredCloneForStream, (JSGlobalObject* globalObject
     ASSERT(callFrame);
     ASSERT(callFrame->argumentCount());
 
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue value = callFrame->uncheckedArgument(0);

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -47,7 +47,7 @@ public:
 
     virtual ~WebAssemblyCachedScriptSourceProvider()
     {
-        m_cachedScript->removeClient(*this);
+        CachedResourceHandle { m_cachedScript }->removeClient(*this);
     }
 
     unsigned hash() const final { return m_cachedScript->scriptHash(); }
@@ -60,7 +60,7 @@ public:
             return nullptr;
 
         if (!m_buffer->isContiguous())
-            m_buffer = m_buffer->makeContiguous();
+            m_buffer = Ref { *m_buffer }->makeContiguous();
 
         return downcast<SharedBuffer>(*m_buffer).data();
     }
@@ -83,7 +83,7 @@ private:
         , m_cachedScript(cachedScript)
         , m_buffer(nullptr)
     {
-        m_cachedScript->addClient(*this);
+        CachedResourceHandle { m_cachedScript }->addClient(*this);
     }
 
     CachedResourceHandle<CachedScript> m_cachedScript;

--- a/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
@@ -70,7 +70,7 @@ public:
             return;
 
         if (!m_buffer->isContiguous())
-            m_buffer = m_buffer->makeContiguous();
+            m_buffer = RefPtr { m_buffer }->makeContiguous();
     }
 
     void unlockUnderlyingBuffer() final

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -120,14 +120,14 @@ public:
 
     void rememberWorld(DOMWrapperWorld& world)
     {
-        ASSERT(!m_worldSet.contains(&world));
-        m_worldSet.add(&world);
+        ASSERT(!m_worldSet.contains(world));
+        m_worldSet.add(world);
     }
 
     void forgetWorld(DOMWrapperWorld& world)
     {
-        ASSERT(m_worldSet.contains(&world));
-        m_worldSet.remove(&world);
+        ASSERT(m_worldSet.contains(world));
+        m_worldSet.remove(world);
     }
 
     virtual String overrideSourceURL(const JSC::StackFrame&, const String& originalSourceURL) const;
@@ -158,7 +158,7 @@ public:
     void addClient(Client& client) { m_clients.add(client); }
 
 private:
-    HashSet<DOMWrapperWorld*> m_worldSet;
+    HashSet<SingleThreadWeakRef<DOMWrapperWorld>> m_worldSet;
     RefPtr<DOMWrapperWorld> m_normalWorld;
 
     JSBuiltinFunctions m_builtinFunctions;

--- a/Source/WebCore/bindings/js/WindowProxy.h
+++ b/Source/WebCore/bindings/js/WindowProxy.h
@@ -38,7 +38,7 @@ class Frame;
 class JSDOMGlobalObject;
 class JSWindowProxy;
 
-class WindowProxy : public RefCounted<WindowProxy> {
+class WindowProxy : public RefCounted<WindowProxy>, public CanMakeSingleThreadWeakPtr<WindowProxy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using ProxyMap = HashMap<RefPtr<DOMWrapperWorld>, JSC::Strong<JSWindowProxy>>;
@@ -51,6 +51,7 @@ public:
     WEBCORE_EXPORT ~WindowProxy();
 
     WEBCORE_EXPORT Frame* frame() const;
+    RefPtr<Frame> protectedFrame() const;
     void detachFromFrame();
     void replaceFrame(Frame&);
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -60,6 +60,11 @@ Frame::~Frame()
     m_navigationScheduler->cancel();
 }
 
+RefPtr<DOMWindow> Frame::protectedWindow() const
+{
+    return virtualWindow();
+}
+
 std::optional<PageIdentifier> Frame::pageID() const
 {
     if (auto* page = this->page())

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -60,6 +60,7 @@ public:
     Ref<WindowProxy> protectedWindowProxy() const;
 
     DOMWindow* window() const { return virtualWindow(); }
+    RefPtr<DOMWindow> protectedWindow() const;
     FrameTree& tree() const { return m_treeNode; }
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in Page.h.


### PR DESCRIPTION
#### cce92d99566ed92ff5c4bd3ad1855f5f5cf88976
<pre>
Adopt more smart pointers in WebCore/bindings
<a href="https://bugs.webkit.org/show_bug.cgi?id=269366">https://bugs.webkit.org/show_bug.cgi?id=269366</a>

Reviewed by Brent Fulgham.

* Source/JavaScriptCore/runtime/JSObject.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::create):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp:
(WebCore::CachedModuleScriptLoader::~CachedModuleScriptLoader):
(WebCore::CachedModuleScriptLoader::load):
(WebCore::CachedModuleScriptLoader::notifyFinished):
* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
(WebCore::CachedScriptSourceProvider::~CachedScriptSourceProvider):
(WebCore::CachedScriptSourceProvider::m_cachedScript):
(WebCore::CachedScriptSourceProvider::protectedScript const):
(WebCore::CachedScriptSourceProvider::hash const):
(WebCore::CachedScriptSourceProvider::source const):
* Source/WebCore/bindings/js/CommonVM.cpp:
(WebCore::commonVMSlow):
(WebCore::addImpureProperty):
(WebCore::protectedCommonVM):
* Source/WebCore/bindings/js/CommonVM.h:
* Source/WebCore/bindings/js/DOMGCOutputConstraint.h:
* Source/WebCore/bindings/js/DOMPromiseProxy.h:
(WebCore::DOMPromiseProxy&lt;IDLType&gt;::resolvePromise):
(WebCore::DOMPromiseProxy&lt;IDLUndefined&gt;::promise):
(WebCore::DOMPromiseProxyWithResolveCallback&lt;IDLType&gt;::promise):
* Source/WebCore/bindings/js/DOMWrapperWorld.cpp:
(WebCore::DOMWrapperWorld::~DOMWrapperWorld):
(WebCore::DOMWrapperWorld::clearWrappers):
(WebCore::DOMWrapperWorld::didCreateWindowProxy):
(WebCore::DOMWrapperWorld::didDestroyWindowProxy):
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::didCreateWindowProxy): Deleted.
(WebCore::DOMWrapperWorld::didDestroyWindowProxy): Deleted.
* Source/WebCore/bindings/js/GCController.cpp:
(WebCore::GCController::garbageCollectOnAlternateThreadForDebugging):
(WebCore::GCController::deleteAllCode):
(WebCore::GCController::deleteAllLinkedCode):
(WebCore::GCController::dumpHeap):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::get):
(WebCore::toJS):
(WebCore::createIDBKeyFromValue):
(WebCore::ensureNthValueOnKeyPath):
(WebCore::deserializeIDBValueToJSValue):
(WebCore::createKeyPathArray):
(WebCore::generateIndexKeyMapForValueIsolatedCopy):
(WebCore::deserializeIDBValueWithKeyInjection):
(WebCore::IDBSerializationContext::initializeVM):
* Source/WebCore/bindings/js/InternalReadableStream.cpp:
(WebCore::invokeReadableStreamFunction):
(WebCore::InternalReadableStream::isLocked const):
(WebCore::InternalReadableStream::isDisturbed const):
(WebCore::InternalReadableStream::cancel):
(WebCore::InternalReadableStream::lock):
(WebCore::InternalReadableStream::pipeTo):
(WebCore::InternalReadableStream::tee):
(WebCore::InternalReadableStream::getReader):
(WebCore::InternalReadableStream::pipeThrough):
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
(WebCore::invokeWritableStreamFunction):
(WebCore::InternalWritableStream::createFromUnderlyingSink):
(WebCore::InternalWritableStream::locked const):
(WebCore::InternalWritableStream::lock):
(WebCore::InternalWritableStream::abortForBindings):
(WebCore::InternalWritableStream::closeForBindings):
(WebCore::InternalWritableStream::closeIfPossible):
(WebCore::InternalWritableStream::getWriter):
* Source/WebCore/bindings/js/JSCallbackData.cpp:
(WebCore::JSCallbackData::invokeCallback):
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::constructElementWithFallback):
(WebCore::JSCustomElementInterface::createElement):
(WebCore::JSCustomElementInterface::tryToConstructCustomElement):
(WebCore::constructCustomElementSynchronously):
(WebCore::JSCustomElementInterface::upgradeElement):
(WebCore::JSCustomElementInterface::invokeCallback):
(WebCore::JSCustomElementInterface::invokeFormStateRestoreCallback):
* Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp:
(WebCore::getCustomElementCallback):
(WebCore::validateCustomElementNameAndThrowIfNeeded):
(WebCore::JSCustomElementRegistry::define):
(WebCore::whenDefinedPromise):
(WebCore::JSCustomElementRegistry::whenDefined):
* Source/WebCore/bindings/js/JSCustomEventCustom.cpp:
(WebCore::JSCustomEvent::detail const):
* Source/WebCore/bindings/js/JSDOMAbstractOperations.h:
(WebCore::isVisibleNamedProperty):
* Source/WebCore/bindings/js/JSDOMAsyncIterator.h:
(WebCore::IteratorTraits&gt;::runNextSteps):
(WebCore::IteratorTraits&gt;::getNextIterationResult):
(WebCore::IteratorTraits&gt;::onPromiseSettled):
(WebCore::IteratorTraits&gt;::createOnSettledFunction):
(WebCore::IteratorTraits&gt;::onPromiseFulFilled):
(WebCore::IteratorTraits&gt;::createOnFulfilledFunction):
(WebCore::IteratorTraits&gt;::reject):
(WebCore::IteratorTraits&gt;::onPromiseRejected):
(WebCore::IteratorTraits&gt;::createOnRejectedFunction):
(WebCore::IteratorTraits&gt;::next):
* Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp:
(WebCore::printErrorMessageForFrame):
(WebCore::canAccessDocument):
(WebCore::BindingSecurity::shouldAllowAccessToFrame):
(WebCore::BindingSecurity::shouldAllowAccessToDOMWindow):
(WebCore::BindingSecurity::shouldAllowAccessToNode):
* Source/WebCore/bindings/js/JSDOMBindingSecurityInlines.h:
(WebCore::BindingSecurity::shouldAllowAccessToDOMWindow):
* Source/WebCore/bindings/js/JSDOMBuiltinConstructor.h:
(WebCore::JSDOMBuiltinConstructor&lt;JSClass&gt;::getDOMStructureForJSObject):
* Source/WebCore/bindings/js/JSDOMCastThisValue.h:
(WebCore::castThisValue):
* Source/WebCore/bindings/js/JSDOMConstructorBase.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/JSDOMConvertAny.h:
(WebCore::VariadicConverter&lt;IDLAny&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertBufferSource.h:
(WebCore::Detail::BufferSourceConverter::convert):
* Source/WebCore/bindings/js/JSDOMConvertCallbacks.h:
(WebCore::Converter&lt;IDLCallbackFunction&lt;T&gt;&gt;::convert):
(WebCore::Converter&lt;IDLCallbackInterface&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertDate.cpp:
(WebCore::valueToDate):
* Source/WebCore/bindings/js/JSDOMConvertEnumeration.h:
(WebCore::Converter&lt;IDLEnumeration&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertEventListener.h:
(WebCore::Converter&lt;IDLEventListener&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp:
(WebCore::reportException):
(WebCore::reportCurrentException):
(WebCore::createDOMException):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
(WebCore::JSDOMGlobalObject::protectedScriptExecutionContext const):
(WebCore::JSDOMGlobalObject::promiseRejectionTracker):
(WebCore::JSDOMGlobalObject::createCrossOriginFunction):
(WebCore::JSDOMGlobalObject::createCrossOriginGetterSetter):
(WebCore::handleResponseOnStreamingAction):
(WebCore::JSDOMGlobalObject::moduleLoaderFetch):
(WebCore::JSDOMGlobalObject::moduleLoaderImportModule):
(WebCore::JSDOMGlobalObject::deriveShadowRealmGlobalObject):
(WebCore::JSDOMGlobalObject::protectedWorld):
(WebCore::toJSDOMGlobalObject):
(WebCore::callerGlobalObject):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDOMGuardedObject.cpp:
(WebCore::DOMGuardedObject::DOMGuardedObject):
* Source/WebCore/bindings/js/JSDOMIterator.cpp:
(WebCore::addValueIterableMethods):
* Source/WebCore/bindings/js/JSDOMIterator.h:
(WebCore::iteratorForEach):
(WebCore::IteratorTraits&gt;::next):
* Source/WebCore/bindings/js/JSDOMMapLike.h:
(WebCore::forwardSizeToMapLike):
(WebCore::forwardEntriesToMapLike):
(WebCore::forwardKeysToMapLike):
(WebCore::forwardValuesToMapLike):
(WebCore::forwardClearToMapLike):
(WebCore::forwardGetToMapLike):
(WebCore::forwardHasToMapLike):
(WebCore::forwardSetToMapLike):
(WebCore::forwardDeleteToMapLike):
* Source/WebCore/bindings/js/JSDOMMicrotask.cpp:
(WebCore::JSDOMMicrotask::run):
* Source/WebCore/bindings/js/JSDOMOperation.h:
(WebCore::IDLOperation::call):
* Source/WebCore/bindings/js/JSDOMPromise.cpp:
(WebCore::DOMPromise::whenPromiseIsSettled):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::callFunction):
(WebCore::DeferredPromise::whenSettled):
(WebCore::DeferredPromise::reject):
(WebCore::createRejectedPromiseWithTypeError):
(WebCore::DeferredPromise::handleTerminationExceptionIfNeeded):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DeferredPromise::resolve):
(WebCore::DeferredPromise::resolveWithNewlyCreated):
(WebCore::DeferredPromise::resolveCallbackValueWithNewlyCreated):
(WebCore::DeferredPromise::reject):
(WebCore::DeferredPromise::resolveWithCallback):
(WebCore::DeferredPromise::rejectWithCallback):
(WebCore::DOMPromiseDeferredBase::reject):
(WebCore::DOMPromiseDeferredBase::rejectType):
(WebCore::DOMPromiseDeferredBase::whenSettled):
(WebCore::DOMPromiseDeferredBase::protectedPromise const):
(WebCore::DOMPromiseDeferred::resolve):
(WebCore::DOMPromiseDeferred&lt;void&gt;::resolve):
(WebCore::callPromiseFunction):
(WebCore::callPromisePairFunction):
* Source/WebCore/bindings/js/JSDOMSetLike.cpp:
(WebCore::getBackingSet):
(WebCore::clearBackingSet):
(WebCore::addToBackingSet):
(WebCore::forwardFunctionCallToBackingSet):
* Source/WebCore/bindings/js/JSDOMSetLike.h:
(WebCore::getAndInitializeBackingSet):
(WebCore::forwardSizeToSetLike):
(WebCore::forwardEntriesToSetLike):
(WebCore::forwardKeysToSetLike):
(WebCore::forwardValuesToSetLike):
(WebCore::forwardClearToSetLike):
(WebCore::forwardHasToSetLike):
(WebCore::forwardAddToSetLike):
(WebCore::forwardDeleteToSetLike):
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::updateDocument):
(WebCore::JSDOMWindowBase::printErrorMessage const):
(WebCore::JSDOMWindowBase::supportsRichSourceInfo):
(WebCore::JSDOMWindowBase::shouldInterruptScript):
(WebCore::JSDOMWindowBase::shouldInterruptScriptBeforeTimeout):
(WebCore::JSDOMWindowBase::javaScriptRuntimeFlags):
(WebCore::JSDOMWindowBase::queueMicrotaskToEventLoop):
(WebCore::JSDOMWindowBase::currentScriptExecutionOwner):
(WebCore::JSDOMWindowBase::fireFrameClearedWatchpointsForWindow):
* Source/WebCore/bindings/js/JSDOMWindowProperties.cpp:
(WebCore::jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter):
(WebCore::JSDOMWindowProperties::finishCreation):
(WebCore::JSDOMWindowProperties::getOwnPropertySlot):
(WebCore::JSDOMWindowProperties::getOwnPropertySlotByIndex):
(WebCore::JSDOMWindowProperties::defineOwnProperty):
* Source/WebCore/bindings/js/JSDOMWrapper.cpp:
(WebCore::cloneAcrossWorlds):
* Source/WebCore/bindings/js/JSDOMWrapperCache.h:
(WebCore::setSubclassStructureIfNeeded):
* Source/WebCore/bindings/js/JSDocumentCustom.cpp:
(WebCore::cachedDocumentWrapper):
(WebCore::reportMemoryForDocumentIfFrameless):
(WebCore::setAdoptedStyleSheetsOnTreeScope):
(WebCore::JSDocument::setAdoptedStyleSheets):
* Source/WebCore/bindings/js/JSElementCustom.cpp:
(WebCore::toJS):
(WebCore::toJSNewlyCreated):
(WebCore::getElementsArrayAttribute):
* Source/WebCore/bindings/js/JSElementInternalsCustom.cpp:
(WebCore::JSElementInternals::setFormValue):
(WebCore::getElementsArrayAttribute):
* Source/WebCore/bindings/js/JSErrorHandler.cpp:
(WebCore::JSErrorHandler::handleEvent):
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::handleEvent):
(WebCore::JSEventListener::functionName const):
* Source/WebCore/bindings/js/JSEventListener.h:
(WebCore::windowEventHandlerAttribute):
(WebCore::setWindowEventHandlerAttribute):
(WebCore::JSEventListener::ensureJSFunction const):
* Source/WebCore/bindings/js/JSEventTargetCustom.h:
(WebCore::JSEventTargetWrapper::JSEventTargetWrapper):
(WebCore::IDLOperation&lt;JSEventTarget&gt;::call):
* Source/WebCore/bindings/js/JSExecState.cpp:
(WebCore::JSExecState::didLeaveScriptContext):
* Source/WebCore/bindings/js/JSExecState.h:
(WebCore::JSExecState::call):
(WebCore::JSExecState::evaluate):
(WebCore::JSExecState::profiledCall):
(WebCore::JSExecState::profiledEvaluate):
(WebCore::JSExecState::linkAndEvaluateModule):
(WebCore::JSExecState::~JSExecState):
* Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp:
(WebCore::constructJSExtendableMessageEvent):
(WebCore::JSExtendableMessageEvent::data const):
* Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/JSHTMLElementCustom.cpp:
(WebCore::constructJSHTMLElement):
(WebCore::JSHTMLElement::pushEventHandlerScope const):
* Source/WebCore/bindings/js/JSHistoryCustom.cpp:
(WebCore::JSHistory::state const):
* Source/WebCore/bindings/js/JSImageDataCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/JSKeyframeEffectCustom.cpp:
(WebCore::JSKeyframeEffect::getKeyframes):
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::JSLazyEventListener::JSLazyEventListener):
(WebCore::JSLazyEventListener::initializeJSFunction const):
(WebCore::JSLazyEventListener::create):
* Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp:
(WebCore::JSC_DEFINE_CUSTOM_GETTER):
(WebCore::jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess):
(WebCore::JSLocalDOMWindow::getOwnPropertySlot):
(WebCore::JSLocalDOMWindow::getOwnPropertySlotByIndex):
(WebCore::JSLocalDOMWindow::put):
(WebCore::JSLocalDOMWindow::putByIndex):
(WebCore::JSLocalDOMWindow::deleteProperty):
(WebCore::JSLocalDOMWindow::deletePropertyByIndex):
(WebCore::addCrossOriginOwnPropertyNames):
(WebCore::addScopedChildrenIndexes):
(WebCore::JSLocalDOMWindow::getOwnPropertyNames):
(WebCore::JSLocalDOMWindow::defineOwnProperty):
(WebCore::JSLocalDOMWindow::getPrototype):
(WebCore::DialogHandler::dialogCreated):
(WebCore::DialogHandler::returnValue const):
(WebCore::JSC_DEFINE_HOST_FUNCTION):
(WebCore::JSLocalDOMWindow::queueMicrotask):
(WebCore::JSLocalDOMWindow::setOpener):
(WebCore::jsLocalDOMWindowInstanceFunction_openDatabaseBody):
(WebCore::JSLocalDOMWindow::openDatabase const):
(WebCore::JSLocalDOMWindow::setOpenDatabase):
* Source/WebCore/bindings/js/JSLocationCustom.cpp:
(WebCore::getOwnPropertySlotCommon):
(WebCore::JSLocation::getOwnPropertySlot):
(WebCore::JSLocation::getOwnPropertySlotByIndex):
(WebCore::JSLocation::put):
(WebCore::JSLocation::putByIndex):
(WebCore::JSLocation::deleteProperty):
(WebCore::JSLocation::deletePropertyByIndex):
(WebCore::JSLocation::getOwnPropertyNames):
(WebCore::JSLocation::defineOwnProperty):
(WebCore::JSLocation::getPrototype):
* Source/WebCore/bindings/js/JSMicrotaskCallback.h:
(WebCore::JSMicrotaskCallback::call):
* Source/WebCore/bindings/js/JSNodeCustom.cpp:
(WebCore::willCreatePossiblyOrphanedTreeByRemovalSlowCase):
* Source/WebCore/bindings/js/JSObservableArray.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
(JSC::JSObservableArray::getOwnPropertyNames):
(JSC::JSObservableArray::getOwnPropertySlot):
(JSC::JSObservableArray::put):
(JSC::JSObservableArray::deleteProperty):
(JSC::JSObservableArray::defineOwnProperty):
* Source/WebCore/bindings/js/JSObservableArray.h:
* Source/WebCore/bindings/js/JSPopStateEventCustom.cpp:
(WebCore::JSPopStateEvent::state const):
* Source/WebCore/bindings/js/JSRTCRtpSFrameTransformCustom.cpp:
(WebCore::JSRTCRtpSFrameTransform::setEncryptionKey):
* Source/WebCore/bindings/js/JSReadableStreamSourceCustom.cpp:
(WebCore::JSReadableStreamSource::start):
(WebCore::JSReadableStreamSource::pull):
* Source/WebCore/bindings/js/JSRemoteDOMWindowBase.cpp:
(WebCore::JSRemoteDOMWindowBase::protectedWrapped const):
* Source/WebCore/bindings/js/JSRemoteDOMWindowBase.h:
* Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp:
(WebCore::JSRemoteDOMWindow::getOwnPropertySlotByIndex):
(WebCore::JSRemoteDOMWindow::put):
(WebCore::JSRemoteDOMWindow::deleteProperty):
(WebCore::JSRemoteDOMWindow::deletePropertyByIndex):
(WebCore::JSRemoteDOMWindow::defineOwnProperty):
* Source/WebCore/bindings/js/JSShadowRootCustom.cpp:
(WebCore::JSShadowRoot::setAdoptedStyleSheets):
* Source/WebCore/bindings/js/JSWebAnimationCustom.cpp:
(WebCore::constructJSWebAnimation):
* Source/WebCore/bindings/js/JSWindowProxy.cpp:
(WebCore::JSWindowProxy::setWindow):
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop):
* Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp:
(WebCore::JSWorkerGlobalScope::queueMicrotask):
* Source/WebCore/bindings/js/ModuleScriptLoader.h:
(WebCore::ModuleScriptLoader::ModuleScriptLoader):
* Source/WebCore/bindings/js/ModuleScriptLoaderClient.h:
* Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp:
(WebCore::invokeReadableStreamDefaultControllerFunction):
(WebCore::ReadableStreamDefaultController::error):
(WebCore::ReadableStreamDefaultController::enqueue):
* Source/WebCore/bindings/js/ScheduledAction.cpp:
(WebCore::ScheduledAction::executeFunctionInContext):
(WebCore::ScheduledAction::execute):
* Source/WebCore/bindings/js/ScriptCachedFrameData.cpp:
(WebCore::ScriptCachedFrameData::ScriptCachedFrameData):
(WebCore::ScriptCachedFrameData::restore):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::~ScriptController):
(WebCore::ScriptController::evaluateInWorld):
(WebCore::ScriptController::linkAndEvaluateModuleScriptInWorld):
(WebCore::ScriptController::evaluateModule):
(WebCore::ScriptController::createWorld):
(WebCore::ScriptController::getAllWorlds):
(WebCore::ScriptController::initScriptForWindowProxy):
(WebCore::ScriptController::protectedFrame const):
(WebCore::ScriptController::setupModuleScriptHandlers):
(WebCore::ScriptController::windowProxy):
(WebCore::ScriptController::jsWindowProxy):
(WebCore::ScriptController::eventHandlerPosition const):
(WebCore::ScriptController::canAccessFromCurrentOrigin):
(WebCore::ScriptController::cacheableBindingRootObject):
(WebCore::ScriptController::bindingRootObject):
(WebCore::ScriptController::clearScriptObjects):
(WebCore::ScriptController::executeScriptIgnoringException):
(WebCore::ScriptController::executeScriptInWorld):
(WebCore::ScriptController::callInWorld):
(WebCore::ScriptController::canExecuteScripts):
(WebCore::ScriptController::executeJavaScriptURL):
(WebCore::ScriptController::reportExceptionFromScriptError):
(WebCore::ScriptController::registerImportMap):
(WebCore::ScriptController::isAcquiringImportMaps):
(WebCore::ScriptController::setAcquiringImportMaps):
(WebCore::ScriptController::setPendingImportMaps):
(WebCore::ScriptController::clearPendingImportMaps):
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/bindings/js/ScriptControllerMac.mm:
(WebCore::ScriptController::disconnectPlatformScriptObjects):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::resolve):
(WebCore::rejectToPropagateNetworkError):
(WebCore::rejectWithFetchError):
(WebCore::ScriptModuleLoader::fetch):
(WebCore::ScriptModuleLoader::responseURLFromRequestURL):
(WebCore::ScriptModuleLoader::evaluate):
(WebCore::ScriptModuleLoader::importModule):
(WebCore::ScriptModuleLoader::createImportMetaProperties):
(WebCore::ScriptModuleLoader::notifyFinished):
* Source/WebCore/bindings/js/StructuredClone.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h:
* Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h:
* Source/WebCore/bindings/js/WebCoreJSClientData.cpp:
(WebCore::JSVMClientData::~JSVMClientData):
(WebCore::JSVMClientData::getAllWorlds):
(WebCore::JSVMClientData::overrideSourceURL const):
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
(WebCore::JSVMClientData::rememberWorld):
(WebCore::JSVMClientData::forgetWorld):
* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::protectedFrame const):
(WebCore::WindowProxy::detachFromFrame):
(WebCore::WindowProxy::replaceFrame):
(WebCore::WindowProxy::destroyJSWindowProxy):
(WebCore::WindowProxy::createJSWindowProxy):
(WebCore::WindowProxy::createJSWindowProxyWithInitializedScript):
(WebCore::WindowProxy::setDOMWindow):
* Source/WebCore/bindings/js/WindowProxy.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::protectedWindow const):
* Source/WebCore/page/Frame.h:

Canonical link: <a href="https://commits.webkit.org/274647@main">https://commits.webkit.org/274647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d47becfae8f4f9765e4a143912eab3888a5fbf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15973 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34325 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13626 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43477 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/33118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39397 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11925 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16083 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46298 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16132 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/9532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5204 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->