### PR TITLE
Move `position` from `NonInheritedFlags` to `StyleBoxData`

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -214,7 +214,6 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_nonInheritedFlags.overflowX = static_cast<unsigned>(initialOverflowX());
     m_nonInheritedFlags.overflowY = static_cast<unsigned>(initialOverflowY());
     m_nonInheritedFlags.clear = static_cast<unsigned>(initialClear());
-    m_nonInheritedFlags.position = static_cast<unsigned>(initialPosition());
     m_nonInheritedFlags.unicodeBidi = static_cast<unsigned>(initialUnicodeBidi());
     m_nonInheritedFlags.floating = static_cast<unsigned>(initialFloating());
     m_nonInheritedFlags.tableLayout = static_cast<unsigned>(initialTableLayout());
@@ -394,7 +393,6 @@ inline void RenderStyle::NonInheritedFlags::copyNonInheritedFrom(const NonInheri
     overflowX = other.overflowX;
     overflowY = other.overflowY;
     clear = other.clear;
-    position = other.position;
     unicodeBidi = other.unicodeBidi;
     floating = other.floating;
     tableLayout = other.tableLayout;
@@ -562,7 +560,7 @@ unsigned RenderStyle::hashForTextAutosizing() const
     hash ^= WTF::FloatHash<float>::hash(m_inheritedData->verticalBorderSpacing);
     hash ^= m_inheritedFlags.boxDirection;
     hash ^= m_inheritedFlags.rtlOrdering;
-    hash ^= m_nonInheritedFlags.position;
+    hash ^= m_nonInheritedData->boxData->m_position;
     hash ^= m_nonInheritedFlags.floating;
     hash ^= m_nonInheritedData->miscData->textOverflow;
     hash ^= m_rareInheritedData->textSecurity;
@@ -584,7 +582,7 @@ bool RenderStyle::equalForTextAutosizing(const RenderStyle& other) const
         && m_inheritedData->verticalBorderSpacing == other.m_inheritedData->verticalBorderSpacing
         && m_inheritedFlags.boxDirection == other.m_inheritedFlags.boxDirection
         && m_inheritedFlags.rtlOrdering == other.m_inheritedFlags.rtlOrdering
-        && m_nonInheritedFlags.position == other.m_nonInheritedFlags.position
+        && m_nonInheritedData->boxData->position() == other.m_nonInheritedData->boxData->position()
         && m_nonInheritedFlags.floating == other.m_nonInheritedFlags.floating
         && m_nonInheritedData->miscData->textOverflow == other.m_nonInheritedData->miscData->textOverflow;
 }
@@ -951,6 +949,9 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
                 || m_nonInheritedData->boxData->maxHeight() != other.m_nonInheritedData->boxData->maxHeight())
                 return true;
 
+            if (m_nonInheritedData->boxData->position() != other.m_nonInheritedData->boxData->position())
+                return true;
+
             if (m_nonInheritedData->boxData->verticalAlign() != other.m_nonInheritedData->boxData->verticalAlign()
                 || m_nonInheritedData->boxData->verticalAlignLength() != other.m_nonInheritedData->boxData->verticalAlignLength())
                 return true;
@@ -1023,7 +1024,6 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
 
     if (m_inheritedFlags.boxDirection != other.m_inheritedFlags.boxDirection
         || m_inheritedFlags.rtlOrdering != other.m_inheritedFlags.rtlOrdering
-        || m_nonInheritedFlags.position != other.m_nonInheritedFlags.position
         || m_nonInheritedFlags.floating != other.m_nonInheritedFlags.floating
         || m_nonInheritedFlags.originalDisplay != other.m_nonInheritedFlags.originalDisplay)
         return true;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -426,7 +426,7 @@ public:
     inline bool hasStaticInlinePosition(bool horizontal) const;
     inline bool hasStaticBlockPosition(bool horizontal) const;
 
-    PositionType position() const { return static_cast<PositionType>(m_nonInheritedFlags.position); }
+    inline PositionType position() const;
     inline bool hasOutOfFlowPosition() const;
     inline bool hasInFlowPosition() const;
     inline bool hasViewportConstrainedPosition() const;
@@ -1104,7 +1104,7 @@ public:
         m_nonInheritedFlags.effectiveDisplay = m_nonInheritedFlags.originalDisplay;
     }
     void setEffectiveDisplay(DisplayType v) { m_nonInheritedFlags.effectiveDisplay = static_cast<unsigned>(v); }
-    void setPosition(PositionType v) { m_nonInheritedFlags.position = static_cast<unsigned>(v); }
+    inline void setPosition(PositionType);
     void setFloating(Float v) { m_nonInheritedFlags.floating = static_cast<unsigned>(v); }
 
     inline void setLeft(Length&&);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -635,6 +635,7 @@ inline float RenderStyle::perspective() const { return m_nonInheritedData->rareD
 inline LengthPoint RenderStyle::perspectiveOrigin() const { return m_nonInheritedData->rareData->perspectiveOrigin(); }
 inline const Length& RenderStyle::perspectiveOriginX() const { return m_nonInheritedData->rareData->perspectiveOriginX; }
 inline const Length& RenderStyle::perspectiveOriginY() const { return m_nonInheritedData->rareData->perspectiveOriginY; }
+inline PositionType RenderStyle::position() const { return m_nonInheritedData->boxData->position(); }
 inline bool RenderStyle::preserveNewline() const { return preserveNewline(whiteSpace()); }
 inline bool RenderStyle::preserves3D() const { return usedTransformStyle3D() == TransformStyle3D::Preserve3D; }
 inline QuotesData* RenderStyle::quotes() const { return m_rareInheritedData->quotes.get(); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -266,6 +266,7 @@ inline void RenderStyle::setPaintOrder(PaintOrder order) { SET(m_rareInheritedDa
 inline void RenderStyle::setPerspective(float perspective) { SET_NESTED(m_nonInheritedData, rareData, perspective, perspective); }
 inline void RenderStyle::setPerspectiveOriginX(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, perspectiveOriginX, WTFMove(length)); }
 inline void RenderStyle::setPerspectiveOriginY(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, perspectiveOriginY, WTFMove(length)); }
+inline void RenderStyle::setPosition(PositionType position) { SET_NESTED(m_nonInheritedData, boxData, m_position, static_cast<unsigned>(position)); }
 inline void RenderStyle::setResize(Resize r) { SET_NESTED(m_nonInheritedData, miscData, resize, static_cast<unsigned>(r)); }
 inline void RenderStyle::setRight(Length&& length) { SET_NESTED(m_nonInheritedData, surroundData, offset.right(), WTFMove(length)); }
 inline void RenderStyle::setRowGap(GapLength&& gapLength) { SET_NESTED(m_nonInheritedData, rareData, rowGap, WTFMove(gapLength)); }

--- a/Source/WebCore/rendering/style/StyleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleBoxData.cpp
@@ -48,6 +48,7 @@ StyleBoxData::StyleBoxData()
     , m_hasAutoUsedZIndex(true)
     , m_boxSizing(static_cast<unsigned>(BoxSizing::ContentBox))
     , m_boxDecorationBreak(static_cast<unsigned>(BoxDecorationBreak::Slice))
+    , m_position(static_cast<unsigned>(RenderStyle::initialPosition()))
     , m_verticalAlign(static_cast<unsigned>(RenderStyle::initialVerticalAlign()))
 {
 }
@@ -67,6 +68,7 @@ inline StyleBoxData::StyleBoxData(const StyleBoxData& o)
     , m_hasAutoUsedZIndex(o.m_hasAutoUsedZIndex)
     , m_boxSizing(o.m_boxSizing)
     , m_boxDecorationBreak(o.m_boxDecorationBreak)
+    , m_position(o.m_position)
     , m_verticalAlign(o.m_verticalAlign)
 {
 }
@@ -91,6 +93,7 @@ bool StyleBoxData::operator==(const StyleBoxData& o) const
         && m_hasAutoUsedZIndex == o.m_hasAutoUsedZIndex
         && m_boxSizing == o.m_boxSizing
         && m_boxDecorationBreak == o.m_boxDecorationBreak
+        && m_position == o.m_position
         && m_verticalAlign == o.m_verticalAlign;
 }
 

--- a/Source/WebCore/rendering/style/StyleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleBoxData.h
@@ -59,6 +59,7 @@ public:
 
     BoxSizing boxSizing() const { return static_cast<BoxSizing>(m_boxSizing); }
     BoxDecorationBreak boxDecorationBreak() const { return static_cast<BoxDecorationBreak>(m_boxDecorationBreak); }
+    PositionType position() const { return static_cast<PositionType>(m_position); }
     VerticalAlign verticalAlign() const { return static_cast<VerticalAlign>(m_verticalAlign); }
 
 private:
@@ -84,6 +85,7 @@ private:
     unsigned m_hasAutoUsedZIndex : 1;
     unsigned m_boxSizing : 1; // BoxSizing
     unsigned m_boxDecorationBreak : 1; // BoxDecorationBreak
+    unsigned m_position : 3; // PositionType
     unsigned m_verticalAlign : 4; // VerticalAlign
 };
 


### PR DESCRIPTION
#### 4ef4a110000dcf0223e2b3631f30ff6d567ecc16
<pre>
Move `position` from `NonInheritedFlags` to `StyleBoxData`
<a href="https://bugs.webkit.org/show_bug.cgi?id=269410">https://bugs.webkit.org/show_bug.cgi?id=269410</a>
<a href="https://rdar.apple.com/122976910">rdar://122976910</a>

Reviewed by Aditya Keerthi and Darin Adler.

Free-up 3 bits from `NonInheritedFlags` for `::target-text` and `text-decoration-line: spelling-error/grammar-error`.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::RenderStyle):
(WebCore::RenderStyle::NonInheritedFlags::copyNonInheritedFrom):
(WebCore::RenderStyle::hashForTextAutosizing const):
(WebCore::RenderStyle::equalForTextAutosizing const):
(WebCore::RenderStyle::changeRequiresLayout const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::position const): Deleted.
(WebCore::RenderStyle::setPosition): Deleted.
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::position const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setPosition):
* Source/WebCore/rendering/style/StyleBoxData.cpp:
(WebCore::StyleBoxData::StyleBoxData):
(WebCore::StyleBoxData::operator== const):
* Source/WebCore/rendering/style/StyleBoxData.h:
(WebCore::StyleBoxData::position const):

Canonical link: <a href="https://commits.webkit.org/274683@main">https://commits.webkit.org/274683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d18be2fa061eb4c1aa5837e23f13049ff9507de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39764 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18743 "Hash 3d18be2f for PR 24462 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42120 "Hash 3d18be2f for PR 24462 does not build (failure)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42071 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/21650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16072 "Hash 3d18be2f for PR 24462 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40338 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/21650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/42120 "Hash 3d18be2f for PR 24462 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/21650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/42120 "Hash 3d18be2f for PR 24462 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/21650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/42120 "Hash 3d18be2f for PR 24462 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/16072 "Hash 3d18be2f for PR 24462 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/42120 "Hash 3d18be2f for PR 24462 does not build (failure)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5226 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->