### PR TITLE
Update layout tests for the unified HTTP stack

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
@@ -2,6 +2,6 @@
 PASS HTTP set/overwrite/delete observed in CookieStore
 FAIL CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies assert_equals: Cookie we wrote using HTTP in cookie jar expected "HTTP-🍪=🔵" but got "HTTP-ðª=ðµ"
 PASS CookieStore set/overwrite/delete observed in HTTP headers
-FAIL HTTP headers agreed with CookieStore on encoding non-ASCII cookies assert_equals: HTTP cookie jar contains only cookie we set expected "🍪=🔵" but got ""
+PASS HTTP headers agreed with CookieStore on encoding non-ASCII cookies
 FAIL Binary HTTP set/overwrite/delete observed in CookieStore assert_equals: Binary cookie we wrote using HTTP in cookie jar expected "HTTP-cookie=value\ufffd" but got "HTTP-cookie=valueï¿½"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/name/name-ctl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/name/name-ctl-expected.txt
@@ -45,7 +45,7 @@ PASS Cookie with %x9 in name is accepted (HTTP).
 FAIL Cookie with %xa in name is rejected or modified (HTTP). assert_equals: The cookie was set as expected. expected "test10 name=10" but got ""
 PASS Cookie with %xb in name is rejected (HTTP).
 PASS Cookie with %xc in name is rejected (HTTP).
-FAIL Cookie with %xd in name is rejected or modified (HTTP). assert_equals: The cookie was set as expected. expected "test13 name=13" but got ""
+PASS Cookie with %xd in name is rejected or modified (HTTP).
 PASS Cookie with %xe in name is rejected (HTTP).
 PASS Cookie with %xf in name is rejected (HTTP).
 PASS Cookie with %x10 in name is rejected (HTTP).

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-ctl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-ctl-expected.txt
@@ -45,7 +45,7 @@ PASS Cookie with %x9 in value is accepted (HTTP).
 FAIL Cookie with %xa in name is rejected or modified (HTTP). assert_equals: The cookie was set as expected. expected "test10 name=10" but got ""
 PASS Cookie with %xb in value is rejected (HTTP).
 PASS Cookie with %xc in value is rejected (HTTP).
-FAIL Cookie with %xd in name is rejected or modified (HTTP). assert_equals: The cookie was set as expected. expected "test13 name=13" but got ""
+PASS Cookie with %xd in name is rejected or modified (HTTP).
 PASS Cookie with %xe in value is rejected (HTTP).
 PASS Cookie with %xf in value is rejected (HTTP).
 PASS Cookie with %x10 in value is rejected (HTTP).

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/handlers/sleep_10_v13_wsh.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/handlers/sleep_10_v13_wsh.py
@@ -4,15 +4,15 @@ import sys, urllib, time
 from mod_pywebsocket import msgutil
 
 def web_socket_do_extra_handshake(request):
-    request.connection.write(b'x')
+    request.connection.write(b'H')
     time.sleep(2)
-    request.connection.write(b'x')
+    request.connection.write(b'T')
     time.sleep(2)
-    request.connection.write(b'x')
+    request.connection.write(b'T')
     time.sleep(2)
-    request.connection.write(b'x')
+    request.connection.write(b'P')
     time.sleep(2)
-    request.connection.write(b'x')
+    request.connection.write(b'/')
     time.sleep(2)
     return
 

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2400,3 +2400,18 @@ webkit.org/b/269327 [ Release ] webrtc/audio-samplerate-change.html [ Pass Failu
 webkit.org/b/269378 [ Debug ] fast/forms/switch/click-disabled.html [ Skip ]
 
 webkit.org/b/269483 [ Debug ] http/wpt/webcodecs/h264-encoder-default-config.https.any.worker.html [ Skip ]
+
+# Failure on the CFNetwork HTTP stack, fixed in the unified HTTP stack
+http/tests/inspector/network/resource-request-headers.html [ Failure ]
+imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html [ Failure ]
+imported/w3c/web-platform-tests/cookies/name/name-ctl.html [ Failure ]
+imported/w3c/web-platform-tests/cookies/value/value-ctl.html [ Failure ]
+
+# Unified HTTP stack: rdar://122693432 (\r\r\n shouldn't be treated as 2 new lines)
+imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https.html [ Failure ]
+
+# Unified HTTP stack: rdar://122480508 (Accept status code fewer than 3 digits)
+imported/w3c/web-platform-tests/fetch/h1-parsing/status-code.window.html [ Failure ]
+
+# Unified HTTP stack: rdar://122480510 (Reject lone CR before message-body)
+imported/w3c/web-platform-tests/fetch/h1-parsing/lone-cr.window.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -592,6 +592,21 @@ imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html [ Fa
 
 webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]
 
+# Failure on the CFNetwork HTTP stack, fixed in the unified HTTP stack
+http/tests/inspector/network/resource-request-headers.html [ Failure ]
+imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html [ Failure ]
+imported/w3c/web-platform-tests/cookies/name/name-ctl.html [ Failure ]
+imported/w3c/web-platform-tests/cookies/value/value-ctl.html [ Failure ]
+
+# Unified HTTP stack: rdar://122693432 (\r\r\n shouldn't be treated as 2 new lines)
+imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https.html [ Failure ]
+
+# Unified HTTP stack: rdar://122480508 (Accept status code fewer than 3 digits)
+imported/w3c/web-platform-tests/fetch/h1-parsing/status-code.window.html [ Failure ]
+
+# Unified HTTP stack: rdar://122480510 (Reject lone CR before message-body)
+imported/w3c/web-platform-tests/fetch/h1-parsing/lone-cr.window.html [ Failure ]
+
 ### END OF (1) Classified failures with bug reports
 ########################################
 
@@ -1420,7 +1435,6 @@ webkit.org/b/229454 [ BigSur Debug ] http/tests/inspector/network/resource-timin
 
 webkit.org/b/229460 [ BigSur Debug ] http/tests/inspector/network/ping-type.html [ Pass Failure ]
 
-webkit.org/b/230056 [ BigSur Debug ] http/tests/inspector/network/resource-request-headers.html [ Pass Failure ]
 webkit.org/b/230056 [ BigSur Debug ] http/tests/inspector/network/har/har-page-aggressive-gc.html [ Pass Failure ]
 
 webkit.org/b/229561 http/tests/navigation/page-cache-video.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/http/tests/inspector/network/resource-request-headers-expected.txt
+++ b/LayoutTests/platform/mac-wk2/http/tests/inspector/network/resource-request-headers-expected.txt
@@ -26,9 +26,7 @@ PASS: Resource should be created.
 PASS: Resource should receive a Response.
 PASS: Resource should have a 401 status code.
 PASS: Response should have a 'WWW-Authenticate' response header for the failure.
-FAIL: 'Authorization' header value should be for badUsername:badPassword.
-    Expected: "Basic YmFkVXNlcm5hbWU6YmFkUGFzc3dvcmQ="
-    Actual: undefined
+PASS: 'Authorization' header value should be for badUsername:badPassword.
 
 -- Running test case: Resource.Metrics.RequestHeaders.BasicAuth.Success
 PASS: Resource should be created.


### PR DESCRIPTION
#### ee1b587c42b25411944e200640a2f93f305d0b3d
<pre>
Update layout tests for the unified HTTP stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=268193">https://bugs.webkit.org/show_bug.cgi?id=268193</a>
<a href="https://rdar.apple.com/121281240">rdar://121281240</a>

Reviewed by Alex Christensen.

These tests are now reporting successes in the new HTTP stack, updating expectations:
- http/tests/inspector/network/resource-request-headers.html
- imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html
- imported/w3c/web-platform-tests/cookies/name/name-ctl.html
- imported/w3c/web-platform-tests/cookies/value/value-ctl.html

These tests are expecting failures in the new HTTP stack, pending fixes:
- imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https.html
- imported/w3c/web-platform-tests/fetch/h1-parsing/status-code.window.html
- imported/w3c/web-platform-tests/fetch/h1-parsing/lone-cr.window.html

This test script is updated:
- imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/close/close-connecting.html

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/name/name-ctl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-ctl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/handlers/sleep_10_v13_wsh.py:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/http/tests/inspector/network/resource-request-headers-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee1b587c42b25411944e200640a2f93f305d0b3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36404 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33462 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39803 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38078 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->