### PR TITLE
Start adopting TZone within WebKit/WebProcess

### DIFF
--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
@@ -47,6 +47,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPaymentCoordinator);
+
 WebPaymentCoordinator::WebPaymentCoordinator(WebPage& webPage)
     : m_webPage(webPage)
 {

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
@@ -35,6 +35,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -50,7 +51,7 @@ class NetworkProcessConnection;
 class WebPage;
 
 class WebPaymentCoordinator final : public WebCore::PaymentCoordinatorClient, private IPC::MessageReceiver, private IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPaymentCoordinator);
 public:
     friend class NetworkProcessConnection;
     explicit WebPaymentCoordinator(WebPage&);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -70,6 +70,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebAutomationSessionProxy);
+
 using namespace WebCore;
 
 template <typename T>

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ class WebPage;
 class WebAutomationDOMWindowObserver;
 
 class WebAutomationSessionProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebAutomationSessionProxy);
 public:
     WebAutomationSessionProxy(const String& sessionIdentifier);
     ~WebAutomationSessionProxy();

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -45,6 +45,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MediaKeySystemPermissionRequestManager);
+
 MediaKeySystemPermissionRequestManager::MediaKeySystemPermissionRequestManager(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
@@ -34,13 +34,14 @@
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class MediaKeySystemPermissionRequestManager : private WebCore::MediaCanStartListener {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(MediaKeySystemPermissionRequestManager);
 public:
     explicit MediaKeySystemPermissionRequestManager(WebPage&);
     ~MediaKeySystemPermissionRequestManager() = default;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionContextProxy);
+
 void WebExtensionContextProxy::addFrameWithExtensionContent(WebFrame& frame)
 {
     m_extensionContentFrames.add(frame);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -34,6 +34,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -53,7 +54,7 @@ struct WebExtensionTabParameters;
 struct WebExtensionWindowParameters;
 
 class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProxy>, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionContextProxy);
     WTF_MAKE_NONCOPYABLE(WebExtensionContextProxy);
 
 public:

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionControllerProxy);
+
 static HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionControllerProxy>>& webExtensionControllerProxies()
 {
     static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionControllerProxy>>> controllers;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -31,6 +31,7 @@
 #include "WebExtensionContextProxy.h"
 #include "WebExtensionControllerParameters.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ class WebFrame;
 class WebPage;
 
 class WebExtensionControllerProxy final : public RefCounted<WebExtensionControllerProxy>, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionControllerProxy);
     WTF_MAKE_NONCOPYABLE(WebExtensionControllerProxy);
 
 public:

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit::ShapeDetection {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteBarcodeDetectorProxy);
+
 Ref<RemoteBarcodeDetectorProxy> RemoteBarcodeDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier, const WebCore::ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions)
 {
     streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteBarcodeDetector(identifier, barcodeDetectorOptions), renderingBackendIdentifier, Seconds::infinity());

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -48,7 +49,7 @@ struct DetectedBarcode;
 namespace WebKit::ShapeDetection {
 
 class RemoteBarcodeDetectorProxy : public WebCore::ShapeDetection::BarcodeDetector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteBarcodeDetectorProxy);
 public:
     static Ref<RemoteBarcodeDetectorProxy> create(Ref<IPC::StreamClientConnection>&&, RenderingBackendIdentifier, ShapeDetectionIdentifier, const WebCore::ShapeDetection::BarcodeDetectorOptions&);
 

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit::ShapeDetection {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteFaceDetectorProxy);
+
 Ref<RemoteFaceDetectorProxy> RemoteFaceDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier, const WebCore::ShapeDetection::FaceDetectorOptions& faceDetectorOptions)
 {
     streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteFaceDetector(identifier, faceDetectorOptions), renderingBackendIdentifier, Seconds::infinity());

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -47,7 +48,7 @@ struct FaceDetectorOptions;
 namespace WebKit::ShapeDetection {
 
 class RemoteFaceDetectorProxy : public WebCore::ShapeDetection::FaceDetector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteFaceDetectorProxy);
 public:
     static Ref<RemoteFaceDetectorProxy> create(Ref<IPC::StreamClientConnection>&&, RenderingBackendIdentifier, ShapeDetectionIdentifier, const WebCore::ShapeDetection::FaceDetectorOptions&);
 

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit::ShapeDetection {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteTextDetectorProxy);
+
 Ref<RemoteTextDetectorProxy> RemoteTextDetectorProxy::create(Ref<IPC::StreamClientConnection>&& streamClientConnection, RenderingBackendIdentifier renderingBackendIdentifier, ShapeDetectionIdentifier identifier)
 {
     streamClientConnection->send(Messages::RemoteRenderingBackend::CreateRemoteTextDetector(identifier), renderingBackendIdentifier, Seconds::infinity());

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -46,7 +47,7 @@ struct DetectedText;
 namespace WebKit::ShapeDetection {
 
 class RemoteTextDetectorProxy : public WebCore::ShapeDetection::TextDetector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteTextDetectorProxy);
 public:
     static Ref<RemoteTextDetectorProxy> create(Ref<IPC::StreamClientConnection>&&, RenderingBackendIdentifier, ShapeDetectionIdentifier);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -32,15 +32,18 @@
 #include "RemoteImageBufferSetProxyMessages.h"
 #include "RemoteRenderingBackendProxy.h"
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(GPU_PROCESS)
 
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ThreadSafeImageBufferSetFlusher);
+
 class RemoteImageBufferSetProxyFlushFence : public ThreadSafeRefCounted<RemoteImageBufferSetProxyFlushFence> {
     WTF_MAKE_NONCOPYABLE(RemoteImageBufferSetProxyFlushFence);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RemoteImageBufferSetProxyFlushFence);
 public:
     static Ref<RemoteImageBufferSetProxyFlushFence> create(IPC::Event event, RenderingUpdateID renderingUpdateID)
     {
@@ -113,7 +116,7 @@ private:
 namespace {
 
 class RemoteImageBufferSetProxyFlusher final : public ThreadSafeImageBufferSetFlusher {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RemoteImageBufferSetProxyFlusher);
 public:
     RemoteImageBufferSetProxyFlusher(RemoteImageBufferSetIdentifier identifier, Ref<RemoteImageBufferSetProxyFlushFence> flushState, unsigned generation)
         : m_identifier(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -33,6 +33,7 @@
 #include "RenderingUpdateID.h"
 #include "WorkQueueMessageReceiver.h"
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(GPU_PROCESS)
 
@@ -51,7 +52,7 @@ struct BufferSetBackendHandle;
 // the code that isn't specific to being remote, and this helper belongs
 // there.
 class ThreadSafeImageBufferSetFlusher {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ThreadSafeImageBufferSetFlusher);
     WTF_MAKE_NONCOPYABLE(ThreadSafeImageBufferSetFlusher);
 public:
     enum class FlushType {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteAdapterProxy);
+
 RemoteAdapterProxy::RemoteAdapterProxy(String&& name, WebCore::WebGPU::SupportedFeatures& features, WebCore::WebGPU::SupportedLimits& limits, bool isFallbackAdapter, RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : Adapter(WTFMove(name), features, limits, isFallbackAdapter)
     , m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUAdapter.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 class RemoteGPUProxy;
@@ -41,7 +42,7 @@ namespace WebKit::WebGPU {
 class ConvertToBackingContext;
 
 class RemoteAdapterProxy final : public WebCore::WebGPU::Adapter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteAdapterProxy);
 public:
     static Ref<RemoteAdapterProxy> create(String&& name, WebCore::WebGPU::SupportedFeatures& features, WebCore::WebGPU::SupportedLimits& limits, bool isFallbackAdapter, RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteBindGroupLayoutProxy);
+
 RemoteBindGroupLayoutProxy::RemoteBindGroupLayoutProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUBindGroupLayout.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteBindGroupLayoutProxy final : public WebCore::WebGPU::BindGroupLayout {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteBindGroupLayoutProxy);
 public:
     static Ref<RemoteBindGroupLayoutProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteBindGroupProxy);
+
 RemoteBindGroupProxy::RemoteBindGroupProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUBindGroup.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteBindGroupProxy final : public WebCore::WebGPU::BindGroup {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteBindGroupProxy);
 public:
     static Ref<RemoteBindGroupProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteBufferProxy);
+
 RemoteBufferProxy::RemoteBufferProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -31,13 +31,14 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUBuffer.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteBufferProxy final : public WebCore::WebGPU::Buffer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteBufferProxy);
 public:
     static Ref<RemoteBufferProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteCommandBufferProxy);
+
 RemoteCommandBufferProxy::RemoteCommandBufferProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUCommandBuffer.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteCommandBufferProxy final : public WebCore::WebGPU::CommandBuffer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteCommandBufferProxy);
 public:
     static Ref<RemoteCommandBufferProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -36,6 +36,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteCommandEncoderProxy);
+
 RemoteCommandEncoderProxy::RemoteCommandEncoderProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUCommandEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteCommandEncoderProxy final : public WebCore::WebGPU::CommandEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteCommandEncoderProxy);
 public:
     static Ref<RemoteCommandEncoderProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteCompositorIntegrationProxy);
+
 RemoteCompositorIntegrationProxy::RemoteCompositorIntegrationProxy(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -31,6 +31,7 @@
 #include "RemotePresentationContextProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUCompositorIntegration.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class ImageBuffer;
@@ -42,7 +43,7 @@ namespace WebKit::WebGPU {
 class ConvertToBackingContext;
 
 class RemoteCompositorIntegrationProxy final : public WebCore::WebGPU::CompositorIntegration {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteCompositorIntegrationProxy);
 public:
     static Ref<RemoteCompositorIntegrationProxy> create(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteComputePassEncoderProxy);
+
 RemoteComputePassEncoderProxy::RemoteComputePassEncoderProxy(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteCommandEncoderProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUComputePassEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteComputePassEncoderProxy final : public WebCore::WebGPU::ComputePassEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteComputePassEncoderProxy);
 public:
     static Ref<RemoteComputePassEncoderProxy> create(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteComputePipelineProxy);
+
 RemoteComputePipelineProxy::RemoteComputePipelineProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUComputePipeline.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
@@ -38,7 +39,7 @@ class ConvertToBackingContext;
 class RemoteBindGroupLayoutProxy;
 
 class RemoteComputePipelineProxy final : public WebCore::WebGPU::ComputePipeline {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteComputePipelineProxy);
 public:
     static Ref<RemoteComputePipelineProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -49,6 +49,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteDeviceProxy);
+
 RemoteDeviceProxy::RemoteDeviceProxy(Ref<WebCore::WebGPU::SupportedFeatures>&& features, Ref<WebCore::WebGPU::SupportedLimits>&& limits, RemoteAdapterProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, WebGPUIdentifier queueIdentifier)
     : Device(WTFMove(features), WTFMove(limits))
     , m_backing(identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/WebGPUCommandEncoderDescriptor.h>
 #include <WebCore/WebGPUDevice.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
@@ -40,7 +41,7 @@ class ConvertToBackingContext;
 class RemoteQueueProxy;
 
 class RemoteDeviceProxy final : public WebCore::WebGPU::Device {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteDeviceProxy);
 public:
     static Ref<RemoteDeviceProxy> create(Ref<WebCore::WebGPU::SupportedFeatures>&& features, Ref<WebCore::WebGPU::SupportedLimits>&& limits, RemoteAdapterProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, WebGPUIdentifier queueIdentifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteExternalTextureProxy);
+
 RemoteExternalTextureProxy::RemoteExternalTextureProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUExternalTexture.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteExternalTextureProxy final : public WebCore::WebGPU::ExternalTexture {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteExternalTextureProxy);
 public:
     static Ref<RemoteExternalTextureProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -43,6 +43,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteGPUProxy);
+
 RefPtr<RemoteGPUProxy> RemoteGPUProxy::create(IPC::Connection& connection, WebGPU::ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, RenderingBackendIdentifier renderingBackend)
 {
     constexpr size_t connectionBufferSizeLog2 = 21;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/WebGPU.h>
 #include <WebCore/WebGPUPresentationContext.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
@@ -49,7 +50,7 @@ class DowncastConvertToBackingContext;
 }
 
 class RemoteGPUProxy final : public WebCore::WebGPU::GPU, private IPC::Connection::Client, public ThreadSafeRefCounted<RemoteGPUProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteGPUProxy);
 public:
     static RefPtr<RemoteGPUProxy> create(IPC::Connection&, WebGPU::ConvertToBackingContext&, WebGPUIdentifier, RenderingBackendIdentifier);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemotePipelineLayoutProxy);
+
 RemotePipelineLayoutProxy::RemotePipelineLayoutProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUPipelineLayout.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemotePipelineLayoutProxy final : public WebCore::WebGPU::PipelineLayout {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemotePipelineLayoutProxy);
 public:
     static Ref<RemotePipelineLayoutProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemotePresentationContextProxy);
+
 RemotePresentationContextProxy::RemotePresentationContextProxy(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <WebCore/WebGPUPresentationContext.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
@@ -38,7 +39,7 @@ class ConvertToBackingContext;
 class RemoteTextureProxy;
 
 class RemotePresentationContextProxy final : public WebCore::WebGPU::PresentationContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemotePresentationContextProxy);
 public:
     static Ref<RemotePresentationContextProxy> create(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteQuerySetProxy);
+
 RemoteQuerySetProxy::RemoteQuerySetProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUQuerySet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteQuerySetProxy final : public WebCore::WebGPU::QuerySet {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteQuerySetProxy);
 public:
     static Ref<RemoteQuerySetProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteQueueProxy);
+
 RemoteQueueProxy::RemoteQueueProxy(RemoteAdapterProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 class ConvertToBackingContext;
 
 class RemoteQueueProxy final : public WebCore::WebGPU::Queue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteQueueProxy);
 public:
     static Ref<RemoteQueueProxy> create(RemoteAdapterProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteRenderBundleEncoderProxy);
+
 RemoteRenderBundleEncoderProxy::RemoteRenderBundleEncoderProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPURenderBundleEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteRenderBundleEncoderProxy final : public WebCore::WebGPU::RenderBundleEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteRenderBundleEncoderProxy);
 public:
     static Ref<RemoteRenderBundleEncoderProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteRenderBundleProxy);
+
 RemoteRenderBundleProxy::RemoteRenderBundleProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPURenderBundle.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteRenderBundleProxy final : public WebCore::WebGPU::RenderBundle {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteRenderBundleProxy);
 public:
     static Ref<RemoteRenderBundleProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteRenderPassEncoderProxy);
+
 RemoteRenderPassEncoderProxy::RemoteRenderPassEncoderProxy(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteCommandEncoderProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPURenderPassEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteRenderPassEncoderProxy final : public WebCore::WebGPU::RenderPassEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteRenderPassEncoderProxy);
 public:
     static Ref<RemoteRenderPassEncoderProxy> create(RemoteCommandEncoderProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteRenderPipelineProxy);
+
 RemoteRenderPipelineProxy::RemoteRenderPipelineProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPURenderPipeline.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
@@ -38,7 +39,7 @@ class ConvertToBackingContext;
 class RemoteBindGroupLayoutProxy;
 
 class RemoteRenderPipelineProxy final : public WebCore::WebGPU::RenderPipeline {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteRenderPipelineProxy);
 public:
     static Ref<RemoteRenderPipelineProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteSamplerProxy);
+
 RemoteSamplerProxy::RemoteSamplerProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUSampler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteSamplerProxy final : public WebCore::WebGPU::Sampler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteSamplerProxy);
 public:
     static Ref<RemoteSamplerProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteShaderModuleProxy);
+
 RemoteShaderModuleProxy::RemoteShaderModuleProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -36,7 +36,7 @@ namespace WebKit::WebGPU {
 class ConvertToBackingContext;
 
 class RemoteShaderModuleProxy final : public WebCore::WebGPU::ShaderModule {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteShaderModuleProxy);
 public:
     static Ref<RemoteShaderModuleProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteTextureProxy);
+
 RemoteTextureProxy::RemoteTextureProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -34,13 +34,14 @@
 #include <WebCore/WebGPUTextureDimension.h>
 #include <WebCore/WebGPUTextureFormat.h>
 #include <WebCore/WebGPUTextureViewDescriptor.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteTextureProxy final : public WebCore::WebGPU::Texture {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteTextureProxy);
 public:
     static Ref<RemoteTextureProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteTextureViewProxy);
+
 RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -30,13 +30,14 @@
 #include "RemoteTextureProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUTextureView.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
 
 class RemoteTextureViewProxy final : public WebCore::WebGPU::TextureView {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteTextureViewProxy);
 public:
     static Ref<RemoteTextureViewProxy> create(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
@@ -55,6 +55,8 @@
 
 namespace WebKit::WebGPU {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DowncastConvertToBackingContext);
+
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const WebCore::WebGPU::Adapter& adapter)
 {
     return static_cast<const RemoteAdapterProxy&>(adapter).backing();

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h
@@ -32,7 +32,7 @@
 namespace WebKit::WebGPU {
 
 class DowncastConvertToBackingContext final : public ConvertToBackingContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(DowncastConvertToBackingContext);
 public:
     static Ref<DowncastConvertToBackingContext> create()
     {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
@@ -37,6 +37,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteAudioHardwareListener);
+
 Ref<RemoteAudioHardwareListener> RemoteAudioHardwareListener::create(AudioHardwareListener::Client& client)
 {
     return adoptRef(*new RemoteAudioHardwareListener(client));

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "RemoteAudioHardwareListenerIdentifier.h"
 #include <WebCore/AudioHardwareListener.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -46,7 +47,7 @@ class RemoteAudioHardwareListener final
     , private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteAudioHardwareListener);
 public:
     static Ref<RemoteAudioHardwareListener> create(WebCore::AudioHardwareListener::Client&);
     ~RemoteAudioHardwareListener();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteAudioSession);
+
 UniqueRef<RemoteAudioSession> RemoteAudioSession::create()
 {
     return makeUniqueRef<RemoteAudioSession>();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "RemoteAudioSessionConfiguration.h"
 #include <WebCore/AudioSession.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -47,7 +48,7 @@ class RemoteAudioSession final
     , public GPUProcessConnection::Client
     , IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteAudioSession);
 public:
     static UniqueRef<RemoteAudioSession> create();
     ~RemoteAudioSession();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteCDMFactory);
+
 RemoteCDMFactory::RemoteCDMFactory(WebProcess&)
 {
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -33,6 +33,7 @@
 #include "WebProcessSupplement.h"
 #include <WebCore/CDMFactory.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -55,7 +56,7 @@ class RemoteCDMFactory final
     : public WebCore::CDMFactory
     , public WebProcessSupplement
     , public CanMakeWeakPtr<RemoteCDMFactory> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteCDMFactory);
 public:
     explicit RemoteCDMFactory(WebProcess&);
     virtual ~RemoteCDMFactory();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteImageDecoderAVFManager);
+
 RefPtr<RemoteImageDecoderAVF> RemoteImageDecoderAVFManager::createImageDecoder(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
 {
     auto sendResult = ensureGPUProcessConnection().connection().sendSync(Messages::RemoteImageDecoderAVFProxy::CreateDecoder(IPC::SharedBufferReference(data), mimeType), 0);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -35,6 +35,7 @@
 #include <WebCore/IntSize.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -45,7 +46,7 @@ class RemoteImageDecoderAVFManager final
     : private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteImageDecoderAVFManager);
 public:
     static Ref<RemoteImageDecoderAVFManager> create();
     virtual ~RemoteImageDecoderAVFManager();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -41,6 +41,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteLegacyCDMFactory);
+
 RemoteLegacyCDMFactory::RemoteLegacyCDMFactory(WebProcess&)
 {
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -32,6 +32,7 @@
 #include "WebProcessSupplement.h"
 #include <WebCore/LegacyCDM.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -59,7 +60,7 @@ class WebProcess;
 class RemoteLegacyCDMFactory final
     : public WebProcessSupplement
     , public CanMakeWeakPtr<RemoteLegacyCDMFactory> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteLegacyCDMFactory);
 public:
     explicit RemoteLegacyCDMFactory(WebProcess&);
     virtual ~RemoteLegacyCDMFactory();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
@@ -40,6 +40,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteMediaEngineConfigurationFactory);
+
 RemoteMediaEngineConfigurationFactory::RemoteMediaEngineConfigurationFactory(WebProcess&)
 {
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
@@ -32,6 +32,7 @@
 #include "WebProcessSupplement.h"
 #include <WebCore/MediaEngineConfigurationFactory.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -47,7 +48,7 @@ class WebProcess;
 class RemoteMediaEngineConfigurationFactory final
     : public WebProcessSupplement
     , public CanMakeWeakPtr<RemoteMediaEngineConfigurationFactory> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteMediaEngineConfigurationFactory);
 public:
     explicit RemoteMediaEngineConfigurationFactory(WebProcess&);
     virtual ~RemoteMediaEngineConfigurationFactory();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -36,6 +36,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerMIMETypeCache);
+
 RemoteMediaPlayerMIMETypeCache::RemoteMediaPlayerMIMETypeCache(RemoteMediaPlayerManager& manager, MediaPlayerEnums::MediaEngineIdentifier engineIdentifier)
     : m_manager(manager)
     , m_engineIdentifier(engineIdentifier)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -30,6 +30,7 @@
 #include <WebCore/MediaPlayerEnums.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ namespace WebKit {
 class RemoteMediaPlayerManager;
 
 class RemoteMediaPlayerMIMETypeCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteMediaPlayerMIMETypeCache);
 public:
     RemoteMediaPlayerMIMETypeCache(RemoteMediaPlayerManager&, WebCore::MediaPlayerEnums::MediaEngineIdentifier);
     ~RemoteMediaPlayerMIMETypeCache() = default;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -52,6 +52,8 @@ namespace WebKit {
 using namespace PAL;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerManager);
+
 class MediaPlayerRemoteFactory final : public MediaPlayerFactory {
 public:
     MediaPlayerRemoteFactory(MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier, RemoteMediaPlayerManager& manager)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -31,6 +31,7 @@
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class MediaPlayerPrivateInterface;
@@ -48,7 +49,7 @@ struct WebProcessCreationParameters;
 class RemoteMediaPlayerManager
     : public GPUProcessConnection::Client
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteMediaPlayerManager);
 public:
     static Ref<RemoteMediaPlayerManager> create();
     ~RemoteMediaPlayerManager();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteMediaResourceProxy);
+
 RemoteMediaResourceProxy::RemoteMediaResourceProxy(Ref<IPC::Connection>&& connection, WebCore::PlatformMediaResource& platformMediaResource, RemoteMediaResourceIdentifier identifier)
     : m_connection(WTFMove(connection))
     , m_platformMediaResource(platformMediaResource)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h
@@ -32,11 +32,12 @@
 #include <WebCore/PlatformMediaResourceLoader.h>
 #include <WebCore/PolicyChecker.h>
 #include <WebCore/ResourceResponse.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class RemoteMediaResourceProxy final : public WebCore::PlatformMediaResourceClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteMediaResourceProxy);
 public:
     RemoteMediaResourceProxy(Ref<IPC::Connection>&&, WebCore::PlatformMediaResource&, RemoteMediaResourceIdentifier);
     ~RemoteMediaResourceProxy();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
@@ -38,6 +38,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteRemoteCommandListener);
+
 Ref<RemoteRemoteCommandListener> RemoteRemoteCommandListener::create(RemoteCommandListenerClient& client)
 {
     return adoptRef(*new RemoteRemoteCommandListener(client));

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "RemoteRemoteCommandListenerIdentifier.h"
 #include <WebCore/RemoteCommandListener.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -46,7 +47,7 @@ class RemoteRemoteCommandListener final
     , private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteRemoteCommandListener);
 public:
     static Ref<RemoteRemoteCommandListener> create(WebCore::RemoteCommandListenerClient&);
     explicit RemoteRemoteCommandListener(WebCore::RemoteCommandListenerClient&);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -31,8 +31,11 @@
 #include "LibWebRTCCodecs.h"
 #include "WebProcess.h"
 #include <wtf/StdUnorderedMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
+
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteVideoCodecFactory);
 
 class RemoteVideoDecoderCallbacks : public ThreadSafeRefCounted<RemoteVideoDecoderCallbacks> {
 public:
@@ -56,7 +59,7 @@ private:
 };
 
 class RemoteVideoDecoder : public WebCore::VideoDecoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RemoteVideoDecoder);
 public:
     RemoteVideoDecoder(LibWebRTCCodecs::Decoder&, Ref<RemoteVideoDecoderCallbacks>&&, uint16_t width, uint16_t height);
     ~RemoteVideoDecoder();
@@ -96,7 +99,7 @@ private:
 };
 
 class RemoteVideoEncoder : public WebCore::VideoEncoder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RemoteVideoEncoder);
 public:
     RemoteVideoEncoder(LibWebRTCCodecs::Encoder&, Ref<RemoteVideoEncoderCallbacks>&&);
     ~RemoteVideoEncoder();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h
@@ -29,13 +29,14 @@
 
 #include <WebCore/VideoDecoder.h>
 #include <WebCore/VideoEncoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebProcess;
 
 class RemoteVideoCodecFactory {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteVideoCodecFactory);
 public:
     explicit RemoteVideoCodecFactory(WebProcess&);
     ~RemoteVideoCodecFactory();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
@@ -42,6 +42,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteVideoFrameProxy);
+
 RemoteVideoFrameProxy::Properties RemoteVideoFrameProxy::properties(WebKit::RemoteVideoFrameReference reference, const WebCore::VideoFrame& videoFrame)
 {
     return {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -32,6 +32,7 @@
 #include "RemoteVideoFrameProxyProperties.h"
 #include <WebCore/VideoFrame.h>
 #include <wtf/ArgumentCoder.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 #if PLATFORM(COCOA)
@@ -47,7 +48,7 @@ class RemoteVideoFrameObjectHeapProxy;
 // A WebCore::VideoFrame class that points to a concrete WebCore::VideoFrame instance
 // in another process, GPU process.
 class RemoteVideoFrameProxy final : public WebCore::VideoFrame {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteVideoFrameProxy);
     WTF_MAKE_NONCOPYABLE(RemoteVideoFrameProxy);
 public:
     using Properties = RemoteVideoFrameProxyProperties;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -51,6 +51,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SourceBufferPrivateRemote);
+
 WorkQueue& SourceBufferPrivateRemote::queue()
 {
     return MediaSourcePrivateRemote::queue();

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -39,6 +39,7 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -60,7 +61,7 @@ class MediaSourcePrivateRemote;
 class SourceBufferPrivateRemote final
     : public WebCore::SourceBufferPrivate
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SourceBufferPrivateRemote);
 public:
     static Ref<SourceBufferPrivateRemote> create(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
     virtual ~SourceBufferPrivateRemote();

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -42,11 +42,14 @@
 #include <WebCore/WebAudioBufferList.h>
 #include <mach/mach_time.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AudioMediaStreamTrackRendererInternalUnitManager);
+
 class AudioMediaStreamTrackRendererInternalUnitManager::Proxy final : public WebCore::AudioMediaStreamTrackRendererInternalUnit, public CanMakeWeakPtr<Proxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(AudioMediaStreamTrackRendererInternalUnitManager::Proxy);
 public:
     explicit Proxy(Client&);
     ~Proxy();

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
@@ -30,6 +30,7 @@
 #include "AudioMediaStreamTrackRendererInternalUnitIdentifier.h"
 #include <WebCore/AudioMediaStreamTrackRendererInternalUnit.h>
 #include <WebCore/SharedMemory.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -43,7 +44,7 @@ class CAAudioStreamDescription;
 namespace WebKit {
 
 class AudioMediaStreamTrackRendererInternalUnitManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AudioMediaStreamTrackRendererInternalUnitManager);
 public:
     AudioMediaStreamTrackRendererInternalUnitManager() = default;
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -58,6 +58,8 @@ ALLOW_COMMA_END
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LibWebRTCCodecs);
+
 static webrtc::WebKitVideoDecoder createVideoDecoder(const webrtc::SdpVideoFormat& format)
 {
     auto& codecs = WebProcess::singleton().libWebRTCCodecs();

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -44,6 +44,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 using CVPixelBufferPoolRef = struct __CVPixelBufferPool*;
 
@@ -67,7 +68,7 @@ namespace WebKit {
 class RemoteVideoFrameObjectHeapProxy;
 
 class LibWebRTCCodecs : public IPC::WorkQueueMessageReceiver, public GPUProcessConnection::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LibWebRTCCodecs);
 public:
     static Ref<LibWebRTCCodecs> create();
     ~LibWebRTCCodecs();

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -47,6 +47,8 @@ namespace WebKit {
 using namespace PAL;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MediaRecorderPrivate);
+
 class MediaRecorderPrivateGPUProcessDidCloseObserver final
     : public GPUProcessConnection::Client
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivateGPUProcessDidCloseObserver> {

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -33,6 +33,7 @@
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/MediaRecorderPrivate.h>
 #include <wtf/MediaTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -51,7 +52,7 @@ class MediaRecorderPrivateGPUProcessDidCloseObserver;
 class MediaRecorderPrivate final
     : public WebCore::MediaRecorderPrivate
     , public CanMakeWeakPtr<MediaRecorderPrivate> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(MediaRecorderPrivate);
 public:
     MediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivate();

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
@@ -34,6 +34,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SampleBufferDisplayLayerManager);
+
 void SampleBufferDisplayLayerManager::didReceiveLayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (auto* layer = m_layers.get(ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID())).get())

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
@@ -29,11 +29,12 @@
 
 #include "SampleBufferDisplayLayer.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class SampleBufferDisplayLayerManager : public CanMakeWeakPtr<SampleBufferDisplayLayerManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SampleBufferDisplayLayerManager);
 public:
     SampleBufferDisplayLayerManager() = default;
     ~SampleBufferDisplayLayerManager() = default;

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -54,6 +54,9 @@ ALLOW_COMMA_END
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SharedVideoFrameWriter);
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SharedVideoFrameReader);
+
 SharedVideoFrameWriter::SharedVideoFrameWriter()
     : m_semaphore(makeUniqueRef<IPC::Semaphore>())
 {

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -35,6 +35,7 @@
 #include <wtf/MediaTime.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 typedef struct __CVBuffer* CVPixelBufferRef;
@@ -64,7 +65,7 @@ struct SharedVideoFrame {
 };
 
 class SharedVideoFrameWriter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SharedVideoFrameWriter);
 public:
     SharedVideoFrameWriter();
 
@@ -98,7 +99,7 @@ private:
 };
 
 class SharedVideoFrameReader {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SharedVideoFrameReader);
 public:
     ~SharedVideoFrameReader();
 

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
@@ -45,6 +45,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(GeolocationPermissionRequestManager);
+
 GeolocationPermissionRequestManager::GeolocationPermissionRequestManager(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
@@ -29,6 +29,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class Geolocation;
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPage;
 
 class GeolocationPermissionRequestManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(GeolocationPermissionRequestManager);
 public:
     explicit GeolocationPermissionRequestManager(WebPage&);
     ~GeolocationPermissionRequestManager();

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -40,6 +40,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebGeolocationManager);
+
 static RegistrableDomain registrableDomainForPage(WebPage& page)
 {
     auto* document = page.corePage() && dynamicDowncast<LocalFrame>(page.corePage()->mainFrame()) ? dynamicDowncast<LocalFrame>(page.corePage()->mainFrame())->document() : nullptr;

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
@@ -31,6 +31,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 
@@ -45,7 +46,7 @@ class WebProcess;
 class WebPage;
 
 class WebGeolocationManager : public WebProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebGeolocationManager);
     WTF_MAKE_NONCOPYABLE(WebGeolocationManager);
 public:
     explicit WebGeolocationManager(WebProcess&);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/PageOverlay.h>
 #include <WebCore/PlatformMouseEvent.h>
 #include <WebCore/Range.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 
@@ -56,7 +57,7 @@ template<> struct ClientTraits<WKBundlePageOverlayAccessibilityClientBase> {
 }
 
 class PageOverlayClientImpl : API::Client<WKBundlePageOverlayClientBase>, public WebKit::WebPageOverlay::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(PageOverlayClientImpl);
 public:
     explicit PageOverlayClientImpl(WKBundlePageOverlayClientBase* client)
     {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
@@ -32,6 +32,7 @@
 #import "PageBanner.h"
 #import "WKAPICast.h"
 #import "WKBundleAPICast.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 template<> struct ClientTraits<WKBundlePageBannerClientBase> {
@@ -43,7 +44,7 @@ namespace WebKit {
 using namespace WebCore;
 
 class PageBannerClientImpl : API::Client<WKBundlePageBannerClientBase>, public PageBanner::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(PageBannerClientImpl);
 public:
     explicit PageBannerClientImpl(WKBundlePageBannerClientBase* client)
     {

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
@@ -36,6 +36,7 @@
 #include <WebCore/Page.h>
 #include <WebCore/PageOverlayController.h>
 #include <WebCore/Settings.h>
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include <WebCore/InspectorOverlay.h>
@@ -44,8 +45,10 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebInspectorClient);
+
 class RepaintIndicatorLayerClient final : public GraphicsLayerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RepaintIndicatorLayerClient);
 public:
     RepaintIndicatorLayerClient(WebInspectorClient& inspectorClient)
         : m_inspectorClient(inspectorClient)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.h
@@ -28,6 +28,7 @@
 #include <WebCore/InspectorClient.h>
 #include <WebCore/PageOverlay.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class GraphicsContext;
@@ -42,7 +43,7 @@ class WebPage;
 class RepaintIndicatorLayerClient;
 
 class WebInspectorClient : public WebCore::InspectorClient, private WebCore::PageOverlay::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebInspectorClient);
 friend class RepaintIndicatorLayerClient;
 public:
     WebInspectorClient(WebPage*);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -43,6 +43,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebInspectorUIExtensionController);
+
 WebInspectorUIExtensionController::WebInspectorUIExtensionController(WebCore::InspectorFrontendClient& inspectorFrontend, WebCore::PageIdentifier pageIdentifier)
     : m_frontendClient(inspectorFrontend)
     , m_inspectorPageIdentifier(pageIdentifier)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
@@ -35,6 +35,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -53,7 +54,7 @@ class WebInspectorUI;
 
 class WebInspectorUIExtensionController
     : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebInspectorUIExtensionController);
     WTF_MAKE_NONCOPYABLE(WebInspectorUIExtensionController);
 public:
     WebInspectorUIExtensionController(WebCore::InspectorFrontendClient&, WebCore::PageIdentifier);

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
@@ -35,6 +35,8 @@ namespace WebKit {
 
 using namespace Inspector;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPageInspectorTarget);
+
 WebPageInspectorTarget::WebPageInspectorTarget(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/InspectorTarget.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -35,7 +36,7 @@ class WebPage;
 class WebPageInspectorTargetFrontendChannel;
 
 class WebPageInspectorTarget final : public Inspector::InspectorTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPageInspectorTarget);
     WTF_MAKE_NONCOPYABLE(WebPageInspectorTarget);
 public:
     explicit WebPageInspectorTarget(WebPage&);

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPageInspectorTargetController);
+
 WebPageInspectorTargetController::WebPageInspectorTargetController(WebPage& page)
     : m_page(page)
     , m_pageTarget(page)

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h
@@ -28,6 +28,7 @@
 #include "WebPageInspectorTarget.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPage;
 
 class WebPageInspectorTargetController {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPageInspectorTargetController);
 public:
     WebPageInspectorTargetController(WebPage&);
     ~WebPageInspectorTargetController();

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPageInspectorTargetFrontendChannel);
+
 WebPageInspectorTargetFrontendChannel::WebPageInspectorTargetFrontendChannel(WebPage& page, const String& targetId, Inspector::FrontendChannel::ConnectionType connectionType)
     : m_page(page)
     , m_targetId(targetId)

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class WebPage;
 
 class WebPageInspectorTargetFrontendChannel final : public Inspector::FrontendChannel {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPageInspectorTargetFrontendChannel);
     WTF_MAKE_NONCOPYABLE(WebPageInspectorTargetFrontendChannel);
 public:
     WebPageInspectorTargetFrontendChannel(WebPage&, const String& targetId, Inspector::FrontendChannel::ConnectionType);

--- a/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
+++ b/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
@@ -35,6 +35,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebMediaKeyStorageManager);
+
 void WebMediaKeyStorageManager::setWebsiteDataStore(const WebProcessDataStoreParameters& parameters)
 {
     m_mediaKeyStorageDirectory = parameters.mediaKeyStorageDirectory;

--- a/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h
+++ b/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h
@@ -27,6 +27,7 @@
 
 #include "WebProcessSupplement.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebProcess;
 
 class WebMediaKeyStorageManager : public WebProcessSupplement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebMediaKeyStorageManager);
     WTF_MAKE_NONCOPYABLE(WebMediaKeyStorageManager);
 public:
     explicit WebMediaKeyStorageManager(WebProcess&) { }

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp
@@ -47,6 +47,8 @@ namespace WebKit {
 using namespace PAL;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteMediaSessionCoordinator);
+
 Ref<RemoteMediaSessionCoordinator> RemoteMediaSessionCoordinator::create(WebPage& page, const String& identifier)
 {
     return adoptRef(*new RemoteMediaSessionCoordinator(page, identifier));

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/MediaSessionCoordinatorPrivate.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebPage;
 
 class RemoteMediaSessionCoordinator final : public WebCore::MediaSessionCoordinatorPrivate , public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteMediaSessionCoordinator);
 public:
     static Ref<RemoteMediaSessionCoordinator> create(WebPage&, const String&);
     ~RemoteMediaSessionCoordinator();

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -41,6 +41,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UserMediaPermissionRequestManager);
+
 UserMediaPermissionRequestManager::UserMediaPermissionRequestManager(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -41,7 +42,7 @@ class UserMediaPermissionRequestManager : public WebCore::MediaCanStartListener
                                         , public WebCore::RealtimeMediaSourceCenter::Observer
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(UserMediaPermissionRequestManager);
 public:
     using WebCore::MediaCanStartListener::weakPtrFactory;
     using WebCore::MediaCanStartListener::WeakValueType;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -97,6 +97,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebLoaderStrategy);
+
 WebLoaderStrategy::WebLoaderStrategy()
     : m_internallyFailedLoadTimer(RunLoop::main(), this, &WebLoaderStrategy::internallyFailedLoadTimerFired)
 {

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -34,6 +34,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct FetchOptions;
@@ -47,7 +48,8 @@ class WebPage;
 class WebURLSchemeTaskProxy;
 
 class WebLoaderStrategy final : public WebCore::LoaderStrategy {
-    WTF_MAKE_NONCOPYABLE(WebLoaderStrategy); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(WebLoaderStrategy);
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebLoaderStrategy);
 public:
     WebLoaderStrategy();
     ~WebLoaderStrategy() final;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LibWebRTCNetwork);
+
 LibWebRTCNetwork::~LibWebRTCNetwork()
 {
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -33,12 +33,13 @@
 #include "WebRTCResolver.h"
 #include <WebCore/LibWebRTCSocketIdentifier.h>
 #include <wtf/FunctionDispatcher.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
 
 class LibWebRTCNetwork : private FunctionDispatcher, private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LibWebRTCNetwork);
 public:
     static UniqueRef<LibWebRTCNetwork> create() { return UniqueRef { *new LibWebRTCNetwork() }; }
     ~LibWebRTCNetwork();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -38,6 +38,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LibWebRTCNetworkManager);
+
 LibWebRTCNetworkManager* LibWebRTCNetworkManager::getOrCreate(WebCore::ScriptExecutionContextIdentifier identifier)
 {
     RefPtr document = Document::allDocumentsMap().get(identifier);

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
@@ -32,11 +32,12 @@
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/RTCNetworkManager.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class LibWebRTCNetworkManager final : public WebCore::RTCNetworkManager, public rtc::NetworkManagerBase, public webrtc::MdnsResponderInterface, public WebRTCMonitor::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LibWebRTCNetworkManager);
 public:
     static LibWebRTCNetworkManager* getOrCreate(WebCore::ScriptExecutionContextIdentifier);
     ~LibWebRTCNetworkManager();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/Page.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/Settings.h>
+#include <wtf/TZoneMalloc.h>
 
 ALLOW_COMMA_BEGIN
 
@@ -94,7 +95,7 @@ void LibWebRTCProvider::setVP9HardwareSupportForTesting(std::optional<bool> valu
 #endif
 
 class RTCSocketFactory final : public LibWebRTCProvider::SuspendableSocketFactory {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RTCSocketFactory);
 public:
     RTCSocketFactory(WebPageProxyIdentifier, String&& userAgent, ScriptExecutionContextIdentifier, bool isFirstParty, RegistrableDomain&&);
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LibWebRTCResolver);
+
 void LibWebRTCResolver::sendOnMainThread(Function<void(IPC::Connection&)>&& callback)
 {
     callOnMainRunLoop([callback = WTFMove(callback)]() {

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
@@ -30,6 +30,7 @@
 #include "LibWebRTCDnsResolverFactory.h"
 #include "LibWebRTCResolverIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -41,7 +42,7 @@ namespace WebKit {
 class LibWebRTCSocketFactory;
 
 class LibWebRTCResolver final : public LibWebRTCDnsResolverFactory::Resolver, private webrtc::AsyncDnsResolverResult, public CanMakeWeakPtr<LibWebRTCResolver> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LibWebRTCResolver);
 public:
     LibWebRTCResolver() : m_identifier(LibWebRTCResolverIdentifier::generate()) { }
     ~LibWebRTCResolver();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -41,6 +41,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LibWebRTCSocket);
+
 LibWebRTCSocket::LibWebRTCSocket(LibWebRTCSocketFactory& factory, WebCore::ScriptExecutionContextIdentifier contextIdentifier, Type type, const rtc::SocketAddress& localAddress, const rtc::SocketAddress& remoteAddress)
     : m_factory(factory)
     , m_identifier(WebCore::LibWebRTCSocketIdentifier::generate())

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -30,6 +30,7 @@
 #include <WebCore/LibWebRTCProvider.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 ALLOW_COMMA_BEGIN
@@ -48,7 +49,7 @@ namespace WebKit {
 class LibWebRTCSocketFactory;
 
 class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeWeakPtr<LibWebRTCSocket> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LibWebRTCSocket);
 public:
     enum class Type { UDP, ClientTCP, ServerConnectionTCP };
 

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebRTCResolver);
+
 WebRTCResolver::WebRTCResolver(LibWebRTCSocketFactory& socketFactory, LibWebRTCResolverIdentifier identifier)
     : m_socketFactory(socketFactory)
     , m_identifier(identifier)

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
@@ -30,6 +30,7 @@
 #include "LibWebRTCResolverIdentifier.h"
 #include "RTCNetwork.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -41,7 +42,7 @@ namespace WebKit {
 class LibWebRTCSocketFactory;
 
 class WebRTCResolver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebRTCResolver);
 public:
     WebRTCResolver(LibWebRTCSocketFactory&, LibWebRTCResolverIdentifier);
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -54,6 +54,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebNotificationManager);
+
 #if ENABLE(NOTIFICATIONS)
 static bool sendMessage(WebPage* page, const Function<bool(IPC::Connection&, uint64_t)>& sendMessage)
 {

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -34,6 +34,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>
@@ -50,7 +51,7 @@ class WebPage;
 class WebProcess;
 
 class WebNotificationManager : public WebProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebNotificationManager);
     WTF_MAKE_NONCOPYABLE(WebNotificationManager);
 public:
     explicit WebNotificationManager(WebProcess&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -28,6 +28,7 @@
 #if ENABLE(PDF_PLUGIN) && HAVE(INCREMENTAL_PDF_APIS)
 
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Threading.h>
@@ -48,7 +49,7 @@ using ByteRangeRequestIdentifier = uint64_t;
 using DataRequestCompletionHandler = Function<void(const uint8_t*, size_t count)>;
 
 class PDFIncrementalLoader : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFIncrementalLoader> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(PDFIncrementalLoader);
     WTF_MAKE_NONCOPYABLE(PDFIncrementalLoader);
     friend class ByteRangeRequest;
     friend class PDFPluginStreamLoaderClient;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -44,13 +44,15 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PDFIncrementalLoader);
+
 // <rdar://problem/61473378> - PDFKit asks for a "way too large" range when the PDF it is loading
 // incrementally turns out to be non-linearized.
 // We'll assume any size over 4GB is PDFKit noticing non-linearized data.
 static const uint32_t nonLinearizedPDFSentinel = std::numeric_limits<uint32_t>::max();
 
 class ByteRangeRequest : public Identified<ByteRangeRequest> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ByteRangeRequest);
 public:
     ByteRangeRequest() = default;
     ByteRangeRequest(uint64_t position, size_t count, DataRequestCompletionHandler&& completionHandler)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -39,6 +39,7 @@
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ScrollableArea.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeTraits.h>
 #include <wtf/WeakPtr.h>
@@ -74,7 +75,7 @@ struct LookupTextResult;
 struct WebHitTestResultData;
 
 class PDFPluginBase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFPluginBase>, public WebCore::ScrollableArea, public PDFScriptEvaluator::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(PDFPluginBase);
     WTF_MAKE_NONCOPYABLE(PDFPluginBase);
     friend class PDFIncrementalLoader;
 public:

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -67,6 +67,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PDFPluginBase);
+
 PluginInfo PDFPluginBase::pluginInfo()
 {
     PluginInfo info;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h
@@ -29,6 +29,7 @@
 
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 typedef const struct OpaqueJSContext* JSContextRef;
@@ -39,7 +40,7 @@ typedef struct OpaqueJSClass* JSClassRef;
 namespace WebKit {
 
 class PDFScriptEvaluator : public RefCounted<PDFScriptEvaluator> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(PDFScriptEvaluator);
     WTF_MAKE_NONCOPYABLE(PDFScriptEvaluator);
 public:
     class Client : public CanMakeWeakPtr<Client> {

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PDFScriptEvaluator);
+
 static void appendValuesInPDFNameSubtreeToVector(RetainPtr<CGPDFDictionaryRef> subtree, Vector<CGPDFObjectRef>& values)
 {
     CGPDFArrayRef names = nullptr;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -53,6 +53,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SpeechRecognitionRealtimeMediaSourceManager);
+
 class SpeechRecognitionRealtimeMediaSourceManager::Source
     : private RealtimeMediaSource::Observer
     , private RealtimeMediaSource::AudioSampleObserver

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -32,6 +32,7 @@
 #include "SandboxExtension.h"
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class CaptureDevice;
@@ -40,7 +41,7 @@ class CaptureDevice;
 namespace WebKit {
 
 class SpeechRecognitionRealtimeMediaSourceManager final : public IPC::MessageReceiver, private IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SpeechRecognitionRealtimeMediaSourceManager);
 public:
     explicit SpeechRecognitionRealtimeMediaSourceManager(Ref<IPC::Connection>&&);
     ~SpeechRecognitionRealtimeMediaSourceManager();

--- a/Source/WebKit/WebProcess/Storage/WebSWOriginTable.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWOriginTable.cpp
@@ -32,6 +32,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSWOriginTable);
+
 bool WebSWOriginTable::contains(const SecurityOriginData& origin) const
 {
     return m_serviceWorkerOriginTable.contains(computeSharedStringHash(origin.toString()));

--- a/Source/WebKit/WebProcess/Storage/WebSWOriginTable.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWOriginTable.h
@@ -27,6 +27,7 @@
 
 #include "SharedStringHashTableReadOnly.h"
 #include <WebCore/SharedMemory.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class SecurityOriginData;
@@ -35,7 +36,7 @@ class SecurityOriginData;
 namespace WebKit {
 
 class WebSWOriginTable {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSWOriginTable);
 public:
     WebSWOriginTable() = default;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include <WebCore/AlternativeTextClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebAlternativeTextClient final : public WebCore::AlternativeTextClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebAlternativeTextClient);
 public:
     explicit WebAlternativeTextClient(WebPage*);
     virtual ~WebAlternativeTextClient();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebAttachmentElementClient);
+
 WebAttachmentElementClient::WebAttachmentElementClient(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h
@@ -28,13 +28,14 @@
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 #include <WebCore/AttachmentElementClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebAttachmentElementClient final : public WebCore::AttachmentElementClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebAttachmentElementClient);
 public:
     explicit WebAttachmentElementClient(WebPage&);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebCaptionPreferencesDelegate);
+
 void WebCaptionPreferencesDelegate::setDisplayMode(WebCore::CaptionUserPreferences::CaptionDisplayMode displayMode)
 {
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::SetCaptionDisplayMode(displayMode), 0);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.h
@@ -28,11 +28,12 @@
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 
 #include <WebCore/CaptionPreferencesDelegate.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebCaptionPreferencesDelegate final : public WebCore::CaptionPreferencesDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebCaptionPreferencesDelegate);
 public:
     virtual ~WebCaptionPreferencesDelegate() { }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -161,6 +161,8 @@ namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebChromeClient);
+
 AXRelayProcessSuspendedNotification::AXRelayProcessSuspendedNotification(Ref<WebPage> page, AutomaticallySend automaticallySend)
     : m_page(page.get())
     , m_automaticallySend(automaticallySend)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/ChromeClient.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -45,7 +46,7 @@ class WebFrame;
 class WebPage;
 
 class WebChromeClient final : public WebCore::ChromeClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebChromeClient);
 public:
     WebChromeClient(WebPage&);
     ~WebChromeClient();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
@@ -39,6 +39,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebContextMenuClient);
+
 void WebContextMenuClient::downloadURL(const URL&)
 {
     // This is handled in the UI process.

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -30,11 +30,12 @@
 
 #include "WebPage.h"
 #include <WebCore/ContextMenuClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebContextMenuClient : public WebCore::ContextMenuClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebContextMenuClient);
 public:
     WebContextMenuClient(WebPage* page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
@@ -33,6 +33,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebDragClient);
+
 void WebDragClient::willPerformDragDestinationAction(DragDestinationAction action, const DragData&)
 {
     if (action == DragDestinationAction::Load)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
@@ -29,13 +29,14 @@
 #if ENABLE(DRAG_SUPPORT)
 
 #include <WebCore/DragClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebDragClient : public WebCore::DragClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebDragClient);
 public:
     WebDragClient(WebPage* page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -72,6 +72,8 @@ namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebEditorClient);
+
 bool WebEditorClient::shouldDeleteRange(const std::optional<SimpleRange>& range)
 {
     return m_page->injectedBundleEditorClient().shouldDeleteRange(*m_page, range);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -28,6 +28,7 @@
 #include "WebPage.h"
 #include <WebCore/EditorClient.h>
 #include <WebCore/TextCheckerClient.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ namespace WebKit {
 class WebPage;
 
 class WebEditorClient final : public WebCore::EditorClient, public WebCore::TextCheckerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebEditorClient);
 public:
     WebEditorClient(WebPage* page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebGeolocationClient);
+
 WebGeolocationClient::~WebGeolocationClient()
 {
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
@@ -27,12 +27,13 @@
 
 #include "WebPage.h"
 #include <WebCore/GeolocationClient.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
 
 class WebGeolocationClient final : public WebCore::GeolocationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebGeolocationClient);
 public:
     WebGeolocationClient(WebPage& page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
@@ -36,6 +36,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebMediaKeySystemClient);
+
 WebMediaKeySystemClient::WebMediaKeySystemClient(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
@@ -28,13 +28,14 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include <WebCore/MediaKeySystemClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebMediaKeySystemClient : public WebCore::MediaKeySystemClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebMediaKeySystemClient);
 public:
     WebMediaKeySystemClient(WebPage&);
     ~WebMediaKeySystemClient() { }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -36,6 +36,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebMessagePortChannelProvider);
+
 WebMessagePortChannelProvider& WebMessagePortChannelProvider::singleton()
 {
     static WebMessagePortChannelProvider* provider = new WebMessagePortChannelProvider;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -28,11 +28,12 @@
 #include <WebCore/MessagePortChannelProvider.h>
 #include <WebCore/MessagePortIdentifier.h>
 #include <WebCore/MessageWithMessagePorts.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebMessagePortChannelProvider final : public WebCore::MessagePortChannelProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebMessagePortChannelProvider);
 public:
     static WebMessagePortChannelProvider& singleton();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
@@ -39,6 +39,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebNotificationClient);
+
 WebNotificationClient::WebNotificationClient(WebPage* page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
@@ -30,13 +30,14 @@
 #include <WebCore/NotificationClient.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebNotificationClient final : public WebCore::NotificationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebNotificationClient);
 public:
     WebNotificationClient(WebPage*);
     virtual ~WebNotificationClient();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebProgressTrackerClient);
+
 WebProgressTrackerClient::WebProgressTrackerClient(WebPage& webPage)
     : m_webPage(webPage)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h
@@ -27,6 +27,7 @@
 #define WebProgressTrackerClient_h
 
 #include <WebCore/ProgressTrackerClient.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class WebPage;
 
 class WebProgressTrackerClient : public WebCore::ProgressTrackerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebProgressTrackerClient);
 public:
     explicit WebProgressTrackerClient(WebPage&);
     

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebScreenOrientationManager);
+
 WebScreenOrientationManager::WebScreenOrientationManager(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include <WebCore/ScreenOrientationManager.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class WebPage;
 
 class WebScreenOrientationManager final : public WebCore::ScreenOrientationManager, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebScreenOrientationManager);
 public:
     explicit WebScreenOrientationManager(WebPage&);
     ~WebScreenOrientationManager();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSpeechSynthesisClient);
+
 const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& WebSpeechSynthesisClient::voiceList()
 {
     // FIXME: this message should not be sent synchronously. Instead, the UI process should

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
@@ -30,13 +30,14 @@
 #include <WebCore/PlatformSpeechSynthesisUtterance.h>
 #include <WebCore/PlatformSpeechSynthesisVoice.h>
 #include <WebCore/SpeechSynthesisClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
     
 class WebSpeechSynthesisClient : public WebCore::SpeechSynthesisClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSpeechSynthesisClient);
 public:
     WebSpeechSynthesisClient(WebPage& page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
@@ -30,6 +30,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebUserMediaClient);
+
 WebUserMediaClient::WebUserMediaClient(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
@@ -23,13 +23,14 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include <WebCore/UserMediaClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPage;
 
 class WebUserMediaClient : public WebCore::UserMediaClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebUserMediaClient);
 public:
     WebUserMediaClient(WebPage&);
     ~WebUserMediaClient() { }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -46,6 +46,7 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebWorkerClient);
 
 UniqueRef<WebWorkerClient> WebWorkerClient::create(WebPage& page, SerialFunctionDispatcher& dispatcher)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -30,6 +30,7 @@
 #include "RemoteVideoFrameObjectHeapProxy.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/WorkerClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore::WebGPU {
 class GPU;
@@ -41,7 +42,7 @@ class WebPage;
 class RemoteRenderingBackendProxy;
 
 class WebWorkerClient : public WebCore::WorkerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebWorkerClient);
 public:
     // Constructed on the main thread, and then transferred to the
     // worker thread. All further operations on this object will

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp
@@ -34,6 +34,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebAlternativeTextClient);
+
 WebAlternativeTextClient::WebAlternativeTextClient(WebPage* webPage)
 : m_page(webPage)
 {

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
@@ -31,6 +31,7 @@
 #include "EditingRange.h"
 #include "MessageReceiver.h"
 #include <WebCore/SimpleRange.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace IPC {
@@ -48,7 +49,7 @@ namespace WebKit {
 class WebPage;
 
 class TextCheckingControllerProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(TextCheckingControllerProxy);
 public:
     TextCheckingControllerProxy(WebPage&);
     ~TextCheckingControllerProxy();

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -55,6 +55,8 @@ typedef NS_ENUM(NSInteger, NSSpellingState) {
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(TextCheckingControllerProxy);
+
 TextCheckingControllerProxy::TextCheckingControllerProxy(WebPage& page)
     : m_page(page)
 {

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -626,7 +626,7 @@ static String& replaceSelectionPasteboardName()
 
 class OverridePasteboardForSelectionReplacement {
     WTF_MAKE_NONCOPYABLE(OverridePasteboardForSelectionReplacement);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(OverridePasteboardForSelectionReplacement);
 public:
     OverridePasteboardForSelectionReplacement(const Vector<String>& types, std::span<const uint8_t> data)
         : m_types(types)

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -52,6 +52,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DrawingArea);
+
 std::unique_ptr<DrawingArea> DrawingArea::create(WebPage& webPage, const WebPageCreationParameters& parameters)
 {
     switch (parameters.drawingAreaType) {

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -39,6 +39,7 @@
 #include <WebCore/PlatformScreen.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 
 namespace WTF {
@@ -71,7 +72,7 @@ struct WebPageCreationParameters;
 struct WebPreferencesStore;
 
 class DrawingArea : public IPC::MessageReceiver, public WebCore::DisplayRefreshMonitorFactory {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(DrawingArea);
     WTF_MAKE_NONCOPYABLE(DrawingArea);
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -63,6 +63,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FindController);
+
 FindController::FindController(WebPage* webPage)
     : m_webPage(webPage)
 {

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -35,6 +35,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -54,7 +55,7 @@ class PluginView;
 class WebPage;
 
 class FindController final : private WebCore::PageOverlay::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(FindController);
     WTF_MAKE_NONCOPYABLE(FindController);
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MomentumEventDispatcher);
+
 static constexpr Seconds deltaHistoryMaximumAge = 500_ms;
 static constexpr Seconds deltaHistoryMaximumInterval = 150_ms;
 static constexpr WebCore::FramesPerSecond idealCurveFrameRate = 60;

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -38,6 +38,7 @@
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct DisplayUpdate;
@@ -49,7 +50,7 @@ namespace WebKit {
 
 class MomentumEventDispatcher {
     WTF_MAKE_NONCOPYABLE(MomentumEventDispatcher);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(MomentumEventDispatcher);
 public:
     class Client {
     friend class MomentumEventDispatcher;

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp
@@ -41,6 +41,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UnifiedTextReplacementController);
+
 static void replaceTextInRange(LocalFrame& frame, const SimpleRange& range, const String& replacementText)
 {
     RefPtr document = frame.document();

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -34,6 +34,7 @@
 #include <WebCore/Range.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/WeakPtr.h>
 
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebPage;
 
 class UnifiedTextReplacementController final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(UnifiedTextReplacementController);
     WTF_MAKE_NONCOPYABLE(UnifiedTextReplacementController);
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
@@ -53,6 +53,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ViewGestureGeometryCollector);
+
 #if PLATFORM(IOS_FAMILY)
 static const double minimumScaleDifferenceForZooming = 0.3;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
@@ -28,6 +28,7 @@
 
 #include "MessageReceiver.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class FloatPoint;
@@ -40,7 +41,7 @@ namespace WebKit {
 class WebPage;
 
 class ViewGestureGeometryCollector : private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ViewGestureGeometryCollector);
 public:
     ViewGestureGeometryCollector(WebPage&);
     ~ViewGestureGeometryCollector();

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -51,6 +51,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebFoundTextRangeController);
+
 WebFoundTextRangeController::WebFoundTextRangeController(WebPage& webPage)
     : m_webPage(webPage)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
@@ -36,6 +36,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ namespace WebKit {
 class WebPage;
 
 class WebFoundTextRangeController : private WebCore::PageOverlay::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebFoundTextRangeController);
     WTF_MAKE_NONCOPYABLE(WebFoundTextRangeController);
 
 public:

--- a/Source/WebKit/WebProcess/WebSleepDisablerClient.cpp
+++ b/Source/WebKit/WebProcess/WebSleepDisablerClient.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSleepDisablerClient);
+
 void WebSleepDisablerClient::didCreateSleepDisabler(WebCore::SleepDisablerIdentifier identifier, const String& reason, bool display, std::optional<WebCore::PageIdentifier> pageID)
 {
     if (auto* webPage = pageID ? WebProcess::singleton().webPage(*pageID) : nullptr)

--- a/Source/WebKit/WebProcess/WebSleepDisablerClient.h
+++ b/Source/WebKit/WebProcess/WebSleepDisablerClient.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include <WebCore/SleepDisablerClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebSleepDisablerClient final : public WebCore::SleepDisablerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSleepDisablerClient);
 public:
     void didCreateSleepDisabler(WebCore::SleepDisablerIdentifier, const String&, bool display, std::optional<WebCore::PageIdentifier>) final;
     void didDestroySleepDisabler(WebCore::SleepDisablerIdentifier, std::optional<WebCore::PageIdentifier>) final;

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
@@ -50,6 +50,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(StorageAreaMap);
+
 StorageAreaMap::StorageAreaMap(StorageNamespaceImpl& storageNamespace, Ref<const WebCore::SecurityOrigin>&& securityOrigin)
     : m_identifier(StorageAreaMapIdentifier::generate())
     , m_namespace(storageNamespace)

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -35,6 +35,7 @@
 #include <wtf/HashCountedSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -49,7 +50,7 @@ class StorageAreaImpl;
 class StorageNamespaceImpl;
 
 class StorageAreaMap final : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(StorageAreaMap);
 public:
     StorageAreaMap(StorageNamespaceImpl&, Ref<const WebCore::SecurityOrigin>&&);
     ~StorageAreaMap();

--- a/Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp
+++ b/Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSystemSoundDelegate);
+
 void WebSystemSoundDelegate::systemBeep()
 {
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::SystemBeep(), 0);

--- a/Source/WebKit/WebProcess/WebSystemSoundDelegate.h
+++ b/Source/WebKit/WebProcess/WebSystemSoundDelegate.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include <WebCore/SystemSoundDelegate.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebSystemSoundDelegate final : public WebCore::SystemSoundDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSystemSoundDelegate);
 public:
     void systemBeep() final;
 };

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AudioSessionRoutingArbitrator);
+
 using namespace WebCore;
 
 AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator(WebProcess& process)

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -29,6 +29,7 @@
 
 #include "WebProcessSupplement.h"
 #include <WebCore/AudioSession.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -38,7 +39,7 @@ class WebProcess;
 class AudioSessionRoutingArbitrator final
     : public WebProcessSupplement
     , public WebCore::AudioSessionRoutingArbitrationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AudioSessionRoutingArbitrator);
 public:
     explicit AudioSessionRoutingArbitrator(WebProcess&);
     virtual ~AudioSessionRoutingArbitrator();

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -40,6 +40,9 @@
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 
 namespace WebKit {
+
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteCaptureSampleManager);
+
 using namespace WebCore;
 
 RemoteCaptureSampleManager::RemoteCaptureSampleManager()

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -41,6 +41,7 @@
 #include <WebCore/WebAudioBufferList.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebCore {
@@ -52,7 +53,7 @@ namespace WebKit {
 class RemoteVideoFrameObjectHeapProxy;
 
 class RemoteCaptureSampleManager : public IPC::WorkQueueMessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteCaptureSampleManager);
 public:
     RemoteCaptureSampleManager();
     ~RemoteCaptureSampleManager();

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -46,6 +46,8 @@ namespace WebKit {
 using namespace PAL;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UserMediaCaptureManager);
+
 UserMediaCaptureManager::UserMediaCaptureManager(WebProcess& process)
     : m_audioFactory(*this)
     , m_videoFactory(*this)

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -35,6 +35,7 @@
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
 #include <WebCore/SharedMemory.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class CAAudioStreamDescription;
@@ -47,7 +48,7 @@ class RemoteRealtimeVideoSource;
 class WebProcess;
 
 class UserMediaCaptureManager : public WebProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(UserMediaCaptureManager);
 public:
     explicit UserMediaCaptureManager(WebProcess&);
     ~UserMediaCaptureManager();

--- a/Source/WebKit/config.h
+++ b/Source/WebKit/config.h
@@ -40,7 +40,7 @@
 #undef new
 #undef delete
 #include <wtf/FastMalloc.h>
-
+#include <wtf/TZoneMallocInlines.h>
 #endif
 
 // ENABLE_WEBDRIVER_ACTIONS_API represents whether mouse, keyboard, touch or wheel interactions are defined


### PR DESCRIPTION
#### 979a5496028befb717410b0862be018a53ae7536
<pre>
Start adopting TZone within WebKit/WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=269476">https://bugs.webkit.org/show_bug.cgi?id=269476</a>
<a href="https://rdar.apple.com/123079742">rdar://123079742</a>

Reviewed by NOBODY (OOPS!).

Adopts the TZone allocator throughout the WebKit/WebProcess directory.

* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp:
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h:
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm:
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp:
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.cpp:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetFrontendChannel.h:
* Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp:
* Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Storage/WebSWOriginTable.cpp:
* Source/WebKit/WebProcess/Storage/WebSWOriginTable.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebAttachmentElementClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
* Source/WebKit/WebProcess/WebPage/FindController.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp:
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h:
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebSleepDisablerClient.cpp:
* Source/WebKit/WebProcess/WebSleepDisablerClient.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp:
* Source/WebKit/WebProcess/WebSystemSoundDelegate.h:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/config.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/979a5496028befb717410b0862be018a53ae7536

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42560 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42919 "Failed to checkout and rebase branch from PR 24605") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36271 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16523 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33407 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34702 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13974 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14015 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39735 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38013 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->