### PR TITLE
[view-transitions] Implement "update pseudo-element styles" algorithm.

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2694,6 +2694,7 @@ rendering/RenderTreeMutationDisallowedScope.cpp
 rendering/RenderVTTCue.cpp
 rendering/RenderVideo.cpp
 rendering/RenderView.cpp
+rendering/RenderViewTransitionCapture.cpp
 rendering/RenderWidget.cpp
 rendering/StyledMarkedText.cpp
 rendering/TableLayout.cpp

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -27,10 +27,14 @@
 #include "ViewTransition.h"
 
 #include "CheckVisibilityOptions.h"
+#include "ComputedStyleExtractor.h"
 #include "Document.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "PseudoElementRequest.h"
+#include "RenderBox.h"
+#include "StyleResolver.h"
+#include "StyleScope.h"
 #include "Styleable.h"
 #include "TypedElementDescendantIteratorInlines.h"
 
@@ -273,6 +277,12 @@ ExceptionOr<void> ViewTransition::captureOldState()
     for (auto& element : captureElements) {
         // FIXME: Fill in the rest of CapturedElement.
         CapturedElement capture;
+
+        CheckedPtr renderBox = dynamicDowncast<RenderBox>(element->renderer());
+        if (renderBox)
+            capture.oldSize = renderBox->size();
+        capture.oldProperties = copyElementBaseProperties(element.get());
+
         auto transitionName = element->computedStyle()->viewTransitionName();
         m_namedElements.add(transitionName->name, capture);
     }
@@ -365,7 +375,7 @@ void ViewTransition::handleTransitionFrame()
     }
 
     // FIXME: If transition’s initial snapshot containing block size is not equal to the snapshot containing block size, then skip the view transition for transition, and return.
-    // FIXME: Update pseudo-element styles for transition.
+    updatePseudoElementStyles();
 }
 
 // https://drafts.csswg.org/css-view-transitions/#clear-view-transition-algorithm
@@ -391,9 +401,55 @@ void ViewTransition::clearViewTransition()
 
     protectedDocument()->setHasViewTransitionPseudoElementTree(false);
     protectedDocument()->setActiveViewTransition(nullptr);
+    protectedDocument()->styleScope().clearViewTransitionStyles();
 
     if (RefPtr documentElement = protectedDocument()->documentElement())
         documentElement->invalidateStyleInternal();
+}
+
+Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(Element& element)
+{
+    // FIXME: Transform - ComputedStyleExtractor.cpp::matrixTransformValue
+    ComputedStyleExtractor styleExtractor(&element);
+
+    CSSPropertyID transitionProperties[] = {
+        CSSPropertyWritingMode,
+        CSSPropertyDirection,
+        CSSPropertyTextOrientation,
+        CSSPropertyMixBlendMode,
+        CSSPropertyBackdropFilter,
+#if ENABLE(DARK_MODE_CSS)
+        CSSPropertyColorScheme,
+#endif
+        CSSPropertyWidth,
+        CSSPropertyHeight,
+    };
+
+    return styleExtractor.copyProperties(transitionProperties);
+}
+
+// https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles
+void ViewTransition::updatePseudoElementStyles()
+{
+    auto& resolver = protectedDocument()->styleScope().resolver();
+
+    for (auto& iter : m_namedElements.map()) {
+        RefPtr<MutableStyleProperties> properties;
+        if (iter.value->newElement)
+            properties = copyElementBaseProperties(*iter.value->newElement);
+        else
+            properties = iter.value->oldProperties;
+
+        if (properties) {
+            if (!iter.value->groupStyleProperties) {
+                iter.value->groupStyleProperties = properties;
+                resolver.setViewTransitionGroupStyles(iter.key, *properties);
+            } else
+                iter.value->groupStyleProperties->mergeAndOverrideOnConflict(*properties);
+        }
+    }
+
+    protectedDocument()->styleScope().didChangeStyleSheetContents();
 }
 
 }

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -29,6 +29,7 @@
 #include "Element.h"
 #include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
+#include "MutableStyleProperties.h"
 #include "ViewTransitionUpdateCallback.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
@@ -52,18 +53,16 @@ struct CapturedElement {
 public:
     // FIXME: Add the following:
     // old image (2d bitmap)
-    // old width / height
+    LayoutSize oldSize;
+    RefPtr<MutableStyleProperties> oldProperties;
     // old transform
-    // old writing mode
-    // old direction
-    // old text-orientation
-    // old mix-blend-mode
     WeakPtr<Element, WeakPtrImplWithEventTargetData> newElement;
+
+    RefPtr<MutableStyleProperties> groupStyleProperties;
 
     // FIXME: Also handle these:
     // group keyframes
     // group animation name rule
-    // group styles rule
     // image pair isolation rule
     // image animation name rule
 };
@@ -92,12 +91,29 @@ public:
         return m_keys;
     }
 
+    auto& map() const
+    {
+        return m_map;
+    }
+
+    auto& map()
+    {
+        return m_map;
+    }
+
     bool isEmpty() const
     {
         return m_keys.isEmpty();
     }
 
     CapturedElement* find(const AtomString& key)
+    {
+        if (auto it = m_map.find(key); it != m_map.end())
+            return &it->value;
+        return nullptr;
+    }
+
+    const CapturedElement* find(const AtomString& key) const
     {
         if (auto it = m_map.find(key); it != m_map.end())
             return &it->value;
@@ -137,6 +153,10 @@ public:
 
 private:
     ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
+
+    Ref<MutableStyleProperties> copyElementBaseProperties(Element&);
+
+    void updatePseudoElementStyles();
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -169,6 +169,7 @@ public:
         VTTCue,
         Video,
         View,
+        ViewTransitionCapture,
 #if ENABLE(MATHML)
         MathMLBlock,
         MathMLFenced,
@@ -254,6 +255,7 @@ public:
         IsImage = 1 << 0,
         IsMedia = 1 << 1,
         IsWidget = 1 << 2,
+        IsViewTransitionCapture = 1 << 3,
     };
 
     enum class SVGModelObjectFlag : uint8_t {
@@ -474,6 +476,7 @@ public:
     bool isRenderSearchField() const { return type() == Type::SearchField; }
     bool isRenderTextControlInnerBlock() const { return type() == Type::TextControlInnerBlock; }
     bool isRenderVideo() const { return type() == Type::Video; }
+    bool isRenderViewTransitionCapture() const { return isRenderReplaced() && m_typeSpecificFlags.replacedFlags().contains(ReplacedFlag::IsViewTransitionCapture); }
     bool isRenderWidget() const { return isRenderReplaced() && m_typeSpecificFlags.replacedFlags().contains(ReplacedFlag::IsWidget); }
     bool isRenderHTMLCanvas() const { return type() == Type::HTMLCanvas; }
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RenderViewTransitionCapture.h"
+
+#include "RenderBoxModelObjectInlines.h"
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(RenderViewTransitionCapture);
+
+RenderViewTransitionCapture::RenderViewTransitionCapture(Type type, Document& document, RenderStyle&& style)
+    : RenderReplaced(type, document, WTFMove(style), { }, ReplacedFlag::IsViewTransitionCapture)
+{ }
+
+void RenderViewTransitionCapture::setImage(const LayoutSize& size)
+{
+    setIntrinsicSize(size);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderReplaced.h"
+
+namespace WebCore {
+
+class RenderViewTransitionCapture : public RenderReplaced {
+    WTF_MAKE_ISO_ALLOCATED(RenderViewTransitionCapture);
+public:
+    RenderViewTransitionCapture(Type, Document&, RenderStyle&&);
+
+    // FIXME: This should be setting the actual image, as well as the instrinsic
+    // size
+    void setImage(const LayoutSize&);
+
+private:
+    ASCIILiteral renderName() const override { return style().pseudoElementType() == PseudoId::ViewTransitionNew ? "RenderViewTransitionNew"_s : "RenderViewTransitionOld"_s; }
+
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderViewTransitionCapture, isRenderViewTransitionCapture())

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -99,6 +99,7 @@ ElementRuleCollector::ElementRuleCollector(const Element& element, const ScopeRu
     , m_authorStyle(ruleSets.authorStyle())
     , m_userStyle(ruleSets.userStyle())
     , m_userAgentMediaQueryStyle(ruleSets.userAgentMediaQueryStyle())
+    , m_dynamicViewTransitionsStyle(ruleSets.dynamicViewTransitionsStyle())
     , m_selectorMatchingState(selectorMatchingState)
     , m_result(makeUnique<MatchResult>(element.isLink()))
 {
@@ -429,6 +430,9 @@ void ElementRuleCollector::matchUARules()
 
     if (m_userAgentMediaQueryStyle)
         matchUARules(*m_userAgentMediaQueryStyle);
+
+    if (m_dynamicViewTransitionsStyle)
+        matchUARules(*m_dynamicViewTransitionsStyle);
 }
 
 void ElementRuleCollector::matchUARules(const RuleSet& rules)

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -122,6 +122,7 @@ private:
     Ref<const RuleSet> m_authorStyle;
     RefPtr<const RuleSet> m_userStyle;
     RefPtr<const RuleSet> m_userAgentMediaQueryStyle;
+    RefPtr<const RuleSet> m_dynamicViewTransitionsStyle;
     SelectorMatchingState* m_selectorMatchingState;
 
     bool m_shouldIncludeEmptyRules { false };

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -61,6 +61,7 @@
 #include "RenderView.h"
 #include "ResolvedStyle.h"
 #include "RuleSet.h"
+#include "RuleSetBuilder.h"
 #include "SVGDocumentExtensions.h"
 #include "SVGElement.h"
 #include "SVGFontFaceElement.h"
@@ -634,7 +635,7 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
     auto hasUsableEntry = cacheEntry && MatchedDeclarationsCache::isCacheable(element, style, parentStyle);
     if (hasUsableEntry) {
         // We can build up the style by copying non-inherited properties from an earlier style object built using the same exact
-        // style declarations. We then only need to apply the inherited properties, if any, as their values can depend on the 
+        // style declarations. We then only need to apply the inherited properties, if any, as their values can depend on the
         // element context. This is fast and saves memory by reusing the style data structures.
         style.copyNonInheritedFrom(*cacheEntry->renderStyle);
 
@@ -722,6 +723,28 @@ bool Resolver::hasViewportDependentMediaQueries() const
 std::optional<DynamicMediaQueryEvaluationChanges> Resolver::evaluateDynamicMediaQueries()
 {
     return m_ruleSets.evaluateDynamicMediaQueryRules(m_mediaQueryEvaluator);
+}
+
+
+void Resolver::setViewTransitionGroupStyles(const AtomString& name, Ref<MutableStyleProperties> properties)
+{
+    if (!m_document)
+        return;
+
+    auto* viewTransitionsStyle = m_ruleSets.dynamicViewTransitionsStyle();
+    RuleSetBuilder builder(*viewTransitionsStyle, mediaQueryEvaluator(), this);
+    CSSSelectorParserContext context(*m_document.get());
+
+    MutableCSSSelectorList selectorList;
+    selectorList.append(MutableCSSSelector::parsePseudoClassSelector("root"_s, context));
+    auto groupSelector = MutableCSSSelector::parsePseudoElementSelector("view-transition-group"_s, context);
+    groupSelector->setArgumentList({ { name } });
+
+    selectorList.first()->appendTagHistory(CSSSelector::Relation::Subselector, WTFMove(groupSelector));
+
+    auto styleRule = StyleRule::create(WTFMove(properties), true, CSSSelectorList(WTFMove(selectorList)));
+
+    builder.addStyleRule(styleRule);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -118,6 +118,8 @@ public:
     std::unique_ptr<RenderStyle> styleForKeyframe(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, BlendingKeyframe&);
     bool isAnimationNameValid(const String&);
 
+    void setViewTransitionGroupStyles(const AtomString&, Ref<MutableStyleProperties>);
+
     // These methods will give back the set of rules that matched for a given element (or a pseudo-element).
     enum CSSRuleFilter {
         UAAndUserCSSRules   = 1 << 1,

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -48,6 +48,7 @@
 #include "ProcessingInstruction.h"
 #include "RenderBoxInlines.h"
 #include "RenderView.h"
+#include "RuleSet.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGStyleElement.h"
 #include "Settings.h"
@@ -114,6 +115,11 @@ void Scope::createDocumentResolver()
 
     m_resolver = Resolver::create(m_document, Resolver::ScopeType::Document);
 
+    if (!m_dynamicViewTransitionsStyle)
+        m_dynamicViewTransitionsStyle = RuleSet::create();
+
+    m_resolver->ruleSets().setDynamicViewTransitionsStyle(m_dynamicViewTransitionsStyle.get());
+
     m_document->fontSelector().buildStarted();
 
     m_resolver->ruleSets().initializeUserStyle();
@@ -174,6 +180,12 @@ void Scope::clearResolver()
     m_resolver = nullptr;
     customPropertyRegistry().clearRegisteredFromStylesheets();
     counterStyleRegistry().clearAuthorCounterStyles();
+}
+
+void Scope::clearViewTransitionStyles()
+{
+    clearResolver();
+    m_dynamicViewTransitionsStyle = nullptr;
 }
 
 void Scope::releaseMemory()

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -65,6 +65,7 @@ namespace Style {
 
 class CustomPropertyRegistry;
 class Resolver;
+class RuleSet;
 
 class Scope : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
@@ -128,6 +129,8 @@ public:
     Resolver* resolverIfExists() { return m_resolver.get(); }
     void clearResolver();
     void releaseMemory();
+
+    void clearViewTransitionStyles();
 
     const Document& document() const { return m_document; }
     Document& document() { return m_document; }
@@ -210,6 +213,8 @@ private:
 
     Vector<RefPtr<StyleSheet>> m_styleSheetsForStyleSheetList;
     Vector<RefPtr<CSSStyleSheet>> m_activeStyleSheets;
+
+    mutable RefPtr<RuleSet> m_dynamicViewTransitionsStyle;
 
     Timer m_pendingUpdateTimer;
 

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -83,6 +83,11 @@ void ScopeRuleSets::updateUserAgentMediaQueryStyleIfNeeded() const
     builder.addRulesFromSheet(*UserAgentStyle::mediaQueryStyleSheet);
 }
 
+RuleSet* ScopeRuleSets::dynamicViewTransitionsStyle() const
+{
+    return m_dynamicViewTransitionsStyle.get();
+}
+
 RuleSet* ScopeRuleSets::userStyle() const
 {
     if (m_usesSharedUserStyle)

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -60,6 +60,7 @@ public:
 
     bool isAuthorStyleDefined() const { return m_isAuthorStyleDefined; }
     RuleSet* userAgentMediaQueryStyle() const;
+    RuleSet* dynamicViewTransitionsStyle() const;
     RuleSet& authorStyle() const { return *m_authorStyle; }
     RuleSet* userStyle() const;
     RuleSet* styleForCascadeLevel(CascadeLevel);
@@ -93,6 +94,11 @@ public:
 
     RuleFeatureSet& mutableFeatures();
 
+    void setDynamicViewTransitionsStyle(RuleSet* ruleSet)
+    {
+        m_dynamicViewTransitionsStyle = ruleSet;
+    }
+
     bool& isInvalidatingStyleWithRuleSets() { return m_isInvalidatingStyleWithRuleSets; }
 
     bool hasMatchingUserOrAuthorStyle(const Function<bool(RuleSet&)>&);
@@ -104,6 +110,7 @@ private:
 
     RefPtr<RuleSet> m_authorStyle;
     mutable RefPtr<RuleSet> m_userAgentMediaQueryStyle;
+    mutable RefPtr<RuleSet> m_dynamicViewTransitionsStyle;
     RefPtr<RuleSet> m_userStyle;
 
     Resolver& m_styleResolver;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -160,7 +160,7 @@ RenderElement* Styleable::renderer() const
             return correctGroup;
 
         // Go through all descendants until we find the relevant pseudo element otherwise.
-        for (auto& descendant : descendantsOfType<RenderBlockFlow>(*correctGroup)) {
+        for (auto& descendant : descendantsOfType<RenderBox>(*correctGroup)) {
             if (descendant.style().pseudoElementType() == pseudoElementIdentifier->pseudoId)
                 return &descendant;
         }


### PR DESCRIPTION
#### 810e27d205f59629bff16d325ae44e5c4d2ea5e4
<pre>
[view-transitions] Implement &quot;update pseudo-element styles&quot; algorithm.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265224">https://bugs.webkit.org/show_bug.cgi?id=265224</a>
<a href="https://rdar.apple.com/118703293">rdar://118703293</a>&gt;

Reviewed by Tim Nguyen.

Implements the basic outline of capturing the computed style from both
the old and new elements, and using these to generate a style rule
for the selector &apos;:root::view-transition-group(transitionName)&apos;.

Adds a mostly empty RenderViewTransitionOld class that we will use
for the replaced snapshot content, but just acts as a placeholder
for the intrinsic size right now.

With these changes, the size of the transitioned element now gets
applied correctly to the :view-transition-new/old renderers, and
styles targetting them (like background color) correctly get
applied and rendered.

The next step is to implement the &apos;capture the image&apos; algorithm
for new and old (likely splitting RenderViewTransformNew as a separate
class), so that we also include the replaced content.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::copyElementBaseProperties):
(WebCore::ViewTransition::updatePseudoElementStyles):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::OrderedNamedElementsMap::map const):
(WebCore::OrderedNamedElementsMap::find const):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderViewTransitionOld const):
* Source/WebCore/rendering/RenderViewTransitionOld.cpp: Added.
(WebCore::RenderViewTransitionOld::RenderViewTransitionOld):
(WebCore::RenderViewTransitionOld::setImage):
* Source/WebCore/rendering/RenderViewTransitionOld.h: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::RenderTreeUpdater::ViewTransition::buildPseudoElementGroup):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ElementRuleCollector):
(WebCore::Style::ElementRuleCollector::matchUARules):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::applyMatchedProperties):
(WebCore::Style::Resolver::setViewTransitionGroupStyles):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createDocumentResolver):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::dynamicViewTransitionsStyle const):
* Source/WebCore/style/StyleScopeRuleSets.h:
(WebCore::Style::ScopeRuleSets::setDynamicViewTransitionsStyle):

Canonical link: <a href="https://commits.webkit.org/274817@main">https://commits.webkit.org/274817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ae504dead819a7c847828a3f19f6011ccc8c473

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42642 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16438 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13919 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43920 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39679 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12237 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16531 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9000 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16580 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->