### PR TITLE
[WGSL] textureBarrier is not implemented

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/storage_texture/read_write-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/storage_texture/read_write-expected.txt
@@ -1,5 +1,32 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Query `webgpu:api,operation,storage_texture,read_write:*` does not match any cases
 
-Harness Error (FAIL), message = Unhandled rejection: Query `webgpu:api,operation,storage_texture,read_write:*` does not match any cases
-
+PASS :basic:format="r32uint";shaderStage="fragment";textureDimension="1d";depthOrArrayLayers=1
+PASS :basic:format="r32uint";shaderStage="fragment";textureDimension="2d";depthOrArrayLayers=1
+PASS :basic:format="r32uint";shaderStage="fragment";textureDimension="2d";depthOrArrayLayers=2
+PASS :basic:format="r32uint";shaderStage="fragment";textureDimension="3d";depthOrArrayLayers=1
+PASS :basic:format="r32uint";shaderStage="fragment";textureDimension="3d";depthOrArrayLayers=2
+PASS :basic:format="r32uint";shaderStage="compute";textureDimension="1d";depthOrArrayLayers=1
+PASS :basic:format="r32uint";shaderStage="compute";textureDimension="2d";depthOrArrayLayers=1
+PASS :basic:format="r32uint";shaderStage="compute";textureDimension="2d";depthOrArrayLayers=2
+PASS :basic:format="r32uint";shaderStage="compute";textureDimension="3d";depthOrArrayLayers=1
+PASS :basic:format="r32uint";shaderStage="compute";textureDimension="3d";depthOrArrayLayers=2
+PASS :basic:format="r32sint";shaderStage="fragment";textureDimension="1d";depthOrArrayLayers=1
+PASS :basic:format="r32sint";shaderStage="fragment";textureDimension="2d";depthOrArrayLayers=1
+PASS :basic:format="r32sint";shaderStage="fragment";textureDimension="2d";depthOrArrayLayers=2
+PASS :basic:format="r32sint";shaderStage="fragment";textureDimension="3d";depthOrArrayLayers=1
+PASS :basic:format="r32sint";shaderStage="fragment";textureDimension="3d";depthOrArrayLayers=2
+PASS :basic:format="r32sint";shaderStage="compute";textureDimension="1d";depthOrArrayLayers=1
+PASS :basic:format="r32sint";shaderStage="compute";textureDimension="2d";depthOrArrayLayers=1
+PASS :basic:format="r32sint";shaderStage="compute";textureDimension="2d";depthOrArrayLayers=2
+PASS :basic:format="r32sint";shaderStage="compute";textureDimension="3d";depthOrArrayLayers=1
+PASS :basic:format="r32sint";shaderStage="compute";textureDimension="3d";depthOrArrayLayers=2
+PASS :basic:format="r32float";shaderStage="fragment";textureDimension="1d";depthOrArrayLayers=1
+PASS :basic:format="r32float";shaderStage="fragment";textureDimension="2d";depthOrArrayLayers=1
+PASS :basic:format="r32float";shaderStage="fragment";textureDimension="2d";depthOrArrayLayers=2
+PASS :basic:format="r32float";shaderStage="fragment";textureDimension="3d";depthOrArrayLayers=1
+PASS :basic:format="r32float";shaderStage="fragment";textureDimension="3d";depthOrArrayLayers=2
+PASS :basic:format="r32float";shaderStage="compute";textureDimension="1d";depthOrArrayLayers=1
+PASS :basic:format="r32float";shaderStage="compute";textureDimension="2d";depthOrArrayLayers=1
+PASS :basic:format="r32float";shaderStage="compute";textureDimension="2d";depthOrArrayLayers=2
+PASS :basic:format="r32float";shaderStage="compute";textureDimension="3d";depthOrArrayLayers=1
+PASS :basic:format="r32float";shaderStage="compute";textureDimension="3d";depthOrArrayLayers=2
 

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1570,6 +1570,11 @@ static void emitStorageBarrier(FunctionDefinitionWriter* writer, AST::CallExpres
     writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_device)");
 }
 
+static void emitTextureBarrier(FunctionDefinitionWriter* writer, AST::CallExpression&)
+{
+    writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_texture)");
+}
+
 static void emitWorkgroupBarrier(FunctionDefinitionWriter* writer, AST::CallExpression&)
 {
     writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_threadgroup)");
@@ -1840,6 +1845,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "quantizeToF16", emitQuantizeToF16 },
             { "radians", emitRadians },
             { "storageBarrier", emitStorageBarrier },
+            { "textureBarrier", emitTextureBarrier },
             { "textureDimensions", emitTextureDimensions },
             { "textureGather", emitTextureGather },
             { "textureGatherCompare", emitTextureGatherCompare },

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -1075,9 +1075,17 @@ function :textureLoad, {
     must_use: true,
 
     [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_1d[S], T, U) => vec4[S],
+    [F, T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_storage_1d[F, read], T) => vec4[ChannelFormat[F]],
+    [F, T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_storage_1d[F, read_write], T) => vec4[ChannelFormat[F]],
     [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_2d[S], vec2[T], U) => vec4[S],
+    [F, T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_storage_2d[F, read], T) => vec4[ChannelFormat[F]],
+    [F, T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_storage_2d[F, read_write], T) => vec4[ChannelFormat[F]],
+    [F, T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_storage_2d_array[F, read], T) => vec4[ChannelFormat[F]],
+    [F, T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_storage_2d_array[F, read_write], T) => vec4[ChannelFormat[F]],
     [T < ConcreteInteger, V < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_2d_array[S], vec2[T], V, U) => vec4[S],
     [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_3d[S], vec3[T], U) => vec4[S],
+    [F, T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_storage_3d[F, read], T) => vec4[ChannelFormat[F]],
+    [F, T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_storage_3d[F, read_write], T) => vec4[ChannelFormat[F]],
     [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_multisampled_2d[S], vec2[T], U) => vec4[S],
 
 
@@ -1368,12 +1376,14 @@ function :textureStore, {
     # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
     # fn textureStore(t: texture_storage_1d<F,write>, coords: C, value: vec4<CF>)
     [F, T < ConcreteInteger].(texture_storage_1d[F, write], T, vec4[ChannelFormat[F]]) => void,
+    [F, T < ConcreteInteger].(texture_storage_1d[F, read_write], T, vec4[ChannelFormat[F]]) => void,
 
     # F is a texel format
     # C is i32, or u32
     # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
     # fn textureStore(t: texture_storage_2d<F,write>, coords: vec2<C>, value: vec4<CF>)
     [F, T < ConcreteInteger].(texture_storage_2d[F, write], vec2[T], vec4[ChannelFormat[F]]) => void,
+    [F, T < ConcreteInteger].(texture_storage_2d[F, read_write], vec2[T], vec4[ChannelFormat[F]]) => void,
 
     # F is a texel format
     # C is i32, or u32
@@ -1381,12 +1391,14 @@ function :textureStore, {
     # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
     # fn textureStore(t: texture_storage_2d_array<F,write>, coords: vec2<C>, array_index: A, value: vec4<CF>)
     [F, T < ConcreteInteger, S < ConcreteInteger].(texture_storage_2d_array[F, write], vec2[T], S, vec4[ChannelFormat[F]]) => void,
+    [F, T < ConcreteInteger, S < ConcreteInteger].(texture_storage_2d_array[F, read_write], vec2[T], S, vec4[ChannelFormat[F]]) => void,
 
     # F is a texel format
     # C is i32, or u32
     # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
     # fn textureStore(t: texture_storage_3d<F,write>, coords: vec3<C>, value: vec4<CF>)
     [F, T < ConcreteInteger].(texture_storage_3d[F, write], vec3[T], vec4[ChannelFormat[F]]) => void,
+    [F, T < ConcreteInteger].(texture_storage_3d[F, read_write], vec3[T], vec4[ChannelFormat[F]]) => void,
 }
 
 # 16.8. Atomic Built-in Functions (https://www.w3.org/TR/WGSL/#atomic-builtin-functions)
@@ -1575,6 +1587,14 @@ function :storageBarrier, {
 }
 
 # 16.11.2.
+function :textureBarrier, {
+    stage: :compute,
+
+    # fn textureBarrier()
+    [].() => void,
+}
+
+# 16.11.3.
 function :workgroupBarrier, {
     stage: :compute,
 
@@ -1582,7 +1602,7 @@ function :workgroupBarrier, {
     [].() => void,
 }
 
-# 16.11.3.
+# 16.11.4.
 function :workgroupUniformLoad, {
     must_use: true,
     stage: :compute,


### PR DESCRIPTION
#### 51530a8c2de28c96031a381300ce9972989b87f0
<pre>
[WGSL] textureBarrier is not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=269412">https://bugs.webkit.org/show_bug.cgi?id=269412</a>
&lt;radar://122977866&gt;

Reviewed by Tadeu Zagallo.

textureBarrier(), textureLoad(), and textureStore() were recently
updated to support read and read_write storage textures.

Add this to the WGSL compiler.

This allows the newly added storage_texture/read_write.html to pass, so add
passing expectations for this test as well.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/storage_texture/read_write-expected.txt:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitTextureBarrier):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:

Canonical link: <a href="https://commits.webkit.org/274851@main">https://commits.webkit.org/274851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42e3986e0860d4b1678adad0d7d38fa4f6fcc9d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35655 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33159 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43565 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39452 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37743 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16186 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9017 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->