### PR TITLE
[threaded-animation-resolution] discrete `filter` interpolation should not be accelerated

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -60,6 +60,7 @@ public:
         bool animatesProperty(KeyframeInterpolation::Property) const final;
         bool isAcceleratedEffectKeyframe() const final { return true; }
 
+        void clearProperty(AcceleratedEffectProperty);
         const OptionSet<AcceleratedEffectProperty>& animatedProperties() const { return m_animatedProperties; }
         const RefPtr<TimingFunction>& timingFunction() const { return m_timingFunction; }
         const AcceleratedEffectValues& values() const { return m_values; }
@@ -72,7 +73,7 @@ public:
         OptionSet<AcceleratedEffectProperty> m_animatedProperties;
     };
 
-    static Ref<AcceleratedEffect> create(const KeyframeEffect&, const IntRect&);
+    static RefPtr<AcceleratedEffect> create(const KeyframeEffect&, const IntRect&, const AcceleratedEffectValues&);
     WEBCORE_EXPORT static Ref<AcceleratedEffect> create(AnimationEffectTiming, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<Seconds> startTime, std::optional<Seconds> holdTime);
 
     virtual ~AcceleratedEffect() = default;
@@ -100,6 +101,8 @@ private:
     AcceleratedEffect(const KeyframeEffect&, const IntRect&);
     explicit AcceleratedEffect(AnimationEffectTiming, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WTF::Seconds> startTime, std::optional<WTF::Seconds> holdTime);
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
+
+    void validateFilters(const AcceleratedEffectValues& baseValues);
 
     // KeyframeInterpolation
     bool isPropertyAdditiveOrCumulative(KeyframeInterpolation::Property) const final;


### PR DESCRIPTION
#### c78d9eaa42973f6f2bb323b620ffc261d7d58a73
<pre>
[threaded-animation-resolution] discrete `filter` interpolation should not be accelerated
<a href="https://bugs.webkit.org/show_bug.cgi?id=269449">https://bugs.webkit.org/show_bug.cgi?id=269449</a>

Reviewed by Dean Jackson.

The CSS `filter` property animates discretely if two `filter` values do not have a shared initial list
of filter operations, as specified in <a href="https://drafts.fxtf.org/filter-effects/#interpolation-of-filters.">https://drafts.fxtf.org/filter-effects/#interpolation-of-filters.</a>
It does not make much sense to accelerate discrete animation of any value but, more importantly, the
system we use to animate `filter` in the UIProcess relies on `CAPresentationModifier` on macOS and
requires a known list of filter operations for initial setup, which falls apart if we are dealing
with mis-matching filter lists. As such we must make sure we don&apos;t create `AcceleratedEffect` objects
that contain `filter` values that will animate discretely.

We change `AcceleratedEffect::create()` to return a `RefPtr` rather than a `Ref` and only return a
value after running the new validation function `validateFilters()` which will find all keyframe
intervals, including those relying on implicit 0% and 100% keyframes, and check there is no
set of filters that will yield a discrete animation. If we find such a pair of filters, we remove
the property from the list of animated properties for those keyframes and the effect itself and,
should we not have a single animated property left, return a `nullptr` value.

* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::Keyframe::clearProperty):
(WebCore::AcceleratedEffect::create):
(WebCore::AcceleratedEffect::validateFilters):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/274755@main">https://commits.webkit.org/274755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e844e180304ba7d25a61b4c955a9d7d2b24275e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33203 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39501 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37775 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16313 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5259 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->