### PR TITLE
Adopt more smart pointers under WebCore/page/

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -82,6 +82,7 @@ public:
 #endif
 
     WTF_EXPORT_PRIVATE static RunLoop& current();
+    static Ref<RunLoop> protectedCurrent() { return current(); }
     WTF_EXPORT_PRIVATE static RunLoop& main();
 #if USE(WEB_THREAD)
     WTF_EXPORT_PRIVATE static RunLoop& web();

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -499,7 +499,7 @@ void DataTransfer::setEffectAllowed(const String&)
 {
 }
 
-void DataTransfer::setDragImage(Element&, int, int)
+void DataTransfer::setDragImage(Ref<Element>&&, int, int)
 {
 }
 
@@ -533,13 +533,13 @@ Ref<DataTransfer> DataTransfer::createForUpdatingDropTarget(const Document& docu
     return dataTransfer;
 }
 
-void DataTransfer::setDragImage(Element& element, int x, int y)
+void DataTransfer::setDragImage(Ref<Element>&& element, int x, int y)
 {
     if (!forDrag() || !canWriteData())
         return;
 
     CachedResourceHandle<CachedImage> image;
-    if (auto* imageElement = dynamicDowncast<HTMLImageElement>(element); imageElement && !imageElement->isConnected())
+    if (auto* imageElement = dynamicDowncast<HTMLImageElement>(element.get()); imageElement && !imageElement->isConnected())
         image = imageElement->cachedImage();
 
     m_dragLocation = IntPoint(x, y);
@@ -553,7 +553,10 @@ void DataTransfer::setDragImage(Element& element, int x, int y)
         m_dragImageLoader->startLoading(m_dragImage);
     }
 
-    m_dragImageElement = image ? nullptr : &element;
+    if (image)
+        m_dragImageElement = nullptr;
+    else
+        m_dragImageElement = WTFMove(element);
 
     updateDragImage();
 }

--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -75,7 +75,7 @@ public:
     void setData(Document&, const String& type, const String& data);
     void setDataFromItemList(Document&, const String& type, const String& data);
 
-    void setDragImage(Element&, int x, int y);
+    void setDragImage(Ref<Element>&&, int x, int y);
 
     void makeInvalidForSecurity() { m_storeMode = StoreMode::Invalid; }
 

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -67,6 +67,11 @@ inline Element* Node::parentElement() const
     return dynamicDowncast<Element>(parentNode());
 }
 
+inline RefPtr<Element> Node::protectedParentElement() const
+{
+    return parentElement();
+}
+
 inline const Element* Element::rootElement() const
 {
     if (isConnected())

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -147,7 +147,8 @@ public:
     ContainerNode* parentNode() const;
     inline RefPtr<ContainerNode> protectedParentNode() const; // Defined in ContainerNode.h.
     static ptrdiff_t parentNodeMemoryOffset() { return OBJECT_OFFSETOF(Node, m_parentNode); }
-    inline Element* parentElement() const;
+    inline Element* parentElement() const; // Defined in ElementInlines.h.
+    inline RefPtr<Element> protectedParentElement() const; // Defined in ElementInlines.h.
     Node* previousSibling() const { return m_previous; }
     RefPtr<Node> protectedPreviousSibling() const { return m_previous; }
     static ptrdiff_t previousSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_previous); }

--- a/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
@@ -183,10 +183,10 @@ void PageDOMDebuggerAgent::willInsertDOMNode(Node& parent)
 
     std::optional<size_t> closestDistance;
     RefPtr<JSC::Breakpoint> closestBreakpoint;
-    Node* closestBreakpointOwner = nullptr;
+    RefPtr<Node> closestBreakpointOwner;
 
     for (auto [breakpointOwner, breakpoint] : m_domSubtreeModifiedBreakpoints) {
-        auto distance = calculateDistance(parent, *breakpointOwner);
+        auto distance = calculateDistance(parent, Ref { *breakpointOwner });
         if (!distance)
             continue;
 

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -184,7 +184,7 @@ static void prepareContextForQRCode(ContextMenuContext& context)
 
     RefPtr<Element> element;
     RefPtr nodeElement = dynamicDowncast<Element>(*node);
-    for (auto& lineage : lineageOfType<Element>(nodeElement ? *nodeElement : *node->parentElement())) {
+    for (auto& lineage : lineageOfType<Element>(nodeElement ? *nodeElement : *node->protectedParentElement())) {
         if (is<HTMLTableElement>(lineage) || is<HTMLCanvasElement>(lineage) || is<HTMLImageElement>(lineage) || is<SVGSVGElement>(lineage)) {
             element = &lineage;
             break;

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -417,7 +417,7 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
     if (!m_documentUnderMouse)
         return DragHandlingMethod::None;
 
-    if (m_dragInitiator && !m_documentUnderMouse->protectedSecurityOrigin()->canReceiveDragData(m_dragInitiator->securityOrigin()))
+    if (m_dragInitiator && !m_documentUnderMouse->protectedSecurityOrigin()->canReceiveDragData(m_dragInitiator->protectedSecurityOrigin()))
         return DragHandlingMethod::None;
 
     bool isHandlingDrag = false;
@@ -960,7 +960,7 @@ void DragController::prepareForDragStart(LocalFrame& source, OptionSet<DragSourc
     }
 
     auto linkURL = hitTestResult->absoluteLinkURL();
-    if (actionMask.contains(DragSourceAction::Link) && !linkURL.isEmpty() && source.document()->securityOrigin().canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton()))
+    if (actionMask.contains(DragSourceAction::Link) && !linkURL.isEmpty() && source.document()->protectedSecurityOrigin()->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton()))
         editor->copyURL(linkURL, hitTestResult->textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline), pasteboard);
 #else
     // FIXME: Make this work on Windows by implementing Editor::writeSelectionToPasteboard and Editor::writeImageToPasteboard.

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -181,7 +181,8 @@ public:
     void cancelDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
     bool performDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
     void updateDragStateAfterEditDragIfNeeded(Element& rootEditableElement);
-    RefPtr<Element> draggedElement() const;
+    static Element* draggedElement();
+    static RefPtr<Element> protectedDraggedElement();
 #endif
 
     void scheduleHoverStateUpdate();

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -824,7 +824,7 @@ Element* FocusController::nextFocusableElementOrScopeOwner(const FocusNavigation
         }
 
         // First try to find a node with the same tabindex as start that comes after start in the scope.
-        if (auto* winner = findElementWithExactTabIndex(scope, scope.nextInScope(start), startTabIndex, event, FocusDirection::Forward))
+        if (auto* winner = findElementWithExactTabIndex(scope, RefPtr { scope.nextInScope(start) }.get(), startTabIndex, event, FocusDirection::Forward))
             return winner;
 
         if (!startTabIndex)
@@ -907,7 +907,7 @@ static bool shouldClearSelectionWhenChangingFocusedElement(const Page& page, Ref
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
     if (!localMainFrame)
         return false;
-    for (auto ancestor = localMainFrame->eventHandler().draggedElement(); ancestor; ancestor = ancestor->parentOrShadowHostElement()) {
+    for (auto* ancestor = localMainFrame->eventHandler().draggedElement(); ancestor; ancestor = ancestor->parentOrShadowHostElement()) {
         if (ancestor == oldFocusedElement)
             return false;
     }

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -72,8 +72,8 @@ Frame* FrameTree::parent() const
 
 void FrameTree::appendChild(Frame& child)
 {
-    ASSERT(child.page() == m_thisFrame.page());
-    child.tree().m_parent = m_thisFrame;
+    ASSERT(child.page() == m_thisFrame->page());
+    child.tree().m_parent = m_thisFrame.ptr();
     WeakPtr<Frame> oldLast = m_lastChild;
     m_lastChild = child;
 
@@ -118,6 +118,11 @@ AtomString FrameTree::generateUniqueName() const
         return top.tree().generateUniqueName();
 
     return makeAtomString("<!--frame", ++m_frameIDGenerator, "-->");
+}
+
+Ref<Frame> FrameTree::protectedThisFrame() const
+{
+    return m_thisFrame.get();
 }
 
 static bool inScope(Frame& frame, TreeScope& scope)
@@ -177,36 +182,36 @@ inline unsigned FrameTree::scopedChildCount(TreeScope* scope) const
 
 Frame* FrameTree::scopedChild(unsigned index) const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame);
+    auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame.get());
     if (!localFrame)
         return nullptr;
-    return scopedChild(index, localFrame->document());
+    return scopedChild(index, localFrame->protectedDocument().get());
 }
 
 Frame* FrameTree::scopedChildByUniqueName(const AtomString& uniqueName) const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame);
+    auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame.get());
     if (!localFrame)
         return nullptr;
     return scopedChild([&](auto& frameTree) {
         return frameTree.uniqueName() == uniqueName;
-    }, localFrame->document());
+    }, localFrame->protectedDocument().get());
 }
 
 Frame* FrameTree::scopedChildBySpecifiedName(const AtomString& specifiedName) const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame);
+    auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame.get());
     if (!localFrame)
         return nullptr;
     return scopedChild([&](auto& frameTree) {
         return frameTree.specifiedName() == specifiedName;
-    }, localFrame->document());
+    }, localFrame->protectedDocument().get());
 }
 
 unsigned FrameTree::scopedChildCount() const
 {
     if (m_scopedChildCount == invalidCount) {
-        if (auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame))
+        if (auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame.get()))
             m_scopedChildCount = scopedChildCount(localFrame->document());
     }
     return m_scopedChildCount;
@@ -262,32 +267,33 @@ static bool isFrameFamiliarWith(Frame& frameA, Frame& frameB)
 inline Frame* FrameTree::find(const AtomString& name, const Function<const AtomString&(const FrameTree&)>& nameGetter, Frame& activeFrame) const
 {
     if (isSelfTargetFrameName(name))
-        return &m_thisFrame;
+        return m_thisFrame.ptr();
 
     if (isTopTargetFrameName(name))
         return &top();
 
     if (isParentTargetFrameName(name))
-        return parent() ? parent() : &m_thisFrame;
+        return parent() ? parent() : m_thisFrame.ptr();
 
     // Since "_blank" cannot be a frame's name, this check is an optimization, not for correctness.
     if (isBlankTargetFrameName(name))
         return nullptr;
 
     // Search subtree starting with this frame first.
-    for (auto* frame = &m_thisFrame; frame; frame = frame->tree().traverseNext(&m_thisFrame)) {
+    Ref thisFrame = m_thisFrame.get();
+    for (auto* frame = thisFrame.ptr(); frame; frame = frame->tree().traverseNext(thisFrame.ptr())) {
         if (nameGetter(frame->tree()) == name)
             return frame;
     }
 
     // Then the rest of the tree.
-    for (Frame* frame = &m_thisFrame.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &thisFrame->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (nameGetter(frame->tree()) == name)
             return frame;
     }
 
     // Search the entire tree of each of the other pages in this namespace.
-    RefPtr page = m_thisFrame.page();
+    RefPtr page = thisFrame->page();
     if (!page)
         return nullptr;
 
@@ -323,10 +329,10 @@ bool FrameTree::isDescendantOf(const Frame* ancestor) const
     if (!ancestor)
         return false;
 
-    if (m_thisFrame.page() != ancestor->page())
+    if (m_thisFrame->page() != ancestor->page())
         return false;
 
-    for (Frame* frame = &m_thisFrame; frame; frame = frame->tree().parent()) {
+    for (Frame* frame = m_thisFrame.ptr(); frame; frame = frame->tree().parent()) {
         if (frame == ancestor)
             return true;
     }
@@ -341,7 +347,7 @@ Frame* FrameTree::traverseNext(const Frame* stayWithin) const
         return child;
     }
 
-    if (&m_thisFrame == stayWithin)
+    if (m_thisFrame.ptr() == stayWithin)
         return nullptr;
 
     auto* sibling = nextSibling();
@@ -350,7 +356,7 @@ Frame* FrameTree::traverseNext(const Frame* stayWithin) const
         return sibling;
     }
 
-    auto* frame = &m_thisFrame;
+    auto* frame = m_thisFrame.ptr();
     while (!sibling && (!stayWithin || frame->tree().parent() != stayWithin)) {
         frame = frame->tree().parent();
         if (!frame)
@@ -368,7 +374,7 @@ Frame* FrameTree::traverseNext(const Frame* stayWithin) const
 
 Frame* FrameTree::traverseNextSkippingChildren(const Frame* stayWithin) const
 {
-    if (&m_thisFrame == stayWithin)
+    if (m_thisFrame.ptr() == stayWithin)
         return nullptr;
     if (auto* sibling = nextSibling())
         return sibling;
@@ -378,7 +384,7 @@ Frame* FrameTree::traverseNextSkippingChildren(const Frame* stayWithin) const
 Frame* FrameTree::nextAncestorSibling(const Frame* stayWithin) const
 {
     ASSERT(!nextSibling());
-    ASSERT(&m_thisFrame != stayWithin);
+    ASSERT(m_thisFrame.ptr() != stayWithin);
     for (auto* ancestor = parent(); ancestor; ancestor = ancestor->tree().parent()) {
         if (ancestor == stayWithin)
             return nullptr;
@@ -407,7 +413,7 @@ Frame* FrameTree::firstRenderedChild() const
 
 Frame* FrameTree::nextRenderedSibling() const
 {
-    auto* sibling = &m_thisFrame;
+    auto* sibling = m_thisFrame.ptr();
 
     while ((sibling = sibling->tree().nextSibling())) {
         if (auto* localSibling = dynamicDowncast<LocalFrame>(sibling); localSibling && localSibling->ownerRenderer())
@@ -425,7 +431,7 @@ Frame* FrameTree::traverseNextRendered(const Frame* stayWithin) const
         return child;
     }
 
-    if (&m_thisFrame == stayWithin)
+    if (m_thisFrame.ptr() == stayWithin)
         return nullptr;
 
     auto* sibling = nextRenderedSibling();
@@ -434,7 +440,7 @@ Frame* FrameTree::traverseNextRendered(const Frame* stayWithin) const
         return sibling;
     }
 
-    auto* frame = &m_thisFrame;
+    auto* frame = m_thisFrame.ptr();
     while (!sibling && (!stayWithin || frame->tree().parent() != stayWithin)) {
         frame = frame->tree().parent();
         if (!frame)
@@ -458,7 +464,7 @@ Frame* FrameTree::traverseNext(CanWrap canWrap, DidWrap* didWrap) const
     if (canWrap == CanWrap::Yes) {
         if (didWrap)
             *didWrap = DidWrap::Yes;
-        return &m_thisFrame.mainFrame();
+        return &m_thisFrame->mainFrame();
     }
 
     return nullptr;
@@ -497,7 +503,7 @@ Frame* FrameTree::traverseNextInPostOrder(CanWrap canWrap) const
 
 Frame* FrameTree::deepFirstChild() const
 {
-    auto* result = &m_thisFrame;
+    auto* result = m_thisFrame.ptr();
     while (auto* next = result->tree().firstChild())
         result = next;
     return result;
@@ -505,7 +511,7 @@ Frame* FrameTree::deepFirstChild() const
 
 Frame* FrameTree::deepLastChild() const
 {
-    auto* result = &m_thisFrame;
+    auto* result = m_thisFrame.ptr();
     for (auto* last = lastChild(); last; last = last->tree().lastChild())
         result = last;
 
@@ -514,14 +520,19 @@ Frame* FrameTree::deepLastChild() const
 
 Frame& FrameTree::top() const
 {
-    ASSERT(m_thisFrame.isMainFrame() || m_thisFrame.tree().parent());
-    return m_thisFrame.mainFrame();
+    ASSERT(m_thisFrame->isMainFrame() || m_thisFrame->tree().parent());
+    return m_thisFrame->mainFrame();
+}
+
+Ref<Frame> FrameTree::protectedTop() const
+{
+    return top();
 }
 
 unsigned FrameTree::depth() const
 {
     unsigned depth = 0;
-    for (auto* parent = &m_thisFrame; parent; parent = parent->tree().parent())
+    for (auto* parent = m_thisFrame.ptr(); parent; parent = parent->tree().parent())
         depth++;
     return depth;
 }
@@ -606,7 +617,7 @@ void showFrameTree(const WebCore::Frame* frame)
         return;
     }
 
-    printFrames(frame->tree().top(), frame, 0);
+    printFrames(frame->tree().protectedTop(), frame, 0);
 }
 
 #endif

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -77,6 +77,7 @@ public:
     WEBCORE_EXPORT unsigned childCount() const;
     unsigned descendantCount() const;
     WEBCORE_EXPORT Frame& top() const;
+    Ref<Frame> protectedTop() const;
     unsigned depth() const;
 
     WEBCORE_EXPORT Frame* scopedChild(unsigned index) const;
@@ -101,7 +102,9 @@ private:
     AtomString uniqueChildName(const AtomString& requestedName) const;
     AtomString generateUniqueName() const;
 
-    Frame& m_thisFrame;
+    Ref<Frame> protectedThisFrame() const;
+
+    WeakRef<Frame> m_thisFrame;
 
     WeakPtr<Frame> m_parent;
     AtomString m_specifiedName; // The actual frame name (may be empty).

--- a/Source/WebCore/page/ImageOverlayController.cpp
+++ b/Source/WebCore/page/ImageOverlayController.cpp
@@ -56,7 +56,7 @@ ImageOverlayController::ImageOverlayController(Page& page)
 
 void ImageOverlayController::selectionQuadsDidChange(LocalFrame& frame, const Vector<FloatQuad>& quads)
 {
-    if (!m_page || !m_page->chrome().client().needsImageOverlayControllerForSelectionPainting())
+    if (!m_page || !protectedPage()->chrome().client().needsImageOverlayControllerForSelectionPainting())
         return;
 
     if (frame.editor().ignoreSelectionChanges() || frame.editor().isGettingDictionaryPopupInfo())
@@ -131,7 +131,7 @@ PageOverlay& ImageOverlayController::installPageOverlayIfNeeded()
         return *m_overlay;
 
     m_overlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
-    m_page->pageOverlayController().installPageOverlay(*m_overlay, PageOverlay::FadeMode::DoNotFade);
+    protectedPage()->pageOverlayController().installPageOverlay(*protectedOverlay(), PageOverlay::FadeMode::DoNotFade);
     return *m_overlay;
 }
 
@@ -150,7 +150,12 @@ void ImageOverlayController::uninstallPageOverlay()
     if (!m_page || !overlayToUninstall)
         return;
 
-    m_page->pageOverlayController().uninstallPageOverlay(*overlayToUninstall, PageOverlay::FadeMode::DoNotFade);
+    protectedPage()->pageOverlayController().uninstallPageOverlay(*overlayToUninstall, PageOverlay::FadeMode::DoNotFade);
+}
+
+RefPtr<Page> ImageOverlayController::protectedPage() const
+{
+    return m_page.get();
 }
 
 void ImageOverlayController::uninstallPageOverlayIfNeeded()

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -91,6 +91,9 @@ private:
     void platformUpdateElementUnderMouse(LocalFrame&, Element* elementUnderMouse);
     bool platformHandleMouseEvent(const PlatformMouseEvent&);
 
+    RefPtr<Page> protectedPage() const;
+    RefPtr<PageOverlay> protectedOverlay() const { return m_overlay; }
+
     SingleThreadWeakPtr<Page> m_page;
     RefPtr<PageOverlay> m_overlay;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_hostElementForSelection;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2574,24 +2574,24 @@ void LocalFrameView::textFragmentIndicatorTimerFired()
 
         constexpr auto hitType = OptionSet { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowVisibleChildFrameContentOnly };
         auto result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects.first().center()), hitType);
-        if (!intersects(range, *result.targetNode()))
+        if (!intersects(range, *result.protectedTargetNode()))
             return;
         
         if (textRects.size() >= 2) {
             result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects[1].center()), hitType);
-            if (!intersects(range, *result.targetNode()))
+            if (!intersects(range, *result.protectedTargetNode()))
                 return;
         }
         
         if (textRects.size() >= 4) {
             result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects.last().center()), hitType);
-            if (!intersects(range, *result.targetNode()))
+            if (!intersects(range, *result.protectedTargetNode()))
                 return;
             result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects[textRects.size() - 2].center()), hitType);
-            if (!intersects(range, *result.targetNode()))
+            if (!intersects(range, *result.protectedTargetNode()))
                 return;
         }
-        document.page()->chrome().client().setTextIndicator(textIndicator->data());
+        document.protectedPage()->chrome().client().setTextIndicator(textIndicator->data());
     }
 }
 
@@ -5758,12 +5758,14 @@ CheckedPtr<RenderView> LocalFrameView::checkedRenderView() const
 
 int LocalFrameView::mapFromLayoutToCSSUnits(LayoutUnit value) const
 {
-    return value / (m_frame->pageZoomFactor() * m_frame->frameScaleFactor());
+    Ref frame = m_frame;
+    return value / (frame->pageZoomFactor() * frame->frameScaleFactor());
 }
 
 LayoutUnit LocalFrameView::mapFromCSSToLayoutUnits(int value) const
 {
-    return LayoutUnit(value * m_frame->pageZoomFactor() * m_frame->frameScaleFactor());
+    Ref frame = m_frame;
+    return LayoutUnit(value * frame->pageZoomFactor() * frame->frameScaleFactor());
 }
 
 void LocalFrameView::didAddWidgetToRenderTree(Widget& widget)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -856,7 +856,7 @@ inline std::optional<std::pair<WeakRef<MediaCanStartListener>, WeakRef<Document,
             continue;
         if (!localFrame->document())
             continue;
-        if (MediaCanStartListener* listener = localFrame->document()->takeAnyMediaCanStartListener())
+        if (MediaCanStartListener* listener = localFrame->protectedDocument()->takeAnyMediaCanStartListener())
             return { { *listener, *localFrame->document() } };
     }
     return std::nullopt;
@@ -873,7 +873,7 @@ void Page::setCanStartMedia(bool canStartMedia)
         auto listener = takeAnyMediaCanStartListener();
         if (!listener)
             break;
-        listener->first->mediaCanStart(listener->second);
+        listener->first->mediaCanStart(Ref { listener->second.get() });
     }
 }
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -200,7 +200,7 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
 
     Vector<Ref<Node>> serializedNodes;
     SerializerMarkupAccumulator accumulator(*this, *document, &serializedNodes);
-    String text = accumulator.serializeNodes(*document->documentElement(), SerializedNodes::SubtreeIncludingNode);
+    String text = accumulator.serializeNodes(*document->protectedDocumentElement(), SerializedNodes::SubtreeIncludingNode);
     m_resources.append({ url, document->suggestedMIMEType(), SharedBuffer::create(textEncoding.encode(text, PAL::UnencodableHandling::Entities)) });
     m_resourceURLs.add(url);
 

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -47,6 +47,11 @@ PerformanceObserver::PerformanceObserver(ScriptExecutionContext& scriptExecution
         ASSERT_NOT_REACHED();
 }
 
+RefPtr<Performance> PerformanceObserver::protectedPerformance() const
+{
+    return m_performance;
+}
+
 void PerformanceObserver::disassociate()
 {
     m_performance = nullptr;
@@ -85,7 +90,7 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
         if (init.buffered) {
             isBuffered = true;
             auto oldSize = m_entriesToDeliver.size();
-            m_performance->appendBufferedEntriesByType(*init.type, m_entriesToDeliver, *this);
+            protectedPerformance()->appendBufferedEntriesByType(*init.type, m_entriesToDeliver, *this);
             auto begin = m_entriesToDeliver.begin();
             auto oldEnd = begin + oldSize;
             auto end = m_entriesToDeliver.end();
@@ -96,7 +101,7 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
     }
 
     if (!m_registered) {
-        m_performance->registerPerformanceObserver(*this);
+        protectedPerformance()->registerPerformanceObserver(*this);
         m_registered = true;
     }
     if (isBuffered)
@@ -112,8 +117,8 @@ Vector<RefPtr<PerformanceEntry>> PerformanceObserver::takeRecords()
 
 void PerformanceObserver::disconnect()
 {
-    if (m_performance)
-        m_performance->unregisterPerformanceObserver(*this);
+    if (RefPtr performance = m_performance)
+        performance->unregisterPerformanceObserver(*this);
 
     m_registered = false;
     m_entriesToDeliver.clear();

--- a/Source/WebCore/page/PerformanceObserver.h
+++ b/Source/WebCore/page/PerformanceObserver.h
@@ -73,6 +73,8 @@ public:
 private:
     PerformanceObserver(ScriptExecutionContext&, Ref<PerformanceObserverCallback>&&);
 
+    RefPtr<Performance> protectedPerformance() const;
+
     RefPtr<Performance> m_performance;
     Vector<RefPtr<PerformanceEntry>> m_entriesToDeliver;
     Ref<PerformanceObserverCallback> m_callback;

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -253,7 +253,7 @@ void PrintContext::spoolPage(GraphicsContext& ctx, int pageNumber, float width)
     ctx.translate(-pageRect.x(), -pageRect.y());
     ctx.clip(pageRect);
     frame.view()->paintContents(ctx, pageRect);
-    outputLinkedDestinations(ctx, *frame.document(), pageRect);
+    outputLinkedDestinations(ctx, *frame.protectedDocument(), pageRect);
     ctx.restore();
 }
 

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -192,10 +192,12 @@ bool ResizeObserver::isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor& visito
         if (auto* target = observation->target(); target && containsWebCoreOpaqueRoot(visitor, target))
             return true;
     }
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_CALL_ARGS_BEGIN
     for (auto& target : m_activeObservationTargets) {
         if (containsWebCoreOpaqueRoot(visitor, target.get()))
             return true;
     }
+IGNORE_CLANG_STATIC_ANALYZER_UNCOUNTED_CALL_ARGS_END
     return !m_targetsWaitingForFirstObservation.isEmpty();
 }
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -335,7 +335,7 @@ bool scrollInDirection(LocalFrame* frame, FocusDirection direction)
 {
     ASSERT(frame);
 
-    if (frame && canScrollInDirection(frame->document(), direction)) {
+    if (frame && canScrollInDirection(frame->protectedDocument().get(), direction)) {
         LayoutUnit dx;
         LayoutUnit dy;
         switch (direction) {
@@ -366,7 +366,7 @@ bool scrollInDirection(Node* container, FocusDirection direction)
 {
     ASSERT(container);
     if (is<Document>(*container))
-        return scrollInDirection(downcast<Document>(*container).frame(), direction);
+        return scrollInDirection(downcast<Document>(*container).protectedFrame().get(), direction);
 
     if (!container->renderBox())
         return false;

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -157,6 +157,7 @@ public:
     float contentImageScaleFactor() const { return m_data.contentImageScaleFactor; }
     Image* contentImageWithHighlight() const { return m_data.contentImageWithHighlight.get(); }
     Image* contentImage() const { return m_data.contentImage.get(); }
+    RefPtr<Image> protectedContentImage() const { return contentImage(); }
 
     TextIndicatorPresentationTransition presentationTransition() const { return m_data.presentationTransition; }
     void setPresentationTransition(TextIndicatorPresentationTransition transition) { m_data.presentationTransition = transition; }

--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
@@ -238,7 +238,7 @@ static bool indicatorWantsFadeIn(const WebCore::TextIndicator& indicator)
 
 static RetainPtr<CAKeyframeAnimation> createBounceAnimation(CFTimeInterval duration)
 {
-    RetainPtr<CAKeyframeAnimation> bounceAnimation = [CAKeyframeAnimation animationWithKeyPath:@"transform"];
+    RetainPtr bounceAnimation = [CAKeyframeAnimation animationWithKeyPath:@"transform"];
     [bounceAnimation setValues:@[
         [NSValue valueWithCATransform3D:CATransform3DIdentity],
         [NSValue valueWithCATransform3D:CATransform3DMakeScale(WebCore::midBounceScale, WebCore::midBounceScale, 1)],
@@ -251,8 +251,8 @@ static RetainPtr<CAKeyframeAnimation> createBounceAnimation(CFTimeInterval durat
 
 static RetainPtr<CABasicAnimation> createContentCrossfadeAnimation(CFTimeInterval duration, WebCore::TextIndicator& textIndicator)
 {
-    RetainPtr<CABasicAnimation> crossfadeAnimation = [CABasicAnimation animationWithKeyPath:@"contents"];
-    auto contentsImage = textIndicator.contentImage()->nativeImage();
+    RetainPtr crossfadeAnimation = [CABasicAnimation animationWithKeyPath:@"contents"];
+    RefPtr contentsImage = textIndicator.protectedContentImage()->nativeImage();
     [crossfadeAnimation setToValue:(__bridge id)contentsImage->platformImage().get()];
     [crossfadeAnimation setFillMode:kCAFillModeForwards];
     [crossfadeAnimation setRemovedOnCompletion:NO];

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -423,7 +423,7 @@ bool EventHandler::passSubframeEventToSubframe(MouseEventWithHitTestResults& eve
         RefPtr widget = downcast<RenderWidget>(*renderer).widget();
         if (!widget || !widget->isLocalFrameView())
             return false;
-        if (!passWidgetMouseDownEventToWidget(downcast<RenderWidget>(renderer.get()))) // May destroy the renderer.
+        if (!passWidgetMouseDownEventToWidget(RefPtr { downcast<RenderWidget>(renderer.get()) }.get())) // May destroy the renderer.
             return false;
         m_mouseDownWasInSubframe = true;
         return true;

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -91,7 +91,7 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
 #else
         auto highlight = adoptCF(PAL::softLink_DataDetectors_DDHighlightCreateWithRectsInVisibleRectWithStyleAndDirection(nullptr, &elementBounds, 1, mainFrameView->visibleContentRect(), static_cast<DDHighlightStyle>(DDHighlightStyleBubbleStandard) | static_cast<DDHighlightStyle>(DDHighlightStyleStandardIconArrow), YES, NSWritingDirectionNatural, NO, YES));
 #endif
-        return ContainerAndHighlight { element, DataDetectorHighlight::createForImageOverlay(*m_page, *this, WTFMove(highlight), *makeRangeSelectingNode(element.get())) };
+        return ContainerAndHighlight { element, DataDetectorHighlight::createForImageOverlay(*protectedPage(), *this, WTFMove(highlight), *makeRangeSelectingNode(element.get())) };
     });
 }
 
@@ -169,7 +169,7 @@ bool ImageOverlayController::handleDataDetectorAction(const HTMLElement& element
     if (!renderer)
         return false;
 
-    m_page->chrome().client().handleClickForDataDetectionResult({ WTFMove(dataDetectionResult), frameView->contentsToWindow(renderer->absoluteBoundingBoxRect()) }, frameView->contentsToWindow(locationInContents));
+    protectedPage()->chrome().client().handleClickForDataDetectionResult({ WTFMove(dataDetectionResult), frameView->contentsToWindow(renderer->absoluteBoundingBoxRect()) }, frameView->contentsToWindow(locationInContents));
     return true;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -39,6 +39,7 @@ public:
 
     ScrollingTreeScrollingNode& scrollingNode() { return m_scrollingNode; }
     const ScrollingTreeScrollingNode& scrollingNode() const { return m_scrollingNode; }
+    Ref<ScrollingTreeScrollingNode> protectedScrollingNode() const { return m_scrollingNode; }
     
     virtual bool startAnimatedScrollToPosition(FloatPoint) = 0;
     virtual void stopAnimatedScroll() = 0;
@@ -83,7 +84,7 @@ protected:
     ScrollElasticity verticalScrollElasticity() const { return m_scrollingNode.verticalScrollElasticity(); }
 
 private:
-    ScrollingTreeScrollingNode& m_scrollingNode;
+    ScrollingTreeScrollingNode& m_scrollingNode; // FIXME : Should use a smart pointer.
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -58,10 +58,11 @@ void ThreadedScrollingTreeScrollingNodeDelegate::updateFromStateNode(const Scrol
 
 void ThreadedScrollingTreeScrollingNodeDelegate::updateSnapScrollState()
 {
-    scrollingNode().setScrollSnapInProgress(m_scrollController.isScrollSnapInProgress());
+    Ref scrollingNode = this->scrollingNode();
+    scrollingNode->setScrollSnapInProgress(m_scrollController.isScrollSnapInProgress());
 
     if (m_scrollController.activeScrollSnapIndexDidChange())
-        scrollingTree().setActiveScrollSnapIndices(scrollingNode().scrollingNodeID(), m_scrollController.activeScrollSnapIndexForAxis(ScrollEventAxis::Horizontal), m_scrollController.activeScrollSnapIndexForAxis(ScrollEventAxis::Vertical));
+        scrollingTree().setActiveScrollSnapIndices(scrollingNode->scrollingNodeID(), m_scrollController.activeScrollSnapIndexForAxis(ScrollEventAxis::Horizontal), m_scrollController.activeScrollSnapIndexForAxis(ScrollEventAxis::Vertical));
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::updateUserScrollInProgressForEvent(const PlatformWheelEvent& wheelEvent)
@@ -70,7 +71,7 @@ void ThreadedScrollingTreeScrollingNodeDelegate::updateUserScrollInProgressForEv
     m_scrollController.updateGestureInProgressState(wheelEvent);
     bool isInUserScroll = m_scrollController.isUserScrollInProgress();
     if (isInUserScroll != wasInUserScroll)
-        scrollingNode().setUserScrollInProgress(isInUserScroll);
+        protectedScrollingNode()->setUserScrollInProgress(isInUserScroll);
 }
 
 bool ThreadedScrollingTreeScrollingNodeDelegate::startAnimatedScrollToPosition(FloatPoint destinationPosition)
@@ -93,7 +94,7 @@ void ThreadedScrollingTreeScrollingNodeDelegate::serviceScrollAnimation(Monotoni
 std::unique_ptr<ScrollingEffectsControllerTimer> ThreadedScrollingTreeScrollingNodeDelegate::createTimer(Function<void()>&& function)
 {
     // This is only used for a scroll snap timer.
-    return WTF::makeUnique<ScrollingEffectsControllerTimer>(RunLoop::current(), [function = WTFMove(function), protectedNode = Ref { scrollingNode() }] {
+    return WTF::makeUnique<ScrollingEffectsControllerTimer>(RunLoop::protectedCurrent(), [function = WTFMove(function), protectedNode = Ref { scrollingNode() }] {
         Locker locker { protectedNode->scrollingTree().treeLock() };
         function();
     });
@@ -101,12 +102,12 @@ std::unique_ptr<ScrollingEffectsControllerTimer> ThreadedScrollingTreeScrollingN
 
 void ThreadedScrollingTreeScrollingNodeDelegate::startAnimationCallback(ScrollingEffectsController&)
 {
-    scrollingNode().setScrollAnimationInProgress(true);
+    protectedScrollingNode()->setScrollAnimationInProgress(true);
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::stopAnimationCallback(ScrollingEffectsController&)
 {
-    scrollingNode().setScrollAnimationInProgress(false);
+    protectedScrollingNode()->setScrollAnimationInProgress(false);
 }
 
 bool ThreadedScrollingTreeScrollingNodeDelegate::allowsHorizontalScrolling() const
@@ -121,7 +122,7 @@ bool ThreadedScrollingTreeScrollingNodeDelegate::allowsVerticalScrolling() const
 
 void ThreadedScrollingTreeScrollingNodeDelegate::immediateScrollBy(const FloatSize& delta, ScrollClamping clamping)
 {
-    scrollingNode().scrollBy(delta, clamping);
+    protectedScrollingNode()->scrollBy(delta, clamping);
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::adjustScrollPositionToBoundsIfNecessary()
@@ -140,47 +141,48 @@ float ThreadedScrollingTreeScrollingNodeDelegate::pageScaleFactor() const
 {
     // FIXME: What should this return for non-root frames, and overflow?
     // Also, this should not have to access ScrollingTreeFrameScrollingNode.
-    if (is<ScrollingTreeFrameScrollingNode>(scrollingNode()))
-        return downcast<ScrollingTreeFrameScrollingNode>(scrollingNode()).frameScaleFactor();
+    if (RefPtr node = dynamicDowncast<ScrollingTreeFrameScrollingNode>(scrollingNode()))
+        return node->frameScaleFactor();
 
     return 1;
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::willStartAnimatedScroll()
 {
-    scrollingNode().willStartAnimatedScroll();
+    protectedScrollingNode()->willStartAnimatedScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::didStopAnimatedScroll()
 {
-    scrollingNode().didStopAnimatedScroll();
+    protectedScrollingNode()->didStopAnimatedScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::willStartWheelEventScroll()
 {
-    scrollingNode().willStartWheelEventScroll();
+    protectedScrollingNode()->willStartWheelEventScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::didStopWheelEventScroll()
 {
-    scrollingNode().didStopWheelEventScroll();
+    protectedScrollingNode()->didStopWheelEventScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::willStartScrollSnapAnimation()
 {
-    scrollingNode().setScrollSnapInProgress(true);
+    protectedScrollingNode()->setScrollSnapInProgress(true);
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::didStopScrollSnapAnimation()
 {
-    scrollingNode().setScrollSnapInProgress(false);
+    protectedScrollingNode()->setScrollSnapInProgress(false);
 }
 
 ScrollExtents ThreadedScrollingTreeScrollingNodeDelegate::scrollExtents() const
 {
+    Ref scrollingNode = this->scrollingNode();
     return {
-        scrollingNode().totalContentsSize(),
-        scrollingNode().scrollableAreaSize()
+        scrollingNode->totalContentsSize(),
+        scrollingNode->scrollableAreaSize()
     };
 }
 


### PR DESCRIPTION
#### b2127af72b9226f59303afbbd62011119bdd0fc8
<pre>
Adopt more smart pointers under WebCore/page/
<a href="https://bugs.webkit.org/show_bug.cgi?id=269480">https://bugs.webkit.org/show_bug.cgi?id=269480</a>

Reviewed by Ryosuke Niwa and Brent Fulgham.

Adopt more smart pointers under WebCore/page/, as recommended by the static analyzer.

* Source/WTF/wtf/RunLoop.h:
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Node::protectedParentElement const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp:
(WebCore::PageDOMDebuggerAgent::willInsertDOMNode):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::prepareContextForQRCode):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::tryDocumentDrag):
(WebCore::DragController::prepareForDragStart const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::draggedElement):
(WebCore::EventHandler::protectedDraggedElement):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::scrollRecursively):
(WebCore::EventHandler::logicalScrollRecursively):
(WebCore::EventHandler::subframeForHitTestResult):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseForceEvent):
(WebCore::EventHandler::canDropCurrentlyDraggedImageAsFile const):
(WebCore::EventHandler::dispatchDragEnterOrDragOverEvent):
(WebCore::EventHandler::updateDragAndDrop):
(WebCore::EventHandler::cancelDragAndDrop):
(WebCore::EventHandler::performDragAndDrop):
(WebCore::EventHandler::handleWheelEventInternal):
(WebCore::EventHandler::handleAccessKey):
(WebCore::EventHandler::internalKeyEvent):
(WebCore::EventHandler::didStartDrag):
(WebCore::EventHandler::updateDragStateAfterEditDragIfNeeded):
(WebCore::EventHandler::shouldDispatchEventsToDragSourceElement):
(WebCore::EventHandler::dispatchEventToDragSourceElement):
(WebCore::EventHandler::dispatchDragStartEventOnSourceElement):
(WebCore::EventHandler::handleDrag):
(WebCore::hitTestResultInFrame):
(WebCore::EventHandler::handleTouchEvent):
(WebCore::EventHandler::draggedElement const): Deleted.
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::nextFocusableElementOrScopeOwner):
(WebCore::shouldClearSelectionWhenChangingFocusedElement):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::appendChild):
(WebCore::FrameTree::protectedThisFrame const):
(WebCore::FrameTree::scopedChild const):
(WebCore::FrameTree::scopedChildByUniqueName const):
(WebCore::FrameTree::scopedChildBySpecifiedName const):
(WebCore::FrameTree::scopedChildCount const):
(WebCore::FrameTree::find const):
(WebCore::FrameTree::isDescendantOf const):
(WebCore::FrameTree::traverseNext const):
(WebCore::FrameTree::traverseNextSkippingChildren const):
(WebCore::FrameTree::nextAncestorSibling const):
(WebCore::FrameTree::nextRenderedSibling const):
(WebCore::FrameTree::traverseNextRendered const):
(WebCore::FrameTree::deepFirstChild const):
(WebCore::FrameTree::deepLastChild const):
(WebCore::FrameTree::top const):
(WebCore::FrameTree::protectedTop const):
(WebCore::FrameTree::depth const):
(showFrameTree):
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/ImageOverlayController.cpp:
(WebCore::ImageOverlayController::selectionQuadsDidChange):
(WebCore::ImageOverlayController::installPageOverlayIfNeeded):
(WebCore::ImageOverlayController::uninstallPageOverlay):
(WebCore::ImageOverlayController::protectedPage const):
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchAllPendingUnloadEvents):
(WebCore::LocalDOMWindow::canShowModalDialog):
(WebCore::LocalDOMWindow::crypto const):
(WebCore::LocalDOMWindow::processPostMessage):
(WebCore::LocalDOMWindow::focus):
(WebCore::LocalDOMWindow::scrollY const):
(WebCore::LocalDOMWindow::getComputedStyle const):
(WebCore::LocalDOMWindow::getMatchedCSSRules const):
(WebCore::LocalDOMWindow::scrollBy const):
(WebCore::LocalDOMWindow::isSameSecurityOriginAsMainFrame const):
(WebCore::LocalDOMWindow::isAllowedToUseDeviceOrientation const):
(WebCore::LocalDOMWindow::hasPermissionToReceiveDeviceMotionOrOrientationEvents const):
(WebCore::LocalDOMWindow::dispatchLoadEvent):
(WebCore::LocalDOMWindow::removeAllEventListeners):
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::crossDomainAccessErrorMessage):
(WebCore::LocalDOMWindow::isInsecureScriptAccess):
(WebCore::LocalDOMWindow::createWindow):
(WebCore::LocalDOMWindow::open):
(WebCore::LocalDOMWindow::showModalDialog):
(WebCore::LocalDOMWindow::cookieStore):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::textFragmentIndicatorTimerFired):
(WebCore::LocalFrameView::mapFromLayoutToCSSUnits const):
(WebCore::LocalFrameView::mapFromCSSToLayoutUnits const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::takeAnyMediaCanStartListener):
(WebCore::Page::setCanStartMedia):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serializeFrame):
* Source/WebCore/page/PerformanceObserver.cpp:
(WebCore::PerformanceObserver::protectedPerformance const):
(WebCore::PerformanceObserver::observe):
(WebCore::PerformanceObserver::disconnect):
* Source/WebCore/page/PerformanceObserver.h:
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::spoolPage):
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::isReachableFromOpaqueRoots const):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::scrollInDirection):
* Source/WebCore/page/TextIndicator.h:
(WebCore::TextIndicator::protectedContentImage const):
* Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm:
(createBounceAnimation):
(createContentCrossfadeAnimation):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passSubframeEventToSubframe):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::updateDataDetectorHighlights):
(WebCore::ImageOverlayController::handleDataDetectorAction):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::protectedScrollingNode const):
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::updateSnapScrollState):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::updateUserScrollInProgressForEvent):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::createTimer):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::startAnimationCallback):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::stopAnimationCallback):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::immediateScrollBy):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::pageScaleFactor const):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::willStartAnimatedScroll):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::didStopAnimatedScroll):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::willStartWheelEventScroll):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::didStopWheelEventScroll):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::willStartScrollSnapAnimation):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::didStopScrollSnapAnimation):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::scrollExtents const):

Canonical link: <a href="https://commits.webkit.org/274827@main">https://commits.webkit.org/274827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ba49e4875a5229b852870e93e41046ac80d8ecb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42597 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33334 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13887 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43875 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33505 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36401 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39646 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39678 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37913 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16486 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46686 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16535 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9604 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5299 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->