### PR TITLE
Fetch keepalive quota should only be restored when the full response body is received

### DIFF
--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -66,16 +66,6 @@ void KeepaliveRequestTracker::registerRequest(CachedResource& resource)
     resource.addClient(*this);
 }
 
-void KeepaliveRequestTracker::responseReceived(CachedResource& resource, const ResourceResponse&, CompletionHandler<void()>&& completionHandler)
-{
-    // Per Fetch specification, allocated quota should be returned before the promise is resolved,
-    // which is when the response is received.
-    unregisterRequest(resource);
-
-    if (completionHandler)
-        completionHandler();
-}
-
 void KeepaliveRequestTracker::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
 {
     unregisterRequest(resource);

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.h
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.h
@@ -37,11 +37,10 @@ public:
     ~KeepaliveRequestTracker();
     bool tryRegisterRequest(CachedResource&);
 
+private:
     // CachedRawResourceClient.
-    void responseReceived(CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) final;
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
 
-private:
     void registerRequest(CachedResource&);
     void unregisterRequest(CachedResource&);
 


### PR DESCRIPTION
#### 5d070f22cea2972484e285c347a15d55e65725e3
<pre>
Fetch keepalive quota should only be restored when the full response body is received
<a href="https://rdar.apple.com/122492438">rdar://122492438</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269464">https://bugs.webkit.org/show_bug.cgi?id=269464</a>

Reviewed by Alex Christensen.

As per spec, quota is computed according all fetch records in group whose request’s keepalive is true and done flag is unset.
The done flag is set when the body is fully received so we need to wait for the load to finish to update the quota.
We can therefore safely remove KeepaliveRequestTracker::responseReceived implementation, as
KeepaliveRequestTracker::notifyFinished will do the job.

Covered by keepalive WPT tests, for instance LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-keepalive-quota.html.

* Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp:
(WebCore::KeepaliveRequestTracker::responseReceived): Deleted.
* Source/WebCore/loader/cache/KeepaliveRequestTracker.h:

Canonical link: <a href="https://commits.webkit.org/274808@main">https://commits.webkit.org/274808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c4f26f38d0d3ea8f920d3929f2fbb7d3f31145

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42431 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35789 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43710 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37825 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16321 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8996 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->