### PR TITLE
Sync `start-transform-transition.html` test from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2083,8 +2083,6 @@ webkit.org/b/223472 [ Release arm64 ] imported/w3c/web-platform-tests/resource-t
 
 webkit.org/b/227753 [ Debug ] fast/dom/Window/post-message-large-array-buffer-should-not-crash.html [ Pass Failure ]
 
-webkit.org/b/207125 transitions/start-transform-transition.html [ Pass Failure ]
-
 webkit.org/b/221017 media/modern-media-controls/media-controller/media-controller-click-on-video-background-should-pause-fullscreen.html [ Timeout Pass ]
 
 webkit.org/b/226600 imported/w3c/web-platform-tests/navigation-timing/test_navigate_within_document.html [ Pass Failure ]

--- a/LayoutTests/transitions/start-transform-transition-expected.txt
+++ b/LayoutTests/transitions/start-transform-transition-expected.txt
@@ -1,3 +1,3 @@
-Box should start transition from style change on timer
 
-PASS
+PASS Box should start transition from style change on timer
+

--- a/LayoutTests/transitions/start-transform-transition.html
+++ b/LayoutTests/transitions/start-transform-transition.html
@@ -1,55 +1,39 @@
+<!DOCTYPE html>
 <html>
 <head>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
   <style>
     .box {
       position: relative;
       width: 100px;
       height: 100px;
       background-color: blue;
-      -webkit-transition-property: -webkit-transform;
-      -webkit-transition-duration: 5s;
-      -webkit-transform: translate(0, 0);
+      transform: translate(0, 0);
+      transition-delay: -1s;
+      transition-duration: 3s;
+      transition-property: transform;
+      transition-timing-function: linear;
     }
 
     .moved {
-      -webkit-transform: translateX(300px);
+      transform: translateX(300px);
     }
   </style>
-  <script>
-    if (window.testRunner) {
-      testRunner.dumpAsText();
-      testRunner.waitUntilDone();
-    }
-
-    function test()
-    {
-      var t = window.getComputedStyle(document.getElementById('box')).webkitTransform;
-      // grab the x value from the matrix()
-      var lastValueRE = /([\.\d]+),[^,]+\)$/;
-      var xTranslate = lastValueRE.exec(t)[1];
-      var result = (xTranslate > 0) ? 'PASS' : 'FAIL: transition should be running, so x > 0';
-      document.getElementById('result').innerHTML = result;
-
-      if (window.testRunner)
-          testRunner.notifyDone();
-    }
-
-    function startTest()
-    {
-      window.setTimeout(function() {
-        document.getElementById('box').className = 'moved box';
-        window.setTimeout(test, 200);
-      }, 200);
-    }
-  </script>
 </head>
-<body onload="startTest()">
-  <p>Box should start transition from style change on timer</p>
+<body>
   <div id="container">
-    <div id="box" class="box" onclick="this.className='redirected box'">
-    </div>
+    <div id="box" class="box"></div>
   </div>
-  <div id="result">
-  </div>
+  <script>
+    'use strict';
+    async_test(t => {
+      box.offsetTop; // Force style recalc
+      setTimeout(t.step_func_done(() => {
+        box.className = 'moved box';
+        assert_equals(getComputedStyle(box).transform, 'matrix(1, 0, 0, 1, 100, 0)');
+      }), 0);
+    }, 'Box should start transition from style change on timer');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
#### d015cf1551cc58dcf879b91775bf3a12c732b4ac
<pre>
Sync `start-transform-transition.html` test from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=207125">https://bugs.webkit.org/show_bug.cgi?id=207125</a>
<a href="https://rdar.apple.com/problem/59112567">rdar://problem/59112567</a>

Reviewed by Antoine Quint.

This patch is to sync `start-transform-transition.html` from Blink / Chromium upstream as per below commit:

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/246d89262dc44712d67ebdcf1be88b4e29a643a4">https://source.chromium.org/chromium/chromium/src/+/246d89262dc44712d67ebdcf1be88b4e29a643a4</a>

* LayoutTests/transitions/start-transform-transition.html: Updated Test Case
* LayoutTests/transitions/start-transform-transition-expected.txt: Updated Test Case Expectation
* LayoutTests/platform/mac/TestExpectations: Remove [ Pass Failure ] Expectation

Canonical link: <a href="https://commits.webkit.org/274884@main">https://commits.webkit.org/274884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8976c80065ab10d63ac99df37e4ce39156eb57cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42711 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16507 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12289 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9044 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->