### PR TITLE
Add timer for repainting document markers.

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -113,6 +113,7 @@ private:
     OptionSet<DocumentMarker::Type> removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarker::Type>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction = nullptr);
 
     void fadeAnimationTimerFired();
+    void unifiedTextReplacementAnimationTimerFired();
 
     Ref<Document> protectedDocument() const;
 
@@ -122,6 +123,7 @@ private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 
     Timer m_fadeAnimationTimer;
+    Timer m_unifiedTextReplacementAnimationTimer;
 };
 
 WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarker::Type, const DocumentMarker::Data& = { });

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -170,6 +170,7 @@ public:
     static constexpr auto green = SRGBA<uint8_t> { 0, 255, 0 };
     static constexpr auto darkGreen = SRGBA<uint8_t> { 0, 128, 0 };
     static constexpr auto orange = SRGBA<uint8_t> { 255, 128, 0 };
+    static constexpr auto purple = SRGBA<uint8_t> { 128, 0, 255 };
 
     static bool isBlackColor(const Color&);
     static bool isWhiteColor(const Color&);

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -215,7 +215,7 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
             return MarkedText::Type::Correction;
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
         case DocumentMarker::Type::UnifiedTextReplacement:
-            return MarkedText::Type::Correction;
+            return MarkedText::Type::UnifiedTextReplacement;
 #endif
         case DocumentMarker::Type::TextMatch:
             return MarkedText::Type::TextMatch;

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -43,6 +43,9 @@ struct MarkedText : public CanMakeCheckedPtr {
         Unmarked,
         GrammarError,
         Correction,
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+        UnifiedTextReplacement,
+#endif
         SpellingError,
         TextMatch,
         DictationAlternatives,


### PR DESCRIPTION
#### 69228c8b8bcb44e81a68ed64e2fd867503d9594c
<pre>
Add timer for repainting document markers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269529">https://bugs.webkit.org/show_bug.cgi?id=269529</a>
<a href="https://rdar.apple.com/123048192">rdar://123048192</a>

Reviewed by Aditya Keerthi.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::DocumentMarkerController):
(WebCore::DocumentMarkerController::detach):
(WebCore::DocumentMarkerController::addMarker):
(WebCore::DocumentMarkerController::removeMarkers):
(WebCore::DocumentMarkerController::unifiedTextReplacementAnimationTimerFired):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/platform/graphics/Color.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::drawUnifiedTextReplacementUnderline):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarker):

Canonical link: <a href="https://commits.webkit.org/274914@main">https://commits.webkit.org/274914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/869950c73eb8579b7d595d0291b7463c165e42bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42830 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36374 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33451 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39788 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12371 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38065 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16719 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9057 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->