### PR TITLE
[UnifiedPDF] Add support for the "Automatically Resize" option.

### DIFF
--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -553,6 +553,11 @@ String contextMenuItemPDFActualSize()
     return WEB_UI_STRING_WITH_MNEMONIC("Actual Size", "_Actual Size", "Actual Size context menu item");
 }
 
+String contextMenuItemPDFAutoSize()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Automatically Resize", "_Automatically Resize", "Automatically Resize context menu item");
+}
+
 String contextMenuItemPDFNextPage()
 {
     return WEB_UI_STRING_WITH_MNEMONIC("Next Page", "_Next Page", "Next Page context menu item");
@@ -564,13 +569,6 @@ String contextMenuItemPDFPreviousPage()
 }
 #endif
 
-#if ENABLE(PDFJS)
-String contextMenuItemPDFAutoSize()
-{
-    return WEB_UI_STRING_WITH_MNEMONIC("Automatically Resize", "_Automatically Resize", "Automatically Resize context menu item");
-}
-
-#endif
 #endif // ENABLE(CONTEXT_MENUS)
 
 #if !PLATFORM(COCOA)

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -190,9 +190,7 @@ namespace WebCore {
     WEBCORE_EXPORT String contextMenuItemPDFActualSize();
     WEBCORE_EXPORT String contextMenuItemPDFNextPage();
     WEBCORE_EXPORT String contextMenuItemPDFPreviousPage();
-#endif
-#if ENABLE(PDFJS)
-    String contextMenuItemPDFAutoSize();
+    WEBCORE_EXPORT String contextMenuItemPDFAutoSize();
 #endif
 #endif // ENABLE(CONTEXT_MENU)
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -52,6 +52,8 @@ public:
         TwoUpContinuous,
     };
 
+    enum class ShouldUpdateAutoSizeScale : bool { No, Yes };
+
     PDFDocumentLayout();
     ~PDFDocumentLayout();
 
@@ -83,6 +85,9 @@ public:
     void setDisplayMode(DisplayMode displayMode) { m_displayMode = displayMode; }
     DisplayMode displayMode() const { return m_displayMode; }
 
+    void setShouldUpdateAutoSizeScale(ShouldUpdateAutoSizeScale autoSizeState) { m_autoSizeState = autoSizeState; }
+    ShouldUpdateAutoSizeScale shouldUpdateAutoSizeScale() const { return m_autoSizeState; }
+
 private:
     void layoutPages(float availableWidth, float maxRowWidth);
 
@@ -102,6 +107,7 @@ private:
     WebCore::FloatRect m_documentBounds;
     float m_scale { 1 };
     DisplayMode m_displayMode { DisplayMode::Continuous };
+    ShouldUpdateAutoSizeScale m_autoSizeState { ShouldUpdateAutoSizeScale::Yes };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -160,7 +160,8 @@ void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWid
     currentYOffset -= pageMargin.height();
     currentYOffset += documentMargin.height();
 
-    m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
+    if (m_autoSizeState == ShouldUpdateAutoSizeScale::Yes)
+        m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
     m_documentBounds = FloatRect { 0, 0, maxRowWidth, currentYOffset };
 
     LOG_WITH_STREAM(PDF, stream << "PDFDocumentLayout::layoutSingleColumn - document bounds " << m_documentBounds << " scale " << m_scale);
@@ -217,7 +218,8 @@ void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidt
     currentYOffset -= pageMargin.height();
     currentYOffset += documentMargin.height();
 
-    m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
+    if (m_autoSizeState == ShouldUpdateAutoSizeScale::Yes)
+        m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
     m_documentBounds = FloatRect { 0, 0, maxRowWidth, currentYOffset };
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -205,6 +205,7 @@ private:
 #if ENABLE(CONTEXT_MENUS)
     enum class ContextMenuItemTag : int8_t {
         Invalid = -1,
+        AutoSize,
         WebSearch,
         DictionaryLookup,
         Copy,
@@ -346,6 +347,7 @@ private:
 #if ENABLE(PDF_HUD)
     void zoomIn() final;
     void zoomOut() final;
+    void resetZoom();
 #endif
 
     std::optional<PDFDocumentLayout::PageIndex> pageIndexWithHoveredAnnotation() const;


### PR DESCRIPTION
#### f2eb34598ea0a1e2e06f6716c724e22e9d228cf7
<pre>
[UnifiedPDF] Add support for the &quot;Automatically Resize&quot; option.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269510">https://bugs.webkit.org/show_bug.cgi?id=269510</a>
<a href="https://rdar.apple.com/122208120">rdar://122208120</a>

Reviewed by Tim Horton.

The automatic resize feature controls whether or not the document
fitting scale is changed in response to the plugin&apos;s available width
changing. This is on by default but is disabled whenever any sort of
zooming occurs. We can keep track of this by adding some extra state to
PDFDocumentLayout that keeps track of whether the document fitting scale
should be adjusted during the layout of the document.

Zooming will update this state to disable the behavior. If the behavior
is disabled but the &quot;Automatically Resize,&quot; context menu item is
selected, then the behavior will be enabled again, the zoom will get
reset to its initial value, and the document will need get laid out
again to compute the new document fitting scale.

* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemPDFAutoSize):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::setShouldUpdateAutoSizeScale):
(WebKit::PDFDocumentLayout::shouldUpdateAutoSizeScale const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::layoutTwoUpColumn):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::toContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::titleForContextMenuItemTag const):
(WebKit::UnifiedPDFPlugin::contextMenuItem const):
(WebKit::UnifiedPDFPlugin::scaleContextMenuItems const):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):
(WebKit::UnifiedPDFPlugin::zoomIn):
(WebKit::UnifiedPDFPlugin::zoomOut):
(WebKit::UnifiedPDFPlugin::resetZoom):

Canonical link: <a href="https://commits.webkit.org/274800@main">https://commits.webkit.org/274800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8300eca3152998707e85ce466583a2bfec2fb54e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42605 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16401 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34600 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43883 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36337 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16494 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8989 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->