### PR TITLE
[cocoa] Add a preference for using the system's default network loader

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -862,6 +862,19 @@ BuiltInNotificationsEnabled:
     WebKit:
       default: false
 
+CFNetworkDefaultNetworkLoaderEnabled:
+  type: bool
+  status: stable
+  category: networking
+  humanReadableName: "Use system default network loader (the default may change without warning)"
+  humanReadableDescription: "Use system default network loader (the default may change without warning)"
+  webcoreBinding: none
+  condition: HAVE(NETWORK_LOADER)
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKit:
+      default: true
+
 CFNetworkNetworkLoaderEnabled:
   type: bool
   status: testable

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1418,10 +1418,9 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
 #endif
 
 #if HAVE(NETWORK_LOADER)
-    if (parameters.useNetworkLoader) {
-        RELEASE_LOG_IF(*parameters.useNetworkLoader, NetworkSession, "Using experimental network loader.");
+    if (parameters.useNetworkLoader)
         configuration._usesNWLoader = *parameters.useNetworkLoader;
-    }
+    RELEASE_LOG(NetworkSession, "Experimental network loader: %{public}s", parameters.useNetworkLoader ? (*parameters.useNetworkLoader ? "enabled" : "disabled") : "default");
 #endif
 
     if (parameters.allowsHSTSWithUntrustedRootCertificate && [configuration respondsToSelector:@selector(_allowsHSTSWithUntrustedRootCertificate)])

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -220,7 +220,16 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
 std::optional<bool> WebsiteDataStore::useNetworkLoader()
 {
 #if HAVE(NETWORK_LOADER)
-    return optionalExperimentalFeatureEnabled(WebPreferencesKey::cFNetworkNetworkLoaderEnabledKey(), std::nullopt);
+    auto isExperimentalNetworkLoaderEnabled = optionalExperimentalFeatureEnabled(WebPreferencesKey::cFNetworkNetworkLoaderEnabledKey(), std::nullopt);
+    auto isDefaultNetworkLoaderEnabled = optionalExperimentalFeatureEnabled(WebPreferencesKey::cFNetworkDefaultNetworkLoaderEnabledKey(), std::nullopt);
+    if (isExperimentalNetworkLoaderEnabled && *isExperimentalNetworkLoaderEnabled)
+        return true;
+    // Experimental loader is not explicitly enabled, and we shouldn't use the system default.
+    if (isDefaultNetworkLoaderEnabled && !*isDefaultNetworkLoaderEnabled)
+        return false;
+
+    // Both preferences are either unset, or they have their default values, so use system default.
+    return std::nullopt;
 #else
     return false;
 #endif


### PR DESCRIPTION
#### e93ffa6841d2ccbaae376e682d02f8ec221b815e
<pre>
[cocoa] Add a preference for using the system&apos;s default network loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=269542">https://bugs.webkit.org/show_bug.cgi?id=269542</a>
<a href="https://rdar.apple.com/123064383">rdar://123064383</a>

Reviewed by NOBODY (OOPS!).

Add an additional preference that controls whether WebKit prefers using the
system&apos;s default network loader. This complements the existing preferences for
enabling the new experimental loader.

If CFNetworkNetworkLoaderEnabled is true, then the experimental network loader
is enabled; else, if that preference is not true, and
CFNetworkDefaultNetworkLoaderEnabled is not false, then we use the system
default. Otherwise, if both CFNetworkNetworkLoaderEnabled and
CFNetworkDefaultNetworkLoaderEnabled are false, then we disable using the
experimental loader.

Tested manually.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::useNetworkLoader):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93ffa6841d2ccbaae376e682d02f8ec221b815e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42732 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36276 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33409 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13978 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44010 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33640 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39737 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39813 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15002 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12304 "Found 1 new test failure: ipc/message-listener-async-message-reply-id.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38020 "276 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16621 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46822 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16670 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9637 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->