### PR TITLE
Skip user activation check in requestStorageAccess if frame ever gets NoModificationAllowedError

### DIFF
--- a/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html
+++ b/LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html
@@ -19,7 +19,7 @@
             setEnableFeature(false, finishJSTest);
         }
 
-        function receiveMessage(event) {
+        function messageReceived(event) {
             if (event.origin !== "http://localhost:8000") {
                 testFailed("Unexpected origin: " + event.origin);
                 endTest();
@@ -33,6 +33,12 @@
 
             if (event.data == "Done") {
                 testPassed("requestStorageAccess result: Granted");
+                endTest();
+                return;
+            }
+
+            if (event.data == "None") {
+                testFailed("requestStorageAccess result: Denied");
                 endTest();
                 return;
             }
@@ -59,18 +65,16 @@
         }
 
         function frameLoaded() {
-            if (!testStarted) {
-                setEnableFeature(true, function() {
-                    activateElement("TheIframeThatRequestsStorageAccess");
-                });
+            if (testStarted)
                 return;
-            }
 
             testStarted = true;
-            activateElement("TheIframeThatRequestsStorageAccess");
+            setEnableFeature(true, function() {
+                activateElement("TheIframeThatRequestsStorageAccess");
+            });
         }
 
-        window.addEventListener("message", receiveMessage, false);
+        window.addEventListener("message", messageReceived, false);
         if (window.testRunner)
             testRunner.setRequestStorageAccessThrowsExceptionUntilReload(true);
     </script>

--- a/LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html
+++ b/LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html
@@ -1,6 +1,15 @@
 <html>
 <head>
     <script>
+        var storageAccessRequestedForClick = false;
+        function bodyClicked() {
+            if (storageAccessRequestedForClick)
+                return;
+
+            storageAccessRequestedForClick = true;
+            performStorageAccessRequest();
+        }
+
         function messageToTop(message) {
             top.postMessage(message, "http://127.0.0.1:8000");
         }
@@ -15,11 +24,18 @@
                 }
 
                 messageToTop(error.name);
-                if (!window.location.hash && error.name == "NoModificationAllowedError") 
+                if (error.name == "NoModificationAllowedError" && location.hash != "#reload") {
+                    location.hash = "reload";
                     location.reload();
+                }
             });
+        }
+
+        if (location.hash == "#reload") {
+            storageAccessRequestedForClick = true;
+            performStorageAccessRequest();
         }
     </script>
 </head>
-<body onclick="performStorageAccessRequest()">
+<body onclick="bodyClicked()"></body>
 </html>

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1290,6 +1290,22 @@ CheckedRef<FrameSelection> LocalFrame::checkedSelection() const
     return document()->selection();
 }
 
+void LocalFrame::storageAccessExceptionReceivedForDomain(const RegistrableDomain& domain)
+{
+    m_storageAccessExceptionDomains.add(domain);
+}
+
+bool LocalFrame::requestSkipUserActivationCheckForStorageAccess(const RegistrableDomain& domain)
+{
+    auto iter = m_storageAccessExceptionDomains.find(domain);
+    if (iter == m_storageAccessExceptionDomains.end())
+        return false;
+
+    // We only allow the domain to skip check once.
+    m_storageAccessExceptionDomains.remove(iter);
+    return true;
+}
+
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
 
 void LocalFrame::didAccessWindowProxyPropertyViaOpener(WindowProxyProperty property)

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -308,6 +308,8 @@ public:
 #endif
 
     WEBCORE_EXPORT RefPtr<DocumentLoader> loaderForWebsitePolicies() const;
+    void storageAccessExceptionReceivedForDomain(const RegistrableDomain&);
+    bool requestSkipUserActivationCheckForStorageAccess(const RegistrableDomain&);
 
     String customUserAgent() const final;
     String customUserAgentAsSiteSpecificQuirks() const final;
@@ -383,6 +385,7 @@ private:
     FloatSize m_overrideScreenSize;
 
     UniqueRef<EventHandler> m_eventHandler;
+    HashSet<RegistrableDomain> m_storageAccessExceptionDomains;
 };
 
 inline LocalFrameView* LocalFrame::view() const


### PR DESCRIPTION
#### 2173fe1250ad9034b35bac7d1495e7ae2fdcacdc
<pre>
Skip user activation check in requestStorageAccess if frame ever gets NoModificationAllowedError
<a href="https://bugs.webkit.org/show_bug.cgi?id=269557">https://bugs.webkit.org/show_bug.cgi?id=269557</a>

Reviewed by Alex Christensen.

If an iframe gets NoModificationAllowedError on requestStorageAccess, it means the request is granted but iframe needs
to reload to get the access. However, after reloading, the iframe would lose user activation, which stops it from
invoking requestStorageAccess again (Storage Access API requires user activation). To solve this, frame now stores user
activation for domains that ever get NoModificationAllowedError. If document does not have active user activation, but
its domain has user activation based on frame&apos;s records, then we will not reject the storage access request.

Updated test: http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html. The test is modified to
invoke requestStorageAccess automatically (without another click) after reload.

* LayoutTests/http/tests/storageAccess/request-throw-exception-on-grant-until-reload.html:
* LayoutTests/http/tests/storageAccess/resources/request-throw-exception-on-grant-until-reload-iframe.html:
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::requestStorageAccessQuickCheck):
(WebCore::DocumentStorageAccess::requestStorageAccess):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::storageAccessExceptionReceivedForDomain):
(WebCore::LocalFrame::requestSkipUserActivationCheckForStorageAccess):
* Source/WebCore/page/LocalFrame.h:

Canonical link: <a href="https://commits.webkit.org/274887@main">https://commits.webkit.org/274887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc5bf4bf50e764344cbff324d668ee408d33c327

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42799 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16595 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16225 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44077 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36502 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12350 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34979 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->