### PR TITLE
Preserve sign of NaN operands in fsub{32,64}

### DIFF
--- a/JSTests/wasm/stress/fsub-nan-copysign.js
+++ b/JSTests/wasm/stress/fsub-nan-copysign.js
@@ -1,0 +1,38 @@
+import * as wabt from "../wabt-wrapper.js";
+import * as assert from '../assert.js';
+
+let wat = `
+(module
+    (type (func (param f64) (result i32)))
+    (func (type 0) (local f64) (local f64) (local f64) (local i32)
+        (local.set 1 (local.get 0))
+        (local.set 2 (local.get 0))
+        (local.set 3 (local.get 0))
+        ;; Do the sub-operation with local/const, const/local, and const/const params
+        (local.set 0 (f64.sub (local.get 1) (f64.const nan)))
+        (local.set 1 (f64.copysign (local.get 1) (local.get 0)))
+        (local.set 0 (f64.sub (f64.const nan) (local.get 2)))
+        (local.set 2 (f64.copysign (local.get 2) (local.get 0)))
+        (local.set 0 (f64.sub (f64.const 0.0) (f64.const nan)))
+        (local.set 3 (f64.copysign (local.get 3) (local.get 0)))
+        ;; If any one of the results is negative, then fail: return a positive integer
+        ;; Otherwise return 0 for success
+        (local.set 4 (f64.lt (local.get 1) (f64.const 0)))
+        (local.set 4 (i32.add (local.get 4) (f64.lt (local.get 1) (f64.const 0))))
+        (local.set 4 (i32.add (local.get 4) (f64.lt (local.get 2) (f64.const 0))))
+        (local.set 4 (i32.add (local.get 4) (f64.lt (local.get 3) (f64.const 0))))
+        (local.get 4)
+    )
+  (export "poc" (func 0))
+)
+`
+
+async function test() {
+    const instance = await wabt.instantiate(wat, {}, {});
+
+    for (let i = 0; i < 50; i++) {
+        assert.eq(instance.exports.poc(1), 0);
+    }
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -60,6 +60,7 @@
 #include "WasmThunks.h"
 #include "WasmTypeDefinition.h"
 #include <bit>
+#include <cmath>
 #include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
 #include <wtf/HashFunctions.h>
@@ -1717,8 +1718,10 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF32Sub(Value lhs, Value rhs, Value& 
         ),
         BLOCK(
             if (rhs.isConst()) {
-                // Add a negative if rhs is a constant.
-                emitMoveConst(Value::fromF32(-rhs.asF32()), Location::fromFPR(wasmScratchFPR));
+                // If rhs is a constant, it will be expressed as a positive
+                // value and so needs to be negated unless it is NaN
+                auto floatVal = std::isnan(rhs.asF32()) ? rhs.asF32() : -rhs.asF32();
+                emitMoveConst(Value::fromF32(floatVal), Location::fromFPR(wasmScratchFPR));
                 m_jit.addFloat(lhsLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
             } else {
                 emitMoveConst(lhs, Location::fromFPR(wasmScratchFPR));
@@ -1738,8 +1741,10 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addF64Sub(Value lhs, Value rhs, Value& 
         ),
         BLOCK(
             if (rhs.isConst()) {
-                // Add a negative if rhs is a constant.
-                emitMoveConst(Value::fromF64(-rhs.asF64()), Location::fromFPR(wasmScratchFPR));
+                // If rhs is a constant, it will be expressed as a positive
+                // value and so needs to be negated unless it is NaN
+                auto floatVal = std::isnan(rhs.asF64()) ? rhs.asF64() : -rhs.asF64();
+                emitMoveConst(Value::fromF64(floatVal), Location::fromFPR(wasmScratchFPR));
                 m_jit.addDouble(lhsLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
             } else {
                 emitMoveConst(lhs, Location::fromFPR(wasmScratchFPR));


### PR DESCRIPTION
#### 5f1ac6454783b0c77f1dc789965e7a097e948771
<pre>
Preserve sign of NaN operands in fsub{32,64}
<a href="https://bugs.webkit.org/show_bug.cgi?id=269509">https://bugs.webkit.org/show_bug.cgi?id=269509</a>
<a href="https://rdar.apple.com/120780768">rdar://120780768</a>

Reviewed by Justin Michaud and Yusuke Suzuki.

Negating a NaN operand for fsub is incorrect, as IEEE defines the result
of an arithmetic operation with a NaN parameter as the NaN itself
(without modification). This is observable when a copysign operation is
done on the result, as copysign itself is exempt from that restriction
and can thus detect the improper negation.
By checking whether the operand is a NaN before negating we avoid this
issue.

* JSTests/wasm/stress/fsub-nan-copysign.js: Added.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Sub):

Canonical link: <a href="https://commits.webkit.org/274910@main">https://commits.webkit.org/274910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e365a6c142c4808c81f34c9cd0fd6766ce2e6ea0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33442 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14015 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44093 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33723 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39777 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39896 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38056 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16704 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46905 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9054 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16753 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9654 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->