### PR TITLE
Unreviewed, reverting 274749@main

### DIFF
--- a/Tools/Scripts/webkitpy/common/find_files.py
+++ b/Tools/Scripts/webkitpy/common/find_files.py
@@ -44,7 +44,6 @@ will be included into the result if the callback returns True.
 The callback has to take three arguments: filesystem, dirname and filename."""
 
 import itertools
-import re
 
 
 def find(filesystem, base_dir, paths=None, skipped_directories=None, file_filter=None, directory_sort_key=None):
@@ -77,27 +76,15 @@ def _normalized_find(filesystem, paths, skipped_directories, file_filter, direct
     sort_fn = (lambda lst: sorted(lst, key=directory_sort_key)) if directory_sort_key else (lambda lst: lst[:])
 
     def sorted_paths_generator(path, function):
-        m = re.search(
-            "^(?P<path>[^?#]*)(?P<variant>(?P<query>\\?[^#]*)?(?P<fragment>#.*)?)$",
-            path,
-        )
-        if not m.group("variant"):
-            return sort_fn(function(m.group("path")))
-
+        base_path, separator, variant = path.partition('?')
+        if not separator:
+            return sort_fn(function(base_path))
         # This isn't perfect, you won't be able glob the variant parts of the test name,
-        # but this is ultimately a design flaw stemming from a layout test not being a
-        # file.
-        result = [
-            "{}{}".format(part, m.group("variant"))
-            for part in function(m.group("path"))
-        ]
+        # but this is ultimately a design flaw stemming from a layout test not being a file
+        result = ['{}{}{}'.format(part, separator, variant) for part in function(base_path)]
         if result:
             return sort_fn(result)
-
-        # If we haven't matched anything, we might have a question-mark in path which we
-        # actually want to match as a glob, rather than treat it as a variant.
         return sort_fn(function(path))
-
 
     paths_to_walk = itertools.chain(*(sorted_paths_generator(path, filesystem.glob) for path in paths))
     all_files = itertools.chain(*(sorted_paths_generator(

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
@@ -399,9 +399,6 @@ class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
 <meta name="variant" content="?#">
 <meta name="variant" content="?1#a">
 <meta name="variant" content="nonsense">
-<meta name=variant content="?only open()ed, not aborted">
-<meta name=variant content="?aborted immediately after send()">
-<meta name=variant content="?call abort() after TIME_NORMAL_LOAD">
         """)
         tests_found = [t.test_path for t in finder.find_tests_by_path(find_paths)]
         self.assertEqual(
@@ -412,47 +409,9 @@ class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
                 "web-platform-tests/variant_test.html#a-m",
                 "web-platform-tests/variant_test.html#n-z",
                 "web-platform-tests/variant_test.html?1#a",
-                "web-platform-tests/variant_test.html?only%20open()ed,%20not%20aborted",
-                "web-platform-tests/variant_test.html?aborted%20immediately%20after%20send()",
-                "web-platform-tests/variant_test.html?call%20abort()%20after%20TIME_NORMAL_LOAD",
             ],
             tests_found,
         )
-
-    def test_find_template_variants_meta_passed_variants(self):
-        finder = self.finder
-
-        path = finder._port.layout_tests_dir() + "/web-platform-tests/variant_test.html"
-
-        find_paths = [
-            path + "?a b",
-            path + "?c%20d",
-            path + "#m n",
-            path + "#o%20p",
-            path + "?e%20f#q%20r",
-        ]
-
-        finder._filesystem.maybe_make_directory(finder._filesystem.dirname(path))
-        finder._filesystem.write_text_file(
-            path,
-            """<!doctype html>
-<meta name=variant content="?a b">
-<meta name=variant content="?c%20d">
-<meta name=variant content="#m n">
-<meta name=variant content="#o%20p">
-<meta name=variant content="?e f#q r">
-        """,
-        )
-        tests_found = [t.test_path for t in finder.find_tests_by_path(find_paths)]
-        self.assertEqual(
-            ['web-platform-tests/variant_test.html?a%20b',
-             'web-platform-tests/variant_test.html?c%20d',
-             'web-platform-tests/variant_test.html#m%20n',
-             'web-platform-tests/variant_test.html#o%20p',
-             'web-platform-tests/variant_test.html?e%20f#q%20r'],
-            tests_found,
-        )
-
 
     def test_find_template_variants_comment(self):
         find_paths = ["web-platform-tests"]


### PR DESCRIPTION
#### f31b38a83be6e93fbe5465e275a512670f021b6e
<pre>
Unreviewed, reverting 274749@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=269517">https://bugs.webkit.org/show_bug.cgi?id=269517</a>
<a href="https://rdar.apple.com/123040615">rdar://123040615</a>

Changed expectation paths for WPT variants

Reverted change:

TestExpectations cannot represent variants with spaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=269484">https://bugs.webkit.org/show_bug.cgi?id=269484</a>
<a href="https://rdar.apple.com/123026314">rdar://123026314</a>
<a href="https://commits.webkit.org/274749@main">https://commits.webkit.org/274749@main</a>

Canonical link: <a href="https://commits.webkit.org/274767@main">https://commits.webkit.org/274767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3618b9560ba62e5394dc82839694d07d384a55d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39982 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/18993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/42289 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/21901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/16323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40556 "Failed to checkout and rebase branch from PR 24551") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/21901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/39850 "Failed to checkout and rebase branch from PR 24551") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/21901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33435 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/21901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39608 "Build is in progress. Recent messages:") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/16323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5269 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->