### PR TITLE
[Site Isolation] Aggregate find string match counts

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5348,8 +5348,8 @@ void WebPageProxy::findString(const String& string, OptionSet<FindOptions> optio
     {
         Ref callbackAggregator = FindStringCallbackAggregator::create(*this, string, options, maxMatchCount, std::forward<decltype(completionHandler)>(completionHandler));
         forEachWebContentProcess([&](auto& webProcess, auto pageID) {
-            webProcess.sendWithAsyncReply(std::forward<M>(message), [callbackAggregator](std::optional<FrameIdentifier> frameID, Vector<IntRect>&&, uint32_t, int32_t, bool didWrap) {
-                callbackAggregator->foundString(frameID, didWrap);
+            webProcess.sendWithAsyncReply(std::forward<M>(message), [callbackAggregator](std::optional<FrameIdentifier> frameID, Vector<IntRect>&&, uint32_t matchCount, int32_t, bool didWrap) {
+                callbackAggregator->foundString(frameID, matchCount, didWrap);
             }, pageID);
         });
     };

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -328,6 +328,7 @@ Tests/WebKitCocoa/WKWebViewDoesNotLogDuringInitialization.mm
 Tests/WebKitCocoa/WKWebViewEditActions.mm
 Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
 Tests/WebKitCocoa/WKWebViewFindString.mm
+Tests/WebKitCocoa/WKWebViewFindStringFindDelegate.mm
 Tests/WebKitCocoa/WKWebViewFirstResponderTests.mm
 Tests/WebKitCocoa/WKWebViewGetContents.mm
 Tests/WebKitCocoa/WKWebViewInspection.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2005,6 +2005,8 @@
 
 /* Begin PBXFileReference section */
 		00CD9F6215BE312C002DA2CE /* BackForwardList.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BackForwardList.mm; sourceTree = "<group>"; };
+		021CCE262B7F2E30002C26EF /* WKWebViewFindStringFindDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebViewFindStringFindDelegate.h; sourceTree = "<group>"; };
+		021CCE332B7F31AB002C26EF /* WKWebViewFindStringFindDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewFindStringFindDelegate.mm; sourceTree = "<group>"; };
 		02238A3D2B2FB47C00442B86 /* VerifyUserGestureFromUIProcess.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VerifyUserGestureFromUIProcess.mm; sourceTree = "<group>"; };
 		041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PublicSuffix.cpp; sourceTree = "<group>"; };
 		0451A5A6235E438E009DF945 /* BumpPointerAllocator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BumpPointerAllocator.cpp; sourceTree = "<group>"; };
@@ -4321,6 +4323,8 @@
 				F4811E5821940B4400A5E0FD /* WKWebViewEditActions.mm */,
 				0F3B94A51A77266C00DE3272 /* WKWebViewEvaluateJavaScript.mm */,
 				CE449E1021AE0F7200E7ADA1 /* WKWebViewFindString.mm */,
+				021CCE262B7F2E30002C26EF /* WKWebViewFindStringFindDelegate.h */,
+				021CCE332B7F31AB002C26EF /* WKWebViewFindStringFindDelegate.mm */,
 				F4106C6821ACBF84004B89A1 /* WKWebViewFirstResponderTests.mm */,
 				D3BE5E341E4CE85E00FD563A /* WKWebViewGetContents.mm */,
 				63A33C552A339ED500EF94B8 /* WKWebViewInspection.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm
@@ -28,8 +28,8 @@
 #import "DeprecatedGlobalValues.h"
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
+#import "WKWebViewFindStringFindDelegate.h"
 #import <WebKit/WKWebViewPrivate.h>
-#import <WebKit/_WKFindDelegate.h>
 #import <WebKit/_WKInputDelegate.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -48,48 +48,6 @@ static const NSUInteger maxCount = 100;
 - (void)_webView:(WKWebView *)webView didStartInputSession:(id <_WKFormInputSession>)inputSession
 {
     focusDidStartInputSession = YES;
-}
-
-@end
-
-@interface WKWebViewFindStringFindDelegate : NSObject <_WKFindDelegate>
-@property (nonatomic, readonly) NSString *findString;
-@property (nonatomic, readonly) NSUInteger matchesCount;
-@property (nonatomic, readonly) NSInteger matchIndex;
-@property (nonatomic, readonly) BOOL didFail;
-@end
-
-@implementation WKWebViewFindStringFindDelegate {
-    RetainPtr<NSString> _findString;
-}
-
-- (NSString *)findString
-{
-    return _findString.get();
-}
-
-- (void)_webView:(WKWebView *)webView didCountMatches:(NSUInteger)matches forString:(NSString *)string
-{
-    _findString = string;
-    _matchesCount = matches;
-    _didFail = NO;
-    isDone = YES;
-}
-
-- (void)_webView:(WKWebView *)webView didFindMatches:(NSUInteger)matches forString:(NSString *)string withMatchIndex:(NSInteger)matchIndex
-{
-    _findString = string;
-    _matchesCount = matches;
-    _matchIndex = matchIndex;
-    _didFail = NO;
-    isDone = YES;
-}
-
-- (void)_webView:(WKWebView *)webView didFailToFindString:(NSString *)string
-{
-    _findString = string;
-    _didFail = YES;
-    isDone = YES;
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindStringFindDelegate.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindStringFindDelegate.h
@@ -23,37 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import <WebKit/_WKFindDelegate.h>
 
-#include <WebCore/FrameIdentifier.h>
-#include <wtf/CompletionHandler.h>
-
-namespace WebKit {
-
-class WebFrameProxy;
-class WebPageProxy;
-
-enum class FindOptions : uint16_t;
-
-class FindStringCallbackAggregator : public RefCounted<FindStringCallbackAggregator> {
-public:
-    static Ref<FindStringCallbackAggregator> create(WebPageProxy&, const String&, OptionSet<FindOptions>, unsigned maxMatchCount, CompletionHandler<void(bool)>&&);
-    void foundString(std::optional<WebCore::FrameIdentifier>, uint32_t matchCount, bool didWrap);
-    ~FindStringCallbackAggregator();
-
-private:
-    FindStringCallbackAggregator(WebPageProxy&, const String&, OptionSet<FindOptions>, unsigned maxMatchCount, CompletionHandler<void(bool)>&&);
-
-    RefPtr<WebFrameProxy> incrementFrame(WebFrameProxy&);
-    bool shouldTargetFrame(WebFrameProxy&, WebFrameProxy& focusedFrame, bool didWrap);
-
-    WeakPtr<WebPageProxy> m_page;
-    String m_string;
-    OptionSet<FindOptions> m_options;
-    unsigned m_maxMatchCount;
-    uint32_t m_matchCount { 0 };
-    CompletionHandler<void(bool)> m_completionHandler;
-    HashMap<WebCore::FrameIdentifier, bool> m_matches;
-};
-
-} // namespace WebKit
+@interface WKWebViewFindStringFindDelegate : NSObject <_WKFindDelegate>
+@property (nonatomic, readonly) NSString *findString;
+@property (nonatomic, readonly) NSUInteger matchesCount;
+@property (nonatomic, readonly) NSInteger matchIndex;
+@property (nonatomic, readonly) BOOL didFail;
+@end


### PR DESCRIPTION
#### 6c9a595ac127781f1c0e17cbb0dabade2ee2334f
<pre>
[Site Isolation] Aggregate find string match counts
<a href="https://bugs.webkit.org/show_bug.cgi?id=269551">https://bugs.webkit.org/show_bug.cgi?id=269551</a>
<a href="https://rdar.apple.com/123067488">rdar://123067488</a>

Reviewed by Alex Christensen.

The find string callback aggregator should sum the match counts from each web process response.

Also reuse the find delegate in `WKWebViewFindString.mm`.

* Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp:
(WebKit::FindStringCallbackAggregator::foundString):
(WebKit::FindStringCallbackAggregator::~FindStringCallbackAggregator):
* Source/WebKit/UIProcess/FindStringCallbackAggregator.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::findString):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm:
(-[WKWebViewFindStringFindDelegate findString]): Deleted.
(-[WKWebViewFindStringFindDelegate _webView:didCountMatches:forString:]): Deleted.
(-[WKWebViewFindStringFindDelegate _webView:didFindMatches:forString:withMatchIndex:]): Deleted.
(-[WKWebViewFindStringFindDelegate _webView:didFailToFindString:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindStringFindDelegate.h: Copied from Source/WebKit/UIProcess/FindStringCallbackAggregator.h.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindStringFindDelegate.mm: Copied from Source/WebKit/UIProcess/FindStringCallbackAggregator.h.
(-[WKWebViewFindStringFindDelegate findString]):
(-[WKWebViewFindStringFindDelegate _webView:didCountMatches:forString:]):
(-[WKWebViewFindStringFindDelegate _webView:didFindMatches:forString:withMatchIndex:]):
(-[WKWebViewFindStringFindDelegate _webView:didFailToFindString:]):

Canonical link: <a href="https://commits.webkit.org/274897@main">https://commits.webkit.org/274897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf785f5bddff7b5abd2ea2ca06958dca13137f7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42798 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16594 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14008 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44076 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36025 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39770 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12348 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16736 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5337 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->