### PR TITLE
[WGSL] Validate the types of let, const and override variables

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -531,13 +531,19 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
     case AST::VariableFlavor::Let:
         if (variableKind == VariableKind::Global)
             return error("module-scope 'let' is invalid, use 'const'");
+        if (!result->isConstructible() && !std::holds_alternative<Types::Pointer>(*result))
+            return error("'", *result, "' cannot be used as the type of a 'let'");
         RELEASE_ASSERT(variable.maybeInitializer());
         break;
     case AST::VariableFlavor::Const:
         RELEASE_ASSERT(variable.maybeInitializer());
+        if (!result->isConstructible())
+            return error("'", *result, "' cannot be used as the type of a 'const'");
         break;
     case AST::VariableFlavor::Override:
         RELEASE_ASSERT(variableKind == VariableKind::Global);
+        if (!satisfies(result, Constraints::ConcreteScalar))
+            return error("'", *result, "' cannot be used as the type of an 'override'");
         break;
     case AST::VariableFlavor::Var:
         AddressSpace addressSpace;


### PR DESCRIPTION
#### 07e9008c10abb247206a9293a1c42873ede003ec
<pre>
[WGSL] Validate the types of let, const and override variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=269374">https://bugs.webkit.org/show_bug.cgi?id=269374</a>
<a href="https://rdar.apple.com/122293575">rdar://122293575</a>

Reviewed by Mike Wyrzykowski.

Check that the type of each of these kinds of declarations is valid according to
the spec table[1].

[1]: <a href="https://www.w3.org/TR/WGSL/#var-and-value">https://www.w3.org/TR/WGSL/#var-and-value</a>

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):

Canonical link: <a href="https://commits.webkit.org/274713@main">https://commits.webkit.org/274713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab4c7f31b9cd5e816a04bb674fd871d29482539f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33109 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13637 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13656 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39399 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37670 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16088 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8932 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->