### PR TITLE
Regression(274445@main): Crash under HTMLMediaElement::updateActiveTextTrackCues() on Hulu.com

### DIFF
--- a/Source/WebCore/platform/PODInterval.h
+++ b/Source/WebCore/platform/PODInterval.h
@@ -143,7 +143,11 @@ public:
             return true;
         if (other.Base::low() < Base::low())
             return false;
-        return Base::high() < other.Base::high();
+        if (Base::high() < other.Base::high())
+            return true;
+        if (other.Base::high() < Base::high())
+            return false;
+        return Base::data().get() < other.Base::data().get();
     }
 
     bool operator==(const PODInterval& other) const


### PR DESCRIPTION
#### fd9c1365ede0b2da49f029ef066691bcc823b9a4
<pre>
Regression(274445@main): Crash under HTMLMediaElement::updateActiveTextTrackCues() on Hulu.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=269394">https://bugs.webkit.org/show_bug.cgi?id=269394</a>
<a href="https://rdar.apple.com/122959342">rdar://122959342</a>

Reviewed by Jer Noble.

In 274445@main, I updated CueInterval to be an alias to:
```
PODInterval&lt;MediaTime, WeakPtr&lt;TextTrackCue, WeakPtrImplWithEventTargetData&gt;&gt;
```
instead of:
```
PODInterval&lt;MediaTime, TextTrackCue*&gt;
```
per our recent smart pointer guidelines.

When doing do, I noticed that PODInterval has different implementations when the
second type is a WeakPtr. Adopting WeakPtr led to build errors because the
PODInterval&apos;s specialization for WeakPtr was missing operator==(). To fix the
build, I copied the generic PODInterval&apos;s operator==() and used it. However, I
failed to noticed that the 2 specializations had different operator&lt;()
implementations as well. In particular, the generic operator&lt;() was checking
userData while the WeakPtr specialization one wasn&apos;t. This mismatch between
operator==() (which was checking userData) and operator&lt;() (which wasn&apos;t checking
userData) was the cause of these crashes.

I now updated operator&lt;() to be the same of both specializations (except for
calling `.get()` to extract the raw pointer from the WeakPtr) and this addressed
the crashes on hulu.com.

* Source/WebCore/platform/PODInterval.h:

Canonical link: <a href="https://commits.webkit.org/274670@main">https://commits.webkit.org/274670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bae3b6f39d00dc272ddd87ca7e20362c6e3c472e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16017 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34356 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13669 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43521 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35642 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11959 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16127 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16176 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5217 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->