### PR TITLE
Drop insecure contexts warning from getGamepads()

### DIFF
--- a/LayoutTests/http/tests/misc/gamepads-insecure-expected.txt
+++ b/LayoutTests/http/tests/misc/gamepads-insecure-expected.txt
@@ -1,2 +1,1 @@
-CONSOLE MESSAGE: Navigator.getGamepads() will be removed from insecure contexts in a future release
-Test that accessing navigator.getGamepads from an insecure context logs a warning
+Test that calling navigator.getGamepads no longer generates a console message in insecure contexts

--- a/LayoutTests/http/tests/misc/gamepads-insecure.html
+++ b/LayoutTests/http/tests/misc/gamepads-insecure.html
@@ -1,5 +1,5 @@
 <body>
-<p>Test that accessing navigator.getGamepads from an insecure context logs a warning</p>
+<p>Test that calling navigator.getGamepads no longer generates a console message in insecure contexts</p>
 <script>
 if (window.testRunner)
     testRunner.dumpAsText();

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -83,14 +83,6 @@ ExceptionOr<const Vector<RefPtr<Gamepad>>&> NavigatorGamepad::getGamepads(Naviga
         return { emptyGamepads.get() };
     }
 
-    if (!document->isSecureContext()) {
-        static std::once_flag onceFlag;
-        std::call_once(onceFlag, [document] {
-            document->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "Navigator.getGamepads() will be removed from insecure contexts in a future release"_s);
-        });
-
-    }
-
     if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Gamepad, *document, LogFeaturePolicyFailure::Yes))
         return Exception { ExceptionCode::SecurityError, "Third-party iframes are not allowed to call getGamepads() unless explicitly allowed via Feature-Policy (gamepad)"_s };
 


### PR DESCRIPTION
#### 5300e773c1e3437248005d2109c89ecc2a7b2bae
<pre>
Drop insecure contexts warning from getGamepads()
<a href="https://bugs.webkit.org/show_bug.cgi?id=269514">https://bugs.webkit.org/show_bug.cgi?id=269514</a>
<a href="https://rdar.apple.com/123039555">rdar://123039555</a>

Reviewed by Chris Dumez.

Removed console warning about restricting to secure contexts.
Chrome is also removed the warning.
Firefox is removing the restriction.
<a href="https://github.com/w3c/gamepad/issues/145#issuecomment-1934211616">https://github.com/w3c/gamepad/issues/145#issuecomment-1934211616</a>

Related pull request on the W3C gamepad spec:
<a href="https://github.com/w3c/gamepad/pull/194">https://github.com/w3c/gamepad/pull/194</a>

* LayoutTests/http/tests/misc/gamepads-insecure-expected.txt:
* LayoutTests/http/tests/misc/gamepads-insecure.html:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:

Canonical link: <a href="https://commits.webkit.org/274962@main">https://commits.webkit.org/274962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2de8eb835ba6430a82a6bb468410fde8cf2d842f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33319 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39634 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37902 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34819 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9079 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->