### PR TITLE
Crash in WebExtensionContext::addListener when Web Extension does not have a background page.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -43,13 +43,13 @@ namespace WebKit {
 
 void WebExtensionContext::addListener(WebPageProxyIdentifier identifier, WebExtensionEventListenerType type, WebExtensionContentWorldType contentWorldType)
 {
-    auto page = WebProcessProxy::webPage(identifier);
+    RefPtr page = WebProcessProxy::webPage(identifier);
     if (!page)
         return;
 
     RELEASE_LOG_DEBUG(Extensions, "Registered event listener for type %{public}hhu in %{public}@ world", enumToUnderlyingType(type), (NSString *)toDebugString(contentWorldType));
 
-    if (!extension().backgroundContentIsPersistent() && m_backgroundWebView.get()._page->identifier() == identifier)
+    if (!extension().backgroundContentIsPersistent() && m_backgroundWebView && m_backgroundWebView.get()._page->identifier() == identifier)
         m_backgroundContentEventListeners.add(type);
 
     auto result = m_eventListenerPages.add({ type, contentWorldType }, WeakPageCountedSet { });
@@ -60,13 +60,13 @@ void WebExtensionContext::removeListener(WebPageProxyIdentifier identifier, WebE
 {
     ASSERT(removedCount);
 
-    auto page = WebProcessProxy::webPage(identifier);
+    RefPtr page = WebProcessProxy::webPage(identifier);
     if (!page)
         return;
 
     RELEASE_LOG_DEBUG(Extensions, "Unregistered %{public}zu event listener(s) for type %{public}hhu in %{public}@ world", removedCount, enumToUnderlyingType(type), (NSString *)toDebugString(contentWorldType));
 
-    if (!extension().backgroundContentIsPersistent() && m_backgroundWebView.get()._page->identifier() == identifier) {
+    if (!extension().backgroundContentIsPersistent() && m_backgroundWebView && m_backgroundWebView.get()._page->identifier() == identifier) {
         for (size_t i = 0; i < removedCount; ++i)
             m_backgroundContentEventListeners.remove(type);
     }


### PR DESCRIPTION
#### 786fc33388fb10648646e930125e2e1fa444a022
<pre>
Crash in WebExtensionContext::addListener when Web Extension does not have a background page.
<a href="https://webkit.org/b/269543">https://webkit.org/b/269543</a>
<a href="https://rdar.apple.com/123052586">rdar://123052586</a>

Reviewed by David Kilzer.

Make sure m_backgroundWebView is not nil before accessing _page-&gt;identifier().

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):

Canonical link: <a href="https://commits.webkit.org/274834@main">https://commits.webkit.org/274834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aeb8c4f0cebf3a7408fc2f1921f8331807f8fcf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42623 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33345 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13901 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13930 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43901 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37930 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16561 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5301 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->