### PR TITLE
UnifiedPDF: Discrete scrolling mode

### DIFF
--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -103,14 +103,14 @@ public:
 
     virtual void updateSnapOffsets() { };
     WEBCORE_EXPORT const LayoutScrollSnapOffsetsInfo* snapOffsetsInfo() const;
-    void setScrollSnapOffsetInfo(const LayoutScrollSnapOffsetsInfo&);
-    void clearSnapOffsets();
+    WEBCORE_EXPORT void setScrollSnapOffsetInfo(const LayoutScrollSnapOffsetsInfo&);
+    WEBCORE_EXPORT void clearSnapOffsets();
     WEBCORE_EXPORT std::optional<unsigned> currentHorizontalSnapPointIndex() const;
     WEBCORE_EXPORT std::optional<unsigned> currentVerticalSnapPointIndex() const;
     WEBCORE_EXPORT void setCurrentHorizontalSnapPointIndex(std::optional<unsigned>);
     WEBCORE_EXPORT void setCurrentVerticalSnapPointIndex(std::optional<unsigned>);
 
-    void resnapAfterLayout();
+    WEBCORE_EXPORT void resnapAfterLayout();
     void doPostThumbMoveSnapping(ScrollbarOrientation);
 
     void stopKeyboardScrollAnimation();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -320,6 +320,13 @@ private:
     bool requestScrollToPosition(const WebCore::ScrollPosition&, const WebCore::ScrollPositionChangeOptions& = WebCore::ScrollPositionChangeOptions::createProgrammatic()) override;
     bool requestStartKeyboardScrollAnimation(const WebCore::KeyboardScroll& scrollData) override;
     bool requestStopKeyboardScrollAnimation(bool immediate) override;
+    void updateSnapOffsets() override;
+
+    bool shouldUseScrollSnapping() const;
+    bool shouldDisplayPage(PDFDocumentLayout::PageIndex);
+    void populateScrollSnapIdentifiers();
+    PDFDocumentLayout::PageIndex pageForScrollSnapIdentifier(ElementIdentifier) const;
+    void determineCurrentlySnappedPage();
 
     WebCore::FloatSize centeringOffset() const;
 
@@ -400,6 +407,9 @@ private:
     RefPtr<PDFPluginPasswordField> m_passwordField;
     RefPtr<PDFPluginPasswordForm> m_passwordForm;
 #endif
+
+    Vector<ElementIdentifier> m_scrollSnapIdentifiers;
+    std::optional<PDFDocumentLayout::PageIndex> m_currentlySnappedPage;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 95e57b0ff9882e5ebd1c28680930eb94ad52532c
<pre>
UnifiedPDF: Discrete scrolling mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=269399">https://bugs.webkit.org/show_bug.cgi?id=269399</a>
<a href="https://rdar.apple.com/121940957">rdar://121940957</a>

Reviewed by Simon Fraser.

* Source/WebCore/platform/ScrollableArea.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updatePageBackgroundLayers):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
Don&apos;t paint pages that we don&apos;t want displayed.

(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
(WebKit::UnifiedPDFPlugin::didChangeScrollOffset):
Determine if the currently-snapped page changed after each scroll.

(WebKit::UnifiedPDFPlugin::populateScrollSnapIdentifiers):
Make fake ElementIdentifiers for each PDF page to appease
insufficiently-DOM-agnostic scroll snapping code.

(WebKit::UnifiedPDFPlugin::pageForScrollSnapIdentifier const):
Find the page index for the given fake ElementIdentifier.

(WebKit::UnifiedPDFPlugin::shouldUseScrollSnapping const):
(WebKit::UnifiedPDFPlugin::updateSnapOffsets):
Build up a synthetic scroll snapping offset table for the PDF pages, with
required stop points at the beginning and end of each page.

(WebKit::UnifiedPDFPlugin::updateSnappedPage):
Look up which page is currently snapped, by scroll position.
This is a bit rough; ideally it would use the current snap point but you
often don&apos;t have one, so instead we just assume it&apos;s the last page that&apos;s not
too far past the current scroll position.
This could be improved.

(WebKit::UnifiedPDFPlugin::shouldDisplayPage):
Determine if the given page should be painted (based on the snapping location).
We show both the snapped page and the one next to it if we&apos;re in 2-up.

(WebKit::UnifiedPDFPlugin::performContextMenuAction):
Resnap when the mode is changed, if needed.

Canonical link: <a href="https://commits.webkit.org/274671@main">https://commits.webkit.org/274671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e364cd6bfa74d7f93953a8e8279923bf80d743db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42264 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16037 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15782 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43541 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35657 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11974 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16147 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8897 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->