### PR TITLE
Don't try to deduplicate SVG presentation attribute style that is likely unique

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -539,6 +539,8 @@ JSC_DEFINE_HOST_FUNCTION(signpostStart, (JSGlobalObject* globalObject, CallFrame
     ++activeJSGlobalObjectSignpostIntervalCount;
     os_signpost_interval_begin(WTFSignpostLogHandle(), os_signpost_id_make_with_pointer(WTFSignpostLogHandle(), globalObject), "JSGlobalObject signpost", "%" PUBLIC_LOG_STRING, message.ascii().data());
 
+    WTFLogAlways("signpostStart %s", message.ascii().data());
+
     return JSValue::encode(jsUndefined());
 }
 
@@ -552,6 +554,8 @@ JSC_DEFINE_HOST_FUNCTION(signpostStop, (JSGlobalObject* globalObject, CallFrame*
 
     os_signpost_interval_end(WTFSignpostLogHandle(), os_signpost_id_make_with_pointer(WTFSignpostLogHandle(), globalObject), "JSGlobalObject signpost", "%" PUBLIC_LOG_STRING, message.ascii().data());
     --activeJSGlobalObjectSignpostIntervalCount;
+
+    WTFLogAlways("signpostStop %s", message.ascii().data());
 
     return JSValue::encode(jsUndefined());
 }

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -85,6 +85,11 @@ Ref<MutableStyleProperties> MutableStyleProperties::createEmpty()
 
 Ref<ImmutableStyleProperties> MutableStyleProperties::immutableCopy() const
 {
+    return ImmutableStyleProperties::create(m_propertyVector.data(), m_propertyVector.size(), cssParserMode());
+}
+
+Ref<ImmutableStyleProperties> MutableStyleProperties::immutableDeduplicatedCopy() const
+{
     return ImmutableStyleProperties::createDeduplicating(m_propertyVector.data(), m_propertyVector.size(), cssParserMode());
 }
 

--- a/Source/WebCore/css/MutableStyleProperties.h
+++ b/Source/WebCore/css/MutableStyleProperties.h
@@ -47,6 +47,7 @@ public:
     WEBCORE_EXPORT ~MutableStyleProperties();
 
     Ref<ImmutableStyleProperties> immutableCopy() const;
+    Ref<ImmutableStyleProperties> immutableDeduplicatedCopy() const;
 
     unsigned propertyCount() const { return m_propertyVector.size(); }
     bool isEmpty() const { return !propertyCount(); }

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -54,7 +54,7 @@ Ref<ImmutableStyleProperties> StyleProperties::immutableCopyIfNeeded() const
 {
     if (auto* immutableProperties = dynamicDowncast<ImmutableStyleProperties>(*this))
         return const_cast<ImmutableStyleProperties&>(*immutableProperties);
-    return downcast<MutableStyleProperties>(*this).immutableCopy();
+    return downcast<MutableStyleProperties>(*this).immutableDeduplicatedCopy();
 }
 
 String serializeLonghandValue(CSSPropertyID property, const CSSValue& value)


### PR DESCRIPTION
#### 20f1c3fa6bbff1049237054dba3666ea8680d138
<pre>
Don&apos;t try to deduplicate SVG presentation attribute style that is likely unique
<a href="https://bugs.webkit.org/show_bug.cgi?id=269439">https://bugs.webkit.org/show_bug.cgi?id=269439</a>
&lt;<a href="https://rdar.apple.com/problem/122994878">rdar://problem/122994878</a>&gt;

Reviewed by Ryosuke Niwa.

* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::immutableCopy const):
(WebCore::MutableStyleProperties::immutableDeduplicatedCopy const):
* Source/WebCore/css/MutableStyleProperties.h:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::immutableCopyIfNeeded const):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::rebuildPresentationalHintStyle):

SVG x/y attributes rarely repeat so avoid deduplication work if they are present.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchAllRules):

Mark SVG properties that are shared much between elements uncacheable to avoid cache bloat.

Canonical link: <a href="https://commits.webkit.org/274715@main">https://commits.webkit.org/274715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/210904475cae7cdd99c606f0db2e7dd589b92b3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35739 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16178 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13745 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43660 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33290 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39510 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12052 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16271 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46471 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8927 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16319 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9556 "Found 1 new JSC stress test failure: stress/sampling-profiler-microtasks.js.dfg-eager (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->