### PR TITLE
Remove access from MediaPlayerPrivateMediaSource to MediaSourcePrivate::buffered

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -202,7 +202,7 @@ MediaTime MediaSource::currentTime() const
     return m_private->currentTime();
 }
 
-const PlatformTimeRanges& MediaSource::buffered() const
+PlatformTimeRanges MediaSource::buffered() const
 {
     assertIsCurrent(m_dispatcher);
 
@@ -404,7 +404,7 @@ bool MediaSource::hasBufferedTime(const MediaTime& time)
     if (time > duration())
         return false;
 
-    auto& ranges = m_private->buffered();
+    auto ranges = m_private->buffered();
     if (!ranges.length())
         return false;
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -87,7 +87,7 @@ public:
     bool isEnded() const;
     void sourceBufferDidChangeActiveState(SourceBuffer&, bool);
     MediaTime duration() const;
-    const PlatformTimeRanges& buffered() const;
+    PlatformTimeRanges buffered() const;
 
     enum class EndOfStreamError { Network, Decode };
     void streamEndedWithError(std::optional<EndOfStreamError>);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8033,13 +8033,11 @@ void HTMLMediaElement::mediaPlayerBufferedTimeRangesChanged()
             if (!track->shouldPurgeCuesFromUnbufferedRanges())
                 continue;
 
-            auto& buffered =
+            track->removeCuesNotInTimeRanges(
 #if ENABLE(MEDIA_SOURCE)
                 m_mediaSource ? m_mediaSource->buffered() :
 #endif
-                m_player->buffered();
-
-            track->removeCuesNotInTimeRanges(buffered);
+                m_player->buffered());
         }
     });
 }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -39,7 +39,7 @@ bool MediaSourcePrivate::hasFutureTime(const MediaTime& currentTime) const
     if (currentTime >= duration())
         return false;
 
-    auto& ranges = buffered();
+    auto ranges = buffered();
     MediaTime nearest = ranges.nearest(currentTime);
     if (abs(nearest - currentTime) > timeFudgeFactor())
         return false;
@@ -73,7 +73,7 @@ RefPtr<MediaSourcePrivateClient> MediaSourcePrivate::client() const
     return m_client.get();
 }
 
-const MediaTime& MediaSourcePrivate::duration() const
+MediaTime MediaSourcePrivate::duration() const
 {
     Locker locker { m_lock };
 
@@ -163,7 +163,7 @@ void MediaSourcePrivate::bufferedChanged(const PlatformTimeRanges& buffered)
     m_buffered = buffered;
 }
 
-const PlatformTimeRanges& MediaSourcePrivate::buffered() const
+PlatformTimeRanges MediaSourcePrivate::buffered() const
 {
     Locker locker { m_lock };
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -95,8 +95,8 @@ public:
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }
 
-    const MediaTime& duration() const;
-    const PlatformTimeRanges& buffered() const;
+    MediaTime duration() const;
+    PlatformTimeRanges buffered() const;
 
     bool hasFutureTime(const MediaTime& currentTime) const;
     bool hasAudio() const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -672,7 +672,8 @@ MediaTime MediaPlayerPrivateMediaSourceAVFObjC::minTimeSeekable() const
 
 const PlatformTimeRanges& MediaPlayerPrivateMediaSourceAVFObjC::buffered() const
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->buffered() : PlatformTimeRanges::emptyRanges();
+    ASSERT_NOT_REACHED();
+    return PlatformTimeRanges::emptyRanges();
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::didLoadingProgress() const

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -300,8 +300,7 @@ void MediaPlayerPrivateGStreamerMSE::didPreroll()
 
 const PlatformTimeRanges& MediaPlayerPrivateGStreamerMSE::buffered() const
 {
-    if (m_mediaSourcePrivate)
-        return m_mediaSourcePrivate->buffered();
+    ASSERT_NOT_REACHED();
     return PlatformTimeRanges::emptyRanges();
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -177,7 +177,8 @@ MediaTime MockMediaPlayerMediaSource::maxTimeSeekable() const
 
 const PlatformTimeRanges& MockMediaPlayerMediaSource::buffered() const
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->buffered() : PlatformTimeRanges::emptyRanges();
+    ASSERT_NOT_REACHED();
+    return PlatformTimeRanges::emptyRanges();
 }
 
 bool MockMediaPlayerMediaSource::didLoadingProgress() const
@@ -247,7 +248,7 @@ void MockMediaPlayerMediaSource::advanceCurrentTime()
     if (!m_mediaSourcePrivate)
         return;
 
-    auto& buffered = m_mediaSourcePrivate->buffered();
+    auto buffered = m_mediaSourcePrivate->buffered();
     size_t pos = buffered.find(m_currentTime);
     if (pos == notFound)
         return;


### PR DESCRIPTION
#### 06c27265e8ab06e41c4f2265e3bba67d08446177
<pre>
Remove access from MediaPlayerPrivateMediaSource to MediaSourcePrivate::buffered
<a href="https://bugs.webkit.org/show_bug.cgi?id=269560">https://bugs.webkit.org/show_bug.cgi?id=269560</a>
<a href="https://rdar.apple.com/problem/123074982">rdar://problem/123074982</a>

Reviewed by Youenn Fablet.

When a MediaSource object is in use, the HTMLMediaElement retrieves the buffered
directly from it rather than from the MediaPlayer/MediaPlayerPrivate.

As such, we don&apos;t need to implement the buffered method for the MediaPlayerPrivateMediaSourceX.

No change in observable behaviour, Covered by existing tests.
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::buffered const):
(WebCore::MediaSource::hasBufferedTime):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerBufferedTimeRangesChanged):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::hasFutureTime const):
(WebCore::MediaSourcePrivate::duration const):
(WebCore::MediaSourcePrivate::buffered const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::buffered const):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::buffered const):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::buffered const):
(WebCore::MockMediaPlayerMediaSource::advanceCurrentTime):

Canonical link: <a href="https://commits.webkit.org/274824@main">https://commits.webkit.org/274824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44a63a79a6469b01fcc07955cac897f328c56f80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42674 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16115 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13934 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36399 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12256 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16563 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16612 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->