### PR TITLE
[GTK][WPE] Handle damage region when rendering with DMA-BUF renderer

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -279,7 +279,7 @@ void ThreadedCompositor::renderLayerTree()
     m_context->swapBuffers();
 
     if (m_scene->isActive())
-        m_client.didRenderFrame();
+        m_client.didRenderFrame(m_scene->lastDamagedRects());
 }
 
 void ThreadedCompositor::sceneUpdateFinished()

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -56,7 +56,7 @@ public:
 
         virtual void resize(const WebCore::IntSize&) = 0;
         virtual void willRenderFrame() = 0;
-        virtual void didRenderFrame() = 0;
+        virtual void didRenderFrame(const Vector<WebCore::IntRect>&) = 0;
         virtual void displayDidRefresh(WebCore::PlatformDisplayID) = 0;
     };
 

--- a/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
@@ -25,6 +25,6 @@ messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
     DidCreateBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier)
     DidCreateBufferSHM(uint64_t id, WebCore::ShareableBitmap::Handle handle)
     DidDestroyBuffer(uint64_t id)
-    Frame(uint64_t id)
+    Frame(uint64_t id, Vector<WebCore::IntRect> damagedRects)
 }
 #endif

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -78,7 +78,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t id);
+    void frame(uint64_t id, const Vector<WebCore::IntRect>&);
     void frameDone();
     void ensureGLContext();
     bool prepareForRendering();
@@ -107,7 +107,7 @@ private:
         };
 
         virtual Type type() const = 0;
-        virtual void didUpdateContents() = 0;
+        virtual void didUpdateContents(Buffer*, const Vector<WebCore::IntRect>&) = 0;
 #if USE(GTK4)
         virtual GdkTexture* texture() const { return nullptr; }
 #else
@@ -139,7 +139,7 @@ private:
         BufferDMABuf(uint64_t id, const WebCore::IntSize&, float deviceScaleFactor, Vector<WTF::UnixFileDescriptor>&&, GRefPtr<GdkDmabufTextureBuilder>&&);
 
         Buffer::Type type() const override { return Buffer::Type::DmaBuf; }
-        void didUpdateContents() override;
+        void didUpdateContents(Buffer*, const Vector<WebCore::IntRect>&) override;
         GdkTexture* texture() const override { return m_texture.get(); }
 
         Vector<WTF::UnixFileDescriptor> m_fds;
@@ -157,7 +157,7 @@ private:
         BufferEGLImage(uint64_t id, const WebCore::IntSize&, float deviceScaleFactor, Vector<WTF::UnixFileDescriptor>&&, EGLImage);
 
         Buffer::Type type() const override { return Buffer::Type::EglImage; }
-        void didUpdateContents() override;
+        void didUpdateContents(Buffer*, const Vector<WebCore::IntRect>&) override;
 #if USE(GTK4)
         GdkTexture* texture() const override { return m_texture.get(); }
 #else
@@ -183,7 +183,7 @@ private:
         BufferGBM(uint64_t id, const WebCore::IntSize&, float deviceScaleFactor, WTF::UnixFileDescriptor&&, struct gbm_bo*);
 
         Buffer::Type type() const override { return Buffer::Type::Gbm; }
-        void didUpdateContents() override;
+        void didUpdateContents(Buffer*, const Vector<WebCore::IntRect>&) override;
         cairo_surface_t* surface() const override { return m_surface.get(); }
 
         WTF::UnixFileDescriptor m_fd;
@@ -201,7 +201,7 @@ private:
         BufferSHM(uint64_t id, RefPtr<WebCore::ShareableBitmap>&&, float deviceScaleFactor);
 
         Buffer::Type type() const override { return Buffer::Type::SharedMemory; }
-        void didUpdateContents() override;
+        void didUpdateContents(Buffer*, const Vector<WebCore::IntRect>&) override;
         cairo_surface_t* surface() const override { return m_surface.get(); }
 
         RefPtr<WebCore::ShareableBitmap> m_bitmap;

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -65,7 +65,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t bufferID);
+    void frame(uint64_t bufferID, const Vector<WebCore::IntRect>&);
     void frameDone();
     void bufferRendered();
 

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -21,6 +21,7 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEVersion.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEEnumTypes.cpp
@@ -40,6 +41,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeysyms.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wpe-platform.h
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEConfig.h

--- a/Source/WebKit/WPEPlatform/wpe/WPERectangle.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPERectangle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,31 +22,36 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#include "config.h"
+#include "WPERectangle.h"
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormat.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#include <wtf/FastMalloc.h>
 
-#undef __WPE_PLATFORM_H_INSIDE__
+/**
+ * WPERectangle:
+ * @x: The X coordinate of the top-left corner of the rectangle.
+ * @y: The Y coordinate of the top-left corner of the rectangle.
+ * @width: The width of the rectangle.
+ * @height: The height of the rectangle.
+ *
+ * Boxed type representing a rectangle with integer coordiantes.
+ */
 
-#endif /* __WPE_PLATFORM_H__ */
+static WPERectangle* wpe_rectangle_copy(WPERectangle* rectangle)
+{
+    g_return_val_if_fail(rectangle, nullptr);
+
+    WPERectangle* copy = static_cast<WPERectangle*>(fastZeroedMalloc(sizeof(WPERectangle)));
+    *copy = *rectangle;
+    return copy;
+}
+
+static void wpe_rectangle_free(WPERectangle* rectangle)
+{
+    g_return_if_fail(rectangle);
+
+    fastFree(rectangle);
+}
+
+G_DEFINE_BOXED_TYPE(WPERectangle, wpe_rectangle, wpe_rectangle_copy, wpe_rectangle_free)

--- a/Source/WebKit/WPEPlatform/wpe/WPERectangle.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPERectangle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,31 +22,31 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#ifndef WPERectangle_h
+#define WPERectangle_h
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormat.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEConfig.h>
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
 #include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
 
-#undef __WPE_PLATFORM_H_INSIDE__
+G_BEGIN_DECLS
 
-#endif /* __WPE_PLATFORM_H__ */
+struct _WPERectangle {
+    int x;
+    int y;
+    int width;
+    int height;
+};
+typedef struct _WPERectangle WPERectangle;
+
+#define WPE_TYPE_RECTANGLE (wpe_rectangle_get_type())
+
+WPE_API GType wpe_rectangle_get_type (void);
+
+G_END_DECLS
+
+#endif /* WPERectangle_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -643,6 +643,8 @@ gboolean wpe_view_unfullscreen(WPEView* view)
  * wpe_view_render_buffer:
  * @view: a #WPEView
  * @buffer: a #WPEBuffer to render
+ * @damage_rects: (nullable) (array length=n_damage_rects): damage rectangles
+ * @n_damage_rects: the total number of elements in @damage_rects
  * @error: return location for error or %NULL to ignore
  *
  * Render the given @buffer into @view.
@@ -651,13 +653,14 @@ gboolean wpe_view_unfullscreen(WPEView* view)
  *
  * Returns: %TRUE if buffer will be rendered, or %FALSE otherwise
  */
-gboolean wpe_view_render_buffer(WPEView* view, WPEBuffer* buffer, GError** error)
+gboolean wpe_view_render_buffer(WPEView* view, WPEBuffer* buffer, WPERectangle* damageRects, guint damageRectsCount, GError** error)
 {
     g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
     g_return_val_if_fail(WPE_IS_BUFFER(buffer), FALSE);
+    g_return_val_if_fail(!damageRects || damageRectsCount > 0, FALSE);
 
     auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->render_buffer(view, buffer, error);
+    return viewClass->render_buffer(view, buffer, damageRects, damageRectsCount, error);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -42,27 +42,30 @@ typedef struct _WPEBuffer WPEBuffer;
 typedef struct _WPEDisplay WPEDisplay;
 typedef struct _WPEEvent WPEEvent;
 typedef struct _WPEMonitor WPEMonitor;
+typedef struct _WPERectangle WPERectangle;
 
 struct _WPEViewClass
 {
     GObjectClass parent_class;
 
-    gboolean    (* render_buffer)                 (WPEView    *view,
-                                                   WPEBuffer  *buffer,
-                                                   GError    **error);
-    WPEMonitor *(* get_monitor)                   (WPEView    *view);
-    gboolean    (* set_fullscreen)                (WPEView    *view,
-                                                   gboolean    fullscreen);
-    GList      *(* get_preferred_dma_buf_formats) (WPEView    *view);
-    void        (* set_cursor_from_name)          (WPEView    *view,
-                                                   const char *name);
-    void        (* set_cursor_from_bytes)         (WPEView    *view,
-                                                   GBytes     *bytes,
-                                                   guint       width,
-                                                   guint       height,
-                                                   guint       stride,
-                                                   guint       hotspot_x,
-                                                   guint       hotspot_y);
+    gboolean    (* render_buffer)                 (WPEView      *view,
+                                                   WPEBuffer    *buffer,
+                                                   WPERectangle *damage_rects,
+                                                   guint         n_damage_rects,
+                                                   GError      **error);
+    WPEMonitor *(* get_monitor)                   (WPEView      *view);
+    gboolean    (* set_fullscreen)                (WPEView      *view,
+                                                   gboolean      fullscreen);
+    GList      *(* get_preferred_dma_buf_formats) (WPEView      *view);
+    void        (* set_cursor_from_name)          (WPEView      *view,
+                                                   const char   *name);
+    void        (* set_cursor_from_bytes)         (WPEView      *view,
+                                                   GBytes       *bytes,
+                                                   guint         width,
+                                                   guint         height,
+                                                   guint         stride,
+                                                   guint         hotspot_x,
+                                                   guint         hotspot_y);
 
     gpointer padding[32];
 };
@@ -91,50 +94,52 @@ typedef enum {
 
 WPE_API GQuark       wpe_view_error_quark                   (void);
 
-WPE_API WPEView     *wpe_view_new                           (WPEDisplay  *display);
-WPE_API WPEDisplay  *wpe_view_get_display                   (WPEView     *view);
-WPE_API int          wpe_view_get_width                     (WPEView     *view);
-WPE_API int          wpe_view_get_height                    (WPEView     *view);
-WPE_API void         wpe_view_set_width                     (WPEView     *view,
-                                                             int          width);
-WPE_API void         wpe_view_set_height                    (WPEView     *view,
-                                                             int          height);
-WPE_API void         wpe_view_resize                        (WPEView     *view,
-                                                             int          width,
-                                                             int          height);
-WPE_API gdouble      wpe_view_get_scale                     (WPEView     *view);
-WPE_API void         wpe_view_set_scale                     (WPEView     *view,
-                                                             gdouble      scale);
-WPE_API void         wpe_view_set_cursor_from_name          (WPEView     *view,
-                                                             const char  *name);
-WPE_API void         wpe_view_set_cursor_from_bytes         (WPEView     *view,
-                                                             GBytes      *bytes,
-                                                             guint        width,
-                                                             guint        height,
-                                                             guint        stride,
-                                                             guint        hotspot_x,
-                                                             guint        hotspot_y);
-WPE_API WPEViewState wpe_view_get_state                     (WPEView     *view);
-WPE_API void         wpe_view_set_state                     (WPEView     *view,
-                                                             WPEViewState state);
-WPE_API WPEMonitor  *wpe_view_get_monitor                   (WPEView     *view);
-WPE_API gboolean     wpe_view_fullscreen                    (WPEView     *view);
-WPE_API gboolean     wpe_view_unfullscreen                  (WPEView     *view);
-WPE_API gboolean     wpe_view_render_buffer                 (WPEView     *view,
-                                                             WPEBuffer   *buffer,
-                                                             GError     **error);
-WPE_API void         wpe_view_buffer_rendered               (WPEView     *view,
-                                                             WPEBuffer   *buffer);
-WPE_API void         wpe_view_event                         (WPEView     *view,
-                                                             WPEEvent    *event);
-WPE_API guint        wpe_view_compute_press_count           (WPEView     *view,
-                                                             gdouble      x,
-                                                             gdouble      y,
-                                                             guint        button,
-                                                             guint32      time);
-WPE_API void         wpe_view_focus_in                      (WPEView     *view);
-WPE_API void         wpe_view_focus_out                     (WPEView     *view);
-WPE_API GList       *wpe_view_get_preferred_dma_buf_formats (WPEView     *view);
+WPE_API WPEView     *wpe_view_new                           (WPEDisplay   *display);
+WPE_API WPEDisplay  *wpe_view_get_display                   (WPEView      *view);
+WPE_API int          wpe_view_get_width                     (WPEView      *view);
+WPE_API int          wpe_view_get_height                    (WPEView      *view);
+WPE_API void         wpe_view_set_width                     (WPEView      *view,
+                                                             int           width);
+WPE_API void         wpe_view_set_height                    (WPEView      *view,
+                                                             int           height);
+WPE_API void         wpe_view_resize                        (WPEView      *view,
+                                                             int           width,
+                                                             int           height);
+WPE_API gdouble      wpe_view_get_scale                     (WPEView      *view);
+WPE_API void         wpe_view_set_scale                     (WPEView      *view,
+                                                             gdouble       scale);
+WPE_API void         wpe_view_set_cursor_from_name          (WPEView      *view,
+                                                             const char   *name);
+WPE_API void         wpe_view_set_cursor_from_bytes         (WPEView      *view,
+                                                             GBytes       *bytes,
+                                                             guint         width,
+                                                             guint         height,
+                                                             guint         stride,
+                                                             guint         hotspot_x,
+                                                             guint         hotspot_y);
+WPE_API WPEViewState wpe_view_get_state                     (WPEView      *view);
+WPE_API void         wpe_view_set_state                     (WPEView      *view,
+                                                             WPEViewState  state);
+WPE_API WPEMonitor  *wpe_view_get_monitor                   (WPEView      *view);
+WPE_API gboolean     wpe_view_fullscreen                    (WPEView      *view);
+WPE_API gboolean     wpe_view_unfullscreen                  (WPEView      *view);
+WPE_API gboolean     wpe_view_render_buffer                 (WPEView      *view,
+                                                             WPEBuffer    *buffer,
+                                                             WPERectangle *damage_rects,
+                                                             guint         n_damage_rects,
+                                                             GError      **error);
+WPE_API void         wpe_view_buffer_rendered               (WPEView      *view,
+                                                             WPEBuffer    *buffer);
+WPE_API void         wpe_view_event                         (WPEView      *view,
+                                                             WPEEvent     *event);
+WPE_API guint        wpe_view_compute_press_count           (WPEView      *view,
+                                                             gdouble       x,
+                                                             gdouble       y,
+                                                             guint         button,
+                                                             guint32       time);
+WPE_API void         wpe_view_focus_in                      (WPEView      *view);
+WPE_API void         wpe_view_focus_out                     (WPEView      *view);
+WPE_API GList       *wpe_view_get_preferred_dma_buf_formats (WPEView      *view);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -384,7 +384,7 @@ static gboolean wpeViewDRMRequestUpdate(WPEViewDRM* view, GError** error)
     return wpeViewDRMCommitLegacy(WPE_VIEW_DRM(view), *drmBuffer, error);
 }
 
-static gboolean wpeViewDRMRenderBuffer(WPEView* view, WPEBuffer* buffer, GError** error)
+static gboolean wpeViewDRMRenderBuffer(WPEView* view, WPEBuffer* buffer, WPERectangle*, guint, GError** error)
 {
     auto* drmBuffer = static_cast<WPE::DRM::Buffer*>(wpe_buffer_get_user_data(buffer));
     if (!drmBuffer) {

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
@@ -90,7 +90,7 @@ static void wpeViewHeadlessDispose(GObject* object)
     G_OBJECT_CLASS(wpe_view_headless_parent_class)->dispose(object);
 }
 
-static gboolean wpeViewHeadlessRenderBuffer(WPEView* view, WPEBuffer* buffer, GError**)
+static gboolean wpeViewHeadlessRenderBuffer(WPEView* view, WPEBuffer* buffer, WPERectangle*, guint, GError**)
 {
     auto* priv = WPE_VIEW_HEADLESS(view)->priv;
     priv->buffer = buffer;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -541,7 +541,7 @@ const struct wl_callback_listener frameListener = {
     }
 };
 
-static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, GError** error)
+static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, WPERectangle* damageRects, guint damageRectsCount, GError** error)
 {
     auto* wlBuffer = createWaylandBuffer(buffer, error);
     if (!wlBuffer)
@@ -552,7 +552,11 @@ static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, GEr
 
     auto* wlSurface = wpe_view_wayland_get_wl_surface(WPE_VIEW_WAYLAND(view));
     wl_surface_attach(wlSurface, wlBuffer, 0, 0);
-    wl_surface_damage(wlSurface, 0, 0, wpe_view_get_width(view), wpe_view_get_height(view));
+    if (damageRects) {
+        for (unsigned i = 0; i < damageRectsCount; ++i)
+            wl_surface_damage(wlSurface, damageRects[i].x, damageRects[i].y, damageRects[i].width, damageRects[i].height);
+    } else
+        wl_surface_damage(wlSurface, 0, 0, wpe_view_get_width(view), wpe_view_get_height(view));
     priv->frameCallback = wl_surface_frame(wlSurface);
     wl_callback_add_listener(priv->frameCallback, &frameListener, view);
     wl_surface_commit(wlSurface);

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -32,6 +32,10 @@ namespace WTF {
 class RunLoop;
 }
 
+namespace WebCore {
+class IntRect;
+}
+
 namespace WebKit {
 
 class WebPage;
@@ -58,7 +62,7 @@ public:
     virtual void willDestroyGLContext() { }
     virtual void finalize() { }
     virtual void willRenderFrame() { }
-    virtual void didRenderFrame() { }
+    virtual void didRenderFrame(const Vector<WebCore::IntRect>&) { }
 
     virtual void didCreateCompositingRunLoop(WTF::RunLoop&) { }
     virtual void willDestroyCompositingRunLoop() { }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -400,9 +400,9 @@ void LayerTreeHost::willRenderFrame()
     m_surface->willRenderFrame();
 }
 
-void LayerTreeHost::didRenderFrame()
+void LayerTreeHost::didRenderFrame(const Vector<WebCore::IntRect>& damagedRects)
 {
-    m_surface->didRenderFrame();
+    m_surface->didRenderFrame(damagedRects);
 #if HAVE(DISPLAY_LINK)
     if (!m_didRenderFrameTimer.isActive())
         m_didRenderFrameTimer.startOneShot(0_s);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -138,7 +138,7 @@ private:
     void didDestroyGLContext() override;
     void resize(const WebCore::IntSize&) override;
     void willRenderFrame() override;
-    void didRenderFrame() override;
+    void didRenderFrame(const Vector<WebCore::IntRect>&) override;
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
 
 #if !HAVE(DISPLAY_LINK)

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -571,7 +571,7 @@ void AcceleratedSurfaceDMABuf::willRenderFrame()
         WTFLogAlways("AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer");
 }
 
-void AcceleratedSurfaceDMABuf::didRenderFrame()
+void AcceleratedSurfaceDMABuf::didRenderFrame(const Vector<WebCore::IntRect>& damagedRects)
 {
     if (!m_target)
         return;
@@ -579,7 +579,7 @@ void AcceleratedSurfaceDMABuf::didRenderFrame()
     glFlush();
 
     m_target->didRenderFrame();
-    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Frame(m_target->id()), m_id);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Frame(m_target->id(), damagedRects), m_id);
 }
 
 void AcceleratedSurfaceDMABuf::releaseBuffer(uint64_t targetID)

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -71,7 +71,7 @@ private:
     void didCreateGLContext() override;
     void willDestroyGLContext() override;
     void willRenderFrame() override;
-    void didRenderFrame() override;
+    void didRenderFrame(const Vector<WebCore::IntRect>&) override;
 
     void didCreateCompositingRunLoop(WTF::RunLoop&) override;
     void willDestroyCompositingRunLoop() override;

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -106,7 +106,7 @@ void AcceleratedSurfaceLibWPE::willRenderFrame()
     wpe_renderer_backend_egl_target_frame_will_render(m_backend);
 }
 
-void AcceleratedSurfaceLibWPE::didRenderFrame()
+void AcceleratedSurfaceLibWPE::didRenderFrame(const Vector<WebCore::IntRect>&)
 {
     ASSERT(m_backend);
     wpe_renderer_backend_egl_target_frame_rendered(m_backend);

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
@@ -56,7 +56,7 @@ public:
     void initialize() override;
     void finalize() override;
     void willRenderFrame() override;
-    void didRenderFrame() override;
+    void didRenderFrame(const Vector<WebCore::IntRect>&) override;
 
 private:
     AcceleratedSurfaceLibWPE(WebPage&, Client&);


### PR DESCRIPTION
#### 8c16fb11c92b26160b784601832f1059110c1475
<pre>
[GTK][WPE] Handle damage region when rendering with DMA-BUF renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=269452">https://bugs.webkit.org/show_bug.cgi?id=269452</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::renderLayerTree):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::BufferDMABuf::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::frame):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPERectangle.cpp: Added.
(wpe_rectangle_copy):
(wpe_rectangle_free):
* Source/WebKit/WPEPlatform/wpe/WPERectangle.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_render_buffer):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(wpeViewDRMRenderBuffer):
* Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp:
(wpeViewHeadlessRenderBuffer):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c16fb11c92b26160b784601832f1059110c1475

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/39834 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/18845 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42378 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35736 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/21747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/16175 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42378 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/40408 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/21747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42378 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/21747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43657 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/21747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43657 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14649 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/16175 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43657 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16268 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16316 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->