### PR TITLE
Adopt more smart pointers in SVG code

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2988,6 +2988,7 @@ svg/SVGGraphicsElement.cpp
 svg/SVGHKernElement.cpp
 svg/SVGImageElement.cpp
 svg/SVGImageLoader.cpp
+svg/SVGLength.cpp
 svg/SVGLengthContext.cpp
 svg/SVGLengthList.cpp
 svg/SVGLengthValue.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10469,6 +10469,13 @@ CheckedPtr<RenderView> Document::checkedRenderView() const
     return m_renderView.get();
 }
 
+Ref<CSSFontSelector> Document::protectedFontSelector() const
+{
+    if (!m_fontSelector)
+        return const_cast<Document&>(*this).ensureFontSelector();
+    return *m_fontSelector;
+}
+
 } // namespace WebCore
 
 #undef DOCUMENT_RELEASE_LOG

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -656,6 +656,7 @@ public:
     const CSSFontSelector* fontSelectorIfExists() const { return m_fontSelector.get(); }
     inline CSSFontSelector& fontSelector();
     inline const CSSFontSelector& fontSelector() const;
+    Ref<CSSFontSelector> protectedFontSelector() const;
 
     WEBCORE_EXPORT bool haveStylesheetsLoaded() const;
     bool isIgnoringPendingStylesheets() const { return m_ignorePendingStylesheets; }

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -83,17 +83,18 @@ void RenderSVGEllipse::updateShapeFromElement()
 
 void RenderSVGEllipse::calculateRadiiAndCenter()
 {
-    SVGLengthContext lengthContext(&graphicsElement());
+    Ref graphicsElement = this->graphicsElement();
+    SVGLengthContext lengthContext(graphicsElement.ptr());
     m_center = FloatPoint(
         lengthContext.valueForLength(style().svgStyle().cx(), SVGLengthMode::Width),
         lengthContext.valueForLength(style().svgStyle().cy(), SVGLengthMode::Height));
-    if (is<SVGCircleElement>(graphicsElement())) {
+    if (is<SVGCircleElement>(graphicsElement)) {
         float radius = lengthContext.valueForLength(style().svgStyle().r());
         m_radii = FloatSize(radius, radius);
         return;
     }
 
-    ASSERT(is<SVGEllipseElement>(graphicsElement()));
+    ASSERT(is<SVGEllipseElement>(graphicsElement));
 
     Length rx = style().svgStyle().rx();
     Length ry = style().svgStyle().ry();

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -53,16 +53,16 @@ void RenderSVGGradientStop::styleDidChange(StyleDifference diff, const RenderSty
 
     // <stop> elements should only be allowed to make renderers under gradient elements
     // but I can imagine a few cases we might not be catching, so let's not crash if our parent isn't a gradient.
-    const auto* gradient = gradientElement();
+    RefPtr gradient = gradientElement();
     if (!gradient)
         return;
 
-    auto* renderer = gradient->renderer();
+    CheckedPtr renderer = gradient->renderer();
     if (!renderer)
         return;
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* gradientRenderer = dynamicDowncast<RenderSVGResourceGradient>(renderer)) {
+    if (auto* gradientRenderer = dynamicDowncast<RenderSVGResourceGradient>(renderer.get())) {
         gradientRenderer->invalidateGradient();
         return;
     }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -77,13 +77,19 @@ SVGImageElement& RenderSVGImage::imageElement() const
     return downcast<SVGImageElement>(RenderSVGModelObject::element());
 }
 
+Ref<SVGImageElement> RenderSVGImage::protectedImageElement() const
+{
+    return imageElement();
+}
+
 FloatRect RenderSVGImage::calculateObjectBoundingBox() const
 {
     LayoutSize intrinsicSize;
     if (CachedImage* cachedImage = imageResource().cachedImage())
         intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().effectiveZoom());
 
-    SVGLengthContext lengthContext(&imageElement());
+    Ref imageElement = this->imageElement();
+    SVGLengthContext lengthContext(imageElement.ptr());
 
     Length width = style().width();
     Length height = style().height();
@@ -104,7 +110,7 @@ FloatRect RenderSVGImage::calculateObjectBoundingBox() const
     else
         concreteHeight = intrinsicSize.height();
 
-    return { imageElement().x().value(lengthContext), imageElement().y().value(lengthContext), concreteWidth, concreteHeight };
+    return { imageElement->x().value(lengthContext), imageElement->y().value(lengthContext), concreteWidth, concreteHeight };
 }
 
 void RenderSVGImage::layout()
@@ -356,7 +362,7 @@ void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     repaintOrMarkForLayout(rect);
 
     if (AXObjectCache* cache = document().existingAXObjectCache())
-        cache->deferRecomputeIsIgnoredIfNeeded(&imageElement());
+        cache->deferRecomputeIsIgnoredIfNeeded(protectedImageElement().ptr());
 }
 
 bool RenderSVGImage::bufferForeground(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
@@ -403,12 +409,12 @@ bool RenderSVGImage::bufferForeground(PaintInfo& paintInfo, const LayoutPoint& p
 
 bool RenderSVGImage::needsHasSVGTransformFlags() const
 {
-    return imageElement().hasTransformRelatedAttributes();
+    return protectedImageElement()->hasTransformRelatedAttributes();
 }
 
 void RenderSVGImage::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
 {
-    applySVGTransform(transform, imageElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+    applySVGTransform(transform, protectedImageElement(), style, boundingBox, std::nullopt, std::nullopt, options);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -40,6 +40,7 @@ public:
     virtual ~RenderSVGImage();
 
     SVGImageElement& imageElement() const;
+    Ref<SVGImageElement> protectedImageElement() const;
 
     RenderImageResource& imageResource() { return *m_imageResource; }
     const RenderImageResource& imageResource() const { return *m_imageResource; }

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -25,7 +25,6 @@
 #include "RenderSVGInlineText.h"
 
 #include "CSSFontSelector.h"
-#include "DocumentInlines.h"
 #include "FloatConversion.h"
 #include "FloatQuad.h"
 #include "InlineRunAndOffset.h"
@@ -233,7 +232,7 @@ void RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
     auto fontDescription = style.fontDescription();
 
     // FIXME: We need to better handle the case when we compute very small fonts below (below 1pt).
-    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.computedSize(), fontDescription.isAbsoluteSize(), scalingFactor, renderer.document()));
+    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.computedSize(), fontDescription.isAbsoluteSize(), scalingFactor, renderer.protectedDocument()));
 
     // SVG controls its own glyph orientation, so don't allow writing-mode
     // to affect it.
@@ -241,7 +240,7 @@ void RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
         fontDescription.setOrientation(FontOrientation::Horizontal);
 
     scaledFont = FontCascade(WTFMove(fontDescription));
-    scaledFont.update(&renderer.document().fontSelector());
+    scaledFont.update(renderer.document().protectedFontSelector().ptr());
 }
 
 SVGInlineTextBox* RenderSVGInlineText::firstTextBox() const

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -224,7 +224,7 @@ bool RenderSVGModelObject::checkIntersection(RenderElement* renderer, const Floa
         return false;
     if (!isGraphicsElement(*renderer))
         return false;
-    auto* svgElement = downcast<SVGGraphicsElement>(renderer->element());
+    RefPtr svgElement = downcast<SVGGraphicsElement>(renderer->element());
     auto ctm = svgElement->getCTM(SVGLocatable::DisallowStyleUpdate);
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
@@ -237,7 +237,7 @@ bool RenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRe
         return false;
     if (!isGraphicsElement(*renderer))
         return false;
-    auto* svgElement = downcast<SVGGraphicsElement>(renderer->element());
+    RefPtr svgElement = downcast<SVGGraphicsElement>(renderer->element());
     auto ctm = svgElement->getCTM(SVGLocatable::DisallowStyleUpdate);
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
@@ -277,14 +277,14 @@ Path RenderSVGModelObject::computeClipPath(AffineTransform& transform) const
     if (layer()->isTransformed())
         transform.multiply(layer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
 
-    if (auto* useElement = dynamicDowncast<SVGUseElement>(element())) {
-        if (auto* clipChildRenderer = useElement->rendererClipChild())
+    if (RefPtr useElement = dynamicDowncast<SVGUseElement>(element())) {
+        if (CheckedPtr clipChildRenderer = useElement->rendererClipChild())
             transform.multiply(downcast<RenderLayerModelObject>(*clipChildRenderer).checkedLayer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
-        if (auto clipChild = useElement->clipChild())
+        if (RefPtr clipChild = useElement->clipChild())
             return pathFromGraphicsElement(*clipChild);
     }
 
-    return pathFromGraphicsElement(downcast<SVGGraphicsElement>(element()));
+    return pathFromGraphicsElement(Ref { downcast<SVGGraphicsElement>(element()) });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -61,16 +61,17 @@ void RenderSVGRect::updateShapeFromElement()
     m_strokeBoundingBox = std::nullopt;
     m_approximateStrokeBoundingBox = std::nullopt;
 
-    SVGLengthContext lengthContext(&rectElement());
+    Ref rectElement = this->rectElement();
+    SVGLengthContext lengthContext(rectElement.ptr());
     FloatSize boundingBoxSize(lengthContext.valueForLength(style().width(), SVGLengthMode::Width), lengthContext.valueForLength(style().height(), SVGLengthMode::Height));
 
     // Spec: "A negative value is illegal. A value of zero disables rendering of the element."
     if (boundingBoxSize.isEmpty())
         return;
 
-    auto& svgStyle = style().svgStyle();
-    if (lengthContext.valueForLength(svgStyle.rx(), SVGLengthMode::Width) > 0
-        || lengthContext.valueForLength(svgStyle.ry(), SVGLengthMode::Height) > 0)
+    Ref svgStyle = style().svgStyle();
+    if (lengthContext.valueForLength(svgStyle->rx(), SVGLengthMode::Width) > 0
+        || lengthContext.valueForLength(svgStyle->ry(), SVGLengthMode::Height) > 0)
         m_shapeType = ShapeType::RoundedRectangle;
     else
         m_shapeType = ShapeType::Rectangle;
@@ -81,17 +82,17 @@ void RenderSVGRect::updateShapeFromElement()
         return;
     }
 
-    m_fillBoundingBox = FloatRect(FloatPoint(lengthContext.valueForLength(svgStyle.x(), SVGLengthMode::Width),
-        lengthContext.valueForLength(svgStyle.y(), SVGLengthMode::Height)),
+    m_fillBoundingBox = FloatRect(FloatPoint(lengthContext.valueForLength(svgStyle->x(), SVGLengthMode::Width),
+        lengthContext.valueForLength(svgStyle->y(), SVGLengthMode::Height)),
         boundingBoxSize);
 
     auto strokeBoundingBox = m_fillBoundingBox;
-    if (svgStyle.hasStroke())
+    if (svgStyle->hasStroke())
         strokeBoundingBox.inflate(this->strokeWidth() / 2);
 
 #if USE(CG)
     // CoreGraphics can inflate the stroke by 1px when drawing a rectangle with antialiasing disabled at non-integer coordinates, we need to compensate.
-    if (svgStyle.shapeRendering() == ShapeRendering::CrispEdges)
+    if (svgStyle->shapeRendering() == ShapeRendering::CrispEdges)
         strokeBoundingBox.inflate(1);
 #endif
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -167,9 +167,9 @@ void RenderSVGResourceClipper::applyMaskClipping(PaintInfo& paintInfo, const Ren
     // - masker/filter not applied when rendering the children
     // - fill is set to the initial fill paint server (solid, black)
     // - stroke is set to the initial stroke paint server (none)
-    auto& frameView = view().frameView();
-    auto oldBehavior = frameView.paintBehavior();
-    frameView.setPaintBehavior(oldBehavior | PaintBehavior::RenderingSVGClipOrMask);
+    Ref frameView = view().frameView();
+    auto oldBehavior = frameView->paintBehavior();
+    frameView->setPaintBehavior(oldBehavior | PaintBehavior::RenderingSVGClipOrMask);
 
     if (!compositedMask || flattenCompositingLayers) {
         pushTransparencyLayer = true;
@@ -183,7 +183,7 @@ void RenderSVGResourceClipper::applyMaskClipping(PaintInfo& paintInfo, const Ren
 
     if (pushTransparencyLayer)
         context.endTransparencyLayer();
-    frameView.setPaintBehavior(oldBehavior);
+    frameView->setPaintBehavior(oldBehavior);
 }
 
 bool RenderSVGResourceClipper::hitTestClipContent(const FloatRect& objectBoundingBox, const LayoutPoint& nodeAtPoint)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -96,9 +96,9 @@ bool RenderSVGResourceGradient::prepareFillOperation(GraphicsContext& context, c
     if (!buildGradientIfNeeded(targetRenderer, style, userspaceTransform))
         return false;
 
-    const auto& svgStyle = style.svgStyle();
-    context.setAlpha(svgStyle.fillOpacity());
-    context.setFillRule(svgStyle.fillRule());
+    Ref svgStyle = style.svgStyle();
+    context.setAlpha(svgStyle->fillOpacity());
+    context.setFillRule(svgStyle->fillRule());
     context.setFillGradient(m_gradient.copyRef().releaseNonNull(), userspaceTransform);
     return true;
 }
@@ -109,13 +109,13 @@ bool RenderSVGResourceGradient::prepareStrokeOperation(GraphicsContext& context,
     if (!buildGradientIfNeeded(targetRenderer, style, userspaceTransform))
         return false;
 
-    const auto& svgStyle = style.svgStyle();
-    if (svgStyle.vectorEffect() == VectorEffect::NonScalingStroke) {
-        if (auto* shape = dynamicDowncast<RenderSVGShape>(targetRenderer))
+    Ref svgStyle = style.svgStyle();
+    if (svgStyle->vectorEffect() == VectorEffect::NonScalingStroke) {
+        if (CheckedPtr shape = dynamicDowncast<RenderSVGShape>(targetRenderer))
             userspaceTransform = shape->nonScalingStrokeTransform() * userspaceTransform;
     }
 
-    context.setAlpha(svgStyle.strokeOpacity());
+    context.setAlpha(svgStyle->strokeOpacity());
     SVGRenderSupport::applyStrokeStyleToContext(context, style, targetRenderer);
     context.setStrokeGradient(m_gradient.copyRef().releaseNonNull(), userspaceTransform);
     return true;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
@@ -43,10 +43,11 @@ void RenderSVGResourceLinearGradient::collectGradientAttributesIfNeeded()
     if (m_attributes.has_value())
         return;
 
-    linearGradientElement().synchronizeAllAttributes();
+    Ref linearGradientElement = this->linearGradientElement();
+    linearGradientElement->synchronizeAllAttributes();
 
     auto attributes = LinearGradientAttributes { };
-    if (linearGradientElement().collectGradientAttributes(attributes))
+    if (linearGradientElement->collectGradientAttributes(attributes))
         m_attributes = WTFMove(attributes);
 }
 
@@ -55,8 +56,9 @@ RefPtr<Gradient> RenderSVGResourceLinearGradient::createGradient(const RenderSty
     if (!m_attributes)
         return nullptr;
 
-    auto startPoint = SVGLengthContext::resolvePoint(&linearGradientElement(), m_attributes->gradientUnits(), m_attributes->x1(), m_attributes->y1());
-    auto endPoint = SVGLengthContext::resolvePoint(&linearGradientElement(), m_attributes->gradientUnits(), m_attributes->x2(), m_attributes->y2());
+    Ref linearGradientElement = this->linearGradientElement();
+    auto startPoint = SVGLengthContext::resolvePoint(linearGradientElement.ptr(), m_attributes->gradientUnits(), m_attributes->x1(), m_attributes->y1());
+    auto endPoint = SVGLengthContext::resolvePoint(linearGradientElement.ptr(), m_attributes->gradientUnits(), m_attributes->x2(), m_attributes->y2());
 
     return Gradient::create(
         Gradient::LinearData { startPoint, endPoint },

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h
@@ -38,6 +38,7 @@ public:
     virtual ~RenderSVGResourceLinearGradient();
 
     inline SVGLinearGradientElement& linearGradientElement() const;
+    inline Ref<SVGLinearGradientElement> protectedLinearGradientElement() const;
 
     SVGUnitTypes::SVGUnitType gradientUnits() const final { return m_attributes ? m_attributes.value().gradientUnits() : SVGUnitTypes::SVG_UNIT_TYPE_UNKNOWN; }
     AffineTransform gradientTransform() const final { return m_attributes ? m_attributes.value().gradientTransform() : identity; }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradientInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradientInlines.h
@@ -36,6 +36,11 @@ inline SVGLinearGradientElement& RenderSVGResourceLinearGradient::linearGradient
     return downcast<SVGLinearGradientElement>(RenderSVGResourceContainer::element());
 }
 
+inline Ref<SVGLinearGradientElement> RenderSVGResourceLinearGradient::protectedLinearGradientElement() const
+{
+    return linearGradientElement();
 }
+
+} // namespace WebCore
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -58,9 +58,9 @@ void RenderSVGResourceMarker::invalidateMarker()
 
 FloatRect RenderSVGResourceMarker::computeViewport() const
 {
-    auto& useMarkerElement = markerElement();
-    SVGLengthContext lengthContext(&useMarkerElement);
-    return { 0, 0, useMarkerElement.markerWidth().value(lengthContext), useMarkerElement.markerHeight().value(lengthContext) };
+    Ref useMarkerElement = markerElement();
+    SVGLengthContext lengthContext(useMarkerElement.ptr());
+    return { 0, 0, useMarkerElement->markerWidth().value(lengthContext), useMarkerElement->markerHeight().value(lengthContext) };
 }
 
 bool RenderSVGResourceMarker::updateLayoutSizeIfNeeded()

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h
@@ -31,8 +31,9 @@ inline SVGMarkerElement& RenderSVGResourceMarker::markerElement() const
 
 FloatPoint RenderSVGResourceMarker::referencePoint() const
 {
-    SVGLengthContext lengthContext(&markerElement());
-    return { markerElement().refX().value(lengthContext), markerElement().refY().value(lengthContext) };
+    Ref markerElement = this->markerElement();
+    SVGLengthContext lengthContext(markerElement.ptr());
+    return { markerElement->refX().value(lengthContext), markerElement->refY().value(lengthContext) };
 }
 
 std::optional<float> RenderSVGResourceMarker::angle() const

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -110,9 +110,9 @@ void RenderSVGResourceMasker::applyMask(PaintInfo& paintInfo, const RenderLayerM
     auto maskColorSpace = DestinationColorSpace::SRGB();
     auto drawColorSpace = DestinationColorSpace::SRGB();
 
-    const auto& svgStyle = style().svgStyle();
+    Ref svgStyle = style().svgStyle();
 #if ENABLE(DESTINATION_COLOR_SPACE_LINEAR_SRGB)
-    if (svgStyle.colorInterpolation() == ColorInterpolation::LinearRGB) {
+    if (svgStyle->colorInterpolation() == ColorInterpolation::LinearRGB) {
 #if USE(CG)
         maskColorSpace = DestinationColorSpace::LinearSRGB();
 #endif
@@ -136,7 +136,7 @@ void RenderSVGResourceMasker::applyMask(PaintInfo& paintInfo, const RenderLayerM
     UNUSED_PARAM(drawColorSpace);
 #endif
 
-    if (svgStyle.maskType() == MaskType::Luminance)
+    if (svgStyle->maskType() == MaskType::Luminance)
         maskImage->convertToLuminanceMask();
 
     context.setCompositeOperation(CompositeOperator::SourceOver);
@@ -160,16 +160,16 @@ FloatRect RenderSVGResourceMasker::resourceBoundingBox(const RenderObject& objec
 
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-    auto& maskElement = this->maskElement();
-    auto maskRect = maskElement.calculateMaskContentRepaintRect(repaintRectCalculation);
-    if (maskElement.maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
+    Ref maskElement = this->maskElement();
+    auto maskRect = maskElement->calculateMaskContentRepaintRect(repaintRectCalculation);
+    if (maskElement->maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
         AffineTransform contentTransform;
         contentTransform.translate(targetBoundingBox.location());
         contentTransform.scale(targetBoundingBox.size());
         maskRect = contentTransform.mapRect(maskRect);
     }
 
-    auto maskBoundaries = SVGLengthContext::resolveRectangle<SVGMaskElement>(&maskElement, maskElement.maskUnits(), targetBoundingBox);
+    auto maskBoundaries = SVGLengthContext::resolveRectangle<SVGMaskElement>(maskElement.ptr(), maskElement->maskUnits(), targetBoundingBox);
     maskRect.intersect(maskBoundaries);
     if (maskRect.isEmpty())
         return targetBoundingBox;

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -50,9 +50,9 @@ void RenderSVGResourcePattern::collectPatternAttributesIfNeeded()
 
     auto attributes = PatternAttributes { };
 
-    SVGPatternElement* current = &patternElement();
+    RefPtr current = &patternElement();
 
-    patternElement().synchronizeAllAttributes();
+    current->synchronizeAllAttributes();
 
     while (current) {
         if (!current->renderer())
@@ -98,7 +98,7 @@ RefPtr<Pattern> RenderSVGResourcePattern::buildPattern(GraphicsContext& context,
     // Compute all necessary transformations to build the tile image & the pattern.
     FloatRect tileBoundaries;
     AffineTransform tileImageTransform;
-    if (!buildTileImageTransform(renderer, *m_attributes, patternElement(), tileBoundaries, tileImageTransform))
+    if (!buildTileImageTransform(renderer, *m_attributes, protectedPatternElement(), tileBoundaries, tileImageTransform))
         return nullptr;
 
     // Ignore 2D rotation, as it doesn't affect the size of the tile.

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
@@ -36,6 +36,7 @@ public:
     virtual ~RenderSVGResourcePattern();
 
     inline SVGPatternElement& patternElement() const;
+    inline Ref<SVGPatternElement> protectedPatternElement() const;
 
     bool prepareFillOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) final;
     bool prepareStrokeOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) final;

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePatternInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePatternInlines.h
@@ -36,6 +36,11 @@ inline SVGPatternElement& RenderSVGResourcePattern::patternElement() const
     return downcast<SVGPatternElement>(RenderSVGResourceContainer::element());
 }
 
+inline Ref<SVGPatternElement> RenderSVGResourcePattern::protectedPatternElement() const
+{
+    return patternElement();
+}
+
 static inline FloatRect calculatePatternBoundaries(const PatternAttributes& attributes, const FloatRect& objectBoundingBox, const SVGPatternElement& patternElement)
 {
     return SVGLengthContext::resolveRectangle(&patternElement, attributes.patternUnits(), objectBoundingBox, attributes.x(), attributes.y(), attributes.width(), attributes.height());

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -177,7 +177,7 @@ bool RenderSVGShape::setupNonScalingStrokeContext(AffineTransform& strokeTransfo
 
 AffineTransform RenderSVGShape::nonScalingStrokeTransform() const
 {
-    return graphicsElement().getScreenCTM(SVGLocatable::DisallowStyleUpdate);
+    return protectedGraphicsElement()->getScreenCTM(SVGLocatable::DisallowStyleUpdate);
 }
 
 void RenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& context)
@@ -392,7 +392,8 @@ FloatRect RenderSVGShape::calculateApproximateStrokeBoundingBox() const
 
 float RenderSVGShape::strokeWidth() const
 {
-    SVGLengthContext lengthContext(&graphicsElement());
+    Ref graphicsElement = this->graphicsElement();
+    SVGLengthContext lengthContext(graphicsElement.ptr());
     return lengthContext.valueForLength(style().strokeWidth());
 }
 
@@ -405,7 +406,7 @@ Path& RenderSVGShape::ensurePath()
 
 std::unique_ptr<Path> RenderSVGShape::createPath() const
 {
-    return makeUnique<Path>(pathFromGraphicsElement(graphicsElement()));
+    return makeUnique<Path>(pathFromGraphicsElement(protectedGraphicsElement()));
 }
 
 void RenderSVGShape::styleWillChange(StyleDifference diff, const RenderStyle& newStyle)
@@ -421,12 +422,12 @@ void RenderSVGShape::styleWillChange(StyleDifference diff, const RenderStyle& ne
 
 bool RenderSVGShape::needsHasSVGTransformFlags() const
 {
-    return graphicsElement().hasTransformRelatedAttributes();
+    return protectedGraphicsElement()->hasTransformRelatedAttributes();
 }
 
 void RenderSVGShape::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
 {
-    applySVGTransform(transform, graphicsElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+    applySVGTransform(transform, protectedGraphicsElement(), style, boundingBox, std::nullopt, std::nullopt, options);
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -76,6 +76,11 @@ SVGTextElement& RenderSVGText::textElement() const
     return downcast<SVGTextElement>(RenderSVGBlock::graphicsElement());
 }
 
+Ref<SVGTextElement> RenderSVGText::protectedTextElement() const
+{
+    return textElement();
+}
+
 bool RenderSVGText::isChildAllowed(const RenderObject& child, const RenderStyle&) const
 {
     return child.isInline();
@@ -504,7 +509,7 @@ bool RenderSVGText::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
 void RenderSVGText::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
-    applySVGTransform(transform, textElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+    applySVGTransform(transform, protectedTextElement(), style, boundingBox, std::nullopt, std::nullopt, options);
 }
 #endif
 
@@ -585,11 +590,11 @@ void RenderSVGText::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 FloatRect RenderSVGText::strokeBoundingBox() const
 {
     FloatRect strokeBoundaries = objectBoundingBox();
-    const SVGRenderStyle& svgStyle = style().svgStyle();
-    if (!svgStyle.hasStroke())
+    if (!style().svgStyle().hasStroke())
         return strokeBoundaries;
 
-    SVGLengthContext lengthContext(&textElement());
+    Ref textElement = this->textElement();
+    SVGLengthContext lengthContext(textElement.ptr());
     strokeBoundaries.inflate(lengthContext.valueForLength(style().strokeWidth()));
     return strokeBoundaries;
 }

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -39,6 +39,7 @@ public:
     virtual ~RenderSVGText();
 
     SVGTextElement& textElement() const;
+    Ref<SVGTextElement> protectedTextElement() const;
 
     bool isChildAllowed(const RenderObject&, const RenderStyle&) const override;
 

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -61,8 +61,7 @@ inline SVGUseElement* associatedUseElement(SVGGraphicsElement& element)
         return useElement;
 
     if (element.isInShadowTree() && is<SVGGElement>(element)) {
-        SVGElement* correspondingElement = element.correspondingElement();
-        if (auto* useElement = dynamicDowncast<SVGUseElement>(correspondingElement))
+        if (auto* useElement = dynamicDowncast<SVGUseElement>(element.correspondingElement()))
             return useElement;
     }
 

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -261,10 +261,8 @@ void SVGInlineTextBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
     if (hasSelection && shouldPaintSelectionHighlight) {
         selectionStyle = parentRenderer.getCachedPseudoStyle({ PseudoId::Selection });
         if (selectionStyle) {
-            const SVGRenderStyle& svgSelectionStyle = selectionStyle->svgStyle();
-
             if (!hasFill)
-                hasFill = svgSelectionStyle.hasFill();
+                hasFill = selectionStyle->svgStyle().hasFill();
             if (!hasVisibleStroke)
                 hasVisibleStroke = selectionStyle->hasVisibleStroke();
         } else
@@ -533,9 +531,7 @@ void SVGInlineTextBox::paintDecoration(GraphicsContext& context, OptionSet<TextD
     if (decorationStyle.visibility() == Visibility::Hidden)
         return;
 
-    const SVGRenderStyle& svgDecorationStyle = decorationStyle.svgStyle();
-
-    bool hasDecorationFill = svgDecorationStyle.hasFill();
+    bool hasDecorationFill = decorationStyle.svgStyle().hasFill();
     bool hasVisibleDecorationStroke = decorationStyle.hasVisibleStroke();
 
     if (hasDecorationFill) {
@@ -653,8 +649,8 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
         {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
             // Optimized code path to support gradient/pattern fill/stroke on text without using temporary ImageBuffers / masking.
-            Gradient* gradient { nullptr };
-            RefPtr<Pattern> pattern { nullptr };
+            RefPtr<Gradient> gradient;
+            RefPtr<Pattern> pattern;
             if (renderer().document().settings().layerBasedSVGEngineEnabled()) {
                 auto* textRootBlock = RenderSVGText::locateRenderSVGTextAncestor(renderer());
                 ASSERT(textRootBlock);

--- a/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
+++ b/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
@@ -124,13 +124,13 @@ public:
 private:
     inline void prepareFillOperation(const RenderLayerModelObject& renderer, const RenderStyle& style, const Color& fillColor) const
     {
-        const auto& svgStyle = style.svgStyle();
+        Ref svgStyle = style.svgStyle();
         if (renderer.view().frameView().paintBehavior().contains(PaintBehavior::RenderingSVGClipOrMask)) {
             m_context.setAlpha(1);
-            m_context.setFillRule(svgStyle.clipRule());
+            m_context.setFillRule(svgStyle->clipRule());
         } else {
-            m_context.setAlpha(svgStyle.fillOpacity());
-            m_context.setFillRule(svgStyle.fillRule());
+            m_context.setAlpha(svgStyle->fillOpacity());
+            m_context.setFillRule(svgStyle->fillRule());
         }
 
         m_context.setFillColor(style.colorByApplyingColorFilter(fillColor));
@@ -138,8 +138,7 @@ private:
 
     inline void prepareStrokeOperation(const RenderLayerModelObject& renderer, const RenderStyle& style, const Color& strokeColor) const
     {
-        const auto& svgStyle = style.svgStyle();
-        m_context.setAlpha(svgStyle.strokeOpacity());
+        m_context.setAlpha(style.svgStyle().strokeOpacity());
         m_context.setStrokeColor(style.colorByApplyingColorFilter(strokeColor));
         SVGRenderSupport::applyStrokeStyleToContext(m_context, style, renderer);
     }
@@ -147,10 +146,10 @@ private:
     template<Operation op>
     static inline Color resolveColorFromStyle(const RenderStyle& style)
     {
-        const auto& svgStyle = style.svgStyle();
+        Ref svgStyle = style.svgStyle();
         if (op == Operation::Fill)
-            return resolveColorFromStyle(style, svgStyle.fillPaintType(), svgStyle.fillPaintColor(), svgStyle.visitedLinkFillPaintType(), svgStyle.visitedLinkFillPaintColor());
-        return resolveColorFromStyle(style, svgStyle.strokePaintType(), svgStyle.strokePaintColor(), svgStyle.visitedLinkStrokePaintType(), svgStyle.visitedLinkStrokePaintColor());
+            return resolveColorFromStyle(style, svgStyle->fillPaintType(), svgStyle->fillPaintColor(), svgStyle->visitedLinkFillPaintType(), svgStyle->visitedLinkFillPaintColor());
+        return resolveColorFromStyle(style, svgStyle->strokePaintType(), svgStyle->strokePaintColor(), svgStyle->visitedLinkStrokePaintType(), svgStyle->visitedLinkStrokePaintColor());
     }
 
     static inline Color resolveColorFromStyle(const RenderStyle& style, SVGPaintType paintType, const StyleColor& paintColor, SVGPaintType visitedLinkPaintType, const StyleColor& visitedLinkPaintColor)
@@ -180,8 +179,8 @@ private:
             return true;
         if (!renderer.parent())
             return false;
-        const auto& parentSVGStyle = renderer.parent()->style().svgStyle();
-        color = renderer.style().colorResolvingCurrentColor(op == Operation::Fill ? parentSVGStyle.fillPaintColor() : parentSVGStyle.strokePaintColor());
+        Ref parentSVGStyle = renderer.parent()->style().svgStyle();
+        color = renderer.style().colorResolvingCurrentColor(op == Operation::Fill ? parentSVGStyle->fillPaintColor() : parentSVGStyle->strokePaintColor());
         return true;
     }
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -388,14 +388,14 @@ inline FloatRect clipPathReferenceBox(const RenderElement& renderer, CSSBoxType 
 
 inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatPoint& point)
 {
-    PathOperation* clipPathOperation = renderer.style().clipPath();
-    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation)) {
+    RefPtr clipPathOperation = renderer.style().clipPath();
+    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         if (!referenceBox.contains(point))
             return false;
         return clipPath->pathForReferenceRect(referenceBox).contains(point, clipPath->windRule());
     }
-    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation)) {
+    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         if (!referenceBox.contains(point))
             return false;
@@ -407,8 +407,8 @@ inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatP
 
 void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, const RenderElement& renderer)
 {
-    PathOperation* clipPathOperation = renderer.style().clipPath();
-    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation)) {
+    RefPtr clipPathOperation = renderer.style().clipPath();
+    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
         auto localToParentTransform = renderer.localToParentTransform();
 
         auto referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
@@ -419,7 +419,7 @@ void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, co
 
         context.clipPath(path, clipPath->windRule());
     }
-    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation)) {
+    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         context.clipPath(clipPath->pathForReferenceRect(FloatRoundedRect { referenceBox }));
     }
@@ -431,7 +431,7 @@ bool SVGRenderSupport::pointInClippingArea(const RenderElement& renderer, const 
     RELEASE_ASSERT(!renderer.document().settings().layerBasedSVGEngineEnabled());
 #endif
 
-    PathOperation* clipPathOperation = renderer.style().clipPath();
+    RefPtr clipPathOperation = renderer.style().clipPath();
     if (is<ShapePathOperation>(clipPathOperation) || is<BoxPathOperation>(clipPathOperation))
         return isPointInCSSClippingArea(renderer, point);
 

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -124,8 +124,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
         }
     }
 
-    PathOperation* clipPathOperation = style.clipPath();
-    bool hasCSSClipping = is<ShapePathOperation>(clipPathOperation) || is<BoxPathOperation>(clipPathOperation);
+    bool hasCSSClipping = is<ShapePathOperation>(style.clipPath()) || is<BoxPathOperation>(style.clipPath());
     if (hasCSSClipping)
         SVGRenderSupport::clipContextToCSSClippingArea(m_paintInfo->context(), renderer);
 

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -162,7 +162,7 @@ static inline String targetReferenceFromResource(SVGElement& element)
     else
         ASSERT_NOT_REACHED();
 
-    return SVGURIReference::fragmentIdentifierFromIRIString(target, element.document());
+    return SVGURIReference::fragmentIdentifierFromIRIString(target, element.protectedDocument());
 }
 
 static inline bool isChainableResource(const SVGElement& element, const SVGElement& linkedResource)
@@ -205,12 +205,12 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
     if (!renderer.element())
         return nullptr;
 
-    auto& element = downcast<SVGElement>(*renderer.element());
+    Ref element = downcast<SVGElement>(*renderer.element());
 
-    auto& treeScope = element.treeScopeForSVGReferences();
-    Document& document = treeScope.documentScope();
+    CheckedRef treeScope = element->treeScopeForSVGReferences();
+    Ref document = treeScope->documentScope();
 
-    const AtomString& tagName = element.localName();
+    const AtomString& tagName = element->localName();
     if (tagName.isNull())
         return nullptr;
 
@@ -231,26 +231,25 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
             if (auto* clipper = getRenderSVGResourceById<LegacyRenderSVGResourceClipper>(treeScope, id))
                 ensureResources(foundResources).setClipper(clipper);
             else
-                treeScope.addPendingSVGResource(id, element);
+                treeScope->addPendingSVGResource(id, element);
         }
 
         if (style.hasFilter()) {
             const FilterOperations& filterOperations = style.filter();
             if (filterOperations.size() == 1) {
-                const FilterOperation& filterOperation = *filterOperations.at(0);
-                if (auto* referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(filterOperation)) {
-                    AtomString id = SVGURIReference::fragmentIdentifierFromIRIString(referenceFilterOperation->url(), element.document());
+                if (RefPtr referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(*filterOperations.at(0))) {
+                    AtomString id = SVGURIReference::fragmentIdentifierFromIRIString(referenceFilterOperation->url(), element->protectedDocument());
                     if (auto* filter = getRenderSVGResourceById<LegacyRenderSVGResourceFilter>(treeScope, id))
                         ensureResources(foundResources).setFilter(filter);
                     else
-                        treeScope.addPendingSVGResource(id, element);
+                        treeScope->addPendingSVGResource(id, element);
                 }
             }
         }
 
         if (style.hasPositionedMask()) {
             // FIXME: We should support all the values in the CSS mask property, but for now just use the first mask-image if it's a reference.
-            auto* maskImage = style.maskImage();
+            RefPtr maskImage = style.maskImage();
             auto reresolvedURL = maskImage ? maskImage->reresolvedURL(document) : URL();
 
             if (!reresolvedURL.isEmpty()) {
@@ -258,7 +257,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
                 if (auto* masker = getRenderSVGResourceById<LegacyRenderSVGResourceMasker>(treeScope, resourceID))
                     ensureResources(foundResources).setMasker(masker);
                 else
-                    treeScope.addPendingSVGResource(resourceID, element);
+                    treeScope->addPendingSVGResource(resourceID, element);
             }
         }
     }
@@ -269,7 +268,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
             if (auto* marker = getRenderSVGResourceById<LegacyRenderSVGResourceMarker>(treeScope, markerId))
                 (ensureResources(foundResources).*setMarker)(marker);
             else
-                treeScope.addPendingSVGResource(markerId, element);
+                treeScope->addPendingSVGResource(markerId, element);
         };
         buildCachedMarkerResource(svgStyle.markerStartResource(), &SVGResources::setMarkerStart);
         buildCachedMarkerResource(svgStyle.markerMidResource(), &SVGResources::setMarkerMid);
@@ -283,7 +282,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
             if (auto* fill = paintingResourceFromSVGPaint(treeScope, svgStyle.fillPaintType(), svgStyle.fillPaintUri(), id, hasPendingResource))
                 ensureResources(foundResources).setFill(fill);
             else if (hasPendingResource)
-                treeScope.addPendingSVGResource(id, element);
+                treeScope->addPendingSVGResource(id, element);
         }
 
         if (svgStyle.hasStroke()) {
@@ -292,7 +291,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
             if (auto* stroke = paintingResourceFromSVGPaint(treeScope, svgStyle.strokePaintType(), svgStyle.strokePaintUri(), id, hasPendingResource))
                 ensureResources(foundResources).setStroke(stroke);
             else if (hasPendingResource)
-                treeScope.addPendingSVGResource(id, element);
+                treeScope->addPendingSVGResource(id, element);
         }
     }
 
@@ -300,8 +299,8 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
         AtomString id(targetReferenceFromResource(element));
         auto* linkedResource = getRenderSVGResourceContainerById(document, id);
         if (!linkedResource)
-            treeScope.addPendingSVGResource(id, element);
-        else if (isChainableResource(element, linkedResource->element()))
+            treeScope->addPendingSVGResource(id, element);
+        else if (isChainableResource(element, linkedResource->protectedElement()))
             ensureResources(foundResources).setLinkedResource(linkedResource);
     }
 

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -179,13 +179,13 @@ void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, StyleDiffere
         if (oldStyle->appleColorFilter() != newStyle.appleColorFilter())
             return true;
 
-        auto& oldSVGStyle = oldStyle->svgStyle();
-        auto& newSVGStyle = newStyle.svgStyle();
+        Ref oldSVGStyle = oldStyle->svgStyle();
+        Ref newSVGStyle = newStyle.svgStyle();
 
-        if (oldSVGStyle.fillPaintUri() != newSVGStyle.fillPaintUri())
+        if (oldSVGStyle->fillPaintUri() != newSVGStyle->fillPaintUri())
             return true;
 
-        if (oldSVGStyle.strokePaintUri() != newSVGStyle.strokePaintUri())
+        if (oldSVGStyle->strokePaintUri() != newSVGStyle->strokePaintUri())
             return true;
 
         return false;

--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
@@ -138,7 +138,7 @@ void SVGRootInlineBox::layoutCharactersInTextBoxes(LegacyInlineFlowBox* start, S
             characterLayout.layoutInlineTextBox(*textBox);
         } else {
             // Skip generated content.
-            Node* node = child->renderer().node();
+            RefPtr node = child->renderer().node();
             if (!node)
                 continue;
 

--- a/Source/WebCore/rendering/svg/SVGTextChunk.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.cpp
@@ -57,8 +57,8 @@ SVGTextChunk::SVGTextChunk(const Vector<SVGInlineTextBox*>& lineLayoutBoxes, uns
         break;
     }
 
-    if (auto* textContentElement = SVGTextContentElement::elementFromRenderer(box->renderer().parent())) {
-        SVGLengthContext lengthContext(textContentElement);
+    if (RefPtr textContentElement = SVGTextContentElement::elementFromRenderer(box->renderer().parent())) {
+        SVGLengthContext lengthContext(textContentElement.get());
         m_desiredTextLength = textContentElement->specifiedTextLength().value(lengthContext);
 
         switch (textContentElement->lengthAdjust()) {

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -112,11 +112,11 @@ void SVGTextLayoutAttributesBuilder::collectTextPositioningElements(RenderBoxMod
         if (!inlineChild)
             continue;
 
-        auto* element = SVGTextPositioningElement::elementFromRenderer(*inlineChild);
+        RefPtr element = SVGTextPositioningElement::elementFromRenderer(*inlineChild);
 
         unsigned atPosition = m_textPositions.size();
         if (element)
-            m_textPositions.append(TextPosition(element, m_textLength));
+            m_textPositions.append(TextPosition(element.get(), m_textLength));
 
         collectTextPositioningElements(*inlineChild, lastCharacterWasSpace);
 
@@ -132,11 +132,11 @@ void SVGTextLayoutAttributesBuilder::collectTextPositioningElements(RenderBoxMod
 
 void SVGTextLayoutAttributesBuilder::buildCharacterDataMap(RenderSVGText& textRoot)
 {
-    SVGTextPositioningElement* outermostTextElement = SVGTextPositioningElement::elementFromRenderer(textRoot);
+    RefPtr outermostTextElement = SVGTextPositioningElement::elementFromRenderer(textRoot);
     ASSERT(outermostTextElement);
 
     // Grab outermost <text> element value lists and insert them in the character data map.
-    TextPosition wholeTextPosition(outermostTextElement, 0, m_textLength);
+    TextPosition wholeTextPosition(outermostTextElement.get(), 0, m_textLength);
     fillCharacterDataMap(wholeTextPosition);
 
     // Handle x/y default attributes.
@@ -193,7 +193,8 @@ void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& po
         return;
 
     float lastRotation = SVGTextLayoutAttributes::emptyValue();
-    SVGLengthContext lengthContext(position.element);
+    RefPtr positionElement = position.element;
+    SVGLengthContext lengthContext(positionElement.get());
     for (unsigned i = 0; i < position.length; ++i) {
         const SVGLengthList* xListPtr = i < xListSize ? &xList : nullptr;
         const SVGLengthList* yListPtr = i < yListSize ? &yList : nullptr;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -65,9 +65,7 @@ AlignmentBaseline SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseli
     ASSERT(textRenderer);
     ASSERT(textRenderer->parent());
 
-    const SVGRenderStyle& svgStyle = textRenderer->style().svgStyle();
-
-    DominantBaseline baseline = svgStyle.dominantBaseline();
+    DominantBaseline baseline = textRenderer->style().svgStyle().dominantBaseline();
     if (baseline == DominantBaseline::Auto) {
         if (isVerticalText)
             baseline = DominantBaseline::Central;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -212,7 +212,7 @@ bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, H
     for (RenderObject* child = lastChild(); child; child = child->previousSibling()) {
         if (child->nodeAtFloatPoint(request, result, localPoint, hitTestAction)) {
             updateHitTestResult(result, LayoutPoint(localPoint));
-            if (result.addNodeToListBasedTestResult(child->node(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(child->protectedNode().get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
                 return true;
         }
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -82,17 +82,18 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
 
 void LegacyRenderSVGEllipse::calculateRadiiAndCenter()
 {
-    SVGLengthContext lengthContext(&graphicsElement());
+    Ref graphicsElement = this->graphicsElement();
+    SVGLengthContext lengthContext(graphicsElement.ptr());
     m_center = FloatPoint(
         lengthContext.valueForLength(style().svgStyle().cx(), SVGLengthMode::Width),
         lengthContext.valueForLength(style().svgStyle().cy(), SVGLengthMode::Height));
-    if (is<SVGCircleElement>(graphicsElement())) {
+    if (is<SVGCircleElement>(graphicsElement)) {
         float radius = lengthContext.valueForLength(style().svgStyle().r());
         m_radii = FloatSize(radius, radius);
         return;
     }
 
-    ASSERT(is<SVGEllipseElement>(graphicsElement()));
+    ASSERT(is<SVGEllipseElement>(graphicsElement));
 
     Length rx = style().svgStyle().rx();
     Length ry = style().svgStyle().ry();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -137,9 +137,10 @@ void LegacyRenderSVGForeignObject::layout()
     FloatRect oldViewport = m_viewport;
 
     // Cache viewport boundaries
-    SVGLengthContext lengthContext(&foreignObjectElement());
-    FloatPoint viewportLocation(foreignObjectElement().x().value(lengthContext), foreignObjectElement().y().value(lengthContext));
-    m_viewport = FloatRect(viewportLocation, FloatSize(foreignObjectElement().width().value(lengthContext), foreignObjectElement().height().value(lengthContext)));
+    Ref foreignObjectElement = this->foreignObjectElement();
+    SVGLengthContext lengthContext(foreignObjectElement.ptr());
+    FloatPoint viewportLocation(foreignObjectElement->x().value(lengthContext), foreignObjectElement->y().value(lengthContext));
+    m_viewport = FloatRect(viewportLocation, FloatSize(foreignObjectElement->width().value(lengthContext), foreignObjectElement->height().value(lengthContext)));
     if (!updateCachedBoundariesInParents)
         updateCachedBoundariesInParents = oldViewport != m_viewport;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -82,7 +82,8 @@ FloatRect LegacyRenderSVGImage::calculateObjectBoundingBox() const
     if (CachedImage* cachedImage = imageResource().cachedImage())
         intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().effectiveZoom());
 
-    SVGLengthContext lengthContext(&imageElement());
+    Ref imageElement = this->imageElement();
+    SVGLengthContext lengthContext(imageElement.ptr());
 
     Length width = style().width();
     Length height = style().height();
@@ -103,7 +104,7 @@ FloatRect LegacyRenderSVGImage::calculateObjectBoundingBox() const
     else
         concreteHeight = intrinsicSize.height();
 
-    return { imageElement().x().value(lengthContext), imageElement().y().value(lengthContext), concreteWidth, concreteHeight };
+    return { imageElement->x().value(lengthContext), imageElement->y().value(lengthContext), concreteWidth, concreteHeight };
 }
 
 bool LegacyRenderSVGImage::updateImageViewport()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -147,7 +147,7 @@ static void getElementCTM(SVGElement* element, AffineTransform& transform)
 {
     ASSERT(element);
 
-    SVGElement* stopAtElement = SVGLocatable::nearestViewportElement(element);
+    RefPtr stopAtElement = SVGLocatable::nearestViewportElement(element);
     ASSERT(stopAtElement);
 
     AffineTransform localTransform;
@@ -157,7 +157,7 @@ static void getElementCTM(SVGElement* element, AffineTransform& transform)
         localTransform = currentElement->renderer()->localToParentTransform();
         transform = localTransform.multiply(transform);
         // For getCTM() computation, stop at the nearest viewport element
-        if (currentElement == stopAtElement)
+        if (currentElement == stopAtElement.get())
             break;
 
         current = current->parentOrShadowHostNode();
@@ -198,12 +198,12 @@ bool LegacyRenderSVGModelObject::checkIntersection(RenderElement* renderer, cons
     if (!isGraphicsElement(*renderer))
         return false;
     AffineTransform ctm;
-    SVGElement* svgElement = downcast<SVGElement>(renderer->element());
-    getElementCTM(svgElement, ctm);
+    RefPtr svgElement = downcast<SVGElement>(renderer->element());
+    getElementCTM(svgElement.get(), ctm);
     ASSERT(svgElement->renderer());
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return intersectsAllowingEmpty(rect, ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
+    return intersectsAllowingEmpty(rect, ctm.mapRect(svgElement->checkedRenderer()->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
 }
 
 bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
@@ -213,12 +213,17 @@ bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const F
     if (!isGraphicsElement(*renderer))
         return false;
     AffineTransform ctm;
-    SVGElement* svgElement = downcast<SVGElement>(renderer->element());
-    getElementCTM(svgElement, ctm);
+    RefPtr svgElement = downcast<SVGElement>(renderer->element());
+    getElementCTM(svgElement.get(), ctm);
     ASSERT(svgElement->renderer());
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return rect.contains(ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
+    return rect.contains(ctm.mapRect(svgElement->checkedRenderer()->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
+}
+
+Ref<SVGElement> LegacyRenderSVGModelObject::protectedElement() const
+{
+    return element();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -63,6 +63,7 @@ public:
     static bool checkEnclosure(RenderElement*, const FloatRect&);
 
     SVGElement& element() const { return downcast<SVGElement>(nodeForNonAnonymous()); }
+    Ref<SVGElement> protectedElement() const;
 
 protected:
     LegacyRenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -58,7 +58,8 @@ void LegacyRenderSVGRect::updateShapeFromElement()
     m_strokeBoundingBox = std::nullopt;
     m_approximateStrokeBoundingBox = std::nullopt;
 
-    SVGLengthContext lengthContext(&rectElement());
+    Ref rectElement = this->rectElement();
+    SVGLengthContext lengthContext(rectElement.ptr());
     FloatSize boundingBoxSize(lengthContext.valueForLength(style().width(), SVGLengthMode::Width), lengthContext.valueForLength(style().height(), SVGLengthMode::Height));
 
     // Spec: "A negative value is illegal. A value of zero disables rendering of the element."

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -49,8 +49,8 @@ static inline bool inheritColorFromParentStyleIfNeeded(RenderElement& object, bo
         return true;
     if (!object.parent())
         return false;
-    const SVGRenderStyle& parentSVGStyle = object.parent()->style().svgStyle();
-    color = object.style().colorResolvingCurrentColor(applyToFill ? parentSVGStyle.fillPaintColor() : parentSVGStyle.strokePaintColor());
+    Ref parentSVGStyle = object.parent()->style().svgStyle();
+    color = object.style().colorResolvingCurrentColor(applyToFill ? parentSVGStyle->fillPaintColor() : parentSVGStyle->strokePaintColor());
     return true;
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -208,10 +208,10 @@ bool LegacyRenderSVGResourceClipper::applyClippingToContext(GraphicsContext& con
             if (!clipper->applyClippingToContext(maskContext, *this, objectBoundingBox, clippedContentBounds))
                 return false;
 
-            succeeded = drawContentIntoMaskImage(*clipperData.imageBuffer, objectBoundingBox, effectiveZoom);
+            succeeded = drawContentIntoMaskImage(Ref { *clipperData.imageBuffer }, objectBoundingBox, effectiveZoom);
             // The context restore applies the clipping on non-CG platforms.
         } else
-            succeeded = drawContentIntoMaskImage(*clipperData.imageBuffer, objectBoundingBox, effectiveZoom);
+            succeeded = drawContentIntoMaskImage(Ref { *clipperData.imageBuffer }, objectBoundingBox, effectiveZoom);
 
         if (!succeeded)
             clipperData = { };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -135,11 +135,11 @@ void LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation()
     if (m_clientLayers.isEmptyIgnoringNullReferences())
         return;
 
-    auto& document = (*m_clientLayers.begin()).renderer().document();
-    if (!document.view() || document.renderTreeBeingDestroyed())
+    Ref document = (*m_clientLayers.begin()).renderer().document();
+    if (!document->view() || document->renderTreeBeingDestroyed())
         return;
 
-    auto inLayout = document.view()->layoutContext().isInLayout();
+    auto inLayout = document->view()->layoutContext().isInLayout();
     for (auto& clientLayer : m_clientLayers) {
         // FIXME: We should not get here while in layout. See webkit.org/b/208903.
         // Repaint should also be triggered through some other means.
@@ -238,7 +238,7 @@ AffineTransform LegacyRenderSVGResourceContainer::transformOnNonScalingStroke(Re
     if (!object->isRenderOrLegacyRenderSVGShape())
         return resourceTransform;
 
-    SVGGraphicsElement* element = downcast<SVGGraphicsElement>(object->node());
+    RefPtr element = downcast<SVGGraphicsElement>(object->node());
     AffineTransform transform = element->getScreenCTM(SVGLocatable::DisallowStyleUpdate);
     transform *= resourceTransform;
     return transform;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -150,7 +150,7 @@ bool LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
         return makeUnique<FilterResults>();
     });
 
-    filterData->targetSwitcher = FilterTargetSwitcher::create(*context, *filterData->filter, filterData->sourceImageRect, colorSpace, &results);
+    filterData->targetSwitcher = FilterTargetSwitcher::create(*context, Ref { *filterData->filter }, filterData->sourceImageRect, colorSpace, &results);
     if (!filterData->targetSwitcher) {
         m_rendererFilterDataMap.remove(renderer);
         return false;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
@@ -60,14 +60,14 @@ void LegacyRenderSVGResourceFilterPrimitive::styleDidChange(StyleDifference diff
     if (diff == StyleDifference::Equal || !oldStyle)
         return;
 
-    const SVGRenderStyle& newStyle = style().svgStyle();
+    Ref newStyle = style().svgStyle();
     if (is<SVGFEFloodElement>(filterPrimitiveElement()) || is<SVGFEDropShadowElement>(filterPrimitiveElement())) {
-        if (newStyle.floodColor() != oldStyle->svgStyle().floodColor())
+        if (newStyle->floodColor() != oldStyle->svgStyle().floodColor())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::flood_colorAttr);
-        if (newStyle.floodOpacity() != oldStyle->svgStyle().floodOpacity())
+        if (newStyle->floodOpacity() != oldStyle->svgStyle().floodOpacity())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::flood_opacityAttr);
     } else if (is<SVGFEDiffuseLightingElement>(filterPrimitiveElement()) || is<SVGFESpecularLightingElement>(filterPrimitiveElement())) {
-        if (newStyle.lightingColor() != oldStyle->svgStyle().lightingColor())
+        if (newStyle->lightingColor() != oldStyle->svgStyle().lightingColor())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::lighting_colorAttr);
     }
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -217,7 +217,7 @@ void LegacyRenderSVGResourceGradient::postApplyResource(RenderElement& renderer,
         if (m_savedContext) {
             auto gradientData = m_gradientMap.find(&renderer);
             if (gradientData != m_gradientMap.end()) {
-                auto& gradient = *gradientData->value->gradient;
+                Ref gradient = *gradientData->value->gradient;
 
                 // Restore on-screen drawing context
                 context = std::exchange(m_savedContext, nullptr);
@@ -225,7 +225,7 @@ void LegacyRenderSVGResourceGradient::postApplyResource(RenderElement& renderer,
                 FloatRect targetRect;
                 AffineTransform userspaceTransform = clipToTextMask(*context, m_imageBuffer, targetRect, renderer, gradientUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX, gradientTransform());
 
-                context->setFillGradient(gradient, userspaceTransform);
+                context->setFillGradient(WTFMove(gradient), userspaceTransform);
                 context->fillRect(targetRect);
 
                 m_imageBuffer = nullptr;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
@@ -90,8 +90,9 @@ const AffineTransform& LegacyRenderSVGResourceMarker::localToParentTransform() c
 
 FloatPoint LegacyRenderSVGResourceMarker::referencePoint() const
 {
-    SVGLengthContext lengthContext(&markerElement());
-    return FloatPoint(markerElement().refX().value(lengthContext), markerElement().refY().value(lengthContext));
+    Ref markerElement = this->markerElement();
+    SVGLengthContext lengthContext(markerElement.ptr());
+    return FloatPoint(markerElement->refX().value(lengthContext), markerElement->refY().value(lengthContext));
 }
 
 std::optional<float> LegacyRenderSVGResourceMarker::angle() const
@@ -147,9 +148,10 @@ void LegacyRenderSVGResourceMarker::calcViewport()
     if (!selfNeedsLayout())
         return;
 
-    SVGLengthContext lengthContext(&markerElement());
-    float w = markerElement().markerWidth().value(lengthContext);
-    float h = markerElement().markerHeight().value(lengthContext);
+    Ref markerElement = this->markerElement();
+    SVGLengthContext lengthContext(markerElement.ptr());
+    float w = markerElement->markerWidth().value(lengthContext);
+    float h = markerElement->markerHeight().value(lengthContext);
     m_viewport = FloatRect(0, 0, w, h);
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -81,8 +81,7 @@ bool LegacyRenderSVGResourceMasker::applyResource(RenderElement& renderer, const
         auto drawColorSpace = DestinationColorSpace::SRGB();
 
 #if ENABLE(DESTINATION_COLOR_SPACE_LINEAR_SRGB)
-        const SVGRenderStyle& svgStyle = style().svgStyle();
-        if (svgStyle.colorInterpolation() == ColorInterpolation::LinearRGB) {
+        if (style().svgStyle().colorInterpolation() == ColorInterpolation::LinearRGB) {
 #if USE(CG)
             maskColorSpace = DestinationColorSpace::LinearSRGB();
 #endif

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -44,6 +44,7 @@ class LegacyRenderSVGResourcePattern final : public LegacyRenderSVGResourceConta
 public:
     LegacyRenderSVGResourcePattern(SVGPatternElement&, RenderStyle&&);
     SVGPatternElement& patternElement() const;
+    Ref<SVGPatternElement> protectedPatternElement() const;
 
     void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp
@@ -39,27 +39,27 @@ LegacyRenderSVGResourceRadialGradient::~LegacyRenderSVGResourceRadialGradient() 
 bool LegacyRenderSVGResourceRadialGradient::collectGradientAttributes()
 {
     m_attributes = RadialGradientAttributes();
-    return radialGradientElement().collectGradientAttributes(m_attributes);
+    return protectedRadialGradientElement()->collectGradientAttributes(m_attributes);
 }
 
 FloatPoint LegacyRenderSVGResourceRadialGradient::centerPoint(const RadialGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolvePoint(&radialGradientElement(), attributes.gradientUnits(), attributes.cx(), attributes.cy());
+    return SVGLengthContext::resolvePoint(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.cx(), attributes.cy());
 }
 
 FloatPoint LegacyRenderSVGResourceRadialGradient::focalPoint(const RadialGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolvePoint(&radialGradientElement(), attributes.gradientUnits(), attributes.fx(), attributes.fy());
+    return SVGLengthContext::resolvePoint(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.fx(), attributes.fy());
 }
 
 float LegacyRenderSVGResourceRadialGradient::radius(const RadialGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolveLength(&radialGradientElement(), attributes.gradientUnits(), attributes.r());
+    return SVGLengthContext::resolveLength(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.r());
 }
 
 float LegacyRenderSVGResourceRadialGradient::focalRadius(const RadialGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolveLength(&radialGradientElement(), attributes.gradientUnits(), attributes.fr());
+    return SVGLengthContext::resolveLength(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.fr());
 }
 
 Ref<Gradient> LegacyRenderSVGResourceRadialGradient::buildGradient(const RenderStyle& style) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
@@ -34,6 +34,7 @@ public:
     virtual ~LegacyRenderSVGResourceRadialGradient();
 
     inline SVGRadialGradientElement& radialGradientElement() const;
+    inline Ref<SVGRadialGradientElement> protectedRadialGradientElement() const;
 
     FloatPoint centerPoint(const RadialGradientAttributes&) const;
     FloatPoint focalPoint(const RadialGradientAttributes&) const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -80,6 +80,11 @@ SVGSVGElement& LegacyRenderSVGRoot::svgSVGElement() const
     return downcast<SVGSVGElement>(nodeForNonAnonymous());
 }
 
+Ref<SVGSVGElement> LegacyRenderSVGRoot::protectedSVGSVGElement() const
+{
+    return svgSVGElement();
+}
+
 bool LegacyRenderSVGRoot::hasIntrinsicAspectRatio() const
 {
     return computeIntrinsicAspectRatio();
@@ -121,7 +126,7 @@ void LegacyRenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicS
 
 bool LegacyRenderSVGRoot::isEmbeddedThroughSVGImage() const
 {
-    return isInSVGImage(&svgSVGElement());
+    return isInSVGImage(protectedSVGSVGElement().ptr());
 }
 
 bool LegacyRenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument() const
@@ -490,7 +495,7 @@ bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResu
             // FIXME: nodeAtFloatPoint() doesn't handle rect-based hit tests yet.
             if (child->nodeAtFloatPoint(request, result, localPoint, hitTestAction)) {
                 updateHitTestResult(result, pointInBorderBox);
-                if (result.addNodeToListBasedTestResult(child->node(), request, locationInContainer) == HitTestProgress::Stop)
+                if (result.addNodeToListBasedTestResult(child->protectedNode().get(), request, locationInContainer) == HitTestProgress::Stop)
                     return true;
             }
         }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -40,6 +40,7 @@ public:
     virtual ~LegacyRenderSVGRoot();
 
     SVGSVGElement& svgSVGElement() const;
+    Ref<SVGSVGElement> protectedSVGSVGElement() const;
 
     bool isEmbeddedThroughSVGImage() const;
     bool isEmbeddedThroughFrameContainingSVGDocument() const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -196,7 +196,7 @@ bool LegacyRenderSVGShape::setupNonScalingStrokeContext(AffineTransform& strokeT
 
 AffineTransform LegacyRenderSVGShape::nonScalingStrokeTransform() const
 {
-    return graphicsElement().getScreenCTM(SVGLocatable::DisallowStyleUpdate);
+    return protectedGraphicsElement()->getScreenCTM(SVGLocatable::DisallowStyleUpdate);
 }
 
 void LegacyRenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& originalContext)
@@ -279,8 +279,8 @@ void LegacyRenderSVGShape::paint(PaintInfo& paintInfo, const LayoutPoint&)
         SVGRenderingContext renderingContext(*this, childPaintInfo);
 
         if (renderingContext.isRenderingPrepared()) {
-            const SVGRenderStyle& svgStyle = style().svgStyle();
-            if (svgStyle.shapeRendering() == ShapeRendering::CrispEdges)
+            Ref svgStyle = style().svgStyle();
+            if (svgStyle->shapeRendering() == ShapeRendering::CrispEdges)
                 childPaintInfo.context().setShouldAntialias(false);
 
             fillStrokeMarkers(childPaintInfo);
@@ -439,7 +439,8 @@ FloatRect LegacyRenderSVGShape::repaintRectInLocalCoordinates(RepaintRectCalcula
 
 float LegacyRenderSVGShape::strokeWidth() const
 {
-    SVGLengthContext lengthContext(&graphicsElement());
+    Ref graphicsElement = this->graphicsElement();
+    SVGLengthContext lengthContext(graphicsElement.ptr());
     return lengthContext.valueForLength(style().strokeWidth());
 }
 
@@ -452,7 +453,7 @@ Path& LegacyRenderSVGShape::ensurePath()
 
 std::unique_ptr<Path> LegacyRenderSVGShape::createPath() const
 {
-    return makeUnique<Path>(pathFromGraphicsElement(graphicsElement()));
+    return makeUnique<Path>(pathFromGraphicsElement(protectedGraphicsElement()));
 }
 
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -44,19 +44,19 @@ LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer(SVG
 
 bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()
 {
-    SVGGraphicsElement& element = graphicsElement();
+    Ref element = graphicsElement();
 
     // If we're either the renderer for a <use> element, or for any <g> element inside the shadow
     // tree, that was created during the use/symbol/svg expansion in SVGUseElement. These containers
     // need to respect the translations induced by their corresponding use elements x/y attributes.
-    auto* useElement = dynamicDowncast<SVGUseElement>(element);
-    if (!useElement && element.isInShadowTree() && is<SVGGElement>(element)) {
-        if (auto* correspondingElement = dynamicDowncast<SVGUseElement>(element.correspondingElement()))
+    auto* useElement = dynamicDowncast<SVGUseElement>(element.get());
+    if (!useElement && element->isInShadowTree() && is<SVGGElement>(element)) {
+        if (auto* correspondingElement = dynamicDowncast<SVGUseElement>(element->correspondingElement()))
             useElement = correspondingElement;
     }
 
     if (useElement) {
-        SVGLengthContext lengthContext(&element);
+        SVGLengthContext lengthContext(element.ptr());
         FloatSize translation(useElement->x().value(lengthContext), useElement->y().value(lengthContext));
         if (translation != m_lastTranslation)
             m_needsTransformUpdate = true;
@@ -73,7 +73,7 @@ bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()
     if (!m_needsTransformUpdate)
         return false;
 
-    m_localTransform = element.animatedLocalTransform();
+    m_localTransform = element->animatedLocalTransform();
     m_localTransform.translate(m_lastTranslation);
     m_needsTransformUpdate = false;
     return true;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
@@ -60,9 +60,9 @@ void LegacyRenderSVGViewportContainer::applyViewportClip(PaintInfo& paintInfo)
 
 void LegacyRenderSVGViewportContainer::calcViewport()
 {
-    SVGSVGElement& element = svgSVGElement();
-    SVGLengthContext lengthContext(&element);
-    FloatRect newViewport(element.x().value(lengthContext), element.y().value(lengthContext), element.width().value(lengthContext), element.height().value(lengthContext));
+    Ref element = svgSVGElement();
+    SVGLengthContext lengthContext(element.ptr());
+    FloatRect newViewport(element->x().value(lengthContext), element->y().value(lengthContext), element->width().value(lengthContext), element->height().value(lengthContext));
 
     if (m_viewport == newViewport)
         return;

--- a/Source/WebCore/svg/SVGAnimateElementBase.cpp
+++ b/Source/WebCore/svg/SVGAnimateElementBase.cpp
@@ -68,7 +68,7 @@ bool SVGAnimateElementBase::hasInvalidCSSAttributeType() const
         return false;
 
     if (!m_hasInvalidCSSAttributeType)
-        m_hasInvalidCSSAttributeType = hasValidAttributeName() && attributeType() == AttributeType::CSS && !isTargetAttributeCSSProperty(targetElement(), attributeName());
+        m_hasInvalidCSSAttributeType = hasValidAttributeName() && attributeType() == AttributeType::CSS && !isTargetAttributeCSSProperty(protectedTargetElement().get(), attributeName());
 
     return m_hasInvalidCSSAttributeType.value();
 }
@@ -78,7 +78,7 @@ bool SVGAnimateElementBase::isDiscreteAnimator() const
     if (!hasValidAttributeType())
         return false;
 
-    auto* animator = this->animator();
+    RefPtr animator = this->animator();
     return animator && animator->isDiscrete();
 }
 
@@ -177,7 +177,7 @@ void SVGAnimateElementBase::applyResultsToTarget()
         return;
 
     if (RefPtr animator = this->animator())
-        animator->apply(*targetElement());
+        animator->apply(*protectedTargetElement());
 }
 
 void SVGAnimateElementBase::stopAnimation(SVGElement* targetElement)
@@ -196,7 +196,7 @@ std::optional<float> SVGAnimateElementBase::calculateDistance(const String& from
         return { };
 
     if (RefPtr animator = this->animator())
-        return animator->calculateDistance(*targetElement(), fromString, toString);
+        return animator->calculateDistance(*protectedTargetElement(), fromString, toString);
 
     return { };
 }

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -204,6 +204,7 @@ void SVGElement::removedFromAncestor(RemovalType removalType, ContainerNode& old
 
 SVGSVGElement* SVGElement::ownerSVGElement() const
 {
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_LOCAL_VARS_BEGIN
     auto* node = parentNode();
     while (node) {
         if (auto* svg = dynamicDowncast<SVGSVGElement>(*node))
@@ -213,6 +214,7 @@ SVGSVGElement* SVGElement::ownerSVGElement() const
     }
 
     return nullptr;
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_LOCAL_VARS_END
 }
 
 SVGElement* SVGElement::viewportElement() const
@@ -303,12 +305,14 @@ SVGElement* SVGElement::correspondingElement() const
 
 RefPtr<SVGUseElement> SVGElement::correspondingUseElement() const
 {
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_LOCAL_VARS_BEGIN
     auto* root = containingShadowRoot();
     if (!root)
         return nullptr;
     if (root->mode() != ShadowRootMode::UserAgent)
         return nullptr;
     return dynamicDowncast<SVGUseElement>(root->host());
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_LOCAL_VARS_END
 }
 
 void SVGElement::setCorrespondingElement(SVGElement* correspondingElement)

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -84,16 +84,16 @@ void SVGFontFaceElement::attributeChanged(const QualifiedName& name, const AtomS
     if (propertyId > 0) {
         // FIXME: Parse using the @font-face descriptor grammars, not the property grammars.
         Ref fontFaceRule = m_fontFaceRule;
-        auto& properties = fontFaceRule->mutableProperties();
-        bool valueChanged = properties.setProperty(propertyId, newValue);
+        Ref properties = fontFaceRule->mutableProperties();
+        bool valueChanged = properties->setProperty(propertyId, newValue);
 
         if (valueChanged) {
             // The above parser is designed for the font-face properties, not descriptors, and the properties accept the global keywords, but descriptors don't.
             // Rather than invasively modifying the parser for the properties to have a special mode, we can simply detect the error condition after-the-fact and
             // avoid it explicitly.
-            if (auto parsedValue = properties.propertyAsValueID(propertyId)) {
+            if (auto parsedValue = properties->propertyAsValueID(propertyId)) {
                 if (isCSSWideKeyword(*parsedValue))
-                    properties.removeProperty(propertyId);
+                    properties->removeProperty(propertyId);
             }
         }
 
@@ -279,7 +279,7 @@ void SVGFontFaceElement::rebuildFontFace()
     }
 
     // we currently ignore all but the first src element, alternatively we could concat them
-    auto srcElement = childrenOfType<SVGFontFaceSrcElement>(*this).first();
+    RefPtr srcElement = childrenOfType<SVGFontFaceSrcElement>(*this).first();
 
     m_fontElement = dynamicDowncast<SVGFontElement>(*parentNode());
     bool describesParentFont = !!m_fontElement;

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -107,10 +107,10 @@ void SVGFontFaceUriElement::loadFont()
         ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
         options.contentSecurityPolicyImposition = isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
-        CachedResourceLoader& cachedResourceLoader = document().cachedResourceLoader();
+        Ref cachedResourceLoader = document().cachedResourceLoader();
         CachedResourceRequest request(ResourceRequest(document().completeURL(href)), options);
         request.setInitiator(*this);
-        m_cachedFont = cachedResourceLoader.requestFont(WTFMove(request), isSVGFontTarget(*this)).value_or(nullptr);
+        m_cachedFont = cachedResourceLoader->requestFont(WTFMove(request), isSVGFontTarget(*this)).value_or(nullptr);
         if (CachedResourceHandle cachedFont = m_cachedFont) {
             cachedFont->addClient(*this);
             cachedFont->beginLoadIfNeeded(cachedResourceLoader);

--- a/Source/WebCore/svg/SVGLength.cpp
+++ b/Source/WebCore/svg/SVGLength.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,45 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "SVGLength.h"
 
-#include "LegacyRenderSVGResourceRadialGradient.h"
-#include "SVGElementTypeHelpers.h"
-#include "SVGRadialGradientElement.h"
+#include "SVGElement.h"
 
 namespace WebCore {
 
-inline SVGRadialGradientElement& LegacyRenderSVGResourceRadialGradient::radialGradientElement() const
+ExceptionOr<float> SVGLength::valueForBindings()
 {
-    return downcast<SVGRadialGradientElement>(LegacyRenderSVGResourceGradient::gradientElement());
+    return m_value.valueForBindings(SVGLengthContext { RefPtr { contextElement() }.get() });
 }
 
-inline Ref<SVGRadialGradientElement> LegacyRenderSVGResourceRadialGradient::protectedRadialGradientElement() const
+ExceptionOr<void> SVGLength::setValueForBindings(float value)
 {
-    return radialGradientElement();
+    if (isReadOnly())
+        return Exception { ExceptionCode::NoModificationAllowedError };
+
+    auto result = m_value.setValue(SVGLengthContext { RefPtr { contextElement() }.get() }, value);
+    if (result.hasException())
+        return result;
+
+    commitChange();
+    return result;
+}
+
+ExceptionOr<void> SVGLength::convertToSpecifiedUnits(unsigned short unitType)
+{
+    if (isReadOnly())
+        return Exception { ExceptionCode::NoModificationAllowedError };
+
+    if (unitType == SVG_LENGTHTYPE_UNKNOWN || unitType > SVG_LENGTHTYPE_PC)
+        return Exception { ExceptionCode::NotSupportedError };
+
+    auto result = m_value.convertToSpecifiedUnits(SVGLengthContext { RefPtr { contextElement() }.get() }, static_cast<SVGLengthType>(unitType));
+    if (result.hasException())
+        return result;
+
+    commitChange();
+    return result;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGLength.h
+++ b/Source/WebCore/svg/SVGLength.h
@@ -84,23 +84,9 @@ public:
         return static_cast<unsigned>(m_value.lengthType());
     }
 
-    ExceptionOr<float> valueForBindings()
-    {
-        return m_value.valueForBindings(SVGLengthContext { contextElement() });
-    }
+    ExceptionOr<float> valueForBindings();
 
-    ExceptionOr<void> setValueForBindings(float value)
-    {
-        if (isReadOnly())
-            return Exception { ExceptionCode::NoModificationAllowedError };
-
-        auto result = m_value.setValue(SVGLengthContext { contextElement() }, value);
-        if (result.hasException())
-            return result;
-        
-        commitChange();
-        return result;
-    }
+    ExceptionOr<void> setValueForBindings(float);
     
     float valueInSpecifiedUnits()
     {
@@ -143,21 +129,7 @@ public:
         return { };
     }
     
-    ExceptionOr<void> convertToSpecifiedUnits(unsigned short unitType)
-    {
-        if (isReadOnly())
-            return Exception { ExceptionCode::NoModificationAllowedError };
-
-        if (unitType == SVG_LENGTHTYPE_UNKNOWN || unitType > SVG_LENGTHTYPE_PC)
-            return Exception { ExceptionCode::NotSupportedError };
-
-        auto result = m_value.convertToSpecifiedUnits(SVGLengthContext { contextElement() }, static_cast<SVGLengthType>(unitType));
-        if (result.hasException())
-            return result;
-
-        commitChange();
-        return result;
-    }
+    ExceptionOr<void> convertToSpecifiedUnits(unsigned short unitType);
     
     String valueAsString() const override
     {

--- a/Source/WebCore/svg/SVGLocatable.cpp
+++ b/Source/WebCore/svg/SVGLocatable.cpp
@@ -61,6 +61,7 @@ SVGElement* SVGLocatable::nearestViewportElement(const SVGElement* element)
 
 SVGElement* SVGLocatable::farthestViewportElement(const SVGElement* element)
 {
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_LOCAL_VARS_BEGIN
     ASSERT(element);
     SVGElement* farthest = nullptr;
     for (Element* current = element->parentOrShadowHostElement(); current; current = current->parentOrShadowHostElement()) {
@@ -69,6 +70,7 @@ SVGElement* SVGLocatable::farthestViewportElement(const SVGElement* element)
             farthest = svgElement;
     }
     return farthest;
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_LOCAL_VARS_END
 }
 
 FloatRect SVGLocatable::getBBox(SVGElement* element, StyleUpdateStrategy styleUpdateStrategy)

--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -90,10 +90,10 @@ Color SVGStopElement::stopColorIncludingOpacity() const
         return Color::transparentBlack;
 
     auto& style = renderer()->style();
-    auto& svgStyle = style.svgStyle();
-    auto stopColor = style.colorResolvingCurrentColor(svgStyle.stopColor());
+    Ref svgStyle = style.svgStyle();
+    auto stopColor = style.colorResolvingCurrentColor(svgStyle->stopColor());
 
-    return stopColor.colorWithAlphaMultipliedBy(svgStyle.stopOpacity());
+    return stopColor.colorWithAlphaMultipliedBy(svgStyle->stopOpacity());
 }
 
 }

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -1403,8 +1403,8 @@ SVGToOTFFontConverter::SVGToOTFFontConverter(const SVGFontElement& fontElement)
     populateEmptyGlyphCharString(m_emptyGlyphCharString, s_outputUnitsPerEm);
 
     std::optional<FloatRect> boundingBox;
-    if (m_missingGlyphElement)
-        processGlyphElement(*m_missingGlyphElement, nullptr, defaultHorizontalAdvance, defaultVerticalAdvance, String(), boundingBox);
+    if (RefPtr missingGlyphElement = m_missingGlyphElement.get())
+        processGlyphElement(*missingGlyphElement, nullptr, defaultHorizontalAdvance, defaultVerticalAdvance, String(), boundingBox);
     else {
         m_glyphs.append(GlyphData(Vector<char>(m_emptyGlyphCharString), nullptr, s_outputUnitsPerEm, s_outputUnitsPerEm, FloatRect(), String()));
         boundingBox = FloatRect(0, 0, s_outputUnitsPerEm, s_outputUnitsPerEm);

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -91,8 +91,8 @@ auto SVGURIReference::targetElementFromIRIString(const String& iri, const TreeSc
     if (id.isEmpty())
         return { };
 
-    auto& document = treeScope.documentScope();
-    auto url = document.completeURL(iri);
+    Ref document = treeScope.documentScope();
+    auto url = document->completeURL(iri);
     if (externalDocument) {
         // Enforce that the referenced url matches the url of the document that we've loaded for it!
         ASSERT(equalIgnoringFragmentIdentifier(url, externalDocument->url()));

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -422,7 +422,7 @@ static void associateClonesWithOriginals(SVGElement& clone, SVGElement& original
     // doing transformations like removing disallowed elements or expanding elements.
     clone.setCorrespondingElement(&original);
     for (auto pair : descendantsOfType<SVGElement>(clone, original))
-        pair.first.setCorrespondingElement(&pair.second);
+        pair.first.setCorrespondingElement(Ref { pair.second }.ptr());
 }
 
 static void associateReplacementCloneWithOriginal(SVGElement& replacementClone, SVGElement& originalClone)
@@ -443,7 +443,7 @@ static void associateReplacementClonesWithOriginals(SVGElement& replacementClone
     // doing transformations like removing disallowed elements or expanding elements.
     associateReplacementCloneWithOriginal(replacementClone, originalClone);
     for (auto pair : descendantsOfType<SVGElement>(replacementClone, originalClone))
-        associateReplacementCloneWithOriginal(pair.first, pair.second);
+        associateReplacementCloneWithOriginal(Ref { pair.first }, Ref { pair.second });
 }
 
 RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
@@ -458,7 +458,7 @@ RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
         // The caller would use the target ID to wait for a pending resource on the wrong document.
         // If we ever want the change that and let the caller to wait on the external document,
         // we should change this function so it returns the appropriate document to go with the ID.
-        if (!targetID->isNull() && isExternalURIReference(original->href(), original->document()))
+        if (!targetID->isNull() && isExternalURIReference(original->href(), original->protectedDocument()))
             *targetID = nullAtom();
     }
     RefPtr target = dynamicDowncast<SVGElement>(targetResult.element.get());
@@ -485,7 +485,7 @@ RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
 
 void SVGUseElement::cloneTarget(ContainerNode& container, SVGElement& target) const
 {
-    Ref targetClone = static_cast<SVGElement&>(target.cloneElementWithChildren(document()).get());
+    Ref targetClone = static_cast<SVGElement&>(target.cloneElementWithChildren(protectedDocument()).get());
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { targetClone };
     associateClonesWithOriginals(targetClone.get(), target);
     removeDisallowedElementsFromSubtree(targetClone.get());
@@ -518,7 +518,7 @@ void SVGUseElement::expandUseElementsInShadowTree() const
         // Spec: In the generated content, the 'use' will be replaced by 'g', where all attributes from the
         // 'use' element except for x, y, width, height and xlink:href are transferred to the generated 'g' element.
 
-        Ref replacementClone = SVGGElement::create(document());
+        Ref replacementClone = SVGGElement::create(protectedDocument());
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { replacementClone };
 
         cloneDataAndChildren(replacementClone.get(), originalClone);
@@ -554,7 +554,7 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
         // the generated 'svg'. If attributes width and/or height are not specified, the generated
         // 'svg' element will use values of 100% for these attributes.
 
-        Ref replacementClone = SVGSVGElement::create(document());
+        Ref replacementClone = SVGSVGElement::create(protectedDocument());
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { replacementClone };
 
         cloneDataAndChildren(replacementClone.get(), originalClone);

--- a/Source/WebCore/svg/SVGVisitedElementTracking.h
+++ b/Source/WebCore/svg/SVGVisitedElementTracking.h
@@ -50,8 +50,8 @@ public:
 
         ~Scope()
         {
-            if (m_element)
-                m_tracking.removeUnique(*m_element);
+            if (RefPtr element = m_element.get())
+                m_tracking.removeUnique(*element);
         }
 
     private:

--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -83,7 +83,7 @@ void SMILTimeContainer::notifyIntervalsChanged()
 
 Seconds SMILTimeContainer::animationFrameDelay() const
 {
-    auto* page = m_ownerSVGElement->document().page();
+    RefPtr page = m_ownerSVGElement->document().page();
     if (!page)
         return SMILAnimationFrameDelay;
     return page->isLowPowerModeEnabled() ? SMILAnimationFrameThrottledDelay : SMILAnimationFrameDelay;
@@ -217,7 +217,7 @@ void SMILTimeContainer::updateDocumentOrderIndexes()
 {
     unsigned timingElementCount = 0;
 
-    for (Ref smilElement : descendantsOfType<SVGSMILElement>(m_ownerSVGElement))
+    for (Ref smilElement : descendantsOfType<SVGSMILElement>(Ref { m_ownerSVGElement.get() }))
         smilElement->setDocumentOrderIndex(timingElementCount++);
 
     m_documentOrderIndexesDirty = false;

--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -76,8 +76,10 @@ RefPtr<SVGImage> SVGImageCache::protectedSVGImage() const
 
 FloatSize SVGImageCache::imageSizeForRenderer(const RenderObject* renderer) const
 {
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_LOCAL_VARS_BEGIN
     auto* image = findImageForRenderer(renderer);
     return image ? image->size() : m_svgImage->size();
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_LOCAL_VARS_END
 }
 
 // FIXME: This doesn't take into account the animation timeline so animations will not


### PR DESCRIPTION
#### 52b690b4dd98356471234e39d40ac00461af71c0
<pre>
Adopt more smart pointers in SVG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=269408">https://bugs.webkit.org/show_bug.cgi?id=269408</a>

Reviewed by Brent Fulgham.

Adopt more smart pointers in SVG code, as reported by the static analyzer.

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::fontSelector const):
(WebCore::Document::protectedFontSelector const):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::protectedImageElement const):
(WebCore::RenderSVGImage::calculateObjectBoundingBox const):
(WebCore::RenderSVGImage::imageChanged):
(WebCore::RenderSVGImage::needsHasSVGTransformFlags const):
(WebCore::RenderSVGImage::applyTransform const):
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::computeNewScaledFontForStyle):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::checkIntersection):
(WebCore::RenderSVGModelObject::checkEnclosure):
(WebCore::RenderSVGModelObject::computeClipPath const):
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::updateShapeFromElement):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyMaskClipping):
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
(WebCore::RenderSVGResourceGradient::prepareFillOperation):
(WebCore::RenderSVGResourceGradient::prepareStrokeOperation):
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp:
(WebCore::RenderSVGResourceLinearGradient::collectGradientAttributesIfNeeded):
(WebCore::RenderSVGResourceLinearGradient::createGradient):
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h:
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradientInlines.h:
(WebCore::RenderSVGResourceLinearGradient::protectedLinearGradientElement const):
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
(WebCore::RenderSVGResourceMarker::computeViewport const):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::applyMask):
(WebCore::RenderSVGResourceMasker::resourceBoundingBox):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::collectPatternAttributesIfNeeded):
(WebCore::RenderSVGResourcePattern::buildPattern):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/RenderSVGResourcePatternInlines.h:
(WebCore::RenderSVGResourcePattern::protectedPatternElement const):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::nonScalingStrokeTransform const):
(WebCore::RenderSVGShape::strokeWidth const):
(WebCore::RenderSVGShape::createPath const):
(WebCore::RenderSVGShape::needsHasSVGTransformFlags const):
(WebCore::RenderSVGShape::applyTransform const):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::protectedTextElement const):
(WebCore::RenderSVGText::applyTransform const):
(WebCore::RenderSVGText::strokeBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
(WebCore::associatedUseElement):
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::paint):
(WebCore::SVGInlineTextBox::paintDecoration):
(WebCore::SVGInlineTextBox::paintTextWithShadows):
* Source/WebCore/rendering/svg/SVGPaintServerHandling.h:
(WebCore::SVGPaintServerHandling::prepareFillOperation const):
(WebCore::SVGPaintServerHandling::prepareStrokeOperation const):
(WebCore::SVGPaintServerHandling::resolveColorFromStyle):
(WebCore::SVGPaintServerHandling::inheritColorFromParentStyleIfNeeded):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::isPointInCSSClippingArea):
(WebCore::SVGRenderSupport::clipContextToCSSClippingArea):
(WebCore::SVGRenderSupport::pointInClippingArea):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGStrokePaintingResource):
(WebCore::writeSVGPaintingFeatures):
(WebCore::operator&lt;&lt;):
(WebCore::writeSVGInlineTextBox):
(WebCore::writeSVGResourceContainer):
(WebCore::writeResources):
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::targetReferenceFromResource):
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::clientStyleChanged):
* Source/WebCore/rendering/svg/SVGRootInlineBox.cpp:
(WebCore::SVGRootInlineBox::layoutCharactersInTextBoxes):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::SVGTextLayoutAttributesBuilder::collectTextPositioningElements):
(WebCore::SVGTextLayoutAttributesBuilder::buildCharacterDataMap):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::parentDefinesTextLength const):
(WebCore::SVGTextLayoutEngine::beginTextPathLayout):
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseline const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::getElementCTM):
(WebCore::LegacyRenderSVGModelObject::checkIntersection):
(WebCore::LegacyRenderSVGModelObject::checkEnclosure):
(WebCore::LegacyRenderSVGModelObject::protectedElement const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::inheritColorFromParentStyleIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::applyClippingToContext):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation):
(WebCore::LegacyRenderSVGResourceContainer::transformOnNonScalingStroke):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp:
(WebCore::LegacyRenderSVGResourceFilterPrimitive::styleDidChange):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::postApplyResource):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::LegacyRenderSVGResourceMasker::applyResource):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::protectedPatternElement const):
(WebCore::LegacyRenderSVGResourcePattern::collectPatternAttributes const):
(WebCore::LegacyRenderSVGResourcePattern::buildPattern):
(WebCore::LegacyRenderSVGResourcePattern::applyResource):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp:
(WebCore::LegacyRenderSVGResourceRadialGradient::collectGradientAttributes):
(WebCore::LegacyRenderSVGResourceRadialGradient::centerPoint const):
(WebCore::LegacyRenderSVGResourceRadialGradient::focalPoint const):
(WebCore::LegacyRenderSVGResourceRadialGradient::radius const):
(WebCore::LegacyRenderSVGResourceRadialGradient::focalRadius const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradientInlines.h:
(WebCore::LegacyRenderSVGResourceRadialGradient::protectedRadialGradientElement const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::protectedSVGSVGElement const):
(WebCore::LegacyRenderSVGRoot::isEmbeddedThroughSVGImage const):
(WebCore::LegacyRenderSVGRoot::nodeAtPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::nonScalingStrokeTransform const):
(WebCore::LegacyRenderSVGShape::paint):
(WebCore::LegacyRenderSVGShape::strokeWidth const):
(WebCore::LegacyRenderSVGShape::createPath const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::calculateLocalTransform):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp:
(WebCore::LegacyRenderSVGViewportContainer::calcViewport):
* Source/WebCore/svg/SVGAnimateElementBase.cpp:
(WebCore::SVGAnimateElementBase::hasInvalidCSSAttributeType const):
(WebCore::SVGAnimateElementBase::isDiscreteAnimator const):
(WebCore::SVGAnimateElementBase::applyResultsToTarget):
(WebCore::SVGAnimateElementBase::calculateDistance):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::ownerSVGElement const):
(WebCore::SVGElement::correspondingUseElement const):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::attributeChanged):
(WebCore::SVGFontFaceElement::rebuildFontFace):
* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
(WebCore::SVGFontFaceUriElement::loadFont):
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::SVGLocatable::farthestViewportElement):
* Source/WebCore/svg/SVGStopElement.cpp:
(WebCore::SVGStopElement::stopColorIncludingOpacity const):
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::SVGToOTFFontConverter):
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::targetElementFromIRIString):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::associateClonesWithOriginals):
(WebCore::associateReplacementClonesWithOriginals):
(WebCore::SVGUseElement::findTarget const):
(WebCore::SVGUseElement::cloneTarget const):
(WebCore::SVGUseElement::expandUseElementsInShadowTree const):
(WebCore::SVGUseElement::expandSymbolElementsInShadowTree const):
* Source/WebCore/svg/SVGVisitedElementTracking.h:
(WebCore::SVGVisitedElementTracking::Scope::~Scope):
* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::animationFrameDelay const):
(WebCore::SMILTimeContainer::updateDocumentOrderIndexes):
* Source/WebCore/svg/graphics/SVGImageCache.cpp:
(WebCore::SVGImageCache::imageSizeForRenderer const):

Canonical link: <a href="https://commits.webkit.org/274780@main">https://commits.webkit.org/274780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b49573fb72bbe56296d50480f8f476598a4a2c36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42493 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35850 "Failed to checkout and rebase branch from PR 24460") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16289 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13831 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43771 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33401 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36266 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39587 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39574 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12143 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34768 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46582 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16431 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9584 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5279 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->