### PR TITLE
Add support for externally_connectable

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -545,6 +545,8 @@ $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageRuntime.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -98,6 +98,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageNamespace.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageNamespace.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageRuntime.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebPageRuntime.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequest.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequestEvent.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -863,6 +863,8 @@ EXTENSION_INTERFACES = \
     WebExtensionAPITest \
     WebExtensionAPIWebNavigation \
     WebExtensionAPIWebNavigationEvent \
+    WebExtensionAPIWebPageNamespace \
+    WebExtensionAPIWebPageRuntime \
     WebExtensionAPIWebRequest \
     WebExtensionAPIWebRequestEvent \
     WebExtensionAPIWindows \

--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
@@ -35,6 +35,7 @@ enum class WebExtensionContentWorldType : uint8_t {
     Main,
     ContentScript,
     Native,
+    WebPage,
 };
 
 inline String toDebugString(WebExtensionContentWorldType contentWorldType)
@@ -46,6 +47,8 @@ inline String toDebugString(WebExtensionContentWorldType contentWorldType)
         return "content script"_s;
     case WebExtensionContentWorldType::Native:
         return "native"_s;
+    case WebExtensionContentWorldType::WebPage:
+        return "web page"_s;
     }
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in
@@ -28,6 +28,7 @@ enum class WebKit::WebExtensionContentWorldType : uint8_t {
     Main,
     ContentScript,
     Native,
+    WebPage,
 }
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionControllerParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionControllerParameters.h
@@ -35,6 +35,8 @@ namespace WebKit {
 struct WebExtensionControllerParameters {
     WebExtensionControllerIdentifier identifier;
 
+    bool testingMode { false };
+
 #if PLATFORM(COCOA)
     Vector<WebExtensionContextParameters> contextParameters;
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionControllerParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionControllerParameters.serialization.in
@@ -25,6 +25,8 @@
 struct WebKit::WebExtensionControllerParameters {
     WebKit::WebExtensionControllerIdentifier identifier;
 
+    bool testingMode;
+
 #if PLATFORM(COCOA)
     Vector<WebKit::WebExtensionContextParameters> contextParameters;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -270,6 +270,16 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
         [context->wrapper() didChangeTabProperties:properties forTab:changedTab];
 }
 
+- (BOOL)_inTestingMode
+{
+    return _webExtensionController->inTestingMode();
+}
+
+- (void)_setTestingMode:(BOOL)testingMode
+{
+    _webExtensionController->setTestingMode(testingMode);
+}
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -387,6 +397,15 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 }
 
 - (void)didChangeTabProperties:(_WKWebExtensionTabChangedProperties)properties forTab:(id<_WKWebExtensionTab>)changedTab
+{
+}
+
+- (BOOL)_inTestingMode
+{
+    return NO;
+}
+
+- (void)_setTestingMode:(BOOL)testingMode
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegatePrivate.h
@@ -35,31 +35,31 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Delegate for the `browser.test.assertTrue()`, `browser.test.assertFalse()`, `browser.test.assertThrows()`, and `browser.test.assertRejects()`  JavaScript testing APIs.
  @discussion Default implementation logs a message to the system console when `result` is `NO`.
  */
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestAssertionResult:(BOOL)result withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestAssertionResult:(BOOL)result withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
 
 /*!
  @abstract Delegate for the `browser.test.assertEq()` and `browser.test.assertDeepEq()` JavaScript testing APIs.
  @discussion Default implementation logs a message to the system console when `result` is `NO`.
  */
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestEqualityResult:(BOOL)result expectedValue:(NSString *)expectedValue actualValue:(NSString *)actualValue withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestEqualityResult:(BOOL)result expectedValue:(NSString *)expectedValue actualValue:(NSString *)actualValue withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
 
 /*!
  @abstract Delegate for the `browser.test.log()` JavaScript testing API.
  @discussion Default implementation always logs the message to the system console.
  */
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
 
 /*!
  @abstract Delegate for the `browser.test.yield()` JavaScript testing API.
  @discussion Default implementation always logs the message to the system console. Test harnesses should use this to exit the run loop to preform other work before resuming extension execution.
  */
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestYieldedWithMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestYieldedWithMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
 
 /*!
  @abstract Delegate for the `browser.test.notifyPass()` and `browser.test.notifyFail()` JavaScript testing APIs.
  @discussion Default implementation logs a message to the system console when `result` is `NO`. Test harnesses should use this to exit the run loop and record a test pass or failure.
  */
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestFinishedWithResult:(BOOL)result message:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestFinishedWithResult:(BOOL)result message:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
 
 /*!
  @abstract Delegate notification about the creation of the background web view in the web extension context.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerPrivate.h
@@ -25,6 +25,16 @@
 
 #import <WebKit/_WKWebExtensionController.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface _WKWebExtensionController ()
 
+/*!
+ @abstract Enables extra `browser.test` APIs and unsupported API stubs for testing.
+ @discussion Defaults to `YES` in debug builds.
+ */
+@property (nonatomic, getter=_inTestingMode, setter=_setTestingMode:) BOOL _testingMode;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
@@ -73,6 +73,10 @@ void WebExtensionContext::portPostMessage(WebExtensionContentWorldType targetCon
         if (auto nativePort = m_nativePortMap.get(channelIdentifier))
             nativePort->receiveMessage(parseJSON(messageJSON, JSONOptions::FragmentsAllowed), std::nullopt);
         return;
+
+    case WebExtensionContentWorldType::WebPage:
+        sendToProcesses(processes(type, WebExtensionContentWorldType::WebPage), Messages::WebExtensionContextProxy::DispatchPortMessageEvent(sendingPageProxyIdentifier, channelIdentifier, messageJSON));
+        return;
     }
 }
 
@@ -202,6 +206,10 @@ void WebExtensionContext::firePortDisconnectEventIfNeeded(WebExtensionContentWor
     case WebExtensionContentWorldType::Native:
         if (auto nativePort = m_nativePortMap.get(channelIdentifier))
             nativePort->reportDisconnection(std::nullopt);
+        return;
+
+    case WebExtensionContentWorldType::WebPage:
+        sendToProcesses(processes(type, WebExtensionContentWorldType::WebPage), Messages::WebExtensionContextProxy::DispatchPortDisconnectEvent(channelIdentifier));
         return;
     }
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,25 +28,21 @@
 #endif
 
 #import "config.h"
-#import "WebExtensionContext.h"
+#import "WebExtensionController.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "Logging.h"
-#import "WebExtensionController.h"
 #import "_WKWebExtensionControllerDelegatePrivate.h"
 #import "_WKWebExtensionControllerInternal.h"
 
 namespace WebKit {
 
-void WebExtensionContext::testResult(bool result, String message, String sourceURL, unsigned lineNumber)
+void WebExtensionController::testResult(bool result, String message, String sourceURL, unsigned lineNumber)
 {
-    if (!isLoaded())
-        return;
-
-    auto delegate = extensionController()->delegate();
-    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestAssertionResult:withMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
-        [delegate _webExtensionController:extensionController()->wrapper() recordTestAssertionResult:result withMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+    auto delegate = this->delegate();
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestAssertionResult:withMessage:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() recordTestAssertionResult:result withMessage:message andSourceURL:sourceURL lineNumber:lineNumber];
         return;
     }
 
@@ -61,14 +57,11 @@ void WebExtensionContext::testResult(bool result, String message, String sourceU
     RELEASE_LOG_ERROR(Extensions, "Test assertion failed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
 }
 
-void WebExtensionContext::testEqual(bool result, String expectedValue, String actualValue, String message, String sourceURL, unsigned lineNumber)
+void WebExtensionController::testEqual(bool result, String expectedValue, String actualValue, String message, String sourceURL, unsigned lineNumber)
 {
-    if (!isLoaded())
-        return;
-
-    auto delegate = extensionController()->delegate();
-    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
-        [delegate _webExtensionController:extensionController()->wrapper() recordTestEqualityResult:result expectedValue:expectedValue actualValue:actualValue withMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+    auto delegate = this->delegate();
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() recordTestEqualityResult:result expectedValue:expectedValue actualValue:actualValue withMessage:message andSourceURL:sourceURL lineNumber:lineNumber];
         return;
     }
 
@@ -83,14 +76,11 @@ void WebExtensionContext::testEqual(bool result, String expectedValue, String ac
     RELEASE_LOG_ERROR(Extensions, "Test equality failed: %{public}@: %{public}@ !== %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)expectedValue, (NSString *)actualValue, (NSString *)sourceURL, lineNumber);
 }
 
-void WebExtensionContext::testMessage(String message, String sourceURL, unsigned lineNumber)
+void WebExtensionController::testMessage(String message, String sourceURL, unsigned lineNumber)
 {
-    if (!isLoaded())
-        return;
-
-    auto delegate = extensionController()->delegate();
-    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
-        [delegate _webExtensionController:extensionController()->wrapper() recordTestMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+    auto delegate = this->delegate();
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestMessage:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() recordTestMessage:message andSourceURL:sourceURL lineNumber:lineNumber];
         return;
     }
 
@@ -100,14 +90,11 @@ void WebExtensionContext::testMessage(String message, String sourceURL, unsigned
     RELEASE_LOG_INFO(Extensions, "Test message: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
 }
 
-void WebExtensionContext::testYielded(String message, String sourceURL, unsigned lineNumber)
+void WebExtensionController::testYielded(String message, String sourceURL, unsigned lineNumber)
 {
-    if (!isLoaded())
-        return;
-
-    auto delegate = extensionController()->delegate();
-    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestYieldedWithMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
-        [delegate _webExtensionController:extensionController()->wrapper() recordTestYieldedWithMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+    auto delegate = this->delegate();
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestYieldedWithMessage:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() recordTestYieldedWithMessage:message andSourceURL:sourceURL lineNumber:lineNumber];
         return;
     }
 
@@ -117,14 +104,11 @@ void WebExtensionContext::testYielded(String message, String sourceURL, unsigned
     RELEASE_LOG_INFO(Extensions, "Test yielded: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
 }
 
-void WebExtensionContext::testFinished(bool result, String message, String sourceURL, unsigned lineNumber)
+void WebExtensionController::testFinished(bool result, String message, String sourceURL, unsigned lineNumber)
 {
-    if (!isLoaded())
-        return;
-
-    auto delegate = extensionController()->delegate();
-    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestFinishedWithResult:message:andSourceURL:lineNumber:forExtensionContext:)]) {
-        [delegate _webExtensionController:extensionController()->wrapper() recordTestFinishedWithResult:result message:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+    auto delegate = this->delegate();
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestFinishedWithResult:message:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() recordTestFinishedWithResult:result message:message andSourceURL:sourceURL lineNumber:lineNumber];
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -439,6 +439,16 @@ RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const WebEx
     return nullptr;
 }
 
+RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const UniqueIdentifier& uniqueIdentifier) const
+{
+    for (Ref context : m_extensionContexts) {
+        if (context->uniqueIdentifier() == uniqueIdentifier)
+            return context.ptr();
+    }
+
+    return nullptr;
+}
+
 RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const URL& url) const
 {
     return m_extensionContextBaseURLMap.get(url.protocolHostAndPort());

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -68,6 +68,16 @@ WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::supportedSchem
     return schemes;
 }
 
+bool WebExtensionMatchPattern::patternsMatchURL(const MatchPatternSet& matchPatterns, URL& url)
+{
+    for (auto& matchPattern : matchPatterns) {
+        if (matchPattern->matchesURL(url))
+            return true;
+    }
+
+    return false;
+}
+
 static HashMap<String, RefPtr<WebExtensionMatchPattern>>& patternCache()
 {
     static MainThreadNeverDestroyed<HashMap<String, RefPtr<WebExtensionMatchPattern>>> cache;
@@ -119,7 +129,7 @@ Ref<WebExtensionMatchPattern> WebExtensionMatchPattern::allHostsAndSchemesMatchP
     return getOrCreate(allHostsAndSchemesPattern).releaseNonNull();
 }
 
-bool WebExtensionMatchPattern::patternsMatchAllHosts(HashSet<Ref<WebExtensionMatchPattern>>& patterns)
+bool WebExtensionMatchPattern::patternsMatchAllHosts(const MatchPatternSet& patterns)
 {
     for (auto& pattern : patterns) {
         if (pattern->matchesAllHosts())

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -701,6 +701,8 @@ private:
     void runtimeConnect(const String& extensionID, WebExtensionPortChannelIdentifier, const String& name, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> error)>&&);
     void runtimeSendNativeMessage(const String& applicationID, const String& messageJSON, CompletionHandler<void(std::optional<String> replyJSON, std::optional<String> error)>&&);
     void runtimeConnectNative(const String& applicationID, WebExtensionPortChannelIdentifier, CompletionHandler<void(std::optional<String> error)>&&);
+    void runtimeWebPageSendMessage(const String& extensionID, const String& messageJSON, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON, std::optional<String> error)>&&);
+    void runtimeWebPageConnect(const String& extensionID, WebExtensionPortChannelIdentifier, const String& name, const WebExtensionMessageSenderParameters&, CompletionHandler<void(WebExtensionTab::Error)>&&);
     void fireRuntimeStartupEventIfNeeded();
     void fireRuntimeInstalledEventIfNeeded();
 
@@ -753,13 +755,6 @@ private:
     void fireTabsActivatedEventIfNeeded(WebExtensionTabIdentifier previousActiveTabIdentifier, WebExtensionTabIdentifier newActiveTabIdentifier, WebExtensionWindowIdentifier);
     void fireTabsHighlightedEventIfNeeded(Vector<WebExtensionTabIdentifier>, WebExtensionWindowIdentifier);
     void fireTabsRemovedEventIfNeeded(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, WindowIsClosing);
-
-    // Test APIs
-    void testResult(bool result, String message, String sourceURL, unsigned lineNumber);
-    void testEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
-    void testMessage(String message, String sourceURL, unsigned lineNumber);
-    void testYielded(String message, String sourceURL, unsigned lineNumber);
-    void testFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
     // WebNavigation APIs
     void webNavigationGetFrame(WebExtensionTabIdentifier, WebExtensionFrameIdentifier, CompletionHandler<void(std::optional<WebExtensionFrameParameters>, std::optional<String> error)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -104,6 +104,8 @@ messages -> WebExtensionContext {
     RuntimeConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> error);
     RuntimeSendNativeMessage(String applicationID, String messageJSON) -> (std::optional<String> replyJSON, std::optional<String> error);
     RuntimeConnectNative(String applicationID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier) -> (std::optional<String> error);
+    RuntimeWebPageSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON, std::optional<String> error);
+    RuntimeWebPageConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> error);
 
     // Scripting APIs
     ScriptingExecuteScript(WebKit::WebExtensionScriptInjectionParameters parameters) -> (std::optional<Vector<WebKit::WebExtensionScriptInjectionResultParameters>> results, WebKit::WebExtensionDynamicScripts::Error error);
@@ -143,13 +145,6 @@ messages -> WebExtensionContext {
     TabsExecuteScript(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (std::optional<Vector<WebKit::WebExtensionScriptInjectionResultParameters>> results, WebKit::WebExtensionTab::Error error);
     TabsInsertCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionTab::Error error);
     TabsRemoveCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionTab::Error error);
-
-    // Test APIs
-    TestResult(bool result, String message, String sourceURL, unsigned lineNumber);
-    TestEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
-    TestMessage(String message, String sourceURL, unsigned lineNumber);
-    TestYielded(String message, String sourceURL, unsigned lineNumber);
-    TestFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
     // WebNavigation APIs
     WebNavigationGetAllFrames(WebKit::WebExtensionTabIdentifier tabIdentifier) -> (std::optional<Vector<WebKit::WebExtensionFrameParameters>> allFrameParameters, std::optional<String> error)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -79,6 +79,7 @@ WebExtensionControllerParameters WebExtensionController::parameters() const
     WebExtensionControllerParameters parameters;
 
     parameters.identifier = identifier();
+    parameters.testingMode = inTestingMode();
     parameters.contextParameters = WTF::map(extensionContexts(), [](auto& context) {
         return context->parameters();
     });

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
@@ -32,6 +32,13 @@ messages -> WebExtensionController {
     DidFinishLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
     DidFailLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
 
+    // Test APIs
+    TestResult(bool result, String message, String sourceURL, unsigned lineNumber);
+    TestEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
+    TestMessage(String message, String sourceURL, unsigned lineNumber);
+    TestYielded(String message, String sourceURL, unsigned lineNumber);
+    TestFinished(bool result, String message, String sourceURL, unsigned lineNumber);
+
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -52,22 +52,23 @@ public:
         return result && result->isValid() ? WTFMove(result) : nullptr;
     }
 
+    using URLSchemeSet = HashSet<String>;
+    using MatchPatternSet = HashSet<Ref<WebExtensionMatchPattern>>;
+
     static RefPtr<WebExtensionMatchPattern> getOrCreate(const String& pattern);
     static RefPtr<WebExtensionMatchPattern> getOrCreate(const String& scheme, const String& host, const String& path);
 
     static Ref<WebExtensionMatchPattern> allURLsMatchPattern();
     static Ref<WebExtensionMatchPattern> allHostsAndSchemesMatchPattern();
 
-    static bool patternsMatchAllHosts(HashSet<Ref<WebExtensionMatchPattern>>&);
+    static bool patternsMatchAllHosts(const MatchPatternSet&);
+    static bool patternsMatchURL(const MatchPatternSet&, URL&);
 
     explicit WebExtensionMatchPattern() { }
     explicit WebExtensionMatchPattern(const String& pattern, NSError **outError = nullptr);
     explicit WebExtensionMatchPattern(const String& scheme, const String& host, const String& path, NSError **outError = nullptr);
 
     ~WebExtensionMatchPattern() { }
-
-    using URLSchemeSet = HashSet<String>;
-    using MatchPatternSet = HashSet<Ref<WebExtensionMatchPattern>>;
 
     enum class Options : uint8_t {
         IgnoreSchemes        = 1 << 0, // Ignore the scheme component when matching.

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -395,7 +395,7 @@
 		1C15497A2926BF03001B9E5B /* WebExtensionAPITestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C15497C2926BF75001B9E5B /* WebExtensionAPITest.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */; };
 		1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C1549822926E7CC001B9E5B /* WebExtensionControllerAPITestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549812926E7CC001B9E5B /* WebExtensionControllerAPITestCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1549842926F091001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C1549D229381BA0001B9E5B /* WebExtensionControllerConfigurationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549D129381B9F001B9E5B /* WebExtensionControllerConfigurationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549D429381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -1576,6 +1576,7 @@
 		71BAA73325FFD09800D7CD5D /* WKModelView.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BAA73125FFCCBA00D7CD5D /* WKModelView.h */; };
 		71E29A342B20610C0010F3C9 /* RemoteAcceleratedEffectStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 71371D1E2B1F89C00092C32D /* RemoteAcceleratedEffectStack.h */; };
 		71FB810B2260627E00323677 /* WebsiteSimulatedMouseEventsDispatchPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 71FB810A2260627A00323677 /* WebsiteSimulatedMouseEventsDispatchPolicy.h */; };
+		726952E02B7F4636009E5F0C /* WebExtensionAPIWebPageRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 726952DF2B7F4636009E5F0C /* WebExtensionAPIWebPageRuntime.h */; };
 		728E86F11795188C0087879E /* WebColorPickerMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 728E86EF1795188C0087879E /* WebColorPickerMac.h */; };
 		74C2F54129AC9C44006C5F97 /* DeferredPaymentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C2F54029AC9C44006C5F97 /* DeferredPaymentRequest.h */; };
 		75A8D2C8187CCFAB00C39C9E /* WKWebsiteDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 75A8D2C4187CCF9F00C39C9E /* WKWebsiteDataStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1981,6 +1982,8 @@
 		B6058CF52B6D98E8006D4C77 /* WebExtensionDataRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = B6058CF32B6D98E7006D4C77 /* WebExtensionDataRecord.h */; };
 		B6114A7F29394A1600380B1B /* JSWebExtensionAPIEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */ = {isa = PBXBuildFile; fileRef = B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */; };
+		B61274A32B7D732400D8ACDA /* WebExtensionAPIWebPageNamespaceCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B61274A12B7D732400D8ACDA /* WebExtensionAPIWebPageNamespaceCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B61274A82B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h in Headers */ = {isa = PBXBuildFile; fileRef = B61274A62B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h */; };
 		B61AFA392950DFB3008220B1 /* WebExtensionAPIPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */; };
 		B61AFA4829510D0F008220B1 /* JSWebExtensionAPIPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */; };
 		B61AFA4929510D0F008220B1 /* JSWebExtensionAPIPermissions.mm in Sources */ = {isa = PBXBuildFile; fileRef = B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -1990,11 +1993,15 @@
 		B62C01BC2A8E7AF600D6A941 /* _WKWebExtensionLocalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6217BB1299C3AE300498BF8 /* _WKWebExtensionLocalization.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B62E7312143047B00069EC35 /* WKHitTestResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B62E7311143047B00069EC35 /* WKHitTestResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B62FB8632AA9180C00E61418 /* WebExtensionAPIScripting.h in Headers */ = {isa = PBXBuildFile; fileRef = B62FB8622AA9180C00E61418 /* WebExtensionAPIScripting.h */; };
+		B63A99762B7EA001004611FD /* JSWebExtensionAPIWebPageRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = B63A99732B7EA000004611FD /* JSWebExtensionAPIWebPageRuntime.h */; };
+		B63A99772B7EA002004611FD /* JSWebExtensionAPIWebPageNamespace.mm in Sources */ = {isa = PBXBuildFile; fileRef = B63A99742B7EA001004611FD /* JSWebExtensionAPIWebPageNamespace.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B63A99782B7EA002004611FD /* JSWebExtensionAPIWebPageRuntime.mm in Sources */ = {isa = PBXBuildFile; fileRef = B63A99752B7EA001004611FD /* JSWebExtensionAPIWebPageRuntime.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B63C10342B51C0B6004A69B8 /* JSWebExtensionAPIStorage.mm in Sources */ = {isa = PBXBuildFile; fileRef = B63C10332B51C09C004A69B8 /* JSWebExtensionAPIStorage.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B63C10352B51C0C5004A69B8 /* JSWebExtensionAPIStorageArea.h in Headers */ = {isa = PBXBuildFile; fileRef = B63C10322B51C09C004A69B8 /* JSWebExtensionAPIStorageArea.h */; };
 		B63C10372B51C102004A69B8 /* JSWebExtensionAPIStorageArea.mm in Sources */ = {isa = PBXBuildFile; fileRef = B63C10362B51C0E5004A69B8 /* JSWebExtensionAPIStorageArea.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B63E9A6E2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.h in Headers */ = {isa = PBXBuildFile; fileRef = B63E9A6C2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.h */; };
 		B63E9A6F2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.mm in Sources */ = {isa = PBXBuildFile; fileRef = B63E9A6D2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B64AF4E52B7D7E6500357639 /* JSWebExtensionAPIWebPageNamespace.h in Headers */ = {isa = PBXBuildFile; fileRef = B64AF4E32B7D7E6300357639 /* JSWebExtensionAPIWebPageNamespace.h */; };
 		B651BC582B460932009654A9 /* WebExtensionAPIStorageAreaCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B651BC562B460932009654A9 /* WebExtensionAPIStorageAreaCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B651BC592B460932009654A9 /* WebExtensionAPIStorageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B651BC572B460932009654A9 /* WebExtensionAPIStorageCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B651BC5D2B460C9D009654A9 /* WebExtensionAPIStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = B651BC5B2B460C9C009654A9 /* WebExtensionAPIStorage.h */; };
@@ -3719,7 +3726,7 @@
 		1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPITest.h; sourceTree = "<group>"; };
 		1C15497D2926C05A001B9E5B /* JSWebExtensionAPITest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPITest.h; sourceTree = "<group>"; };
 		1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPITest.mm; sourceTree = "<group>"; };
-		1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPITestCocoa.mm; sourceTree = "<group>"; };
+		1C1549812926E7CC001B9E5B /* WebExtensionControllerAPITestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionControllerAPITestCocoa.mm; sourceTree = "<group>"; };
 		1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerDelegatePrivate.h; sourceTree = "<group>"; };
 		1C1549CE293812F8001B9E5B /* WebExtensionControllerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerConfiguration.h; sourceTree = "<group>"; };
 		1C1549CF293817FE001B9E5B /* WebExtensionControllerConfiguration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionControllerConfiguration.cpp; sourceTree = "<group>"; };
@@ -6313,6 +6320,7 @@
 		72440D3A287CF58900FADBC4 /* RemoteImageBufferProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteImageBufferProxy.cpp; sourceTree = "<group>"; };
 		724DCF21284862FC0026ACF4 /* ImageBufferShareableAllocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferShareableAllocator.h; sourceTree = "<group>"; };
 		724DCF22284862FC0026ACF4 /* ImageBufferShareableAllocator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferShareableAllocator.cpp; sourceTree = "<group>"; };
+		726952DF2B7F4636009E5F0C /* WebExtensionAPIWebPageRuntime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebPageRuntime.h; sourceTree = "<group>"; };
 		726D56DD253A64810002EF90 /* RemoteResourceCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteResourceCache.cpp; sourceTree = "<group>"; };
 		726D56DE253A64810002EF90 /* RemoteResourceCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteResourceCache.h; sourceTree = "<group>"; };
 		727A7F342407857D004D2931 /* ImageBufferShareableMappedIOSurfaceBackend.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferShareableMappedIOSurfaceBackend.cpp; sourceTree = "<group>"; };
@@ -7099,6 +7107,8 @@
 		B6114A7C2939498000380B1B /* JSWebExtensionAPIEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIEvent.h; sourceTree = "<group>"; };
 		B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIEvent.mm; sourceTree = "<group>"; };
 		B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionEventListenerType.h; sourceTree = "<group>"; };
+		B61274A12B7D732400D8ACDA /* WebExtensionAPIWebPageNamespaceCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWebPageNamespaceCocoa.mm; sourceTree = "<group>"; };
+		B61274A62B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebPageNamespace.h; sourceTree = "<group>"; };
 		B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIPermissions.h; sourceTree = "<group>"; };
 		B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIPermissions.mm; sourceTree = "<group>"; };
 		B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionLocalization.h; sourceTree = "<group>"; };
@@ -7111,11 +7121,15 @@
 		B62E7311143047B00069EC35 /* WKHitTestResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHitTestResult.h; sourceTree = "<group>"; };
 		B62FB8622AA9180C00E61418 /* WebExtensionAPIScripting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIScripting.h; sourceTree = "<group>"; };
 		B63403F814910D57001070B5 /* APIObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIObject.cpp; sourceTree = "<group>"; };
+		B63A99732B7EA000004611FD /* JSWebExtensionAPIWebPageRuntime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIWebPageRuntime.h; sourceTree = "<group>"; };
+		B63A99742B7EA001004611FD /* JSWebExtensionAPIWebPageNamespace.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebPageNamespace.mm; sourceTree = "<group>"; };
+		B63A99752B7EA001004611FD /* JSWebExtensionAPIWebPageRuntime.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebPageRuntime.mm; sourceTree = "<group>"; };
 		B63C10322B51C09C004A69B8 /* JSWebExtensionAPIStorageArea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIStorageArea.h; sourceTree = "<group>"; };
 		B63C10332B51C09C004A69B8 /* JSWebExtensionAPIStorage.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIStorage.mm; sourceTree = "<group>"; };
 		B63C10362B51C0E5004A69B8 /* JSWebExtensionAPIStorageArea.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIStorageArea.mm; sourceTree = "<group>"; };
 		B63E9A6C2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIScripting.h; sourceTree = "<group>"; };
 		B63E9A6D2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIScripting.mm; sourceTree = "<group>"; };
+		B64AF4E32B7D7E6300357639 /* JSWebExtensionAPIWebPageNamespace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIWebPageNamespace.h; sourceTree = "<group>"; };
 		B651BC562B460932009654A9 /* WebExtensionAPIStorageAreaCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIStorageAreaCocoa.mm; sourceTree = "<group>"; };
 		B651BC572B460932009654A9 /* WebExtensionAPIStorageCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIStorageCocoa.mm; sourceTree = "<group>"; };
 		B651BC5A2B460C9C009654A9 /* WebExtensionAPIStorageArea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebExtensionAPIStorageArea.h; path = WebProcess/Extensions/API/WebExtensionAPIStorageArea.h; sourceTree = SOURCE_ROOT; };
@@ -7130,6 +7144,8 @@
 		B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebExtensionAPIPermissions.h; path = WebProcess/Extensions/API/WebExtensionAPIPermissions.h; sourceTree = SOURCE_ROOT; };
 		B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIPermissionsCocoa.mm; sourceTree = "<group>"; };
 		B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIPermissionsCocoa.mm; sourceTree = "<group>"; };
+		B6630E8C2B7D2A3200CD971F /* WebExtensionAPIWebPageNamespace.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIWebPageNamespace.idl; sourceTree = "<group>"; };
+		B665516A2B7D2AEE00FBE51E /* WebExtensionAPIWebPageRuntime.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIWebPageRuntime.idl; sourceTree = "<group>"; };
 		B66F88B92B6C312400FB1734 /* FullScreenMediaDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FullScreenMediaDetails.h; sourceTree = "<group>"; };
 		B66F88BB2B6C3EDE00FB1734 /* FullScreenMediaDetails.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = FullScreenMediaDetails.serialization.in; sourceTree = "<group>"; };
 		B66F88BF2B6D1F1200FB1734 /* PreviewWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewWindowController.swift; sourceTree = "<group>"; };
@@ -9537,9 +9553,9 @@
 				B624FF142ABE4CB000F6EDF6 /* WebExtensionContextAPIScriptingCocoa.mm */,
 				B6B156602B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm */,
 				1C1D9C862AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm */,
-				1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */,
 				33B5A80E2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm */,
 				1C49579A2A9813AA007D0B64 /* WebExtensionContextAPIWindowsCocoa.mm */,
+				1C1549812926E7CC001B9E5B /* WebExtensionControllerAPITestCocoa.mm */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -9588,6 +9604,8 @@
 				1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */,
 				3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */,
 				33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */,
+				B61274A62B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h */,
+				726952DF2B7F4636009E5F0C /* WebExtensionAPIWebPageRuntime.h */,
 				3399E1552B59F0E5008BFB60 /* WebExtensionAPIWebRequest.h */,
 				337042032B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h */,
 				1C5ACFAF2A96F9F200C041C0 /* WebExtensionAPIWindows.h */,
@@ -9625,6 +9643,7 @@
 				1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */,
 				3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */,
 				33F6833F293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm */,
+				B61274A12B7D732400D8ACDA /* WebExtensionAPIWebPageNamespaceCocoa.mm */,
 				3399E1572B59F0FC008BFB60 /* WebExtensionAPIWebRequestCocoa.mm */,
 				337042052B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm */,
 				1C5ACFB72A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm */,
@@ -9802,6 +9821,8 @@
 				1CDA62A02925DA3700D90390 /* WebExtensionAPITest.idl */,
 				33066F09293A90DC008C5749 /* WebExtensionAPIWebNavigation.idl */,
 				3302293F2938263E001F00FA /* WebExtensionAPIWebNavigationEvent.idl */,
+				B6630E8C2B7D2A3200CD971F /* WebExtensionAPIWebPageNamespace.idl */,
+				B665516A2B7D2AEE00FBE51E /* WebExtensionAPIWebPageRuntime.idl */,
 				3399E14E2B59ECEB008BFB60 /* WebExtensionAPIWebRequest.idl */,
 				337041FF2B5895C00077FF78 /* WebExtensionAPIWebRequestEvent.idl */,
 				1C5ACF9E2A96E15400C041C0 /* WebExtensionAPIWindows.idl */,
@@ -14866,6 +14887,10 @@
 				3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */,
 				33F68335293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.h */,
 				33F68336293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm */,
+				B64AF4E32B7D7E6300357639 /* JSWebExtensionAPIWebPageNamespace.h */,
+				B63A99742B7EA001004611FD /* JSWebExtensionAPIWebPageNamespace.mm */,
+				B63A99732B7EA000004611FD /* JSWebExtensionAPIWebPageRuntime.h */,
+				B63A99752B7EA001004611FD /* JSWebExtensionAPIWebPageRuntime.mm */,
 				3399E1512B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.h */,
 				3399E1502B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.mm */,
 				337042012B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.h */,
@@ -16117,6 +16142,8 @@
 				B63C10352B51C0C5004A69B8 /* JSWebExtensionAPIStorageArea.h in Headers */,
 				1C5ACFAC2A96F8D500C041C0 /* JSWebExtensionAPITabs.h in Headers */,
 				3399E1522B59EFD7008BFB60 /* JSWebExtensionAPIWebNavigation.h in Headers */,
+				B64AF4E52B7D7E6500357639 /* JSWebExtensionAPIWebPageNamespace.h in Headers */,
+				B63A99762B7EA001004611FD /* JSWebExtensionAPIWebPageRuntime.h in Headers */,
 				3399E1542B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.h in Headers */,
 				1C5ACFA52A96F8C400C041C0 /* JSWebExtensionAPIWindows.h in Headers */,
 				1C5ACFA82A96F8C400C041C0 /* JSWebExtensionAPIWindowsEvent.h in Headers */,
@@ -16612,6 +16639,8 @@
 				1C15497C2926BF75001B9E5B /* WebExtensionAPITest.h in Headers */,
 				3375A37529429DF50028536D /* WebExtensionAPIWebNavigation.h in Headers */,
 				33F6833E293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h in Headers */,
+				B61274A82B7D738100D8ACDA /* WebExtensionAPIWebPageNamespace.h in Headers */,
+				726952E02B7F4636009E5F0C /* WebExtensionAPIWebPageRuntime.h in Headers */,
 				3399E1562B59F0F0008BFB60 /* WebExtensionAPIWebRequest.h in Headers */,
 				337042042B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h in Headers */,
 				1C5ACFB02A96F9F200C041C0 /* WebExtensionAPIWindows.h in Headers */,
@@ -19051,6 +19080,8 @@
 				1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */,
 				3375A3772942A19D0028536D /* JSWebExtensionAPIWebNavigation.mm in Sources */,
 				33F68338293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm in Sources */,
+				B63A99772B7EA002004611FD /* JSWebExtensionAPIWebPageNamespace.mm in Sources */,
+				B63A99782B7EA002004611FD /* JSWebExtensionAPIWebPageRuntime.mm in Sources */,
 				3399E1532B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.mm in Sources */,
 				337042022B58A0B70077FF78 /* JSWebExtensionAPIWebRequestEvent.mm in Sources */,
 				1C5ACFA62A96F8C400C041C0 /* JSWebExtensionAPIWindows.mm in Sources */,
@@ -19399,6 +19430,7 @@
 				1C15497A2926BF03001B9E5B /* WebExtensionAPITestCocoa.mm in Sources */,
 				3375A37129429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm in Sources */,
 				33F68340293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm in Sources */,
+				B61274A32B7D732400D8ACDA /* WebExtensionAPIWebPageNamespaceCocoa.mm in Sources */,
 				3399E1582B59F0FC008BFB60 /* WebExtensionAPIWebRequestCocoa.mm in Sources */,
 				337042062B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm in Sources */,
 				1C5ACFB82A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm in Sources */,
@@ -19422,13 +19454,13 @@
 				B624FF152ABE4CB100F6EDF6 /* WebExtensionContextAPIScriptingCocoa.mm in Sources */,
 				B6B156612B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm in Sources */,
 				1C1D9C872AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm in Sources */,
-				1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */,
 				33B5A80F2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm in Sources */,
 				1C49579B2A9813AA007D0B64 /* WebExtensionContextAPIWindowsCocoa.mm in Sources */,
 				1C0234DC28A0268C00AC1E5B /* WebExtensionContextCocoa.mm in Sources */,
 				1C0234CD28A00FE400AC1E5B /* WebExtensionContextMessageReceiver.cpp in Sources */,
 				330A30E52951112200F84419 /* WebExtensionContextProxyCocoa.mm in Sources */,
 				1C0234CE28A00FE600AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp in Sources */,
+				1C1549822926E7CC001B9E5B /* WebExtensionControllerAPITestCocoa.mm in Sources */,
 				1CBEE27028F4DDA1006D1A02 /* WebExtensionControllerCocoa.mm in Sources */,
 				1C1549D229381BA0001B9E5B /* WebExtensionControllerConfigurationCocoa.mm in Sources */,
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -550,7 +550,7 @@ WebExtensionAPIEvent& WebExtensionAPIAction::onClicked()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/onClicked
 
     if (!m_onClicked)
-        m_onClicked = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::ActionOnClicked);
+        m_onClicked = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::ActionOnClicked);
 
     return *m_onClicked;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -173,7 +173,7 @@ WebExtensionAPIEvent& WebExtensionAPIAlarms::onAlarm()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm
 
     if (!m_onAlarm)
-        m_onAlarm = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::AlarmsOnAlarm);
+        m_onAlarm = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::AlarmsOnAlarm);
 
     return *m_onAlarm;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
@@ -84,7 +84,7 @@ WebExtensionAPIEvent& WebExtensionAPICommands::onCommand()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onCommand
 
     if (!m_onCommand)
-        m_onCommand = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::CommandsOnCommand);
+        m_onCommand = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::CommandsOnCommand);
 
     return *m_onCommand;
 }
@@ -94,7 +94,7 @@ WebExtensionAPIEvent& WebExtensionAPICommands::onChanged()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onChanged
 
     if (!m_onChanged)
-        m_onChanged = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::CommandsOnChanged);
+        m_onChanged = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::CommandsOnChanged);
 
     return *m_onChanged;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -408,7 +408,7 @@ WebExtensionAPIEvent& WebExtensionAPICookies::onChanged()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/onChanged
 
     if (!m_onChanged)
-        m_onChanged = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::CookiesOnChanged);
+        m_onChanged = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::CookiesOnChanged);
 
     return *m_onChanged;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsCocoa.mm
@@ -46,7 +46,7 @@ WebExtensionAPIDevToolsInspectedWindow& WebExtensionAPIDevTools::inspectedWindow
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow
 
     if (!m_inspectedWindow)
-        m_inspectedWindow = WebExtensionAPIDevToolsInspectedWindow::create(forMainWorld(), runtime(), extensionContext());
+        m_inspectedWindow = WebExtensionAPIDevToolsInspectedWindow::create(*this);
 
     return *m_inspectedWindow;
 }
@@ -56,7 +56,7 @@ WebExtensionAPIDevToolsNetwork& WebExtensionAPIDevTools::network()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network
 
     if (!m_network)
-        m_network = WebExtensionAPIDevToolsNetwork::create(forMainWorld(), runtime(), extensionContext());
+        m_network = WebExtensionAPIDevToolsNetwork::create(*this);
 
     return *m_network;
 }
@@ -66,7 +66,7 @@ WebExtensionAPIDevToolsPanels& WebExtensionAPIDevTools::panels()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels
 
     if (!m_panels)
-        m_panels = WebExtensionAPIDevToolsPanels::create(forMainWorld(), runtime(), extensionContext());
+        m_panels = WebExtensionAPIDevToolsPanels::create(*this);
 
     return *m_panels;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
@@ -45,7 +45,7 @@ WebExtensionAPIEvent& WebExtensionAPIDevToolsExtensionPanel::onShown()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionPanel
 
     if (!m_onShown)
-        m_onShown = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::DevToolsExtensionPanelOnShown);
+        m_onShown = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::DevToolsExtensionPanelOnShown);
 
     return *m_onShown;
 }
@@ -55,7 +55,7 @@ WebExtensionAPIEvent& WebExtensionAPIDevToolsExtensionPanel::onHidden()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionPanel
 
     if (!m_onHidden)
-        m_onHidden = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::DevToolsExtensionPanelOnHidden);
+        m_onHidden = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::DevToolsExtensionPanelOnHidden);
 
     return *m_onHidden;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
@@ -58,7 +58,7 @@ void WebExtensionAPIDevToolsPanels::createPanel(WebPage& page, NSString *title, 
             return;
         }
 
-        Ref extensionPanel = WebExtensionAPIDevToolsExtensionPanel::create(forMainWorld(), runtime(), extensionContext());
+        Ref extensionPanel = WebExtensionAPIDevToolsExtensionPanel::create(*this);
         m_extensionPanels.set(result.value(), extensionPanel);
 
         auto globalContext = callback->globalContext();
@@ -86,7 +86,7 @@ WebExtensionAPIEvent& WebExtensionAPIDevToolsPanels::onThemeChanged()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/onThemeChanged
 
     if (!m_onThemeChanged)
-        m_onThemeChanged = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::DevToolsPanelsOnThemeChanged);
+        m_onThemeChanged = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::DevToolsPanelsOnThemeChanged);
 
     return *m_onThemeChanged;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -418,7 +418,7 @@ WebExtensionAPIEvent& WebExtensionAPIMenus::onClicked()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/onClicked
 
     if (!m_onClicked)
-        m_onClicked = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::MenusOnClicked);
+        m_onClicked = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::MenusOnClicked);
 
     return *m_onClicked;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -79,7 +79,7 @@ WebExtensionAPIAction& WebExtensionAPINamespace::action()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action
 
     if (!m_action)
-        m_action = WebExtensionAPIAction::create(forMainWorld(), runtime(), extensionContext());
+        m_action = WebExtensionAPIAction::create(*this);
 
     return *m_action;
 }
@@ -89,7 +89,7 @@ WebExtensionAPIAlarms& WebExtensionAPINamespace::alarms()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms
 
     if (!m_alarms)
-        m_alarms = WebExtensionAPIAlarms::create(forMainWorld(), runtime(), extensionContext());
+        m_alarms = WebExtensionAPIAlarms::create(*this);
 
     return *m_alarms;
 }
@@ -99,7 +99,7 @@ WebExtensionAPICommands& WebExtensionAPINamespace::commands()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands
 
     if (!m_commands)
-        m_commands = WebExtensionAPICommands::create(forMainWorld(), runtime(), extensionContext());
+        m_commands = WebExtensionAPICommands::create(*this);
 
     return *m_commands;
 }
@@ -109,7 +109,7 @@ WebExtensionAPICookies& WebExtensionAPINamespace::cookies()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies
 
     if (!m_cookies)
-        m_cookies = WebExtensionAPICookies::create(forMainWorld(), runtime(), extensionContext());
+        m_cookies = WebExtensionAPICookies::create(*this);
 
     return *m_cookies;
 }
@@ -119,7 +119,7 @@ WebExtensionAPIDeclarativeNetRequest& WebExtensionAPINamespace::declarativeNetRe
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest
 
     if (!m_declarativeNetRequest)
-        m_declarativeNetRequest = WebExtensionAPIDeclarativeNetRequest::create(forMainWorld(), runtime(), extensionContext());
+        m_declarativeNetRequest = WebExtensionAPIDeclarativeNetRequest::create(*this);
 
     return *m_declarativeNetRequest;
 }
@@ -130,7 +130,7 @@ WebExtensionAPIDevTools& WebExtensionAPINamespace::devtools()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools
 
     if (!m_devtools)
-        m_devtools = WebExtensionAPIDevTools::create(forMainWorld(), runtime(), extensionContext());
+        m_devtools = WebExtensionAPIDevTools::create(*this);
 
     return *m_devtools;
 }
@@ -141,7 +141,7 @@ WebExtensionAPIExtension& WebExtensionAPINamespace::extension()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension
 
     if (!m_extension)
-        m_extension = WebExtensionAPIExtension::create(forMainWorld(), runtime(), extensionContext());
+        m_extension = WebExtensionAPIExtension::create(*this);
 
     return *m_extension;
 }
@@ -151,7 +151,7 @@ WebExtensionAPILocalization& WebExtensionAPINamespace::i18n()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/i18n
 
     if (!m_i18n)
-        m_i18n = WebExtensionAPILocalization::create(forMainWorld(), runtime(), extensionContext());
+        m_i18n = WebExtensionAPILocalization::create(*this);
 
     return *m_i18n;
 }
@@ -161,7 +161,7 @@ WebExtensionAPIMenus& WebExtensionAPINamespace::menus()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus
 
     if (!m_menus)
-        m_menus = WebExtensionAPIMenus::create(forMainWorld(), runtime(), extensionContext());
+        m_menus = WebExtensionAPIMenus::create(*this);
 
     return *m_menus;
 }
@@ -171,7 +171,7 @@ WebExtensionAPINotifications& WebExtensionAPINamespace::notifications()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications
 
     if (!m_notifications)
-        m_notifications = WebExtensionAPINotifications::create(forMainWorld(), runtime(), extensionContext());
+        m_notifications = WebExtensionAPINotifications::create(*this);
 
     return *m_notifications;
 }
@@ -181,17 +181,17 @@ WebExtensionAPIPermissions& WebExtensionAPINamespace::permissions()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions
 
     if (!m_permissions)
-        m_permissions = WebExtensionAPIPermissions::create(forMainWorld(), runtime(), extensionContext());
+        m_permissions = WebExtensionAPIPermissions::create(*this);
 
     return *m_permissions;
 }
 
-WebExtensionAPIRuntime& WebExtensionAPINamespace::runtime()
+WebExtensionAPIRuntime& WebExtensionAPINamespace::runtime() const
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime
 
     if (!m_runtime)
-        m_runtime = WebExtensionAPIRuntime::create(forMainWorld(), extensionContext());
+        m_runtime = WebExtensionAPIRuntime::create(contentWorldType(), extensionContext());
 
     return *m_runtime;
 }
@@ -201,7 +201,7 @@ WebExtensionAPIScripting& WebExtensionAPINamespace::scripting()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting
 
     if (!m_scripting)
-        m_scripting = WebExtensionAPIScripting::create(forMainWorld(), runtime(), extensionContext());
+        m_scripting = WebExtensionAPIScripting::create(*this);
 
     return *m_scripting;
 }
@@ -211,7 +211,7 @@ WebExtensionAPIStorage& WebExtensionAPINamespace::storage()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage
 
     if (!m_storage)
-        m_storage = WebExtensionAPIStorage::create(forMainWorld(), runtime(), extensionContext());
+        m_storage = WebExtensionAPIStorage::create(*this);
 
     return *m_storage;
 }
@@ -221,7 +221,7 @@ WebExtensionAPITabs& WebExtensionAPINamespace::tabs()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs
 
     if (!m_tabs)
-        m_tabs = WebExtensionAPITabs::create(forMainWorld(), runtime(), extensionContext());
+        m_tabs = WebExtensionAPITabs::create(*this);
 
     return *m_tabs;
 }
@@ -231,7 +231,7 @@ WebExtensionAPITest& WebExtensionAPINamespace::test()
     // Documentation: None (Testing Only)
 
     if (!m_test)
-        m_test = WebExtensionAPITest::create(forMainWorld(), runtime(), extensionContext());
+        m_test = WebExtensionAPITest::create(*this);
 
     return *m_test;
 }
@@ -241,7 +241,7 @@ WebExtensionAPIWindows& WebExtensionAPINamespace::windows()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows
 
     if (!m_windows)
-        m_windows = WebExtensionAPIWindows::create(forMainWorld(), runtime(), extensionContext());
+        m_windows = WebExtensionAPIWindows::create(*this);
 
     return *m_windows;
 }
@@ -251,7 +251,7 @@ WebExtensionAPIWebNavigation& WebExtensionAPINamespace::webNavigation()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation
 
     if (!m_webNavigation)
-        m_webNavigation = WebExtensionAPIWebNavigation::create(forMainWorld(), runtime(), extensionContext());
+        m_webNavigation = WebExtensionAPIWebNavigation::create(*this);
 
     return *m_webNavigation;
 }
@@ -261,7 +261,7 @@ WebExtensionAPIWebRequest& WebExtensionAPINamespace::webRequest()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest
 
     if (!m_webRequest)
-        m_webRequest = WebExtensionAPIWebRequest::create(forMainWorld(), runtime(), extensionContext());
+        m_webRequest = WebExtensionAPIWebRequest::create(*this);
 
     return *m_webRequest;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINotificationsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINotificationsCocoa.mm
@@ -39,7 +39,7 @@ WebExtensionAPIEvent& WebExtensionAPINotifications::onClicked()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onClicked
 
     if (!m_onClicked)
-        m_onClicked = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::NotificationsOnClicked);
+        m_onClicked = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::NotificationsOnClicked);
 
     return *m_onClicked;
 }
@@ -49,7 +49,7 @@ WebExtensionAPIEvent& WebExtensionAPINotifications::onButtonClicked()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/notifications/onButtonClicked
 
     if (!m_onButtonClicked)
-        m_onButtonClicked = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::NotificationsOnButtonClicked);
+        m_onButtonClicked = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::NotificationsOnButtonClicked);
 
     return *m_onButtonClicked;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -245,7 +245,7 @@ WebExtensionAPIEvent& WebExtensionAPIPermissions::onAdded()
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onAdded
 
     if (!m_onAdded)
-        m_onAdded = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PermissionsOnAdded);
+        m_onAdded = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::PermissionsOnAdded);
 
     return *m_onAdded;
 }
@@ -255,7 +255,7 @@ WebExtensionAPIEvent& WebExtensionAPIPermissions::onRemoved()
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved
 
     if (!m_onRemoved)
-        m_onRemoved = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PermissionsOnRemoved);
+        m_onRemoved = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::PermissionsOnRemoved);
 
     return *m_onRemoved;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -39,6 +39,7 @@
 #import "WebExtensionAPINamespace.h"
 #import "WebExtensionAPIRuntime.h"
 #import "WebExtensionContextMessages.h"
+#import "WebExtensionControllerProxy.h"
 #import "WebExtensionUtilities.h"
 #import "WebProcess.h"
 
@@ -190,7 +191,7 @@ WebExtensionAPIEvent& WebExtensionAPIPort::onMessage()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#onmessage
 
     if (!m_onMessage)
-        m_onMessage = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PortOnMessage);
+        m_onMessage = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::PortOnMessage);
 
     return *m_onMessage;
 }
@@ -200,7 +201,7 @@ WebExtensionAPIEvent& WebExtensionAPIPort::onDisconnect()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#ondisconnect
 
     if (!m_onDisconnect)
-        m_onDisconnect = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PortOnDisconnect);
+        m_onDisconnect = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::PortOnDisconnect);
 
     return *m_onDisconnect;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -247,7 +247,7 @@ WebExtensionAPIEvent& WebExtensionAPIStorageArea::onChanged()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged
 
     if (!m_onChanged)
-        m_onChanged = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::StorageOnChanged);
+        m_onChanged = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::StorageOnChanged);
 
     return *m_onChanged;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
@@ -54,7 +54,7 @@ WebExtensionAPIStorageArea& WebExtensionAPIStorage::local()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/local
 
     if (!m_local)
-        m_local = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), WebExtensionDataType::Local);
+        m_local = WebExtensionAPIStorageArea::create(*this, WebExtensionDataType::Local);
 
     return *m_local;
 }
@@ -64,7 +64,7 @@ WebExtensionAPIStorageArea& WebExtensionAPIStorage::session()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/session
 
     if (!m_session)
-        m_session = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), WebExtensionDataType::Session);
+        m_session = WebExtensionAPIStorageArea::create(*this, WebExtensionDataType::Session);
 
     return *m_session;
 }
@@ -74,7 +74,7 @@ WebExtensionAPIStorageArea& WebExtensionAPIStorage::sync()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync
 
     if (!m_sync)
-        m_sync = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), WebExtensionDataType::Sync);
+        m_sync = WebExtensionAPIStorageArea::create(*this, WebExtensionDataType::Sync);
 
     return *m_sync;
 }
@@ -99,7 +99,7 @@ WebExtensionAPIEvent& WebExtensionAPIStorage::onChanged()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/onChanged
 
     if (!m_onChanged)
-        m_onChanged = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::StorageOnChanged);
+        m_onChanged = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::StorageOnChanged);
 
     return *m_onChanged;
 }
@@ -111,7 +111,7 @@ void WebExtensionContextProxy::dispatchStorageChangedEvent(const String& onChang
     enumerateFramesAndNamespaceObjects([&](WebFrame&, auto& namespaceObject) {
         namespaceObject.storage().onChanged().invokeListenersWithArgument(onChangedData);
         namespaceObject.storage().storageAreaForType(dataType).onChanged().invokeListenersWithArgument(onChangedData);
-    }, toDOMWorld(contentWorldType));
+    }, toDOMWrapperWorld(contentWorldType));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -1004,7 +1004,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
         frame.url(),
     };
 
-    auto port = WebExtensionAPIPort::create(forMainWorld(), runtime(), extensionContext(), *frame.page(), WebExtensionContentWorldType::ContentScript, resolvedName);
+    auto port = WebExtensionAPIPort::create(*this, *frame.page(), WebExtensionContentWorldType::ContentScript, resolvedName);
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsConnect(tabIdentifer.value(), port->channelIdentifier(), resolvedName, targetFrameIdentifier, senderParameters), [=, globalContext = JSRetainPtr { JSContextGetGlobalContext(context) }, protectedThis = Ref { *this }](WebExtensionTab::Error error) {
         if (!error)
@@ -1088,7 +1088,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onActivated()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onActivated
 
     if (!m_onActivated)
-        m_onActivated = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnActivated);
+        m_onActivated = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnActivated);
 
     return *m_onActivated;
 }
@@ -1098,7 +1098,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onAttached()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onAttached
 
     if (!m_onAttached)
-        m_onAttached = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnAttached);
+        m_onAttached = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnAttached);
 
     return *m_onAttached;
 }
@@ -1108,7 +1108,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onCreated()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onCreated
 
     if (!m_onCreated)
-        m_onCreated = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnCreated);
+        m_onCreated = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnCreated);
 
     return *m_onCreated;
 }
@@ -1118,7 +1118,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onDetached()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onDetached
 
     if (!m_onDetached)
-        m_onDetached = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnDetached);
+        m_onDetached = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnDetached);
 
     return *m_onDetached;
 }
@@ -1128,7 +1128,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onHighlighted()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlighted
 
     if (!m_onHighlighted)
-        m_onHighlighted = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnHighlighted);
+        m_onHighlighted = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnHighlighted);
 
     return *m_onHighlighted;
 }
@@ -1138,7 +1138,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onMoved()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onMoved
 
     if (!m_onMoved)
-        m_onMoved = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnMoved);
+        m_onMoved = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnMoved);
 
     return *m_onMoved;
 }
@@ -1148,7 +1148,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onRemoved()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved
 
     if (!m_onRemoved)
-        m_onRemoved = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnRemoved);
+        m_onRemoved = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnRemoved);
 
     return *m_onRemoved;
 }
@@ -1158,7 +1158,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onReplaced()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onReplaced
 
     if (!m_onReplaced)
-        m_onReplaced = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnReplaced);
+        m_onReplaced = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnReplaced);
 
     return *m_onReplaced;
 }
@@ -1168,7 +1168,7 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onUpdated()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated
 
     if (!m_onUpdated)
-        m_onUpdated = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnUpdated);
+        m_onUpdated = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TabsOnUpdated);
 
     return *m_onUpdated;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -33,7 +33,8 @@
 #import "CocoaHelpers.h"
 #import "MessageSenderInlines.h"
 #import "WebExtensionAPINamespace.h"
-#import "WebExtensionContextMessages.h"
+#import "WebExtensionControllerMessages.h"
+#import "WebExtensionControllerProxy.h"
 #import "WebExtensionEventListenerType.h"
 #import "WebProcess.h"
 #import <JavaScriptCore/APICast.h>
@@ -60,19 +61,46 @@ static std::pair<String, unsigned> scriptLocation(JSContextRef context)
 void WebExtensionAPITest::notifyFail(JSContextRef context, NSString *message)
 {
     auto location = scriptLocation(context);
-    WebProcess::singleton().send(Messages::WebExtensionContext::TestFinished(false, message, location.first, location.second), extensionContext().identifier());
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(false, message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
 void WebExtensionAPITest::notifyPass(JSContextRef context, NSString *message)
 {
     auto location = scriptLocation(context);
-    WebProcess::singleton().send(Messages::WebExtensionContext::TestFinished(true, message, location.first, location.second), extensionContext().identifier());
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestFinished(true, message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
 void WebExtensionAPITest::yield(JSContextRef context, NSString *message)
 {
     auto location = scriptLocation(context);
-    WebProcess::singleton().send(Messages::WebExtensionContext::TestYielded(message, location.first, location.second), extensionContext().identifier());
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestYielded(message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
 inline NSString *debugString(JSValue *value)
@@ -85,7 +113,16 @@ inline NSString *debugString(JSValue *value)
 void WebExtensionAPITest::log(JSContextRef context, JSValue *value)
 {
     auto location = scriptLocation(context);
-    WebProcess::singleton().send(Messages::WebExtensionContext::TestMessage(debugString(value), location.first, location.second), extensionContext().identifier());
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestMessage(debugString(value), location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
 void WebExtensionAPITest::fail(JSContextRef context, NSString *message)
@@ -101,7 +138,16 @@ void WebExtensionAPITest::succeed(JSContextRef context, NSString *message)
 void WebExtensionAPITest::assertTrue(JSContextRef context, bool actualValue, NSString *message)
 {
     auto location = scriptLocation(context);
-    WebProcess::singleton().send(Messages::WebExtensionContext::TestResult(actualValue, message, location.first, location.second), extensionContext().identifier());
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestResult(actualValue, message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
 void WebExtensionAPITest::assertFalse(JSContextRef context, bool actualValue, NSString *message)
@@ -120,7 +166,16 @@ void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValue *actualValu
     BOOL deepEqual = strictEqual || [expectedJSONValue isEqualToString:actualJSONValue];
 
     auto location = scriptLocation(context);
-    WebProcess::singleton().send(Messages::WebExtensionContext::TestEqual(deepEqual, expectedJSONValue, actualJSONValue, message, location.first, location.second), extensionContext().identifier());
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestEqual(deepEqual, expectedJSONValue, actualJSONValue, message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
 static NSString *combineMessages(NSString *messageOne, NSString *messageTwo)
@@ -132,10 +187,19 @@ static NSString *combineMessages(NSString *messageOne, NSString *messageTwo)
     return messageTwo;
 }
 
-static void assertEquals(WebExtensionContextProxy& extensionContext, JSContextRef context, bool result, NSString *expectedString, NSString *actualString, NSString *message)
+static void assertEquals(JSContextRef context, bool result, NSString *expectedString, NSString *actualString, NSString *message)
 {
     auto location = scriptLocation(context);
-    WebProcess::singleton().send(Messages::WebExtensionContext::TestEqual(result, expectedString, actualString, message, location.first, location.second), extensionContext.identifier());
+
+    RefPtr page = toWebPage(context);
+    if (!page)
+        return;
+
+    RefPtr webExtensionControllerProxy = page->webExtensionControllerProxy();
+    if (!webExtensionControllerProxy)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionController::TestEqual(result, expectedString, actualString, message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
 void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message)
@@ -147,7 +211,7 @@ void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *actualValue, J
     if (!strictEqual && [expectedJSONValue isEqualToString:actualJSONValue])
         actualJSONValue = [actualJSONValue stringByAppendingString:@" (different)"];
 
-    assertEquals(extensionContext(), context, strictEqual, expectedJSONValue, actualJSONValue, message);
+    assertEquals(context, strictEqual, expectedJSONValue, actualJSONValue, message);
 }
 
 JSValue *WebExtensionAPITest::assertRejects(JSContextRef context, JSValue *promise, JSValue *expectedError, NSString *message)
@@ -162,7 +226,7 @@ JSValue *WebExtensionAPITest::assertRejects(JSContextRef context, JSValue *promi
 
     [promise _awaitThenableResolutionWithCompletionHandler:^(JSValue *result, JSValue *error) {
         if (result || !error) {
-            assertEquals(extensionContext(), context, false, expectedError ? debugString(expectedError) : @"(any error)", result ? debugString(result) : @"(no error)", combineMessages(message, @"Promise did not reject with an error"));
+            assertEquals(context, false, expectedError ? debugString(expectedError) : @"(any error)", result ? debugString(result) : @"(no error)", combineMessages(message, @"Promise did not reject with an error"));
             [resolveCallback callWithArguments:nil];
             return;
         }
@@ -170,19 +234,19 @@ JSValue *WebExtensionAPITest::assertRejects(JSContextRef context, JSValue *promi
         JSValue *errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"] : error;
 
         if (!expectedError) {
-            assertEquals(extensionContext(), context, true, @"(any error)", debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error"));
+            assertEquals(context, true, @"(any error)", debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error"));
             [resolveCallback callWithArguments:nil];
             return;
         }
 
         if (expectedError._isRegularExpression) {
             JSValue *testResult = [expectedError invokeMethod:@"test" withArguments:@[ errorMessageValue ]];
-            assertEquals(extensionContext(), context, testResult.toBool, debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't match the regular expression"));
+            assertEquals(context, testResult.toBool, debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't match the regular expression"));
             [resolveCallback callWithArguments:nil];
             return;
         }
 
-        assertEquals(extensionContext(), context, [expectedError isEqualWithTypeCoercionToObject:errorMessageValue], debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't equal"));
+        assertEquals(context, [expectedError isEqualWithTypeCoercionToObject:errorMessageValue], debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't equal"));
         [resolveCallback callWithArguments:nil];
     }];
 
@@ -221,7 +285,7 @@ void WebExtensionAPITest::assertThrows(JSContextRef context, JSValue *function, 
 
     JSValue *exceptionValue = function.context.exception;
     if (!exceptionValue) {
-        assertEquals(extensionContext(), context, false, expectedError ? debugString(expectedError) : @"(any exception)", @"(no exception)", combineMessages(message, @"Function did not throw an exception"));
+        assertEquals(context, false, expectedError ? debugString(expectedError) : @"(any exception)", @"(no exception)", combineMessages(message, @"Function did not throw an exception"));
         return;
     }
 
@@ -231,17 +295,17 @@ void WebExtensionAPITest::assertThrows(JSContextRef context, JSValue *function, 
     function.context.exception = nil;
 
     if (!expectedError) {
-        assertEquals(extensionContext(), context, true, @"(any exception)", debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception"));
+        assertEquals(context, true, @"(any exception)", debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception"));
         return;
     }
 
     if (expectedError._isRegularExpression) {
         JSValue *testResult = [expectedError invokeMethod:@"test" withArguments:@[ exceptionMessageValue ]];
-        assertEquals(extensionContext(), context, testResult.toBool, debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't match the regular expression"));
+        assertEquals(context, testResult.toBool, debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't match the regular expression"));
         return;
     }
 
-    assertEquals(extensionContext(), context, [expectedError isEqualWithTypeCoercionToObject:exceptionMessageValue], debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't equal"));
+    assertEquals(context, [expectedError isEqualWithTypeCoercionToObject:exceptionMessageValue], debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't equal"));
 }
 
 JSValue *WebExtensionAPITest::assertSafe(JSContextRef context, JSValue *function, NSString *message)
@@ -275,7 +339,7 @@ JSValue *WebExtensionAPITest::assertSafeResolve(JSContextRef context, JSValue *f
 WebExtensionAPIEvent& WebExtensionAPITest::testEvent()
 {
     if (!m_event)
-        m_event = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::ActionOnClicked);
+        m_event = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::ActionOnClicked);
 
     return *m_event;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -139,7 +139,7 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onBeforeNavigat
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate
 
     if (!m_onBeforeNavigateEvent)
-        m_onBeforeNavigateEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnBeforeNavigate);
+        m_onBeforeNavigateEvent = WebExtensionAPIWebNavigationEvent::create(*this, WebExtensionEventListenerType::WebNavigationOnBeforeNavigate);
 
     return *m_onBeforeNavigateEvent;
 }
@@ -149,7 +149,7 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onCommitted()
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted
 
     if (!m_onCommittedEvent)
-        m_onCommittedEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnCommitted);
+        m_onCommittedEvent = WebExtensionAPIWebNavigationEvent::create(*this, WebExtensionEventListenerType::WebNavigationOnCommitted);
 
     return *m_onCommittedEvent;
 }
@@ -159,7 +159,7 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onDOMContentLoa
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded
 
     if (!m_onDOMContentLoadedEvent)
-        m_onDOMContentLoadedEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded);
+        m_onDOMContentLoadedEvent = WebExtensionAPIWebNavigationEvent::create(*this, WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded);
 
     return *m_onDOMContentLoadedEvent;
 }
@@ -169,7 +169,7 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onCompleted()
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted
 
     if (!m_onCompletedEvent)
-        m_onCompletedEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnCompleted);
+        m_onCompletedEvent = WebExtensionAPIWebNavigationEvent::create(*this, WebExtensionEventListenerType::WebNavigationOnCompleted);
 
     return *m_onCompletedEvent;
 }
@@ -179,7 +179,7 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onErrorOccurred
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred
 
     if (!m_onErrorOccurredEvent)
-        m_onErrorOccurredEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnErrorOccurred);
+        m_onErrorOccurredEvent = WebExtensionAPIWebNavigationEvent::create(*this, WebExtensionEventListenerType::WebNavigationOnErrorOccurred);
 
     return *m_onErrorOccurredEvent;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -43,7 +43,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onBeforeRequest()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest
 
     if (!m_onBeforeRequestEvent)
-        m_onBeforeRequestEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnBeforeRequest);
+        m_onBeforeRequestEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnBeforeRequest);
 
     return *m_onBeforeRequestEvent;
 }
@@ -53,7 +53,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onBeforeSendHeaders()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeSendHeaders
 
     if (!m_onBeforeSendHeadersEvent)
-        m_onBeforeSendHeadersEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnBeforeSendHeaders);
+        m_onBeforeSendHeadersEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnBeforeSendHeaders);
 
     return *m_onBeforeSendHeadersEvent;
 }
@@ -63,7 +63,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onSendHeaders()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onSendHeaders
 
     if (!m_onSendHeadersEvent)
-        m_onSendHeadersEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnSendHeaders);
+        m_onSendHeadersEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnSendHeaders);
 
     return *m_onSendHeadersEvent;
 }
@@ -73,7 +73,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onHeadersReceived()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived
 
     if (!m_onHeadersReceivedEvent)
-        m_onHeadersReceivedEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnHeadersReceived);
+        m_onHeadersReceivedEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnHeadersReceived);
 
     return *m_onHeadersReceivedEvent;
 }
@@ -83,7 +83,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onAuthRequired()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired
 
     if (!m_onAuthRequiredEvent)
-        m_onAuthRequiredEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnAuthRequired);
+        m_onAuthRequiredEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnAuthRequired);
 
     return *m_onAuthRequiredEvent;
 }
@@ -93,7 +93,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onBeforeRedirect()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRedirect
 
     if (!m_onBeforeRedirectEvent)
-        m_onBeforeRedirectEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnBeforeRedirect);
+        m_onBeforeRedirectEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnBeforeRedirect);
 
     return *m_onBeforeRedirectEvent;
 }
@@ -103,7 +103,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onResponseStarted()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onResponseStarted
 
     if (!m_onResponseStartedEvent)
-        m_onResponseStartedEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnResponseStarted);
+        m_onResponseStartedEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnResponseStarted);
 
     return *m_onResponseStartedEvent;
 }
@@ -113,7 +113,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onCompleted()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onCompleted
 
     if (!m_onCompletedEvent)
-        m_onCompletedEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnCompleted);
+        m_onCompletedEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnCompleted);
 
     return *m_onCompletedEvent;
 }
@@ -123,7 +123,7 @@ WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onErrorOccurred()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onErrorOccurred
 
     if (!m_onErrorOccurredEvent)
-        m_onErrorOccurredEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnErrorOccurred);
+        m_onErrorOccurredEvent = WebExtensionAPIWebRequestEvent::create(*this, WebExtensionEventListenerType::WebRequestOnErrorOccurred);
 
     return *m_onErrorOccurredEvent;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -559,7 +559,7 @@ WebExtensionAPIWindowsEvent& WebExtensionAPIWindows::onCreated()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onCreated
 
     if (!m_onCreated)
-        m_onCreated = WebExtensionAPIWindowsEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WindowsOnCreated);
+        m_onCreated = WebExtensionAPIWindowsEvent::create(*this, WebExtensionEventListenerType::WindowsOnCreated);
 
     return *m_onCreated;
 }
@@ -569,7 +569,7 @@ WebExtensionAPIWindowsEvent& WebExtensionAPIWindows::onRemoved()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onRemoved
 
     if (!m_onRemoved)
-        m_onRemoved = WebExtensionAPIWindowsEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WindowsOnRemoved);
+        m_onRemoved = WebExtensionAPIWindowsEvent::create(*this, WebExtensionEventListenerType::WindowsOnRemoved);
 
     return *m_onRemoved;
 }
@@ -579,7 +579,7 @@ WebExtensionAPIWindowsEvent& WebExtensionAPIWindows::onFocusChanged()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onFocusChanged
 
     if (!m_onFocusChanged)
-        m_onFocusChanged = WebExtensionAPIWindowsEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WindowsOnFocusChanged);
+        m_onFocusChanged = WebExtensionAPIWindowsEvent::create(*this, WebExtensionEventListenerType::WindowsOnFocusChanged);
 
     return *m_onFocusChanged;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -62,8 +62,8 @@ public:
     }
 
 private:
-    explicit WebExtensionAPIEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
-        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    explicit WebExtensionAPIEvent(const WebExtensionAPIObject& parentObject, WebExtensionEventListenerType type)
+        : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
     }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -77,7 +77,7 @@ public:
     WebExtensionAPINotifications& notifications();
     WebExtensionAPIAction& pageAction() { return action(); }
     WebExtensionAPIPermissions& permissions();
-    WebExtensionAPIRuntime& runtime() final;
+    WebExtensionAPIRuntime& runtime() const final;
     WebExtensionAPIScripting& scripting();
     WebExtensionAPIStorage& storage();
     WebExtensionAPITabs& tabs();
@@ -101,7 +101,7 @@ private:
     RefPtr<WebExtensionAPIMenus> m_menus;
     RefPtr<WebExtensionAPINotifications> m_notifications;
     RefPtr<WebExtensionAPIPermissions> m_permissions;
-    RefPtr<WebExtensionAPIRuntime> m_runtime;
+    mutable RefPtr<WebExtensionAPIRuntime> m_runtime;
     RefPtr<WebExtensionAPIScripting> m_scripting;
     RefPtr<WebExtensionAPIStorage> m_storage;
     RefPtr<WebExtensionAPITabs> m_tabs;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -80,8 +80,8 @@ public:
 private:
     friend class WebExtensionContextProxy;
 
-    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name)
-        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name)
+        : WebExtensionAPIObject(parentObject)
         , m_targetContentWorldType(targetContentWorldType)
         , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
         , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
@@ -90,8 +90,18 @@ private:
         add();
     }
 
-    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
-        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    explicit WebExtensionAPIPort(WebExtensionContentWorldType contentWorldType, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name)
+        : WebExtensionAPIObject(contentWorldType, runtime, context)
+        , m_targetContentWorldType(targetContentWorldType)
+        , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
+        , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
+        , m_name(name)
+    {
+        add();
+    }
+
+    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
+        : WebExtensionAPIObject(parentObject)
         , m_targetContentWorldType(targetContentWorldType)
         , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
         , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
@@ -101,8 +111,8 @@ private:
         add();
     }
 
-    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPage& page, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
-        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPage& page, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
+        : WebExtensionAPIObject(parentObject)
         , m_targetContentWorldType(targetContentWorldType)
         , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
         , m_channelIdentifier(channelIdentifier)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "JSWebExtensionAPIRuntime.h"
+#include "JSWebExtensionAPIWebPageRuntime.h"
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
 
@@ -59,7 +60,7 @@ class WebExtensionAPIRuntime : public WebExtensionAPIObject, public WebExtension
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIRuntime, runtime);
 
 public:
-    WebExtensionAPIRuntime& runtime() final { return *this; }
+    WebExtensionAPIRuntime& runtime() const final { return const_cast<WebExtensionAPIRuntime&>(*this); }
 
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage&);
@@ -89,14 +90,32 @@ public:
     WebExtensionAPIEvent& onInstalled();
     WebExtensionAPIEvent& onMessage();
     WebExtensionAPIEvent& onStartup();
+    WebExtensionAPIEvent& onConnectExternal();
+    WebExtensionAPIEvent& onMessageExternal();
 
 private:
+    friend class WebExtensionAPIWebPageRuntime;
+
     static bool parseConnectOptions(NSDictionary *, std::optional<String>& name, NSString *sourceKey, NSString **outExceptionString);
 
     RefPtr<WebExtensionAPIEvent> m_onConnect;
     RefPtr<WebExtensionAPIEvent> m_onInstalled;
     RefPtr<WebExtensionAPIEvent> m_onMessage;
     RefPtr<WebExtensionAPIEvent> m_onStartup;
+    RefPtr<WebExtensionAPIEvent> m_onConnectExternal;
+    RefPtr<WebExtensionAPIEvent> m_onMessageExternal;
+#endif
+};
+
+class WebExtensionAPIWebPageRuntime : public WebExtensionAPIObject, public WebExtensionAPIRuntimeBase {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebPageRuntime, webPageRuntime);
+
+public:
+    WebExtensionAPIWebPageRuntime& runtime() const final { return const_cast<WebExtensionAPIWebPageRuntime&>(*this); }
+
+#if PLATFORM(COCOA)
+    void sendMessage(WebFrame&, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebFrame&, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -62,8 +62,8 @@ public:
     WebExtensionAPIEvent& onChanged();
 
 private:
-    explicit WebExtensionAPIStorageArea(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionDataType type)
-        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    explicit WebExtensionAPIStorageArea(const WebExtensionAPIObject& parentObject, WebExtensionDataType type)
+        : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
     }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -64,8 +64,8 @@ public:
     }
 
 private:
-    explicit WebExtensionAPIWebNavigationEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
-        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    explicit WebExtensionAPIWebNavigationEvent(const WebExtensionAPIObject& parentObject, WebExtensionEventListenerType type)
+        : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
     }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
@@ -23,44 +23,36 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !__has_feature(objc_arc)
-#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
-#endif
+#pragma once
 
-#import "config.h"
-#import "WebExtensionAPIDevToolsNetwork.h"
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-#if ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
-
-#import "CocoaHelpers.h"
-#import "JSWebExtensionWrapper.h"
-#import "MessageSenderInlines.h"
-#import "WebExtensionAPIEvent.h"
-#import "WebExtensionAPINamespace.h"
+#include "JSWebExtensionAPIWebPageNamespace.h"
+#include "JSWebExtensionWrappable.h"
+#include "WebExtensionAPIObject.h"
 
 namespace WebKit {
 
-WebExtensionAPIEvent& WebExtensionAPIDevToolsNetwork::onNavigated()
-{
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
+class WebExtensionAPITest;
+class WebExtensionAPIWebPageRuntime;
+class WebPage;
 
-    if (!m_onNavigated)
-        m_onNavigated = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::DevToolsNetworkOnNavigated);
+class WebExtensionAPIWebPageNamespace : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebPageNamespace, webPageNamespace);
 
-    return *m_onNavigated;
-}
+public:
+#if PLATFORM(COCOA)
+    bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage&);
 
-void WebExtensionContextProxy::dispatchDevToolsNetworkNavigatedEvent(const URL& url)
-{
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
+    WebExtensionAPIWebPageRuntime& runtime() const;
+    WebExtensionAPITest& test();
 
-    NSString *urlString = url.string();
-
-    enumerateNamespaceObjects([&](auto& namespaceObject) {
-        namespaceObject.devtools().network().onNavigated().invokeListenersWithArgument(urlString);
-    });
-}
+private:
+    mutable RefPtr<WebExtensionAPIWebPageRuntime> m_runtime;
+    RefPtr<WebExtensionAPITest> m_test;
+#endif
+};
 
 } // namespace WebKit
 
-#endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageRuntime.h
@@ -23,44 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !__has_feature(objc_arc)
-#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
-#endif
+#pragma once
 
-#import "config.h"
-#import "WebExtensionAPIDevToolsNetwork.h"
-
-#if ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
-
-#import "CocoaHelpers.h"
-#import "JSWebExtensionWrapper.h"
-#import "MessageSenderInlines.h"
-#import "WebExtensionAPIEvent.h"
-#import "WebExtensionAPINamespace.h"
+#if ENABLE(WK_WEB_EXTENSIONS)
 
 namespace WebKit {
 
-WebExtensionAPIEvent& WebExtensionAPIDevToolsNetwork::onNavigated()
-{
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
-
-    if (!m_onNavigated)
-        m_onNavigated = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::DevToolsNetworkOnNavigated);
-
-    return *m_onNavigated;
-}
-
-void WebExtensionContextProxy::dispatchDevToolsNetworkNavigatedEvent(const URL& url)
-{
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
-
-    NSString *urlString = url.string();
-
-    enumerateNamespaceObjects([&](auto& namespaceObject) {
-        namespaceObject.devtools().network().onNavigated().invokeListenersWithArgument(urlString);
-    });
-}
+// FIXME: Remove once JSWebExtensionAPIWebPageNamespace.mm doesn't auto include it.
 
 } // namespace WebKit
 
-#endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -64,8 +64,8 @@ public:
     }
 
 private:
-    explicit WebExtensionAPIWebRequestEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
-        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    explicit WebExtensionAPIWebRequestEvent(const WebExtensionAPIObject& parentObject, WebExtensionEventListenerType type)
+        : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
     }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -61,8 +61,8 @@ public:
     }
 
 private:
-    explicit WebExtensionAPIWindowsEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
-        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    explicit WebExtensionAPIWindowsEvent(const WebExtensionAPIObject& parentObject, WebExtensionEventListenerType type)
+        : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
     }

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -33,9 +33,11 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "JSWebExtensionAPINamespace.h"
+#include "JSWebExtensionAPIWebPageNamespace.h"
 #include "JSWebExtensionWrapper.h"
 #include "MessageSenderInlines.h"
 #include "WebExtensionAPINamespace.h"
+#include "WebExtensionAPIWebPageNamespace.h"
 #include "WebExtensionContextProxy.h"
 #include "WebExtensionControllerMessages.h"
 #include "WebExtensionFrameIdentifier.h"
@@ -53,7 +55,7 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
     bool isMainWorld = world.isNormal();
 
     if (!extension && isMainWorld) {
-        // FIXME: <https://webkit.org/b/246491> Add bindings for externally connectable.
+        addBindingsToWebPageFrameIfNecessary(frame, world);
         return;
     }
 
@@ -72,16 +74,16 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
     if (!isMainWorld)
         extension->setContentScriptWorld(&world);
 
-    auto forMainWorld = isMainWorld ? WebExtensionAPINamespace::ForMainWorld::Yes : WebExtensionAPINamespace::ForMainWorld::No;
+    auto contentWorldType = isMainWorld ? WebExtensionContentWorldType::Main : WebExtensionContentWorldType::ContentScript;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     if (extension->isInspectorBackgroundPage(page)) {
         // Inspector background pages have a limited set of APIs (like content scripts).
-        forMainWorld = WebExtensionAPINamespace::ForMainWorld::No;
+        contentWorldType = WebExtensionContentWorldType::ContentScript;
     }
 #endif
 
-    namespaceObject = toJS(context, WebExtensionAPINamespace::create(forMainWorld, *extension).ptr());
+    namespaceObject = toJS(context, WebExtensionAPINamespace::create(contentWorldType, *extension).ptr());
 
     JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
@@ -104,10 +106,24 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
 
     extension->addFrameWithExtensionContent(frame);
 
-    namespaceObject = toJS(context, WebExtensionAPINamespace::create(WebExtensionAPINamespace::ForMainWorld::Yes, *extension).ptr());
+    namespaceObject = toJS(context, WebExtensionAPINamespace::create(WebExtensionContentWorldType::Main, *extension).ptr());
 
     JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+}
+
+void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame& frame, DOMWrapperWorld& world)
+{
+    auto context = frame.jsContextForWorld(world);
+    auto globalObject = JSContextGetGlobalObject(context);
+
+    auto namespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser").get(), nullptr);
+    if (namespaceObject && JSValueIsObject(context, namespaceObject))
+        return;
+
+    namespaceObject = toJS(context, WebExtensionAPIWebPageNamespace::create(WebExtensionContentWorldType::WebPage).ptr());
+
+    JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 }
 
 void WebExtensionControllerProxy::didStartProvisionalLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
@@ -53,6 +53,8 @@
     readonly attribute WebExtensionAPIEvent onConnect;
     readonly attribute WebExtensionAPIEvent onMessage;
 
+    [MainWorldOnly] readonly attribute WebExtensionAPIEvent onConnectExternal;
+    [MainWorldOnly] readonly attribute WebExtensionAPIEvent onMessageExternal;
     [MainWorldOnly] readonly attribute WebExtensionAPIEvent onStartup;
     [MainWorldOnly] readonly attribute WebExtensionAPIEvent onInstalled;
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace.idl
@@ -23,44 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !__has_feature(objc_arc)
-#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
-#endif
+[
+    Conditional=WK_WEB_EXTENSIONS,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIWebPageNamespace {
 
-#import "config.h"
-#import "WebExtensionAPIDevToolsNetwork.h"
+    readonly attribute WebExtensionAPIWebPageRuntime runtime;
+    [Dynamic] readonly attribute WebExtensionAPITest test;
 
-#if ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
-
-#import "CocoaHelpers.h"
-#import "JSWebExtensionWrapper.h"
-#import "MessageSenderInlines.h"
-#import "WebExtensionAPIEvent.h"
-#import "WebExtensionAPINamespace.h"
-
-namespace WebKit {
-
-WebExtensionAPIEvent& WebExtensionAPIDevToolsNetwork::onNavigated()
-{
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
-
-    if (!m_onNavigated)
-        m_onNavigated = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::DevToolsNetworkOnNavigated);
-
-    return *m_onNavigated;
-}
-
-void WebExtensionContextProxy::dispatchDevToolsNetworkNavigatedEvent(const URL& url)
-{
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
-
-    NSString *urlString = url.string();
-
-    enumerateNamespaceObjects([&](auto& namespaceObject) {
-        namespaceObject.devtools().network().onNavigated().invokeListenersWithArgument(urlString);
-    });
-}
-
-} // namespace WebKit
-
-#endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
+};

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageRuntime.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageRuntime.idl
@@ -23,44 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !__has_feature(objc_arc)
-#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
-#endif
+[
+    Conditional=WK_WEB_EXTENSIONS,
+    ReturnsPromiseWhenCallbackIsOmitted
+] interface WebExtensionAPIWebPageRuntime {
 
-#import "config.h"
-#import "WebExtensionAPIDevToolsNetwork.h"
+    [RaisesException, NeedsFrame, ProcessArgumentsLeftToRight] void sendMessage(DOMString extensionId, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect(DOMString extensionId, [Optional, NSDictionary] any options);
 
-#if ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
-
-#import "CocoaHelpers.h"
-#import "JSWebExtensionWrapper.h"
-#import "MessageSenderInlines.h"
-#import "WebExtensionAPIEvent.h"
-#import "WebExtensionAPINamespace.h"
-
-namespace WebKit {
-
-WebExtensionAPIEvent& WebExtensionAPIDevToolsNetwork::onNavigated()
-{
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
-
-    if (!m_onNavigated)
-        m_onNavigated = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::DevToolsNetworkOnNavigated);
-
-    return *m_onNavigated;
-}
-
-void WebExtensionContextProxy::dispatchDevToolsNetworkNavigatedEvent(const URL& url)
-{
-    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onNavigated
-
-    NSString *urlString = url.string();
-
-    enumerateNamespaceObjects([&](auto& namespaceObject) {
-        namespaceObject.devtools().network().onNavigated().invokeListenersWithArgument(urlString);
-    });
-}
-
-} // namespace WebKit
-
-#endif // ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
+};

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -31,6 +31,7 @@
 #include "JSWebExtensionAPINamespace.h"
 #include "JSWebExtensionWrapper.h"
 #include "WebExtensionAPINamespace.h"
+#include "WebExtensionControllerProxy.h"
 #include "WebFrame.h"
 #include "WebPage.h"
 #include "WebProcess.h"
@@ -38,6 +39,11 @@
 namespace WebKit {
 
 using namespace WebCore;
+
+WebExtensionControllerProxy* WebExtensionContextProxy::extensionControllerProxy() const
+{
+    return m_extensionControllerProxy.get();
+}
 
 void WebExtensionContextProxy::addFrameWithExtensionContent(WebFrame& frame)
 {

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -45,6 +45,7 @@ namespace WebKit {
 
 class WebExtensionAPINamespace;
 class WebExtensionAPIStorage;
+class WebExtensionControllerProxy;
 class WebExtensionMatchPattern;
 class WebFrame;
 
@@ -58,7 +59,7 @@ class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProx
 
 public:
     static RefPtr<WebExtensionContextProxy> get(WebExtensionContextIdentifier);
-    static Ref<WebExtensionContextProxy> getOrCreate(const WebExtensionContextParameters&, WebPage* = nullptr);
+    static Ref<WebExtensionContextProxy> getOrCreate(const WebExtensionContextParameters&, WebExtensionControllerProxy&, WebPage* = nullptr);
 
     ~WebExtensionContextProxy();
 
@@ -68,6 +69,7 @@ public:
     using WeakPageTabWindowMap = WeakHashMap<WebPage, TabWindowIdentifierPair>;
 
     WebExtensionContextIdentifier identifier() { return m_identifier; }
+    WebExtensionControllerProxy* extensionControllerProxy() const;
 
     bool operator==(const WebExtensionContextProxy& other) const { return (this == &other); }
 
@@ -85,7 +87,7 @@ public:
 
     bool inTestingMode() { return m_testingMode; }
 
-    WebCore::DOMWrapperWorld& toDOMWorld(WebExtensionContentWorldType);
+    WebCore::DOMWrapperWorld& toDOMWrapperWorld(WebExtensionContentWorldType);
 
     static WebCore::DOMWrapperWorld& mainWorld() { return WebCore::mainThreadNormalWorld(); }
 
@@ -168,8 +170,8 @@ private:
     void dispatchPortDisconnectEvent(WebExtensionPortChannelIdentifier);
 
     // Runtime
-    void internalDispatchRuntimeMessageEvent(WebCore::DOMWrapperWorld&, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
-    void internalDispatchRuntimeConnectEvent(WebCore::DOMWrapperWorld&, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
+    void internalDispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
+    void internalDispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
     void dispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
     void dispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
     void dispatchRuntimeInstalledEvent(WebExtensionContext::InstallReason, String previousVersion);
@@ -207,6 +209,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     WebExtensionContextIdentifier m_identifier;
+    WeakPtr<WebExtensionControllerProxy> m_extensionControllerProxy;
     URL m_baseURL;
     String m_uniqueIdentifier;
     RetainPtr<_WKWebExtensionLocalization> m_localization;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
@@ -57,11 +57,12 @@ Ref<WebExtensionControllerProxy> WebExtensionControllerProxy::getOrCreate(const 
         WebExtensionContextProxyBaseURLMap baseURLMap;
 
         for (auto& contextParameters : parameters.contextParameters) {
-            Ref context = WebExtensionContextProxy::getOrCreate(contextParameters, newPage);
+            Ref context = WebExtensionContextProxy::getOrCreate(contextParameters, controller, newPage);
             baseURLMap.add(contextParameters.baseURL.protocolHostAndPort(), context);
             contexts.add(context);
         }
 
+        controller.m_testingMode = parameters.testingMode;
         controller.m_extensionContexts = WTFMove(contexts);
         controller.m_extensionContextBaseURLMap = WTFMove(baseURLMap);
     };
@@ -92,7 +93,7 @@ WebExtensionControllerProxy::~WebExtensionControllerProxy()
 
 void WebExtensionControllerProxy::load(const WebExtensionContextParameters& contextParameters)
 {
-    auto context = WebExtensionContextProxy::getOrCreate(contextParameters);
+    auto context = WebExtensionContextProxy::getOrCreate(contextParameters, *this);
     m_extensionContextBaseURLMap.add(contextParameters.baseURL.protocolHostAndPort(), context);
     m_extensionContexts.add(context);
 }

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -59,15 +59,20 @@ public:
 
     bool operator==(const WebExtensionControllerProxy& other) const { return (this == &other); }
 
+    bool inTestingMode() { return m_testingMode; }
+
 #if PLATFORM(COCOA)
     void globalObjectIsAvailableForFrame(WebPage&, WebFrame&, WebCore::DOMWrapperWorld&);
     void serviceWorkerGlobalObjectIsAvailableForFrame(WebPage&, WebFrame&, WebCore::DOMWrapperWorld&);
+    void addBindingsToWebPageFrameIfNecessary(WebFrame&, WebCore::DOMWrapperWorld&);
 
     void didStartProvisionalLoadForFrame(WebPage&, WebFrame&, const URL&);
     void didCommitLoadForFrame(WebPage&, WebFrame&, const URL&);
     void didFinishLoadForFrame(WebPage&, WebFrame&, const URL&);
     // FIXME: Include the error here.
     void didFailLoadForFrame(WebPage&, WebFrame&, const URL&);
+
+    RefPtr<WebExtensionContextProxy> extensionContext(const String& uniqueIdentifier) const;
 #endif
 
 private:
@@ -81,13 +86,13 @@ private:
     void unload(WebExtensionContextIdentifier);
 
     RefPtr<WebExtensionContextProxy> extensionContext(const URL&) const;
-    RefPtr<WebExtensionContextProxy> extensionContext(const String& uniqueIdentifier) const;
     RefPtr<WebExtensionContextProxy> extensionContext(WebFrame&, WebCore::DOMWrapperWorld&) const;
 
     const WebExtensionContextProxySet& extensionContexts() const { return m_extensionContexts; }
 #endif
 
     WebExtensionControllerIdentifier m_identifier;
+    bool m_testingMode { false };
 
 #if PLATFORM(COCOA)
     WebExtensionContextProxySet m_extensionContexts;

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -62,6 +62,7 @@
     _context = [[_WKWebExtensionContext alloc] initForExtension:extension];
     _controller = [[_WKWebExtensionController alloc] initWithConfiguration:configuration ?: _WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
+    _controller._testingMode = YES;
     _context._testingMode = YES;
 
     // This should always be self. If you need the delegate, use the controllerDelegate property.
@@ -244,7 +245,7 @@
     _done = true;
 }
 
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestAssertionResult:(BOOL)result withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestAssertionResult:(BOOL)result withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
 {
     if (result)
         return;
@@ -255,7 +256,7 @@
     ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, message.UTF8String) = ::testing::Message();
 }
 
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestEqualityResult:(BOOL)result expectedValue:(NSString *)expectedValue actualValue:(NSString *)actualValue withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestEqualityResult:(BOOL)result expectedValue:(NSString *)expectedValue actualValue:(NSString *)actualValue withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
 {
     if (result)
         return;
@@ -269,18 +270,18 @@
         << "Expected: " << expectedValue.UTF8String;
 }
 
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
 {
     printf("\n%s:%u\n%s\n\n", sourceURL.UTF8String, lineNumber, message.UTF8String);
 }
 
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestYieldedWithMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestYieldedWithMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
 {
     _done = true;
     _yieldMessage = [message copy] ?: @"";
 }
 
-- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestFinishedWithResult:(BOOL)result message:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestFinishedWithResult:(BOOL)result message:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
 {
     _done = true;
 


### PR DESCRIPTION
#### b69952d3e355d35df99864dc9b7dbd33dd323f60
<pre>
Add support for externally_connectable
<a href="https://bugs.webkit.org/show_bug.cgi?id=268856">https://bugs.webkit.org/show_bug.cgi?id=268856</a>
<a href="https://rdar.apple.com/122422972">rdar://122422972</a>

Authors: Kiara Rose, Timothy Hatcher

Reviewed by Timothy Hatcher.

This patch creates seperate runtime and namespace objects to use for web pages
that wish to send and receive messages from extensions.

Also change how WebExtensionAPIObject tracks the world, and simplify child object creation
by passing the parent object. This touched all the API files, those changed files are elided.

Also change WebExtensionController to have a concept of testMode, so WebPage APIs can
use the browser.test API too, without an extensionContext. This required changing the
UI process WebExtensionContextAPITestCocoa to be WebExtensionControllerAPITestCocoa and
changing the delegates to no longer get a context. This wasn&apos;t used, so it is fine to remove.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:

* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h:
(WebKit::toDebugString):
* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in:
Add a new WebExtensionContentWorldType::WebPage to distinguish messages being sent to and from web pages.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::portPostMessage):
(WebKit::WebExtensionContext::firePortDisconnectEventIfNeeded):
Notify ports created from webPageRuntime.connect that the port was disconnected.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeWebPageSendMessage):
(WebKit::WebExtensionContext::runtimeWebPageConnect):

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::extensionContext const):
Mehtod to return extension context with a given unique identifier.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::matchesPatternSetContainsMatchForURL):
Return true if one of the match pattern in the MatchPatternSet matches the given URL.

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionAPIWebPageRuntime::connect):

(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
Use the contentWorldType from the sendersParameters to determine which onConnect listeners
we should call.

(WebKit::WebExtensionContextProxy::dispatchRuntimeMessageEvent):
Event listeners cannot be added for the webPageRuntime namespace object.

(WebKit::WebExtensionContextProxy::internalDispatchRuntimeConnectEvent):
Use the contentWorldType from the sendersParameters to determine which onConnect listeners
we should call.

(WebKit::WebExtensionContextProxy::dispatchRuntimeConnectEvent):
Event listeners cannot be added for the webPageRuntime namespace object.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm:
Copied from Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h.
(WebKit::WebExtensionAPIWebPageNamespace::runtime):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageRuntimeCocoa.mm: Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::WebExtensionAPIObject):

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h:
Copied from Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h.

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageRuntime.h:
Copied from Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h.

* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::toDOMWorld):

* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary):
Inject custom browser namespace object for web pages.

* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageNamespace.idl:
Copied from Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageRuntime.idl:
Copied from Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h.
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:

Canonical link: <a href="https://commits.webkit.org/274898@main">https://commits.webkit.org/274898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2de9d4055b1bc676047b1b1179e81e3c81861b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19333 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42628 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/22269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16662 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40895 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/22269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/22269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/22269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/44144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5338 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->