### PR TITLE
[MultiRep HEIC] Add support for custom rendering

### DIFF
--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -29,6 +29,7 @@
 #include "CachedResourceClient.h"
 #include "CachedResourceClientWalker.h"
 #include "CachedResourceLoader.h"
+#include "Font.h"
 #include "FrameLoader.h"
 #include "FrameLoaderTypes.h"
 #include "LocalFrame.h"
@@ -37,6 +38,7 @@
 #include "MIMETypeRegistry.h"
 #include "MemoryCache.h"
 #include "RenderElement.h"
+#include "RenderImage.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGImage.h"
 #include "SecurityOrigin.h"
@@ -52,6 +54,10 @@
 
 #if USE(CG)
 #include "PDFDocumentImage.h"
+#endif
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+#include "MultiRepresentationHEICMetrics.h"
 #endif
 
 namespace WebCore {
@@ -313,6 +319,13 @@ FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, SizeT
     RefPtr image = m_image;
     if (!image)
         return { };
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && renderImage->isMultiRepresentationHEIC()) {
+        auto metrics = renderImage->style().fontCascade().primaryFont().metricsForMultiRepresentationHEIC();
+        return metrics.size();
+    }
+#endif
 
     if (image->drawsSVGImage() && sizeType == UsedSize)
         return m_svgImageCache->imageSizeForRenderer(renderer);

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -63,6 +63,9 @@ class FontDescription;
 class GlyphPage;
 
 struct GlyphData;
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+struct MultiRepresentationHEICMetrics;
+#endif
 
 enum FontVariant : uint8_t { AutoVariant, NormalVariant, SmallCapsVariant, EmphasisMarkVariant, BrokenIdeographVariant };
 enum Pitch : uint8_t { UnknownPitch, FixedPitch, VariablePitch };
@@ -212,6 +215,9 @@ public:
     bool supportsAllSmallCaps() const;
     bool supportsPetiteCaps() const;
     bool supportsAllPetiteCaps() const;
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    MultiRepresentationHEICMetrics metricsForMultiRepresentationHEIC() const;
+#endif
 #endif
 
     bool canRenderCombiningCharacterSequence(StringView) const;

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -272,6 +272,10 @@ public:
 
     WEBCORE_EXPORT virtual void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&);
 
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    ImageDrawResult drawMultiRepresentationHEIC(Image&, const Font&, const FloatRect& destination, ImagePaintingOptions = { ImageOrientation::Orientation::FromImage });
+#endif
+
     virtual void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) = 0;
     WEBCORE_EXPORT virtual void drawPattern(ImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { });
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -27,14 +27,20 @@
 #import "GraphicsContext.h"
 
 #import "DisplayListRecorder.h"
+#import "Font.h"
 #import "GraphicsContextCG.h"
 #import "IOSurface.h"
 #import "IntRect.h"
+#import <pal/spi/cf/CoreTextSPI.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/FeatureFlagsSPI.h>
 #import <pal/spi/mac/NSGraphicsSPI.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/StdLibExtras.h>
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+#include "MultiRepresentationHEICMetrics.h"
+#endif
 
 #if USE(APPKIT)
 #import <AppKit/AppKit.h>
@@ -56,6 +62,17 @@ namespace WebCore {
 
 // NSColor, NSBezierPath, and NSGraphicsContext calls do not raise exceptions
 // so we don't block exceptions.
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/GraphicsContextCocoaAdditions.mm>
+#else
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+ImageDrawResult GraphicsContext::drawMultiRepresentationHEIC(Image&, const Font&, const FloatRect&, ImagePaintingOptions)
+{
+    return ImageDrawResult::DidNothing;
+}
+#endif
+#endif
 
 void GraphicsContextCG::drawFocusRing(const Path& path, float, const Color& color)
 {

--- a/Source/WebCore/platform/graphics/cocoa/MultiRepresentationHEICMetrics.h
+++ b/Source/WebCore/platform/graphics/cocoa/MultiRepresentationHEICMetrics.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+
+#include "FloatSize.h"
+
+namespace WebCore {
+
+struct MultiRepresentationHEICMetrics {
+    float width;
+    float ascent;
+    float descent;
+
+    FloatSize size() const { return { width, ascent + descent }; }
+};
+
+}
+
+#endif // ENABLE(MULTI_REPRESENTATION_HEIC)

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -47,6 +47,10 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/StdLibExtras.h>
 
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+#include "MultiRepresentationHEICMetrics.h"
+#endif
+
 #include <pal/cf/CoreTextSoftLink.h>
 
 namespace WebCore {
@@ -938,5 +942,16 @@ bool Font::hasAnyComplexColorFormatGlyphs(const GlyphBufferGlyph* glyphs, unsign
     }
     return false;
 }
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/FontCoreTextAdditions.cpp>
+#else
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+MultiRepresentationHEICMetrics Font::metricsForMultiRepresentationHEIC() const
+{
+    return { };
+}
+#endif
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -84,6 +84,10 @@ public:
 
     bool hasAnimatedImage() const;
 
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    bool isMultiRepresentationHEIC() const;
+#endif
+
 protected:
     RenderImage(Type, Element&, RenderStyle&&, OptionSet<ReplacedFlag>, StyleImage* = nullptr, const float imageDevicePixelRatio = 1.0f);
     void willBeDestroyed() override;
@@ -138,6 +142,8 @@ private:
 
     LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred = ComputeActual) const override;
     LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const override;
+
+    LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const override;
 
     bool shouldCollapseToEmpty() const;
 


### PR DESCRIPTION
#### ed687398f954fb809436745aa529879d73c579a2
<pre>
[MultiRep HEIC] Add support for custom rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=269497">https://bugs.webkit.org/show_bug.cgi?id=269497</a>
<a href="https://rdar.apple.com/122975322">rdar://122975322</a>

Reviewed by Said Abou-Hallawa.

Add custom sizing and baseline support for multi-representation HEIC.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::imageSizeForRenderer const):
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::drawMultiRepresentationHEIC):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
(WebCore::GraphicsContext::drawMultiRepresentationHEIC):
* Source/WebCore/platform/graphics/cocoa/MultiRepresentationHEICMetrics.h: Added.
(WebCore::MultiRepresentationHEICMetrics::size const):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::metricsForMultiRepresentationHEIC const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::styleDidChange):
(WebCore::RenderImage::baselinePosition const):
(WebCore::RenderImage::hasAnimatedImage const):
(WebCore::RenderImage::isMultiRepresentationHEIC const):
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/RenderImage.h:

Canonical link: <a href="https://commits.webkit.org/274890@main">https://commits.webkit.org/274890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5ece54826b1a80b7c06005f11bbe50b080a5aa4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42788 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16584 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34737 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36020 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12343 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16677 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16726 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5333 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->