### PR TITLE
[MultiRep HEIC] Ensure data is preserved when copying rich content

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -125,6 +125,9 @@ struct WEBCORE_EXPORT AttributedString {
             RetainPtr<NSDate>,
             ColorFromCGColor,
             ColorFromPlatformColor,
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+            MultiRepresentationHEICAttachmentData,
+#endif
             TextAttachmentFileWrapper,
             TextAttachmentMissingImage
         > value;

--- a/Source/WebCore/editing/cocoa/TextAttachmentForSerialization.h
+++ b/Source/WebCore/editing/cocoa/TextAttachmentForSerialization.h
@@ -27,7 +27,9 @@
 
 #if PLATFORM(COCOA)
 
+#include "Image.h"
 #include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -43,6 +45,26 @@ struct TextAttachmentFileWrapper {
     RetainPtr<CFDataRef> data;
     String accessibilityLabel;
 };
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+
+struct MultiRepresentationHEICAttachmentSingleImage {
+    RefPtr<Image> image;
+    FloatSize size;
+};
+
+struct MultiRepresentationHEICAttachmentData {
+    String identifier;
+    String description;
+    Vector<MultiRepresentationHEICAttachmentSingleImage> images;
+
+    // Not serialized.
+    // FIXME: Remove this once same-process AttributedString to NSAttributeedString conversion
+    // is removed. See https://bugs.webkit.org/show_bug.cgi?id=269384.
+    RetainPtr<CFDataRef> data;
+};
+
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -70,6 +70,10 @@
 #include "ImageControlsMac.h"
 #endif
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/MultiRepresentationHEICAdditions.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLImageElement);
@@ -914,6 +918,17 @@ bool HTMLImageElement::isSystemPreviewImage() const
     if (auto* pictureElement = dynamicDowncast<HTMLPictureElement>(parent))
         return pictureElement->isSystemPreviewImage();
     return false;
+}
+#endif
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+bool HTMLImageElement::isMultiRepresentationHEIC() const
+{
+    if (!m_sourceElement)
+        return false;
+
+    auto& typeAttribute = m_sourceElement->attributeWithoutSynchronization(typeAttr);
+    return typeAttribute == MULTI_REPRESENTATION_HEIC_MIME_TYPE_STRING;
 }
 #endif
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -142,6 +142,10 @@ public:
     WEBCORE_EXPORT bool isSystemPreviewImage() const;
 #endif
 
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    bool isMultiRepresentationHEIC() const;
+#endif
+
     void loadDeferredImage();
 
     AtomString srcsetForBindings() const;
@@ -180,6 +184,8 @@ public:
     bool originClean(const SecurityOrigin&) const;
 
     void collectExtraStyleForPresentationalHints(MutableStyleProperties&);
+
+    Image* image() const;
 
 protected:
     HTMLImageElement(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
@@ -272,8 +278,6 @@ private:
     WeakPtr<HTMLSourceElement, WeakPtrImplWithEventTargetData> m_sourceElement;
 
     Vector<MQ::MediaQueryResult> m_dynamicMediaQueryResults;
-
-    Image* image() const;
 
     friend class HTMLPictureElement;
 };

--- a/Source/WebCore/platform/graphics/ImageAdapter.h
+++ b/Source/WebCore/platform/graphics/ImageAdapter.h
@@ -25,8 +25,16 @@
 
 #pragma once
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/WebMultiRepresentationHEICAttachmentDeclarationsAdditions.h>
+#endif
+
 #if USE(APPKIT)
 OBJC_CLASS NSImage;
+#endif
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+OBJC_CLASS WebMultiRepresentationHEICAttachment;
 #endif
 
 #if USE(CG)
@@ -85,6 +93,10 @@ public:
     WEBCORE_EXPORT CFDataRef tiffRepresentation();
 #endif
 
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    WebMultiRepresentationHEICAttachment *multiRepresentationHEIC();
+#endif
+
 #if PLATFORM(GTK)
     GRefPtr<GdkPixbuf> gdkPixbuf();
 #if USE(GTK4)
@@ -115,6 +127,9 @@ private:
 #endif
 #if USE(CG)
     mutable RetainPtr<CFDataRef> m_tiffRep; // Cached TIFF rep for all the frames. Only built lazily if someone queries for one.
+#endif
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    mutable RetainPtr<WebMultiRepresentationHEICAttachment> m_multiRepHEIC;
 #endif
 };
 

--- a/Source/WebCore/platform/ios/UIFoundationSoftLink.h
+++ b/Source/WebCore/platform/ios/UIFoundationSoftLink.h
@@ -41,4 +41,8 @@ SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextTableBlock)
 SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextTable)
 SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextTab)
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/UIFoundationSoftLinkAdditions.h>
+#endif
+
 #endif

--- a/Source/WebCore/platform/ios/UIFoundationSoftLink.mm
+++ b/Source/WebCore/platform/ios/UIFoundationSoftLink.mm
@@ -42,4 +42,8 @@ SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextTableBlock)
 SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextTable)
 SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextTab)
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/UIFoundationSoftLinkAdditions.mm>
+#endif
+
 #endif

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -94,7 +94,12 @@ header: <WebCore/ResourceRequest.h>
 }
 
 [Nested] struct WebCore::AttributedString::AttributeValue {
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    std::variant<double, String, URL, Ref<WebCore::Font>, Vector<String>, Vector<double>, WebCore::AttributedString::ParagraphStyleWithTableAndListIDs, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::MultiRepresentationHEICAttachmentData, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
+#endif
+#if !ENABLE(MULTI_REPRESENTATION_HEIC)
     std::variant<double, String, URL, Ref<WebCore::Font>, Vector<String>, Vector<double>, WebCore::AttributedString::ParagraphStyleWithTableAndListIDs, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
+#endif
 }
 
 [Nested] struct WebCore::AttributedString::ColorFromPlatformColor {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7495,6 +7495,7 @@ enum class WebCore::ContextMenuItemType : uint8_t {
 };
 
 #if PLATFORM(COCOA)
+
 header: <WebCore/TextAttachmentForSerialization.h>
 [CustomHeader] struct WebCore::TextAttachmentMissingImage {
 }
@@ -7507,6 +7508,23 @@ header: <WebCore/TextAttachmentForSerialization.h>
     RetainPtr<CFDataRef> data;
     String accessibilityLabel;
 }
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+
+[CustomHeader] struct WebCore::MultiRepresentationHEICAttachmentSingleImage {
+    RefPtr<WebCore::Image> image;
+    WebCore::FloatSize size;
+}
+
+[CustomHeader] struct WebCore::MultiRepresentationHEICAttachmentData {
+    String identifier;
+    String description;
+    Vector<WebCore::MultiRepresentationHEICAttachmentSingleImage> images;
+    [NotSerialized] RetainPtr<CFDataRef> data;
+}
+
+#endif
+
 #endif
 
 [Nested] enum class WebCore::PopupMenuStyle::Size : uint8_t {


### PR DESCRIPTION
#### 1d46d6999740b7e33536645aadfdc0a45afce20e
<pre>
[MultiRep HEIC] Ensure data is preserved when copying rich content
<a href="https://bugs.webkit.org/show_bug.cgi?id=269348">https://bugs.webkit.org/show_bug.cgi?id=269348</a>
<a href="https://rdar.apple.com/122932418">rdar://122932418</a>

Reviewed by Richard Robinson.

* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:

Decompose the attachment into individual bitmaps for serialization.

(WebCore::toNSObject):
(WebCore::extractValue):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:

Add a HEIC attachment to the attributed string when a multi-representation
HEIC is encountered.

(HTMLConverter::_addMultiRepresentationHEICAttachmentForImageElement):
(HTMLConverter::_processElement):
(attachmentForElement):
(WebCore::editingAttributedString):
* Source/WebCore/editing/cocoa/TextAttachmentForSerialization.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::isMultiRepresentationHEIC const):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/platform/graphics/ImageAdapter.h:
* Source/WebCore/platform/graphics/mac/ImageAdapterMac.mm:
(WebCore::ImageAdapter::multiRepresentationHEIC):
(WebCore::ImageAdapter::invalidate):
* Source/WebCore/platform/ios/UIFoundationSoftLink.h:
* Source/WebCore/platform/ios/UIFoundationSoftLink.mm:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/274690@main">https://commits.webkit.org/274690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d79b437e68f36b4060901be1a2077d224d1dc18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16049 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40315 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34376 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13684 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43553 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35666 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11984 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16223 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5231 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->