### PR TITLE
[threaded-animation-resolution] add support for CSS Motion Path properties

### DIFF
--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -93,7 +93,12 @@ constexpr OptionSet<AcceleratedEffectProperty> transformRelatedAcceleratedProper
     AcceleratedEffectProperty::Transform,
     AcceleratedEffectProperty::Translate,
     AcceleratedEffectProperty::Rotate,
-    AcceleratedEffectProperty::Scale
+    AcceleratedEffectProperty::Scale,
+    AcceleratedEffectProperty::OffsetAnchor,
+    AcceleratedEffectProperty::OffsetDistance,
+    AcceleratedEffectProperty::OffsetPath,
+    AcceleratedEffectProperty::OffsetPosition,
+    AcceleratedEffectProperty::OffsetRotate
 };
 
 struct CSSPropertiesBitSet {

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -32,6 +32,7 @@
 #include "LengthPoint.h"
 #include "OffsetRotation.h"
 #include "PathOperation.h"
+#include "RenderStyleConstants.h"
 #include "RotateTransformOperation.h"
 #include "ScaleTransformOperation.h"
 #include "TransformOperations.h"
@@ -42,11 +43,14 @@ namespace WebCore {
 
 class IntRect;
 class Path;
+class RenderLayerModelObject;
 class RenderStyle;
 
 struct AcceleratedEffectValues {
     float opacity { 1 };
+    std::optional<TransformOperationData> transformOperationData;
     LengthPoint transformOrigin { };
+    TransformBox transformBox { TransformBox::ContentBox };
     TransformOperations transform { };
     RefPtr<TransformOperation> translate;
     RefPtr<TransformOperation> scale;
@@ -63,11 +67,11 @@ struct AcceleratedEffectValues {
     {
     }
 
-    AcceleratedEffectValues(float opacity, LengthPoint&& transformOrigin, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, RefPtr<PathOperation>&& offsetPath, Length&& offsetDistance, LengthPoint&& offsetPosition, LengthPoint&& offsetAnchor, OffsetRotation&& offsetRotate, FilterOperations&& filter
-        , FilterOperations&& backdropFilter
-        )
+    AcceleratedEffectValues(float opacity, std::optional<TransformOperationData>&& transformOperationData, LengthPoint&& transformOrigin, TransformBox transformBox, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, RefPtr<PathOperation>&& offsetPath, Length&& offsetDistance, LengthPoint&& offsetPosition, LengthPoint&& offsetAnchor, OffsetRotation&& offsetRotate, FilterOperations&& filter, FilterOperations&& backdropFilter)
         : opacity(opacity)
+        , transformOperationData(WTFMove(transformOperationData))
         , transformOrigin(WTFMove(transformOrigin))
+        , transformBox(transformBox)
         , transform(WTFMove(transform))
         , translate(WTFMove(translate))
         , scale(WTFMove(scale))
@@ -85,7 +89,7 @@ struct AcceleratedEffectValues {
     WEBCORE_EXPORT AcceleratedEffectValues clone() const;
 
     WEBCORE_EXPORT AcceleratedEffectValues(const AcceleratedEffectValues&);
-    AcceleratedEffectValues(const RenderStyle&, const IntRect&);
+    AcceleratedEffectValues(const RenderStyle&, const IntRect&, const RenderLayerModelObject* = nullptr);
     AcceleratedEffectValues& operator=(const AcceleratedEffectValues&) = default;
 
     WEBCORE_EXPORT TransformationMatrix computedTransformationMatrix(const FloatRect&) const;

--- a/Source/WebCore/platform/animation/AnimationUtilities.h
+++ b/Source/WebCore/platform/animation/AnimationUtilities.h
@@ -52,6 +52,17 @@ struct BlendingContext {
     {
         return compositeOperation == CompositeOperation::Replace && iterationCompositeOperation == IterationCompositeOperation::Replace;
     }
+
+    void normalizeProgress()
+    {
+        // https://drafts.csswg.org/web-animations-1/#discrete
+        // The property's values cannot be meaningfully combined, thus it is not additive and
+        // interpolation swaps from Va to Vb at 50% (p=0.5).
+        if (isDiscrete) {
+            progress = progress < 0.5 ? 0 : 1;
+            compositeOperation = CompositeOperation::Replace;
+        }
+    }
 };
 
 inline int blend(int from, int to, const BlendingContext& context)

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -48,6 +48,7 @@ class MotionPath {
 public:
     static std::optional<MotionPathData> motionPathDataForRenderer(const RenderElement&);
     static bool needsUpdateAfterContainingBlockLayout(const PathOperation&);
+    static void applyMotionPathTransform(TransformationMatrix&, const TransformOperationData&, const FloatPoint& transformOrigin, const PathOperation&, const LengthPoint& offsetAnchor, const Length& offsetDistance, const OffsetRotation&, TransformBox);
     static void applyMotionPathTransform(const RenderStyle&, const TransformOperationData&, TransformationMatrix&);
     WEBCORE_EXPORT static std::optional<Path> computePathForBox(const BoxPathOperation&, const TransformOperationData&);
     static std::optional<Path> computePathForRay(const RayPathOperation&, const TransformOperationData&);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4050,10 +4050,11 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& anim
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 bool RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()
 {
-    if (!renderer().settings().acceleratedCompositedAnimationsEnabled())
+    auto& renderer = this->renderer();
+    if (!renderer.settings().acceleratedCompositedAnimationsEnabled())
         return false;
 
-    auto target = Styleable::fromRenderer(renderer());
+    auto target = Styleable::fromRenderer(renderer);
     ASSERT(target);
 
     bool hasInterpolatingEffect = false;
@@ -4061,7 +4062,7 @@ bool RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()
 
     auto baseValues = [&]() -> AcceleratedEffectValues {
         if (auto* style = target->lastStyleChangeEventStyle())
-            return { *style, borderBoxRect };
+            return { *style, borderBoxRect, &renderer };
         return { };
     }();
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5914,6 +5914,15 @@ enum class WebCore::StorageType : uint8_t {
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
+header: <WebCore/RenderStyleConstants.h>
+[CustomHeader] enum class WebCore::TransformBox : uint8_t {
+    StrokeBox,
+    ContentBox,
+    BorderBox,
+    FillBox,
+    ViewBox
+};
+
 class WebCore::OffsetRotation {
     bool hasAuto();
     float angle();
@@ -5964,7 +5973,9 @@ enum class WebCore::CompositeOperation : uint8_t {
 
 struct WebCore::AcceleratedEffectValues {
     float opacity;
+    std::optional<WebCore::TransformOperationData> transformOperationData;
     WebCore::LengthPoint transformOrigin;
+    WebCore::TransformBox transformBox;
     WebCore::TransformOperations transform;
     RefPtr<WebCore::TransformOperation> translate;
     RefPtr<WebCore::TransformOperation> scale;


### PR DESCRIPTION
#### 6e1a4631f5a8234497d346e367a31df3a29fcd23
<pre>
[threaded-animation-resolution] add support for CSS Motion Path properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=269503">https://bugs.webkit.org/show_bug.cgi?id=269503</a>

Reviewed by Dean Jackson.

With threaded animation resolution we can now add support for accelerated interpolation
of CSS Motion Path properties, the `offset` shorthand and its longhands.

To do this, we need to add two new members to `AcceleratedEffectValues`:

    std::optional&lt;TransformOperationData&gt; transformOperationData;
    TransformBox transformBox;

These two new members are required to be able to call into an alternate version of the
`MotionPath::applyMotionPathTransform()` method which works without a RenderStyle, but
rather using individual properties read from RenderStyle. We also adjust the `AcceleratedEffectValues`
constructor to take in a renderer to be able to set up those two new members.

This also required a small refactor related to `BlendingContext` since we need to be
able to adjust the context for discrete interpolation in the case of the `offset-rotate`
property which has an ASSERT() to check we only call its blending function for a discrete
interpolation if the context reflects that.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendStandardProperty):
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::blend):
(WebCore::AcceleratedEffect::apply):
(WebCore::AcceleratedEffect::animatesTransformRelatedProperty const):
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
(WebCore::AcceleratedEffectValues::clone const):
(WebCore::AcceleratedEffectValues::computedTransformationMatrix const):
* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/platform/animation/AnimationUtilities.h:
(WebCore::BlendingContext::normalizeProgress):
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::applyMotionPathTransform):
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/274803@main">https://commits.webkit.org/274803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d299aff9d9024dd1b28e6cccea7b76e981292b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42509 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33288 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15990 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13836 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13862 "layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36278 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39601 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37868 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16398 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16447 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5286 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->