### PR TITLE
[UnifiedPDF] Context menu should have "Next Page" and "Previous Page" navigation options.

### DIFF
--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -552,13 +552,6 @@ String contextMenuItemPDFActualSize()
 {
     return WEB_UI_STRING_WITH_MNEMONIC("Actual Size", "_Actual Size", "Actual Size context menu item");
 }
-#endif
-
-#if ENABLE(PDFJS)
-String contextMenuItemPDFAutoSize()
-{
-    return WEB_UI_STRING_WITH_MNEMONIC("Automatically Resize", "_Automatically Resize", "Automatically Resize context menu item");
-}
 
 String contextMenuItemPDFNextPage()
 {
@@ -569,6 +562,14 @@ String contextMenuItemPDFPreviousPage()
 {
     return WEB_UI_STRING_WITH_MNEMONIC("Previous Page", "_Previous Page", "Previous Page context menu item");
 }
+#endif
+
+#if ENABLE(PDFJS)
+String contextMenuItemPDFAutoSize()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Automatically Resize", "_Automatically Resize", "Automatically Resize context menu item");
+}
+
 #endif
 #endif // ENABLE(CONTEXT_MENUS)
 

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -188,11 +188,11 @@ namespace WebCore {
     WEBCORE_EXPORT String contextMenuItemPDFZoomIn();
     WEBCORE_EXPORT String contextMenuItemPDFZoomOut();
     WEBCORE_EXPORT String contextMenuItemPDFActualSize();
+    WEBCORE_EXPORT String contextMenuItemPDFNextPage();
+    WEBCORE_EXPORT String contextMenuItemPDFPreviousPage();
 #endif
 #if ENABLE(PDFJS)
     String contextMenuItemPDFAutoSize();
-    String contextMenuItemPDFNextPage();
-    String contextMenuItemPDFPreviousPage();
 #endif
 #endif // ENABLE(CONTEXT_MENU)
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -209,7 +209,9 @@ private:
         DictionaryLookup,
         Copy,
         CopyLink,
+        NextPage,
         OpenWithPreview,
+        PreviousPage,
         SinglePage,
         SinglePageContinuous,
         TwoPages,
@@ -221,13 +223,14 @@ private:
     };
 
     std::optional<PDFContextMenu> createContextMenu(const WebMouseEvent&) const;
-    PDFContextMenuItem contextMenuItem(ContextMenuItemTag) const;
+    PDFContextMenuItem contextMenuItem(ContextMenuItemTag, bool hasAction = true) const;
     String titleForContextMenuItemTag(ContextMenuItemTag) const;
     bool isDisplayModeContextMenuItemTag(ContextMenuItemTag) const;
     PDFContextMenuItem separatorContextMenuItem() const;
     Vector<PDFContextMenuItem> selectionContextMenuItems(const WebCore::IntPoint& contextMenuEventRootViewPoint) const;
     Vector<PDFContextMenuItem> displayModeContextMenuItems() const;
     Vector<PDFContextMenuItem> scaleContextMenuItems() const;
+    Vector<PDFContextMenuItem> navigationContextMenuItems() const;
     ContextMenuItemTag toContextMenuItemTag(int tagValue) const;
     void performContextMenuAction(ContextMenuItemTag, const WebCore::IntPoint& contextMenuEventRootViewPoint);
 
@@ -357,7 +360,12 @@ private:
     WebCore::IntPoint convertFromPageToContents(const WebCore::IntPoint&, PDFDocumentLayout::PageIndex) const;
     WebCore::IntRect convertFromPageToContents(const WebCore::IntRect&, PDFDocumentLayout::PageIndex) const;
 
+    WebCore::IntPoint convertFromDocumentToContents(WebCore::IntPoint) const;
+
+    WebCore::IntPoint offsetContentsSpacePointByPageMargins(WebCore::IntPoint pointInContentsSpace) const;
+
     std::optional<PDFDocumentLayout::PageIndex> pageIndexForDocumentPoint(const WebCore::IntPoint&) const;
+    std::optional<PDFDocumentLayout::PageIndex> indexForCurrentPageInView() const;
 
     RetainPtr<PDFAnnotation> annotationForRootViewPoint(const WebCore::IntPoint&) const;
 


### PR DESCRIPTION
#### 799678c6dd8cd120146f7acb293ba006761b569d
<pre>
[UnifiedPDF] Context menu should have &quot;Next Page&quot; and &quot;Previous Page&quot; navigation options.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269347">https://bugs.webkit.org/show_bug.cgi?id=269347</a>
<a href="https://rdar.apple.com/122931085">rdar://122931085</a>

Reviewed by Tim Horton.

Adds the next and previous page items to the context menu. The &quot;Next
Page,&quot; option is only able to be selected if the current page that is
in the view is not the last page. Likewise, the &quot;Previous Page,&quot; option
is only selectable if the current page is not the first page. Regardless
both of the options are shown but are disabled in those scenarios.

In order to determine which page we are on we take the very center of
the view and see which page that point is contained in. This code
currently works only for single page display modes so a follow up will
be needed to get it working for two page display modes.

For scrolling between the pages we take the layout bounds, convert them
to the contents space, subtract out the page margins, and then
perform a scroll without animation to that point. Modified
scrollToPointInPage to use this new helper function that subtracts out
the page margins instead of the document margins like it was before and
which I don&apos;t think was correct.

Also rearranged the context menu slightly so that the ordering of the
items matches the current order displayed with the legacy plugin.

* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemPDFActualSize):
(WebCore::contextMenuItemPDFAutoSize):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::indexForCurrentPageInView const):
(WebKit::UnifiedPDFPlugin::convertFromPageToContents const):
(WebKit::UnifiedPDFPlugin::convertFromDocumentToContents const):
(WebKit::UnifiedPDFPlugin::offsetContentsSpacePointByPageMargins const):
(WebKit::UnifiedPDFPlugin::scrollToPointInPage):
(WebKit::UnifiedPDFPlugin::scrollToPage):
(WebKit::UnifiedPDFPlugin::toContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::UnifiedPDFPlugin::titleForContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::contextMenuItem const):
(WebKit::UnifiedPDFPlugin::navigationContextMenuItems const):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):

Canonical link: <a href="https://commits.webkit.org/274737@main">https://commits.webkit.org/274737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a571d9d681b59137a4f1f8b7e616f6dad499ed44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16144 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33187 "Found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13720 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39479 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37764 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16237 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8946 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->