### PR TITLE
Remove Cairo dependency for BackingStore

### DIFF
--- a/Source/WebKit/Platform/WC.cmake
+++ b/Source/WebKit/Platform/WC.cmake
@@ -36,6 +36,12 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
 )
 
+if (USE_CAIRO)
+    list(APPEND WebKit_SOURCES
+        UIProcess/cairo/BackingStoreCairo.cpp
+    )
+endif ()
+
 if (USE_GRAPHICS_LAYER_TEXTURE_MAPPER)
     list(APPEND WebKit_SOURCES
         WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -289,7 +289,6 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/UIProcess/Inspector/glib"
     "${WEBKIT_DIR}/UIProcess/Inspector/gtk"
     "${WEBKIT_DIR}/UIProcess/Notifications/glib/"
-    "${WEBKIT_DIR}/UIProcess/cairo"
     "${WEBKIT_DIR}/UIProcess/geoclue"
     "${WEBKIT_DIR}/UIProcess/glib"
     "${WEBKIT_DIR}/UIProcess/gstreamer"

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -139,12 +139,11 @@ if (USE_CAIRO)
 
         UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
 
-        UIProcess/cairo/BackingStore.cpp
+        UIProcess/cairo/BackingStoreCairo.cpp
     )
 
     list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
         "${WEBKIT_DIR}/UIProcess/API/C/cairo"
-        "${WEBKIT_DIR}/UIProcess/cairo"
     )
 
     list(APPEND WebKit_LIBRARIES

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -153,12 +153,9 @@ if (USE_CAIRO)
         Shared/API/c/cairo/WKImageCairo.cpp
 
         UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
-
-        UIProcess/cairo/BackingStore.cpp
     )
     list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
         "${WEBKIT_DIR}/UIProcess/API/C/cairo"
-        "${WEBKIT_DIR}/UIProcess/cairo"
     )
     list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
         Shared/API/c/cairo/WKImageCairo.h

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -254,7 +254,7 @@ UIProcess/linux/MemoryPressureMonitor.cpp
 UIProcess/WebsiteData/glib/WebsiteDataStoreGLib.cpp
 UIProcess/WebsiteData/soup/WebsiteDataStoreSoup.cpp
 
-UIProcess/cairo/BackingStore.cpp
+UIProcess/cairo/BackingStoreCairo.cpp
 
 UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp

--- a/Source/WebKit/UIProcess/BackingStore.h
+++ b/Source/WebKit/UIProcess/BackingStore.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#if USE(CAIRO)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
 
 #include <WebCore/IntSize.h>
-#include <WebCore/RefPtrCairo.h>
+#include <WebCore/PlatformImage.h>
 #include <pal/HysteresisActivity.h>
 #include <wtf/Noncopyable.h>
 
@@ -38,6 +38,10 @@ class IntRect;
 
 namespace WebKit {
 struct UpdateInfo;
+
+#if USE(CAIRO)
+using PlatformPaintContextPtr = cairo_t*;
+#endif
 
 class BackingStore {
     WTF_MAKE_FAST_ALLOCATED;
@@ -49,7 +53,7 @@ public:
     const WebCore::IntSize& size() const { return m_size; }
     float deviceScaleFactor() const { return m_deviceScaleFactor; }
 
-    void paint(cairo_t*, const WebCore::IntRect&);
+    void paint(PlatformPaintContextPtr, const WebCore::IntRect&);
     void incorporateUpdate(UpdateInfo&&);
 
 private:
@@ -57,11 +61,11 @@ private:
 
     WebCore::IntSize m_size;
     float m_deviceScaleFactor { 1 };
-    RefPtr<cairo_surface_t> m_surface;
-    RefPtr<cairo_surface_t> m_scrollSurface;
+    WebCore::PlatformImagePtr m_surface;
+    WebCore::PlatformImagePtr m_scrollSurface;
     PAL::HysteresisActivity m_scrolledHysteresis;
 };
 
 } // namespace WebKit
 
-#endif // USE(CAIRO)
+#endif // USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -48,20 +48,16 @@
 #include <wtf/glib/RunLoopSourcePriority.h>
 #endif
 
-#if USE(CAIRO) && !PLATFORM(WPE)
-#include "BackingStore.h"
-#endif
-
 namespace WebKit {
 using namespace WebCore;
 
 DrawingAreaProxyCoordinatedGraphics::DrawingAreaProxyCoordinatedGraphics(WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::CoordinatedGraphics, webPageProxy, webProcessProxy)
-#if USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
     , m_discardBackingStoreTimer(RunLoop::current(), this, &DrawingAreaProxyCoordinatedGraphics::discardBackingStore)
 #endif
 {
-#if USE(GLIB_EVENT_LOOP) && USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GLIB_EVENT_LOOP) && (USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE)))
     m_discardBackingStoreTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
 #endif
 }
@@ -73,8 +69,8 @@ DrawingAreaProxyCoordinatedGraphics::~DrawingAreaProxyCoordinatedGraphics()
         exitAcceleratedCompositingMode();
 }
 
-#if USE(CAIRO) && !PLATFORM(WPE)
-void DrawingAreaProxyCoordinatedGraphics::paint(cairo_t* cr, const IntRect& rect, Region& unpaintedRegion)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+void DrawingAreaProxyCoordinatedGraphics::paint(PlatformPaintContextPtr cr, const IntRect& rect, Region& unpaintedRegion)
 {
     unpaintedRegion = rect;
 
@@ -166,7 +162,7 @@ void DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange()
 
 void DrawingAreaProxyCoordinatedGraphics::setBackingStoreIsDiscardable(bool isBackingStoreDiscardable)
 {
-#if USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
     if (m_isBackingStoreDiscardable == isBackingStoreDiscardable)
         return;
 
@@ -199,7 +195,7 @@ void DrawingAreaProxyCoordinatedGraphics::update(uint64_t, UpdateInfo&& updateIn
 
     // FIXME: Handle the case where the view is hidden.
 
-#if USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
     incorporateUpdate(WTFMove(updateInfo));
 #endif
 
@@ -215,7 +211,7 @@ void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(uint64
 void DrawingAreaProxyCoordinatedGraphics::exitAcceleratedCompositingMode(uint64_t, UpdateInfo&& updateInfo)
 {
     exitAcceleratedCompositingMode();
-#if USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
     incorporateUpdate(WTFMove(updateInfo));
 #endif
 }
@@ -233,7 +229,7 @@ bool DrawingAreaProxyCoordinatedGraphics::alwaysUseCompositing() const
 void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)
 {
     ASSERT(!isInAcceleratedCompositingMode());
-#if USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
     m_backingStore = nullptr;
 #endif
     m_layerTreeContext = layerTreeContext;
@@ -281,7 +277,7 @@ void DrawingAreaProxyCoordinatedGraphics::didUpdateGeometry()
         sendUpdateGeometry();
 }
 
-#if USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
 void DrawingAreaProxyCoordinatedGraphics::discardBackingStoreSoon()
 {
     if (!m_backingStore || !m_isBackingStoreDiscardable || m_discardBackingStoreTimer.isActive())

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -31,8 +31,8 @@
 #include "LayerTreeContext.h"
 #include <wtf/RunLoop.h>
 
-#if USE(CAIRO) && !PLATFORM(WPE)
-typedef struct _cairo cairo_t;
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#include "BackingStore.h"
 #endif
 
 namespace WebCore {
@@ -41,15 +41,13 @@ class Region;
 
 namespace WebKit {
 
-class BackingStore;
-
 class DrawingAreaProxyCoordinatedGraphics final : public DrawingAreaProxy {
 public:
     DrawingAreaProxyCoordinatedGraphics(WebPageProxy&, WebProcessProxy&);
     virtual ~DrawingAreaProxyCoordinatedGraphics();
 
-#if USE(CAIRO) && !PLATFORM(WPE)
-    void paint(cairo_t*, const WebCore::IntRect&, WebCore::Region& unpaintedRegion);
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+    void paint(PlatformPaintContextPtr, const WebCore::IntRect&, WebCore::Region& unpaintedRegion);
 #endif
 
     bool isInAcceleratedCompositingMode() const { return !m_layerTreeContext.isEmpty(); }
@@ -88,7 +86,7 @@ private:
     void sendUpdateGeometry();
     void didUpdateGeometry();
 
-#if USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
     bool forceUpdateIfNeeded();
     void incorporateUpdate(UpdateInfo&&);
     void discardBackingStoreSoon();
@@ -120,7 +118,7 @@ private:
     WebCore::IntSize m_lastSentSize;
 
 
-#if USE(CAIRO) && !PLATFORM(WPE)
+#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
     bool m_isBackingStoreDiscardable { true };
     bool m_inForceUpdate { false };
     std::unique_ptr<BackingStore> m_backingStore;

--- a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
+++ b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
@@ -68,7 +68,7 @@ BackingStore::~BackingStore()
 {
 }
 
-void BackingStore::paint(cairo_t* cr, const IntRect& rect)
+void BackingStore::paint(PlatformPaintContextPtr cr, const IntRect& rect)
 {
     cairo_save(cr);
     cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -45,7 +45,7 @@ DrawingAreaProxyWC::DrawingAreaProxyWC(WebPageProxy& webPageProxy, WebProcessPro
 {
 }
 
-void DrawingAreaProxyWC::paint(cairo_t* context, const WebCore::IntRect& rect, WebCore::Region& unpaintedRegion)
+void DrawingAreaProxyWC::paint(PlatformPaintContextPtr context, const WebCore::IntRect& rect, WebCore::Region& unpaintedRegion)
 {
     unpaintedRegion = rect;
 

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
@@ -40,7 +40,7 @@ class DrawingAreaProxyWC final : public DrawingAreaProxy {
 public:
     DrawingAreaProxyWC(WebPageProxy&, WebProcessProxy&);
 
-    void paint(cairo_t*, const WebCore::IntRect&, WebCore::Region& unpaintedRegion);
+    void paint(PlatformPaintContextPtr, const WebCore::IntRect&, WebCore::Region& unpaintedRegion);
 
 private:
     // DrawingAreaProxy


### PR DESCRIPTION
#### 6619d9b70306f0cdf01f83b058ab995df16a4480
<pre>
Remove Cairo dependency for BackingStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=269495">https://bugs.webkit.org/show_bug.cgi?id=269495</a>

Reviewed by Adrian Perez de Castro.

Both `USE(GRAPHICS_LAYER)` and `USE(CAIRO)` for non-WPE platforms use instances
of `BackingStore`. To prepare for a `USE(SKIA)` implementation of it make the
code more cross-platform by using platform agnostic definitions. Rename and
move files accordingly to fit conventions.

Actual Skia implementation will come later.

* Source/WebKit/Platform/WC.cmake:
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/PlatformWin.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/BackingStore.h: Renamed from Source/WebKit/UIProcess/cairo/BackingStore.h.
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp: Renamed from Source/WebKit/UIProcess/cairo/BackingStore.cpp.
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp:
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h:

Canonical link: <a href="https://commits.webkit.org/274823@main">https://commits.webkit.org/274823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dfe2d981cbd7a04b1c6bf2b64d4dfdf0e9ef75f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40044 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42589 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33326 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13877 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13908 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43867 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39642 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37910 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16478 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9002 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->