### PR TITLE
getComputedStyle() should work with functional pseudo-elements like ::highlight()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt
@@ -6,7 +6,7 @@ PASS Originating element container for ::after
 PASS Originating element container for ::marker
 PASS Originating element container for ::first-line
 PASS Originating element container for ::first-letter
-FAIL Originating element container  for ::highlight assert_equals: expected "20px" but got ""
+PASS Originating element container  for ::highlight
 PASS Originating element container for outer ::first-line
 PASS Originating element container for outer ::first-letter
 PASS Originating element container for ::backdrop

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-013-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-013-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Initial text-decoration-thickness for highlight pseudo assert_equals: expected "0px" but got ""
-FAIL text-decoration-thickness for highlight pseudo depending on container assert_equals: expected "30px" but got ""
-FAIL text-decoration-thickness for highlight pseudo depending on container only defined in a query assert_equals: expected "30px" but got ""
+PASS Initial text-decoration-thickness for highlight pseudo
+PASS text-decoration-thickness for highlight pseudo depending on container
+PASS text-decoration-thickness for highlight pseudo depending on container only defined in a query
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
-FAIL Different getComputedStyle() for ::highlight(bar) and same element assert_equals: Background color is cyan. expected "rgb(0, 255, 255)" but got ""
+PASS getComputedStyle() for ::highlight(foo)
+PASS Different getComputedStyle() for ::highlight(bar) and same element
 FAIL getComputedStyle() for ::highlight(foo): should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
 FAIL getComputedStyle() for ::highlight(foo)) should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
 FAIL getComputedStyle() for ::highlight(foo)( should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
-PASS getComputedStyle() for ::highlight should be element's default
+FAIL getComputedStyle() for ::highlight should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
 FAIL getComputedStyle() for ::highlight(foo)(foo) should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
 FAIL getComputedStyle() for ::highlight(foo)() should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
 FAIL getComputedStyle() for :::highlight(foo) should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt
@@ -7,6 +7,6 @@ PASS getComputedStyle() for ::spelling-error at #target1
 PASS getComputedStyle() for ::spelling-error at #target2
 PASS getComputedStyle() for ::grammar-error at #target1
 PASS getComputedStyle() for ::grammar-error at #target2
-FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
-FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
+PASS getComputedStyle() for ::highlight(foo) at #target1
+PASS getComputedStyle() for ::highlight(foo) at #target2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-inheritance-expected.txt
@@ -3,5 +3,5 @@ FAIL getComputedStyle() for ::selection assert_equals: Background color is lime.
 FAIL getComputedStyle() for ::target-text assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
 FAIL getComputedStyle() for ::spelling-error assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
 FAIL getComputedStyle() for ::grammar-error assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-visited-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-visited-expected.txt
@@ -7,6 +7,6 @@ PASS getComputedStyle() for ::spelling-error at #target1
 PASS getComputedStyle() for ::spelling-error at #target2
 PASS getComputedStyle() for ::grammar-error at #target1
 PASS getComputedStyle() for ::grammar-error at #target2
-FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
-FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
+PASS getComputedStyle() for ::highlight(foo) at #target1
+PASS getComputedStyle() for ::highlight(foo) at #target2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-computed-expected.txt
@@ -31,7 +31,7 @@ PASS getComputedStyle() for ::grammar-error(foo) should return an empty CSSStyle
 PASS getComputedStyle() for ::grammar-error() should return an empty CSSStyleDeclaration
 PASS getComputedStyle() for :::grammar-error should return an empty CSSStyleDeclaration
 PASS getComputedStyle() for ::grammar-error. should return an empty CSSStyleDeclaration
-FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
+PASS getComputedStyle() for ::highlight(foo)
 PASS getComputedStyle() for ::highlight(foo): should return an empty CSSStyleDeclaration
 PASS getComputedStyle() for ::highlight(foo)) should return an empty CSSStyleDeclaration
 PASS getComputedStyle() for ::highlight(foo)( should return an empty CSSStyleDeclaration
@@ -39,5 +39,5 @@ PASS getComputedStyle() for ::highlight(foo)(foo) should return an empty CSSStyl
 PASS getComputedStyle() for ::highlight(foo)() should return an empty CSSStyleDeclaration
 PASS getComputedStyle() for :::highlight(foo) should return an empty CSSStyleDeclaration
 PASS getComputedStyle() for ::highlight(foo). should return an empty CSSStyleDeclaration
-FAIL Different getComputedStyle() for ::highlight(bar) and same element assert_equals: Background color is blue. expected "rgb(0, 0, 255)" but got ""
+PASS Different getComputedStyle() for ::highlight(bar) and same element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-inheritance-computed-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-inheritance-computed-001-expected.txt
@@ -7,6 +7,6 @@ FAIL getComputedStyle() for ::spelling-error at #child1 assert_equals: Backgroun
 FAIL getComputedStyle() for ::spelling-error at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 FAIL getComputedStyle() for ::grammar-error at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 FAIL getComputedStyle() for ::grammar-error at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::highlight(foo) at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
-FAIL getComputedStyle() for ::highlight(foo) at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo) at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL getComputedStyle() for ::highlight(foo) at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt
@@ -7,6 +7,6 @@ PASS getComputedStyle() for ::spelling-error at #target1
 PASS getComputedStyle() for ::spelling-error at #target2
 PASS getComputedStyle() for ::grammar-error at #target1
 PASS getComputedStyle() for ::grammar-error at #target2
-FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
-FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
+PASS getComputedStyle() for ::highlight(foo) at #target1
+PASS getComputedStyle() for ::highlight(foo) at #target2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/mix-blend-mode-only-on-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/mix-blend-mode-only-on-transition-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Blend modes are set up on paired transitions assert_equals: expected "auto" but got ""
+FAIL Blend modes are set up on paired transitions assert_equals: expected "isolate" but got "auto"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: group expected "rgb(255, 0, 0)" but got ""
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: group expected "rgb(255, 0, 0)" but got "rgba(0, 0, 0, 0)"
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: group expected "rgb(255, 0, 0)" but got ""
+Harness Error (FAIL), message = Unhandled rejection: assert_equals: group expected "rgb(255, 0, 0)" but got "rgba(0, 0, 0, 0)"
 
 PASS style inheritance of pseudo elements
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
@@ -17,13 +17,13 @@ PASS CSSStyleDeclaration is immutable
 PASS Unknown pseudo-element with a known identifier: backdrop
 FAIL Unknown pseudo-element with a known identifier: file-selector-button assert_equals: Should return the ::file-selector-button style expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 PASS Unknown pseudo-element with a known identifier: grammar-error
-FAIL Unknown pseudo-element with a known identifier: highlight(name) assert_equals: Should return the ::highlight(name) style expected "rgb(0, 128, 0)" but got ""
+PASS Unknown pseudo-element with a known identifier: highlight(name)
 PASS Unknown pseudo-element with a known identifier: marker
 FAIL Unknown pseudo-element with a known identifier: placeholder assert_equals: Should return the ::placeholder style expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 PASS Unknown pseudo-element with a known identifier: spelling-error
 PASS Unknown pseudo-element with a known identifier: view-transition
-FAIL Unknown pseudo-element with a known identifier: view-transition-image-pair(name) assert_equals: Should return the ::view-transition-image-pair(name) style expected "rgb(0, 128, 0)" but got ""
-FAIL Unknown pseudo-element with a known identifier: view-transition-group(name) assert_equals: Should return the ::view-transition-group(name) style expected "rgb(0, 128, 0)" but got ""
-FAIL Unknown pseudo-element with a known identifier: view-transition-old(name) assert_equals: Should return the ::view-transition-old(name) style expected "rgb(0, 128, 0)" but got ""
-FAIL Unknown pseudo-element with a known identifier: view-transition-new(name) assert_equals: Should return the ::view-transition-new(name) style expected "rgb(0, 128, 0)" but got ""
+PASS Unknown pseudo-element with a known identifier: view-transition-image-pair(name)
+PASS Unknown pseudo-element with a known identifier: view-transition-group(name)
+PASS Unknown pseudo-element with a known identifier: view-transition-old(name)
+PASS Unknown pseudo-element with a known identifier: view-transition-new(name)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-with-argument-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-with-argument-expected.txt
@@ -1,0 +1,12 @@
+Item
+
+PASS This pseudo-element should not parse: ::before(test)
+PASS This pseudo-element should not parse: ::highlight
+PASS This pseudo-element should not parse: ::highlight (name)
+PASS This pseudo-element should not parse: ::highlight(name)a
+PASS This pseudo-element should not parse: ::view-transition-group(*)
+PASS This pseudo-element should parse: ::highlight(name)
+PASS This pseudo-element should parse: ::highlight(
+name
+PASS This pseudo-element should parse: ::highlight(name	
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-with-argument.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-with-argument.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: Handling pseudo-elements with arguments</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<style>
+#pseudo-invalid::highlight(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition-image-pair(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition-group(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition-old(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition-new(name) {
+  color: rgb(0, 128, 0);
+}
+</style>
+<ul><li id="pseudo-invalid">Item</li></ul>
+<script>
+[
+  "::before(test)",
+  "::highlight",
+  "::highlight (name)",
+  "::highlight(name)a",
+  "::view-transition-group(*)",
+].forEach(nonParsablePseudoIdentifier => {
+  test(() => {
+    const li = document.querySelector('li');
+    assert_equals(getComputedStyle(li, nonParsablePseudoIdentifier).length, 0);
+  }, `This pseudo-element should not parse: ${nonParsablePseudoIdentifier}`)
+});
+
+[
+  "::highlight(name)",
+  "::highlight(\nname",
+  "::highlight(name\t"
+].forEach(parsablePseudoIdentifier => {
+  test(() => {
+    const li = document.querySelector('li');
+    assert_true(getComputedStyle(li, parsablePseudoIdentifier).length != 0);
+    assert_equals(getComputedStyle(li, parsablePseudoIdentifier).color, "rgb(0, 128, 0)");
+  }, `This pseudo-element should parse: ${parsablePseudoIdentifier}`);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log
@@ -140,6 +140,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-logical-enumeration.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-margins-roundtrip.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-property-order.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-with-argument.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-resolved-colors.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-resolved-min-max-clamping.html

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -358,7 +358,12 @@ std::optional<PseudoId> pseudoIdFromString(const String& pseudoElement)
 
     // FIXME: This parserContext should include a document to get the proper settings.
     CSSSelectorParserContext parserContext { CSSParserContext { HTMLStandardMode } };
-    return CSSSelector::parsePseudoElement(pseudoElement, parserContext);
+    auto [pseudoElementIsParsable, pseudoElementIdentifier] = CSSSelector::parsePseudoElement(pseudoElement, parserContext);
+    if (!pseudoElementIsParsable || (pseudoElementIdentifier && !pseudoElementIdentifier->nameArgument.isNull()))
+        return { };
+    if (!pseudoElementIdentifier)
+        return PseudoId::None;
+    return pseudoElementIdentifier->pseudoId;
 }
 
 AtomString animatablePropertyAsString(AnimatableCSSProperty property)

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -27,6 +27,7 @@
 #include "CSSSelector.h"
 
 #include "CSSMarkup.h"
+#include "CSSParserIdioms.h"
 #include "CSSParserTokenRange.h"
 #include "CSSSelectorInlines.h"
 #include "CSSSelectorList.h"
@@ -336,33 +337,70 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElementName(St
     return *type;
 }
 
-// FIXME: We should eventually deduplicate this with CSSSelectorParser::consumePseudo() somehow.
-std::optional<PseudoId> CSSSelector::parsePseudoElement(const String& input, const CSSSelectorParserContext& context)
+static std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifierFor(CSSSelectorPseudoElement type)
 {
-    // FIXME: Add support for FunctionToken (webkit.org/b/264103).
+    auto pseudoId = CSSSelector::pseudoId(type);
+    if (pseudoId == PseudoId::None)
+        return { };
+    return Style::PseudoElementIdentifier { pseudoId };
+}
+
+// FIXME: We should eventually deduplicate this with CSSSelectorParser::consumePseudo() somehow.
+std::pair<bool, std::optional<Style::PseudoElementIdentifier>> CSSSelector::parsePseudoElement(const String& input, const CSSSelectorParserContext& context)
+{
     auto tokenizer = CSSTokenizer { input };
     auto range = tokenizer.tokenRange();
     auto token = range.consume();
     if (token.type() != ColonToken)
-        return std::nullopt;
+        return { };
     token = range.consume();
     if (token.type() == IdentToken) {
         if (!range.atEnd())
-            return std::nullopt;
+            return { };
         auto pseudoClassOrElement = findPseudoClassAndCompatibilityElementName(token.value());
         if (!pseudoClassOrElement.compatibilityPseudoElement)
-            return std::nullopt;
+            return { };
         ASSERT(CSSSelector::isPseudoElementEnabled(*pseudoClassOrElement.compatibilityPseudoElement, token.value(), context));
-        return pseudoId(*pseudoClassOrElement.compatibilityPseudoElement);
+        return { true, pseudoElementIdentifierFor(*pseudoClassOrElement.compatibilityPseudoElement) };
     }
     if (token.type() != ColonToken)
-        return std::nullopt;
-    token = range.consume();
-    if (token.type() != IdentToken || !range.atEnd())
-        return std::nullopt;
-    if (auto pseudoElement = parsePseudoElementName(token.value(), context))
-        return pseudoId(*pseudoElement);
-    return std::nullopt;
+        return { };
+    token = range.peek();
+    if ((token.type() != IdentToken && token.type() != FunctionToken))
+        return { };
+    auto pseudoElement = parsePseudoElementName(token.value(), context);
+    if (!pseudoElement)
+        return { };
+    if (token.type() == IdentToken) {
+        range.consume();
+        if (!range.atEnd() || CSSSelector::pseudoElementRequiresArgument(*pseudoElement))
+            return { };
+        return { true, pseudoElementIdentifierFor(*pseudoElement) };
+    }
+    ASSERT(token.type() == FunctionToken);
+    auto block = range.consumeBlock();
+    if (!range.atEnd())
+        return { };
+    block.consumeWhitespace();
+    switch (*pseudoElement) {
+    case CSSSelector::PseudoElement::Highlight: {
+        auto& ident = block.consumeIncludingWhitespace();
+        if (ident.type() != IdentToken || !block.atEnd())
+            return { };
+        return { true, Style::PseudoElementIdentifier { PseudoId::Highlight, ident.value().toAtomString() } };
+    }
+    case CSSSelector::PseudoElement::ViewTransitionGroup:
+    case CSSSelector::PseudoElement::ViewTransitionImagePair:
+    case CSSSelector::PseudoElement::ViewTransitionOld:
+    case CSSSelector::PseudoElement::ViewTransitionNew: {
+        auto& ident = block.consumeIncludingWhitespace();
+        if (ident.type() != IdentToken || !isValidCustomIdentifier(ident.id()) || !block.atEnd())
+            return { };
+        return { true, Style::PseudoElementIdentifier { pseudoId(*pseudoElement), ident.value().toAtomString() } };
+    }
+    default:
+        return { };
+    }
 }
 
 const CSSSelector* CSSSelector::firstInCompound() const

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -23,6 +23,7 @@
 
 #include "CSSParserContext.h"
 #include "CSSSelectorEnums.h"
+#include "PseudoElementIdentifier.h"
 #include "QualifiedName.h"
 #include "RenderStyleConstants.h"
 #include <wtf/EnumTraits.h>
@@ -118,7 +119,7 @@ public:
     static PseudoId pseudoId(PseudoElement);
     static bool isPseudoClassEnabled(PseudoClass, const CSSSelectorParserContext&);
     static bool isPseudoElementEnabled(PseudoElement, StringView, const CSSSelectorParserContext&);
-    static std::optional<PseudoId> parsePseudoElement(const String&, const CSSSelectorParserContext&);
+    static std::pair<bool, std::optional<Style::PseudoElementIdentifier>> parsePseudoElement(const String&, const CSSSelectorParserContext&);
     static std::optional<PseudoElement> parsePseudoElementName(StringView, const CSSSelectorParserContext&);
     static bool pseudoClassRequiresArgument(PseudoClass);
     static bool pseudoElementRequiresArgument(PseudoElement);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1616,12 +1616,10 @@ Ref<CSSStyleDeclaration> LocalDOMWindow::getComputedStyle(Element& element, cons
     if (!pseudoElt.startsWith(':'))
         return CSSComputedStyleDeclaration::create(element, std::nullopt);
 
-    // FIXME: This does not work for pseudo-elements that take arguments (webkit.org/b/264103).
-    auto pseudoId = CSSSelector::parsePseudoElement(pseudoElt, CSSSelectorParserContext { element.protectedDocument() });
-    if (!pseudoId)
+    auto [pseudoElementIsParsable, pseudoElementIdentifier] = CSSSelector::parsePseudoElement(pseudoElt, CSSSelectorParserContext { element.protectedDocument() });
+    if (!pseudoElementIsParsable)
         return CSSComputedStyleDeclaration::createEmpty(element);
-    // FIXME: CSSSelector::parsePseudoElement should never return PseudoId::None.
-    return CSSComputedStyleDeclaration::create(element, pseudoId == PseudoId::None ? std::nullopt : std::optional(Style::PseudoElementIdentifier { *pseudoId }));
+    return CSSComputedStyleDeclaration::create(element, pseudoElementIdentifier);
 }
 
 RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const String& pseudoElement, bool authorOnly) const
@@ -1631,10 +1629,10 @@ RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const S
 
     // FIXME: This parser context won't get the right settings without a document.
     auto parserContext = document() ? CSSSelectorParserContext { *protectedDocument() } : CSSSelectorParserContext { CSSParserContext { HTMLStandardMode } };
-    auto optionalPseudoId = CSSSelector::parsePseudoElement(pseudoElement, parserContext);
-    if (!optionalPseudoId && !pseudoElement.isEmpty())
+    auto [pseudoElementIsParsable, pseudoElementIdentifier] = CSSSelector::parsePseudoElement(pseudoElement, parserContext);
+    if (!(pseudoElementIsParsable || (pseudoElementIdentifier && !pseudoElementIdentifier->nameArgument.isNull())) && !pseudoElement.isEmpty())
         return nullptr;
-    auto pseudoId = optionalPseudoId ? *optionalPseudoId : PseudoId::None;
+    auto pseudoId = pseudoElementIdentifier ? pseudoElementIdentifier->pseudoId : PseudoId::None;
 
     RefPtr frame = this->frame();
     frame->protectedDocument()->styleScope().flushPendingUpdate();

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -65,6 +65,11 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
     // Document::setWritingMode/DirectionSetOnDocumentElement. We can't skip the applying by caching.
     if (&element == element.document().documentElement())
         return false;
+    // FIXME: Without the following early return we hit the final assert in
+    // Element::resolvePseudoElementStyle(). Making matchedPseudoElementIds
+    // PseudoElementIdentifier-aware might be a possible solution.
+    if (!style.pseudoElementNameArgument().isNull())
+        return false;
     // content:attr() value depends on the element it is being applied to.
     if (style.hasAttrContent() || (style.pseudoElementType() != PseudoId::None && parentStyle.hasAttrContent()))
         return false;


### PR DESCRIPTION
#### 2a9c86135d14c9f140a25f4e60f4bcff5b504e53
<pre>
getComputedStyle() should work with functional pseudo-elements like ::highlight()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264103">https://bugs.webkit.org/show_bug.cgi?id=264103</a>
<a href="https://rdar.apple.com/117864743">rdar://117864743</a>

Reviewed by Antti Koivisto.

This adds parsing support for pseudo-elements with an argument to
CSSSelector::parsePseudoElement(). For now only getComputedStyle()
makes use of it and other callers continue to treat pseudo-elements
with an argument as an error.

To avoid hitting an assert introduced by 274629@main and also problems
found in debugging where a RenderStyle&apos;s pseudoElementNameArgument
would get overwritten this makes
MatchedDeclarationsCache::isCacheable() return false when there is such
an argument.

New tests are upstreamed here:
<a href="https://github.com/web-platform-tests/wpt/pull/44607">https://github.com/web-platform-tests/wpt/pull/44607</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-013-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-visited-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-inheritance-computed-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/mix-blend-mode-only-on-transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-with-argument-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-with-argument.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::pseudoIdFromString):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::pseudoElementIdentifierFor):
(WebCore::CSSSelector::parsePseudoElement):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getComputedStyle const):
(WebCore::LocalDOMWindow::getMatchedCSSRules const):
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):

Canonical link: <a href="https://commits.webkit.org/274846@main">https://commits.webkit.org/274846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bc0327ca8154926055aafa0bc95250d53cec443

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42722 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16518 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16169 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36450 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12296 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16611 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/34935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5309 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->