### PR TITLE
Remove the SVG pathSegList interface

### DIFF
--- a/Source/WebCore/svg/SVGPathSeg.idl
+++ b/Source/WebCore/svg/SVGPathSeg.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     CustomToJSObject,
     Exposed=Window
 ] interface SVGPathSeg {

--- a/Source/WebCore/svg/SVGPathSegArcAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegArcAbs.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegArcAbs : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegArcRel.idl
+++ b/Source/WebCore/svg/SVGPathSegArcRel.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegArcRel : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegClosePath.idl
+++ b/Source/WebCore/svg/SVGPathSegClosePath.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegClosePath : SVGPathSeg {
 };

--- a/Source/WebCore/svg/SVGPathSegCurvetoCubicAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegCurvetoCubicAbs.idl
@@ -25,6 +25,7 @@
  */ 
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegCurvetoCubicAbs : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegCurvetoCubicRel.idl
+++ b/Source/WebCore/svg/SVGPathSegCurvetoCubicRel.idl
@@ -25,6 +25,7 @@
  */ 
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegCurvetoCubicRel : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegCurvetoCubicSmoothAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegCurvetoCubicSmoothAbs.idl
@@ -25,6 +25,7 @@
  */ 
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegCurvetoCubicSmoothAbs : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegCurvetoCubicSmoothRel.idl
+++ b/Source/WebCore/svg/SVGPathSegCurvetoCubicSmoothRel.idl
@@ -25,6 +25,7 @@
  */ 
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegCurvetoCubicSmoothRel : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegCurvetoQuadraticAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegCurvetoQuadraticAbs.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegCurvetoQuadraticAbs : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegCurvetoQuadraticRel.idl
+++ b/Source/WebCore/svg/SVGPathSegCurvetoQuadraticRel.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegCurvetoQuadraticRel : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegCurvetoQuadraticSmoothAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegCurvetoQuadraticSmoothAbs.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegCurvetoQuadraticSmoothAbs : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegCurvetoQuadraticSmoothRel.idl
+++ b/Source/WebCore/svg/SVGPathSegCurvetoQuadraticSmoothRel.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegCurvetoQuadraticSmoothRel : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegLinetoAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegLinetoAbs.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegLinetoAbs : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegLinetoHorizontalAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegLinetoHorizontalAbs.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegLinetoHorizontalAbs : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegLinetoHorizontalRel.idl
+++ b/Source/WebCore/svg/SVGPathSegLinetoHorizontalRel.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegLinetoHorizontalRel : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegLinetoRel.idl
+++ b/Source/WebCore/svg/SVGPathSegLinetoRel.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegLinetoRel : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegLinetoVerticalAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegLinetoVerticalAbs.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegLinetoVerticalAbs : SVGPathSeg {
     attribute unrestricted float y;

--- a/Source/WebCore/svg/SVGPathSegLinetoVerticalRel.idl
+++ b/Source/WebCore/svg/SVGPathSegLinetoVerticalRel.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegLinetoVerticalRel : SVGPathSeg {
     attribute unrestricted float y;

--- a/Source/WebCore/svg/SVGPathSegList.idl
+++ b/Source/WebCore/svg/SVGPathSegList.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegList {
     readonly attribute unsigned long length;

--- a/Source/WebCore/svg/SVGPathSegMovetoAbs.idl
+++ b/Source/WebCore/svg/SVGPathSegMovetoAbs.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegMovetoAbs : SVGPathSeg {
     attribute unrestricted float x;

--- a/Source/WebCore/svg/SVGPathSegMovetoRel.idl
+++ b/Source/WebCore/svg/SVGPathSegMovetoRel.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    LegacyNoInterfaceObject,
     Exposed=Window
 ] interface SVGPathSegMovetoRel : SVGPathSeg {
     attribute unrestricted float x;


### PR DESCRIPTION
#### f0c68cd55cb3903b55b27f95b982e0ea4f0c720c
<pre>
Remove the SVG pathSegList interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=168519">https://bugs.webkit.org/show_bug.cgi?id=168519</a>
<a href="https://rdar.apple.com/97100338">rdar://97100338</a>

Reviewed by NOBODY (OOPS!).

Chrome 48 removed SVGPathSeg in 2015.
Firefox removed it in 2018.
This will fix one of the tests on <a href="http://wpt.fyi/svg/historical.html">http://wpt.fyi/svg/historical.html</a>

* Source/WebCore/svg/SVGPathSeg.idl:
* Source/WebCore/svg/SVGPathSegArcAbs.idl:
* Source/WebCore/svg/SVGPathSegArcRel.idl:
* Source/WebCore/svg/SVGPathSegClosePath.idl:
* Source/WebCore/svg/SVGPathSegCurvetoCubicAbs.idl:
* Source/WebCore/svg/SVGPathSegCurvetoCubicRel.idl:
* Source/WebCore/svg/SVGPathSegCurvetoCubicSmoothAbs.idl:
* Source/WebCore/svg/SVGPathSegCurvetoCubicSmoothRel.idl:
* Source/WebCore/svg/SVGPathSegCurvetoQuadraticAbs.idl:
* Source/WebCore/svg/SVGPathSegCurvetoQuadraticRel.idl:
* Source/WebCore/svg/SVGPathSegCurvetoQuadraticSmoothAbs.idl:
* Source/WebCore/svg/SVGPathSegCurvetoQuadraticSmoothRel.idl:
* Source/WebCore/svg/SVGPathSegLinetoAbs.idl:
* Source/WebCore/svg/SVGPathSegLinetoHorizontalAbs.idl:
* Source/WebCore/svg/SVGPathSegLinetoHorizontalRel.idl:
* Source/WebCore/svg/SVGPathSegLinetoRel.idl:
* Source/WebCore/svg/SVGPathSegLinetoVerticalAbs.idl:
* Source/WebCore/svg/SVGPathSegLinetoVerticalRel.idl:
* Source/WebCore/svg/SVGPathSegList.idl:
* Source/WebCore/svg/SVGPathSegMovetoAbs.idl:
* Source/WebCore/svg/SVGPathSegMovetoRel.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0c68cd55cb3903b55b27f95b982e0ea4f0c720c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42649 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16445 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33364 "Found 6 new test failures: fast/dom/Window/window-lookup-precedence.html, imported/w3c/web-platform-tests/dom/historical.html, imported/w3c/web-platform-tests/svg/historical.html, svg/custom/js-svg-constructors.svg, svg/dom/path-segments.html, svg/dom/svg2-inheritance.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40678 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16095 "2 new passes 7 flakes 4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13920 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13956 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35589 "Found 7 new test failures: fast/dom/Window/window-lookup-precedence.html, imported/w3c/web-platform-tests/dom/historical.html, imported/w3c/web-platform-tests/svg/historical.html, svg/custom/global-constructors.html, svg/custom/js-svg-constructors.svg, svg/dom/path-segments.html, svg/dom/svg2-inheritance.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36383 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35924 "Found 7 new test failures: fast/dom/Window/window-lookup-precedence.html, imported/w3c/web-platform-tests/dom/historical.html, imported/w3c/web-platform-tests/svg/historical.html, svg/custom/global-constructors.html, svg/custom/js-svg-constructors.svg, svg/dom/path-segments.html, svg/dom/svg2-inheritance.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39683 "Found 7 new test failures: fast/dom/Window/window-lookup-precedence.html, imported/w3c/web-platform-tests/dom/historical.html, imported/w3c/web-platform-tests/svg/historical.html, svg/custom/global-constructors.html, svg/custom/js-svg-constructors.svg, svg/dom/path-segments.html, svg/dom/svg2-inheritance.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14919 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12243 "Found 7 new test failures: fast/dom/Window/window-lookup-precedence.html, imported/w3c/web-platform-tests/dom/historical.html, imported/w3c/web-platform-tests/svg/historical.html, svg/custom/global-constructors.html, svg/custom/js-svg-constructors.svg, svg/dom/path-segments.html, svg/dom/svg2-inheritance.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37958 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->