### PR TITLE
[WebGPU] GPUObjectBase.idl is out of date with the specification

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/reflection-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/reflection-expected.txt
@@ -1,5 +1,8 @@
 
 PASS :buffer_reflection_attributes:
+PASS :buffer_creation_from_reflection:
 PASS :texture_reflection_attributes:
+PASS :texture_creation_from_reflection:
 PASS :query_set_reflection_attributes:
+PASS :query_set_creation_from_reflection:
 

--- a/Source/WebCore/Modules/WebGPU/GPUObjectBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUObjectBase.idl
@@ -29,5 +29,5 @@
     EnabledBySetting=WebGPUEnabled
 ]
 interface mixin GPUObjectBase {
-    attribute USVString? label; // FIXME: https://bugs.webkit.org/show_bug.cgi?id=236723 This is supposed to be (USVString or undefined) but our bindings generator can't handle that.
+    attribute USVString label;
 };


### PR DESCRIPTION
#### eb5b248caf78e497f647e7763d2f7627b45f7e39
<pre>
[WebGPU] GPUObjectBase.idl is out of date with the specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=269489">https://bugs.webkit.org/show_bug.cgi?id=269489</a>
&lt;radar://123027766&gt;

Reviewed by Dan Glastonbury.

Previously label was optional or UVString, but now it is simply UVString.

Matching the specification also results in the newly added reflection tests
to pass, so update the expectation.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/reflection-expected.txt:
* Source/WebCore/Modules/WebGPU/GPUObjectBase.idl:

Canonical link: <a href="https://commits.webkit.org/274786@main">https://commits.webkit.org/274786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1d9ef80461e967a1efe6973baa1933f9e77760c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33268 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13812 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39576 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37848 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16361 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8980 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->