### PR TITLE
[UnifiedPDF] Fix context menu page navigation for 2up.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -46,9 +46,9 @@ public:
     using PageIndex = size_t; // This is a zero-based index.
 
     enum class DisplayMode : uint8_t {
-        SinglePage,
-        Continuous,
-        TwoUp,
+        SinglePageDiscrete,
+        SinglePageContinuous,
+        TwoUpDiscrete,
         TwoUpContinuous,
     };
 
@@ -64,8 +64,13 @@ public:
     static constexpr WebCore::FloatSize documentMargin { 6, 8 };
     static constexpr WebCore::FloatSize pageMargin { 4, 6 };
 
+    bool isLeftPageIndex(PageIndex) const;
+    bool isRightPageIndex(PageIndex) const;
+    bool isLastPageIndex(PageIndex) const;
+
     RetainPtr<PDFPage> pageAtIndex(PageIndex) const;
     std::optional<unsigned> indexForPage(RetainPtr<PDFPage>) const;
+    PDFDocumentLayout::PageIndex nearestPageIndexForDocumentPoint(WebCore::IntPoint) const;
 
     // This is not scaled by scale().
     WebCore::FloatRect layoutBoundsForPageAtIndex(PageIndex) const;
@@ -84,6 +89,10 @@ public:
 
     void setDisplayMode(DisplayMode displayMode) { m_displayMode = displayMode; }
     DisplayMode displayMode() const { return m_displayMode; }
+    bool isSinglePageDisplayMode() const { return m_displayMode == DisplayMode::SinglePageDiscrete || m_displayMode == DisplayMode::SinglePageContinuous; }
+    bool isTwoUpDisplayMode() const { return m_displayMode == DisplayMode::TwoUpDiscrete || m_displayMode == DisplayMode::TwoUpContinuous; }
+
+    unsigned pagesPerRow() const { return isSinglePageDisplayMode() ? 1 : 2; }
 
     void setShouldUpdateAutoSizeScale(ShouldUpdateAutoSizeScale autoSizeState) { m_autoSizeState = autoSizeState; }
     ShouldUpdateAutoSizeScale shouldUpdateAutoSizeScale() const { return m_autoSizeState; }
@@ -106,7 +115,7 @@ private:
     Vector<PageGeometry> m_pageGeometry;
     WebCore::FloatRect m_documentBounds;
     float m_scale { 1 };
-    DisplayMode m_displayMode { DisplayMode::Continuous };
+    DisplayMode m_displayMode { DisplayMode::SinglePageContinuous };
     ShouldUpdateAutoSizeScale m_autoSizeState { ShouldUpdateAutoSizeScale::Yes };
 };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -368,7 +368,7 @@ private:
     WebCore::IntPoint offsetContentsSpacePointByPageMargins(WebCore::IntPoint pointInContentsSpace) const;
 
     std::optional<PDFDocumentLayout::PageIndex> pageIndexForDocumentPoint(const WebCore::IntPoint&) const;
-    std::optional<PDFDocumentLayout::PageIndex> indexForCurrentPageInView() const;
+    PDFDocumentLayout::PageIndex indexForCurrentPageInView() const;
 
     RetainPtr<PDFAnnotation> annotationForRootViewPoint(const WebCore::IntPoint&) const;
 


### PR DESCRIPTION
#### 55b05170db3b61e4d6266a0a9580f4665adcbb39
<pre>
[UnifiedPDF] Fix context menu page navigation for 2up.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269501">https://bugs.webkit.org/show_bug.cgi?id=269501</a>
<a href="https://rdar.apple.com/problem/123032781">rdar://problem/123032781</a>

Reviewed by Simon Fraser.

274737@main provided the initial implementation for navigating between
pages using context menu options. It worked fine for pages in single
page display modes but not all the time in two up display modes. This
patch tries to address that by making sure we navigate between pairs
of pages in two up mode.

When determining which page to scroll to in two up mode we need to
consider whether the &quot;current page,&quot; is the first page in the row or the
second page in the row. If we are navigating forwards and the &quot;current
page,&quot; is the first page in the row, then we need to navigate two pages
forward to go to the next row. Similarly, if we are navigating backwards
and the &quot;current page,&quot; is the second page in the row, we need to
go two pages backwards.

I also changed indexForCurrentPageInView to use a new method,
nearestPageIndexForDocumentPoint, instead of pageIndexForDocumentPoint
since it was not guaranteed the later would alawys return a page index.
Fow single page mode, this new method iterates over the pages in order
and compares the point with the bottom of each page. Once we find a page
point&apos;s Y location that is lower than the document points&apos; then we have
found the page the point is contained in. Two up modes works in the
same way except we also need to compare the X location for the points.

I also renamed the DisplayModes enums to explicitly state whether they
are discrete or continuous to help introduce some new helpers without
them having confusing names (isSinglePageDisplayMode and
isTwoUpDisplayMode).

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::isSinglePageDisplayMode const):
(WebKit::PDFDocumentLayout::isTwoUpDisplayMode const):
(WebKit::PDFDocumentLayout::pagesPerRow const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::isLeftPageIndex const):
(WebKit::PDFDocumentLayout::isRightPageIndex const):
(WebKit::PDFDocumentLayout::isLastPageIndex const):
(WebKit::PDFDocumentLayout::nearestPageIndexForDocumentPoint const):
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::layoutPages):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::shouldUseScrollSnapping const):
(WebKit::UnifiedPDFPlugin::shouldDisplayPage):
(WebKit::UnifiedPDFPlugin::indexForCurrentPageInView const):
(WebKit::UnifiedPDFPlugin::contextMenuItemTagFromDisplayMode const):
(WebKit::UnifiedPDFPlugin::displayModeFromContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::navigationContextMenuItems const):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):

Canonical link: <a href="https://commits.webkit.org/274858@main">https://commits.webkit.org/274858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2ea08c1bd9d8069a6b1a23f10cdf84fc7ffc25b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42644 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33359 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13952 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39681 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16533 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9021 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->