### PR TITLE
[Cocoa] Implement LinearMediaKit versions of PlaybackSessionInterface and VideoPresentationInterface

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -982,7 +982,8 @@
 #define ENABLE_EXTENSION_CAPABILITIES 1
 #endif
 
+// FIXME: Re-enable once rdar://122200702 is resolved.
 #if !defined(ENABLE_LINEAR_MEDIA_PLAYER) \
     && USE(LINEARMEDIAKIT)
-#define ENABLE_LINEAR_MEDIA_PLAYER 1
+#define ENABLE_LINEAR_MEDIA_PLAYER 0
 #endif

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -433,8 +433,8 @@ $(PROJECT_DIR)/Modules/credentialmanagement/CredentialCreationOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialMediationRequirement.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialsContainer.idl
-$(PROJECT_DIR)/Modules/credentialmanagement/DigitalIdentity.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/DigitalIdentity.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/IdentityCredentialProtocol.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/IdentityRequestProvider.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/Navigator+Credentials.idl

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		A10826FA1F576292004772AC /* WebPanel.mm in Sources */ = {isa = PBXBuildFile; fileRef = A10826F81F576292004772AC /* WebPanel.mm */; };
 		A1175B4F1F6B337300C4B9F0 /* PopupMenu.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1175B4D1F6B337300C4B9F0 /* PopupMenu.mm */; };
 		A1175B581F6B470500C4B9F0 /* DefaultSearchProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1175B561F6B470500C4B9F0 /* DefaultSearchProvider.cpp */; };
+		A1D4D22D2B7E04CA0008C40E /* LinearMediaKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D4D22C2B7E04CA0008C40E /* LinearMediaKitSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1F63CA021A4DBF7006FB43B /* PassKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1F63C9E21A4DBF7006FB43B /* PassKitSoftLink.mm */; };
 		A30D41221F0DD0EA00B71954 /* KillRing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A30D411F1F0DD0EA00B71954 /* KillRing.cpp */; };
 		A30D41251F0DD12D00B71954 /* KillRingMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = A30D41241F0DD12D00B71954 /* KillRingMac.mm */; };
@@ -628,6 +629,7 @@
 		A1175B561F6B470500C4B9F0 /* DefaultSearchProvider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultSearchProvider.cpp; sourceTree = "<group>"; };
 		A1175B591F6B4A8400C4B9F0 /* NSScrollViewSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSScrollViewSPI.h; sourceTree = "<group>"; };
 		A169B040248EF03900EE8B7B /* PassKitInstallmentsSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PassKitInstallmentsSPI.h; sourceTree = "<group>"; };
+		A1D4D22C2B7E04CA0008C40E /* LinearMediaKitSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LinearMediaKitSPI.h; sourceTree = "<group>"; };
 		A1F63C9D21A4DBF7006FB43B /* PassKitSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PassKitSoftLink.h; sourceTree = "<group>"; };
 		A1F63C9E21A4DBF7006FB43B /* PassKitSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PassKitSoftLink.mm; sourceTree = "<group>"; };
 		A30D411E1F0DD0EA00B71954 /* KillRing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KillRing.h; sourceTree = "<group>"; };
@@ -743,6 +745,7 @@
 				0C2DA1201F3BE9E700DBC317 /* cocoa */,
 				0C5AF90D1F43A4A4002EAC02 /* ios */,
 				0C77856E1F4512E900F4EBB6 /* mac */,
+				A1D4D2272B7E04AA0008C40E /* vision */,
 			);
 			path = spi;
 			sourceTree = "<group>";
@@ -1172,6 +1175,14 @@
 			path = cocoa;
 			sourceTree = "<group>";
 		};
+		A1D4D2272B7E04AA0008C40E /* vision */ = {
+			isa = PBXGroup;
+			children = (
+				A1D4D22C2B7E04CA0008C40E /* LinearMediaKitSPI.h */,
+			);
+			path = vision;
+			sourceTree = "<group>";
+		};
 		A30D411D1F0DD0AC00B71954 /* text */ = {
 			isa = PBXGroup;
 			children = (
@@ -1360,6 +1371,7 @@
 				DD20DDE927BC90D70093D175 /* IOPSLibSPI.h in Headers */,
 				DD20DE4F27BC90D80093D175 /* KillRing.h in Headers */,
 				DD20DDED27BC90D70093D175 /* LaunchServicesSPI.h in Headers */,
+				A1D4D22D2B7E04CA0008C40E /* LinearMediaKitSPI.h in Headers */,
 				F47471EE2ACA17AF00E0D4AB /* LinkPresentationSoftLink.h in Headers */,
 				F410F1552ACA2EBA00A79859 /* LinkPresentationSPI.h in Headers */,
 				7A46A8112A3265C8007BDD04 /* LockdownModeSoftLink.h in Headers */,

--- a/Source/WebCore/PAL/pal/spi/vision/LinearMediaKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/vision/LinearMediaKitSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,19 @@
 
 #pragma once
 
-namespace WebCore {
+#if USE(LINEARMEDIAKIT)
 
-class NullVideoPresentationInterface;
-class VideoPresentationInterfaceAVKit;
-class VideoPresentationInterfaceIOS;
-class VideoPresentationInterfaceMac;
+#import <UIKit/UIKit.h>
 
-#if PLATFORM(WATCHOS)
-using PlatformVideoPresentationInterface = NullVideoPresentationInterface;
-#elif ENABLE(LINEAR_MEDIA_PLAYER)
-using PlatformVideoPresentationInterface = VideoPresentationInterfaceIOS;
-#elif PLATFORM(IOS_FAMILY)
-using PlatformVideoPresentationInterface = VideoPresentationInterfaceAVKit;
-#elif PLATFORM(MAC)
-using PlatformVideoPresentationInterface = VideoPresentationInterfaceMac;
+#if USE(APPLE_INTERNAL_SDK)
+
+#import <LinearMediaKit/LinearMediaKit.h>
+
+#else
+
+@interface LMPlayableViewController : UIViewController
+@end
+
 #endif
 
-} // namespace WebCore
+#endif // USE(LINEARMEDIAKIT)

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -71,6 +71,7 @@ public:
     virtual void setPlaybackRate(double) = 0;
     virtual void selectAudioMediaOption(uint64_t index) = 0;
     virtual void selectLegibleMediaOption(uint64_t index) = 0;
+    virtual void toggleFullscreen() = 0;
     virtual void togglePictureInPicture() = 0;
     virtual void toggleInWindow() = 0;
     virtual void toggleMuted() = 0;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -72,6 +72,7 @@ public:
     WEBCORE_EXPORT void setPlaybackRate(double) final;
     WEBCORE_EXPORT void selectAudioMediaOption(uint64_t index) final;
     WEBCORE_EXPORT void selectLegibleMediaOption(uint64_t index) final;
+    WEBCORE_EXPORT void toggleFullscreen() final;
     WEBCORE_EXPORT void togglePictureInPicture() final;
     WEBCORE_EXPORT void toggleInWindow() final;
     WEBCORE_EXPORT void toggleMuted() final;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -336,6 +336,21 @@ void PlaybackSessionModelMediaElement::selectLegibleMediaOption(uint64_t index)
     m_mediaElement->setSelectedTextTrack(textTrack);
 }
 
+void PlaybackSessionModelMediaElement::toggleFullscreen()
+{
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    ASSERT(is<HTMLVideoElement>(*m_mediaElement));
+    if (!is<HTMLVideoElement>(*m_mediaElement))
+        return;
+
+    auto& element = downcast<HTMLVideoElement>(*m_mediaElement);
+    if (element.fullscreenMode() == MediaPlayerEnums::VideoFullscreenModeStandard)
+        element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
+    else
+        element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::Fullscreen);
+#endif
+}
+
 void PlaybackSessionModelMediaElement::togglePictureInPicture()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h
@@ -29,10 +29,13 @@ namespace WebCore {
 
 class NullPlaybackSessionInterface;
 class PlaybackSessionInterfaceAVKit;
+class PlaybackSessionInterfaceIOS;
 class PlaybackSessionInterfaceMac;
 
 #if PLATFORM(WATCHOS)
 using PlatformPlaybackSessionInterface = NullPlaybackSessionInterface;
+#elif ENABLE(LINEAR_MEDIA_PLAYER)
+using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceIOS;
 #elif PLATFORM(IOS_FAMILY)
 using PlatformPlaybackSessionInterface = PlaybackSessionInterfaceAVKit;
 #elif PLATFORM(MAC)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -22,20 +22,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#pragma once
-#if PLATFORM(COCOA) && HAVE(AVKIT)
-#include "PlaybackSessionInterfaceIOS.h"
-namespace WebCore {
-class WEBCORE_EXPORT PlaybackSessionInterfaceAVKit
-    : public PlaybackSessionInterfaceIOS {
 
+#pragma once
+
+#if PLATFORM(COCOA) && HAVE(AVKIT)
+
+#include "PlaybackSessionInterfaceIOS.h"
+
+namespace WebCore {
+
+class WEBCORE_EXPORT PlaybackSessionInterfaceAVKit final : public PlaybackSessionInterfaceIOS {
 public:
     static Ref<PlaybackSessionInterfaceAVKit> create(PlaybackSessionModel&);
     ~PlaybackSessionInterfaceAVKit();
     void invalidate() final;
 
     WebAVPlayerController *playerController() const final;
-
+    WKSLinearMediaPlayer *linearMediaPlayer() const final;
     void durationChanged(double) final;
     void currentTimeChanged(double currentTime, double anchorTime) final;
     void bufferedTimeChanged(double) final;
@@ -54,6 +57,7 @@ public:
 
 private:
     PlaybackSessionInterfaceAVKit(PlaybackSessionModel&);
+
     RetainPtr<WebAVPlayerController> m_playerController;
 
 };

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -73,6 +73,11 @@ WebAVPlayerController *PlaybackSessionInterfaceAVKit::playerController() const
     return m_playerController.get();
 }
 
+WKSLinearMediaPlayer *PlaybackSessionInterfaceAVKit::linearMediaPlayer() const
+{
+    return nullptr;
+}
+
 void PlaybackSessionInterfaceAVKit::invalidate()
 {
     if (!m_playbackSessionModel)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -23,13 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #pragma once
 
 #if PLATFORM(COCOA) && HAVE(AVKIT)
 
 #include "EventListener.h"
 #include "HTMLMediaElementEnums.h"
+#include "MediaPlayerIdentifier.h"
 #include "PlaybackSessionModel.h"
 #include "Timer.h"
 #include <functional>
@@ -40,9 +40,11 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/WeakPtr.h>
 
+OBJC_CLASS WKSLinearMediaPlayer;
 OBJC_CLASS WebAVPlayerController;
 
 namespace WebCore {
+
 class IntRect;
 class PlaybackSessionModel;
 class WebPlaybackSessionChangeObserver;
@@ -50,11 +52,13 @@ class WebPlaybackSessionChangeObserver;
 class WEBCORE_EXPORT PlaybackSessionInterfaceIOS
     : public PlaybackSessionModelClient
     , public RefCounted<PlaybackSessionInterfaceIOS> {
-
 public:
     void initialize();
+    virtual void invalidate();
     virtual ~PlaybackSessionInterfaceIOS();
+
     virtual WebAVPlayerController *playerController() const = 0;
+    virtual WKSLinearMediaPlayer *linearMediaPlayer() const = 0;
     PlaybackSessionModel* playbackSessionModel() const;
     void durationChanged(double) override = 0;
     void currentTimeChanged(double currentTime, double anchorTime) override = 0;
@@ -70,7 +74,8 @@ public:
     void volumeChanged(double) override = 0;
     void modelDestroyed() override;
 
-    virtual void invalidate();
+    std::optional<MediaPlayerIdentifier> playerIdentifier() const;
+    void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>);
 
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
@@ -83,8 +88,10 @@ protected:
     PlaybackSessionInterfaceIOS(PlaybackSessionModel&);
     PlaybackSessionModel* m_playbackSessionModel { nullptr };
 
+private:
+    std::optional<MediaPlayerIdentifier> m_playerIdentifier;
 };
 
-}
+} // namespace WebCore
 
 #endif // PLATFORM(COCOA) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
@@ -23,7 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #import "config.h"
 #import "PlaybackSessionInterfaceIOS.h"
 
@@ -40,7 +39,6 @@
 
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
-
 
 namespace WebCore {
 
@@ -84,7 +82,6 @@ void PlaybackSessionInterfaceIOS::invalidate()
     m_playbackSessionModel = nullptr;
 }
 
-
 PlaybackSessionModel* PlaybackSessionInterfaceIOS::playbackSessionModel() const
 {
     return m_playbackSessionModel;
@@ -95,6 +92,16 @@ void PlaybackSessionInterfaceIOS::modelDestroyed()
     ASSERT(isUIThread());
     invalidate();
     ASSERT(!m_playbackSessionModel);
+}
+
+std::optional<MediaPlayerIdentifier> PlaybackSessionInterfaceIOS::playerIdentifier() const
+{
+    return m_playerIdentifier;
+}
+
+void PlaybackSessionInterfaceIOS::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
+{
+    m_playerIdentifier = WTFMove(identifier);
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -114,6 +121,6 @@ WTFLogChannel& PlaybackSessionInterfaceIOS::logChannel() const
 }
 #endif
 
-}
+} // namespace WebCore
 
 #endif // PLATFORM(COCOA) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
@@ -41,11 +41,9 @@ namespace WebCore {
 class PlaybackSessionInterfaceIOS;
 
 class VideoPresentationInterfaceAVKit final : public VideoPresentationInterfaceIOS {
-
 public:
     WEBCORE_EXPORT static Ref<VideoPresentationInterfaceAVKit> create(PlaybackSessionInterfaceIOS&);
     WEBCORE_EXPORT ~VideoPresentationInterfaceAVKit();
-    WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const;
 
     WEBCORE_EXPORT void hasVideoChanged(bool) final;
 
@@ -53,6 +51,7 @@ public:
     const char* logClassName() const { return "VideoPresentationInterfaceAVKit"; };
 #endif
 
+    WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const final;
     WEBCORE_EXPORT void setupFullscreen(UIView& videoView, const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     WEBCORE_EXPORT bool pictureInPictureWasStartedWhenEnteringBackground() const final;
     WEBCORE_EXPORT void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) final;
@@ -61,8 +60,10 @@ public:
     bool allowsPictureInPicturePlayback() const { return m_allowsPictureInPicturePlayback; }
     void presentFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&&) final;
     void dismissFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&&) final;
+
 private:
     WEBCORE_EXPORT VideoPresentationInterfaceAVKit(PlaybackSessionInterfaceIOS&);
+
     void updateRouteSharingPolicy() final;
     void setupPlayerViewController() final;
     void invalidatePlayerViewController() final;
@@ -72,10 +73,12 @@ private:
     void setShowsPlaybackControls(bool) final;
     void setContentDimensions(const FloatSize&) final;
     void setAllowsPictureInPicturePlayback(bool) final;
+    bool isExternalPlaybackActive() const final;
 
     RetainPtr<WebAVPlayerViewControllerDelegate> m_playerViewControllerDelegate;
     RetainPtr<WebAVPlayerViewController> m_playerViewController;
 };
+
 } // namespace WebCore
 
 #endif // PLATFORM(IOS_FAMILY) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -818,6 +818,7 @@ void VideoPresentationInterfaceAVKit::setupPlayerViewController()
 {
     if (!m_playerViewController)
         m_playerViewController = adoptNS([[WebAVPlayerViewController alloc] initWithFullscreenInterface:this]);
+
     [m_playerViewController setShowsPlaybackControls:NO];
     [m_playerViewController setPlayerController:(AVPlayerController *)playerController()];
     [m_playerViewController setDelegate:m_playerViewControllerDelegate.get()];
@@ -825,6 +826,7 @@ void VideoPresentationInterfaceAVKit::setupPlayerViewController()
     [playerController() setAllowsPictureInPicture:m_allowsPictureInPicturePlayback];
     if (!m_routingContextUID.isEmpty())
         [m_playerViewController setWebKitOverrideRouteSharingPolicy:(NSUInteger)m_routeSharingPolicy routingContextUID:m_routingContextUID];
+
 #if PLATFORM(WATCHOS)
     m_viewController = videoPresentationModel() ? videoPresentationModel()->createVideoFullscreenViewController(avPlayerViewController()) : nil;
 #endif
@@ -875,6 +877,11 @@ void VideoPresentationInterfaceAVKit::setShowsPlaybackControls(bool showsPlaybac
 void VideoPresentationInterfaceAVKit::setContentDimensions(const FloatSize& contentDimensions)
 {
     [playerController() setContentDimensions:contentDimensions];
+}
+
+bool VideoPresentationInterfaceAVKit::isExternalPlaybackActive() const
+{
+    return [playerController() isExternalPlaybackActive];
 }
 
 static std::optional<bool> isPictureInPictureSupported;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -124,7 +124,7 @@ public:
     };
 
     RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel.get(); }
-    virtual bool shouldExitFullscreenWithReason(ExitFullScreenReason);
+    WEBCORE_EXPORT virtual bool shouldExitFullscreenWithReason(ExitFullScreenReason);
     HTMLMediaElementEnums::VideoFullscreenMode mode() const { return m_currentMode.mode(); }
     WEBCORE_EXPORT virtual bool mayAutomaticallyShowVideoPictureInPicture() const = 0;
     void prepareForPictureInPictureStop(Function<void(bool)>&& callback);
@@ -132,12 +132,12 @@ public:
     bool inPictureInPicture() const { return m_enteringPictureInPicture || m_currentMode.hasPictureInPicture(); }
     bool returningToStandby() const { return m_returningToStandby; }
 
-    virtual void willStartPictureInPicture();
-    virtual void didStartPictureInPicture();
-    virtual void failedToStartPictureInPicture();
+    WEBCORE_EXPORT virtual void willStartPictureInPicture();
+    WEBCORE_EXPORT virtual void didStartPictureInPicture();
+    WEBCORE_EXPORT virtual void failedToStartPictureInPicture();
     void willStopPictureInPicture();
-    virtual void didStopPictureInPicture();
-    virtual void prepareForPictureInPictureStopWithCompletionHandler(void (^)(BOOL));
+    WEBCORE_EXPORT virtual void didStopPictureInPicture();
+    WEBCORE_EXPORT virtual void prepareForPictureInPictureStopWithCompletionHandler(void (^)(BOOL));
     virtual bool isPlayingVideoInEnhancedFullscreen() const = 0;
 
     WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool shouldNotifyModel);
@@ -149,7 +149,7 @@ public:
 #endif
     WEBCORE_EXPORT virtual bool pictureInPictureWasStartedWhenEnteringBackground() const = 0;
 
-    std::optional<MediaPlayerIdentifier> playerIdentifier() const { return m_playerIdentifier; }
+    WEBCORE_EXPORT std::optional<MediaPlayerIdentifier> playerIdentifier() const;
 
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
@@ -160,6 +160,7 @@ public:
 
 protected:
     WEBCORE_EXPORT VideoPresentationInterfaceIOS(PlaybackSessionInterfaceIOS&);
+
     RunLoop::Timer m_watchdogTimer;
     RetainPtr<UIView> m_parentView;
     Mode m_targetMode;
@@ -176,7 +177,6 @@ protected:
     RetainPtr<UIViewController> m_viewController;
     bool m_hasVideoContentLayer { false };
     Function<void(bool)> m_prepareToInlineCallback;
-    std::optional<MediaPlayerIdentifier> m_playerIdentifier;
     bool m_exitingPictureInPicture { false };
     bool m_shouldReturnToFullscreenWhenStoppingPictureInPicture { false };
     bool m_enterFullscreenNeedsExitPictureInPicture { false };
@@ -220,6 +220,7 @@ protected:
     virtual void setShowsPlaybackControls(bool) = 0;
     virtual void setContentDimensions(const FloatSize&) = 0;
     virtual void setAllowsPictureInPicturePlayback(bool) = 0;
+    virtual bool isExternalPlaybackActive() const = 0;
 
 #if PLATFORM(WATCHOS)
     bool m_waitingForPreparedToExit { false };
@@ -227,10 +228,12 @@ protected:
 private:
     void returnToStandby();
     void watchdogTimerFired();
+
     bool m_finalizeSetupNeedsVideoContentLayer { false };
     bool m_finalizeSetupNeedsReturnVideoContentLayer { false };
     Ref<PlaybackSessionInterfaceIOS> m_playbackSessionInterface;
 };
+
 } // namespace WebCore
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -154,9 +154,14 @@ void VideoPresentationInterfaceIOS::setupFullscreen(UIView& videoView, const Flo
     doSetup();
 }
 
+std::optional<MediaPlayerIdentifier>VideoPresentationInterfaceIOS::playerIdentifier() const
+{
+    return m_playbackSessionInterface->playerIdentifier();
+}
+
 void VideoPresentationInterfaceIOS::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
 {
-    m_playerIdentifier = identifier;
+    m_playbackSessionInterface->setPlayerIdentifier(WTFMove(identifier));
 }
 
 void VideoPresentationInterfaceIOS::requestHideAndExitFullscreen()
@@ -230,7 +235,7 @@ void VideoPresentationInterfaceIOS::doSetup()
 
     if (!m_playerLayerView)
         m_playerLayerView = adoptNS([allocWebAVPlayerLayerViewInstance() init]);
-    [m_playerLayerView setHidden:[playerController() isExternalPlaybackActive]];
+    [m_playerLayerView setHidden:isExternalPlaybackActive()];
     [m_playerLayerView setBackgroundColor:clearUIColor()];
     [m_playerLayerView setVideoView:m_videoView.get()];
 

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -161,6 +161,7 @@ private:
     ExternalPlaybackTargetType externalPlaybackTargetType() const override;
     String externalPlaybackLocalizedDeviceName() const override;
     bool wirelessVideoPlaybackDisabled() const override;
+    void toggleFullscreen() override { }
     void togglePictureInPicture() override { }
     void toggleInWindow() override { }
     void toggleMuted() override;

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -219,6 +219,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CacheStoragePolicy.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCArray.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCAuditToken.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFCharacterSet.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFType.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFURL.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCColor.serialization.in
@@ -242,7 +243,6 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPresentationIntent.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCString.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCURL.serialization.in
-$(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFCharacterSet.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/InsertTextOptions.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -25,38 +25,46 @@
 
 #pragma once
 
-#if PLATFORM(VISION) && HAVE(AVKIT)
+#if ENABLE(LINEAR_MEDIA_PLAYER)
 
 #include <WebCore/PlaybackSessionInterfaceIOS.h>
+
+OBJC_CLASS WKLinearMediaPlayerDelegate;
 
 namespace WebKit {
 
 using namespace WebCore;
 
-class PlaybackSessionInterfaceLMK : public PlaybackSessionInterfaceIOS {
+class PlaybackSessionInterfaceLMK final : public PlaybackSessionInterfaceIOS {
 public:
+    static Ref<PlaybackSessionInterfaceLMK> create(PlaybackSessionModel&);
     ~PlaybackSessionInterfaceLMK();
 
-    WebAVPlayerController *playerController() const override;
-    void durationChanged(double) override;
-    void currentTimeChanged(double, double) override;
-    void bufferedTimeChanged(double) override;
-    void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) override;
-    void seekableRangesChanged(const TimeRanges&, double, double) override;
-    void canPlayFastReverseChanged(bool) override;
-    void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) override;
-    void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) override;
-    void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) override;
-    void wirelessVideoPlaybackDisabledChanged(bool) override;
-    void mutedChanged(bool) override;
-    void volumeChanged(double) override;
+    WebAVPlayerController *playerController() const final { return nullptr; }
+    WKSLinearMediaPlayer *linearMediaPlayer() const final;
+    void durationChanged(double) final;
+    void currentTimeChanged(double, double) final;
+    void bufferedTimeChanged(double) final { }
+    void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final;
+    void seekableRangesChanged(const TimeRanges&, double, double) final;
+    void canPlayFastReverseChanged(bool) final;
+    void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
+    void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
+    void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) final { }
+    void wirelessVideoPlaybackDisabledChanged(bool) final { }
+    void mutedChanged(bool) final;
+    void volumeChanged(double) final;
 #if !RELEASE_LOG_DISABLED
-    const char* logClassName() const override;
+    const char* logClassName() const final;
 #endif
 
 private:
     PlaybackSessionInterfaceLMK(PlaybackSessionModel&);
+
+    RetainPtr<WKSLinearMediaPlayer> m_player;
+    RetainPtr<WKLinearMediaPlayerDelegate> m_playerDelegate;
 };
+
 } // namespace WebKit
 
-#endif // PLATFORM(VISION) && HAVE(AVKIT)
+#endif // ENABLE(LINEAR_MEDIA_PLAYER)

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#if PLATFORM(VISION)
+#if ENABLE(LINEAR_MEDIA_PLAYER)
 
 #include <WebCore/VideoPresentationInterfaceIOS.h>
 
 OBJC_CLASS LMPlayableViewController;
-OBJC_CLASS WKPlayableViewControllerDelegate;
+OBJC_CLASS WKSLinearMediaPlayer;
 
 namespace WebCore {
 class PlaybackSessionInterfaceIOS;
@@ -47,17 +47,15 @@ public:
     const char* logClassName() const { return "VideoPresentationInterfaceLMK"; };
 #endif
     ~VideoPresentationInterfaceLMK();
-    void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool);
-    bool pictureInPictureWasStartedWhenEnteringBackground() const final;
-    AVPlayerViewController *avPlayerViewController() const;
 
-    void hasVideoChanged(bool);
-    void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) final;
-    bool mayAutomaticallyShowVideoPictureInPicture() const;
-    bool isPlayingVideoInEnhancedFullscreen() const;
 private:
     VideoPresentationInterfaceLMK(PlaybackSessionInterfaceIOS&);
 
+    bool pictureInPictureWasStartedWhenEnteringBackground() const final { return false; }
+    bool mayAutomaticallyShowVideoPictureInPicture() const final { return false; }
+    bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
+    void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final;
+    void hasVideoChanged(bool) final { }
     void updateRouteSharingPolicy() final { }
     void setupPlayerViewController() final;
     void invalidatePlayerViewController() final;
@@ -69,12 +67,14 @@ private:
     void setShowsPlaybackControls(bool) final;
     void setContentDimensions(const FloatSize&) final;
     void setAllowsPictureInPicturePlayback(bool) final { }
+    bool isExternalPlaybackActive() const final { return false; }
+    AVPlayerViewController *avPlayerViewController() const final { return nullptr; }
+
+    WKSLinearMediaPlayer *linearMediaPlayer() const;
 
     RetainPtr<LMPlayableViewController> m_playerViewController;
-    RetainPtr<WKPlayableViewControllerDelegate> m_playerViewControllerDelegate;
-    RetainPtr<UIViewController> m_presentingViewController;
 };
 
 } // namespace WebKit
 
-#endif // PLATFORM(VISION)
+#endif // ENABLE(LINEAR_MEDIA_PLAYER)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -98,6 +98,7 @@ private:
     void setPlaybackRate(double) final;
     void selectAudioMediaOption(uint64_t) final;
     void selectLegibleMediaOption(uint64_t) final;
+    void toggleFullscreen() final;
     void togglePictureInPicture() final;
     void toggleInWindow() final;
     void toggleMuted() final;
@@ -249,6 +250,7 @@ private:
     void setPlaybackRate(PlaybackSessionContextIdentifier, double);
     void selectAudioMediaOption(PlaybackSessionContextIdentifier, uint64_t index);
     void selectLegibleMediaOption(PlaybackSessionContextIdentifier, uint64_t index);
+    void toggleFullscreen(PlaybackSessionContextIdentifier);
     void togglePictureInPicture(PlaybackSessionContextIdentifier);
     void toggleInWindow(PlaybackSessionContextIdentifier);
     void toggleMuted(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -34,7 +34,9 @@
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "PageClient.h"
+#import "PlaybackSessionInterfaceLMK.h"
 #import "PlaybackSessionManagerProxy.h"
+#import "VideoPresentationInterfaceLMK.h"
 #import "VideoPresentationManagerMessages.h"
 #import "VideoPresentationManagerProxyMessages.h"
 #import "WKVideoView.h"
@@ -569,7 +571,17 @@ VideoPresentationManagerProxy::ModelInterfaceTuple VideoPresentationManagerProxy
     Ref playbackSessionModel = m_playbackSessionManagerProxy->ensureModel(contextId);
     auto model = VideoPresentationModelContext::create(*this, playbackSessionModel, contextId);
     Ref playbackSessionInterface = m_playbackSessionManagerProxy->ensureInterface(contextId);
-    Ref<PlatformVideoPresentationInterface> interface = PlatformVideoPresentationInterface::create(playbackSessionInterface.get());
+
+    RefPtr<PlatformVideoPresentationInterface> interface;
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    if (m_page->preferences().linearMediaPlayerEnabled())
+        interface = VideoPresentationInterfaceLMK::create(playbackSessionInterface.get());
+    else
+        interface = VideoPresentationInterfaceAVKit::create(playbackSessionInterface.get());
+#else
+    interface = PlatformVideoPresentationInterface::create(playbackSessionInterface.get());
+#endif
+
     m_playbackSessionManagerProxy->addClientForContext(contextId);
 
     interface->setVideoPresentationModel(model.ptr());

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h
@@ -29,6 +29,8 @@
 
 SOFT_LINK_LIBRARY_FOR_HEADER(WebKit, WebKitSwift)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKGroupSessionObserver)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaPlayer)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaTimeRange)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionContainerItem)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionTextItem)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionScrollableItem)

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
@@ -59,6 +59,8 @@ void* WebKitSwiftLibrary(bool isOptional)
 }
 
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKGroupSessionObserver)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKSLinearMediaPlayer)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKSLinearMediaTimeRange)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionContainerItem)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionTextItem)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionScrollableItem)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -1926,6 +1926,7 @@
 		A1AE0EC32B166439008A2563 /* ExtensionCapabilityGranter.h in Headers */ = {isa = PBXBuildFile; fileRef = A1AE0EC12B1663D4008A2563 /* ExtensionCapabilityGranter.h */; };
 		A1B4DCE125A7923C007D178C /* MediaSampleByteRange.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B4DCDF25A79211007D178C /* MediaSampleByteRange.h */; };
 		A1C512C9190656E500448914 /* WebPreviewLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A1C512C7190656E500448914 /* WebPreviewLoaderClient.h */; };
+		A1D4D2092B7DE6D00008C40E /* PlaybackSessionInterfaceLMK.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F6B9EFA2B7AA21B0051676F /* PlaybackSessionInterfaceLMK.mm */; };
 		A1D615672B06BBAC002D0E19 /* ExtensionCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D615622B06BBAB002D0E19 /* ExtensionCapability.h */; };
 		A1D6156B2B06BBAC002D0E19 /* AssertionCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D615662B06BBAB002D0E19 /* AssertionCapability.h */; };
 		A1D6156D2B06BCB2002D0E19 /* ExtensionKitSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D6156C2B06BCB2002D0E19 /* ExtensionKitSoftLink.h */; };
@@ -19024,6 +19025,7 @@
 				31F060E11654318500F3281C /* NetworkSocketChannelMessageReceiver.cpp in Sources */,
 				93085DD226E2F58D000EC6A7 /* NetworkStorageManagerMessageReceiver.cpp in Sources */,
 				51452703271FBA3A000467B6 /* NotificationManagerMessageHandlerMessageReceiver.cpp in Sources */,
+				A1D4D2092B7DE6D00008C40E /* PlaybackSessionInterfaceLMK.mm in Sources */,
 				CDA29A281CBEB67A00901CCF /* PlaybackSessionManagerMessageReceiver.cpp in Sources */,
 				CDA29A2A1CBEB67A00901CCF /* PlaybackSessionManagerProxyMessageReceiver.cpp in Sources */,
 				C15CBB3723F37ECB00300CC7 /* PreferenceObserver.mm in Sources */,
@@ -19581,7 +19583,9 @@
 		};
 		5C400E6A29DB8AB500446F6F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
 			targetProxy = 5C400E6929DB8AB500446F6F /* PBXContainerItemProxy */;
 		};
@@ -19597,19 +19601,25 @@
 		};
 		5CE4B60729CEBB760038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
 			targetProxy = 5CE4B60629CEBB760038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62329CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
 			targetProxy = 5CE4B62229CF880B0038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62529CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
 			targetProxy = 5CE4B62429CF880B0038F565 /* PBXContainerItemProxy */;
 		};

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -32,6 +32,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class LMPlayableViewController;
 @class WKSLinearMediaPlayer;
 
 API_AVAILABLE(visionos(1.0))
@@ -105,7 +106,7 @@ API_AVAILABLE(visionos(1.0))
 @property (nonatomic, copy) NSArray<UIViewController *> *contentInfoViewControllers;
 @property (nonatomic, copy) NSArray<UIAction *> *contextualActions;
 @property (nonatomic, strong, nullable) UIView *contextualActionsInfoView;
-@property (nonatomic, strong, nullable) NSValue *contentDimensions;
+@property (nonatomic) CGSize contentDimensions;
 @property (nonatomic) WKSLinearMediaContentMode contentMode;
 @property (nonatomic, strong, nullable) CALayer *videoLayer;
 @property (nonatomic) WKSLinearMediaViewingMode anticipatedViewingMode;
@@ -127,13 +128,15 @@ API_AVAILABLE(visionos(1.0))
 @property (nonatomic) BOOL isPlayableOffline;
 @property (nonatomic) BOOL allowPip;
 @property (nonatomic) BOOL allowFullScreenFromInline;
-@property (nonatomic, strong, nullable) NSNumber *isLiveStream;
+@property (nonatomic) BOOL isLiveStream;
 @property (nonatomic, strong, nullable) NSNumber *recommendedViewingRatio;
 @property (nonatomic) WKSLinearMediaFullscreenBehaviors fullscreenSceneBehaviors;
 @property (nonatomic) double startTime;
 @property (nonatomic) double endTime;
 @property (nonatomic, strong, nullable) NSDate *startDate;
 @property (nonatomic, strong, nullable) NSDate *endDate;
+
+- (LMPlayableViewController *)makeViewController;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -163,6 +163,7 @@ private:
     void selectAudioMediaOption(PlaybackSessionContextIdentifier, uint64_t index);
     void selectLegibleMediaOption(PlaybackSessionContextIdentifier, uint64_t index);
     void handleControlledElementIDRequest(PlaybackSessionContextIdentifier);
+    void toggleFullscreen(PlaybackSessionContextIdentifier);
     void togglePictureInPicture(PlaybackSessionContextIdentifier);
     void toggleInWindow(PlaybackSessionContextIdentifier);
     void toggleMuted(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
@@ -38,6 +38,7 @@ messages -> PlaybackSessionManager {
     SelectAudioMediaOption(WebKit::PlaybackSessionContextIdentifier contextId, uint64_t index)
     SelectLegibleMediaOption(WebKit::PlaybackSessionContextIdentifier contextId, uint64_t index)
     HandleControlledElementIDRequest(WebKit::PlaybackSessionContextIdentifier contextId)
+    ToggleFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     TogglePictureInPicture(WebKit::PlaybackSessionContextIdentifier contextId)
     ToggleInWindow(WebKit::PlaybackSessionContextIdentifier contextId)
     ToggleMuted(WebKit::PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -510,6 +510,12 @@ void PlaybackSessionManager::handleControlledElementIDRequest(PlaybackSessionCon
         m_page->send(Messages::PlaybackSessionManagerProxy::HandleControlledElementIDResponse(contextId, element->getIdAttribute()));
 }
 
+void PlaybackSessionManager::toggleFullscreen(PlaybackSessionContextIdentifier contextId)
+{
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
+    ensureModel(contextId).toggleFullscreen();
+}
+
 void PlaybackSessionManager::togglePictureInPicture(PlaybackSessionContextIdentifier contextId)
 {
     UserGestureIndicator indicator(IsProcessingUserGesture::Yes);


### PR DESCRIPTION
#### fecabc2385988b2c0e4ba5397bf8d6c3f9e5721a
<pre>
[Cocoa] Implement LinearMediaKit versions of PlaybackSessionInterface and VideoPresentationInterface
<a href="https://bugs.webkit.org/show_bug.cgi?id=269442">https://bugs.webkit.org/show_bug.cgi?id=269442</a>
<a href="https://rdar.apple.com/problem/122995773">rdar://problem/122995773</a>

Reviewed by Jer Noble.

Provided implementations of PlaybackSessionInterfaceLMK and VideoPresentationInterfaceLMK backed by
LMPlayableViewController and WKSLinearMediaPlayer.

* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
Implemented toggleFullscreen by setting the media element&apos;s presentation mode.

* Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h:
* Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h:
Defined PlatformPlaybackSessionInterface to PlaybackSessionInterfaceIOS and
PlatformVideoPresentationInterface to VideoPresentationInterfaceIOS on platforms with
ENABLE(LINEAR_MEDIA_PLAYER). Using abstract base classes allow us to vary the implementation based
on the setting of the LinearMediaPlayer runtime preference.

* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm:
Added a virtual linearMediaPlayer() and moved m_playerIdentifier from VideoPresentationInterfaceIOS.

* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
Added a virtual isExternalPlaybackActive() and moved m_playerIdentifier to PlaybackSessionInterfaceIOS.

* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
Implemented in terms of WKSLinearMediaPlayer.

* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
Created either VideoPresentationInterfaceLMK or VideoPresentationInterfaceAVKit based on the value
of the LinearMediaPlayer runtime preference.

* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm:
Soft-linked WKSLinearMediaPlayer and WKSLinearMediaTimeRange.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
Worked around known issues in Playable.

* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h:
Used scalars instead of NSValues where possible. Declared -makeViewController.

Canonical link: <a href="https://commits.webkit.org/274743@main">https://commits.webkit.org/274743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0529ca9d9d6749838a45c84d68e84d90e2fb0fe5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/39889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/18900 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42264 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42433 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35791 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/42196 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/21805 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/16230 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42433 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/40463 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/21805 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42264 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42433 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/21805 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42264 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43712 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/33342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/21805 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42264 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43712 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/39515 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/16230 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43712 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42264 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/46523 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8949 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16372 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/46523 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->