### PR TITLE
Add support for themeName and onThemeChanged for devtools Web Extensions.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -406,6 +406,7 @@ def types_that_cannot_be_forward_declared():
         'IPC::FontReference',
         'IPC::Semaphore',
         'IPC::Signal',
+        'Inspector::ExtensionAppearance',
         'Inspector::ExtensionTabID',
         'MachSendRight',
         'MediaTime',
@@ -741,6 +742,7 @@ def headers_for_type(type):
     special_cases = {
         'CVPixelBufferRef': ['<WebCore/CVUtilities.h>'],
         'GCGLint': ['<WebCore/GraphicsTypesGL.h>'],
+        'Inspector::ExtensionAppearance': ['"InspectorExtensionTypes.h"'],
         'Inspector::ExtensionError': ['"InspectorExtensionTypes.h"'],
         'Inspector::ExtensionTabID': ['"InspectorExtensionTypes.h"'],
         'Inspector::FrontendChannel::ConnectionType': ['<JavaScriptCore/InspectorFrontendChannel.h>'],

--- a/Source/WebKit/Shared/InspectorExtensionTypes.h
+++ b/Source/WebKit/Shared/InspectorExtensionTypes.h
@@ -45,6 +45,11 @@ using ExtensionID = WTF::String;
 using ExtensionVoidResult = Expected<void, ExtensionError>;
 using ExtensionEvaluationResult = Expected<Expected<Ref<API::SerializedScriptValue>, WebCore::ExceptionDetails>, ExtensionError>;
 
+enum class ExtensionAppearance : bool {
+    Light,
+    Dark
+};
+
 enum class ExtensionError : uint8_t {
     ContextDestroyed,
     InternalError,

--- a/Source/WebKit/Shared/InspectorExtensionTypes.serialization.in
+++ b/Source/WebKit/Shared/InspectorExtensionTypes.serialization.in
@@ -32,4 +32,6 @@ enum class Inspector::ExtensionError : uint8_t {
     NotImplemented,
 };
 
+enum class Inspector::ExtensionAppearance : bool;
+
 #endif // ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h
@@ -40,6 +40,7 @@ public:
     virtual void didHideExtensionTab(const Inspector::ExtensionTabID&) { }
     virtual void didNavigateExtensionTab(const Inspector::ExtensionTabID&, const WTF::URL&) { }
     virtual void inspectedPageDidNavigate(const WTF::URL&) { }
+    virtual void effectiveAppearanceDidChange(Inspector::ExtensionAppearance) { }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -388,6 +388,7 @@ public:
     void didShowInspectorExtensionPanel(API::InspectorExtension&, const Inspector::ExtensionTabID&, WebCore::FrameIdentifier) const;
     void didHideInspectorExtensionPanel(API::InspectorExtension&, const Inspector::ExtensionTabID&) const;
     void inspectedPageDidNavigate(API::InspectorExtension&, const URL&);
+    void inspectorEffectiveAppearanceDidChange(API::InspectorExtension&, Inspector::ExtensionAppearance);
 #endif
 
     WebExtensionAction& defaultAction();

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -309,6 +309,17 @@ void WebInspectorUIExtensionControllerProxy::inspectedPageDidNavigate(const URL&
     }
 }
 
+void WebInspectorUIExtensionControllerProxy::effectiveAppearanceDidChange(Inspector::ExtensionAppearance appearance)
+{
+    for (auto& extension : copyToVector(m_extensionAPIObjectMap.values())) {
+        auto extensionClient = extension->client();
+        if (!extensionClient)
+            continue;
+
+        extensionClient->effectiveAppearanceDidChange(appearance);
+    }
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
@@ -75,6 +75,7 @@ public:
     // Notifications.
     void inspectorFrontendLoaded();
     void inspectorFrontendWillClose();
+    void effectiveAppearanceDidChange(Inspector::ExtensionAppearance);
 
 private:
     explicit WebInspectorUIExtensionControllerProxy(WebPageProxy& inspectorPage);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -654,6 +654,19 @@ void WebInspectorUIProxy::setForcedAppearance(InspectorFrontendClient::Appearanc
     platformSetForcedAppearance(appearance);
 }
 
+void WebInspectorUIProxy::effectiveAppearanceDidChange(InspectorFrontendClient::Appearance appearance)
+{
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    if (!m_extensionController)
+        return;
+
+    ASSERT(appearance == WebCore::InspectorFrontendClient::Appearance::Dark || appearance == WebCore::InspectorFrontendClient::Appearance::Light);
+    auto extensionAppearance = appearance == WebCore::InspectorFrontendClient::Appearance::Dark ? Inspector::ExtensionAppearance::Dark : Inspector::ExtensionAppearance::Light;
+
+    m_extensionController->effectiveAppearanceDidChange(extensionAppearance);
+#endif
+}
+
 void WebInspectorUIProxy::openURLExternally(const String& url)
 {
     if (m_inspectorClient)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -264,6 +264,7 @@ private:
     void bringInspectedPageToFront();
     void attachAvailabilityChanged(bool);
     void setForcedAppearance(WebCore::InspectorFrontendClient::Appearance);
+    void effectiveAppearanceDidChange(WebCore::InspectorFrontendClient::Appearance);
     void inspectedURLChanged(const String&);
     void showCertificate(const WebCore::CertificateInfo&);
     void setInspectorPageDeveloperExtrasEnabled(bool);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in
@@ -33,6 +33,8 @@ messages -> WebInspectorUIProxy {
     ResetState()
 
     SetForcedAppearance(WebCore::InspectorFrontendClient::Appearance appearance)
+    EffectiveAppearanceDidChange(WebCore::InspectorFrontendClient::Appearance appearance)
+
     OpenURLExternally(String url)
     RevealFileExternally(String path)
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
@@ -37,6 +37,7 @@
 #import "JSWebExtensionWrapper.h"
 #import "MessageSenderInlines.h"
 #import "WebExtensionAPIEvent.h"
+#import "WebExtensionAPINamespace.h"
 #import "WebExtensionContextMessages.h"
 #import "WebProcess.h"
 
@@ -71,9 +72,13 @@ NSString *WebExtensionAPIDevToolsPanels::themeName()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/themeName
 
-    // FIXME: <https://webkit.org/b/246485> Implement.
+    switch (m_theme) {
+    case Inspector::ExtensionAppearance::Light:
+        return @"light";
 
-    return nil;
+    case Inspector::ExtensionAppearance::Dark:
+        return @"dark";
+    }
 }
 
 WebExtensionAPIEvent& WebExtensionAPIDevToolsPanels::onThemeChanged()
@@ -84,6 +89,17 @@ WebExtensionAPIEvent& WebExtensionAPIDevToolsPanels::onThemeChanged()
         m_onThemeChanged = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::DevToolsPanelsOnThemeChanged);
 
     return *m_onThemeChanged;
+}
+
+void WebExtensionContextProxy::dispatchDevToolsPanelsThemeChangedEvent(Inspector::ExtensionAppearance appearance)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/onThemeChanged
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        auto& panels = namespaceObject.devtools().panels();
+        panels.setTheme(appearance);
+        panels.onThemeChanged().invokeListenersWithArgument(panels.themeName());
+    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
@@ -47,12 +47,16 @@ public:
 
     NSString *themeName();
 
+    Inspector::ExtensionAppearance theme() const { return m_theme; }
+    void setTheme(Inspector::ExtensionAppearance appearance) { m_theme = appearance; }
+
     WebExtensionAPIEvent& onThemeChanged();
 #endif
 
 private:
     RefPtr<WebExtensionAPIEvent> m_onThemeChanged;
     HashMap<Inspector::ExtensionTabID, Ref<WebExtensionAPIDevToolsExtensionPanel>> m_extensionPanels;
+    Inspector::ExtensionAppearance m_theme { Inspector::ExtensionAppearance::Light };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -149,6 +149,7 @@ private:
     void dispatchDevToolsExtensionPanelShownEvent(Inspector::ExtensionTabID, WebCore::FrameIdentifier);
     void dispatchDevToolsExtensionPanelHiddenEvent(Inspector::ExtensionTabID);
     void dispatchDevToolsNetworkNavigatedEvent(const URL&);
+    void dispatchDevToolsPanelsThemeChangedEvent(Inspector::ExtensionAppearance);
 #endif
 
     // Extension

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -45,6 +45,7 @@ messages -> WebExtensionContextProxy {
     DispatchDevToolsExtensionPanelShownEvent(Inspector::ExtensionTabID identifier, WebCore::FrameIdentifier frameIdentifier)
     DispatchDevToolsExtensionPanelHiddenEvent(Inspector::ExtensionTabID identifier)
     DispatchDevToolsNetworkNavigatedEvent(URL url)
+    DispatchDevToolsPanelsThemeChangedEvent(Inspector::ExtensionAppearance appearance)
 #endif
 
     // Extension

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -185,6 +185,11 @@ void WebInspectorUI::setForcedAppearance(WebCore::InspectorFrontendClient::Appea
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetForcedAppearance(appearance), m_inspectedPageIdentifier);
 }
 
+void WebInspectorUI::effectiveAppearanceDidChange(WebCore::InspectorFrontendClient::Appearance appearance)
+{
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::EffectiveAppearanceDidChange(appearance), m_inspectedPageIdentifier);
+}
+
 WebCore::UserInterfaceLayoutDirection WebInspectorUI::userInterfaceLayoutDirection() const
 {
     return m_page.corePage()->userInterfaceLayoutDirection();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -126,6 +126,7 @@ public:
     void resetState() override;
 
     void setForcedAppearance(WebCore::InspectorFrontendClient::Appearance) override;
+    void effectiveAppearanceDidChange(WebCore::InspectorFrontendClient::Appearance);
 
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() const override;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6087,6 +6087,9 @@ RetainPtr<PDFDocument> WebPage::pdfDocumentForPrintingFrame(LocalFrame* coreFram
 void WebPage::effectiveAppearanceDidChange(bool useDarkAppearance, bool useElevatedUserInterfaceLevel)
 {
     corePage()->effectiveAppearanceDidChange(useDarkAppearance, useElevatedUserInterfaceLevel);
+
+    if (m_inspectorUI)
+        m_inspectorUI->effectiveAppearanceDidChange(useDarkAppearance ? WebCore::InspectorFrontendClient::Appearance::Dark : WebCore::InspectorFrontendClient::Appearance::Light);
 }
 
 void WebPage::freezeLayerTreeDueToSwipeAnimation()


### PR DESCRIPTION
#### ec5b31644d06ea268cd38c3ffb6593fc1e91d47f
<pre>
Add support for themeName and onThemeChanged for devtools Web Extensions.
<a href="https://webkit.org/b/246485">https://webkit.org/b/246485</a>
<a href="https://rdar.apple.com/problem/114823326">rdar://problem/114823326</a>

Reviewed by Brian Weinstein.

* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
(headers_for_type):
* Source/WebKit/Shared/InspectorExtensionTypes.h:
* Source/WebKit/Shared/InspectorExtensionTypes.serialization.in:
* Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h:
(API::InspectorExtensionClient::effectiveAppearanceDidChange):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadInspectorBackgroundPage): Hook up the new client function.
(WebKit::WebExtensionContext::inspectorEffectiveAppearanceDidChange): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::effectiveAppearanceDidChange): Added.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::effectiveAppearanceDidChange): Added.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm:
(WebKit::WebExtensionAPIDevToolsPanels::themeName): Implemneted.
(WebKit::WebExtensionContextProxy::dispatchDevToolsPanelsThemeChangedEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h:
(WebKit::WebExtensionAPIDevToolsPanels::theme const): Added.
(WebKit::WebExtensionAPIDevToolsPanels::setTheme): Added.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::effectiveAppearanceDidChange): Added.
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::effectiveAppearanceDidChange): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm:
(TEST(WKWebExtensionAPIDevTools, PanelsThemeName)): Added.

Canonical link: <a href="https://commits.webkit.org/274703@main">https://commits.webkit.org/274703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f6377d1266cb49ef7da9a4e4367f98ba31f314c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33170 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13722 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/39645 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13722 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39463 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12009 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16260 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5237 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->