### PR TITLE
Adopt more smart pointers in FrameLoader.cpp

### DIFF
--- a/Source/WebCore/loader/FrameLoadRequest.cpp
+++ b/Source/WebCore/loader/FrameLoadRequest.cpp
@@ -65,9 +65,19 @@ Document& FrameLoadRequest::requester()
     return m_requester.get();
 }
 
+Ref<Document> FrameLoadRequest::protectedRequester() const
+{
+    return m_requester;
+}
+
 const SecurityOrigin& FrameLoadRequest::requesterSecurityOrigin() const
 {
     return m_requesterSecurityOrigin.get();
+}
+
+Ref<SecurityOrigin> FrameLoadRequest::protectedRequesterSecurityOrigin() const
+{
+    return m_requesterSecurityOrigin;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -52,7 +52,9 @@ public:
     bool isEmpty() const { return m_resourceRequest.isEmpty(); }
 
     WEBCORE_EXPORT Document& requester();
+    Ref<Document> protectedRequester() const;
     const SecurityOrigin& requesterSecurityOrigin() const;
+    Ref<SecurityOrigin> protectedRequesterSecurityOrigin() const;
 
     ResourceRequest& resourceRequest() { return m_resourceRequest; }
     const ResourceRequest& resourceRequest() const { return m_resourceRequest; }


### PR DESCRIPTION
#### 6328556e366c4d5150c9a3403e5a7f66d419cc91
<pre>
Adopt more smart pointers in FrameLoader.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=269398">https://bugs.webkit.org/show_bug.cgi?id=269398</a>

Reviewed by Brent Fulgham.

Adopt more smart pointers in FrameLoader.cpp, as recommended by the static analyzer.

* Source/WebCore/loader/FrameLoadRequest.cpp:
(WebCore::FrameLoadRequest::protectedRequester const):
(WebCore::FrameLoadRequest::protectedRequesterSecurityOrigin const):
* Source/WebCore/loader/FrameLoadRequest.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::isInVisibleAndActivePage):
(WebCore::FrameLoader::submitForm):
(WebCore::shouldClearWindowName):
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::outgoingReferrer const):
(WebCore::FrameLoader::setOpener):
(WebCore::FrameLoader::setFirstPartyForCookies):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::completed):
(WebCore::FrameLoader::isNavigationAllowed const):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithNavigationAction):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::setPolicyDocumentLoader):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::numPendingOrLoadingRequests const):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::scrollToFragmentWithParentBoundary):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::shouldInterruptLoadForXFrameOptions):
(WebCore::FrameLoader::shouldTreatURLAsSameAsCurrent const):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::createWindow):

Canonical link: <a href="https://commits.webkit.org/274673@main">https://commits.webkit.org/274673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9aae3a55e23e0d174f3412cf9d1179ea5d7d986

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35615 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16023 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34360 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35647 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11965 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16133 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16182 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5218 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->