### PR TITLE
[view-transitions] Support script-originated animations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7018,13 +7018,12 @@ imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overfl
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-hidden.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api.html [ ImageOnlyFailure ]
 
 # Timeouts
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/web-animation-pseudo-incorrect-name.html [ Skip ]
 
 # Flakes
 imported/w3c/web-platform-tests/css/css-view-transitions/synchronous-callback-skipped-before-run.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Error: assert_equals: container(target) expected "absolute" but got "static"
+CONSOLE MESSAGE: Error: assert_equals: container(target) expected "multiply" but got "normal"
 CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
 
 Harness Error (FAIL), message = Unhandled rejection: Type error

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<title>View transitions: check pseudo element's display property</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<title>View transitions: check pseudo element's default styles</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -30,34 +30,34 @@ promise_test(() => {
   assert_implements(document.startViewTransition, "Missing document.startViewTransition");
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition(() => {
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition").position, "fixed", ":view-transition");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute", "container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").mixBlendMode, "multiply", "container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").textOrientation, "upright", "container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").colorScheme, "dark light", "container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(target)").position, "absolute", "wrapper(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed", "::view-transition");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute", "container(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").mixBlendMode, "multiply", "container(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").textOrientation, "upright", "container(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").colorScheme, "dark light", "container(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(target)").position, "absolute", "wrapper(target)");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(target)").position, "absolute", "outgoing(target)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(target)").position, "absolute", "outgoing(target)");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").position, "absolute", "container(root)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").mixBlendMode, "normal", "container(root)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").position, "absolute", "wrapper(root)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").position, "absolute", "outgoing(root)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").position, "absolute", "container(root)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").mixBlendMode, "normal", "container(root)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").position, "absolute", "wrapper(root)");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").position, "absolute", "outgoing(root)");
 
       requestAnimationFrame(() => {
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition").position, "fixed", "raf :view-transition");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute", "raf container(target)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").mixBlendMode, "multiply", "raf container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").textOrientation, "upright", "raf container(target)");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").colorScheme, "dark light", "raf container(target)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(target)").position, "fixed", "raf wrapper(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed", "raf ::view-transition");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute", "raf container(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").mixBlendMode, "multiply", "raf container(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").textOrientation, "upright", "raf container(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").colorScheme, "dark light", "raf container(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(target)").position, "fixed", "raf wrapper(target)");
 
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(target)").position, "absolute", "raf outgoing(target)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(target)").position, "absolute", "raf outgoing(target)");
 
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").position, "absolute", "raf container(root)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").mixBlendMode, "normal", "raf container(root)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").position, "absolute", "raf wrapper(root)");
-        assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").position, "absolute", "raf outgoing(root)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").position, "absolute", "raf container(root)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").mixBlendMode, "normal", "raf container(root)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").position, "absolute", "raf wrapper(root)");
+        assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").position, "absolute", "raf outgoing(root)");
       });
     });
     await transition.finished;
@@ -69,42 +69,42 @@ promise_test(() => {
   assert_implements(document.startViewTransition, "Missing document.startViewTransition");
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition(() => {
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition").position, "fixed");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(target)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(target)").position, "absolute");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(target)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(target)").position, "absolute");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").position, "absolute");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").position, "absolute");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").position, "absolute");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").position, "absolute");
 
       target.remove();
     });
 
     await transition.ready;
 
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition").position, "fixed");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").mixBlendMode, "multiply");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").textOrientation, "upright");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").colorScheme, "dark light");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(target)").position, "fixed");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition").position, "fixed");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").mixBlendMode, "multiply");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").textOrientation, "upright");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").colorScheme, "dark light");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(target)").position, "fixed");
 
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(target)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-new(target)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(target)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(target)").position, "absolute");
 
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").position, "absolute");
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-new(root)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").position, "absolute");
 
-    assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute");
+    assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute");
 
     await transition.finished;
 
     // With custom ua sheets not applying to non-existing pseudo, the value should be the default (not absolute)
-    assert_not_equals(getComputedStyle(document.documentElement, ":view-transition-group(target)").position, "absolute");
+    assert_not_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").position, "absolute");
 
     resolve();
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animation-pseudo-incorrect-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animation-pseudo-incorrect-name-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: The string did not match the expected pattern.
 
-Harness Error (FAIL), message = Unhandled rejection: The string did not match the expected pattern.
-
-TIMEOUT animation created with incorrect name Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: The string did not match the expected pattern.
-
-TIMEOUT animation created with incorrect name Test timed out
+PASS animation created with incorrect name
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1223,28 +1223,23 @@ const String KeyframeEffect::pseudoElement() const
 
     // The target pseudo-selector. null if this effect has no effect target or if the effect target is an element (i.e. not a pseudo-element).
     // When the effect target is a pseudo-element, this specifies the pseudo-element selector (e.g. ::before).
-    // FIXME: This needs proper serialization for name arguments.
     if (targetsPseudoElement())
-        return pseudoIdAsString(m_pseudoElementIdentifier->pseudoId);
+        return pseudoElementIdentifierAsString(m_pseudoElementIdentifier);
     return { };
 }
 
 ExceptionOr<void> KeyframeEffect::setPseudoElement(const String& pseudoElement)
 {
     // https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-pseudoelement
-    // FIXME: This needs proper conversion for name arguments.
-    auto pseudoId = pseudoIdFromString(pseudoElement);
-    if (!pseudoId)
+    auto [parsed, pseudoElementIdentifier] = pseudoElementIdentifierFromString(pseudoElement, document());
+    if (!parsed)
         return Exception { ExceptionCode::SyntaxError, "Parsing pseudo-element selector failed"_s };
 
-    if (!m_pseudoElementIdentifier && pseudoId == PseudoId::None)
-        return { };
-
-    if (m_pseudoElementIdentifier && *pseudoId == m_pseudoElementIdentifier->pseudoId)
+    if (m_pseudoElementIdentifier == pseudoElementIdentifier)
         return { };
 
     auto& previousTargetStyleable = targetStyleable();
-    m_pseudoElementIdentifier = pseudoId == PseudoId::None ? std::nullopt : std::optional(Style::PseudoElementIdentifier { *pseudoId });
+    m_pseudoElementIdentifier = pseudoElementIdentifier;
     didChangeTargetStyleable(previousTargetStyleable);
 
     return { };

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
@@ -46,19 +46,17 @@ StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(enum EventInterface
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)
 {
-    // FIXME: This should work with the pseudo-element name argument.
-    auto pseudoId = pseudoIdFromString(m_pseudoElement);
-    if (pseudoId && *pseudoId != PseudoId::None)
-        m_pseudoElementIdentifier = { *pseudoId };
+    auto* node = dynamicDowncast<Node>(target());
+    auto [parsed, pseudoElementIdentifier] = pseudoElementIdentifierFromString(m_pseudoElement, node ? &node->document() : nullptr);
+    m_pseudoElementIdentifier = parsed ? pseudoElementIdentifier : std::nullopt;
 }
 
 StyleOriginatedAnimationEvent::~StyleOriginatedAnimationEvent() = default;
 
 const String& StyleOriginatedAnimationEvent::pseudoElement()
 {
-    // FIXME: This doesn't work with the pseudo-element name argument.
     if (m_pseudoElementIdentifier && m_pseudoElement.isNull())
-        m_pseudoElement = pseudoIdAsString(m_pseudoElementIdentifier->pseudoId);
+        m_pseudoElement = pseudoElementIdentifierAsString(m_pseudoElementIdentifier);
     return m_pseudoElement;
 }
 

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -58,8 +58,8 @@ const auto timeEpsilon = Seconds::fromMilliseconds(0.001);
 
 bool compareAnimationsByCompositeOrder(const WebAnimation&, const WebAnimation&);
 bool compareAnimationEventsByCompositeOrder(const AnimationEventBase&, const AnimationEventBase&);
-String pseudoIdAsString(PseudoId);
-std::optional<PseudoId> pseudoIdFromString(const String&);
+String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementIdentifier>&);
+std::pair<bool, std::optional<Style::PseudoElementIdentifier>> pseudoElementIdentifierFromString(const String&, Document*);
 AtomString animatablePropertyAsString(AnimatableCSSProperty);
 
 } // namespace WebCore


### PR DESCRIPTION
#### fd1700a9494c4ead2a8d7add78378403081646b7
<pre>
[view-transitions] Support script-originated animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=269468">https://bugs.webkit.org/show_bug.cgi?id=269468</a>
<a href="https://rdar.apple.com/123016183">rdar://123016183</a>

Reviewed by Matt Woodrow and Matthieu Dubet.

- Switch to use pseudoElementIdentifier in order to support view transition pseudo-elements
- Pass in a document to the relevant CSSSelectorParserContext so the view transition setting state is passed over

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/web-animation-pseudo-incorrect-name-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::pseudoElement const):
(WebCore::KeyframeEffect::setPseudoElement):
* Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp:
(WebCore::StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent):
(WebCore::StyleOriginatedAnimationEvent::pseudoElement):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::pseudoElementIdentifierAsString):
(WebCore::pseudoElementIdentifierFromString):
(WebCore::pseudoIdAsString): Deleted.
(WebCore::pseudoIdFromString): Deleted.
* Source/WebCore/animation/WebAnimationUtilities.h:

Canonical link: <a href="https://commits.webkit.org/274961@main">https://commits.webkit.org/274961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d21445eb037923e6f0aa3c48a4f9d118c3b91d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43073 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36610 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42828 "Failed to checkout and rebase branch from PR 24523") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16863 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41095 "Failed to checkout and rebase branch from PR 24523") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/16482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44347 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16955 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/35190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17005 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5372 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->