### PR TITLE
[JSC] Add more profiling macro invocations to libPAS

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_result.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_result.c
@@ -34,6 +34,8 @@ pas_allocation_result pas_allocation_result_zero_large_slow(pas_allocation_resul
 {
     size_t page_size;
 
+    PAS_PROFILE(ZERO_ALLOCATION_RESULT, result.begin);
+
     page_size = pas_page_malloc_alignment();
     if (pas_is_aligned(size, page_size) && pas_is_aligned(result.begin, page_size))
         pas_page_malloc_zero_fill((void*)result.begin, size);

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
@@ -93,7 +93,10 @@ pas_allocation_result_zero(pas_allocation_result result,
     if (size >= (1ULL << PAS_VA_BASED_ZERO_MEMORY_SHIFT))
         return pas_allocation_result_zero_large_slow(result, size);
 
-    pas_zero_memory((void*)result.begin, size);
+    PAS_PROFILE(ZERO_ALLOCATION_RESULT, result.begin);
+    void* memory = (void*)result.begin;
+    pas_zero_memory(memory, size);
+
     return pas_allocation_result_create_success_with_zero_mode(result.begin, pas_zero_mode_is_all_zero);
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
@@ -41,6 +41,7 @@ bool pas_try_deallocate_known_large(void* ptr,
     uintptr_t begin;
 
     begin = (uintptr_t)ptr;
+    PAS_PROFILE(TRY_DEALLOCATE_KNOWN_LARGE, begin);
     
     pas_heap_lock_lock();
     

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -188,9 +188,13 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate(void* ptr,
                                                  pas_deallocation_mode deallocation_mode)
 {
     static const bool verbose = false;
-    
-    PAS_PROFILE(ptr, TRY_DEALLOCATE);
+
     pas_thread_local_cache* thread_local_cache;
+    uintptr_t begin;
+
+    begin = (uintptr_t)ptr;
+    PAS_PROFILE(TRY_DEALLOCATE, begin);
+    ptr = (void*)begin;
 
     if (verbose)
         pas_log("try_deallocate for %p\n", ptr);

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h
@@ -132,6 +132,7 @@ static inline pas_fast_megapage_kind pas_fast_megapage_table_get(
     pas_fast_megapage_table* table,
     uintptr_t begin)
 {
+    PAS_PROFILE(MEGAPAGE_GET, begin);
     return pas_fast_megapage_table_get_by_index(table, begin >> PAS_FAST_MEGAPAGE_SHIFT);
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_free_granules.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_free_granules.c
@@ -41,10 +41,15 @@ void pas_free_granules_compute_and_mark_decommitted(pas_free_granules* free_gran
     static const bool verbose = false;
     
     size_t granule_index;
+    uintptr_t granule_begin;
     
     PAS_ASSERT(num_granules >= 2); /* If there is only one granule then we don't have use counts. */
     PAS_ASSERT(num_granules <= PAS_MAX_GRANULES);
     
+    granule_begin = (uintptr_t)free_granules;
+    PAS_PROFILE(ZERO_FREE_GRANULES, granule_begin);
+    free_granules = (pas_free_granules*)granule_begin;
+
     pas_zero_memory(free_granules, sizeof(pas_free_granules));
 
     for (granule_index = num_granules; granule_index--;) {

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -48,6 +48,7 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
 {
     static const bool verbose = false;
     pas_heap* heap;
+    uintptr_t begin;
 
     if (verbose) {
         pas_log("Creating heap for size = %lu, alignment = %lu.\n",
@@ -61,6 +62,11 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
                               config->get_type_alignment(heap_ref->type)));
     
     heap = pas_immortal_heap_allocate(sizeof(pas_heap), "pas_heap", pas_object_allocation);
+
+    begin = (uintptr_t)heap;
+    PAS_PROFILE(CREATE_HEAP, begin);
+    heap = (void*)begin;
+
     pas_zero_memory(heap, sizeof(pas_heap));
     heap->type = heap_ref->type;
     pas_segregated_heap_construct(

--- a/Source/bmalloc/libpas/src/libpas/pas_large_map.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_map.c
@@ -42,6 +42,8 @@ pas_tiny_large_map_second_level_hashtable_in_flux_stash pas_tiny_large_map_secon
 
 pas_large_map_entry pas_large_map_find(uintptr_t begin)
 {
+    PAS_PROFILE(LARGE_MAP_FIND, begin);
+
     uintptr_t tiny_base;
     pas_first_level_tiny_large_map_entry* first_level_tiny_entry;
     pas_small_large_map_entry* small_entry;
@@ -75,6 +77,8 @@ void pas_large_map_add(pas_large_map_entry entry)
     static const bool verbose = false;
     
     pas_heap_lock_assert_held();
+
+    PAS_PROFILE(LARGE_MAP_ADD, entry.begin, entry.end);
 
     if (verbose)
         pas_log("adding %p...%p, heap = %p.\n", (void*)entry.begin, (void*)entry.end, entry.heap);
@@ -151,6 +155,8 @@ pas_large_map_entry pas_large_map_take(uintptr_t begin)
     uintptr_t tiny_base;
     pas_first_level_tiny_large_map_entry* first_level_tiny_entry;
     pas_small_large_map_entry small_entry;
+
+    PAS_PROFILE(LARGE_MAP_TAKE, begin);
 
     pas_heap_lock_assert_held();
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
@@ -67,8 +67,9 @@ typedef struct {
         \
         switch (arguments.header_placement_mode) { \
         case pas_page_header_at_head_of_page: { \
-            PAS_PROFILE(boundary, PAGE_HEADER); \
-            return (pas_page_base*)boundary; \
+            uintptr_t ptr = (uintptr_t)boundary; \
+            PAS_PROFILE(PAGE_HEADER, ptr); \
+            return (pas_page_base*)ptr; \
         } \
         \
         case pas_page_header_in_table: { \

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h
@@ -49,8 +49,9 @@ typedef struct {
         \
         switch (name ## _header_placement_mode) { \
         case pas_page_header_at_head_of_page: { \
-            PAS_PROFILE(boundary, PAGE_HEADER); \
-            return (pas_page_base*)boundary; \
+            uintptr_t ptr = (uintptr_t)boundary; \
+            PAS_PROFILE(PAGE_HEADER, ptr); \
+            return (pas_page_base*)ptr; \
         } \
         \
         case pas_page_header_in_table: { \

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -131,6 +131,10 @@ pas_page_malloc_try_allocate_without_deallocating_padding(
                       do that explicitly. */
         return result;
     }
+
+    uintptr_t pages_begin = (uintptr_t)mmap_result;
+    PAS_PROFILE(PAGE_ALLOCATION, pages_begin);
+    mmap_result = (void*)pages_begin;
     
     mapped = (char*)mmap_result;
     mapped_end = mapped + mapped_size;
@@ -287,8 +291,10 @@ void pas_page_malloc_deallocate(void* ptr, size_t size)
     uintptr_t ptr_as_int;
     
     ptr_as_int = (uintptr_t)ptr;
+    PAS_PROFILE(PAGE_DEALLOCATION, ptr_as_int);
     PAS_ASSERT(pas_is_aligned(ptr_as_int, pas_page_malloc_alignment()));
     PAS_ASSERT(pas_is_aligned(size, pas_page_malloc_alignment()));
+    ptr = (void*)ptr_as_int;
     
     if (!size)
         return;

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -199,8 +199,9 @@ pas_try_reallocate(void* old_ptr,
                    void* allocate_callback_arg)
 {
     uintptr_t begin;
-    PAS_PROFILE(old_ptr, REALLOCATE);
     begin = (uintptr_t)old_ptr;
+    PAS_PROFILE(TRY_REALLOCATE, begin);
+    old_ptr = (void*)begin;
 
     switch (config.fast_megapage_kind_func(begin)) {
     case pas_small_exclusive_segregated_fast_megapage_kind: {

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -183,7 +183,6 @@ PAS_BEGIN_EXTERN_C;
 
 static PAS_ALWAYS_INLINE void pas_zero_memory(void* memory, size_t size)
 {
-    PAS_PROFILE(memory, ZERO_MEMORY);
     memset(memory, 0, size);
 }
 


### PR DESCRIPTION
#### f2c960faab0bd7ec1f387e1535cb346d7e099aa4
<pre>
[JSC] Add more profiling macro invocations to libPAS
<a href="https://bugs.webkit.org/show_bug.cgi?id=269528">https://bugs.webkit.org/show_bug.cgi?id=269528</a>
<a href="https://rdar.apple.com/122974187">rdar://122974187</a>

Reviewed by Justin Michaud and Yusuke Suzuki.

Adds PAS_PROFILE invocations to more places throughout libPAS,
and standardizes the PAS_PROFILE interface - a discriminator is
expected in the first parameter (like the similar BPROFILE_ALLOCATION
macro in bmalloc), followed by any number of arguments that are
expected to be uintptr_t lvalues.

* Source/bmalloc/libpas/src/libpas/pas_allocation_result.c:
(pas_allocation_result_zero_large_slow):
* Source/bmalloc/libpas/src/libpas/pas_allocation_result.h:
(pas_allocation_result_zero):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.c:
(pas_try_deallocate_known_large):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
(pas_try_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h:
(pas_fast_megapage_table_get):
* Source/bmalloc/libpas/src/libpas/pas_free_granules.c:
(pas_free_granules_compute_and_mark_decommitted):
* Source/bmalloc/libpas/src/libpas/pas_heap.c:
(pas_heap_create):
* Source/bmalloc/libpas/src/libpas/pas_large_map.c:
(pas_large_map_find):
(pas_large_map_add):
(pas_large_map_take):
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_page_malloc_try_allocate_without_deallocating_padding):
(pas_page_malloc_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):
* Source/bmalloc/libpas/src/libpas/pas_utils.h:
(pas_zero_memory):

Canonical link: <a href="https://commits.webkit.org/274843@main">https://commits.webkit.org/274843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ffd8f00805635207aa0f656f8fe517d5a863a81

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40045 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42590 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33328 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13880 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43868 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33498 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39645 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39671 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37912 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16479 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46679 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16528 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9603 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5306 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->