### PR TITLE
[resultsdbpy] Pasting a list of tests will populate them in the incorrect order.

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/search.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/search.js
@@ -48,7 +48,7 @@ function SearchBar(callback, suites) {
                                 };
                                 element.onmouseout = () => {mouseCount = mouseCount > 0 ? mouseCount - 1 : 0};
                                 element.onclick = () => {
-                                    callback({suite: key, test: test});
+                                    callback([{suite: key, test: test}], false);
                                     closeSearch();
                                 }
                             }
@@ -187,7 +187,7 @@ function SearchBar(callback, suites) {
 
                 } else if (event.keyCode == 0x0D /* VK_RETURN */) {
                     if (candidatesRef.state.selected)
-                        callback(candidatesRef.state.selected);
+                        callback([candidatesRef.state.selected], false);
                     else {
                         let pairs = [];
                         Object.keys(candidates).forEach(suite => {
@@ -200,7 +200,7 @@ function SearchBar(callback, suites) {
                         });
                         if (!pairs.length)
                             return;
-                        callback(...pairs);
+                        callback(pairs, false);
                     }
                     closeSearch();
                 } else if (event.keyCode == 0x1B /* DOM_VK_ESCAPE */)
@@ -238,7 +238,7 @@ function SearchBar(callback, suites) {
                             });
                             outstanding -= 1;
                             if (outstanding <= 0) {
-                                callback(...pairs);
+                                callback(pairs, true);
                                 closeSearch();
                             }
                         });

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
@@ -50,7 +50,7 @@ class SearchView {
         this.currentLimit = this.currentParams.limit ? parseInt(this.currentParams.limit[this.currentParams.limit.length - 1]) : DEFAULT_LIMIT;
         delete this.currentParams.limit;
 
-        let state = {children: [], prepending: []};
+        let state = {children: [], prepending: [], appending: []};
         if (this.currentParams.test && (!this.currentParams.suite || this.currentParams.test.length != this.currentParams.suite.length))
             state = {error: "Query Error", description: 'Must have the same number of suites and tests in query'};
         else if (this.currentParams.test) {
@@ -138,12 +138,21 @@ class SearchView {
                 if (diff.prepending) {
                     diff.prepending.forEach(child => {
                         if (element.firstElementChild)
-                            DOM.after(element.firstElementChild, renderChild(child));
+                            DOM.before(element.firstElementChild, renderChild(child));
                         else
                             DOM.inject(element, renderChild(child));
                         this.ref.state.children.unshift(child);
                     });
-                } 
+                }
+                if (diff.appending) {
+                    diff.appending.forEach(child => {
+                        if (element.lastElementChild)
+                            DOM.after(element.lastElementChild, renderChild(child));
+                        else
+                            DOM.inject(element, renderChild(child));
+                        this.ref.state.children.push(child);
+                    });
+                }
             }
         });
     }
@@ -263,7 +272,7 @@ DOM.inject(
                     viewport = element;
                 }
             })}>
-            ${SearchBar(function () {
+            ${SearchBar(function (pairs, append) {
                 const splitURL = document.URL.split('?');
                 let params = queryToParams(splitURL[1]);
                 if (!params.suite)
@@ -271,25 +280,32 @@ DOM.inject(
                 if (!params.test)
                     params.test = [];
 
-                for (let i = 0; i < arguments.length; i++) {
+                for (let i = 0; i < pairs.length; i++) {
                     let needToAdd = true;
                     if (!needToAdd)
                         continue;
 
                     let child = {
-                        suite: arguments[i].suite,
-                        test: arguments[i].test,
-                        timeline: new TimelineFromEndpoint(`api/results/${arguments[i].suite}/${arguments[i].test}`, {
-                            suite: arguments[i].suite, 
-                            test: arguments[i].test, 
+                        suite: pairs[i].suite,
+                        test: pairs[i].test,
+                        timeline: new TimelineFromEndpoint(`api/results/${pairs[i].suite}/${pairs[i].test}`, {
+                            suite: pairs[i].suite, 
+                            test: pairs[i].test, 
                             searchEvent: onCommitSearch,
                             viewport,
                         }),
                     }
 
-                    view.ref.setState({prepending: [child]});
-                    params.suite.push(child.suite);
-                    params.test.push(child.test);
+                    if (append) {
+                        view.ref.setState({appending: [child]});
+                        params.suite.push(child.suite);
+                        params.test.push(child.test);
+                    } else {
+                        view.ref.setState({prepending: [child]});
+                        params.suite.unshift(child.suite);
+                        params.test.unshift(child.test);
+                    }
+                    
                 }
                 const queryString = paramsToQuery(params);
                 window.history.pushState(queryString, '', splitURL[0] + '?' + queryString);


### PR DESCRIPTION
#### 906ea4c76edaf6742ddef7a2f83a6fcf34828d6d
<pre>
[resultsdbpy] Pasting a list of tests will populate them in the incorrect order.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269401">https://bugs.webkit.org/show_bug.cgi?id=269401</a>

Reviewed by Jonathan Bedard.

When pasting a list of tests into the results database search box, the tests will populate in the incorrect order.
Make the search bar can have different mode for adding new test view, for user pick from the search bar, it will always prepend
for user paste list, it will append each list item

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/search.js:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html:

Canonical link: <a href="https://commits.webkit.org/274750@main">https://commits.webkit.org/274750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/614f50c503c3fd60a60fa84267c9000f83c5b29c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35667 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33171 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13702 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/39632 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39458 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37737 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/39812 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16199 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8955 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->