### PR TITLE
Canvas draw text caching experiment

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2576,6 +2576,7 @@ rendering/BorderEdge.cpp
 rendering/BorderPainter.cpp
 rendering/BreakLines.cpp
 rendering/CSSFilter.cpp
+rendering/CanvasGlyphDisplayListCache.cpp
 rendering/CaretRectComputation.cpp
 rendering/ClipRect.cpp
 rendering/ContentfulPaintChecker.cpp

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -248,6 +248,7 @@ public:
         const FontCascadeDescription& fontDescription() const;
         float width(const TextRun&, GlyphOverflow* = 0) const;
         void drawBidiText(GraphicsContext&, const TextRun&, const FloatPoint&, FontCascade::CustomFontNotReadyAction) const;
+        const FontCascade& fontCascade() const { return m_font; }
 
 #if ASSERT_ENABLED
         bool isPopulated() const { return m_font.fonts(); }
@@ -345,6 +346,7 @@ protected:
     void drawText(const String& text, double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
     bool canDrawText(double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
     void drawTextUnchecked(const TextRun&, double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
+    void drawBidiText(GraphicsContext&, const TextRun&, const FloatPoint&);
 
     Ref<TextMetrics> measureTextInternal(const TextRun&);
     Ref<TextMetrics> measureTextInternal(const String& text);
@@ -461,6 +463,7 @@ private:
     mutable std::variant<CachedContentsTransparent, CachedContentsUnknown, CachedContentsImageData> m_cachedContents;
     CanvasRenderingContext2DSettings m_settings;
     bool m_hasDeferredOperations { false };
+    DisplayList::DisplayList* m_glyphDisplayList { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -234,6 +234,12 @@ std::unique_ptr<DisplayList::DisplayList> FontCascade::displayListForTextRun(Gra
 
     if (glyphBuffer.isEmpty())
         return nullptr;
+#if PLATFORM(COCOA)
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=252347
+    // DisplayLists don't handle OTSVG glyphs correctly. From LayoutTests it seems to affect only Cocoa (rdar://105515478).
+    if (hasOTSVGGlyph(glyphBuffer))
+        return nullptr;
+#endif
 
     std::unique_ptr<DisplayList::DisplayList> displayList = makeUnique<DisplayList::DisplayList>();
     DisplayList::RecorderImpl recordingContext(*displayList, context.state().clone(GraphicsContextState::Purpose::Initial), { },

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -216,6 +216,8 @@ public:
     static CodePath characterRangeCodePath(const LChar*, unsigned) { return CodePath::Simple; }
     static CodePath characterRangeCodePath(const UChar*, unsigned len);
 
+    bool hasOTSVGGlyph(const GlyphBuffer&) const;
+
     bool primaryFontIsSystemFont() const;
 
     static float syntheticObliqueAngle() { return 14; }

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -514,4 +514,13 @@ ResolvedEmojiPolicy FontCascade::resolveEmojiPolicy(FontVariantEmoji fontVariant
     }
 }
 
+bool FontCascade::hasOTSVGGlyph(const GlyphBuffer& glyphBuffer) const
+{
+    for (unsigned i = 0; i < glyphBuffer.size(); ++i) {
+        if (glyphBuffer.fontAt(i).findOTSVGGlyphs(glyphBuffer.glyphs(i), 1))
+            return true;
+    }
+    return false;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/CanvasGlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/CanvasGlyphDisplayListCache.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CanvasGlyphDisplayListCache.h"
+
+#include "DisplayListItems.h"
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+CanvasGlyphDisplayListCache& CanvasGlyphDisplayListCache::singleton()
+{
+    static NeverDestroyed<CanvasGlyphDisplayListCache> cache;
+    return cache;
+}
+
+void CanvasGlyphDisplayListCache::clear()
+{
+    m_entries.clear();
+}
+
+unsigned CanvasGlyphDisplayListCache::size() const
+{
+    return m_entries.size();
+}
+
+DisplayList::DisplayList* CanvasGlyphDisplayListCache::getDisplayList(const FontCascade& font, GraphicsContext& context, const TextRun& textRun)
+{
+    if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
+        if (!m_entries.isEmpty()) {
+            LOG(MemoryPressure, "CanvasGlyphDisplayListCache::%s - Under memory pressure - size: %d", __FUNCTION__, size());
+            clear();
+        }
+        return nullptr;
+    }
+
+    if (font.isLoadingCustomFonts() || !font.fonts())
+        return nullptr;
+
+    if (auto entry = m_entries.find(CanvasGlyphDisplayListCacheKey { textRun, font, context }); entry != m_entries.end())
+        return entry->value.get();
+
+    if (auto displayList = font.displayListForTextRun(context, textRun)) {
+        CanvasGlyphDisplayListCacheKey key { textRun, font, context };
+        if (!canShareDisplayList(*displayList))
+            return nullptr;
+
+        auto addResult = m_entries.add(key, WTFMove(displayList));
+        return addResult.iterator->value.get();
+    }
+
+    return nullptr;
+}
+
+bool CanvasGlyphDisplayListCache::canShareDisplayList(const DisplayList::DisplayList& displayList)
+{
+    for (auto& item : displayList.items()) {
+        if (!(std::holds_alternative<DisplayList::Translate>(item)
+            || std::holds_alternative<DisplayList::Scale>(item)
+            || std::holds_alternative<DisplayList::ConcatenateCTM>(item)
+            || std::holds_alternative<DisplayList::DrawDecomposedGlyphs>(item)
+            || std::holds_alternative<DisplayList::DrawImageBuffer>(item)
+            || std::holds_alternative<DisplayList::DrawNativeImage>(item)
+            || std::holds_alternative<DisplayList::BeginTransparencyLayer>(item)
+            || std::holds_alternative<DisplayList::EndTransparencyLayer>(item)))
+            return false;
+    }
+    return true;
+}
+} // namespace WebCore

--- a/Source/WebCore/rendering/CanvasGlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/CanvasGlyphDisplayListCache.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DisplayList.h"
+#include "FloatSizeHash.h"
+#include "FontCascade.h"
+#include "Logging.h"
+#include "TextRun.h"
+#include "TextRunHash.h"
+#include <memory>
+#include <wtf/GetPtr.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
+#include <wtf/MemoryPressureHandler.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+class CanvasGlyphDisplayListCacheKey {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend struct CanvasGlyphDisplayListCacheEntryHashTraits;
+    friend void add(Hasher&, const CanvasGlyphDisplayListCacheKey&);
+public:
+    bool operator==(const CanvasGlyphDisplayListCacheKey& other) const
+    {
+        return m_textRun == other.m_textRun
+            && m_scaleFactor == other.m_scaleFactor
+            && m_fontCascadeGeneration == other.m_fontCascadeGeneration
+            && m_shouldSubpixelQuantizeFont == other.m_shouldSubpixelQuantizeFont;
+    }
+
+    CanvasGlyphDisplayListCacheKey()
+    : m_textRun(WTF::HashTableEmptyValue)
+    { }
+
+    CanvasGlyphDisplayListCacheKey(WTF::HashTableDeletedValueType)
+    : m_textRun(WTF::HashTableDeletedValue)
+    { }
+
+    CanvasGlyphDisplayListCacheKey(const TextRun& textRun, const FontCascade& font, GraphicsContext& context)
+        : m_textRun(textRun.isolatedCopy())
+        , m_scaleFactor(context.scaleFactor())
+        , m_fontCascadeGeneration(font.generation())
+        , m_shouldSubpixelQuantizeFont(context.shouldSubpixelQuantizeFonts())
+    {
+    }
+
+private:
+    TextRun m_textRun;
+    FloatSize m_scaleFactor;
+    unsigned m_fontCascadeGeneration;
+    bool m_shouldSubpixelQuantizeFont;
+};
+
+inline void add(Hasher& hasher, const CanvasGlyphDisplayListCacheKey& key)
+{
+    add(hasher, key.m_textRun, key.m_scaleFactor.width(), key.m_scaleFactor.height(), key.m_fontCascadeGeneration, key.m_shouldSubpixelQuantizeFont);
+}
+
+struct CanvasGlyphDisplayListCacheEntryHash {
+    static unsigned hash(const CanvasGlyphDisplayListCacheKey& key) { return computeHash(key); }
+    static bool equal (const CanvasGlyphDisplayListCacheKey& a, CanvasGlyphDisplayListCacheKey b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+struct CanvasGlyphDisplayListCacheEntryHashTraits : SimpleClassHashTraits<CanvasGlyphDisplayListCacheKey> {
+    static const bool emptyValueIsZero = false;
+    static CanvasGlyphDisplayListCacheKey emptyValue() { return { }; }
+    static void constructDeletedValue(CanvasGlyphDisplayListCacheKey& slot) { new (NotNull, &slot) CanvasGlyphDisplayListCacheKey(WTF::HashTableDeletedValue); }
+    static bool isDeletedValue(const CanvasGlyphDisplayListCacheKey& key) { return key.m_textRun.isHashTableDeletedValue(); }
+};
+
+class CanvasGlyphDisplayListCache {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend class CanvasGlyphDisplayListCacheKey;
+public:
+    CanvasGlyphDisplayListCache() = default;
+
+    static CanvasGlyphDisplayListCache& singleton();
+
+    DisplayList::DisplayList* getDisplayList(const FontCascade&, GraphicsContext&, const TextRun&);
+
+    void clear();
+    unsigned size() const;
+
+private:
+    static bool canShareDisplayList(const DisplayList::DisplayList&);
+    HashMap<CanvasGlyphDisplayListCacheKey, std::unique_ptr<DisplayList::DisplayList>, CanvasGlyphDisplayListCacheEntryHash, CanvasGlyphDisplayListCacheEntryHashTraits> m_entries;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct DefaultHash<WebCore::CanvasGlyphDisplayListCacheKey> : WebCore::CanvasGlyphDisplayListCacheEntryHash { };
+
+} // namespace WTF


### PR DESCRIPTION
#### 8b20cc91502be0d3cc3f3d828ca515ff705fb2c0
<pre>
Canvas draw text caching experiment
<a href="https://bugs.webkit.org/show_bug.cgi?id=269406">https://bugs.webkit.org/show_bug.cgi?id=269406</a>
<a href="https://rdar.apple.com/117815293">rdar://117815293</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
(WebCore::CanvasRenderingContext2DBase::drawBidiText):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::displayListForTextRun const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::hasOTSVGGlyph const):
* Source/WebCore/rendering/CanvasGlyphDisplayListCache.cpp: Added.
(WebCore::CanvasGlyphDisplayListCache::singleton):
(WebCore::CanvasGlyphDisplayListCache::clear):
(WebCore::CanvasGlyphDisplayListCache::size const):
(WebCore::CanvasGlyphDisplayListCache::getDisplayList):
(WebCore::CanvasGlyphDisplayListCache::canShareDisplayList):
* Source/WebCore/rendering/CanvasGlyphDisplayListCache.h: Added.
(WebCore::CanvasGlyphDisplayListCacheKey::operator== const):
(WebCore::CanvasGlyphDisplayListCacheKey::CanvasGlyphDisplayListCacheKey):
(WebCore::add):
(WebCore::CanvasGlyphDisplayListCacheEntryHash::hash):
(WebCore::CanvasGlyphDisplayListCacheEntryHash::equal):
(WebCore::CanvasGlyphDisplayListCacheEntryHashTraits::emptyValue):
(WebCore::CanvasGlyphDisplayListCacheEntryHashTraits::constructDeletedValue):
(WebCore::CanvasGlyphDisplayListCacheEntryHashTraits::isDeletedValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b20cc91502be0d3cc3f3d828ca515ff705fb2c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43873 "Failed to checkout and rebase branch from PR 24461") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20318 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36202 "Found 96 new test failures: fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html, fast/canvas/canvas-blending-text.html, fast/canvas/canvas-direction.html, fast/canvas/canvas-set-font-with-updated-style.html, fast/canvas/fill-gradient-text-with-web-font.html, fast/canvas/translate-text.html, fast/text/canvas-fonts.html, imported/blink/fast/canvas/bidi-multi-run.html, imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.draw.fill.maxWidth.fontface.html, imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.draw.fill.maxWidth.small.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44447 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19944 "Found 13 new test failures: fast/canvas/2d.fillText.gradient.html, fast/canvas/2d.text.draw.fill.maxWidth.gradient.html, fast/canvas/canvas-text-alignment.html, fast/canvas/fill-gradient-text-with-web-font.html, fast/canvas/gradient-text-with-shadow.html, http/tests/canvas/color-fonts/fill-gradient-sbix-2.html, http/tests/canvas/color-fonts/fill-gradient-sbix-3.html, http/tests/canvas/color-fonts/fill-gradient-sbix-4.html, http/tests/canvas/color-fonts/fill-gradient-sbix.html, http/tests/canvas/color-fonts/stroke-gradient-sbix-2.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17466 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38863 "Found 19 new test failures: fast/canvas/2d.fillText.gradient.html, fast/canvas/canvas-text-alignment.html, fast/canvas/fill-gradient-text-with-web-font.html, fast/canvas/gradient-text-with-shadow.html, http/tests/canvas/color-fonts/fill-gradient-sbix-2.html, http/tests/canvas/color-fonts/fill-gradient-sbix-3.html, http/tests/canvas/color-fonts/fill-gradient-sbix-4.html, http/tests/canvas/color-fonts/fill-gradient-sbix.html, http/tests/canvas/color-fonts/stroke-gradient-sbix-2.html, http/tests/canvas/color-fonts/stroke-gradient-sbix-3.html ... (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1924 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40035 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39163 "Found 14 new test failures: fast/canvas/2d.fillText.gradient.html, fast/canvas/canvas-text-alignment.html, fast/canvas/fill-gradient-text-with-web-font.html, fast/canvas/gradient-text-with-shadow.html, http/tests/canvas/color-fonts/fill-gradient-sbix-2.html, http/tests/canvas/color-fonts/fill-gradient-sbix-3.html, http/tests/canvas/color-fonts/fill-gradient-sbix-4.html, http/tests/canvas/color-fonts/fill-gradient-sbix.html, http/tests/canvas/color-fonts/stroke-gradient-sbix-2.html, http/tests/canvas/color-fonts/stroke-gradient-sbix-3.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18878 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15454 "Found 4 new test failures: fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html, http/tests/media/media-stream/get-display-media-iframe-allow-attribute.html, http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html, inspector/canvas/recording-offscreen-canvas-2d-frameCount.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43011 "Found 81 new test failures: fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html, fast/canvas/canvas-blending-text.html, fast/canvas/canvas-direction.html, fast/canvas/canvas-set-font-with-updated-style.html, fast/canvas/fill-gradient-text-with-web-font.html, fast/text/canvas-fonts.html, http/wpt/webcodecs/h264_small-size.any.html, imported/blink/fast/canvas/bidi-multi-run.html, imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.draw.fill.maxWidth.fontface.html, imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.draw.fill.maxWidth.small.html ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20272 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41712 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->