### PR TITLE
[WPE] REGRESSION(274544@main): Build fails due to Clang -Wcast-align errors

### DIFF
--- a/Tools/ImageDiff/skia/PlatformImageSkia.cpp
+++ b/Tools/ImageDiff/skia/PlatformImageSkia.cpp
@@ -27,10 +27,10 @@
 
 #include <cstdio>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-align"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
 #include <skia/codec/SkPngDecoder.h>
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 #include <skia/core/SkImage.h>
 #include <skia/core/SkPixmap.h>

--- a/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
+++ b/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
@@ -36,10 +36,10 @@
 #endif
 
 #if defined(USE_SKIA) && USE_SKIA
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-align"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
 #include <skia/core/SkPixmap.h>
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
 namespace WPEToolingBackends {


### PR DESCRIPTION
#### 45d96da23f0121bd46d10a637ef6a76a3ed53cb3
<pre>
[WPE] REGRESSION(274544@main): Build fails due to Clang -Wcast-align errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=269360">https://bugs.webkit.org/show_bug.cgi?id=269360</a>

Reviewed by Michael Catanzaro.

Use &quot;#pragma GCC diagnostic ...&quot; instead of &quot;#pragma clang diagnostic ...&quot;
because Clang will recognize the GCC variant but not the other way around.
This way we avoid GCC complaining due to -Wunknown-pragmas.

* Tools/ImageDiff/skia/PlatformImageSkia.cpp:
* Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp:

Canonical link: <a href="https://commits.webkit.org/274654@main">https://commits.webkit.org/274654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41133bb938168170f442ca8b25ba46540e2e7578

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42225 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15998 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15746 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43502 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36036 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11943 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16108 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5209 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->