### PR TITLE
[macOS] Implement _isInWindowActive SPI

### DIFF
--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -74,7 +74,7 @@ public:
     virtual void selectLegibleMediaOption(uint64_t index) = 0;
     virtual void toggleFullscreen() = 0;
     virtual void togglePictureInPicture() = 0;
-    virtual void toggleInWindow() = 0;
+    virtual void toggleInWindowFullscreen() = 0;
     virtual void toggleMuted() = 0;
     virtual void setMuted(bool) = 0;
     virtual void setVolume(double) = 0;
@@ -112,6 +112,7 @@ public:
     virtual double volume() const = 0;
     virtual bool isPictureInPictureSupported() const = 0;
     virtual bool isPictureInPictureActive() const = 0;
+    virtual bool isInWindowFullscreenActive() const { return false; }
 
 #if !RELEASE_LOG_DISABLED
     virtual const void* logIdentifier() const { return nullptr; }
@@ -139,6 +140,7 @@ public:
     virtual void volumeChanged(double) { }
     virtual void isPictureInPictureSupportedChanged(bool) { }
     virtual void pictureInPictureActiveChanged(bool) { }
+    virtual void isInWindowFullscreenActiveChanged(bool) { }
     virtual void ensureControlsManager() { }
     virtual void modelDestroyed() { }
 };

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -74,7 +74,7 @@ public:
     WEBCORE_EXPORT void selectLegibleMediaOption(uint64_t index) final;
     WEBCORE_EXPORT void toggleFullscreen() final;
     WEBCORE_EXPORT void togglePictureInPicture() final;
-    WEBCORE_EXPORT void toggleInWindow() final;
+    WEBCORE_EXPORT void toggleInWindowFullscreen() final;
     WEBCORE_EXPORT void toggleMuted() final;
     WEBCORE_EXPORT void setMuted(bool) final;
     WEBCORE_EXPORT void setVolume(double) final;
@@ -106,6 +106,7 @@ public:
     double volume() const final;
     bool isPictureInPictureSupported() const final;
     bool isPictureInPictureActive() const final;
+    bool isInWindowFullscreenActive() const final;
 
 private:
     WEBCORE_EXPORT PlaybackSessionModelMediaElement();

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -210,9 +210,12 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
     if (all
         || eventName == eventNames().webkitpresentationmodechangedEvent) {
         bool isPictureInPictureActive = this->isPictureInPictureActive();
+        bool isInWindowFullscreenActive = this->isInWindowFullscreenActive();
 
-        for (auto& client : m_clients)
+        for (auto& client : m_clients) {
             client->pictureInPictureActiveChanged(isPictureInPictureActive);
+            client->isInWindowFullscreenActiveChanged(isInWindowFullscreenActive);
+        }
     }
 
 
@@ -366,7 +369,7 @@ void PlaybackSessionModelMediaElement::togglePictureInPicture()
 #endif
 }
 
-void PlaybackSessionModelMediaElement::toggleInWindow()
+void PlaybackSessionModelMediaElement::toggleInWindowFullscreen()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     ASSERT(is<HTMLVideoElement>(*m_mediaElement));
@@ -374,6 +377,8 @@ void PlaybackSessionModelMediaElement::toggleInWindow()
         return;
 
     auto& element = downcast<HTMLVideoElement>(*m_mediaElement);
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes, &element.document());
+
     if (element.fullscreenMode() == MediaPlayerEnums::VideoFullscreenModeInWindow)
         element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
     else
@@ -475,6 +480,7 @@ const Vector<AtomString>& PlaybackSessionModelMediaElement::observedEventNames()
         eventNames().volumechangeEvent,
         eventNames().waitingEvent,
         eventNames().webkitcurrentplaybacktargetiswirelesschangedEvent,
+        eventNames().webkitpresentationmodechangedEvent,
     });
     return names.get();
 }
@@ -663,6 +669,14 @@ bool PlaybackSessionModelMediaElement::isPictureInPictureActive() const
         return false;
 
     return (m_mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture;
+}
+
+bool PlaybackSessionModelMediaElement::isInWindowFullscreenActive() const
+{
+    if (!m_mediaElement)
+        return false;
+
+    return (m_mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModeInWindow) == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -163,7 +163,7 @@ private:
     bool wirelessVideoPlaybackDisabled() const override;
     void toggleFullscreen() override { }
     void togglePictureInPicture() override { }
-    void toggleInWindow() override { }
+    void toggleInWindowFullscreen() override { }
     void toggleMuted() override;
     void setMuted(bool) final;
     void setVolume(double) final;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -49,6 +49,9 @@ public:
     virtual ~PlaybackSessionInterfaceMac();
     PlaybackSessionModel* playbackSessionModel() const;
 
+    bool isInWindowFullscreenActive() const;
+    void toggleInWindowFullscreen();
+
     // PlaybackSessionModelClient
     void durationChanged(double) final;
     void currentTimeChanged(double /*currentTime*/, double /*anchorTime*/) final;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -67,6 +67,17 @@ PlaybackSessionModel* PlaybackSessionInterfaceMac::playbackSessionModel() const
     return m_playbackSessionModel.get();
 }
 
+bool PlaybackSessionInterfaceMac::isInWindowFullscreenActive() const
+{
+    return m_playbackSessionModel && m_playbackSessionModel->isInWindowFullscreenActive();
+}
+
+void PlaybackSessionInterfaceMac::toggleInWindowFullscreen()
+{
+    if (m_playbackSessionModel)
+        m_playbackSessionModel->toggleInWindowFullscreen();
+}
+
 void PlaybackSessionInterfaceMac::durationChanged(double duration)
 {
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
@@ -247,6 +258,8 @@ void PlaybackSessionInterfaceMac::setPlayBackControlsManager(WebPlaybackControls
     manager.playing = m_playbackSessionModel->isPlaying();
     [manager setAudioMediaSelectionOptions:m_playbackSessionModel->audioMediaSelectionOptions() withSelectedIndex:static_cast<NSUInteger>(m_playbackSessionModel->audioMediaSelectedIndex())];
     [manager setLegibleMediaSelectionOptions:m_playbackSessionModel->legibleMediaSelectionOptions() withSelectedIndex:static_cast<NSUInteger>(m_playbackSessionModel->legibleMediaSelectedIndex())];
+
+    updatePlaybackControlsManagerCanTogglePictureInPicture();
 }
 
 void PlaybackSessionInterfaceMac::updatePlaybackControlsManagerCanTogglePictureInPicture()

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -422,7 +422,7 @@ static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOptio
 - (void)toggleInWindow
 {
     if (auto* model = _playbackSessionInterfaceMac->playbackSessionModel())
-        model->toggleInWindow();
+        model->toggleInWindowFullscreen();
 }
 
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2568,7 +2568,11 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 
 - (BOOL)_isInWindowActive
 {
+#if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
+    return _impl->isInWindowFullscreenActive();
+#else
     return NO;
+#endif
 }
 
 - (void)_togglePictureInPicture
@@ -2593,7 +2597,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 {
     THROW_IF_SUSPENDED;
 #if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
-    _impl->toggleInWindow();
+    _impl->toggleInWindowFullscreen();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -74,6 +74,7 @@ public:
     void volumeChanged(double);
     void pictureInPictureSupportedChanged(bool);
     void pictureInPictureActiveChanged(bool);
+    void isInWindowFullscreenActiveChanged(bool);
 
     bool wirelessVideoPlaybackDisabled() const final { return m_wirelessVideoPlaybackDisabled; }
 
@@ -100,7 +101,7 @@ private:
     void selectLegibleMediaOption(uint64_t) final;
     void toggleFullscreen() final;
     void togglePictureInPicture() final;
-    void toggleInWindow() final;
+    void toggleInWindowFullscreen() final;
     void toggleMuted() final;
     void setMuted(bool) final;
     void setVolume(double) final;
@@ -132,6 +133,7 @@ private:
     double volume() const final { return m_volume; }
     bool isPictureInPictureSupported() const final { return m_pictureInPictureSupported; }
     bool isPictureInPictureActive() const final { return m_pictureInPictureActive; }
+    bool isInWindowFullscreenActive() const final { return m_isInWindowFullscreenActive; }
 
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(const void* identifier) { m_logIdentifier = identifier; }
@@ -170,6 +172,7 @@ private:
     double m_volume { 0 };
     bool m_pictureInPictureSupported { false };
     bool m_pictureInPictureActive { false };
+    bool m_isInWindowFullscreenActive { false };
 
 #if !RELEASE_LOG_DISABLED
     const void* m_logIdentifier { nullptr };
@@ -235,6 +238,7 @@ private:
     void mutedChanged(PlaybackSessionContextIdentifier, bool muted);
     void volumeChanged(PlaybackSessionContextIdentifier, double volume);
     void pictureInPictureSupportedChanged(PlaybackSessionContextIdentifier, bool pictureInPictureSupported);
+    void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool isInWindow);
 
     // Messages to PlaybackSessionManager
     void play(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -38,6 +38,7 @@ messages -> PlaybackSessionManagerProxy {
     MutedChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool muted);
     VolumeChanged(WebKit::PlaybackSessionContextIdentifier contextId, double volume);
     PictureInPictureSupportedChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool pictureInPictureSupported)
+    IsInWindowFullscreenActiveChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool isInWindow)
     SetUpPlaybackControlsManagerWithID(WebKit::PlaybackSessionContextIdentifier contextId)
     ClearPlaybackControlsManager()
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -199,7 +199,7 @@ void PlaybackSessionModelContext::togglePictureInPicture()
         m_manager->togglePictureInPicture(m_contextId);
 }
 
-void PlaybackSessionModelContext::toggleInWindow()
+void PlaybackSessionModelContext::toggleInWindowFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
@@ -378,6 +378,13 @@ void PlaybackSessionModelContext::pictureInPictureActiveChanged(bool active)
     m_pictureInPictureActive = active;
     for (auto& client : m_clients)
         client.pictureInPictureActiveChanged(active);
+}
+
+void PlaybackSessionModelContext::isInWindowFullscreenActiveChanged(bool active)
+{
+    m_isInWindowFullscreenActive = active;
+    for (auto& client : m_clients)
+        client.isInWindowFullscreenActiveChanged(active);
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -602,6 +609,11 @@ void PlaybackSessionManagerProxy::rateChanged(PlaybackSessionContextIdentifier c
 void PlaybackSessionManagerProxy::pictureInPictureSupportedChanged(PlaybackSessionContextIdentifier contextId, bool supported)
 {
     ensureModel(contextId).pictureInPictureSupportedChanged(supported);
+}
+
+void PlaybackSessionManagerProxy::isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier contextId, bool active)
+{
+    ensureModel(contextId).isInWindowFullscreenActiveChanged(active);
 }
 
 void PlaybackSessionManagerProxy::handleControlledElementIDResponse(PlaybackSessionContextIdentifier contextId, String identifier) const

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL prefersHomeIndicatorAutoHidden;
 @property (assign, nonatomic, getter=isPlaying) BOOL playing;
 @property (assign, nonatomic, getter=isPictureInPictureActive) BOOL pictureInPictureActive;
+@property (assign, nonatomic, getter=isinWindowFullscreenActive) BOOL inWindowFullscreenActive;
 @property (assign, nonatomic, getter=isAnimating) BOOL animating;
 
 - (id)initWithWebView:(WKWebView *)webView;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -645,7 +645,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
     bool isPictureInPictureActive();
     void togglePictureInPicture();
-    void toggleInWindow();
+    bool isInWindowFullscreenActive() const;
+    void toggleInWindowFullscreen();
     void updateMediaPlaybackControlsManager();
 
     AVTouchBarScrubber *mediaPlaybackControlsView() const;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6019,9 +6019,18 @@ void WebViewImpl::togglePictureInPicture()
     [m_playbackControlsManager togglePictureInPicture];
 }
 
-void WebViewImpl::toggleInWindow()
+bool WebViewImpl::isInWindowFullscreenActive() const
 {
-    [m_playbackControlsManager toggleInWindow];
+    if (auto* interface = m_page->playbackSessionManager()->controlsManagerInterface())
+        return interface->isInWindowFullscreenActive();
+
+    return false;
+}
+
+void WebViewImpl::toggleInWindowFullscreen()
+{
+    if (auto* interface = m_page->playbackSessionManager()->controlsManagerInterface())
+        return interface->toggleInWindowFullscreen();
 }
 
 void WebViewImpl::updateMediaPlaybackControlsManager()

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -87,6 +87,7 @@ private:
     void mutedChanged(bool) final;
     void volumeChanged(double) final;
     void isPictureInPictureSupportedChanged(bool) final;
+    void isInWindowFullscreenActiveChanged(bool) final;
 
     PlaybackSessionInterfaceContext(PlaybackSessionManager&, PlaybackSessionContextIdentifier);
 
@@ -146,6 +147,7 @@ private:
     void mutedChanged(PlaybackSessionContextIdentifier, bool);
     void volumeChanged(PlaybackSessionContextIdentifier, double);
     void isPictureInPictureSupportedChanged(PlaybackSessionContextIdentifier, bool);
+    void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool);
 
     // Messages from PlaybackSessionManagerProxy
     void play(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -158,6 +158,12 @@ void PlaybackSessionInterfaceContext::volumeChanged(double volume)
         m_manager->volumeChanged(m_contextId, volume);
 }
 
+void PlaybackSessionInterfaceContext::isInWindowFullscreenActiveChanged(bool isInWindow)
+{
+    if (m_manager)
+        m_manager->isInWindowFullscreenActiveChanged(m_contextId, isInWindow);
+}
+
 #pragma mark - PlaybackSessionManager
 
 Ref<PlaybackSessionManager> PlaybackSessionManager::create(WebPage& page)
@@ -418,6 +424,11 @@ void PlaybackSessionManager::isPictureInPictureSupportedChanged(PlaybackSessionC
     m_page->send(Messages::PlaybackSessionManagerProxy::PictureInPictureSupportedChanged(contextId, supported));
 }
 
+void PlaybackSessionManager::isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier contextId, bool inWindow)
+{
+    m_page->send(Messages::PlaybackSessionManagerProxy::IsInWindowFullscreenActiveChanged(contextId, inWindow));
+}
+
 #pragma mark Messages from PlaybackSessionManagerProxy:
 
 void PlaybackSessionManager::play(PlaybackSessionContextIdentifier contextId)
@@ -524,8 +535,7 @@ void PlaybackSessionManager::togglePictureInPicture(PlaybackSessionContextIdenti
 
 void PlaybackSessionManager::toggleInWindow(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
-    ensureModel(contextId).toggleInWindow();
+    ensureModel(contextId).toggleInWindowFullscreen();
 }
 
 void PlaybackSessionManager::toggleMuted(PlaybackSessionContextIdentifier contextId)

--- a/Tools/MiniBrowser/mac/BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.h
@@ -84,6 +84,9 @@
 - (IBAction)toggleMainThreadStalls:(id)sender;
 - (BOOL)mainThreadStallsEnabled;
 
+- (IBAction)togglePictureInPicture:(id)sender;
+- (IBAction)toggleInWindowFullscreen:(id)sender;
+
 - (void)didChangeSettings;
 - (BOOL)webViewFillsWindow;
 - (void)setWebViewFillsWindow:(BOOL)fillWindow;

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -256,6 +256,16 @@
     [self doesNotRecognizeSelector:_cmd];
 }
 
+- (IBAction)togglePictureInPicture:(id)sender
+{
+    [self doesNotRecognizeSelector:_cmd];
+}
+
+- (IBAction)toggleInWindowFullscreen:(id)sender
+{
+    [self doesNotRecognizeSelector:_cmd];
+}
+
 - (void)didChangeSettings
 {
     [self doesNotRecognizeSelector:_cmd];

--- a/Tools/MiniBrowser/mac/MainMenu.xib
+++ b/Tools/MiniBrowser/mac/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23028.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23028.2"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -817,6 +817,19 @@
                                     <action selector="toggleMainThreadStalls:" target="-1" id="djY-Q4-9vO"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="7we-y7-Jht"/>
+                            <menuItem title="Toggle Picture-in-Picture" id="7bx-Lc-ODh">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="togglePictureInPicture:" target="-1" id="6NA-Zd-J8d"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Toggle In-Window Fullscreen" id="4IE-QS-EOO">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleInWindowFullscreen:" target="-1" id="RKY-mx-1L8"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="553"/>
                             <menuItem title="Dump Source To Console" id="566">
                                 <modifierMask key="keyEquivalentModifierMask"/>
@@ -926,5 +939,8 @@
             </connections>
         </customObject>
         <customObject id="420" customClass="NSFontManager"/>
+        <menuItem title="Item" id="Aoz-N4-aFP">
+            <modifierMask key="keyEquivalentModifierMask"/>
+        </menuItem>
     </objects>
 </document>

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -206,6 +206,16 @@ static const int testFooterBannerHeight = 58;
     return 1;
 }
 
+- (IBAction)togglePictureInPicture:(id)sender
+{
+    [_webView _togglePictureInPicture];
+}
+
+- (IBAction)toggleInWindowFullscreen:(id)sender
+{
+    [_webView _toggleInWindow];
+}
+
 - (void)_webView:(WKWebView *)webView requestNotificationPermissionForSecurityOrigin:(WKSecurityOrigin *)securityOrigin decisionHandler:(void (^)(BOOL))decisionHandler
 {
     NSDictionary *permissions = [[NSUserDefaults standardUserDefaults] dictionaryForKey:@"NotificationPermissions"];
@@ -302,6 +312,17 @@ static BOOL areEssentiallyEqual(double a, double b)
         menuItem.state = _webView._alwaysShowsVerticalScroller ? NSControlStateValueOn : NSControlStateValueOff;
     else if (action == @selector(toggleMainThreadStalls:))
         menuItem.state = self.mainThreadStallsEnabled ? NSControlStateValueOn : NSControlStateValueOff;
+
+    [_webView _updateMediaPlaybackControlsManager];
+    if (action == @selector(togglePictureInPicture:)) {
+        menuItem.state = _webView._isPictureInPictureActive ? NSControlStateValueOn : NSControlStateValueOff;
+        return _webView._canTogglePictureInPicture;
+    }
+
+    if (action == @selector(toggleInWindowFullscreen:)) {
+        menuItem.state = _webView._isInWindowActive ? NSControlStateValueOn : NSControlStateValueOff;
+        return _webView._canToggleInWindow;
+    }
 
     if (action == @selector(setPageScale:))
         [menuItem setState:areEssentiallyEqual([_webView _pageScale], [self pageScaleForMenuItemTag:[menuItem tag]])];

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -167,7 +167,7 @@ Tests/WebKitCocoa/LocalStoragePersistence.mm
 Tests/WebKitCocoa/LocalStorageQuirkTest.mm
 Tests/WebKitCocoa/MediaBufferingPolicy.mm
 Tests/WebKitCocoa/MediaDocument.mm
-Tests/WebKitCocoa/MediaLoading.mm
+Tests/WebKitCocoa/MediaLoading.mm @no-unify
 Tests/WebKitCocoa/MediaMutedState.mm
 Tests/WebKitCocoa/MediaSession.mm
 Tests/WebKitCocoa/MediaType.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1049,6 +1049,8 @@
 		CDC9442F1EF205D60059C3C4 /* mediastreamtrack-detached.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDC9442B1EF1FBD20059C3C4 /* mediastreamtrack-detached.html */; };
 		CDCFA7AA1E45183200C2433D /* SampleMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDCFA7A91E45122F00C2433D /* SampleMap.cpp */; };
 		CDE195B51CFE0B880053D256 /* FullscreenTopContentInset.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CDE195B21CFE0ADE0053D256 /* FullscreenTopContentInset.html */; };
+		CDE4E4E52B7E787900B3AE35 /* InWindowFullscreen.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDE4E4E42B7E787900B3AE35 /* InWindowFullscreen.mm */; };
+		CDE4E4F42B7F278600B3AE35 /* MediaLoading.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD0370E224A44B7A00BA3CAE /* MediaLoading.mm */; };
 		CDE77D2525A6591C00D4115E /* FullscreenPointerLeave.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDE77D2425A6591C00D4115E /* FullscreenPointerLeave.mm */; };
 		CE06DF9B1E1851F200E570C9 /* SecurityOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE06DF9A1E1851F200E570C9 /* SecurityOrigin.cpp */; };
 		CE14F1A4181873B0001C2705 /* WillPerformClientRedirectToURLCrash.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CE14F1A2181873B0001C2705 /* WillPerformClientRedirectToURLCrash.html */; };
@@ -3354,6 +3356,7 @@
 		CDDC7C6825FFF6D000224278 /* FullscreenRemoveNodeBeforeEnter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenRemoveNodeBeforeEnter.mm; sourceTree = "<group>"; };
 		CDE195B21CFE0ADE0053D256 /* FullscreenTopContentInset.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = FullscreenTopContentInset.html; sourceTree = "<group>"; };
 		CDE195B31CFE0ADE0053D256 /* TopContentInset.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TopContentInset.mm; sourceTree = "<group>"; };
+		CDE4E4E42B7E787900B3AE35 /* InWindowFullscreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InWindowFullscreen.mm; sourceTree = "<group>"; };
 		CDE77D2425A6591C00D4115E /* FullscreenPointerLeave.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenPointerLeave.mm; sourceTree = "<group>"; };
 		CDED342E249DDD9D0002AE7A /* AudioRoutingArbitration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioRoutingArbitration.mm; sourceTree = "<group>"; };
 		CDF0B789216D484300421ECC /* CloseWebViewDuringEnterFullscreen.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CloseWebViewDuringEnterFullscreen.mm; sourceTree = "<group>"; };
@@ -5621,6 +5624,7 @@
 				9B26FC6B159D061000CC3765 /* HTMLFormCollectionNamedItem.mm */,
 				F44A9AF62649BBDD00E7CB16 /* ImmediateActionTests.mm */,
 				C507E8A614C6545B005D6B3B /* InspectorBar.mm */,
+				CDE4E4E42B7E787900B3AE35 /* InWindowFullscreen.mm */,
 				57F10D921C7E7B3800ECDF30 /* IsNavigationActionTrusted.mm */,
 				51820A4C22F4EE7700DF0A01 /* JavascriptURLNavigation.mm */,
 				4BB4160116815B2600824238 /* JSWrapperForNodeInWebFrame.mm */,
@@ -6592,6 +6596,7 @@
 				7A909A811D877480007E10F8 /* IntPointTests.cpp in Sources */,
 				7A909A821D877480007E10F8 /* IntRectTests.cpp in Sources */,
 				7A909A831D877480007E10F8 /* IntSizeTests.cpp in Sources */,
+				CDE4E4E52B7E787900B3AE35 /* InWindowFullscreen.mm in Sources */,
 				7BB62ABE29BB4BAA00228CD6 /* IOSurfaceTests.mm in Sources */,
 				F4B8A5C128F8B54F00E3F54F /* IPAddressTests.cpp in Sources */,
 				5C0BF8931DD599BD00B00328 /* IsNavigationActionTrusted.mm in Sources */,
@@ -6895,6 +6900,7 @@
 				CDA93DAD22F4F11E00490A69 /* FullscreenTouchSecheuristicTests.cpp in Sources */,
 				2E7765CD16C4D80A00BA2BB1 /* mainIOS.mm in Sources */,
 				2E7765CF16C4D81100BA2BB1 /* mainMac.mm in Sources */,
+				CDE4E4F42B7F278600B3AE35 /* MediaLoading.mm in Sources */,
 				5797FE311EB15A6800B2F4A0 /* NavigationClientDefaultCrypto.cpp in Sources */,
 				7AD3FE8E1D76131200B169A4 /* TransformationMatrix.cpp in Sources */,
 			);

--- a/Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+static RetainPtr<TestWKWebView> createInWindowFullscreenWebView()
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    [configuration preferences].elementFullscreenEnabled = YES;
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeAudio];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    return webView;
+}
+
+template <typename Callable>
+static void testEventually(Callable&& c)
+{
+    int tries = 0;
+    do {
+        if (c())
+            break;
+        TestWebKitAPI::Util::runFor(0.1_s);
+    } while (++tries <= 100);
+}
+
+TEST(InWindowFullscreen, EmptyDocument)
+{
+    auto webView = createInWindowFullscreenWebView();
+    [webView synchronouslyLoadHTMLString:@"<html></html>"];
+    EXPECT_FALSE([webView _canToggleInWindow]);
+    EXPECT_FALSE([webView _isInWindowActive]);
+
+    [webView _close];
+}
+
+TEST(InWindowFullscreen, CanToggleAfterPlaybackStarts)
+{
+    auto webView = createInWindowFullscreenWebView();
+    [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
+
+    bool isPlaying = false;
+    [webView performAfterReceivingMessage:@"playing" action:[&] { isPlaying = true; }];
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"go()"];
+    TestWebKitAPI::Util::run(&isPlaying);
+
+    [webView _updateMediaPlaybackControlsManager];
+    testEventually([&] {
+        [webView _updateMediaPlaybackControlsManager];
+        return [webView _canToggleInWindow];
+    });
+    EXPECT_TRUE([webView _canToggleInWindow]);
+
+    [webView _close];
+}
+
+TEST(InWindowFullscreen, ToggleChangesIsActive)
+{
+    auto webView = createInWindowFullscreenWebView();
+    [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
+
+    bool isPlaying = false;
+    [webView performAfterReceivingMessage:@"playing" action:[&] { isPlaying = true; }];
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"go()"];
+    TestWebKitAPI::Util::run(&isPlaying);
+
+    testEventually([&] {
+        [webView _updateMediaPlaybackControlsManager];
+        return [webView _canToggleInWindow];
+    });
+    EXPECT_TRUE([webView _canToggleInWindow]);
+
+    [webView _toggleInWindow];
+    testEventually([&] {
+        return [webView _isInWindowActive];
+    });
+    EXPECT_TRUE([webView _isInWindowActive]);
+
+    [webView _toggleInWindow];
+    testEventually([&] {
+        return ![webView _isInWindowActive];
+    });
+    EXPECT_FALSE([webView _isInWindowActive]);
+
+    [webView _close];
+}
+
+TEST(InWindowFullscreen, ToggleChangesIsActiveWithoutUserGesture)
+{
+    auto webView = createInWindowFullscreenWebView();
+    [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
+
+    bool isPlaying = false;
+    [webView performAfterReceivingMessage:@"playing" action:[&] { isPlaying = true; }];
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"go()"];
+    TestWebKitAPI::Util::run(&isPlaying);
+
+    testEventually([&] {
+        [webView _updateMediaPlaybackControlsManager];
+        return [webView _canToggleInWindow];
+    });
+    EXPECT_TRUE([webView _canToggleInWindow]);
+
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"internals.consumeTransientActivation()"];
+
+    [webView _toggleInWindow];
+    testEventually([&] {
+        return [webView _isInWindowActive];
+    });
+    EXPECT_TRUE([webView _isInWindowActive]);
+}
+
+}


### PR DESCRIPTION
#### 402f8772f2520846e873094226fe4bdb43be14d3
<pre>
[macOS] Implement _isInWindowActive SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=269499">https://bugs.webkit.org/show_bug.cgi?id=269499</a>
<a href="https://rdar.apple.com/122827633">rdar://122827633</a>

Reviewed by Andy Estes.

Implement _isInWindowActive by pushing activation state up from the WebContent
process to be cached locally in the UIProcess for ease of querying.

- Rename isInWindow() to isInWindowFullscreen() in a number of places,
  for disambiguation reasons.

- Add Debug menu items to MiniBrowser to toggle both in-window fullscreen
  and picture-in-picture modes for testing purposes.

- Add API tests for both availability and active states of in-window fullscreen.

* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
(WebCore::PlaybackSessionModelClient::isInWindowFullscreenActiveChanged):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::updateForEventName):
(WebCore::PlaybackSessionModelMediaElement::toggleInWindowFullscreen):
(WebCore::PlaybackSessionModelMediaElement::observedEventNames):
(WebCore::PlaybackSessionModelMediaElement::isInWindowFullscreenActive const):
(WebCore::PlaybackSessionModelMediaElement::toggleInWindow): Deleted.
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm:
(WebCore::PlaybackSessionInterfaceMac::isInWindowFullscreenActive const):
(WebCore::PlaybackSessionInterfaceMac::toggleInWindowFullscreen):
(WebCore::PlaybackSessionInterfaceMac::setPlayBackControlsManager):
* Source/WebCore/platform/mac/WebPlaybackControlsManager.mm:
(-[WebPlaybackControlsManager toggleInWindow]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _isInWindowActive]):
(-[WKWebView _toggleInWindow]):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::toggleInWindowFullscreen):
(WebKit::PlaybackSessionModelContext::isInWindowFullscreenActiveChanged):
(WebKit::PlaybackSessionManagerProxy::isInWindowFullscreenActiveChanged):
(WebKit::PlaybackSessionModelContext::toggleInWindow): Deleted.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController setInWindowFullscreenActive:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::isInWindowFullscreenActive const):
(WebKit::WebViewImpl::toggleInWindowFullscreen):
(WebKit::WebViewImpl::toggleInWindow): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionInterfaceContext::isInWindowFullscreenActiveChanged):
(WebKit::PlaybackSessionManager::isInWindowFullscreenActiveChanged):
(WebKit::PlaybackSessionManager::toggleInWindow):
* Tools/MiniBrowser/mac/BrowserWindowController.h:
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController togglePictureInPicture:]):
(-[BrowserWindowController toggleInWindowFullscreen:]):
* Tools/MiniBrowser/mac/MainMenu.xib:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController togglePictureInPicture:]):
(-[WK2BrowserWindowController toggleInWindowFullscreen:]):
(-[WK2BrowserWindowController validateMenuItem:]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm: Added.
(TestWebKitAPI::createInWindowFullscreenWebView):
(TestWebKitAPI::testEventually):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/274832@main">https://commits.webkit.org/274832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b95e389173d5e23730775d5fff522bea47124ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42652 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16448 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13924 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43930 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35929 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39685 "Found 1 new test failure: fast/repaint/animation-after-layer-scroll.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12245 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16541 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9010 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->