### PR TITLE
[CMake] Centralize cURL definitions

### DIFF
--- a/Source/WebKit/Platform/Curl.cmake
+++ b/Source/WebKit/Platform/Curl.cmake
@@ -1,0 +1,36 @@
+list(APPEND WebKit_SOURCES
+    NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
+
+    NetworkProcess/cache/NetworkCacheDataCurl.cpp
+    NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
+
+    NetworkProcess/curl/NetworkDataTaskCurl.cpp
+    NetworkProcess/curl/NetworkProcessCurl.cpp
+    NetworkProcess/curl/NetworkProcessMainCurl.cpp
+    NetworkProcess/curl/NetworkSessionCurl.cpp
+    NetworkProcess/curl/WebSocketTaskCurl.cpp
+
+    Shared/API/c/curl/WKCertificateInfoCurl.cpp
+
+    Shared/curl/WebCoreArgumentCodersCurl.cpp
+
+    UIProcess/API/C/curl/WKProtectionSpaceCurl.cpp
+    UIProcess/API/C/curl/WKWebsiteDataStoreRefCurl.cpp
+
+    UIProcess/WebsiteData/curl/WebsiteDataStoreCurl.cpp
+
+    WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
+)
+
+list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
+    "${WEBKIT_DIR}/NetworkProcess/curl"
+    "${WEBKIT_DIR}/UIProcess/API/C/curl"
+    "${WEBKIT_DIR}/WebProcess/WebCoreSupport/curl"
+)
+
+list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
+    Shared/API/c/curl/WKCertificateInfoCurl.h
+
+    UIProcess/API/C/curl/WKProtectionSpaceCurl.h
+    UIProcess/API/C/curl/WKWebsiteDataStoreRefCurl.h
+)

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -1,4 +1,5 @@
 include(Headers.cmake)
+include(Platform/Curl.cmake)
 
 set(WebKit_USE_PREFIX_HEADER ON)
 
@@ -39,17 +40,6 @@ list(APPEND WebKit_SOURCES
 
     NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 
-    NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
-
-    NetworkProcess/cache/NetworkCacheDataCurl.cpp
-    NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
-
-    NetworkProcess/curl/NetworkDataTaskCurl.cpp
-    NetworkProcess/curl/NetworkProcessCurl.cpp
-    NetworkProcess/curl/NetworkProcessMainCurl.cpp
-    NetworkProcess/curl/NetworkSessionCurl.cpp
-    NetworkProcess/curl/WebSocketTaskCurl.cpp
-
     Platform/IPC/unix/ArgumentCodersUnix.cpp
     Platform/IPC/unix/ConnectionUnix.cpp
     Platform/IPC/unix/IPCSemaphoreUnix.cpp
@@ -59,11 +49,7 @@ list(APPEND WebKit_SOURCES
     Platform/unix/LoggingUnix.cpp
     Platform/unix/ModuleUnix.cpp
 
-    Shared/API/c/curl/WKCertificateInfoCurl.cpp
-
     Shared/API/c/playstation/WKEventPlayStation.cpp
-
-    Shared/curl/WebCoreArgumentCodersCurl.cpp
 
     Shared/libwpe/NativeWebKeyboardEventLibWPE.cpp
     Shared/libwpe/NativeWebMouseEventLibWPE.cpp
@@ -82,9 +68,6 @@ list(APPEND WebKit_SOURCES
     UIProcess/API/C/WKUserScriptRef.cpp
     UIProcess/API/C/WKViewportAttributes.cpp
 
-    UIProcess/API/C/curl/WKProtectionSpaceCurl.cpp
-    UIProcess/API/C/curl/WKWebsiteDataStoreRefCurl.cpp
-
     UIProcess/API/C/playstation/WKContextConfigurationPlayStation.cpp
     UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
     UIProcess/API/C/playstation/WKRunloop.cpp
@@ -93,8 +76,6 @@ list(APPEND WebKit_SOURCES
     UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 
     UIProcess/Launcher/playstation/ProcessLauncherPlayStation.cpp
-
-    UIProcess/WebsiteData/curl/WebsiteDataStoreCurl.cpp
 
     UIProcess/WebsiteData/playstation/WebsiteDataStorePlayStation.cpp
 
@@ -108,8 +89,6 @@ list(APPEND WebKit_SOURCES
     WebProcess/GPU/media/playstation/VideoLayerRemotePlayStation.cpp
 
     WebProcess/InjectedBundle/playstation/InjectedBundlePlayStation.cpp
-
-    WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
 
     WebProcess/WebPage/AcceleratedSurface.cpp
 
@@ -125,20 +104,17 @@ list(APPEND WebKit_SOURCES
 )
 
 list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
-    "${WEBKIT_DIR}/NetworkProcess/curl"
     "${WEBKIT_DIR}/Platform/IPC/unix"
     "${WEBKIT_DIR}/Platform/classifier"
     "${WEBKIT_DIR}/Platform/generic"
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics"
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics/threadedcompositor"
     "${WEBKIT_DIR}/Shared/libwpe"
-    "${WEBKIT_DIR}/UIProcess/API/C/curl"
     "${WEBKIT_DIR}/UIProcess/API/C/playstation"
     "${WEBKIT_DIR}/UIProcess/API/libwpe"
     "${WEBKIT_DIR}/UIProcess/API/playstation"
     "${WEBKIT_DIR}/UIProcess/CoordinatedGraphics"
     "${WEBKIT_DIR}/UIProcess/playstation"
-    "${WEBKIT_DIR}/WebProcess/WebCoreSupport/curl"
     "${WEBKIT_DIR}/WebProcess/WebPage/CoordinatedGraphics"
     "${WEBKIT_DIR}/WebProcess/WebPage/libwpe"
 )
@@ -219,13 +195,8 @@ endif ()
 
 # PlayStation specific
 list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
-    Shared/API/c/curl/WKCertificateInfoCurl.h
-
     Shared/API/c/playstation/WKBasePlayStation.h
     Shared/API/c/playstation/WKEventPlayStation.h
-
-    UIProcess/API/C/curl/WKProtectionSpaceCurl.h
-    UIProcess/API/C/curl/WKWebsiteDataStoreRefCurl.h
 
     UIProcess/API/C/playstation/WKContextConfigurationPlayStation.h
     UIProcess/API/C/playstation/WKPagePrivatePlayStation.h

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -5,6 +5,7 @@ set(GPUProcess_OUTPUT_NAME WebKitGPUProcess)
 set(PluginProcess_OUTPUT_NAME WebKitPluginProcess)
 
 include(Headers.cmake)
+include(Platform/Curl.cmake)
 include(Platform/WC.cmake)
 
 list(APPEND WebKit_SOURCES
@@ -17,17 +18,6 @@ list(APPEND WebKit_SOURCES
 
     NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 
-    NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
-
-    NetworkProcess/cache/NetworkCacheDataCurl.cpp
-    NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
-
-    NetworkProcess/curl/NetworkDataTaskCurl.cpp
-    NetworkProcess/curl/NetworkProcessCurl.cpp
-    NetworkProcess/curl/NetworkProcessMainCurl.cpp
-    NetworkProcess/curl/NetworkSessionCurl.cpp
-    NetworkProcess/curl/WebSocketTaskCurl.cpp
-
     Platform/IPC/win/ArgumentCodersWin.cpp
     Platform/IPC/win/ConnectionWin.cpp
     Platform/IPC/win/IPCSemaphoreWin.cpp
@@ -39,10 +29,6 @@ list(APPEND WebKit_SOURCES
 
     Shared/API/c/cairo/WKImageCairo.cpp
 
-    Shared/API/c/curl/WKCertificateInfoCurl.cpp
-
-    Shared/curl/WebCoreArgumentCodersCurl.cpp
-
     Shared/win/AuxiliaryProcessMainWin.cpp
     Shared/win/NativeWebKeyboardEventWin.cpp
     Shared/win/NativeWebMouseEventWin.cpp
@@ -52,9 +38,6 @@ list(APPEND WebKit_SOURCES
     Shared/win/WebEventFactory.cpp
 
     UIProcess/API/C/WKViewportAttributes.cpp
-
-    UIProcess/API/C/curl/WKProtectionSpaceCurl.cpp
-    UIProcess/API/C/curl/WKWebsiteDataStoreRefCurl.cpp
 
     UIProcess/API/C/win/WKView.cpp
 
@@ -72,7 +55,6 @@ list(APPEND WebKit_SOURCES
 
     UIProcess/Launcher/win/ProcessLauncherWin.cpp
 
-    UIProcess/WebsiteData/curl/WebsiteDataStoreCurl.cpp
     UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
 
     UIProcess/cairo/BackingStore.cpp
@@ -93,8 +75,6 @@ list(APPEND WebKit_SOURCES
 
     WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
 
-    WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
-
     WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
 
     WebProcess/WebPage/AcceleratedSurface.cpp
@@ -111,7 +91,6 @@ list(APPEND WebKit_SOURCES
 )
 
 list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
-    "${WEBKIT_DIR}/NetworkProcess/curl"
     "${WEBKIT_DIR}/Platform/IPC/win"
     "${WEBKIT_DIR}/Platform/classifier"
     "${WEBKIT_DIR}/Platform/generic"
@@ -121,7 +100,6 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics/threadedcompositor"
     "${WEBKIT_DIR}/Shared/win"
     "${WEBKIT_DIR}/UIProcess/API/C/cairo"
-    "${WEBKIT_DIR}/UIProcess/API/C/curl"
     "${WEBKIT_DIR}/UIProcess/API/C/win"
     "${WEBKIT_DIR}/UIProcess/API/cpp/win"
     "${WEBKIT_DIR}/UIProcess/API/win"
@@ -134,7 +112,6 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/win"
     "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/win/DOM"
     "${WEBKIT_DIR}/WebProcess/Inspector/win"
-    "${WEBKIT_DIR}/WebProcess/WebCoreSupport/curl"
     "${WEBKIT_DIR}/WebProcess/WebCoreSupport/win"
     "${WEBKIT_DIR}/WebProcess/WebPage/CoordinatedGraphics"
     "${WEBKIT_DIR}/WebProcess/WebPage/win"
@@ -173,12 +150,7 @@ endif ()
 list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     Shared/API/c/cairo/WKImageCairo.h
 
-    Shared/API/c/curl/WKCertificateInfoCurl.h
-
     Shared/API/c/win/WKBaseWin.h
-
-    UIProcess/API/C/curl/WKProtectionSpaceCurl.h
-    UIProcess/API/C/curl/WKWebsiteDataStoreRefCurl.h
 
     UIProcess/API/C/win/WKView.h
 )


### PR DESCRIPTION
#### 43d1049f80d50d5f3e1ca94adf21fb82df8edb64
<pre>
[CMake] Centralize cURL definitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=269424">https://bugs.webkit.org/show_bug.cgi?id=269424</a>

Reviewed by Fujii Hironori.

Share `USE(CURL)` build definitions between ports.

* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/PlatformWin.cmake:
* Source/WebKit/Platform/Curl.cmake: Added.

Canonical link: <a href="https://commits.webkit.org/274681@main">https://commits.webkit.org/274681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cb4cd1cf174cf444d1cb4eddab2a9e708dddab6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18740 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42296 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16069 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40335 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5225 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->