### PR TITLE
[Skia] Implement conic gradients

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
@@ -136,16 +136,11 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
 
             return SkGradientShader::MakeTwoPointConical(start, startRadius, end, endRadius, colors.data(), nullptr, positions.data(), colors.size(), tileMode, interpolation, &matrix);
         },
-        [&](const ConicData&) {
-            // FIXME: Just some initial gradient for testing purposes.
-            SkPoint pts[] = { SkPoint::Make(0, 0), SkPoint::Make(20, 20) };
-            SkColor colors[] = { SK_ColorRED, SK_ColorGREEN, SK_ColorBLUE };
-            SkScalar pos[] = { 0.0f, 0.5f, 1.0f };
+        [&](const ConicData& data) {
+            // Skia's renders it tilted by 90 degrees, so offset that rotation in the matrix
+            matrix.preRotate(SkRadiansToDegrees(data.angleRadians) - 90.0f, data.point0.x(), data.point0.y());
 
-            notImplemented();
-
-            auto gradient = SkGradientShader::MakeLinear(pts, colors, pos, 3, SkTileMode::kClamp);
-            return gradient;
+            return SkGradientShader::MakeSweep(data.point0.x(), data.point0.y(), colors.data(), SkColorSpace::MakeSRGB(), positions.data(), colors.size(), 0, &matrix);
         });
 
     return m_shader;


### PR DESCRIPTION
#### b307c2ebeeb0c272a87b479fdf8cbf6c3bd027f6
<pre>
[Skia] Implement conic gradients
<a href="https://bugs.webkit.org/show_bug.cgi?id=269396">https://bugs.webkit.org/show_bug.cgi?id=269396</a>

Reviewed by Don Olmstead.

Implement conic gradients using a Sweep gradient shader provided by
Skia. Skia renders it starting from the positive horizontal coordinate
space, so adjust that to what is expected for web by rotating it back
90 degress. The pivot point is the center of the conic.

* Source/WebCore/platform/graphics/skia/GradientSkia.cpp:
(WebCore::Gradient::shader):

Canonical link: <a href="https://commits.webkit.org/274667@main">https://commits.webkit.org/274667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d7c03d3c4e7f27d260817e3182b6391a3df0c62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42245 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16018 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13666 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35643 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11960 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16128 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8896 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16177 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->