### PR TITLE
Check for USE_CAIRO in PlatformWin.cmake files

### DIFF
--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -1,11 +1,14 @@
 add_definitions(/bigobj -D__STDC_CONSTANT_MACROS)
 
 include(platform/Adwaita.cmake)
-include(platform/Cairo.cmake)
 include(platform/Curl.cmake)
 include(platform/ImageDecoders.cmake)
 include(platform/OpenSSL.cmake)
 include(platform/TextureMapper.cmake)
+
+if (USE_CAIRO)
+    include(platform/Cairo.cmake)
+endif ()
 
 if (USE_DAWN)
     include(platform/Dawn.cmake)
@@ -34,7 +37,6 @@ list(APPEND WebCore_SOURCES
 
     page/win/DragControllerWin.cpp
     page/win/EventHandlerWin.cpp
-    page/win/FrameCairoWin.cpp
     page/win/FrameWin.cpp
     page/win/ResourceUsageOverlayWin.cpp
     page/win/ResourceUsageThreadWin.cpp
@@ -64,13 +66,10 @@ list(APPEND WebCore_SOURCES
     platform/graphics/win/FontCacheWin.cpp
     platform/graphics/win/FontCustomPlatformDataWin.cpp
     platform/graphics/win/FontDescriptionWin.cpp
-    platform/graphics/win/FontPlatformDataCairoWin.cpp
     platform/graphics/win/FontPlatformDataWin.cpp
     platform/graphics/win/FontWin.cpp
     platform/graphics/win/FullScreenController.cpp
     platform/graphics/win/FullScreenWindow.cpp
-    platform/graphics/win/GlyphPageTreeNodeCairoWin.cpp
-    platform/graphics/win/GraphicsContextCairoWin.cpp
     platform/graphics/win/GraphicsContextWin.cpp
     platform/graphics/win/IconWin.cpp
     platform/graphics/win/ImageAdapterWin.cpp
@@ -79,7 +78,6 @@ list(APPEND WebCore_SOURCES
     platform/graphics/win/IntSizeWin.cpp
     platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
     platform/graphics/win/PlatformDisplayWin.cpp
-    platform/graphics/win/SimpleFontDataCairoWin.cpp
     platform/graphics/win/SimpleFontDataWin.cpp
     platform/graphics/win/SystemFontDatabaseWin.cpp
     platform/graphics/win/TransformationMatrixWin.cpp
@@ -95,7 +93,6 @@ list(APPEND WebCore_SOURCES
     platform/win/ClipboardUtilitiesWin.cpp
     platform/win/CursorWin.cpp
     platform/win/DragDataWin.cpp
-    platform/win/DragImageCairoWin.cpp
     platform/win/DragImageWin.cpp
     platform/win/GDIUtilities.cpp
     platform/win/KeyEventWin.cpp
@@ -153,6 +150,10 @@ list(APPEND WebCore_LIBRARIES
     usp10
 )
 
+list(APPEND WebCoreTestSupport_LIBRARIES
+    shlwapi
+)
+
 set(iconFiles
     Resources/missingImage.png
     Resources/missingImage@2x.png
@@ -197,6 +198,19 @@ if (ENABLE_VIDEO AND USE_MEDIA_FOUNDATION)
     list(APPEND WebCore_PRIVATE_LIBRARIES MediaFoundation)
 endif ()
 
+if (USE_CAIRO)
+    list(APPEND WebCore_SOURCES
+        page/win/FrameCairoWin.cpp
+
+        platform/graphics/win/FontPlatformDataCairoWin.cpp
+        platform/graphics/win/GlyphPageTreeNodeCairoWin.cpp
+        platform/graphics/win/GraphicsContextCairoWin.cpp
+        platform/graphics/win/SimpleFontDataCairoWin.cpp
+
+        platform/win/DragImageCairoWin.cpp
+    )
+endif ()
+
 if (USE_WOFF2)
     # The WOFF2 libraries don't compile as DLLs on Windows, so add in
     # the additional libraries WOFF2::dec requires
@@ -205,8 +219,3 @@ if (USE_WOFF2)
         WOFF2::common
     )
 endif ()
-
-list(APPEND WebCoreTestSupport_LIBRARIES
-    Cairo::Cairo
-    shlwapi
-)

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -27,8 +27,6 @@ list(APPEND WebKit_SOURCES
     Platform/win/LoggingWin.cpp
     Platform/win/ModuleWin.cpp
 
-    Shared/API/c/cairo/WKImageCairo.cpp
-
     Shared/win/AuxiliaryProcessMainWin.cpp
     Shared/win/NativeWebKeyboardEventWin.cpp
     Shared/win/NativeWebMouseEventWin.cpp
@@ -40,8 +38,6 @@ list(APPEND WebKit_SOURCES
     UIProcess/API/C/WKViewportAttributes.cpp
 
     UIProcess/API/C/win/WKView.cpp
-
-    UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
 
     UIProcess/Automation/win/WebAutomationSessionWin.cpp
 
@@ -58,8 +54,6 @@ list(APPEND WebKit_SOURCES
     UIProcess/Launcher/win/ProcessLauncherWin.cpp
 
     UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
-
-    UIProcess/cairo/BackingStore.cpp
 
     UIProcess/win/AutomationClientWin.cpp
     UIProcess/win/PageClientImpl.cpp
@@ -102,7 +96,6 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics"
     "${WEBKIT_DIR}/Shared/CoordinatedGraphics/threadedcompositor"
     "${WEBKIT_DIR}/Shared/win"
-    "${WEBKIT_DIR}/UIProcess/API/C/cairo"
     "${WEBKIT_DIR}/UIProcess/API/C/win"
     "${WEBKIT_DIR}/UIProcess/API/cpp/win"
     "${WEBKIT_DIR}/UIProcess/API/win"
@@ -110,7 +103,6 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/UIProcess/Inspector/socket"
     "${WEBKIT_DIR}/UIProcess/Inspector/win"
     "${WEBKIT_DIR}/UIProcess/Plugins/win"
-    "${WEBKIT_DIR}/UIProcess/cairo"
     "${WEBKIT_DIR}/UIProcess/win"
     "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/win"
     "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/win/DOM"
@@ -119,6 +111,12 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/WebProcess/WebPage/CoordinatedGraphics"
     "${WEBKIT_DIR}/WebProcess/WebPage/win"
     "${WEBKIT_DIR}/win"
+)
+
+list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
+    Shared/API/c/win/WKBaseWin.h
+
+    UIProcess/API/C/win/WKView.h
 )
 
 list(APPEND WebKit_PRIVATE_LIBRARIES
@@ -150,10 +148,19 @@ if (ENABLE_REMOTE_INSPECTOR)
     )
 endif ()
 
-list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
-    Shared/API/c/cairo/WKImageCairo.h
+if (USE_CAIRO)
+    list(APPEND WebKit_SOURCES
+        Shared/API/c/cairo/WKImageCairo.cpp
 
-    Shared/API/c/win/WKBaseWin.h
+        UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
 
-    UIProcess/API/C/win/WKView.h
-)
+        UIProcess/cairo/BackingStore.cpp
+    )
+    list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBKIT_DIR}/UIProcess/API/C/cairo"
+        "${WEBKIT_DIR}/UIProcess/cairo"
+    )
+    list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
+        Shared/API/c/cairo/WKImageCairo.h
+    )
+endif ()

--- a/Tools/ImageDiff/PlatformWin.cmake
+++ b/Tools/ImageDiff/PlatformWin.cmake
@@ -1,1 +1,3 @@
-include(Cairo.cmake)
+if (USE_CAIRO)
+    include(Cairo.cmake)
+endif ()


### PR DESCRIPTION
#### d062230acc064088efd401138f5029b5be1dd6fc
<pre>
Check for USE_CAIRO in PlatformWin.cmake files
<a href="https://bugs.webkit.org/show_bug.cgi?id=269500">https://bugs.webkit.org/show_bug.cgi?id=269500</a>

Reviewed by Fujii Hironori.

Add explicit checks for `USE_CAIRO` in `PlatformWin.cmake` files before
appending Cairo specific build options.

This is in preparation for building with `USE_SKIA` on Windows.

* Source/WebCore/PlatformWin.cmake:
* Source/WebKit/PlatformWin.cmake:
* Tools/ImageDiff/PlatformWin.cmake:

Canonical link: <a href="https://commits.webkit.org/274772@main">https://commits.webkit.org/274772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b59495e868f21c26f04fa4a536b60d722ed91232

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18999 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42295 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/21907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16329 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40562 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/21907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/21907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/21907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5274 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->