### PR TITLE
Update test expectations after 273643@main

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https-expected.txt
@@ -78,7 +78,7 @@ PASS inbound-rtp's codecId
 PASS inbound-rtp's timestamp
 PASS inbound-rtp's type
 PASS inbound-rtp's id
-FAIL outbound-rtp's rtxSsrc assert_true: Is rtxSsrc present expected true got false
+PASS outbound-rtp's rtxSsrc
 PASS outbound-rtp's mediaSourceId
 FAIL outbound-rtp's senderId assert_true: Is senderId present expected true got false
 PASS outbound-rtp's remoteId
@@ -187,7 +187,7 @@ PASS peer-connection's type
 PASS peer-connection's id
 PASS data-channel's label
 PASS data-channel's protocol
-FAIL data-channel's dataChannelIdentifier assert_true: Is dataChannelIdentifier present expected true got false
+PASS data-channel's dataChannelIdentifier
 PASS data-channel's state
 PASS data-channel's messagesSent
 PASS data-channel's bytesSent

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2393,8 +2393,6 @@ webkit.org/b/269086 [ Release ] imported/w3c/web-platform-tests/feature-policy/f
 
 webkit.org/b/269116 imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002.html [ Failure ]
 
-webkit.org/b/269314 [ Release ] imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html [ Failure ]
-
 webkit.org/b/269321 webgl/1.0.3/conformance/uniforms/out-of-bounds-uniform-array-access.html [ Timeout ]
 
 webkit.org/b/269327 [ Release ] webrtc/audio-samplerate-change.html [ Pass Failure ]


### PR DESCRIPTION
#### 4ac0fb5bb613c425d0126beb5a289cf119e5018d
<pre>
Update test expectations after 273643@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=269314">https://bugs.webkit.org/show_bug.cgi?id=269314</a>
&lt;<a href="https://rdar.apple.com/problem/122902728">rdar://problem/122902728</a>&gt;

Reviewed by Per Arne Vollan.

The improvements to add missing stats in WebRTC progressed a WPT WebRTC test case.

* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https-expected.txt:
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/274891@main">https://commits.webkit.org/274891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/238eb4e78e470f65021e5df409de0c66e5747706

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42822 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16618 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16244 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44100 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12364 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9045 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->