### PR TITLE
[CMake] Centralize WC definitions

### DIFF
--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -17,7 +17,6 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/platform/graphics/egl"
     "${WEBCORE_DIR}/platform/graphics/opengl"
     "${WEBCORE_DIR}/platform/graphics/opentype"
-    "${WEBCORE_DIR}/platform/graphics/wc"
     "${WEBCORE_DIR}/platform/graphics/win"
     "${WEBCORE_DIR}/platform/mediacapabilities"
     "${WEBCORE_DIR}/platform/network/win"

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -144,6 +144,9 @@ if (ENABLE_WEBGL)
 endif ()
 
 if (USE_GRAPHICS_LAYER_WC)
+    list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBCORE_DIR}/platform/graphics/wc"
+    )
     list(APPEND WebCore_SOURCES
         platform/graphics/texmap/TextureMapperSparseBackingStore.cpp
     )

--- a/Source/WebKit/Platform/WC.cmake
+++ b/Source/WebKit/Platform/WC.cmake
@@ -1,0 +1,43 @@
+list(APPEND WebKit_SOURCES
+    GPUProcess/graphics/RemoteGraphicsContextGLWC.cpp
+
+    GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+    GPUProcess/graphics/wc/WCContentBufferManager.cpp
+    GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
+    GPUProcess/graphics/wc/WCScene.cpp
+    GPUProcess/graphics/wc/WCSceneContext.cpp
+
+    UIProcess/wc/DrawingAreaProxyWC.cpp
+
+    WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
+    WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+
+    WebProcess/WebPage/wc/DrawingAreaWC.cpp
+    WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+    WebProcess/WebPage/wc/WCBackingStore.cpp
+    WebProcess/WebPage/wc/WCLayerFactory.cpp
+    WebProcess/WebPage/wc/WCTileGrid.cpp
+)
+
+list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
+    "${WEBKIT_DIR}/GPUProcess/graphics/wc"
+    "${WEBKIT_DIR}/Shared/wc"
+    "${WEBKIT_DIR}/UIProcess/wc"
+    "${WEBKIT_DIR}/WebProcess/GPU/graphics/wc"
+    "${WEBKIT_DIR}/WebProcess/WebPage/wc"
+)
+
+list(APPEND WebKit_MESSAGES_IN_FILES
+    GPUProcess/graphics/wc/RemoteWCLayerTreeHost
+)
+
+list(APPEND WebKit_SERIALIZATION_IN_FILES
+    WebProcess/WebPage/wc/WCBackingStore.serialization.in
+    WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
+)
+
+if (USE_GRAPHICS_LAYER_TEXTURE_MAPPER)
+    list(APPEND WebKit_SOURCES
+        WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+    )
+endif ()

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -179,43 +179,7 @@ if (USE_COORDINATED_GRAPHICS)
 endif ()
 
 if (USE_GRAPHICS_LAYER_WC)
-    list(APPEND WebKit_SOURCES
-        GPUProcess/graphics/RemoteGraphicsContextGLWC.cpp
-
-        GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
-        GPUProcess/graphics/wc/WCContentBufferManager.cpp
-        GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
-        GPUProcess/graphics/wc/WCScene.cpp
-        GPUProcess/graphics/wc/WCSceneContext.cpp
-
-        UIProcess/wc/DrawingAreaProxyWC.cpp
-
-        WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
-        WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
-
-        WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
-
-        WebProcess/WebPage/wc/DrawingAreaWC.cpp
-        WebProcess/WebPage/wc/GraphicsLayerWC.cpp
-        WebProcess/WebPage/wc/WCLayerFactory.cpp
-        WebProcess/WebPage/wc/WCTileGrid.cpp
-    )
-
-    list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
-        "${WEBKIT_DIR}/GPUProcess/graphics/wc"
-        "${WEBKIT_DIR}/Shared/wc"
-        "${WEBKIT_DIR}/UIProcess/wc"
-        "${WEBKIT_DIR}/WebProcess/GPU/graphics/wc"
-        "${WEBKIT_DIR}/WebProcess/WebPage/wc"
-    )
-
-    list(APPEND WebKit_MESSAGES_IN_FILES
-        GPUProcess/graphics/wc/RemoteWCLayerTreeHost
-    )
-
-    list(APPEND WebKit_SERIALIZATION_IN_FILES
-        WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
-    )
+    include(Platform/WC.cmake)
 endif ()
 
 if (USE_WPE_BACKEND_PLAYSTATION)

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -5,16 +5,9 @@ set(GPUProcess_OUTPUT_NAME WebKitGPUProcess)
 set(PluginProcess_OUTPUT_NAME WebKitPluginProcess)
 
 include(Headers.cmake)
+include(Platform/WC.cmake)
 
 list(APPEND WebKit_SOURCES
-    GPUProcess/graphics/RemoteGraphicsContextGLWC.cpp
-
-    GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
-    GPUProcess/graphics/wc/WCContentBufferManager.cpp
-    GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
-    GPUProcess/graphics/wc/WCScene.cpp
-    GPUProcess/graphics/wc/WCSceneContext.cpp
-
     GPUProcess/media/win/RemoteMediaPlayerProxyWin.cpp
 
     GPUProcess/win/GPUProcessMainWin.cpp
@@ -84,17 +77,12 @@ list(APPEND WebKit_SOURCES
 
     UIProcess/cairo/BackingStore.cpp
 
-    UIProcess/wc/DrawingAreaProxyWC.cpp
-
     UIProcess/win/PageClientImpl.cpp
     UIProcess/win/WebContextMenuProxyWin.cpp
     UIProcess/win/WebPageProxyWin.cpp
     UIProcess/win/WebPopupMenuProxyWin.cpp
     UIProcess/win/WebProcessPoolWin.cpp
     UIProcess/win/WebView.cpp
-
-    WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
-    WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
 
     WebProcess/GPU/media/win/VideoLayerRemoteWin.cpp
 
@@ -113,13 +101,6 @@ list(APPEND WebKit_SOURCES
 
     WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
     WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
-    WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
-
-    WebProcess/WebPage/wc/DrawingAreaWC.cpp
-    WebProcess/WebPage/wc/GraphicsLayerWC.cpp
-    WebProcess/WebPage/wc/WCBackingStore.cpp
-    WebProcess/WebPage/wc/WCLayerFactory.cpp
-    WebProcess/WebPage/wc/WCTileGrid.cpp
 
     WebProcess/WebPage/win/WebPageWin.cpp
 
@@ -130,7 +111,6 @@ list(APPEND WebKit_SOURCES
 )
 
 list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
-    "${WEBKIT_DIR}/GPUProcess/graphics/wc"
     "${WEBKIT_DIR}/NetworkProcess/curl"
     "${WEBKIT_DIR}/Platform/IPC/win"
     "${WEBKIT_DIR}/Platform/classifier"
@@ -139,7 +119,6 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/API/c/win"
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics"
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics/threadedcompositor"
-    "${WEBKIT_DIR}/Shared/wc"
     "${WEBKIT_DIR}/Shared/win"
     "${WEBKIT_DIR}/UIProcess/API/C/cairo"
     "${WEBKIT_DIR}/UIProcess/API/C/curl"
@@ -151,27 +130,15 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/UIProcess/Inspector/win"
     "${WEBKIT_DIR}/UIProcess/Plugins/win"
     "${WEBKIT_DIR}/UIProcess/cairo"
-    "${WEBKIT_DIR}/UIProcess/wc"
     "${WEBKIT_DIR}/UIProcess/win"
-    "${WEBKIT_DIR}/WebProcess/GPU/graphics/wc"
     "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/win"
     "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/win/DOM"
     "${WEBKIT_DIR}/WebProcess/Inspector/win"
     "${WEBKIT_DIR}/WebProcess/WebCoreSupport/curl"
     "${WEBKIT_DIR}/WebProcess/WebCoreSupport/win"
     "${WEBKIT_DIR}/WebProcess/WebPage/CoordinatedGraphics"
-    "${WEBKIT_DIR}/WebProcess/WebPage/wc"
     "${WEBKIT_DIR}/WebProcess/WebPage/win"
     "${WEBKIT_DIR}/win"
-)
-
-list(APPEND WebKit_MESSAGES_IN_FILES
-    GPUProcess/graphics/wc/RemoteWCLayerTreeHost
-)
-
-list(APPEND WebKit_SERIALIZATION_IN_FILES
-    WebProcess/WebPage/wc/WCBackingStore.serialization.in
-    WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
 )
 
 list(APPEND WebKit_PRIVATE_LIBRARIES


### PR DESCRIPTION
#### 42469865934158548fa1313cba5520571f041ec3
<pre>
[CMake] Centralize WC definitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=269407">https://bugs.webkit.org/show_bug.cgi?id=269407</a>

Reviewed by Fujii Hironori.

Share `USE(GRAPHICS_LAYER_WC)` build definitions between ports.

* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/PlatformWin.cmake:
* Source/WebKit/Platform/WC.cmake: Added.

Canonical link: <a href="https://commits.webkit.org/274672@main">https://commits.webkit.org/274672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b614a6980fb81f20fa97b7b105274a125a82415

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42271 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16044 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15787 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43548 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36077 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16154 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5219 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->