### PR TITLE
[Unified Text Replacement] `WebPage::autocorrectionContextRange` sometimes returns an incorrect range

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -877,7 +877,19 @@ void WebPage::textReplacementSessionDidReceiveEditAction(const WTF::UUID& uuid, 
 
 std::optional<SimpleRange> WebPage::autocorrectionContextRange()
 {
+    // The algorithm this function uses is essentially:
+    //
+    // 1. Get the current start and end positions of the selection.
+    //
+    // 2. Ideally, the selection range will simply just be extended to the edges of the sentence each
+    //    position is part of. If this has enough words and characters, the algorithm is finished.
+    //
+    // 3. Otherwise, leave the end position alone, and start moving the start position backwards,
+    //    word-by-word, until the minimum word count / maximum context length has been reached.
+
     Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+
+    VisiblePosition contextStartPosition;
 
     VisiblePosition startPosition = frame->selection().selection().start();
     VisiblePosition endPosition = frame->selection().selection().end();
@@ -887,10 +899,17 @@ std::optional<SimpleRange> WebPage::autocorrectionContextRange()
 
     auto firstPositionInEditableContent = startOfEditableContent(startPosition);
 
+    // If the start position is at the very start of the editable content, we can't go back any more
+    // than that, so use the original start position if that is the case.
     if (startPosition != firstPositionInEditableContent) {
-        VisiblePosition contextStartPosition = startPosition;
+        // Otherwise, start going backwards to find an ideal start position.
+
+        contextStartPosition = startPosition;
         unsigned totalContextLength = 0;
 
+        // Keep trying to go back as much as possible until the minimum word count or context length
+        // has been reached; and only go back word-by-word, so that the range doesn't cut off part
+        // of a word.
         for (unsigned i = 0; i < minContextWordCount; ++i) {
             auto previousPosition = startOfWord(positionOfNextBoundaryOfGranularity(contextStartPosition, TextGranularity::WordGranularity, SelectionDirection::Backward));
             if (previousPosition.isNull())
@@ -908,18 +927,27 @@ std::optional<SimpleRange> WebPage::autocorrectionContextRange()
             contextStartPosition = previousPosition;
         }
 
+        // If the beginning of the sentence the original position is a part of is before the new start position,
+        // use that, since it will not cut off a sentence, and will provide at least equal or more context.
         VisiblePosition sentenceContextStartPosition = startOfSentence(startPosition);
         if (sentenceContextStartPosition.isNotNull() && sentenceContextStartPosition < contextStartPosition)
-            startPosition = sentenceContextStartPosition;
+            contextStartPosition = sentenceContextStartPosition;
     }
 
+    // Otherwise, just use the original start position.
+    if (contextStartPosition.isNull())
+        contextStartPosition = startPosition;
+
+    // If the end position is at the very end of the editable content, we can't go forward any more
+    // than that, so use the original end position if that is the case.
     if (endPosition != endOfEditableContent(endPosition)) {
+        // Otherwise, move the end position to the end of the sentence the original end position is part of, if applicable.
         VisiblePosition nextPosition = endOfSentence(endPosition);
         if (nextPosition.isNotNull() && nextPosition > endPosition)
             endPosition = nextPosition;
     }
 
-    return makeSimpleRange(startPosition, endPosition);
+    return makeSimpleRange(contextStartPosition, endPosition);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 7003dbcab5b68f602cad24dd95030c9b67b26e73
<pre>
[Unified Text Replacement] `WebPage::autocorrectionContextRange` sometimes returns an incorrect range
<a href="https://bugs.webkit.org/show_bug.cgi?id=269385">https://bugs.webkit.org/show_bug.cgi?id=269385</a>
<a href="https://rdar.apple.com/122960194">rdar://122960194</a>

Reviewed by Aditya Keerthi.

This function was previously (incorrectly) refactored; fix by reverting it to its original state,
and making the proper fix by simply null-checking the relevant range as appropriate.

Also add some clarifying comments.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::autocorrectionContextRange):

Canonical link: <a href="https://commits.webkit.org/274660@main">https://commits.webkit.org/274660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54c68ee54b665c6892b70dfbfae1e9d0d4e39d3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42233 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16006 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34347 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13657 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35633 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11950 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16165 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5214 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15773 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->