### PR TITLE
[WebGPU] GPUAdapter::requestDevice rejects with a TypeError in cases which it should return an invalid device

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -31,6 +31,10 @@
 #include "JSGPUAdapterInfo.h"
 #include "JSGPUDevice.h"
 
+#include <wtf/HashSet.h>
+#include <wtf/HashTraits.h>
+#include <wtf/SortedArrayMap.h>
+
 namespace WebCore {
 
 String GPUAdapter::name() const
@@ -61,13 +65,53 @@ static WebGPU::DeviceDescriptor convertToBacking(const std::optional<GPUDeviceDe
     return options->convertToBacking();
 }
 
+static GPUFeatureName convertFeatureNameToEnum(const String& stringValue)
+{
+    static constexpr std::pair<ComparableASCIILiteral, GPUFeatureName> mappings[] = {
+        { "bgra8unorm-storage", GPUFeatureName::Bgra8unormStorage },
+        { "depth-clip-control", GPUFeatureName::DepthClipControl },
+        { "depth32float-stencil8", GPUFeatureName::Depth32floatStencil8 },
+        { "float32-filterable", GPUFeatureName::Float32Filterable },
+        { "indirect-first-instance", GPUFeatureName::IndirectFirstInstance },
+        { "rg11b10ufloat-renderable", GPUFeatureName::Rg11b10ufloatRenderable },
+        { "shader-f16", GPUFeatureName::ShaderF16 },
+        { "texture-compression-astc", GPUFeatureName::TextureCompressionAstc },
+        { "texture-compression-bc", GPUFeatureName::TextureCompressionBc },
+        { "texture-compression-etc2", GPUFeatureName::TextureCompressionEtc2 },
+        { "timestamp-query", GPUFeatureName::TimestampQuery },
+    };
+    static constexpr SortedArrayMap enumerationMapping { mappings };
+    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
+        return *enumerationValue;
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+static bool isSubset(const Vector<GPUFeatureName>& expectedSubset, const Vector<String>& expectedSuperset)
+{
+    HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> expectedSupersetHashSet;
+    for (auto& featureName : expectedSuperset)
+        expectedSupersetHashSet.add(static_cast<uint32_t>(convertFeatureNameToEnum(featureName)));
+
+    for (auto& featureName : expectedSubset) {
+        if (!expectedSupersetHashSet.contains(static_cast<uint32_t>(featureName)))
+            return false;
+    }
+
+    return true;
+}
+
 void GPUAdapter::requestDevice(ScriptExecutionContext& scriptExecutionContext, const std::optional<GPUDeviceDescriptor>& deviceDescriptor, RequestDevicePromise&& promise)
 {
+    auto& existingFeatures = m_backing->features().features();
+    if (deviceDescriptor && !isSubset(deviceDescriptor->requiredFeatures, existingFeatures)) {
+        promise.reject(Exception(ExceptionCode::TypeError));
+        return;
+    }
+
     m_backing->requestDevice(convertToBacking(deviceDescriptor), [deviceDescriptor, promise = WTFMove(promise), scriptExecutionContextRef = Ref { scriptExecutionContext }](RefPtr<WebGPU::Device>&& device) mutable {
         if (!device.get())
             promise.reject(Exception(ExceptionCode::OperationError));
-        else if (deviceDescriptor && deviceDescriptor->requiredFeatures.size() > device->features().features().size())
-            promise.reject(Exception(ExceptionCode::TypeError));
         else {
             Ref<GPUDevice> gpuDevice = GPUDevice::create(scriptExecutionContextRef.ptr(), device.releaseNonNull());
             gpuDevice->suspendIfNeeded();


### PR DESCRIPTION
#### 8f845a8c3b622a8678d973ba94443abab944cae1
<pre>
[WebGPU] GPUAdapter::requestDevice rejects with a TypeError in cases which it should return an invalid device
<a href="https://bugs.webkit.org/show_bug.cgi?id=269444">https://bugs.webkit.org/show_bug.cgi?id=269444</a>
&lt;radar://122996101&gt;

Reviewed by Tadeu Zagallo.

Features should be validated against the Adapter&apos;s features,
not the returned device&apos;s features.

* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::convertFeatureNameToEnum):
(WebCore::isSubset):
(WebCore::GPUAdapter::requestDevice):

Canonical link: <a href="https://commits.webkit.org/274862@main">https://commits.webkit.org/274862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43c6c27fe3ab34a34605cc7552a751684adc0210

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33290 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13845 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43793 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33423 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39602 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12154 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16404 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9027 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->