### PR TITLE
Add type information for WebKit::ObjectValue and WebKit::CoreIPCNumber::NumberHolder

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
@@ -24,6 +24,9 @@
 
 webkit_platform_headers: "ArgumentCodersCocoa.h" "CoreIPCNSCFObject.h"
 
+# rdar://122953036
+using WebKit::ObjectValue = std::variant<std::nullptr_t,CoreIPCAVOutputContext,CoreIPCArray,CoreIPCCFType,CoreIPCCNContact,CoreIPCCNPhoneNumber,CoreIPCCNPostalAddress,CoreIPCDateComponents,CoreIPCPKContact,CoreIPCPKPaymentMerchantSession,CoreIPCPKPayment,CoreIPCPKPaymentToken,CoreIPCPKShippingMethod,CoreIPCPKDateComponentsRange,CoreIPCPKPaymentMethod,CoreIPCColor,CoreIPCDDActionContext,CoreIPCDDScannerResult,CoreIPCData,CoreIPCDate,CoreIPCDictionary,CoreIPCError,CoreIPCFont,CoreIPCLocale,CoreIPCNSValue,CoreIPCNumber,CoreIPCNull,CoreIPCPersonNameComponents,CoreIPCPresentationIntent,CoreIPCSecureCoding,CoreIPCString,CoreIPCURL>;
+
 [WebKitPlatform] class WebKit::CoreIPCNSCFObject {
     [Validator='WebKit::CoreIPCNSCFObject::valueIsAllowed(decoder, *value)'] UniqueRef<WebKit::ObjectValue> value();
 }

--- a/Source/WebKit/Shared/cf/CoreIPCNumber.serialization.in
+++ b/Source/WebKit/Shared/cf/CoreIPCNumber.serialization.in
@@ -24,6 +24,8 @@
 
 webkit_platform_headers: "CoreIPCNumber.h"
 
+using WebKit::CoreIPCNumber::NumberHolder = std::variant<char,unsigned char,short,unsigned short,int,unsigned,long,unsigned long,long long,unsigned long long,float,double>;
+
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCNumber {
      WebKit::CoreIPCNumber::NumberHolder get()
 }


### PR DESCRIPTION
#### 8e17eb5c67eb7ebf4afff6900304b94d0ce8ae0c
<pre>
Add type information for WebKit::ObjectValue and WebKit::CoreIPCNumber::NumberHolder
<a href="https://bugs.webkit.org/show_bug.cgi?id=269376">https://bugs.webkit.org/show_bug.cgi?id=269376</a>
<a href="https://rdar.apple.com/122956144">rdar://122956144</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in:
* Source/WebKit/Shared/cf/CoreIPCNumber.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e17eb5c67eb7ebf4afff6900304b94d0ce8ae0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35575 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33112 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13631 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43487 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37690 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16093 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->