### PR TITLE
Adopt more smart pointers in WebKit/IPC

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -84,6 +84,7 @@ public:
     WTF_EXPORT_PRIVATE static RunLoop& current();
     static Ref<RunLoop> protectedCurrent() { return current(); }
     WTF_EXPORT_PRIVATE static RunLoop& main();
+    static Ref<RunLoop> protectedMain() { return main(); }
 #if USE(WEB_THREAD)
     WTF_EXPORT_PRIVATE static RunLoop& web();
     WTF_EXPORT_PRIVATE static RunLoop* webIfExists();

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -466,6 +466,7 @@ private:
     size_t incomingMessagesDispatchingBatchSize() const;
 
     Timeout timeoutRespectingIgnoreTimeoutsForTesting(Timeout) const;
+    Ref<WorkQueue> protectedConnectionQueue() const { return m_connectionQueue; }
 
 #if PLATFORM(COCOA)
     bool sendMessage(std::unique_ptr<MachMessage>);

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.cpp
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.cpp
@@ -201,7 +201,7 @@ bool putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(JSC::JSGlobalOb
     if (value.isUndefined()) {
         auto arrayBuffer = JSC::ArrayBuffer::create(buffer);
         if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode()))
-            value = JSC::JSArrayBuffer::create(globalObject->vm(), structure, WTFMove(arrayBuffer));
+            value = JSC::JSArrayBuffer::create(Ref { globalObject->vm() }, structure, WTFMove(arrayBuffer));
     }
 
     array->putDirectIndex(globalObject, index, value);

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -64,7 +64,7 @@ public:
 
     void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
     {
-        m_queue->dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = m_receiver]() mutable {
+        Ref { m_queue }->dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = m_receiver]() mutable {
             connection->dispatchMessageReceiverMessage(receiver.get(), WTFMove(message));
         });
     }

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -64,7 +64,7 @@ auto SharedBufferReference::serializableBuffer() const -> std::optional<Serializ
         return std::nullopt;
     if (!m_size)
         return SerializableBuffer { 0, std::nullopt };
-    auto sharedMemoryBuffer = m_memory ? m_memory : SharedMemory::copyBuffer(*m_buffer);
+    auto sharedMemoryBuffer = m_memory ? m_memory : SharedMemory::copyBuffer(*m_buffer.copyRef());
     return SerializableBuffer { m_size, sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly) };
 }
 #endif
@@ -74,11 +74,11 @@ RefPtr<WebCore::SharedBuffer> SharedBufferReference::unsafeBuffer() const
 #if !USE(UNIX_DOMAIN_SOCKETS)
     RELEASE_ASSERT_WITH_MESSAGE(isEmpty() || (!m_buffer && m_memory), "Must only be called on IPC's receiver side");
 
-    if (m_memory)
-        return m_memory->createSharedBuffer(m_size);
+    if (RefPtr memory = m_memory)
+        return memory->createSharedBuffer(m_size);
 #endif
-    if (m_buffer)
-        return m_buffer->makeContiguous();
+    if (RefPtr buffer = m_buffer)
+        return buffer->makeContiguous();
     return nullptr;
 }
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -109,18 +109,18 @@ void StreamClientConnection::setMaxBatchSize(unsigned size)
 void StreamClientConnection::open(Connection::Client& receiver, SerialFunctionDispatcher& dispatcher)
 {
     m_dedicatedConnectionClient.emplace(receiver);
-    m_connection->open(*m_dedicatedConnectionClient, dispatcher);
+    protectedConnection()->open(*m_dedicatedConnectionClient, dispatcher);
 }
 
 Error StreamClientConnection::flushSentMessages(Timeout timeout)
 {
     wakeUpServer(WakeUpServer::Yes);
-    return m_connection->flushSentMessages(WTFMove(timeout));
+    return protectedConnection()->flushSentMessages(WTFMove(timeout));
 }
 
 void StreamClientConnection::invalidate()
 {
-    m_connection->invalidate();
+    protectedConnection()->invalidate();
 }
 
 void StreamClientConnection::wakeUpServer(WakeUpServer wakeUpResult)
@@ -152,12 +152,12 @@ Connection& StreamClientConnection::connectionForTesting()
 
 void StreamClientConnection::addWorkQueueMessageReceiver(ReceiverName name, WorkQueue& workQueue, WorkQueueMessageReceiver& receiver, uint64_t destinationID)
 {
-    m_connection->addWorkQueueMessageReceiver(name, workQueue, receiver, destinationID);
+    protectedConnection()->addWorkQueueMessageReceiver(name, workQueue, receiver, destinationID);
 }
 
 void StreamClientConnection::removeWorkQueueMessageReceiver(ReceiverName name, uint64_t destinationID)
 {
-    m_connection->removeWorkQueueMessageReceiver(name, destinationID);
+    protectedConnection()->removeWorkQueueMessageReceiver(name, destinationID);
 }
 
 }

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -42,7 +42,7 @@ StreamConnectionBuffer::~StreamConnectionBuffer() = default;
 
 StreamConnectionBuffer::Handle StreamConnectionBuffer::createHandle()
 {
-    auto handle = m_sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadWrite);
+    auto handle = Ref { m_sharedMemory }->createHandle(WebCore::SharedMemory::Protection::ReadWrite);
     if (!handle)
         CRASH();
     return { WTFMove(*handle) };

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -122,6 +122,8 @@ private:
     bool dispatchStreamMessage(Decoder&&, StreamMessageReceiver&);
     bool dispatchOutOfStreamMessage(Decoder&&);
 
+    RefPtr<StreamConnectionWorkQueue> protectedWorkQueue() const;
+
     using WakeUpClient = StreamServerConnectionBuffer::WakeUpClient;
     const Ref<IPC::Connection> m_connection;
     RefPtr<StreamConnectionWorkQueue> m_workQueue;

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -209,7 +209,7 @@ void Connection::platformOpen()
         mach_port_mod_refs(mach_task_self(), receivePort, MACH_PORT_RIGHT_RECEIVE, -1);
     });
 
-    m_connectionQueue->dispatch([strongRef = Ref { *this }, this] {
+    protectedConnectionQueue()->dispatch([strongRef = Ref { *this }, this] {
         dispatch_resume(m_receiveSource.get());
     });
 }


### PR DESCRIPTION
#### fe2b1e4018d44716805191bbb260753de065440b
<pre>
Adopt more smart pointers in WebKit/IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=269538">https://bugs.webkit.org/show_bug.cgi?id=269538</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/RunLoop.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::ConnectionAndIncomingMessage::dispatch):
(IPC::Connection::invalidate):
(IPC::Connection::sendMessage):
(IPC::Connection::sendMessageWithAsyncReply):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::dispatchIncomingMessageForTesting):
(IPC::Connection::dispatchOnReceiveQueueForTesting):
(IPC::Connection::wakeUpRunLoop):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::protectedConnectionQueue const):
* Source/WebKit/Platform/IPC/JSIPCBinding.cpp:
(IPC::putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined):
* Source/WebKit/Platform/IPC/MessageReceiveQueues.h:
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::serializableBuffer const):
(IPC::SharedBufferReference::unsafeBuffer const):
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::open):
(IPC::StreamClientConnection::flushSentMessages):
(IPC::StreamClientConnection::invalidate):
(IPC::StreamClientConnection::addWorkQueueMessageReceiver):
(IPC::StreamClientConnection::removeWorkQueueMessageReceiver):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::waitForAndDispatchImmediately):
(IPC::StreamClientConnection::waitForAsyncReplyAndDispatchImmediately):
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::createHandle):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::open):
(IPC::StreamServerConnection::invalidate):
(IPC::StreamServerConnection::enqueueMessage):
(IPC::StreamServerConnection::dispatchStreamMessages):
(IPC::StreamServerConnection::processSetStreamDestinationID):
(IPC::StreamServerConnection::dispatchStreamMessage):
(IPC::StreamServerConnection::dispatchOutOfStreamMessage):
(IPC::StreamServerConnection::protectedWorkQueue const):
(IPC::StreamServerConnection::sendDeserializationErrorSyncReply):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::platformOpen):

Canonical link: <a href="https://commits.webkit.org/274847@main">https://commits.webkit.org/274847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3ce66bb997f782f5aaea603cbbeccd1c212ca23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42609 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33344 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43887 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33517 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39658 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37931 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16498 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46698 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16547 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9608 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5310 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->