### PR TITLE
[Skia] Implement dashed lines support

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -36,10 +36,12 @@
 #include "NotImplemented.h"
 #include <skia/core/SkImage.h>
 #include <skia/core/SkPath.h>
+#include <skia/core/SkPathEffect.h>
 #include <skia/core/SkPathTypes.h>
 #include <skia/core/SkRRect.h>
 #include <skia/core/SkRegion.h>
 #include <skia/core/SkTileMode.h>
+#include <skia/effects/SkDashPathEffect.h>
 #include <wtf/MathExtras.h>
 
 #if USE(THEME_ADWAITA)
@@ -334,6 +336,9 @@ SkPaint GraphicsContextSkia::createStrokePaint(std::optional<Color> strokeColor)
         paint.setColor(SkColorSetARGB(a, r, g, b));
     }
 
+    if (!m_skiaState.m_dash.array.isEmpty())
+        paint.setPathEffect(SkDashPathEffect::Make(m_skiaState.m_dash.array.data(), m_skiaState.m_dash.array.size(), m_skiaState.m_dash.offset));
+
     return paint;
 }
 
@@ -534,9 +539,12 @@ void GraphicsContextSkia::setLineCap(LineCap lineCap)
     m_skiaState.m_stroke.cap = toSkiaCap(lineCap);
 }
 
-void GraphicsContextSkia::setLineDash(const DashArray&, float /*dashOffset*/)
+void GraphicsContextSkia::setLineDash(const DashArray& dashArray, float dashOffset)
 {
-    notImplemented();
+    ASSERT(!(dashArray.size() % 2));
+
+    m_skiaState.m_dash.array = dashArray;
+    m_skiaState.m_dash.offset = dashOffset;
 }
 
 void GraphicsContextSkia::setLineJoin(LineJoin lineJoin)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -113,6 +113,11 @@ private:
             SkPaint::Cap cap { SkPaint::kButt_Cap };
             SkPaint::Join join { SkPaint::kMiter_Join };
         } m_stroke;
+
+        struct {
+            DashArray array;
+            float offset { 0.0f };
+        } m_dash;
     };
 
     sk_sp<SkSurface> m_surface;


### PR DESCRIPTION
#### cd61c8608c6c65738c722254a49f2a6a0e8ae39c
<pre>
[Skia] Implement dashed lines support
<a href="https://bugs.webkit.org/show_bug.cgi?id=269471">https://bugs.webkit.org/show_bug.cgi?id=269471</a>

Reviewed by Adrian Perez de Castro and Don Olmstead.

Store the dash data (the array, and the offset) into an auxiliary struct
field. If populated, use that to create a SkDashPathEffect, and apply
the effect to the SkPaint used for stroke.

The constructor of SkDashPathEffect has the exact same semantics that
of the array and offset passed to GraphicsContextSkia::setLineDash(),
which makes it extra easy since no conversion needs to happen.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::createStrokePaint const):
(WebCore::GraphicsContextSkia::setLineDash):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:

Canonical link: <a href="https://commits.webkit.org/274758@main">https://commits.webkit.org/274758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ae8bd013d3eabf3ec336ce8b8a70fdb91feb239

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42462 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16259 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34518 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43741 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36246 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16352 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5261 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->