### PR TITLE
[MSE] GPUConnection::sendSync should only ever be performed on the main thread

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -179,7 +179,9 @@ void SourceBufferPrivateRemote::setActive(bool active)
 bool SourceBufferPrivateRemote::canSwitchToType(const ContentType& contentType)
 {
     bool canSwitch = false;
-    ensureOnDispatcherSync([&, contentTypeString = contentType.raw().isolatedCopy()] {
+    // FIXME: Uses a new Connection for remote playback, and not the main GPUProcessConnection's one.
+    // FIXME: m_mimeTypeCache is a main-thread only object.
+    callOnMainRunLoopAndWait([&, contentTypeString = contentType.raw().isolatedCopy()] {
         RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
         if (gpuProcessConnection && isGPURunning()) {
             ContentType contentType { contentTypeString };
@@ -222,7 +224,8 @@ Ref<MediaPromise> SourceBufferPrivateRemote::removeCodedFrames(const MediaTime& 
 
 void SourceBufferPrivateRemote::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime)
 {
-    ensureOnDispatcherSync([&] {
+    // FIXME: Uses a new Connection for remote playback, and not the main GPUProcessConnection's one.
+    callOnMainRunLoopAndWait([&] {
         auto gpuProcessConnection = m_gpuProcessConnection.get();
         if (!gpuProcessConnection || !isGPURunning())
             return;
@@ -521,7 +524,8 @@ void SourceBufferPrivateRemote::memoryPressure(uint64_t maximumBufferSize, const
 MediaTime SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID(TrackID trackID)
 {
     MediaTime result = MediaTime::invalidTime();
-    ensureOnDispatcherSync([&] {
+    // FIXME: Uses a new Connection for remote playback, and not the main GPUProcessConnection's one.
+    callOnMainRunLoopAndWait([&] {
         auto gpuProcessConnection = m_gpuProcessConnection.get();
         if (!gpuProcessConnection || !isGPURunning())
             return;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -144,7 +144,7 @@ private:
     friend class MessageReceiver;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     Ref<MessageReceiver> m_receiver;
-    RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;
+    const RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;
     ThreadSafeWeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
 
     std::atomic<uint64_t> m_totalTrackBufferSizeInBytes = { 0 };


### PR DESCRIPTION
#### f76100e64e9407be725c296707e69455cb3f8a18
<pre>
[MSE] GPUConnection::sendSync should only ever be performed on the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=269459">https://bugs.webkit.org/show_bug.cgi?id=269459</a>
<a href="https://rdar.apple.com/123005739">rdar://123005739</a>

Reviewed by Youenn Fablet.

We run the sendSync operation through the main thread, as running them through
the MediaSourceRemote WorkQueue could trigger an assert in debug build or out
of order events otherwise.

The modified methods are already called on the main thread so we have no risk in
introducing a dead lock.

Covered by existing tests. No change of behaviour.

* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::addSourceBuffer):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::canSwitchToType):
(WebKit::SourceBufferPrivateRemote::evictCodedFrames):
(WebKit::SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/274735@main">https://commits.webkit.org/274735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87ef71d17e562338f8b4a3e9546c6d9cff92dbe0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35775 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16214 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13803 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43696 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36209 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39541 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12085 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16307 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8944 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16356 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->