### PR TITLE
TestExpectations cannot represent variants with spaces

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -30,6 +30,8 @@ import errno
 import json
 import logging
 import re
+import sys
+import urllib
 
 from webkitpy.common import find_files
 from webkitpy.layout_tests.models.test import Test
@@ -174,7 +176,9 @@ class LayoutTestFinder(object):
             if "web-platform-tests" not in f:
                 expanded.append(f)
                 continue
-            f, variant_separator, passed_variant = f.partition('?')
+            m = re.search("^(?P<path>[^?#]*)(?P<variant>(?P<query>\\?[^#]*)?(?P<fragment>#.*)?)$", f)
+            f = m.group("path")
+            passed_variant = self._percent_encoded_variant(m.group("variant"))
             opened_file = fs.open_text_file_for_reading(f)
             try:
                 first_line = opened_file.readline()
@@ -182,23 +186,15 @@ class LayoutTestFinder(object):
                     expanded.append(f)
                     continue
 
+                variants = []
                 if first_line.strip() == TEMPLATED_TEST_HEADER:
-                    variants = []
                     for line in iter(opened_file.readline, ''):
                         results = re.match(r'<!--\s*META:\s*variant=(\S*)\s*-->', line)
                         if not results:
                             continue
                         variant = results.group(1)
-                        if self._is_valid_variant(variant):
-                            variants.append(variant)
-                    if variants:
-                        for variant in variants:
-                            if not passed_variant or variant.startswith(variant_separator + passed_variant):
-                                expanded.append(f + variant)
-                    else:
-                        expanded.append(f)
+                        variants.append(variant)
                 else:
-                    variants = []
                     for line in iter(opened_file.readline, ''):
                         try:
                             line = line.lstrip()
@@ -220,20 +216,47 @@ class LayoutTestFinder(object):
                             while line[end_index] not in end_chars:
                                 end_index += 1
                             variant = line[start_index:end_index]
-                            if self._is_valid_variant(variant):
-                                variants.append(line[start_index:end_index])
+                            variants.append(variant)
                         except IndexError:
                             continue
-                    if len(variants):
-                        for variant in variants:
-                            if not passed_variant or variant.startswith(variant_separator + passed_variant):
-                                expanded.append(f + variant)
-                    else:
-                        expanded.append(f)
+
+                variants = [v for v in variants if self._is_valid_variant(v)]
+                if len(variants):
+                    for variant in variants:
+                        variant = self._percent_encoded_variant(variant)
+                        if not passed_variant or variant.startswith(passed_variant):
+                            expanded.append(f + variant)
+                else:
+                    expanded.append(f)
             except UnicodeDecodeError:
                 expanded.append(f)
                 continue
         return expanded
+
+    def _percent_encoded_variant(self, variant):
+        m = re.search("^(?P<path>[^?#]*)(?P<variant>(?P<query>\\?[^#]*)?(?P<fragment>#.*)?)$", variant)
+        path, _, query, fragment = m.groups()
+        assert m.group("path") == ""
+
+        # This is all code points not in the "query percent-encode set" [URL], minus
+        # characters urllib.parse.quote never quotes.
+        safe_query = "!$%&'()*+,/:;=?@[\\]^`{|}~"
+
+        # This is all code points not in the "fragment percent-encode set" [URL], minus
+        # characters urllib.parse.quote never quotes.
+        safe_fragment = "!#$%&'()*+,/:;=?@[\\]^{|}~"
+
+        query = "" if query is None else query
+        fragment = "" if fragment is None else fragment
+
+        if sys.version_info > (3,):
+            query = urllib.parse.quote(query, safe=safe_query, encoding="utf-8")
+            fragment = urllib.parse.quote(fragment, safe=safe_fragment, encoding="utf-8")
+        else:
+            query = urllib.quote(query.encode("utf-8"), safe=safe_query).decode("ascii")
+            fragment = urllib.quote(fragment.encode("utf-8"), safe=safe_fragment).decode("ascii")
+
+        return "{}{}".format(query, fragment)
 
     def _is_valid_variant(self, variant):
         return variant == "" or (len(variant) > 1 and variant[0] in ("?", "#")) and variant != "?#"

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
@@ -399,6 +399,9 @@ class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
 <meta name="variant" content="?#">
 <meta name="variant" content="?1#a">
 <meta name="variant" content="nonsense">
+<meta name=variant content="?only open()ed, not aborted">
+<meta name=variant content="?aborted immediately after send()">
+<meta name=variant content="?call abort() after TIME_NORMAL_LOAD">
         """)
         tests_found = [t.test_path for t in finder.find_tests_by_path(find_paths)]
         self.assertEqual(
@@ -409,9 +412,47 @@ class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
                 "web-platform-tests/variant_test.html#a-m",
                 "web-platform-tests/variant_test.html#n-z",
                 "web-platform-tests/variant_test.html?1#a",
+                "web-platform-tests/variant_test.html?only%20open()ed,%20not%20aborted",
+                "web-platform-tests/variant_test.html?aborted%20immediately%20after%20send()",
+                "web-platform-tests/variant_test.html?call%20abort()%20after%20TIME_NORMAL_LOAD",
             ],
             tests_found,
         )
+
+    def test_find_template_variants_meta_passed_variants(self):
+        finder = self.finder
+
+        path = finder._port.layout_tests_dir() + "/web-platform-tests/variant_test.html"
+
+        find_paths = [
+            path + "?a b",
+            path + "?c%20d",
+            path + "#m n",
+            path + "#o%20p",
+            path + "?e%20f#q%20r",
+        ]
+
+        finder._filesystem.maybe_make_directory(finder._filesystem.dirname(path))
+        finder._filesystem.write_text_file(
+            path,
+            """<!doctype html>
+<meta name=variant content="?a b">
+<meta name=variant content="?c%20d">
+<meta name=variant content="#m n">
+<meta name=variant content="#o%20p">
+<meta name=variant content="?e f#q r">
+        """,
+        )
+        tests_found = [t.test_path for t in finder.find_tests_by_path(find_paths)]
+        self.assertEqual(
+            ['web-platform-tests/variant_test.html?a%20b',
+             'web-platform-tests/variant_test.html?c%20d',
+             'web-platform-tests/variant_test.html#m%20n',
+             'web-platform-tests/variant_test.html#o%20p',
+             'web-platform-tests/variant_test.html?e%20f#q%20r'],
+            tests_found,
+        )
+
 
     def test_find_template_variants_comment(self):
         find_paths = ["web-platform-tests"]


### PR DESCRIPTION
#### 4ddb4ae9f2b82d334dabab737be670f94edb54e7
<pre>
TestExpectations cannot represent variants with spaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=269484">https://bugs.webkit.org/show_bug.cgi?id=269484</a>
<a href="https://rdar.apple.com/123026314">rdar://123026314</a>

Reviewed by Jonathan Bedard.

This converts variants to always be percent-encoded (specifically: the variant
should be encoded identically to the output from the URL parser).

Along with this, this fixes various places where we only handled query variants
(and not fragment variants).

* Tools/Scripts/webkitpy/common/find_files.py:
(_normalized_find.sorted_paths_generator): Handle fragment variants
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder._expand_variants): De-duplicate code, handle fragment passed variants, percent encode everything
(LayoutTestFinder._percent_encoded_variant): Actually do percent encoding of variants
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py:

Canonical link: <a href="https://commits.webkit.org/274749@main">https://commits.webkit.org/274749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a147285dd3e454282ac79dcd494e782d1e7c6205

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18930 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42226 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/21837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/16260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40493 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/21837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/39787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/21837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/21837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/16260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5256 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->