### PR TITLE
[iOS] Pressing any modifier with a hardware keyboard debug asserts under -[WebEvent characters]

### DIFF
--- a/Source/WebCore/platform/ios/WebEvent.mm
+++ b/Source/WebCore/platform/ios/WebEvent.mm
@@ -52,6 +52,9 @@ using WebCore::windowsKeyCodeForCharCode;
 #if USE(BROWSERENGINEKIT)
     RetainPtr<BEKeyEntry> _originalKeyEntry;
 #endif
+#if ASSERT_ENABLED
+    BOOL _shouldAssertWhenAccessingCharactersForKey;
+#endif
 }
 
 @synthesize type = _type;
@@ -387,15 +390,15 @@ static NSString *normalizedStringWithAppKitCompatibilityMapping(NSString *charac
 
 - (NSString *)characters
 {
-    ASSERT(_type == WebEventKeyDown || _type == WebEventKeyUp);
-    ASSERT(!(_keyboardFlags & WebEventKeyboardInputModifierFlagsChanged));
+    ASSERT_IMPLIES(_shouldAssertWhenAccessingCharactersForKey, _type == WebEventKeyDown || _type == WebEventKeyUp);
+    ASSERT_IMPLIES(_shouldAssertWhenAccessingCharactersForKey, !(_keyboardFlags & WebEventKeyboardInputModifierFlagsChanged));
     return retainPtr(_characters).autorelease();
 }
 
 - (NSString *)charactersIgnoringModifiers
 {
-    ASSERT(_type == WebEventKeyDown || _type == WebEventKeyUp);
-    ASSERT(!(_keyboardFlags & WebEventKeyboardInputModifierFlagsChanged));
+    ASSERT_IMPLIES(_shouldAssertWhenAccessingCharactersForKey, _type == WebEventKeyDown || _type == WebEventKeyUp);
+    ASSERT_IMPLIES(_shouldAssertWhenAccessingCharactersForKey, !(_keyboardFlags & WebEventKeyboardInputModifierFlagsChanged));
     return retainPtr(_charactersIgnoringModifiers).autorelease();
 }
 
@@ -573,6 +576,9 @@ static inline bool isChangingKeyModifiers(BEKeyEntry *event)
     _tabKey = NO; // FIXME: Populate this field appropriately.
     _keyRepeating = event.keyRepeating;
     _originalKeyEntry = event;
+#if ASSERT_ENABLED
+    _shouldAssertWhenAccessingCharactersForKey = YES;
+#endif
 
     return self;
 }


### PR DESCRIPTION
#### 7fd6818d91806bf407ec38e3be19038ee2790e98
<pre>
[iOS] Pressing any modifier with a hardware keyboard debug asserts under -[WebEvent characters]
<a href="https://bugs.webkit.org/show_bug.cgi?id=269430">https://bugs.webkit.org/show_bug.cgi?id=269430</a>
<a href="https://rdar.apple.com/122968675">rdar://122968675</a>

Reviewed by Aditya Keerthi.

In iOS 17.4, UIKit now always calls into `-characters` and `-charactersIgnoringModifiers` in the
process of constructing a `UIKeyEvent` from a `WebEvent` (which is eventually wrapped in a
`BEKeyEvent`). For modifier keys, this ends up triggering assertions in these two methods.

To keep these assertions relevant when using `BEKeyEntry` for key event dispatch, only allow them to
trigger once the key event arrives in WebKit code, and we proceed to unwrap the `BEKeyEntry` back
into the underlying `WebEvent`.

This fixes ~25 failing tests in debug iOS.

* Source/WebCore/platform/ios/WebEvent.mm:
(-[WebEvent characters]):
(-[WebEvent charactersIgnoringModifiers]):
(-[WebEvent initWithKeyEntry:]):

Canonical link: <a href="https://commits.webkit.org/274701@main">https://commits.webkit.org/274701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c002f22220fcffbf8d982b93329e532bd444d06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16130 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13727 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43612 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39469 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12014 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16223 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8921 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->