### PR TITLE
[UnifiedPDF] Paint PDF content off the main thread

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -198,7 +198,7 @@ public:
     //     auto nativeImage = buffer.copyNativeImage();
     //     buffer = nullptr;
     WEBCORE_EXPORT static RefPtr<NativeImage> sinkIntoNativeImage(RefPtr<ImageBuffer>);
-    static RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer>);
+    WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer>);
     static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
 
     WEBCORE_EXPORT virtual void convertToLuminanceMask();

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -697,6 +697,7 @@ WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
 WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
 WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 
 WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3271,6 +3271,8 @@
 		0F931C1A18C5711900DBB8D4 /* ScrollingTreeScrollingNodeDelegateIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeScrollingNodeDelegateIOS.h; sourceTree = "<group>"; };
 		0F931C1B18C5711900DBA7C3 /* ScrollingTreeOverflowScrollingNodeIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollingTreeOverflowScrollingNodeIOS.mm; sourceTree = "<group>"; };
 		0F931C1B18C5711900DBB8D4 /* ScrollingTreeScrollingNodeDelegateIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollingTreeScrollingNodeDelegateIOS.mm; sourceTree = "<group>"; };
+		0F9B0BC22B7DB9BF0003E962 /* PDFPageCoverage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PDFPageCoverage.h; sourceTree = "<group>"; };
+		0F9B0BC32B7DB9BF0003E962 /* PDFPageCoverage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PDFPageCoverage.mm; sourceTree = "<group>"; };
 		0F9FA7DA26CEFAD100872684 /* MediaKeySystemPermissionRequestManagerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaKeySystemPermissionRequestManagerProxy.cpp; sourceTree = "<group>"; };
 		0F9FA7DB26CEFADA00872684 /* MediaKeySystemPermissionRequestProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaKeySystemPermissionRequestProxy.cpp; sourceTree = "<group>"; };
 		0FA7467E27BB611800B5FF5A /* ImageBufferBackendHandleSharing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferBackendHandleSharing.h; sourceTree = "<group>"; };
@@ -8610,6 +8612,8 @@
 				0F23ADDF2B7D240C00E6199B /* AsyncPDFRenderer.mm */,
 				0F3D56732AC651390086D64E /* PDFDocumentLayout.h */,
 				0F3D56722AC651390086D64E /* PDFDocumentLayout.mm */,
+				0F9B0BC22B7DB9BF0003E962 /* PDFPageCoverage.h */,
+				0F9B0BC32B7DB9BF0003E962 /* PDFPageCoverage.mm */,
 				0FFACF042AC2453300ED8DB6 /* UnifiedPDFPlugin.h */,
 				0FFACF032AC2453300ED8DB6 /* UnifiedPDFPlugin.mm */,
 			);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -29,6 +29,7 @@
 #if ENABLE(UNIFIED_PDF)
 
 #include "Logging.h"
+#include "PDFPageCoverage.h"
 #include "UnifiedPDFPlugin.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <PDFKit/PDFKit.h>
@@ -46,12 +47,21 @@ Ref<AsyncPDFRenderer> AsyncPDFRenderer::create(UnifiedPDFPlugin& plugin)
 
 AsyncPDFRenderer::AsyncPDFRenderer(UnifiedPDFPlugin& plugin)
     : m_plugin(plugin)
-    , m_paintingWorkQueue(WorkQueue::create("WebKit: PDF Painting Work Queue"_s, WorkQueue::QOS::UserInteractive)) // Maybe make this concurrent?
+    , m_paintingWorkQueue(ConcurrentWorkQueue::create("WebKit: PDF Painting Work Queue"_s, WorkQueue::QOS::UserInteractive)) // Maybe make this concurrent?
+    , m_currentConfigurationIdentifier(PDFConfigurationIdentifier::generate())
 {
 }
 
 AsyncPDFRenderer::~AsyncPDFRenderer()
 {
+    teardown();
+}
+
+void AsyncPDFRenderer::teardown()
+{
+    if (!m_pdfContentsLayer)
+        return;
+
     if (auto* tiledBacking = m_pdfContentsLayer->tiledBacking())
         tiledBacking->setClient(nullptr);
 }
@@ -64,11 +74,18 @@ void AsyncPDFRenderer::setupWithLayer(GraphicsLayer& layer)
         tiledBacking->setClient(this);
 }
 
+void AsyncPDFRenderer::setShowDebugBorders(bool showDebugBorders)
+{
+    m_showDebugBorders = showDebugBorders;
+}
+
 void AsyncPDFRenderer::willRepaintTile(TileGridIndex gridIndex, TileIndex tileIndex, const FloatRect& tileRect, const FloatRect& tileDirtyRect)
 {
     auto tileInfo = TileForGrid { gridIndex, tileIndex };
 
-    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::willRepaintTile " << tileIndex << " " << tileRect << " (dirty rect " << tileDirtyRect << ") - already queued " << m_enqueuedTileRenders.contains(tileInfo) << " have cached tile " << m_rendereredTiles.contains(tileInfo));
+    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::willRepaintTile " << tileInfo << " rect " << tileRect << " (dirty rect " << tileDirtyRect << ") - already queued "
+        << m_enqueuedTileRenders.contains(tileInfo) << " have cached tile " << m_rendereredTiles.contains(tileInfo));
+
     // Currently we always do full tile paints.
     UNUSED_PARAM(tileDirtyRect);
 
@@ -86,6 +103,8 @@ void AsyncPDFRenderer::willRemoveTile(TileGridIndex gridIndex, TileIndex tileInd
 {
     auto tileInfo = TileForGrid { gridIndex, tileIndex };
 
+    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::willRemoveTile " << tileInfo);
+
     m_enqueuedTileRenders.remove(tileInfo);
     m_rendereredTiles.remove(tileInfo);
 }
@@ -93,14 +112,35 @@ void AsyncPDFRenderer::willRemoveTile(TileGridIndex gridIndex, TileIndex tileInd
 void AsyncPDFRenderer::willRepaintAllTiles(TileGridIndex)
 {
     // FIXME: Could remove per-grid, when we use more than one grid.
+    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::willRepaintAllTiles");
+
     m_enqueuedTileRenders.clear();
     m_rendereredTiles.clear();
 }
 
-void AsyncPDFRenderer::clearCachedTiles()
+void AsyncPDFRenderer::layoutConfigurationChanged()
 {
+    m_currentConfigurationIdentifier = PDFConfigurationIdentifier::generate();
+    clearRequestsAndCachedTiles();
+}
+
+void AsyncPDFRenderer::clearRequestsAndCachedTiles()
+{
+    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::clearRequestsAndCachedTiles");
+
     m_enqueuedTileRenders.clear();
     m_rendereredTiles.clear();
+}
+
+AffineTransform AsyncPDFRenderer::tileToPaintingTransform(float pageScaleFactor)
+{
+    float inversePageScale = 1 / pageScaleFactor;
+    return AffineTransform::makeScale({ inversePageScale, inversePageScale });
+}
+
+FloatRect AsyncPDFRenderer::convertTileRectToPaintingCoords(const FloatRect& tileRect, float pageScaleFactor)
+{
+    return tileToPaintingTransform(pageScaleFactor).mapRect(tileRect);
 }
 
 void AsyncPDFRenderer::enqueuePaintWithClip(const TileForGrid& tileInfo, const FloatRect& tileRect)
@@ -111,56 +151,62 @@ void AsyncPDFRenderer::enqueuePaintWithClip(const TileForGrid& tileInfo, const F
     if (!plugin)
         return;
 
-    auto pdfDocument = plugin->pdfDocument();
+    RetainPtr pdfDocument = plugin->pdfDocument();
     if (!pdfDocument) {
         LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::enqueueLayerPaint - document is null, bailing");
         return;
     }
 
-    auto pageCoverage = plugin->pageCoverageForRect(tileRect);
+    auto paintingClipRect = convertTileRectToPaintingCoords(tileRect, plugin->scaleFactor());
+    auto pageCoverage = plugin->pageCoverageForRect(paintingClipRect);
     if (pageCoverage.pages.isEmpty())
         return;
 
-    m_enqueuedTileRenders.add(tileInfo, pageCoverage);
+    auto tileRenderInfo = TileRenderInfo { pageCoverage, m_currentConfigurationIdentifier };
+    m_enqueuedTileRenders.add(tileInfo, tileRenderInfo);
 
-    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::enqueuePaintWithClip for tile at " << tileInfo.tileIndex);
+    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::enqueuePaintWithClip for tile " << tileInfo << " " << tileRenderInfo.pageCoverage);
 
-    m_paintingWorkQueue->dispatch([protectedThis = Ref { *this }, pdfDocument = WTFMove(pdfDocument), tileInfo, tileRect, pageCoverage]() mutable {
-        protectedThis->paintTileOnWorkQueue(WTFMove(pdfDocument), tileInfo, tileRect, pageCoverage);
+    m_paintingWorkQueue->dispatch([protectedThis = Ref { *this }, pdfDocument = WTFMove(pdfDocument), tileInfo, tileRect, tileRenderInfo]() mutable {
+        protectedThis->paintTileOnWorkQueue(WTFMove(pdfDocument), tileInfo, tileRect, tileRenderInfo);
     });
 }
 
-void AsyncPDFRenderer::paintTileOnWorkQueue(RetainPtr<PDFDocument>&& pdfDocument, const TileForGrid& tileInfo, const FloatRect& tileRect, const PDFPageCoverage& pageCoverage)
+void AsyncPDFRenderer::paintTileOnWorkQueue(RetainPtr<PDFDocument>&& pdfDocument, const TileForGrid& tileInfo, const FloatRect& tileRect, const TileRenderInfo& renderInfo)
 {
-    assertIsCurrent(m_paintingWorkQueue);
+    ASSERT(!isMainRunLoop());
 
-    auto tileBuffer = ImageBuffer::create(tileRect.size(), RenderingPurpose::Unspecified, pageCoverage.deviceScaleFactor, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    // FIXME: We should take a lock and check m_enqueuedTileRenders here, since we don't want to spend time painting a tile which will only be thrown away.
+
+    auto tileBuffer = ImageBuffer::create(tileRect.size(), RenderingPurpose::Unspecified, renderInfo.pageCoverage.deviceScaleFactor, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
     if (!tileBuffer)
         return;
 
-    // transform the origin
-
-    paintPDFIntoBuffer(WTFMove(pdfDocument), *tileBuffer, tileInfo, tileRect, pageCoverage);
+    paintPDFIntoBuffer(WTFMove(pdfDocument), *tileBuffer, tileInfo, tileRect, renderInfo);
 
     // This is really a no-op (but only works if there's just one ref).
     auto bufferCopy = ImageBuffer::sinkIntoBufferForDifferentThread(WTFMove(tileBuffer));
     ASSERT(bufferCopy);
 
-    transferBufferToMainThread(WTFMove(bufferCopy), tileInfo, tileRect);
+    transferBufferToMainThread(WTFMove(bufferCopy), tileInfo, tileRect, renderInfo);
 }
 
-void AsyncPDFRenderer::paintPDFIntoBuffer(RetainPtr<PDFDocument>&& pdfDocument, Ref<ImageBuffer> imageBuffer, const TileForGrid& tileInfo, const FloatRect& tileRect, const PDFPageCoverage& pageCoverage)
+void AsyncPDFRenderer::paintPDFIntoBuffer(RetainPtr<PDFDocument>&& pdfDocument, Ref<ImageBuffer> imageBuffer, const TileForGrid& tileInfo, const FloatRect& tileRect, const TileRenderInfo& renderInfo)
 {
-    assertIsCurrent(m_paintingWorkQueue);
+    ASSERT(!isMainRunLoop());
 
     auto& context = imageBuffer->context();
 
     auto stateSaver = GraphicsContextStateSaver(context);
 
     context.translate(FloatPoint { -tileRect.location() });
-    context.scale(pageCoverage.documentScale);
 
-    for (auto& pageInfo : pageCoverage.pages) {
+    if (m_showDebugBorders.load())
+        context.fillRect(tileRect, Color::green.colorWithAlphaByte(32));
+
+    context.scale(renderInfo.pageCoverage.pdfDocumentScale * renderInfo.pageCoverage.pageScaleFactor);
+
+    for (auto& pageInfo : renderInfo.pageCoverage.pages) {
         RetainPtr pdfPage = [pdfDocument pageAtIndex:pageInfo.pageIndex];
         if (!pdfPage)
             continue;
@@ -169,23 +215,22 @@ void AsyncPDFRenderer::paintPDFIntoBuffer(RetainPtr<PDFDocument>&& pdfDocument, 
 
         auto pageStateSaver = GraphicsContextStateSaver(context);
         context.clip(destinationRect);
-        context.fillRect(destinationRect, Color::white);
 
         // Translate the context to the bottom of pageBounds and flip, so that PDFKit operates
         // from this page's drawing origin.
         context.translate(destinationRect.minXMaxYCorner());
         context.scale({ 1, -1 });
 
-        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer: painting PDF page " << pageInfo.pageIndex << " into rect " << destinationRect << " with clip " << tileRect);
+        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer: tile " << tileInfo << " painting PDF page " << pageInfo.pageIndex << " into rect " << destinationRect << " with clip " << tileRect);
         [pdfPage drawWithBox:kPDFDisplayBoxCropBox toContext:context.platformContext()];
     }
 }
 
-void AsyncPDFRenderer::transferBufferToMainThread(RefPtr<ImageBuffer>&& imageBuffer, const TileForGrid& tileInfo, const FloatRect& tileRect)
+void AsyncPDFRenderer::transferBufferToMainThread(RefPtr<ImageBuffer>&& imageBuffer, const TileForGrid& tileInfo, const FloatRect& tileRect, const TileRenderInfo& renderInfo)
 {
-    assertIsCurrent(m_paintingWorkQueue);
+    ASSERT(!isMainRunLoop());
 
-    callOnMainRunLoop([weakThis = ThreadSafeWeakPtr { *this }, imageBuffer = WTFMove(imageBuffer), tileInfo, tileRect]() {
+    callOnMainRunLoop([weakThis = ThreadSafeWeakPtr { *this }, imageBuffer = WTFMove(imageBuffer), tileInfo, tileRect, renderInfo]() {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -193,44 +238,76 @@ void AsyncPDFRenderer::transferBufferToMainThread(RefPtr<ImageBuffer>&& imageBuf
         if (!protectedThis->m_pdfContentsLayer)
             return;
 
-        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::transferBufferToMainThread - got results for tile at " << tileInfo.tileIndex << " (" << protectedThis->m_rendereredTiles.size() << " tiles in cache)");
+        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::transferBufferToMainThread - got results for tile at " << tileInfo
+            << " (" << protectedThis->m_rendereredTiles.size() << " tiles in cache). Request removed " << !protectedThis->m_enqueuedTileRenders.contains(tileInfo)
+            << " configuration changed " << (renderInfo.configurationIdentifier != protectedThis->m_currentConfigurationIdentifier));
 
         // If the request for this tile has been revoked, don't cache it.
         if (!protectedThis->m_enqueuedTileRenders.contains(tileInfo))
             return;
 
-        auto bufferAndClip = BufferAndClip { WTFMove(imageBuffer), tileRect };
+        // Configuration has changed.
+        if (renderInfo.configurationIdentifier != protectedThis->m_currentConfigurationIdentifier) {
+            auto it = protectedThis->m_enqueuedTileRenders.find(tileInfo);
+            if (it != protectedThis->m_enqueuedTileRenders.end() && it->value.configurationIdentifier == renderInfo.configurationIdentifier)
+                protectedThis->m_enqueuedTileRenders.remove(it);
+            return;
+        }
+
+        auto bufferAndClip = BufferAndClip { WTFMove(imageBuffer), tileRect, protectedThis->m_currentConfigurationIdentifier };
         protectedThis->m_rendereredTiles.add(tileInfo, WTFMove(bufferAndClip));
 
-        protectedThis->m_pdfContentsLayer->setNeedsDisplayInRect(tileRect);
+        auto paintingClipRect = convertTileRectToPaintingCoords(tileRect, renderInfo.pageCoverage.pageScaleFactor);
+        protectedThis->m_pdfContentsLayer->setNeedsDisplayInRect(paintingClipRect);
     });
 }
 
-bool AsyncPDFRenderer::paintTileForClip(GraphicsContext& context, const FloatRect& clip)
+bool AsyncPDFRenderer::paintTilesForPaintingRect(GraphicsContext& context, float pageScaleFactor, const FloatRect& destinationRect)
 {
     ASSERT(isMainRunLoop());
 
     bool paintedATile = false;
 
+    auto stateSaver = GraphicsContextStateSaver(context);
+
+    // This scale takes us from "painting" coordinates into the coordinate system of the tile grid,
+    // so we can paint tiles directly.
+
+    auto scaleTransform = tileToPaintingTransform(pageScaleFactor);
+    context.concatCTM(scaleTransform);
+
     for (auto& keyValuePair : m_rendereredTiles) {
         auto& tileInfo = keyValuePair.key;
         auto& bufferAndClip = keyValuePair.value;
 
-        if (!clip.intersects(bufferAndClip.tileClip))
+        m_enqueuedTileRenders.remove(tileInfo);
+
+        // FIXME: if we stored PDFPageCoverage we could skip non-relevant tiles
+
+        auto tileClipInPaintingCoordinates = scaleTransform.mapRect(bufferAndClip.tileClip);
+        if (!destinationRect.intersects(tileClipInPaintingCoordinates))
             continue;
 
-        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::paintTileForClip - painting tile for " << tileInfo.tileIndex << " with clip " << bufferAndClip.tileClip);
+        if (bufferAndClip.configurationIdentifier != m_currentConfigurationIdentifier) {
+            if (m_showDebugBorders.load())
+                context.fillRect(bufferAndClip.tileClip, Color::orange.colorWithAlphaByte(32));
+            continue;
+        }
 
-        auto stateSaver = GraphicsContextStateSaver(context);
+        LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::paintTilesForPaintingRect " << destinationRect  << " - painting tile for " << tileInfo << " with clip " << bufferAndClip.tileClip << " scale " << pageScaleFactor);
 
         context.drawImageBuffer(*bufferAndClip.buffer, bufferAndClip.tileClip.location());
         paintedATile = true;
-
-        m_enqueuedTileRenders.remove(tileInfo);
     }
 
     // FIXME: Ideally return true if we covered the entire dirty rect.
     return paintedATile;
+}
+
+TextStream& operator<<(TextStream& ts, const TileForGrid& tileInfo)
+{
+    ts << "[" << tileInfo.gridIndex << ":" << tileInfo.tileIndex << "]";
+    return ts;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "PDFDocumentLayout.h"
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebKit {
+
+struct PerPageInfo {
+    PDFDocumentLayout::PageIndex pageIndex { 0 };
+    WebCore::FloatRect pageBounds;
+};
+
+struct PDFPageCoverage {
+    Vector<PerPageInfo> pages;
+    float deviceScaleFactor { 1 };
+    float pdfDocumentScale { 1 };
+    float pageScaleFactor { 1 };
+};
+
+WTF::TextStream& operator<<(WTF::TextStream&, const PerPageInfo&);
+WTF::TextStream& operator<<(WTF::TextStream&, const PDFPageCoverage&);
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PDFPageCoverage.h"
+
+#if ENABLE(UNIFIED_PDF)
+
+namespace WebKit {
+
+TextStream& operator<<(TextStream& ts, const PerPageInfo& pageInfo)
+{
+    ts << "PerPageInfo " << pageInfo.pageIndex << " bounds " << pageInfo.pageBounds;
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, const PDFPageCoverage& coverage)
+{
+    ts << "PDFPageCoverage " << coverage.pages << " pdfDocumentScale " << coverage.pdfDocumentScale << " " << " page scale " << coverage.pageScaleFactor;
+    return ts;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -43,13 +43,17 @@ enum class DelegatedScrollingMode : uint8_t;
 
 namespace WebKit {
 
-struct LookupTextResult;
-struct PDFContextMenu;
-struct PDFContextMenuItem;
+class AsyncPDFRenderer;
 class PDFPluginPasswordField;
 class PDFPluginPasswordForm;
 class WebFrame;
 class WebMouseEvent;
+
+struct LookupTextResult;
+struct PDFContextMenu;
+struct PDFContextMenuItem;
+struct PDFPageCoverage;
+
 enum class WebEventType : uint8_t;
 enum class WebMouseEventButton : int8_t;
 enum class WebEventModifier : uint8_t;
@@ -70,17 +74,6 @@ private:
 enum class AnnotationSearchDirection : bool {
     Forward,
     Backward
-};
-
-struct PerPageInfo {
-    PDFDocumentLayout::PageIndex pageIndex { 0 };
-    WebCore::FloatRect pageBounds;
-};
-
-struct PDFPageCoverage {
-    Vector<PerPageInfo> pages;
-    float deviceScaleFactor { 1 };
-    float documentScale { 1 };
 };
 
 class UnifiedPDFPlugin final : public PDFPluginBase, public WebCore::GraphicsLayerClient {
@@ -381,9 +374,14 @@ private:
 
     bool isTaggedPDF() const;
 
+    std::pair<bool, bool> shouldShowDebugIndicators() const;
+
 #if PLATFORM(MAC)
     void createPasswordEntryForm();
 #endif
+
+    Ref<AsyncPDFRenderer> asyncRenderer();
+    RefPtr<AsyncPDFRenderer> asyncRendererIfExists() const;
 
     PDFDocumentLayout m_documentLayout;
     RefPtr<WebCore::GraphicsLayer> m_rootLayer;
@@ -432,6 +430,8 @@ private:
     std::optional<PDFDocumentLayout::PageIndex> m_currentlySnappedPage;
 
     Vector<WebCore::FloatRect> m_findMatchRectsInDocumentCoordinates;
+
+    RefPtr<AsyncPDFRenderer> m_asyncRenderer;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 72c98dc7d00b14e390e83ba0b7723d69c6357bf8
<pre>
[UnifiedPDF] Paint PDF content off the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=269505">https://bugs.webkit.org/show_bug.cgi?id=269505</a>
<a href="https://rdar.apple.com/119632313">rdar://119632313</a>

Reviewed by Tim Horton.

Enable AsyncPDFRenderer which paints PDF tiles off the main thread. The one line at
`asyncRenderer()-&gt;setupWithLayer(*m_contentsLayer)` creates the AsyncPDFRenderer, and the
rest of the code is conditional on it being non-null.

There are various sources of complexity in managing the cache of tiles, and painting them
correctly. First, the TiledBackingClient callbacks are all in terms of tile coordinates,
which are independent of the page scale factor that we push onto m_contentsLayer (since
TiledBacking has a behavior of mapping back to screen space to create the tiles, so they are
always 512x512 in screen space). This complexity is handled by
`convertTileRectToPaintingCoords()` and `tileToPaintingTransform()`. When comparing clips
etc we have to take care to map into the right coordinate systems.

Second, we have to not paint tiles that were generated earlier when the scale was different,
so AsyncPDFRenderer uses a `ObjectIdentifier&lt;PDFConfiguration&gt;` to track configurations, and
throws away tiles if the configuration changed while they were painting; this is necessary
to avoid lots of issues when resizing.

Painting the cached tiles themselves is done inside the per-page painting loop; this is
necessary to clip out pages for which `shouldDisplayPage()` is false, in non-continuous
scrolling modes. This is not ideal, because we have (per-tile * per-page * per-cached tile)
runtime performance, which will need optimizing.

* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
(WebKit::AsyncPDFRenderer::paintingWorkQueue const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::AsyncPDFRenderer):
(WebKit::AsyncPDFRenderer::~AsyncPDFRenderer):
(WebKit::AsyncPDFRenderer::teardown):
(WebKit::AsyncPDFRenderer::setShowDebugBorders):
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::willRemoveTile):
(WebKit::AsyncPDFRenderer::willRepaintAllTiles):
(WebKit::AsyncPDFRenderer::layoutConfigurationChanged):
(WebKit::AsyncPDFRenderer::clearRequestsAndCachedTiles):
(WebKit::AsyncPDFRenderer::tileToPaintingTransform):
(WebKit::AsyncPDFRenderer::convertTileRectToPaintingCoords):
(WebKit::AsyncPDFRenderer::enqueuePaintWithClip):
(WebKit::AsyncPDFRenderer::paintTileOnWorkQueue):
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer):
(WebKit::AsyncPDFRenderer::transferBufferToMainThread):
(WebKit::AsyncPDFRenderer::paintTilesForPaintingRect):
(WebKit::operator&lt;&lt;):
(WebKit::AsyncPDFRenderer::clearCachedTiles): Deleted.
(WebKit::AsyncPDFRenderer::paintTileForClip): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h: Added.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm: Added.
(WebKit::operator&lt;&lt;):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::asyncRenderer):
(WebKit::UnifiedPDFPlugin::asyncRendererIfExists const):
(WebKit::UnifiedPDFPlugin::ensureLayers):
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::shouldShowDebugIndicators const):
(WebKit::UnifiedPDFPlugin::didChangeSettings):
(WebKit::UnifiedPDFPlugin::pageCoverageForRect const):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):

Canonical link: <a href="https://commits.webkit.org/274802@main">https://commits.webkit.org/274802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e13bfae470a783876f4dfed22b6a7c98ecb5a202

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42604 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16400 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13888 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43882 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36340 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39685 "Build is in progress. Recent messages:") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12208 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16493 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8990 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->