### PR TITLE
Sync `animation-events-prefixed-*` tests from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/imported/blink/animations/animation-events-prefixed-01-expected.txt
+++ b/LayoutTests/imported/blink/animations/animation-events-prefixed-01-expected.txt
@@ -1,3 +1,3 @@
-Tests that prefixed animation events are correctly fired.
-PASS: All events have been received as expected.
+
+PASS Tests that prefixed animation events are correctly fired
 

--- a/LayoutTests/imported/blink/animations/animation-events-prefixed-01.html
+++ b/LayoutTests/imported/blink/animations/animation-events-prefixed-01.html
@@ -1,70 +1,57 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>Tests that prefixed animation events are correctly fired.</title>
-  <style>
-    #box {
-      position: relative;
-      left: 100px;
-      top: 10px;
-      height: 100px;
-      width: 100px;
-      background-color: #999;
-    }
+<title>Tests that prefixed animation events are correctly fired.</title>
+<style>
+  #box {
+    position: relative;
+    left: 100px;
+    top: 10px;
+    height: 100px;
+    width: 100px;
+    background-color: #999;
+  }
 
-    .animate {
-      animation-duration: 0.3s;
-      animation-name: anim;
-    }
+  .animate {
+    animation-duration: 0.3s;
+    animation-name: anim;
+  }
 
-    @keyframes anim {
-        from { left: 200px; }
-        to   { left: 300px; }
-    }
-  </style>
-  <script>
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        testRunner.waitUntilDone();
-    }
+  @keyframes anim {
+      from { left: 200px; }
+      to   { left: 300px; }
+  }
+</style>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+var startEventReceived = false;
+var endEventReceived = false;
 
-    var startEventReceived = false;
-    var endEventReceived = false;
+document.addEventListener('webkitAnimationStart', () => {
+  startEventReceived = true;
+});
 
-    document.addEventListener('webkitAnimationStart', function() {
-      startEventReceived = true;
-    }, false);
+document.addEventListener('webkitAnimationEnd', () => {
+  endEventReceived = true;
+  document.getElementById('box').className = '';
+  // Launch again the animation to catch the animation iteration events this time.
+  requestAnimationFrame(function () {
+    document.getElementById('box').style.webkitAnimationIterationCount = "infinite";
+    document.getElementById('box').className = 'animate';
+  });
+});
 
-    document.addEventListener('webkitAnimationIteration', function() {
-      if (startEventReceived && endEventReceived) {
-        document.getElementById('result').innerHTML = 'PASS: All events have been received as expected.';
-        if (window.testRunner)
-            testRunner.notifyDone();
-      }
-    }, false);
+async_test(t => {
+  window.addEventListener("load", t.step_func(() => {
+    // Animation begins once we append the DOM node to the document.
+    var boxNode = document.createElement('div');
+    boxNode.id = 'box';
+    boxNode.className = 'animate';
+    document.body.appendChild(boxNode);
 
-    document.addEventListener('webkitAnimationEnd', function() {
-      endEventReceived = true;
-      document.getElementById('box').className = '';
-      // Launch again the animation to catch the animation iteration events this time.
-      setTimeout(function () {
-        document.getElementById('box').style.webkitAnimationIterationCount = "infinite";
-        document.getElementById('box').className = 'animate';
-      }, 200);
-    }, false);
-
-    onload = function()
-    {
-      // Animation begins once we append the DOM node to the document.
-      var boxNode = document.createElement('div');
-      boxNode.id = 'box';
-      boxNode.className = 'animate';
-      document.body.appendChild(boxNode);
-    }
-  </script>
-</head>
-<body>
-Tests that prefixed animation events are correctly fired.
-<pre id="result">FAIL: No animation events received</pre>
-</body>
-</html>
+    document.addEventListener('webkitAnimationIteration', t.step_func_done(() => {
+      assert_true(startEventReceived);
+      assert_true(endEventReceived);
+    }));
+  }));
+}, "Tests that prefixed animation events are correctly fired");
+</script>

--- a/LayoutTests/imported/blink/animations/animation-events-prefixed-02-expected.txt
+++ b/LayoutTests/imported/blink/animations/animation-events-prefixed-02-expected.txt
@@ -1,3 +1,3 @@
-Tests that unprefixed animation events are correctly fired when listeners are on both versions.
-PASS: All events have been received as expected.
+
+PASS Tests that unprefixed animation events are correctly fired when listeners are on both versions
 

--- a/LayoutTests/imported/blink/animations/animation-events-prefixed-02.html
+++ b/LayoutTests/imported/blink/animations/animation-events-prefixed-02.html
@@ -1,89 +1,71 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>Tests that unprefixed animation events are correctly fired when listeners are on both versions.</title>
-  <style>
-    #box {
-      position: relative;
-      left: 100px;
-      top: 10px;
-      height: 100px;
-      width: 100px;
-      background-color: #999;
-    }
+<title>Tests that unprefixed animation events are correctly fired when listeners are on both versions.</title>
+<style>
+#box {
+  position: relative;
+  left: 100px;
+  top: 10px;
+  height: 100px;
+  width: 100px;
+  background-color: #999;
+}
 
-    .animate {
-      animation-duration: 0.3s;
-      animation-name: anim;
-    }
+.animate {
+  animation-duration: 0.3s;
+  animation-name: anim;
+}
 
-    @keyframes anim {
-        from { left: 200px; }
-        to   { left: 300px; }
-    }
-  </style>
-  <script>
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        testRunner.waitUntilDone();
-    }
+@keyframes anim {
+    from { left: 200px; }
+    to   { left: 300px; }
+}
+</style>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+var startEventReceived = false;
+var endEventReceived = false;
+var prefixedEventReceived = 0;
 
-    function fail() {
-      document.getElementById('result').innerHTML = 'FAIL: Got ' + iterationEventReceived + ' animationCount events and '
-      + prefixedEventReceived + ' prefixed events.';
-    }
+document.addEventListener('webkitAnimationStart', () => {
+  prefixedEventReceived++;
+});
 
-    var startEventReceived = false;
-    var endEventReceived = false;
-    var prefixedEventReceived = 0;
+document.addEventListener('animationstart', () => {
+  startEventReceived = true;
+});
 
-    document.addEventListener('webkitAnimationStart', function() {
-      prefixedEventReceived++;
-    }, false);
+document.addEventListener('webkitAnimationIteration', () => {
+  prefixedEventReceived++;
+});
 
-    document.addEventListener('animationstart', function() {
-      startEventReceived = true;
-    }, false);
+document.addEventListener('webkitAnimationEnd', () => {
+  prefixedEventReceived++;
+});
 
-    document.addEventListener('animationiteration', function() {
-      if (startEventReceived && endEventReceived && prefixedEventReceived == 0) {
-        document.getElementById('result').innerHTML = 'PASS: All events have been received as expected.';
-      } else
-        fail();
-      if (window.testRunner)
-            testRunner.notifyDone();
-    }, false);
+document.addEventListener('animationend', () => {
+  endEventReceived = true;
+  document.getElementById('box').className = '';
 
-    document.addEventListener('webkitAnimationIteration', function() {
-      prefixedEventReceived++;
-    }, false);
+  document.getElementById('box').offsetTop; // force style recalc
 
-    document.addEventListener('webkitAnimationEnd', function() {
-      prefixedEventReceived++;
-    }, false);
+  // Launch again the animation to catch the animation iteration events this time.
+  document.getElementById('box').style.animationIterationCount = "infinite";
+  document.getElementById('box').className = 'animate';
+});
 
-    document.addEventListener('animationend', function() {
-      endEventReceived = true;
-      document.getElementById('box').className = '';
-      // Launch again the animation to catch the animation iteration events this time.
-      setTimeout(function () {
-        document.getElementById('box').style.animationIterationCount = "infinite";
-        document.getElementById('box').className = 'animate';
-      }, 200);
-    }, false);
-
-    onload = function()
-    {
-      // Animation begins once we append the DOM node to the document.
-      var boxNode = document.createElement('div');
-      boxNode.id = 'box';
-      boxNode.className = 'animate';
-      document.body.appendChild(boxNode);
-    }
-  </script>
-</head>
-<body>
-Tests that unprefixed animation events are correctly fired when listeners are on both versions.
-<pre id="result">FAIL: No animation events received</pre>
-</body>
-</html>
+async_test(t => {
+  window.addEventListener("load", t.step_func(() => {
+    // Animation begins once we append the DOM node to the document.
+    var boxNode = document.createElement('div');
+    boxNode.id = 'box';
+    boxNode.className = 'animate';
+    document.body.appendChild(boxNode);
+    document.addEventListener('animationiteration', t.step_func_done(() => {
+      assert_true(startEventReceived);
+      assert_true(endEventReceived);
+      assert_equals(prefixedEventReceived, 0);
+    }));
+  }));
+}, "Tests that unprefixed animation events are correctly fired when listeners are on both versions");
+</script>

--- a/LayoutTests/imported/blink/animations/animation-events-prefixed-03-expected.txt
+++ b/LayoutTests/imported/blink/animations/animation-events-prefixed-03-expected.txt
@@ -1,3 +1,3 @@
-Tests that prefixed animation events are correctly fired when using html event listeners.
-PASS: All events have been received as expected.
+
+PASS Prefixed animation events should be fired with html event listeners
 

--- a/LayoutTests/imported/blink/animations/animation-events-prefixed-03.html
+++ b/LayoutTests/imported/blink/animations/animation-events-prefixed-03.html
@@ -1,62 +1,55 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>Tests that prefixed animation events are correctly fired when using html event listeners.</title>
-  <style>
-    #box {
-      position: relative;
-      left: 100px;
-      top: 10px;
-      height: 100px;
-      width: 100px;
-      background-color: #999;
-    }
+<title>Tests that prefixed animation events are correctly fired when using html event listeners.</title>
+<style>
+#box {
+  position: relative;
+  left: 100px;
+  top: 10px;
+  height: 100px;
+  width: 100px;
+  background-color: #999;
+}
 
-    .animate {
-      animation-duration: 0.3s;
-      animation-name: anim;
-    }
+.animate {
+  animation-duration: 0.3s;
+  animation-name: anim;
+}
 
-    @keyframes anim {
-        from { left: 200px; }
-        to   { left: 300px; }
-    }
-  </style>
-  <script>
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        testRunner.waitUntilDone();
-    }
+@keyframes anim {
+  from { left: 200px; }
+  to   { left: 300px; }
+}
+</style>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+var startEventReceived = false;
+var endEventReceived = false;
 
-    var startEventReceived = false;
-    var endEventReceived = false;
+function recordAnimationStart() {
+  startEventReceived = true;
+}
 
-    function recordAnimationStart() {
-      startEventReceived = true;
-    }
+function recordAnimationEnd() {
+  endEventReceived = true;
+  document.getElementById('box').className = '';
 
-    function recordAnimationIteration() {
-      if (startEventReceived && endEventReceived) {
-        document.getElementById('result').innerHTML = 'PASS: All events have been received as expected.';
-        if (window.testRunner)
-            testRunner.notifyDone();
-      }
-    }
+  document.getElementById('box').offsetTop; // force style recalc
 
-    function recordAnimationEnd() {
-      endEventReceived = true;
-      document.getElementById('box').className = '';
-      // Launch again the animation to catch the animation iteration events this time.
-      setTimeout(function () {
-        document.getElementById('box').style.animationIterationCount = "infinite";
-        document.getElementById('box').className = 'animate';
-      }, 200);
-    }
-  </script>
-</head>
-<body>
-Tests that prefixed animation events are correctly fired when using html event listeners.
-<pre id="result">FAIL: No animation events received</pre>
-<div id="box" onwebkitanimationstart="recordAnimationStart();" onwebkitanimationend="recordAnimationEnd();" onwebkitanimationiteration="recordAnimationIteration();" class="animate"></div>
-</body>
-</html>
+  // Launch again the animation to catch the animation iteration events this time.
+  document.getElementById('box').style.animationIterationCount = "infinite";
+  document.getElementById('box').className = 'animate';
+}
+
+async_test(t => {
+  window.addEventListener("load", t.step_func(() => {
+    const box = document.getElementById('box');
+    box.addEventListener("animationiteration", t.step_func_done(() => {
+      assert_true(startEventReceived);
+      assert_true(endEventReceived);
+    }));
+  }));
+}, "Prefixed animation events should be fired with html event listeners");
+</script>
+<div id="box" onwebkitanimationstart="recordAnimationStart();"
+onwebkitanimationend="recordAnimationEnd();"class="animate"></div>

--- a/LayoutTests/imported/blink/virtual/stable/animations-unprefixed/animation-events-prefixed-04-expected.txt
+++ b/LayoutTests/imported/blink/virtual/stable/animations-unprefixed/animation-events-prefixed-04-expected.txt
@@ -1,4 +1,3 @@
-Tests that custom events with prefixed animations names are correctly dispatched.
-PASS: webkitAnimationStart event listener has been called.
-PASS: webkitAnimationIteration event listener has been called.
-PASS: webkitAnimationEnd event has been called.
+
+PASS Tests that custom events with prefixed animations names are correctly dispatched
+

--- a/LayoutTests/imported/blink/virtual/stable/animations-unprefixed/animation-events-prefixed-04.html
+++ b/LayoutTests/imported/blink/virtual/stable/animations-unprefixed/animation-events-prefixed-04.html
@@ -1,48 +1,28 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>Tests that custom events with prefixed animations names are correctly dispatched.</title>
-  <script>
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        testRunner.waitUntilDone();
-    }
-
-    document.addEventListener('animationstart', function(e) {
-      document.getElementById('result').innerHTML += 'FAIL: animationstart event listener should not have been called.<br>';
-    }, false);
-
-    document.addEventListener('webkitAnimationStart', function(e) {
-      document.getElementById('result').innerHTML += 'PASS: webkitAnimationStart event listener has been called.<br>';
-    }, false);
-
-    document.addEventListener('animationiteration', function(e) {
-      document.getElementById('result').innerHTML += 'FAIL: animationiteration event listener should not have been called.<br>';
-    }, false);
-
-    document.addEventListener('webkitAnimationIteration', function(e) {
-      document.getElementById('result').innerHTML += 'PASS: webkitAnimationIteration event listener has been called.<br>';
-    }, false);
-
-    document.addEventListener('animationend', function(e) {
-      document.getElementById('result').innerHTML += 'FAIL: animationend event listener should not have been called.';
-      if (window.testRunner)
-        testRunner.notifyDone();
-    }, false);
-
-    document.addEventListener('webkitAnimationEnd', function(e) {
-      document.getElementById('result').innerHTML += 'PASS: webkitAnimationEnd event has been called.';
-      if (window.testRunner)
-        testRunner.notifyDone();
-    }, false);
-
-  </script>
-</head>
-<body>
-Tests that custom events with prefixed animations names are correctly dispatched.
-<pre id="result"></pre>
-</body>
+<title>Tests that custom events with prefixed animations names are correctly dispatched.</title>
+<script src="../../../../../resources/testharness.js"></script>
+<script src="../../../../../resources/testharnessreport.js"></script>
 <script>
+var webkitAnimationStartReceived = false;
+var webkitAnimationIterationReceived = false;
+
+document.addEventListener('webkitAnimationStart', () => {
+  webkitAnimationStartReceived = true;
+});
+
+document.addEventListener('webkitAnimationIteration', () => {
+  webkitAnimationIterationReceived = true;
+});
+
+async_test(t => {
+  document.addEventListener('animationstart', t.unreached_func('animationstart event listener should not have been called'));
+  document.addEventListener('animationiteration', t.unreached_func('animationiteration event listener should not have been called'));
+  document.addEventListener('animationend', t.unreached_func('animationend event listener should not have been called'));
+  document.addEventListener('webkitAnimationEnd', t.step_func_done(() => {
+    assert_true(webkitAnimationStartReceived);
+    assert_true(webkitAnimationIterationReceived);
+  }));
+
   var custom = document.createEvent('CustomEvent');
   custom.initCustomEvent('webkitAnimationStart', true, true, null);
   document.dispatchEvent(custom);
@@ -52,5 +32,5 @@ Tests that custom events with prefixed animations names are correctly dispatched
   custom = document.createEvent('CustomEvent');
   custom.initCustomEvent('webkitAnimationEnd', true, true, null);
   document.dispatchEvent(custom);
+}, "Tests that custom events with prefixed animations names are correctly dispatched");
 </script>
-</html>


### PR DESCRIPTION
#### d1274a1f94713f089625a31039e2c6d712845aec
<pre>
Sync `animation-events-prefixed-*` tests from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=161208">https://bugs.webkit.org/show_bug.cgi?id=161208</a>

Reviewed by Antoine Quint.

This patch is to sync all `animation-events-prefixed-*` tests from Blink / Chromium upstream, which were
modified in below commit:

Partial Merge (Prefixed): <a href="https://source.chromium.org/chromium/chromium/src/+/a8ddfde5071f182c11adcbe1060a93b3332c92e7">https://source.chromium.org/chromium/chromium/src/+/a8ddfde5071f182c11adcbe1060a93b3332c92e7</a>

&gt; Updated (use `testharness`):
* LayoutTests/imported/blink/animations/animation-events-prefixed-01.html:
* LayoutTests/imported/blink/animations/animation-events-prefixed-01-expected.txt:
* LayoutTests/imported/blink/animations/animation-events-prefixed-02.html:
* LayoutTests/imported/blink/animations/animation-events-prefixed-02-expected.txt:
* LayoutTests/imported/blink/animations/animation-events-prefixed-03.html:
* LayoutTests/imported/blink/animations/animation-events-prefixed-03-expected.txt:
* LayoutTests/imported/blink/virtual/stable/animations-unprefixed/animation-events-prefixed-04.html:
* LayoutTests/imported/blink/virtual/stable/animations-unprefixed/animation-events-prefixed-04-expected.txt:

Canonical link: <a href="https://commits.webkit.org/274831@main">https://commits.webkit.org/274831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69ef795cb3fb275b7b444467889d77bb2436a6aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42675 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13940 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43953 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39700 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12257 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34891 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9011 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16613 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->