### PR TITLE
WebKitSwift.h:26:9: error: 'WebKitSwift/WKSLinearMediaPlayer.h' file not found (in target 'WebKit' from project 'WebKit')

### DIFF
--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -35,7 +35,6 @@ public:
     void invalidate() final;
 
     WebAVPlayerController *playerController() const final;
-    WKSLinearMediaPlayer *linearMediaPlayer() const final;
 
     void durationChanged(double) final;
     void currentTimeChanged(double currentTime, double anchorTime) final;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -73,11 +73,6 @@ WebAVPlayerController *PlaybackSessionInterfaceAVKit::playerController() const
     return m_playerController.get();
 }
 
-WKSLinearMediaPlayer *PlaybackSessionInterfaceAVKit::linearMediaPlayer() const
-{
-    return nullptr;
-}
-
 void PlaybackSessionInterfaceAVKit::invalidate()
 {
     if (!m_playbackSessionModel)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -40,7 +40,6 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/WeakPtr.h>
 
-OBJC_CLASS WKSLinearMediaPlayer;
 OBJC_CLASS WebAVPlayerController;
 
 namespace WebCore {
@@ -56,7 +55,6 @@ public:
     void initialize();
     virtual ~PlaybackSessionInterfaceIOS();
     virtual WebAVPlayerController *playerController() const = 0;
-    virtual WKSLinearMediaPlayer *linearMediaPlayer() const = 0;
     PlaybackSessionModel* playbackSessionModel() const;
     void durationChanged(double) override = 0;
     void currentTimeChanged(double currentTime, double anchorTime) override = 0;
@@ -72,7 +70,7 @@ public:
     void volumeChanged(double) override = 0;
     void modelDestroyed() override;
 
-    virtual void invalidate() = 0;
+    virtual void invalidate();
 
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -29,9 +29,6 @@
 
 #include <WebCore/PlaybackSessionInterfaceIOS.h>
 
-OBJC_CLASS WKLinearMediaPlayerDelegate;
-OBJC_CLASS WKSLinearMediaPlayer;
-
 namespace WebKit {
 
 using namespace WebCore;
@@ -39,10 +36,8 @@ using namespace WebCore;
 class PlaybackSessionInterfaceLMK : public PlaybackSessionInterfaceIOS {
 public:
     ~PlaybackSessionInterfaceLMK();
-    void invalidate() final;
 
     WebAVPlayerController *playerController() const override;
-    WKSLinearMediaPlayer *linearMediaPlayer() const final { return m_player.get(); }
     void durationChanged(double) override;
     void currentTimeChanged(double, double) override;
     void bufferedTimeChanged(double) override;
@@ -61,9 +56,6 @@ public:
 
 private:
     PlaybackSessionInterfaceLMK(PlaybackSessionModel&);
-
-    RetainPtr<WKSLinearMediaPlayer> m_player;
-    RetainPtr<WKLinearMediaPlayerDelegate> m_playerDelegate;
 };
 } // namespace WebKit
 

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -30,32 +30,7 @@
 
 #import <WebCore/MediaSelectionOption.h>
 #import <WebCore/TimeRanges.h>
-#import <WebKitSwift/WebKitSwift.h>
 #import <wtf/WeakPtr.h>
-
-#import "WebKitSwiftSoftLink.h"
-
-@interface WKLinearMediaPlayerDelegate : NSObject <WKSLinearMediaPlayerDelegate>
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithInterface:(WebKit::PlaybackSessionInterfaceLMK&)interface;
-@end
-
-@implementation WKLinearMediaPlayerDelegate {
-    WeakPtr<WebKit::PlaybackSessionInterfaceLMK> _interface;
-}
-
-- (instancetype)initWithInterface:(WebKit::PlaybackSessionInterfaceLMK&)interface
-{
-    self = [super init];
-    if (!self)
-        return nil;
-
-    _interface = interface;
-    return self;
-}
-
-@end
 
 namespace WebKit {
 
@@ -68,23 +43,13 @@ Ref<PlaybackSessionInterfaceLMK> PlaybackSessionInterfaceLMK::create(PlaybackSes
 
 PlaybackSessionInterfaceLMK::PlaybackSessionInterfaceLMK(PlaybackSessionModel& model)
     : PlaybackSessionInterfaceIOS { model }
-    , m_player { adoptNS([allocWKSLinearMediaPlayerInstance() init]) }
-    , m_playerDelegate { adoptNS([[WKLinearMediaPlayerDelegate alloc] initWithInterface:*this]) }
 {
-    ASSERT(isUIThread());
-    [m_player setDelegate:m_playerDelegate.get()];
 }
 
 PlaybackSessionInterfaceLMK::~PlaybackSessionInterfaceLMK()
 {
     ASSERT(isUIThread());
     invalidate();
-}
-
-void PlaybackSessionInterfaceLMK::invalidate()
-{
-    [m_player setDelegate:nullptr];
-    PlaybackSessionInterfaceIOS::invalidate();
 }
 
 WebAVPlayerController *PlaybackSessionInterfaceLMK::playerController() const
@@ -94,14 +59,12 @@ WebAVPlayerController *PlaybackSessionInterfaceLMK::playerController() const
 
 void PlaybackSessionInterfaceLMK::durationChanged(double duration)
 {
-    [m_player setDuration:duration];
-    [m_player setCanTogglePlayback:YES];
-    [m_player setHasAudioContent:YES];
+
 }
 
 void PlaybackSessionInterfaceLMK::currentTimeChanged(double currentTime, double)
 {
-    [m_player setCurrentTime:currentTime];
+
 }
 
 void PlaybackSessionInterfaceLMK::bufferedTimeChanged(double bufferedTime)

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -31,7 +31,6 @@
 
 OBJC_CLASS LMPlayableViewController;
 OBJC_CLASS WKPlayableViewControllerDelegate;
-OBJC_CLASS WKSLinearMediaPlayer;
 
 namespace WebCore {
 class PlaybackSessionInterfaceIOS;
@@ -58,8 +57,6 @@ public:
     bool isPlayingVideoInEnhancedFullscreen() const;
 private:
     VideoPresentationInterfaceLMK(PlaybackSessionInterfaceIOS&);
-
-    WKSLinearMediaPlayer *linearMediaPlayer() const;
 
     void updateRouteSharingPolicy() final { }
     void setupPlayerViewController() final;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -31,7 +31,6 @@
 #import "PlaybackSessionInterfaceLMK.h"
 #import <UIKit/UIKit.h>
 #import <WebCore/WebAVPlayerLayerView.h>
-#import <WebKitSwift/WebKitSwift.h>
 
 namespace WebKit {
 
@@ -48,11 +47,6 @@ Ref<VideoPresentationInterfaceLMK> VideoPresentationInterfaceLMK::create(Playbac
 VideoPresentationInterfaceLMK::VideoPresentationInterfaceLMK(PlaybackSessionInterfaceIOS& playbackSessionInterface)
     : VideoPresentationInterfaceIOS { playbackSessionInterface }
 {
-}
-
-WKSLinearMediaPlayer *VideoPresentationInterfaceLMK::linearMediaPlayer() const
-{
-    return nullptr;
 }
 
 void VideoPresentationInterfaceLMK::setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool)


### PR DESCRIPTION
#### 5bdc3dad5f5b1264ddd2699aa9b9377aa69f8f43
<pre>
WebKitSwift.h:26:9: error: &apos;WebKitSwift/WKSLinearMediaPlayer.h&apos; file not found (in target &apos;WebKit&apos; from project &apos;WebKit&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=269392">https://bugs.webkit.org/show_bug.cgi?id=269392</a>
<a href="https://rdar.apple.com/122956083">rdar://122956083</a>

Reviewed by Andy Estes.

Removing usage of WKLinearMediaPlayerDelegate and WKSLinearMediaPlayer.

* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebCore::PlaybackSessionInterfaceAVKit::linearMediaPlayer const): Deleted.
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
(): Deleted.
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::PlaybackSessionInterfaceLMK):
(WebKit::PlaybackSessionInterfaceLMK::durationChanged):
(WebKit::PlaybackSessionInterfaceLMK::currentTimeChanged):
(-[WKLinearMediaPlayerDelegate initWithInterface:]): Deleted.
(): Deleted.
(WebKit::PlaybackSessionInterfaceLMK::invalidate): Deleted.
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::linearMediaPlayer const): Deleted.

Canonical link: <a href="https://commits.webkit.org/274691@main">https://commits.webkit.org/274691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9998d0c345d9e7d14aad58871c137fcc23e0ea9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42238 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33130 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39421 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37699 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16121 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8916 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->