### PR TITLE
[Skia] Add support for multi-threaded CPU rendering

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -35,6 +35,7 @@
 #include "TransformationMatrix.h"
 #include <wtf/Function.h>
 #include <wtf/RunLoop.h>
+#include <wtf/WorkerPool.h>
 #include <wtf/text/StringHash.h>
 
 #if USE(SKIA)
@@ -63,7 +64,9 @@ public:
     virtual Nicosia::PaintingEngine& paintingEngine() = 0;
 #elif USE(SKIA)
     virtual SkiaAcceleratedBufferPool* skiaAcceleratedBufferPool() const = 0;
+    virtual WorkerPool* skiaUnacceleratedThreadedRenderingPool() const = 0;
 #endif
+
     virtual RefPtr<Nicosia::ImageBackingStore> imageBackingStore(uint64_t, Function<RefPtr<Nicosia::Buffer>()>) = 0;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -38,6 +38,7 @@
 #include <WebCore/NicosiaPlatformLayer.h>
 #include <WebCore/NicosiaScene.h>
 #include <WebCore/NicosiaSceneIntegration.h>
+#include <wtf/WorkerPool.h>
 
 namespace Nicosia {
 class ImageBackingStore;
@@ -100,6 +101,7 @@ private:
     Nicosia::PaintingEngine& paintingEngine() override;
 #elif USE(SKIA)
     SkiaAcceleratedBufferPool* skiaAcceleratedBufferPool() const override { return m_skiaAcceleratedBufferPool.get(); }
+    WorkerPool* skiaUnacceleratedThreadedRenderingPool() const override { return m_skiaUnacceleratedThreadedRenderingPool.get(); }
 #endif
     RefPtr<Nicosia::ImageBackingStore> imageBackingStore(uint64_t, Function<RefPtr<Nicosia::Buffer>()>) override;
 
@@ -134,6 +136,7 @@ private:
     std::unique_ptr<Nicosia::PaintingEngine> m_paintingEngine;
 #elif USE(SKIA)
     std::unique_ptr<SkiaAcceleratedBufferPool> m_skiaAcceleratedBufferPool;
+    RefPtr<WorkerPool> m_skiaUnacceleratedThreadedRenderingPool;
 #endif
     HashMap<uint64_t, Ref<Nicosia::ImageBackingStore>> m_imageBackingStores;
 


### PR DESCRIPTION
#### 203eb419d8226c5a5214c7f637b4529964f5a434
<pre>
[Skia] Add support for multi-threaded CPU rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=269450">https://bugs.webkit.org/show_bug.cgi?id=269450</a>

Reviewed by Carlos Garcia Campos.

Currently CoordinatedGraphicsLayer::paintTile() creates an Nicosia::Un-
cceleratedBuffer, paints the GraphicsLayer into it and returns the
finished buffer. The resulting Nicosia::Buffers are collected and will
be used later on in the ThreadedCompositor to swap the tile buffers.

Each tile is painted sequentially using the same procedure. To better
exploit multicores, we record a DisplayList (which should be faster
than painting), and then post tasks to a WorkerPool, to replay the
DisplayList and perform the drawing. With that concept, painting of
tiles happens in parallel. The buffer-consuming code in
CoordinatedBackingStoreTile::swapBuffers() properly waits for painting
completion before it attempts to access the pixel data (in the CPU
backend case) - therefore we can easily parallelize the tile painting,
just like it has been done in the Cairo case, but re-using the
cross-platform display list recording/replaying approach instead of a
custom NicosiaCairoOperationRecorder-like class.

This improves MotionMark performance, even on desktop, when CPU painting
is used. The improvement does not scale linear with the number of threads
used - not all tiles are equally &quot;occupied&quot;, and thus some benefit more
from doing non-sequential painting, others not.

Covered by existing tests.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::skiaNumberOfCpuPaintingThreads):
(WebKit::CompositingCoordinator::CompositingCoordinator):
(WebKit::CompositingCoordinator::invalidate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/275170@main">https://commits.webkit.org/275170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1049679dbfae1dcff1304078651f7f66db4b443

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17419 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14640 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44949 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37263 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13025 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17509 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9220 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->