### PR TITLE
Adopt more smart pointers in HTMLVideoElement / HTMLAudioElement

### DIFF
--- a/Source/WebCore/html/HTMLAudioElement.cpp
+++ b/Source/WebCore/html/HTMLAudioElement.cpp
@@ -47,14 +47,14 @@ inline HTMLAudioElement::HTMLAudioElement(const QualifiedName& tagName, Document
 
 Ref<HTMLAudioElement> HTMLAudioElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
 {
-    auto element = adoptRef(*new HTMLAudioElement(tagName, document, createdByParser));
+    Ref element = adoptRef(*new HTMLAudioElement(tagName, document, createdByParser));
     element->suspendIfNeeded();
     return element;
 }
 
 Ref<HTMLAudioElement> HTMLAudioElement::createForLegacyFactoryFunction(Document& document, const AtomString& src)
 {
-    auto element = create(audioTag, document, false);
+    Ref element = create(audioTag, document, false);
     element->setAttributeWithoutSynchronization(preloadAttr, autoAtom());
     element->setAttributeWithoutSynchronization(srcAttr, src);
     return element;

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -468,7 +468,7 @@ void HTMLImageElement::didAttachRenderers()
     RenderImageResource& renderImageResource = renderImage->imageResource();
     if (renderImageResource.cachedImage())
         return;
-    renderImageResource.setCachedImage(m_imageLoader->image());
+    renderImageResource.setCachedImage(m_imageLoader->protectedImage());
 
     // If we have no image at all because we have no src attribute, set
     // image height and width for the alt text instead.

--- a/Source/WebCore/html/HTMLPlugInImageElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInImageElement.cpp
@@ -176,7 +176,7 @@ void HTMLPlugInImageElement::didAttachRenderers()
         if (auto* renderImage = dynamicDowncast<RenderImage>(renderer())) {
             auto& renderImageResource = renderImage->imageResource();
             if (!renderImageResource.cachedImage())
-                renderImageResource.setCachedImage(m_imageLoader->image());
+                renderImageResource.setCachedImage(m_imageLoader->protectedImage());
         }
     }
 

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -156,7 +156,7 @@ private:
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-    PictureInPictureObserver* m_pictureInPictureObserver { nullptr };
+    WeakPtr<PictureInPictureObserver> m_pictureInPictureObserver;
 #endif
 
     struct VideoFrameRequest {

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -146,7 +146,7 @@ void ImageInputType::attach()
         return;
 
     auto& imageResource = renderer->imageResource();
-    imageResource.setCachedImage(imageLoader.image());
+    imageResource.setCachedImage(imageLoader.protectedImage());
 
     // If we have no image at all because we have no src attribute, set
     // image height and width for the alt text instead.

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -480,7 +480,7 @@ void ImageLoader::updateRenderer()
     // change is happening between two images.
     CachedImage* cachedImage = imageResource->cachedImage();
     if (m_image != cachedImage && (m_imageComplete || !cachedImage))
-        imageResource->setCachedImage(m_image.get());
+        imageResource->setCachedImage(CachedResourceHandle { m_image });
 }
 
 void ImageLoader::updatedHasPendingEvent()

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -57,7 +57,7 @@ void RenderImageResource::shutdown()
     setCachedImage(nullptr);
 }
 
-void RenderImageResource::setCachedImage(CachedImage* newImage)
+void RenderImageResource::setCachedImage(CachedResourceHandle<CachedImage>&& newImage)
 {
     if (m_cachedImage == newImage)
         return;
@@ -68,7 +68,7 @@ void RenderImageResource::setCachedImage(CachedImage* newImage)
         // removeClient may have destroyed the renderer.
         return;
     }
-    m_cachedImage = newImage;
+    m_cachedImage = WTFMove(newImage);
     m_cachedImageRemoveClientIsNeeded = true;
     if (!m_cachedImage)
         return;

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -46,7 +46,7 @@ public:
     virtual void initialize(RenderElement& renderer) { initialize(renderer, nullptr); }
     virtual void shutdown();
 
-    void setCachedImage(CachedImage*);
+    void setCachedImage(CachedResourceHandle<CachedImage>&&);
     CachedImage* cachedImage() const { return m_cachedImage.get(); }
 
     void resetAnimation();

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -172,13 +172,13 @@ void SVGImageElement::didAttachRenderers()
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (CheckedPtr image = dynamicDowncast<RenderSVGImage>(renderer()); image && !image->imageResource().cachedImage()) {
-        image->checkedImageResource()->setCachedImage(m_imageLoader.image());
+        image->checkedImageResource()->setCachedImage(m_imageLoader.protectedImage());
         return;
     }
 #endif
 
     if (CheckedPtr image = dynamicDowncast<LegacyRenderSVGImage>(renderer()); image && !image->imageResource().cachedImage()) {
-        image->checkedImageResource()->setCachedImage(m_imageLoader.protectedImage().get());
+        image->checkedImageResource()->setCachedImage(m_imageLoader.protectedImage());
         return;
     }
 }


### PR DESCRIPTION
#### 99d31c7f2c1c447d83f1275db7ab9cb871684f96
<pre>
Adopt more smart pointers in HTMLVideoElement / HTMLAudioElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=269381">https://bugs.webkit.org/show_bug.cgi?id=269381</a>

Reviewed by Darin Adler.

* Source/WebCore/html/HTMLAudioElement.cpp:
(WebCore::HTMLAudioElement::create):
(WebCore::HTMLAudioElement::createForLegacyFactoryFunction):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::didAttachRenderers):
* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::didAttachRenderers):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::create):
(WebCore::HTMLVideoElement::didAttachRenderers):
(WebCore::HTMLVideoElement::attributeChanged):
(WebCore::HTMLVideoElement::supportsFullscreen const):
(WebCore::HTMLVideoElement::posterImageURL const):
(WebCore::HTMLVideoElement::exitToFullscreenModeWithoutAnimationIfPossible):
(WebCore::HTMLVideoElement::requestVideoFrameCallback):
(WebCore::HTMLVideoElement::serviceRequestVideoFrameCallbacks):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::attach):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateRenderer):
* Source/WebCore/rendering/RenderImageResource.cpp:
(WebCore::RenderImageResource::setCachedImage):
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::didAttachRenderers):

Canonical link: <a href="https://commits.webkit.org/274655@main">https://commits.webkit.org/274655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f312ef408e61edb385bf9f8956645c8ca5237a97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42223 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15996 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34341 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35627 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11942 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16106 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5210 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->