### PR TITLE
[WGSL] Constant bitcast function does not handle vectors of doubles

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -1652,6 +1652,11 @@ CONSTANT_FUNCTION(Bitcast)
             if (!i32)
                 return { makeString("value ", String::number(*abstractInt), " cannot be represented as 'i32'") };
             value = bitwise_cast<uint32_t>(*i32);
+        } else if (auto* abstractFloat = std::get_if<double>(&argument)) {
+            auto f32 = convertFloat<float>(*abstractFloat);
+            if (!f32)
+                return { makeString("value ", String::number(*abstractFloat), " cannot be represented as 'f32'") };
+            value = bitwise_cast<uint32_t>(*f32);
         } else {
             RELEASE_ASSERT_NOT_REACHED();
             value = 0;


### PR DESCRIPTION
#### 986082f5bc52ce35c6dbaa13b4207b3a936e6779
<pre>
[WGSL] Constant bitcast function does not handle vectors of doubles
<a href="https://bugs.webkit.org/show_bug.cgi?id=269391">https://bugs.webkit.org/show_bug.cgi?id=269391</a>
<a href="https://rdar.apple.com/122293522">rdar://122293522</a>

Reviewed by Mike Wyrzykowski.

Bitcast needs to accept abstract values due to special edge cases, but it also
needs to concretize the values for the default case. We were missing a conversion
from double (abstract float) to f32 when bitcasting between vectors of different
sizes.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/274719@main">https://commits.webkit.org/274719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/415cc88dccaa7b2fad6a1fa3579bd8f4ca32b5b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35604 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33133 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13736 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43516 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39422 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37700 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16122 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8935 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->