### PR TITLE
[WGSL] Fix arrayLength when using pointer variables

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1650,10 +1650,9 @@ static void emitAtomicExchange(FunctionDefinitionWriter* writer, AST::CallExpres
     atomicFunction("atomic_exchange_explicit", writer, call);
 }
 
-static void emitArrayLength(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+[[noreturn]] static void emitArrayLength(FunctionDefinitionWriter*, AST::CallExpression&)
 {
-    writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(".size()");
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 static void emitDistance(FunctionDefinitionWriter* writer, AST::CallExpression& call)

--- a/Source/WebGPU/WGSL/PointerRewriter.cpp
+++ b/Source/WebGPU/WGSL/PointerRewriter.cpp
@@ -136,7 +136,11 @@ void PointerRewriter::visit(AST::IdentifierExpression& identifier)
     if (!variable || !*variable)
         return;
 
-    m_callGraph.ast().replace(identifier, **variable);
+    auto& identity = m_callGraph.ast().astBuilder().construct<AST::IdentityExpression>(
+        identifier.span(),
+        **variable
+    );
+    m_callGraph.ast().replace(identifier, identity);
 }
 
 void PointerRewriter::visit(AST::UnaryExpression& unary)


### PR DESCRIPTION
#### 30a16f3e2486b1627e6249729e8e837b584cac19
<pre>
[WGSL] Fix arrayLength when using pointer variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=269371">https://bugs.webkit.org/show_bug.cgi?id=269371</a>
<a href="https://rdar.apple.com/122293523">rdar://122293523</a>

Reviewed by Mike Wyrzykowski.

We eliminate pointer variables by replacing references to the variables with the
variable initializer expression. This caused a few issues with the global variable
rewriter:
- since we see multiple pointers to the same ast node, we can end up replacing it
  multiple times. In order to fix that we wrap the initializer in an identity expression
  and handle that nin the rewriter.
- avoid rewriting the array when we encounter an arrayLength call, since that is unnecessary
- finally, we assert that we should never encounter calls to arrayLength in the final
  program. All of those should have been rewritten, and the code it generated was not correct

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
(WGSL::RewriteGlobalVariables::readVariable const):
(WGSL::RewriteGlobalVariables::readVariable): Deleted.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitArrayLength):
* Source/WebGPU/WGSL/PointerRewriter.cpp:
(WGSL::PointerRewriter::visit):

Canonical link: <a href="https://commits.webkit.org/274712@main">https://commits.webkit.org/274712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8f94072e9bd58435a80ebf5b1a4e6ce68b09c7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42220 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33121 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13649 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13681 "layout-tests (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43497 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39410 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37696 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16103 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8931 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->