### PR TITLE
Use generated structures instead of NSDictionary to serialize members of ObjC classes

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
@@ -45,114 +45,262 @@ static RetainPtr<NSDictionary> dictionaryForWebKitSecureCodingType(id object)
     return [archiver accumulatedDictionary];
 }
 
+template<typename T> static RetainPtr<NSDictionary> dictionaryFromVector(const Vector<std::pair<String, RetainPtr<T>>>& vector)
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithCapacity:vector.size()];
+    for (auto& pair : vector)
+        dictionary[pair.first] = pair.second;
+    return dictionary;
+}
+
+template<typename T> static RetainPtr<NSDictionary> dictionaryFromOptionalVector(const std::optional<Vector<std::pair<String, RetainPtr<T>>>>& vector)
+{
+    if (!vector)
+        return nil;
+    return dictionaryFromVector<T>(*vector);
+}
+
+template<typename T> static Vector<std::pair<String, RetainPtr<T>>> vectorFromDictionary(NSDictionary *dictionary)
+{
+    if (![dictionary isKindOfClass:NSDictionary.class])
+        return { };
+    __block Vector<std::pair<String, RetainPtr<T>>> result;
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL*){
+        if ([key isKindOfClass:NSString.class] && [value isKindOfClass:IPC::getClass<T>()])
+            result.append((NSString *)key, (T)value);
+    }];
+    return result;
+}
+
+template<typename T> static std::optional<Vector<std::pair<String, RetainPtr<T>>>> optionalVectorFromDictionary(NSDictionary *dictionary)
+{
+    if (![dictionary isKindOfClass:NSDictionary.class])
+        return std::nullopt;
+    return vectorFromDictionary<T>(dictionary);
+}
+
+template<typename T> static RetainPtr<NSArray> arrayFromVector(const Vector<RetainPtr<T>>& vector)
+{
+    return createNSArray(vector, [] (auto& t) {
+        return t.get();
+    });
+}
+
+template<typename T> static RetainPtr<NSArray> arrayFromOptionalVector(const std::optional<Vector<RetainPtr<T>>>& vector)
+{
+    if (!vector)
+        return nil;
+    return arrayFromVector<T>(*vector);
+}
+
+template<typename T> static Vector<RetainPtr<T>> vectorFromArray(NSArray *array)
+{
+    if (![array isKindOfClass:NSArray.class])
+        return { };
+    Vector<RetainPtr<T>> result;
+    for (id element in array) {
+        if ([element isKindOfClass:IPC::getClass<T>()])
+            result.append((T *)element);
+    }
+    return result;
+}
+
+template<typename T> static std::optional<Vector<RetainPtr<T>>> optionalVectorFromArray(NSArray *array)
+{
+    if (![array isKindOfClass:NSArray.class])
+        return std::nullopt;
+    return vectorFromArray<T>(array);
+}
+
 #if USE(AVFOUNDATION)
-CoreIPCAVOutputContext::CoreIPCAVOutputContext(AVOutputContext *object)
-    : m_propertyList(dictionaryForWebKitSecureCodingType(object))
+CoreIPCAVOutputContext::CoreIPCAVOutputContext(
+    RetainPtr<NSString>&& AVOutputContextSerializationKeyContextID,
+    RetainPtr<NSString>&& AVOutputContextSerializationKeyContextType
+)
+    : m_AVOutputContextSerializationKeyContextID(WTFMove(AVOutputContextSerializationKeyContextID))
+    , m_AVOutputContextSerializationKeyContextType(WTFMove(AVOutputContextSerializationKeyContextType))
 {
 }
 
-bool CoreIPCAVOutputContext::isValidDictionary(CoreIPCDictionary& dictionary)
+CoreIPCAVOutputContext::CoreIPCAVOutputContext(AVOutputContext *object)
 {
-    if (!dictionary.keyHasValueOfType("AVOutputContextSerializationKeyContextID"_s, IPC::NSType::String))
-        return false;
+    auto dictionary = dictionaryForWebKitSecureCodingType(object);
+    m_AVOutputContextSerializationKeyContextID = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"];
+    if (!m_AVOutputContextSerializationKeyContextID || IPC::typeFromObject(m_AVOutputContextSerializationKeyContextID.get()) != IPC::NSType::String) {
+        m_AVOutputContextSerializationKeyContextID = nullptr;
+    }
 
-    if (!dictionary.keyHasValueOfType("AVOutputContextSerializationKeyContextType"_s, IPC::NSType::String))
-        return false;
+    m_AVOutputContextSerializationKeyContextType = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"];
+    if (!m_AVOutputContextSerializationKeyContextType || IPC::typeFromObject(m_AVOutputContextSerializationKeyContextType.get()) != IPC::NSType::String) {
+        m_AVOutputContextSerializationKeyContextType = nullptr;
+    }
 
-    return true;
 }
 
 RetainPtr<id> CoreIPCAVOutputContext::toID() const
 {
+    auto propertyList = [NSMutableDictionary dictionaryWithCapacity:2];
+    if (m_AVOutputContextSerializationKeyContextID)
+        propertyList[@"AVOutputContextSerializationKeyContextID"] = m_AVOutputContextSerializationKeyContextID.get();
+    if (m_AVOutputContextSerializationKeyContextType)
+        propertyList[@"AVOutputContextSerializationKeyContextType"] = m_AVOutputContextSerializationKeyContextType.get();
     if (![PAL::getAVOutputContextClass() instancesRespondToSelector:@selector(_initWithWebKitPropertyListData:)]) {
-        auto unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:m_propertyList.toID().get()]);
+        auto unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:propertyList]);
         return adoptNS([[PAL::getAVOutputContextClass() alloc] initWithCoder:unarchiver.get()]);
     }
-    return adoptNS([[PAL::getAVOutputContextClass() alloc] _initWithWebKitPropertyListData:m_propertyList.toID().get()]);
+    return adoptNS([[PAL::getAVOutputContextClass() alloc] _initWithWebKitPropertyListData:propertyList]);
 }
 #endif // USE(AVFOUNDATION)
 
-CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(NSSomeFoundationType *object)
-    : m_propertyList([object _webKitPropertyListData])
+CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(
+    RetainPtr<NSString>&& StringKey,
+    RetainPtr<NSNumber>&& NumberKey,
+    RetainPtr<NSNumber>&& OptionalNumberKey,
+    RetainPtr<NSArray>&& ArrayKey,
+    RetainPtr<NSArray>&& OptionalArrayKey,
+    RetainPtr<NSDictionary>&& DictionaryKey,
+    RetainPtr<NSDictionary>&& OptionalDictionaryKey
+)
+    : m_StringKey(WTFMove(StringKey))
+    , m_NumberKey(WTFMove(NumberKey))
+    , m_OptionalNumberKey(WTFMove(OptionalNumberKey))
+    , m_ArrayKey(WTFMove(ArrayKey))
+    , m_OptionalArrayKey(WTFMove(OptionalArrayKey))
+    , m_DictionaryKey(WTFMove(DictionaryKey))
+    , m_OptionalDictionaryKey(WTFMove(OptionalDictionaryKey))
 {
 }
 
-bool CoreIPCNSSomeFoundationType::isValidDictionary(CoreIPCDictionary& dictionary)
+CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(NSSomeFoundationType *object)
 {
-    if (!dictionary.keyHasValueOfType("StringKey"_s, IPC::NSType::String))
-        return false;
+    auto dictionary = dictionaryForWebKitSecureCodingType(object);
+    m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
+    if (!m_StringKey || IPC::typeFromObject(m_StringKey.get()) != IPC::NSType::String) {
+        m_StringKey = nullptr;
+    }
 
-    if (!dictionary.keyHasValueOfType("NumberKey"_s, IPC::NSType::Number))
-        return false;
+    m_NumberKey = (NSNumber *)[dictionary objectForKey:@"NumberKey"];
+    if (!m_NumberKey || IPC::typeFromObject(m_NumberKey.get()) != IPC::NSType::Number) {
+        m_NumberKey = nullptr;
+    }
 
-    if (!dictionary.keyIsMissingOrHasValueOfType("OptionalNumberKey"_s, IPC::NSType::Number))
-        return false;
+    m_OptionalNumberKey = (NSNumber *)[dictionary objectForKey:@"OptionalNumberKey"];
+    if (m_OptionalNumberKey && IPC::typeFromObject(m_OptionalNumberKey.get()) != IPC::NSType::Number) {
+        m_OptionalNumberKey = nullptr;
+    }
 
-    if (!dictionary.keyHasValueOfType("ArrayKey"_s, IPC::NSType::Array))
-        return false;
+    m_ArrayKey = (NSArray *)[dictionary objectForKey:@"ArrayKey"];
+    if (!m_ArrayKey || IPC::typeFromObject(m_ArrayKey.get()) != IPC::NSType::Array) {
+        m_ArrayKey = nullptr;
+    }
 
-    if (!dictionary.keyIsMissingOrHasValueOfType("OptionalArrayKey"_s, IPC::NSType::Array))
-        return false;
+    m_OptionalArrayKey = (NSArray *)[dictionary objectForKey:@"OptionalArrayKey"];
+    if (m_OptionalArrayKey && IPC::typeFromObject(m_OptionalArrayKey.get()) != IPC::NSType::Array) {
+        m_OptionalArrayKey = nullptr;
+    }
 
-    if (!dictionary.keyHasValueOfType("DictionaryKey"_s, IPC::NSType::Dictionary))
-        return false;
+    m_DictionaryKey = (NSDictionary *)[dictionary objectForKey:@"DictionaryKey"];
+    if (!m_DictionaryKey || IPC::typeFromObject(m_DictionaryKey.get()) != IPC::NSType::Dictionary) {
+        m_DictionaryKey = nullptr;
+    }
 
-    if (!dictionary.keyIsMissingOrHasValueOfType("OptionalDictionaryKey"_s, IPC::NSType::Dictionary))
-        return false;
+    m_OptionalDictionaryKey = (NSDictionary *)[dictionary objectForKey:@"OptionalDictionaryKey"];
+    if (m_OptionalDictionaryKey && IPC::typeFromObject(m_OptionalDictionaryKey.get()) != IPC::NSType::Dictionary) {
+        m_OptionalDictionaryKey = nullptr;
+    }
 
-    return true;
 }
 
 RetainPtr<id> CoreIPCNSSomeFoundationType::toID() const
 {
+    auto propertyList = [NSMutableDictionary dictionaryWithCapacity:7];
+    if (m_StringKey)
+        propertyList[@"StringKey"] = m_StringKey.get();
+    if (m_NumberKey)
+        propertyList[@"NumberKey"] = m_NumberKey.get();
+    if (m_OptionalNumberKey)
+        propertyList[@"OptionalNumberKey"] = m_OptionalNumberKey.get();
+    if (m_ArrayKey)
+        propertyList[@"ArrayKey"] = m_ArrayKey.get();
+    if (m_OptionalArrayKey)
+        propertyList[@"OptionalArrayKey"] = m_OptionalArrayKey.get();
+    if (m_DictionaryKey)
+        propertyList[@"DictionaryKey"] = m_DictionaryKey.get();
+    if (m_OptionalDictionaryKey)
+        propertyList[@"OptionalDictionaryKey"] = m_OptionalDictionaryKey.get();
     RELEASE_ASSERT([NSSomeFoundationType instancesRespondToSelector:@selector(_initWithWebKitPropertyListData:)]);
-    return adoptNS([[NSSomeFoundationType alloc] _initWithWebKitPropertyListData:m_propertyList.toID().get()]);
+    return adoptNS([[NSSomeFoundationType alloc] _initWithWebKitPropertyListData:propertyList]);
 }
 
 #if ENABLE(DATA_DETECTION)
-CoreIPCDDScannerResult::CoreIPCDDScannerResult(DDScannerResult *object)
-    : m_propertyList([object _webKitPropertyListData])
+CoreIPCDDScannerResult::CoreIPCDDScannerResult(
+    RetainPtr<NSString>&& StringKey,
+    RetainPtr<NSNumber>&& NumberKey,
+    RetainPtr<NSNumber>&& OptionalNumberKey,
+    Vector<RetainPtr<DDScannerResult>>&& ArrayKey,
+    std::optional<Vector<RetainPtr<DDScannerResult>>>&& OptionalArrayKey,
+    Vector<std::pair<String, RetainPtr<Number>>>&& DictionaryKey,
+    std::optional<Vector<std::pair<String, RetainPtr<DDScannerResult>>>>&& OptionalDictionaryKey,
+    Vector<RetainPtr<NSData>>&& DataArrayKey,
+    Vector<RetainPtr<SecTrustRef>>&& SecTrustArrayKey
+)
+    : m_StringKey(WTFMove(StringKey))
+    , m_NumberKey(WTFMove(NumberKey))
+    , m_OptionalNumberKey(WTFMove(OptionalNumberKey))
+    , m_ArrayKey(WTFMove(ArrayKey))
+    , m_OptionalArrayKey(WTFMove(OptionalArrayKey))
+    , m_DictionaryKey(WTFMove(DictionaryKey))
+    , m_OptionalDictionaryKey(WTFMove(OptionalDictionaryKey))
+    , m_DataArrayKey(WTFMove(DataArrayKey))
+    , m_SecTrustArrayKey(WTFMove(SecTrustArrayKey))
 {
 }
 
-bool CoreIPCDDScannerResult::isValidDictionary(CoreIPCDictionary& dictionary)
+CoreIPCDDScannerResult::CoreIPCDDScannerResult(DDScannerResult *object)
 {
-    if (!dictionary.keyHasValueOfType("StringKey"_s, IPC::NSType::String))
-        return false;
+    auto dictionary = dictionaryForWebKitSecureCodingType(object);
+    m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
+    if (!m_StringKey || IPC::typeFromObject(m_StringKey.get()) != IPC::NSType::String) {
+        m_StringKey = nullptr;
+    }
 
-    if (!dictionary.keyHasValueOfType("NumberKey"_s, IPC::NSType::Number))
-        return false;
+    m_NumberKey = (NSNumber *)[dictionary objectForKey:@"NumberKey"];
+    if (!m_NumberKey || IPC::typeFromObject(m_NumberKey.get()) != IPC::NSType::Number) {
+        m_NumberKey = nullptr;
+    }
 
-    if (!dictionary.keyIsMissingOrHasValueOfType("OptionalNumberKey"_s, IPC::NSType::Number))
-        return false;
+    m_OptionalNumberKey = (NSNumber *)[dictionary objectForKey:@"OptionalNumberKey"];
+    if (m_OptionalNumberKey && IPC::typeFromObject(m_OptionalNumberKey.get()) != IPC::NSType::Number) {
+        m_OptionalNumberKey = nullptr;
+    }
 
-    if (!dictionary.keyHasValueOfType("ArrayKey"_s, IPC::NSType::Array))
-        return false;
-    if (!dictionary.collectionValuesAreOfType("ArrayKey"_s, IPC::NSType::DDScannerResult))
-        return false;
-
-    if (!dictionary.keyIsMissingOrHasValueOfType("OptionalArrayKey"_s, IPC::NSType::Array))
-        return false;
-    if (!dictionary.collectionValuesAreOfType("OptionalArrayKey"_s, IPC::NSType::DDScannerResult))
-        return false;
-
-    if (!dictionary.keyHasValueOfType("DictionaryKey"_s, IPC::NSType::Dictionary))
-        return false;
-    if (!dictionary.collectionValuesAreOfType("DictionaryKey"_s, IPC::NSType::String, IPC::NSType::Number))
-        return false;
-
-    if (!dictionary.keyIsMissingOrHasValueOfType("OptionalDictionaryKey"_s, IPC::NSType::Dictionary))
-        return false;
-    if (!dictionary.collectionValuesAreOfType("OptionalDictionaryKey"_s, IPC::NSType::String, IPC::NSType::DDScannerResult))
-        return false;
-
-    return true;
+    m_ArrayKey = vectorFromArray<DDScannerResult>((NSArray *)[dictionary objectForKey:@"ArrayKey"]);
+    m_OptionalArrayKey = optionalVectorFromArray<DDScannerResult>((NSArray *)[dictionary objectForKey:@"OptionalArrayKey"]);
+    m_DictionaryKey = vectorFromDictionary<Number>((NSDictionary *)[dictionary objectForKey:@"DictionaryKey"]);
+    m_OptionalDictionaryKey = optionalVectorFromDictionary<DDScannerResult>((NSDictionary *)[dictionary objectForKey:@"OptionalDictionaryKey"]);
+    m_DataArrayKey = vectorFromArray<NSData>((NSArray *)[dictionary objectForKey:@"DataArrayKey"]);
+    m_SecTrustArrayKey = vectorFromArray<SecTrustRef>((NSArray *)[dictionary objectForKey:@"SecTrustArrayKey"]);
 }
 
 RetainPtr<id> CoreIPCDDScannerResult::toID() const
 {
+    auto propertyList = [NSMutableDictionary dictionaryWithCapacity:9];
+    if (m_StringKey)
+        propertyList[@"StringKey"] = m_StringKey.get();
+    if (m_NumberKey)
+        propertyList[@"NumberKey"] = m_NumberKey.get();
+    if (m_OptionalNumberKey)
+        propertyList[@"OptionalNumberKey"] = m_OptionalNumberKey.get();
+    propertyList[@"ArrayKey"] = arrayFromVector(m_ArrayKey).get();
+    if (auto array = arrayFromOptionalVector(m_OptionalArrayKey))
+        propertyList[@"OptionalArrayKey"] = array.get();
+    propertyList[@"DictionaryKey"] = dictionaryFromVector(m_DictionaryKey).get();
+    if (auto dictionary = dictionaryFromOptionalVector(m_OptionalDictionaryKey))
+        propertyList[@"OptionalDictionaryKey"] = dictionary.get();
+    propertyList[@"DataArrayKey"] = arrayFromVector(m_DataArrayKey).get();
+    propertyList[@"SecTrustArrayKey"] = arrayFromVector(m_SecTrustArrayKey).get();
     RELEASE_ASSERT([PAL::getDDScannerResultClass() instancesRespondToSelector:@selector(_initWithWebKitPropertyListData:)]);
-    return adoptNS([[PAL::getDDScannerResultClass() alloc] _initWithWebKitPropertyListData:m_propertyList.toID().get()]);
+    return adoptNS([[PAL::getDDScannerResultClass() alloc] _initWithWebKitPropertyListData:propertyList]);
 }
 #endif // ENABLE(DATA_DETECTION)
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h
@@ -26,6 +26,7 @@
 
 #if PLATFORM(COCOA)
 #include "CoreIPCTypes.h"
+#include <wtf/cocoa/VectorCocoa.h>
 
 #if USE(AVFOUNDATION)
 OBJC_CLASS AVOutputContext;
@@ -42,66 +43,86 @@ class CoreIPCAVOutputContext {
 public:
     CoreIPCAVOutputContext(AVOutputContext *);
     CoreIPCAVOutputContext(const RetainPtr<AVOutputContext>& object)
-        : CoreIPCAVOutputContext(object.get())
-    {
-    }
+        : CoreIPCAVOutputContext(object.get()) { }
 
-    static bool isValidDictionary(CoreIPCDictionary&);
     RetainPtr<id> toID() const;
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCAVOutputContext, void>;
 
-    CoreIPCAVOutputContext(CoreIPCDictionary&& propertyList)
-        : m_propertyList(WTFMove(propertyList))
-    {
-    }
+    CoreIPCAVOutputContext(
+        RetainPtr<NSString>&&,
+        RetainPtr<NSString>&&
+    );
 
-    CoreIPCDictionary m_propertyList;
+    RetainPtr<NSString> m_AVOutputContextSerializationKeyContextID;
+    RetainPtr<NSString> m_AVOutputContextSerializationKeyContextType;
 };
 #endif
+
 class CoreIPCNSSomeFoundationType {
 public:
     CoreIPCNSSomeFoundationType(NSSomeFoundationType *);
     CoreIPCNSSomeFoundationType(const RetainPtr<NSSomeFoundationType>& object)
-        : CoreIPCNSSomeFoundationType(object.get())
-    {
-    }
+        : CoreIPCNSSomeFoundationType(object.get()) { }
 
-    static bool isValidDictionary(CoreIPCDictionary&);
     RetainPtr<id> toID() const;
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCNSSomeFoundationType, void>;
 
-    CoreIPCNSSomeFoundationType(CoreIPCDictionary&& propertyList)
-        : m_propertyList(WTFMove(propertyList))
-    {
-    }
+    CoreIPCNSSomeFoundationType(
+        RetainPtr<NSString>&&,
+        RetainPtr<NSNumber>&&,
+        RetainPtr<NSNumber>&&,
+        RetainPtr<NSArray>&&,
+        RetainPtr<NSArray>&&,
+        RetainPtr<NSDictionary>&&,
+        RetainPtr<NSDictionary>&&
+    );
 
-    CoreIPCDictionary m_propertyList;
+    RetainPtr<NSString> m_StringKey;
+    RetainPtr<NSNumber> m_NumberKey;
+    RetainPtr<NSNumber> m_OptionalNumberKey;
+    RetainPtr<NSArray> m_ArrayKey;
+    RetainPtr<NSArray> m_OptionalArrayKey;
+    RetainPtr<NSDictionary> m_DictionaryKey;
+    RetainPtr<NSDictionary> m_OptionalDictionaryKey;
 };
+
 #if ENABLE(DATA_DETECTION)
 class CoreIPCDDScannerResult {
 public:
     CoreIPCDDScannerResult(DDScannerResult *);
     CoreIPCDDScannerResult(const RetainPtr<DDScannerResult>& object)
-        : CoreIPCDDScannerResult(object.get())
-    {
-    }
+        : CoreIPCDDScannerResult(object.get()) { }
 
-    static bool isValidDictionary(CoreIPCDictionary&);
     RetainPtr<id> toID() const;
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCDDScannerResult, void>;
 
-    CoreIPCDDScannerResult(CoreIPCDictionary&& propertyList)
-        : m_propertyList(WTFMove(propertyList))
-    {
-    }
+    CoreIPCDDScannerResult(
+        RetainPtr<NSString>&&,
+        RetainPtr<NSNumber>&&,
+        RetainPtr<NSNumber>&&,
+        Vector<RetainPtr<DDScannerResult>>&&,
+        std::optional<Vector<RetainPtr<DDScannerResult>>>&&,
+        Vector<std::pair<String, RetainPtr<Number>>>&&,
+        std::optional<Vector<std::pair<String, RetainPtr<DDScannerResult>>>>&&,
+        Vector<RetainPtr<NSData>>&&,
+        Vector<RetainPtr<SecTrustRef>>&&
+    );
 
-    CoreIPCDictionary m_propertyList;
+    RetainPtr<NSString> m_StringKey;
+    RetainPtr<NSNumber> m_NumberKey;
+    RetainPtr<NSNumber> m_OptionalNumberKey;
+    Vector<RetainPtr<DDScannerResult>> m_ArrayKey;
+    std::optional<Vector<RetainPtr<DDScannerResult>>> m_OptionalArrayKey;
+    Vector<std::pair<String, RetainPtr<Number>>> m_DictionaryKey;
+    std::optional<Vector<std::pair<String, RetainPtr<DDScannerResult>>>> m_OptionalDictionaryKey;
+    Vector<RetainPtr<NSData>> m_DataArrayKey;
+    Vector<RetainPtr<SecTrustRef>> m_SecTrustArrayKey;
 };
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -359,93 +359,29 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "request"_s
             },
         } },
-        { "webkit_secure_coding AVOutputContext"_s, {
-            {
-                "AVOutputContextSerializationKeyContextID"_s,
-                "WebKit::CoreIPCString"_s
-            },
-            {
-                "AVOutputContextSerializationKeyContextType"_s,
-                "WebKit::CoreIPCString"_s
-            },
-        } },
         { "WebKit::CoreIPCAVOutputContext"_s, {
-            {
-                "WebKit::CoreIPCDictionary"_s,
-                "m_propertyList"_s
-            },
-        } },
-        { "webkit_secure_coding NSSomeFoundationType"_s, {
-            {
-                "StringKey"_s,
-                "WebKit::CoreIPCString"_s
-            },
-            {
-                "NumberKey"_s,
-                "WebKit::CoreIPCNumber"_s
-            },
-            {
-                "OptionalNumberKey"_s,
-                "WebKit::CoreIPCNumber?"_s
-            },
-            {
-                "ArrayKey"_s,
-                "WebKit::CoreIPCArray"_s
-            },
-            {
-                "OptionalArrayKey"_s,
-                "WebKit::CoreIPCArray?"_s
-            },
-            {
-                "DictionaryKey"_s,
-                "WebKit::CoreIPCDictionary"_s
-            },
-            {
-                "OptionalDictionaryKey"_s,
-                "WebKit::CoreIPCDictionary?"_s
-            },
+            { "RetainPtr<NSString>"_s , "AVOutputContextSerializationKeyContextID"_s },
+            { "RetainPtr<NSString>"_s , "AVOutputContextSerializationKeyContextType"_s },
         } },
         { "WebKit::CoreIPCNSSomeFoundationType"_s, {
-            {
-                "WebKit::CoreIPCDictionary"_s,
-                "m_propertyList"_s
-            },
-        } },
-        { "webkit_secure_coding DDScannerResult"_s, {
-            {
-                "StringKey"_s,
-                "WebKit::CoreIPCString"_s
-            },
-            {
-                "NumberKey"_s,
-                "WebKit::CoreIPCNumber"_s
-            },
-            {
-                "OptionalNumberKey"_s,
-                "WebKit::CoreIPCNumber?"_s
-            },
-            {
-                "ArrayKey"_s,
-                "WebKit::CoreIPCArray<WebKit::CoreIPCDDScannerResult>"_s
-            },
-            {
-                "OptionalArrayKey"_s,
-                "WebKit::CoreIPCArray<WebKit::CoreIPCDDScannerResult>?"_s
-            },
-            {
-                "DictionaryKey"_s,
-                "WebKit::CoreIPCDictionary<WebKit::CoreIPCString, WebKit::CoreIPCNumber>"_s
-            },
-            {
-                "OptionalDictionaryKey"_s,
-                "WebKit::CoreIPCDictionary<WebKit::CoreIPCString, WebKit::CoreIPCDDScannerResult>?"_s
-            },
+            { "RetainPtr<NSString>"_s , "StringKey"_s },
+            { "RetainPtr<NSNumber>"_s , "NumberKey"_s },
+            { "RetainPtr<NSNumber>"_s , "OptionalNumberKey"_s },
+            { "RetainPtr<NSArray>"_s , "ArrayKey"_s },
+            { "RetainPtr<NSArray>"_s , "OptionalArrayKey"_s },
+            { "RetainPtr<NSDictionary>"_s , "DictionaryKey"_s },
+            { "RetainPtr<NSDictionary>"_s , "OptionalDictionaryKey"_s },
         } },
         { "WebKit::CoreIPCDDScannerResult"_s, {
-            {
-                "WebKit::CoreIPCDictionary"_s,
-                "m_propertyList"_s
-            },
+            { "RetainPtr<NSString>"_s , "StringKey"_s },
+            { "RetainPtr<NSNumber>"_s , "NumberKey"_s },
+            { "RetainPtr<NSNumber>"_s , "OptionalNumberKey"_s },
+            { "Vector<RetainPtr<DDScannerResult>>"_s , "ArrayKey"_s },
+            { "std::optional<Vector<RetainPtr<DDScannerResult>>>"_s , "OptionalArrayKey"_s },
+            { "Vector<std::pair<String, RetainPtr<Number>>>"_s , "DictionaryKey"_s },
+            { "std::optional<Vector<std::pair<String, RetainPtr<DDScannerResult>>>>"_s , "OptionalDictionaryKey"_s },
+            { "Vector<RetainPtr<NSData>>"_s , "DataArrayKey"_s },
+            { "Vector<RetainPtr<SecTrustRef>>"_s , "SecTrustArrayKey"_s },
         } },
         { "WebKit::RValueWithFunctionCalls"_s, {
             {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -259,6 +259,8 @@ secure_coding_headers: <pal/cocoa/DataDetectorsCoreSoftLink.h>
     OptionalArrayKey: Array<DDScannerResult>?
     DictionaryKey: Dictionary<String, Number>
     OptionalDictionaryKey: Dictionary<String, DDScannerResult>?
+    DataArrayKey: Array<Data>
+    SecTrustArrayKey: Array<SecTrustRef>
 }
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -89,31 +89,38 @@ std::optional<WebKit::PlatformClass> ArgumentCoder<WebKit::PlatformClass>::decod
 #if USE(AVFOUNDATION)
 void ArgumentCoder<WebKit::CoreIPCAVOutputContext>::encode(Encoder& encoder, const WebKit::CoreIPCAVOutputContext& instance)
 {
-    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_propertyList)>, WebKit::CoreIPCDictionary>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_AVOutputContextSerializationKeyContextID)>, RetainPtr<NSString>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_AVOutputContextSerializationKeyContextType)>, RetainPtr<NSString>>);
     struct ShouldBeSameSizeAsAVOutputContext : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::CoreIPCAVOutputContext>, false> {
-        WebKit::CoreIPCDictionary m_propertyList;
+        RetainPtr<NSString> AVOutputContextSerializationKeyContextID;
+        RetainPtr<NSString> AVOutputContextSerializationKeyContextType;
     };
     static_assert(sizeof(ShouldBeSameSizeAsAVOutputContext) == sizeof(WebKit::CoreIPCAVOutputContext));
     static_assert(MembersInCorrectOrder < 0
-        , offsetof(WebKit::CoreIPCAVOutputContext, m_propertyList)
+        , offsetof(WebKit::CoreIPCAVOutputContext, m_AVOutputContextSerializationKeyContextID)
+        , offsetof(WebKit::CoreIPCAVOutputContext, m_AVOutputContextSerializationKeyContextType)
     >::value);
 
-    encoder << instance.m_propertyList;
+    encoder << instance.m_AVOutputContextSerializationKeyContextID;
+    encoder << instance.m_AVOutputContextSerializationKeyContextType;
 }
 
 std::optional<WebKit::CoreIPCAVOutputContext> ArgumentCoder<WebKit::CoreIPCAVOutputContext>::decode(Decoder& decoder)
 {
-    auto m_propertyList = decoder.decode<WebKit::CoreIPCDictionary>();
-    if (UNLIKELY(!decoder.isValid()))
+    auto AVOutputContextSerializationKeyContextID = decoder.decode<RetainPtr<NSString>>();
+    if (!AVOutputContextSerializationKeyContextID)
         return std::nullopt;
 
-    if (!(WebKit::CoreIPCAVOutputContext::isValidDictionary(*m_propertyList)))
+    auto AVOutputContextSerializationKeyContextType = decoder.decode<RetainPtr<NSString>>();
+    if (!AVOutputContextSerializationKeyContextType)
         return std::nullopt;
+
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {
         WebKit::CoreIPCAVOutputContext {
-            WTFMove(*m_propertyList)
+            WTFMove(*AVOutputContextSerializationKeyContextID),
+            WTFMove(*AVOutputContextSerializationKeyContextType)
         }
     };
 }
@@ -122,31 +129,83 @@ std::optional<WebKit::CoreIPCAVOutputContext> ArgumentCoder<WebKit::CoreIPCAVOut
 
 void ArgumentCoder<WebKit::CoreIPCNSSomeFoundationType>::encode(Encoder& encoder, const WebKit::CoreIPCNSSomeFoundationType& instance)
 {
-    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_propertyList)>, WebKit::CoreIPCDictionary>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_StringKey)>, RetainPtr<NSString>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_NumberKey)>, RetainPtr<NSNumber>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_OptionalNumberKey)>, RetainPtr<NSNumber>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_ArrayKey)>, RetainPtr<NSArray>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_OptionalArrayKey)>, RetainPtr<NSArray>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_DictionaryKey)>, RetainPtr<NSDictionary>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_OptionalDictionaryKey)>, RetainPtr<NSDictionary>>);
     struct ShouldBeSameSizeAsNSSomeFoundationType : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::CoreIPCNSSomeFoundationType>, false> {
-        WebKit::CoreIPCDictionary m_propertyList;
+        RetainPtr<NSString> StringKey;
+        RetainPtr<NSNumber> NumberKey;
+        RetainPtr<NSNumber> OptionalNumberKey;
+        RetainPtr<NSArray> ArrayKey;
+        RetainPtr<NSArray> OptionalArrayKey;
+        RetainPtr<NSDictionary> DictionaryKey;
+        RetainPtr<NSDictionary> OptionalDictionaryKey;
     };
     static_assert(sizeof(ShouldBeSameSizeAsNSSomeFoundationType) == sizeof(WebKit::CoreIPCNSSomeFoundationType));
     static_assert(MembersInCorrectOrder < 0
-        , offsetof(WebKit::CoreIPCNSSomeFoundationType, m_propertyList)
+        , offsetof(WebKit::CoreIPCNSSomeFoundationType, m_StringKey)
+        , offsetof(WebKit::CoreIPCNSSomeFoundationType, m_NumberKey)
+        , offsetof(WebKit::CoreIPCNSSomeFoundationType, m_OptionalNumberKey)
+        , offsetof(WebKit::CoreIPCNSSomeFoundationType, m_ArrayKey)
+        , offsetof(WebKit::CoreIPCNSSomeFoundationType, m_OptionalArrayKey)
+        , offsetof(WebKit::CoreIPCNSSomeFoundationType, m_DictionaryKey)
+        , offsetof(WebKit::CoreIPCNSSomeFoundationType, m_OptionalDictionaryKey)
     >::value);
 
-    encoder << instance.m_propertyList;
+    encoder << instance.m_StringKey;
+    encoder << instance.m_NumberKey;
+    encoder << instance.m_OptionalNumberKey;
+    encoder << instance.m_ArrayKey;
+    encoder << instance.m_OptionalArrayKey;
+    encoder << instance.m_DictionaryKey;
+    encoder << instance.m_OptionalDictionaryKey;
 }
 
 std::optional<WebKit::CoreIPCNSSomeFoundationType> ArgumentCoder<WebKit::CoreIPCNSSomeFoundationType>::decode(Decoder& decoder)
 {
-    auto m_propertyList = decoder.decode<WebKit::CoreIPCDictionary>();
-    if (UNLIKELY(!decoder.isValid()))
+    auto StringKey = decoder.decode<RetainPtr<NSString>>();
+    if (!StringKey)
         return std::nullopt;
 
-    if (!(WebKit::CoreIPCNSSomeFoundationType::isValidDictionary(*m_propertyList)))
+    auto NumberKey = decoder.decode<RetainPtr<NSNumber>>();
+    if (!NumberKey)
         return std::nullopt;
+
+    auto OptionalNumberKey = decoder.decode<RetainPtr<NSNumber>>();
+    if (!OptionalNumberKey)
+        return std::nullopt;
+
+    auto ArrayKey = decoder.decode<RetainPtr<NSArray>>();
+    if (!ArrayKey)
+        return std::nullopt;
+
+    auto OptionalArrayKey = decoder.decode<RetainPtr<NSArray>>();
+    if (!OptionalArrayKey)
+        return std::nullopt;
+
+    auto DictionaryKey = decoder.decode<RetainPtr<NSDictionary>>();
+    if (!DictionaryKey)
+        return std::nullopt;
+
+    auto OptionalDictionaryKey = decoder.decode<RetainPtr<NSDictionary>>();
+    if (!OptionalDictionaryKey)
+        return std::nullopt;
+
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {
         WebKit::CoreIPCNSSomeFoundationType {
-            WTFMove(*m_propertyList)
+            WTFMove(*StringKey),
+            WTFMove(*NumberKey),
+            WTFMove(*OptionalNumberKey),
+            WTFMove(*ArrayKey),
+            WTFMove(*OptionalArrayKey),
+            WTFMove(*DictionaryKey),
+            WTFMove(*OptionalDictionaryKey)
         }
     };
 }
@@ -154,31 +213,101 @@ std::optional<WebKit::CoreIPCNSSomeFoundationType> ArgumentCoder<WebKit::CoreIPC
 #if ENABLE(DATA_DETECTION)
 void ArgumentCoder<WebKit::CoreIPCDDScannerResult>::encode(Encoder& encoder, const WebKit::CoreIPCDDScannerResult& instance)
 {
-    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_propertyList)>, WebKit::CoreIPCDictionary>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_StringKey)>, RetainPtr<NSString>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_NumberKey)>, RetainPtr<NSNumber>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_OptionalNumberKey)>, RetainPtr<NSNumber>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_ArrayKey)>, Vector<RetainPtr<DDScannerResult>>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_OptionalArrayKey)>, std::optional<Vector<RetainPtr<DDScannerResult>>>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_DictionaryKey)>, Vector<std::pair<String, RetainPtr<Number>>>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_OptionalDictionaryKey)>, std::optional<Vector<std::pair<String, RetainPtr<DDScannerResult>>>>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_DataArrayKey)>, Vector<RetainPtr<NSData>>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_SecTrustArrayKey)>, Vector<RetainPtr<SecTrustRef>>>);
     struct ShouldBeSameSizeAsDDScannerResult : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::CoreIPCDDScannerResult>, false> {
-        WebKit::CoreIPCDictionary m_propertyList;
+        RetainPtr<NSString> StringKey;
+        RetainPtr<NSNumber> NumberKey;
+        RetainPtr<NSNumber> OptionalNumberKey;
+        Vector<RetainPtr<DDScannerResult>> ArrayKey;
+        std::optional<Vector<RetainPtr<DDScannerResult>>> OptionalArrayKey;
+        Vector<std::pair<String, RetainPtr<Number>>> DictionaryKey;
+        std::optional<Vector<std::pair<String, RetainPtr<DDScannerResult>>>> OptionalDictionaryKey;
+        Vector<RetainPtr<NSData>> DataArrayKey;
+        Vector<RetainPtr<SecTrustRef>> SecTrustArrayKey;
     };
     static_assert(sizeof(ShouldBeSameSizeAsDDScannerResult) == sizeof(WebKit::CoreIPCDDScannerResult));
     static_assert(MembersInCorrectOrder < 0
-        , offsetof(WebKit::CoreIPCDDScannerResult, m_propertyList)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_StringKey)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_NumberKey)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_OptionalNumberKey)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_ArrayKey)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_OptionalArrayKey)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_DictionaryKey)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_OptionalDictionaryKey)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_DataArrayKey)
+        , offsetof(WebKit::CoreIPCDDScannerResult, m_SecTrustArrayKey)
     >::value);
 
-    encoder << instance.m_propertyList;
+    encoder << instance.m_StringKey;
+    encoder << instance.m_NumberKey;
+    encoder << instance.m_OptionalNumberKey;
+    encoder << instance.m_ArrayKey;
+    encoder << instance.m_OptionalArrayKey;
+    encoder << instance.m_DictionaryKey;
+    encoder << instance.m_OptionalDictionaryKey;
+    encoder << instance.m_DataArrayKey;
+    encoder << instance.m_SecTrustArrayKey;
 }
 
 std::optional<WebKit::CoreIPCDDScannerResult> ArgumentCoder<WebKit::CoreIPCDDScannerResult>::decode(Decoder& decoder)
 {
-    auto m_propertyList = decoder.decode<WebKit::CoreIPCDictionary>();
-    if (UNLIKELY(!decoder.isValid()))
+    auto StringKey = decoder.decode<RetainPtr<NSString>>();
+    if (!StringKey)
         return std::nullopt;
 
-    if (!(WebKit::CoreIPCDDScannerResult::isValidDictionary(*m_propertyList)))
+    auto NumberKey = decoder.decode<RetainPtr<NSNumber>>();
+    if (!NumberKey)
         return std::nullopt;
+
+    auto OptionalNumberKey = decoder.decode<RetainPtr<NSNumber>>();
+    if (!OptionalNumberKey)
+        return std::nullopt;
+
+    auto ArrayKey = decoder.decode<Vector<RetainPtr<DDScannerResult>>>();
+    if (!ArrayKey)
+        return std::nullopt;
+
+    auto OptionalArrayKey = decoder.decode<std::optional<Vector<RetainPtr<DDScannerResult>>>>();
+    if (!OptionalArrayKey)
+        return std::nullopt;
+
+    auto DictionaryKey = decoder.decode<Vector<std::pair<String, RetainPtr<Number>>>>();
+    if (!DictionaryKey)
+        return std::nullopt;
+
+    auto OptionalDictionaryKey = decoder.decode<std::optional<Vector<std::pair<String, RetainPtr<DDScannerResult>>>>>();
+    if (!OptionalDictionaryKey)
+        return std::nullopt;
+
+    auto DataArrayKey = decoder.decode<Vector<RetainPtr<NSData>>>();
+    if (!DataArrayKey)
+        return std::nullopt;
+
+    auto SecTrustArrayKey = decoder.decode<Vector<RetainPtr<SecTrustRef>>>();
+    if (!SecTrustArrayKey)
+        return std::nullopt;
+
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {
         WebKit::CoreIPCDDScannerResult {
-            WTFMove(*m_propertyList)
+            WTFMove(*StringKey),
+            WTFMove(*NumberKey),
+            WTFMove(*OptionalNumberKey),
+            WTFMove(*ArrayKey),
+            WTFMove(*OptionalArrayKey),
+            WTFMove(*DictionaryKey),
+            WTFMove(*OptionalDictionaryKey),
+            WTFMove(*DataArrayKey),
+            WTFMove(*SecTrustArrayKey)
         }
     };
 }

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -103,11 +103,9 @@ enum class NSType : uint8_t {
     Null,
     PersonNameComponents,
     PresentationIntent,
-    SecTrustRef,
     SecureCoding,
     String,
     URL,
-    NSURLProtectionSpace,
     NSValue,
     CF,
     Unknown,
@@ -161,6 +159,7 @@ template<> Class getClass<PKPaymentToken>();
 template<> Class getClass<PKShippingMethod>();
 template<> Class getClass<PKDateComponentsRange>();
 template<> Class getClass<PKPaymentMethod>();
+template<> Class getClass<PKSecureElementPass>();
 #endif
 
 void encodeObjectWithWrapper(Encoder&, id);
@@ -190,10 +189,13 @@ static inline bool isObjectClassAllowed(id object, const HashSet<Class>& allowed
 template<typename T, typename>
 std::optional<RetainPtr<T>> decodeRequiringAllowedClasses(Decoder& decoder)
 {
+#if ASSERT_ENABLED
+    auto allowedClasses = decoder.allowedClasses();
+#endif
     auto result = decodeObjectFromWrapper(decoder, decoder.allowedClasses());
     if (!result)
         return std::nullopt;
-    ASSERT(!*result || isObjectClassAllowed((*result).get(), decoder.allowedClasses()));
+    ASSERT(!*result || isObjectClassAllowed((*result).get(), allowedClasses));
     return { *result };
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h
@@ -46,11 +46,6 @@ public:
 
     RetainPtr<id> toID() const;
 
-    bool keyHasValueOfType(const String&, IPC::NSType) const;
-    bool keyIsMissingOrHasValueOfType(const String&, IPC::NSType) const;
-    bool collectionValuesAreOfType(const String& key, IPC::NSType) const;
-    bool collectionValuesAreOfType(const String& key, IPC::NSType, IPC::NSType) const;
-
 private:
     friend struct IPC::ArgumentCoder<CoreIPCDictionary, void>;
 
@@ -58,9 +53,6 @@ private:
 
     CoreIPCDictionary(ValueType&&);
 
-    void createNSDictionaryIfNeeded() const;
-
-    mutable RetainPtr<NSDictionary> m_nsDictionary;
     ValueType m_keyValuePairs;
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
@@ -33,7 +33,6 @@
 namespace WebKit {
 
 CoreIPCDictionary::CoreIPCDictionary(NSDictionary *dictionary)
-    : m_nsDictionary(dictionary)
 {
     m_keyValuePairs.reserveInitialCapacity(dictionary.count);
 
@@ -61,79 +60,12 @@ CoreIPCDictionary::~CoreIPCDictionary() = default;
 CoreIPCDictionary::CoreIPCDictionary(ValueType&& keyValuePairs)
     : m_keyValuePairs(WTFMove(keyValuePairs)) { }
 
-bool CoreIPCDictionary::keyHasValueOfType(const String& key, IPC::NSType type) const
-{
-    createNSDictionaryIfNeeded();
-    id object = [m_nsDictionary.get() objectForKey:(NSString *)key];
-    if (!object) {
-        // Many objects have a required key that sometimes has a missing value, which is okay.
-        return true;
-    }
-
-    return IPC::typeFromObject(object) == type;
-}
-
-bool CoreIPCDictionary::keyIsMissingOrHasValueOfType(const String& key, IPC::NSType type) const
-{
-    createNSDictionaryIfNeeded();
-    id object = [m_nsDictionary.get() objectForKey:(NSString *)key];
-    if (!object)
-        return true;
-    return IPC::typeFromObject(object) == type;
-}
-
-bool CoreIPCDictionary::collectionValuesAreOfType(const String& key, IPC::NSType targetType) const
-{
-    createNSDictionaryIfNeeded();
-    NSArray *object = [m_nsDictionary.get() objectForKey:(NSString *)key];
-    if (!object)
-        return true;
-
-    if (![object isKindOfClass:NSArray.class])
-        return false;
-
-    for (id value in object) {
-        if (IPC::typeFromObject(value) != targetType)
-            return false;
-    }
-
-    return true;
-}
-
-bool CoreIPCDictionary::collectionValuesAreOfType(const String& key, IPC::NSType keyType, IPC::NSType valueType) const
-{
-    createNSDictionaryIfNeeded();
-    NSDictionary *object = [m_nsDictionary.get() objectForKey:(NSString *)key];
-    if (!object)
-        return true;
-
-    if (![object isKindOfClass:NSDictionary.class])
-        return false;
-
-    for (id key in object) {
-        if (IPC::typeFromObject(key) != keyType)
-            return false;
-        if (IPC::typeFromObject(((NSDictionary *)object)[key]) != valueType)
-            return false;
-    }
-
-    return true;
-}
-
-void CoreIPCDictionary::createNSDictionaryIfNeeded() const
-{
-    if (!m_nsDictionary) {
-        auto result = adoptNS([[NSMutableDictionary alloc] initWithCapacity:m_keyValuePairs.size()]);
-        for (auto& keyValuePair : m_keyValuePairs)
-            [result setObject:keyValuePair.value.toID().get() forKey:keyValuePair.key.toID().get()];
-        m_nsDictionary = WTFMove(result);
-    }
-}
-
 RetainPtr<id> CoreIPCDictionary::toID() const
 {
-    createNSDictionaryIfNeeded();
-    return m_nsDictionary;
+    auto result = adoptNS([[NSMutableDictionary alloc] initWithCapacity:m_keyValuePairs.size()]);
+    for (auto& keyValuePair : m_keyValuePairs)
+        [result setObject:keyValuePair.value.toID().get() forKey:keyValuePair.key.toID().get()];
+    return result;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in
@@ -25,7 +25,6 @@
 webkit_platform_headers: "CoreIPCDictionary.h"
 
 [WebKitPlatform] class WebKit::CoreIPCDictionary {
-    [NotSerialized] RetainPtr<NSDictionary> m_nsDictionary;
     Vector<KeyValuePair<WebKit::CoreIPCNSCFObject, WebKit::CoreIPCNSCFObject>> m_keyValuePairs;
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -104,8 +104,7 @@ using ObjectValue = std::variant<
     CoreIPCPresentationIntent,
     CoreIPCSecureCoding,
     CoreIPCString,
-    CoreIPCURL,
-    CoreIPCNSURLProtectionSpace
+    CoreIPCURL
 >;
 
 class CoreIPCNSCFObject {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -125,9 +125,6 @@ static ObjectValue valueFromID(id object)
         return CoreIPCString((NSString *)object);
     case IPC::NSType::URL:
         return CoreIPCURL((NSURL *)object);
-    case IPC::NSType::NSURLProtectionSpace:
-        return CoreIPCNSURLProtectionSpace((NSURLProtectionSpace *)object);
-    case IPC::NSType::SecTrustRef:
     case IPC::NSType::CF:
         return CoreIPCCFType((CFTypeRef)object);
     case IPC::NSType::Unknown:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLProtectionSpace.serialization.in
@@ -23,13 +23,7 @@
 #if PLATFORM(COCOA)
 
 [WebKitSecureCodingClass=NSURLProtectionSpace.class, SupportWKKeyedCoder] webkit_secure_coding NSURLProtectionSpace {
-    host: String
-    port: Number
-    type: Number
-    realm: String
-    scheme: Number
-    distnames: Array<Data>
-    trust: SecTrustRef
+    __nsurlprotectionspace_proto_plist: Dictionary
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -89,6 +89,7 @@ secure_coding_header: <pal/cocoa/PassKitSoftLink.h>
     endDateComponents: NSDateComponents
 }
 
+additional_forward_declaration: OBJC_CLASS PKSecureElementPass
 [WebKitSecureCodingClass=PAL::getPKPaymentMethodClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentMethod {
     type: Number
     displayName: String


### PR DESCRIPTION
#### dc8400212ff7ed91d184f6340b65758f860b5de5
<pre>
Use generated structures instead of NSDictionary to serialize members of ObjC classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=269438">https://bugs.webkit.org/show_bug.cgi?id=269438</a>
<a href="https://rdar.apple.com/122994790">rdar://122994790</a>

Reviewed by Brady Eidson.

This makes it so that we don&apos;t need to expand what an NSDictionary can contain in order
to increase the number of ObjC classes that are serialized using generated serialization.

This also makes it so we don&apos;t need &quot;webkit_secure_coding&quot; in SerializedTypeInfo.cpp,
so all the metadata has the same form.

We can also simplify CoreIPCDictionary to just a vector of key/value pairs.

If a type is not declared as optional with a question mark in the serialization.in file,
then we debug assert on the encoding side if it is missing and we fail to decode on the
decoding side if it is missing.

* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedType.name_declaration_for_serialized_type_info):
(SerializedType.members_for_serialized_type_info):
(MemberVariable.value_without_question_mark):
(MemberVariable):
(MemberVariable.ns_type_enum_value):
(MemberVariable.array_contents):
(MemberVariable.dictionary_contents):
(MemberVariable.has_container_contents):
(MemberVariable.ns_type):
(MemberVariable.dictionary_type):
(MemberVariable.value_is_optional):
(check_type_members):
(check_type_members.is):
(encode_type):
(decode_type):
(construct_type):
(generate_impl):
(generate_one_serialized_type_info):
(generate_serialized_type_info):
(parse_serialized_types):
(generate_webkit_secure_coding_impl):
(generate_webkit_secure_coding_impl.is):
(generate_webkit_secure_coding_header):
(generate_one_dictionary_member_validation): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::dictionaryFromVector):
(WebKit::dictionaryFromOptionalVector):
(WebKit::vectorFromDictionary):
(WebKit::optionalVectorFromDictionary):
(WebKit::arrayFromVector):
(WebKit::arrayFromOptionalVector):
(WebKit::vectorFromArray):
(WebKit::optionalVectorFromArray):
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
(WebKit::CoreIPCAVOutputContext::toID const):
(WebKit::CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType):
(WebKit::CoreIPCNSSomeFoundationType::toID const):
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
(WebKit::CoreIPCDDScannerResult::toID const):
(WebKit::CoreIPCAVOutputContext::isValidDictionary): Deleted.
(WebKit::CoreIPCNSSomeFoundationType::isValidDictionary): Deleted.
(WebKit::CoreIPCDDScannerResult::isValidDictionary): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h:
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
(WebKit::CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType):
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebKit::CoreIPCAVOutputContext&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCAVOutputContext&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCNSSomeFoundationType&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCNSSomeFoundationType&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCDDScannerResult&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCDDScannerResult&gt;::decode):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;PKSecureElementPass&gt;):
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.h:
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm:
(WebKit::CoreIPCDictionary::CoreIPCDictionary):
(WebKit::CoreIPCDictionary::toID const):
(WebKit::CoreIPCDictionary::keyHasValueOfType const): Deleted.
(WebKit::CoreIPCDictionary::keyIsMissingOrHasValueOfType const): Deleted.
(WebKit::CoreIPCDictionary::collectionValuesAreOfType const): Deleted.
(WebKit::CoreIPCDictionary::createNSDictionaryIfNeeded const): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:

Canonical link: <a href="https://commits.webkit.org/274799@main">https://commits.webkit.org/274799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/266e28559df15793dc33f042409fb05e39485ebd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40051 "16 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42596 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16392 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13882 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/39919 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36334 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12202 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16485 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5285 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->