### PR TITLE
Return initial value for `stop-color` instead of `transparentBlack`

### DIFF
--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -86,8 +86,10 @@ bool SVGStopElement::rendererIsNeeded(const RenderStyle&)
 
 Color SVGStopElement::stopColorIncludingOpacity() const
 {
+    // Return initial value 'black' as per web specification below:
+    // https://svgwg.org/svg2-draft/pservers.html#StopColorProperties
     if (!renderer())
-        return Color::transparentBlack;
+        return Color::black;
 
     auto& style = renderer()->style();
     Ref svgStyle = style.svgStyle();


### PR DESCRIPTION
#### dcd60b82e8d89608e2cb5072c7e3f3ee040102c8
<pre>
Return initial value for `stop-color` instead of `transparentBlack`

<a href="https://bugs.webkit.org/show_bug.cgi?id=269545">https://bugs.webkit.org/show_bug.cgi?id=269545</a>

Reviewed by Nikolas Zimmermann.

This patch is to better align with expectations and web-specification by
returning initial value (black) rather than &apos;transparentBlack&apos; for `stop-color`
in absence of &apos;renderer&apos;.

Web-Spec: <a href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperties">https://svgwg.org/svg2-draft/pservers.html#StopColorProperties</a>

* Source/WebCore/svg/SVGStopElement.cpp:
(SVGStopElement::stopColorIncludingOpacity):

Canonical link: <a href="https://commits.webkit.org/274997@main">https://commits.webkit.org/274997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6db0bcccaa68cf06aaa7b9aea540556b2ad58c30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36175 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33351 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39673 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37943 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16520 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9097 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->