### PR TITLE
Maps sometimes crashes in -[NSPopover showRelativeToRect:ofView:preferredEdge:] when presenting a date picker

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
@@ -228,6 +228,10 @@
     [self _scaleDownToFitHeightIfNeeded];
 }
 
+#if !PLATFORM(MACCATALYST)
+// FIXME: This platform conditional works around the fact that -isBeingPresented is sometimes NO in Catalyst, when presenting
+// a popover. This may cause a crash in the case where this size transition occurs while the popover is appearing.
+
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
@@ -235,6 +239,8 @@
     if (!self.isBeingPresented && !self.isBeingDismissed)
         [self dismissDatePickerAnimated:NO];
 }
+
+#endif // !PLATFORM(MACCATALYST)
 
 - (void)_scaleDownToFitHeightIfNeeded
 {


### PR DESCRIPTION
#### 6579616b4bb7adc583d862b1fe09586128f9f32e
<pre>
Maps sometimes crashes in -[NSPopover showRelativeToRect:ofView:preferredEdge:] when presenting a date picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=269513">https://bugs.webkit.org/show_bug.cgi?id=269513</a>
<a href="https://rdar.apple.com/121850106">rdar://121850106</a>

Reviewed by Aditya Keerthi.

The changes in <a href="https://commits.webkit.org/272922@main">https://commits.webkit.org/272922@main</a> mitigated cases where rotating on iOS caused the date picker to
lay out incorrectly. In previous iOS releases, this used to cause the date picker to dismiss altogether, so this change
restored that behavior by adding logic to immediately dismiss the date picker when the size of the popover container is
changing outside of the scope of presentation or dismissal (i.e. during rotation).

However, on Catalyst, the `-isBeingPresented` flag is `NO` despite being in the middle of popover presentation, so we
end up immediately dismissing the popover while it&apos;s in the middle of presenting, which causes a crash in AppKit.
<a href="https://rdar.apple.com/123039861">rdar://123039861</a> tracks the that the flag returns NO during presentation; for now, we&apos;ll address this by avoiding this
codepath altogether on Catalyst, since it&apos;s only intended to kick in during device rotation on iOS anyways.

* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:

Canonical link: <a href="https://commits.webkit.org/274782@main">https://commits.webkit.org/274782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab09c2f5249c6f9ff657584c20e73b02c27c63f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42528 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16324 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13840 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36285 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16417 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8975 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->