### PR TITLE
Fix guards of WKImageCairo

### DIFF
--- a/Source/WebKit/Shared/API/c/cairo/WKImageCairo.cpp
+++ b/Source/WebKit/Shared/API/c/cairo/WKImageCairo.cpp
@@ -34,21 +34,24 @@
 #include <WebCore/GraphicsContextCairo.h>
 #include <WebCore/ShareableBitmap.h>
 #include <cairo.h>
+#else
+#include <WebCore/NotImplemented.h>
 #endif
 
 cairo_surface_t* WKImageCreateCairoSurface(WKImageRef imageRef)
 {
-#if USE(SKIA)
-    // FIXME
-    return nullptr;
-#else
+#if USE(CAIRO)
     // We cannot pass a RefPtr through the API here, so we just leak the reference.
     return WebKit::toImpl(imageRef)->createCairoSurface().leakRef();
+#else
+    notImplemented();
+    return nullptr;
 #endif
 }
 
 WKImageRef WKImageCreateFromCairoSurface(cairo_surface_t* surface, WKImageOptions options)
 {
+#if USE(CAIRO)
     WebCore::IntSize imageSize(cairo_image_surface_get_width(surface), cairo_image_surface_get_height(surface));
     auto webImage = WebKit::WebImage::create(imageSize, WebKit::toImageOptions(options), WebCore::DestinationColorSpace::SRGB());
     if (!webImage->context())
@@ -62,4 +65,8 @@ WKImageRef WKImageCreateFromCairoSurface(cairo_surface_t* surface, WKImageOption
     cairo_fill(cr);
 
     return toAPI(webImage.leakRef());
+#else
+    notImplemented();
+    return nullptr;
+#endif
 }


### PR DESCRIPTION
#### 4ce338dca0934b42ce9d999725f36343c517d707
<pre>
Fix guards of WKImageCairo
<a href="https://bugs.webkit.org/show_bug.cgi?id=269414">https://bugs.webkit.org/show_bug.cgi?id=269414</a>

Reviewed by Adrian Perez de Castro.

Prefer `USE(CAIRO)` over `USE(SKIA)` to guard implementation of API functions
in `WKImageCairo.cpp`.

* Source/WebKit/Shared/API/c/cairo/WKImageCairo.cpp:

Canonical link: <a href="https://commits.webkit.org/274745@main">https://commits.webkit.org/274745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ac0f74ae68a3493119d9c6445b792bb98f6fd59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42439 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16236 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13792 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35784 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16329 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8954 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16378 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->