### PR TITLE
[visionOS] Attach a FigVideoTarget to AVPlayers when a receiver endpoint is available

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.cpp
@@ -34,6 +34,7 @@
 SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, MediaToolbox, PAL_EXPORT)
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, MediaToolbox, FigPhotoDecompressionSetHardwareCutoff, void, (int format, size_t numPixelsCutoff), (format, numPixelsCutoff), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, MediaToolbox, FigVideoTargetCreateWithVideoReceiverEndpointID, OSStatus, (CFAllocatorRef allocator, xpc_object_t videoReceiverXPCEndpointID, CFDictionaryRef creationOptions, FigVideoTargetRef* videoTargetOut), (allocator, videoReceiverXPCEndpointID, creationOptions, videoTargetOut), PAL_EXPORT)
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, MediaToolbox, MTShouldPlayHDRVideo, Boolean, (CFArrayRef displayList), (displayList), PAL_EXPORT)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, MediaToolbox, MTOverrideShouldPlayHDRVideo, void, (Boolean override, Boolean playHDRVideo), (override, playHDRVideo), PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.h
@@ -27,13 +27,14 @@
 
 #if USE(MEDIATOOLBOX)
 
-#include <MediaToolbox/MediaToolbox.h>
 #include <pal/spi/cocoa/MediaToolboxSPI.h>
 #include <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, MediaToolbox)
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, MediaToolbox, FigPhotoDecompressionSetHardwareCutoff, void, (int, size_t numPixelsCutoff), (format, numPixelsCutoff))
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, MediaToolbox, FigVideoTargetCreateWithVideoReceiverEndpointID, OSStatus, (CFAllocatorRef allocator, xpc_object_t videoReceiverXPCEndpointID, CFDictionaryRef creationOptions, FigVideoTargetRef* videoTargetOut), (allocator, videoReceiverXPCEndpointID, creationOptions, videoTargetOut))
+#define FigVideoTargetCreateWithVideoReceiverEndpointID PAL::softLink_MediaToolbox_FigVideoTargetCreateWithVideoReceiverEndpointID
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, MediaToolbox, MTShouldPlayHDRVideo, Boolean, (CFArrayRef displayList), (displayList))
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, MediaToolbox, MTOverrideShouldPlayHDRVideo, void, (Boolean override, Boolean playHDRVideo), (override, playHDRVideo))

--- a/Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h
@@ -27,7 +27,10 @@
 
 #if USE(MEDIATOOLBOX)
 
+#include <MediaToolbox/MediaToolbox.h>
+
 #include <pal/spi/cf/CoreMediaSPI.h>
+#include <wtf/spi/darwin/XPCSPI.h>
 
 #if HAVE(MT_PLUGIN_FORMAT_READER)
 
@@ -205,6 +208,11 @@ typedef struct {
 #endif // !USE(APPLE_INTERNAL_SDK)
 
 #endif // HAVE(MT_PLUGIN_FORMAT_READER)
+
+WTF_EXTERN_C_BEGIN
+typedef struct OpaqueFigVideoTarget *FigVideoTargetRef;
+OSStatus FigVideoTargetCreateWithVideoReceiverEndpointID(CFAllocatorRef, xpc_object_t videoReceiverXPCEndpointID, CFDictionaryRef creationOptions, FigVideoTargetRef* videoTargetOut);
+WTF_EXTERN_C_END
 
 // FIXME (68673547): Use actual <MediaToolbox/FigPhoto.h> and FigPhotoContainerFormat enum when we weak-link instead of soft-link MediaToolbox and CoreMedia.
 #define kPALFigPhotoContainerFormat_HEIF 0

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -56,6 +56,7 @@ OBJC_CLASS WebCoreAVFPullDelegate;
 
 typedef struct CGImage *CGImageRef;
 typedef struct __CVBuffer *CVPixelBufferRef;
+typedef struct OpaqueFigVideoTarget *FigVideoTargetRef;
 typedef NSString *AVMediaCharacteristic;
 typedef double NSTimeInterval;
 
@@ -369,7 +370,8 @@ private:
 
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics(AVPlayerLayer*) const;
 
-    void setVideoReceiverEndpoint(const VideoReceiverEndpoint&) final { }
+    void setVideoReceiverEndpoint(const VideoReceiverEndpoint&) final;
+    void clearVideoReceiverEndpoint();
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     const String& spatialTrackingLabel() const final;
@@ -388,6 +390,10 @@ private:
     bool m_videoFrameHasDrawn { false };
     bool m_haveCheckedPlayability { false };
     bool m_createAssetPending { false };
+
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    RetainPtr<FigVideoTargetRef> m_videoTarget;
+#endif
 
 #if ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)
     RefPtr<AudioSourceProviderAVFObjC> m_provider;

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -163,6 +163,12 @@
         model->toggleFullscreen();
 }
 
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player didExitFullscreenWithError:(NSError * _Nullable)error
+{
+    if (auto model = _model.get())
+        model->setVideoReceiverEndpoint(nullptr);
+}
+
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setVideoReceiverEndpoint:(xpc_object_t)videoReceiverEndpoint
 {
     if (auto model = _model.get())
@@ -185,11 +191,11 @@ PlaybackSessionInterfaceLMK::PlaybackSessionInterfaceLMK(PlaybackSessionModel& m
     , m_player { adoptNS([allocWKSLinearMediaPlayerInstance() init]) }
     , m_playerDelegate { adoptNS([[WKLinearMediaPlayerDelegate alloc] initWithModel:model]) }
 {
+    [m_player setDelegate:m_playerDelegate.get()];
 }
 
 PlaybackSessionInterfaceLMK::~PlaybackSessionInterfaceLMK()
 {
-    ASSERT(isUIThread());
     invalidate();
 }
 

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -63,13 +63,16 @@ void VideoPresentationInterfaceLMK::setupFullscreen(UIView& videoView, const Flo
 
 void VideoPresentationInterfaceLMK::setupPlayerViewController()
 {
-    if (!m_playerViewController)
-        m_playerViewController = [linearMediaPlayer() makeViewController];
+    if (m_playerViewController)
+        return;
 
     linearMediaPlayer().allowFullScreenFromInline = YES;
     linearMediaPlayer().contentType = WKSLinearMediaContentTypePlanar;
     linearMediaPlayer().presentationMode = WKSLinearMediaPresentationModeInline;
+    linearMediaPlayer().captionLayer = captionsLayer();
     linearMediaPlayer().videoLayer = [m_playerLayerView playerLayer];
+
+    m_playerViewController = [linearMediaPlayer() makeViewController];
 }
 
 void VideoPresentationInterfaceLMK::invalidatePlayerViewController()

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -103,6 +103,9 @@
            (global-name "com.apple.coremedia.capturesession")      ; Actually for video capture
            (global-name "com.apple.coremedia.capturesource")       ; Also for video capture (<rdar://problem/15794291>).
            (global-name "com.apple.coremedia.cpe.xpc") ; Needed for HDR playback.
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+           (global-name "com.apple.coremedia.videotarget.xpc") ; Needed for FigVideoTarget
+#endif
            (global-name "com.apple.coremedia.remotequeue"))
     (allow mach-lookup
 #if HAVE(REFACTORED_MEDIASERVERD)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -229,7 +229,7 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public var captionLayerPublisher: AnyPublisher<CALayer?, Never> {
-        publisher(for: \.captionLayer).eraseToAnyPublisher()
+        Just(nil).eraseToAnyPublisher()
     }
 
     public var captionContentInsetsPublisher: AnyPublisher<UIEdgeInsets, Never> {
@@ -504,7 +504,12 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func makeDefaultEntity() -> Entity? {
-        ContentType.makeDefaultEntity(player: AVPlayer())
+#if canImport(LinearMediaKit, _version: 205)
+        if let captionLayer = captionLayer {
+            return ContentType.makeEntity(captionLayer: captionLayer)
+        }
+#endif
+        return nil
     }
 
     public func setTimeResolverInterval(_ interval: TimeInterval) {


### PR DESCRIPTION
#### 4c41ca668ae286837aa75be14f091232419d9858
<pre>
[visionOS] Attach a FigVideoTarget to AVPlayers when a receiver endpoint is available
<a href="https://bugs.webkit.org/show_bug.cgi?id=269561">https://bugs.webkit.org/show_bug.cgi?id=269561</a>
<a href="https://rdar.apple.com/123073265">rdar://123073265</a>

Reviewed by Jer Noble.

When MediaPlayer has a VideoReceiverEndpoint, use it to create a FigVideoTarget and add it to
MediaPlayerPrivateAVFoundationObjC&apos;s AVPlayer. In order for LinearMediaPlayer to emit a
VideoReceiverEndpoint, also created an Entity with a caption layer rather than an AVPlayer.

* Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.cpp:
* Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.h:
* Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h:
Declared and soft-linked FigVideoTargetCreateWithVideoReceiverEndpointID.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
When non-null, used the VideoReceiverEndpoint to create a FigVideoTargetRef, added it to AVPlayer,
and removed the player from the AVPlayerLayer. When null, removed the video target from the player
and re-attached the player to the AVPlayerLayer.

* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
Cleared the VideoReceiverEndpoint when exiting fullscreen. Drive-by fix: set m_playerDelegate as
m_player&apos;s delegate.

* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
Set m_player&apos;s captionLayer prior to creating a view controller.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
Allowed lookup of mach port com.apple.coremedia.videotarget.xpc.

* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
Stopped publishing captionLayer and used it to create an Entity instead.

Canonical link: <a href="https://commits.webkit.org/274909@main">https://commits.webkit.org/274909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dfe2307d240f99f73c3320ddff98a376d6a93bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16642 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14031 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44124 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39802 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12380 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16735 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9052 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->