### PR TITLE
[Wasm-GC] Make type reflection throw correctly in JS API

### DIFF
--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.cpp
@@ -85,32 +85,9 @@ JSObject* JSWebAssemblyGlobal::type(JSGlobalObject* globalObject)
     result->putDirect(vm, Identifier::fromString(vm, "mutable"_s), jsBoolean(m_global->mutability() == Wasm::Mutable));
 
     Wasm::Type valueType = m_global->type();
-    JSString* valueString = nullptr;
-    switch (valueType.kind) {
-    case Wasm::TypeKind::I32:
-        valueString = jsNontrivialString(vm, "i32"_s);
-        break;
-    case Wasm::TypeKind::I64:
-        valueString = jsNontrivialString(vm, "i64"_s);
-        break;
-    case Wasm::TypeKind::F32:
-        valueString = jsNontrivialString(vm, "f32"_s);
-        break;
-    case Wasm::TypeKind::F64:
-        valueString = jsNontrivialString(vm, "f64"_s);
-        break;
-    case Wasm::TypeKind::V128:
-        valueString = jsNontrivialString(vm, "v128"_s);
-        break;
-    default: {
-        if (Wasm::isFuncref(valueType))
-            valueString = jsNontrivialString(vm, "funcref"_s);
-        else if (Wasm::isExternref(valueType))
-            valueString = jsNontrivialString(vm, "externref"_s);
-        else
-            RELEASE_ASSERT_NOT_REACHED();
-    }
-    }
+    JSString* valueString = typeToJSAPIString(vm, valueType);
+    if (!valueString)
+        return nullptr;
     result->putDirect(vm, Identifier::fromString(vm, "value"_s), valueString);
 
     return result;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
@@ -121,10 +121,16 @@ JSObject* JSWebAssemblyTable::type(JSGlobalObject* globalObject)
     JSString* elementString = nullptr;
     switch (element) {
     case Wasm::TableElementType::Funcref:
-        elementString = jsNontrivialString(vm, "funcref"_s);
+        if (m_table->wasmType().isNullable())
+            elementString = jsNontrivialString(vm, "funcref"_s);
+        else
+            return nullptr;
         break;
     case Wasm::TableElementType::Externref:
-        elementString = jsNontrivialString(vm, "externref"_s);
+        if (isExternref(m_table->wasmType()) && m_table->wasmType().isNullable())
+            elementString = jsNontrivialString(vm, "externref"_s);
+        else
+            return nullptr;
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
@@ -87,7 +87,11 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyGlobalProtoFuncType, (JSGlobalObject* global
     JSWebAssemblyGlobal* global = getGlobal(globalObject, vm, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(global->type(globalObject)));
+    JSObject* typeDescriptor = global->type(globalObject);
+    if (!typeDescriptor)
+        return throwVMTypeError(globalObject, throwScope, "WebAssembly.Global.prototype.type unable to produce type descriptor for the given global"_s);
+
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(typeDescriptor));
 }
 
 JSC_DEFINE_HOST_FUNCTION(webAssemblyGlobalProtoGetterFuncValue, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
@@ -183,7 +183,10 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncType, (JSGlobalObject* globalO
 
     JSWebAssemblyTable* table = getTable(globalObject, vm, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(table->type(globalObject)));
+    JSObject* typeDescriptor = table->type(globalObject);
+    if (!typeDescriptor)
+        return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.type unable to produce type descriptor for the given table"_s);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(typeDescriptor));
 }
 
 WebAssemblyTablePrototype* WebAssemblyTablePrototype::create(VM& vm, JSGlobalObject*, Structure* structure)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
@@ -104,8 +104,12 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTagProtoFuncType, (JSGlobalObject* globalObj
 
     MarkedArgumentBuffer argList;
     argList.ensureCapacity(tag.parameterCount());
-    for (size_t i = 0; i < tag.parameterCount(); ++i)
-        argList.append(Wasm::typeToString(vm, tag.parameter(i).kind));
+    for (size_t i = 0; i < tag.parameterCount(); ++i) {
+        JSString* valueString = typeToJSAPIString(vm, tag.parameter(i));
+        if (!valueString)
+            return throwVMTypeError(globalObject, throwScope, "WebAssembly.Tag.prototype.type unable to produce type descriptor for the given tag"_s);
+        argList.append(valueString);
+    }
 
     if (UNLIKELY(argList.hasOverflowed())) {
         throwOutOfMemoryError(globalObject, throwScope);


### PR DESCRIPTION
#### dafde6a4c8f54052136cbe85d228007ebabcc353
<pre>
[Wasm-GC] Make type reflection throw correctly in JS API
<a href="https://bugs.webkit.org/show_bug.cgi?id=265722">https://bugs.webkit.org/show_bug.cgi?id=265722</a>

Reviewed by Justin Michaud.

Ensure that type reflection functions throw an exception appropriately
when ref types are unrepresentable (yet) in the JS API.

This behavior may change (to return a string for some cases instead of
erroring) depending on spec changes, but in any case there should be a defined
code path for them.

* JSTests/wasm/gc/js-api.js:
(module):
(testTag):
(testTable): Deleted.
(testImport): Deleted.
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::typeToJSAPIString):
(JSC::Wasm::typeToString): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.cpp:
(JSC::JSWebAssemblyGlobal::type):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp:
(JSC::JSWebAssemblyTable::type):
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/274900@main">https://commits.webkit.org/274900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e19eff2bf86b3c22995226bda7ab1a77aea147c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36174 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33341 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13898 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43897 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33527 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39661 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38003 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16508 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46708 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9051 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16557 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9610 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->