### PR TITLE
Adopt more smart pointers in PluginView.cpp

### DIFF
--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -152,8 +152,8 @@ public:
 
     EventHandler& eventHandler() { return m_eventHandler; }
     const EventHandler& eventHandler() const { return m_eventHandler; }
-    CheckedRef<EventHandler> checkedEventHandler();
-    CheckedRef<const EventHandler> checkedEventHandler() const;
+    WEBCORE_EXPORT CheckedRef<EventHandler> checkedEventHandler();
+    WEBCORE_EXPORT CheckedRef<const EventHandler> checkedEventHandler() const;
 
     const FrameLoader& loader() const { return m_loader.get(); }
     FrameLoader& loader() { return m_loader.get(); }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -374,7 +374,7 @@ public:
     const DragController& dragController() const { return m_dragController.get(); }
 #endif
     FocusController& focusController() const { return *m_focusController; }
-    CheckedRef<FocusController> checkedFocusController() const;
+    WEBCORE_EXPORT CheckedRef<FocusController> checkedFocusController() const;
 #if ENABLE(CONTEXT_MENUS)
     ContextMenuController& contextMenuController() { return m_contextMenuController.get(); }
     const ContextMenuController& contextMenuController() const { return m_contextMenuController.get(); }

--- a/Source/WebCore/platform/Widget.cpp
+++ b/Source/WebCore/platform/Widget.cpp
@@ -46,6 +46,11 @@ ScrollView* Widget::parent() const
     return m_parent.get();
 }
 
+RefPtr<ScrollView> Widget::protectedParent() const
+{
+    return m_parent.get();
+}
+
 void Widget::setParent(ScrollView* view)
 {
     ASSERT(!view || !m_parent);

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -138,6 +138,7 @@ public:
     WEBCORE_EXPORT void removeFromParent();
     WEBCORE_EXPORT virtual void setParent(ScrollView* view);
     WEBCORE_EXPORT ScrollView* parent() const;
+    WEBCORE_EXPORT RefPtr<ScrollView> protectedParent() const;
     FrameView* root() const;
 
     virtual void handleEvent(Event&) { }

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -82,6 +82,7 @@ public:
     void layerHostingStrategyDidChange() final;
 
     WebCore::HTMLPlugInElement& pluginElement() const { return m_pluginElement; }
+    Ref<WebCore::HTMLPlugInElement> protectedPluginElement() const;
     const URL& mainResourceURL() const { return m_mainResourceURL; }
 
     void didBeginMagnificationGesture();
@@ -175,6 +176,8 @@ private:
     void setParentVisible(bool) final;
     bool transformsAffectFrameRect() final;
     void clipRectChanged() final;
+
+    RefPtr<WebPage> protectedWebPage() const;
 
     Ref<WebCore::HTMLPlugInElement> m_pluginElement;
     Ref<PDFPluginBase> m_plugin;


### PR DESCRIPTION
#### 2c6e63feae97417bfd99cafef71fbcd42a0241eb
<pre>
Adopt more smart pointers in PluginView.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=269502">https://bugs.webkit.org/show_bug.cgi?id=269502</a>

Reviewed by Tim Horton.

* Source/WebCore/platform/Widget.cpp:
(WebCore::Widget::protectedParent const):
* Source/WebCore/platform/Widget.h:
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::Stream::start):
(WebKit::PluginView::Stream::cancel):
(WebKit::PluginView::Stream::didReceiveResponse):
(WebKit::PluginView::Stream::didReceiveData):
(WebKit::PluginView::Stream::didFail):
(WebKit::PluginView::Stream::didFinishLoading):
(WebKit::PluginView::create):
(WebKit::PluginView::PluginView):
(WebKit::PluginView::~PluginView):
(WebKit::PluginView::webPage const):
(WebKit::PluginView::manualLoadDidReceiveResponse):
(WebKit::PluginView::manualLoadDidReceiveData):
(WebKit::PluginView::manualLoadDidFinishLoading):
(WebKit::PluginView::protectedPluginElement const):
(WebKit::PluginView::layerHostingStrategyDidChange):
(WebKit::PluginView::manualLoadDidFail):
(WebKit::PluginView::didBeginMagnificationGesture):
(WebKit::PluginView::didEndMagnificationGesture):
(WebKit::PluginView::setPageScaleFactor):
(WebKit::PluginView::pageScaleFactor const):
(WebKit::PluginView::webPageDestroyed):
(WebKit::PluginView::setDeviceScaleFactor):
(WebKit::PluginView::accessibilityAssociatedPluginParentForElement const):
(WebKit::PluginView::accessibilityObject const):
(WebKit::PluginView::initializePlugin):
(WebKit::PluginView::layerHostingStrategy const):
(WebKit::PluginView::platformLayer const):
(WebKit::PluginView::graphicsLayer const):
(WebKit::PluginView::scroll):
(WebKit::PluginView::scrollPositionForTesting const):
(WebKit::PluginView::horizontalScrollbar):
(WebKit::PluginView::verticalScrollbar):
(WebKit::PluginView::wantsWheelEvents):
(WebKit::PluginView::paint):
(WebKit::PluginView::countFindMatches):
(WebKit::PluginView::findString):
(WebKit::PluginView::selectionString const):
(WebKit::PluginView::handleEvent):
(WebKit::PluginView::handleEditingCommand):
(WebKit::PluginView::isEditingCommandEnabled):
(WebKit::PluginView::willDetachRenderer):
(WebKit::PluginView::usesAsyncScrolling const):
(WebKit::PluginView::scrollingNodeID const):
(WebKit::PluginView::didAttachScrollingNode):
(WebKit::PluginView::liveResourceData const):
(WebKit::PluginView::performDictionaryLookupAtLocation):
(WebKit::PluginView::notifyWidget):
(WebKit::PluginView::viewGeometryDidChange):
(WebKit::PluginView::viewVisibilityDidChange):
(WebKit::PluginView::clipRectInWindowCoordinates const):
(WebKit::PluginView::focusPluginElement):
(WebKit::PluginView::pendingResourceRequestTimerFired):
(WebKit::PluginView::shouldCreateTransientPaintingSnapshot const):
(WebKit::PluginView::isBeingDestroyed const):
(WebKit::PluginView::pdfDocumentForPrinting const):
(WebKit::PluginView::pdfDocumentSizeForPrinting const):
(WebKit::PluginView::accessibilityHitTest const):
(WebKit::PluginView::lookupTextAtLocation const):
(WebKit::PluginView::rectForSelectionInRootView const):
(WebKit::PluginView::contentScaleFactor const):
(WebKit::PluginView::isUsingUISideCompositing const):
(WebKit::PluginView::didChangeSettings):
(WebKit::PluginView::windowActivityDidChange):
(WebKit::PluginView::didSameDocumentNavigationForFrame):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/274794@main">https://commits.webkit.org/274794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92aadd494e2ed9938bc455fd03f50b27ce3ef354

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42441 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42610 "Failed to checkout and rebase branch from PR 24544") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16406 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/42610 "Failed to checkout and rebase branch from PR 24544") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16061 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/42610 "Failed to checkout and rebase branch from PR 24544") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43888 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8988 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->