### PR TITLE
[UI] test tzone on

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -326,7 +326,7 @@
 #if CPU(ARM64) && OS(DARWIN)
 // Only MacroAssemblerARM64 is known to build.
 // Building with TZONE_MALLOC currently disabled for all platforms.
-#define USE_TZONE_MALLOC 0
+#define USE_TZONE_MALLOC 1
 #else
 #define USE_TZONE_MALLOC 0
 #endif

--- a/Source/WTF/wtf/TZoneMallocInitialization.h
+++ b/Source/WTF/wtf/TZoneMallocInitialization.h
@@ -39,11 +39,11 @@
 
 #include <bmalloc/TZoneHeapManager.h>
 
-#if USE(DARWIN_TZONE_SEED)
-#include <WebKitAdditions/TZoneAdditions.h>
-#else
+//#if USE(DARWIN_TZONE_SEED)
+//#include <WebKitAdditions/TZoneAdditions.h>
+//#else
 #define GET_TZONE_SEED_FROM_ENV(x) nullptr
-#endif
+//#endif
 
 #if !BUSE(TZONE)
 #error "TZones enabled in WTF, but not enabled in bmalloc"

--- a/Source/WebKit/UIProcess/API/APIAutomationClient.h
+++ b/Source/WebKit/UIProcess/API/APIAutomationClient.h
@@ -27,6 +27,7 @@
 #define APIAutomationClient_h
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebProcessPool;
@@ -35,7 +36,7 @@ class WebProcessPool;
 namespace API {
 
 class AutomationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(AutomationClient);
 public:
     virtual ~AutomationClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIAutomationSessionClient.h
+++ b/Source/WebKit/UIProcess/API/APIAutomationSessionClient.h
@@ -27,6 +27,7 @@
 #define APIAutomationSessionClient_h
 
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -41,7 +42,7 @@ enum AutomationSessionBrowsingContextOptions : uint16_t {
 };
 
 class AutomationSessionClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(AutomationSessionClient);
 public:
     enum class JavaScriptDialogType {
         Alert,

--- a/Source/WebKit/UIProcess/API/APIContextMenuClient.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuClient.h
@@ -34,6 +34,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 OBJC_CLASS NSMenu;
 
@@ -49,7 +50,7 @@ class WebPageProxy;
 namespace API {
 
 class ContextMenuClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ContextMenuClient);
 public:
     virtual ~ContextMenuClient() { }
 

--- a/Source/WebKit/UIProcess/API/APICustomProtocolManagerClient.h
+++ b/Source/WebKit/UIProcess/API/APICustomProtocolManagerClient.h
@@ -27,6 +27,7 @@
 
 #include "LegacyCustomProtocolID.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class LegacyCustomProtocolManagerProxy;
@@ -39,7 +40,7 @@ class ResourceRequest;
 namespace API {
 
 class CustomProtocolManagerClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(CustomProtocolManagerClient);
 public:
     virtual ~CustomProtocolManagerClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIDataTaskClient.h
+++ b/Source/WebKit/UIProcess/API/APIDataTaskClient.h
@@ -28,6 +28,7 @@
 #include "AuthenticationChallengeDisposition.h"
 #include "AuthenticationChallengeProxy.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class Credential;
@@ -41,7 +42,7 @@ namespace API {
 class Data;
 
 class DataTaskClient : public RefCounted<DataTaskClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(DataTaskClient);
 public:
     static Ref<DataTaskClient> create() { return adoptRef(*new DataTaskClient); }
     virtual ~DataTaskClient() { }

--- a/Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h
+++ b/Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 enum DiagnosticLoggingResultType : uint8_t;

--- a/Source/WebKit/UIProcess/API/APIDownloadClient.h
+++ b/Source/WebKit/UIProcess/API/APIDownloadClient.h
@@ -30,6 +30,7 @@
 #include "AuthenticationDecisionListener.h"
 #include "DownloadID.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -52,7 +53,7 @@ namespace API {
 class Data;
 
 class DownloadClient : public RefCounted<DownloadClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(DownloadClient);
 public:
     virtual ~DownloadClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIFindClient.h
+++ b/Source/WebKit/UIProcess/API/APIFindClient.h
@@ -27,6 +27,7 @@
 #define APIFindClient_h
 
 #include <WebCore/PlatformLayer.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 OBJC_CLASS CALayer;
@@ -42,7 +43,7 @@ class WebPageProxy;
 namespace API {
 
 class FindClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(FindClient);
 public:
     virtual ~FindClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIFindMatchesClient.h
+++ b/Source/WebKit/UIProcess/API/APIFindMatchesClient.h
@@ -27,6 +27,7 @@
 #define APIFindMatchesClient_h
 
 #include <WebCore/IntRect.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -38,7 +39,7 @@ class WebPageProxy;
 namespace API {
 
 class FindMatchesClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(FindMatchesClient);
 public:
     virtual ~FindMatchesClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIFormClient.h
+++ b/Source/WebKit/UIProcess/API/APIFormClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebFrameProxy;
@@ -36,7 +37,7 @@ namespace API {
 class Object;
 
 class FormClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(FormClient);
 public:
     virtual ~FormClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIFullscreenClient.h
+++ b/Source/WebKit/UIProcess/API/APIFullscreenClient.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebKit {
 class WebPageProxy;
 }
@@ -32,7 +34,7 @@ class WebPageProxy;
 namespace API {
 
 class FullscreenClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(FullscreenClient);
 public:
     enum Type {
         APIType,

--- a/Source/WebKit/UIProcess/API/APIGeolocationProvider.h
+++ b/Source/WebKit/UIProcess/API/APIGeolocationProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebGeolocationManagerProxy;
@@ -34,7 +35,7 @@ class WebGeolocationManagerProxy;
 namespace API {
 
 class GeolocationProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(GeolocationProvider);
 public:
     virtual ~GeolocationProvider() { }
 

--- a/Source/WebKit/UIProcess/API/APIHistoryClient.h
+++ b/Source/WebKit/UIProcess/API/APIHistoryClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebPageProxy;
@@ -35,7 +36,7 @@ struct WebNavigationDataStore;
 namespace API {
 
 class HistoryClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(HistoryClient);
 public:
     virtual ~HistoryClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIIconDatabaseClient.h
+++ b/Source/WebKit/UIProcess/API/APIIconDatabaseClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebIconDatabase;
@@ -34,7 +35,7 @@ class WebIconDatabase;
 namespace API {
 
 class IconDatabaseClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(IconDatabaseClient);
 public:
     virtual ~IconDatabaseClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIIconLoadingClient.h
+++ b/Source/WebKit/UIProcess/API/APIIconLoadingClient.h
@@ -28,13 +28,14 @@
 #include <WebCore/LinkIcon.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace API {
 
 class Data;
 
 class IconLoadingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(IconLoadingClient);
 public:
     virtual ~IconLoadingClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/API/APIInjectedBundleClient.h
@@ -29,6 +29,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebProcessPool;
@@ -37,7 +38,7 @@ class WebProcessPool;
 namespace API {
 
 class InjectedBundleClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(InjectedBundleClient);
 public:
     virtual ~InjectedBundleClient() = default;
 

--- a/Source/WebKit/UIProcess/API/APIInspectorClient.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebInspectorUIProxy;
@@ -34,7 +35,7 @@ class WebInspectorUIProxy;
 namespace API {
 
 class InspectorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(InspectorClient);
 public:
     virtual ~InspectorClient() = default;
 

--- a/Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h
+++ b/Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h
@@ -28,11 +28,12 @@
 #include "InspectorExtensionTypes.h"
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace API {
 
 class InspectorExtensionClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(InspectorExtensionClient);
 public:
     virtual ~InspectorExtensionClient() = default;
 

--- a/Source/WebKit/UIProcess/API/APILegacyContextHistoryClient.h
+++ b/Source/WebKit/UIProcess/API/APILegacyContextHistoryClient.h
@@ -27,6 +27,7 @@
 #define APILegacyContextHistoryClient_h
 
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 class WebFrameProxy;
@@ -38,7 +39,7 @@ struct WebNavigationDataStore;
 namespace API {
 
 class LegacyContextHistoryClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(LegacyContextHistoryClient);
 public:
     virtual ~LegacyContextHistoryClient() { }
 

--- a/Source/WebKit/UIProcess/API/APILoaderClient.h
+++ b/Source/WebKit/UIProcess/API/APILoaderClient.h
@@ -29,6 +29,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayoutMilestone.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class ResourceError;
@@ -50,7 +51,7 @@ class Navigation;
 class Object;
 
 class LoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(LoaderClient);
 public:
     virtual ~LoaderClient() { }
     virtual void didStartProvisionalLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, API::Object*) { }

--- a/Source/WebKit/UIProcess/API/APINavigationClient.h
+++ b/Source/WebKit/UIProcess/API/APINavigationClient.h
@@ -37,6 +37,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayoutMilestone.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if HAVE(APP_SSO)
 #include "SOAuthorizationLoadPolicy.h"
@@ -73,7 +74,7 @@ class NavigationResponse;
 class Object;
 
 class NavigationClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NavigationClient);
 public:
     virtual ~NavigationClient() { }
 

--- a/Source/WebKit/UIProcess/API/APINotificationProvider.h
+++ b/Source/WebKit/UIProcess/API/APINotificationProvider.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebKit {
@@ -42,7 +43,7 @@ class NotificationResources;
 namespace API {
 
 class NotificationProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NotificationProvider);
 public:
     virtual ~NotificationProvider() = default;
 

--- a/Source/WebKit/UIProcess/API/APIPolicyClient.h
+++ b/Source/WebKit/UIProcess/API/APIPolicyClient.h
@@ -28,6 +28,7 @@
 #include "WebFramePolicyListenerProxy.h"
 #include <WebCore/FrameLoaderTypes.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 class ResourceError;
@@ -46,7 +47,7 @@ namespace API {
 class Object;
 
 class PolicyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(PolicyClient);
 public:
     virtual ~PolicyClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -36,6 +36,7 @@
 #include <WebCore/PermissionState.h>
 #include <WebCore/ScreenOrientationType.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/PlatformViewController.h>
@@ -93,7 +94,7 @@ class SecurityOrigin;
 class WebAuthenticationPanel;
 
 class UIClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(UIClient);
 public:
     virtual ~UIClient() { }
 

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h
@@ -31,6 +31,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/spi/cocoa/SecuritySPI.h>
 #include <wtf/text/WTFString.h>
 
@@ -43,7 +44,7 @@ class AuthenticatorAssertionResponse;
 namespace API {
 
 class WebAuthenticationPanelClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebAuthenticationPanelClient);
 public:
     virtual ~WebAuthenticationPanelClient() = default;
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2433,7 +2433,7 @@ void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClie
 }
 
 class StateClient final : public API::Client<WKPageStateClientBase>, public PageLoadState::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(StateClient);
 public:
     explicit StateClient(const WKPageStateClientBase* client)
     {

--- a/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
@@ -24,12 +24,13 @@
  */
 
 #import "PageLoadState.h"
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
 
 class PageLoadStateObserver : public PageLoadState::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(PageLoadStateObserver);
 public:
     PageLoadStateObserver(id object, NSString *activeURLKey = @"activeURL")
         : m_object(object)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -46,7 +46,7 @@ static NSArray<NSHTTPCookie *> *coreCookiesToNSCookies(const Vector<WebCore::Coo
 }
 
 class WKHTTPCookieStoreObserver : public API::HTTPCookieStore::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WKHTTPCookieStoreObserver);
 public:
     explicit WKHTTPCookieStoreObserver(id<WKHTTPCookieStoreObserver> observer)
         : m_observer(observer)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -125,7 +125,7 @@
 }
 
 class ScriptMessageHandlerDelegate final : public WebKit::WebScriptMessageHandler::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ScriptMessageHandlerDelegate);
 public:
     ScriptMessageHandlerDelegate(WKUserContentController *controller, id <WKScriptMessageHandler> handler, NSString *name)
         : m_controller(controller)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3785,7 +3785,7 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
     _inputDelegate = inputDelegate;
 
     class FormClient : public API::FormClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(FormClient);
     public:
         explicit FormClient(WKWebView *webView)
             : m_webView(webView)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -620,7 +620,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     class WKMediaSessionCoordinatorForTesting
         : public WebKit::MediaSessionCoordinatorProxyPrivate
         , public WebCore::MediaSessionCoordinatorClient {
-        WTF_MAKE_FAST_ALLOCATED;
+            WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WKMediaSessionCoordinatorForTesting);
     public:
 
         static Ref<WKMediaSessionCoordinatorForTesting> create(id <_WKMediaSessionCoordinator> privateCoordinator)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -129,7 +129,7 @@ static WebCore::ModalContainerObservationPolicy coreModalContainerObservationPol
 }
 
 class WebPagePreferencesLockdownModeObserver final : public LockdownModeObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebPagePreferencesLockdownModeObserver);
 public:
     WebPagePreferencesLockdownModeObserver(id object)
         : m_object(object)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
@@ -53,7 +53,7 @@
 namespace WebKit {
 
 class _WKRemoteWebInspectorUIProxyClient final : public RemoteWebInspectorUIProxyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(_WKRemoteWebInspectorUIProxyClient);
 public:
     _WKRemoteWebInspectorUIProxyClient(_WKRemoteWebInspectorViewController *controller)
         : m_controller(controller)

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.h
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <wtf/Forward.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
@@ -38,7 +39,7 @@ OBJC_CLASS UIWindow;
 namespace WebKit {
 
 class ApplicationStateTracker : public CanMakeWeakPtr<ApplicationStateTracker> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ApplicationStateTracker);
 public:
     ApplicationStateTracker(UIView *, SEL didEnterBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector);
     ~ApplicationStateTracker();

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -53,6 +53,8 @@ static NSNotificationName const viewServiceForegroundNotificationName = @"_UIVie
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ApplicationStateTracker);
+
 static WeakHashSet<ApplicationStateTracker>& allApplicationStateTrackers()
 {
     static NeverDestroyed<WeakHashSet<ApplicationStateTracker>> trackers;

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp
@@ -42,6 +42,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AuthenticationChallengeProxy);
+
 AuthenticationChallengeProxy::AuthenticationChallengeProxy(WebCore::AuthenticationChallenge&& authenticationChallenge, AuthenticationChallengeIdentifier challengeID, Ref<IPC::Connection>&& connection, WeakPtr<SecKeyProxyStore>&& secKeyProxyStore)
     : m_coreAuthenticationChallenge(WTFMove(authenticationChallenge))
     , m_listener(AuthenticationDecisionListener::create([challengeID, connection = WTFMove(connection), secKeyProxyStore = WTFMove(secKeyProxyStore)](AuthenticationChallengeDisposition disposition, const WebCore::Credential& credential) {

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
@@ -28,6 +28,7 @@
 #include "APIObject.h"
 #include "IdentifierTypes.h"
 #include <WebCore/AuthenticationChallenge.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -42,6 +43,7 @@ class WebCredential;
 class WebProtectionSpace;
 
 class AuthenticationChallengeProxy : public API::ObjectImpl<API::Object::Type::AuthenticationChallenge> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(AuthenticationChallengeProxy);
 public:
     static Ref<AuthenticationChallengeProxy> create(WebCore::AuthenticationChallenge&& authenticationChallenge, AuthenticationChallengeIdentifier challengeID, Ref<IPC::Connection>&& connection, WeakPtr<SecKeyProxyStore>&& secKeyProxyStore)
     {

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationDecisionListener.cpp
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationDecisionListener.cpp
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AuthenticationDecisionListener);
+
 AuthenticationDecisionListener::AuthenticationDecisionListener(CompletionHandler<void(AuthenticationChallengeDisposition, const WebCore::Credential&)>&& completionHandler)
     : m_completionHandler(WTFMove(completionHandler))
 {

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationDecisionListener.h
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationDecisionListener.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/Credential.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -36,6 +37,7 @@ enum class AuthenticationChallengeDisposition : uint8_t;
 class AuthenticationChallengeProxy;
 
 class AuthenticationDecisionListener : public API::ObjectImpl<API::Object::Type::AuthenticationDecisionListener> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(AuthenticationDecisionListener);
 public:
     static Ref<AuthenticationDecisionListener> create(CompletionHandler<void(AuthenticationChallengeDisposition, const WebCore::Credential&)>&& completionHandler)
     {

--- a/Source/WebKit/UIProcess/Authentication/WebCredential.cpp
+++ b/Source/WebKit/UIProcess/Authentication/WebCredential.cpp
@@ -28,6 +28,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebCredential);
+
 WebCredential::WebCredential(const WebCore::Credential& credential)
     : m_coreCredential(credential)
 {

--- a/Source/WebKit/UIProcess/Authentication/WebCredential.h
+++ b/Source/WebKit/UIProcess/Authentication/WebCredential.h
@@ -29,10 +29,12 @@
 #include "APIObject.h"
 #include "APIString.h"
 #include <WebCore/Credential.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebCredential : public API::ObjectImpl<API::Object::Type::Credential> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebCredential);
 public:
     ~WebCredential();
 

--- a/Source/WebKit/UIProcess/Authentication/WebProtectionSpace.cpp
+++ b/Source/WebKit/UIProcess/Authentication/WebProtectionSpace.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebProtectionSpace);
+
 WebProtectionSpace::WebProtectionSpace(const WebCore::ProtectionSpace& coreProtectionSpace)
     : m_coreProtectionSpace(coreProtectionSpace)
 {

--- a/Source/WebKit/UIProcess/Authentication/WebProtectionSpace.h
+++ b/Source/WebKit/UIProcess/Authentication/WebProtectionSpace.h
@@ -28,10 +28,12 @@
 
 #include "APIObject.h"
 #include <WebCore/ProtectionSpace.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebProtectionSpace : public API::ObjectImpl<API::Object::Type::ProtectionSpace> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebProtectionSpace);
 public:
     static Ref<WebProtectionSpace> create(const WebCore::ProtectionSpace& protectionSpace)
     {

--- a/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.h
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.h
@@ -29,6 +29,7 @@
 
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS SecKeyProxy;
@@ -40,6 +41,7 @@ class Credential;
 namespace WebKit {
 
 class SecKeyProxyStore : public RefCounted<SecKeyProxyStore>, public CanMakeWeakPtr<SecKeyProxyStore> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(SecKeyProxyStore);
 public:
     static Ref<SecKeyProxyStore> create() { return adoptRef(* new SecKeyProxyStore()); }
 

--- a/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.mm
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SecKeyProxyStore);
+
 bool SecKeyProxyStore::initialize(const WebCore::Credential& credential)
 {
     if (!credential.isEmpty() && credential.nsCredential().identity)

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -41,6 +41,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SimulatedInputDispatcher);
+
 SimulatedInputSourceState SimulatedInputSourceState::emptyStateForSourceType(SimulatedInputSourceType type)
 {
     SimulatedInputSourceState result { };

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
@@ -34,6 +34,8 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -130,6 +132,7 @@ public:
 
 class SimulatedInputDispatcher : public RefCounted<SimulatedInputDispatcher> {
     WTF_MAKE_NONCOPYABLE(SimulatedInputDispatcher);
+    WTF_MAKE_WK_TZONE_ALLOCATED(SimulatedInputDispatcher);
 public:
     class Client {
     public:

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -69,6 +69,8 @@ namespace WebKit {
 using namespace Inspector;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AutomationCommandError);
+
 String AutomationCommandError::toProtocolString()
 {
     String protocolErrorName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(type);

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -40,6 +40,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include <JavaScriptCore/RemoteAutomationTarget.h>
@@ -84,6 +85,7 @@ class WebPageProxy;
 class WebProcessPool;
 
 class AutomationCommandError {
+    WTF_MAKE_WK_TZONE_ALLOCATED(AutomationCommandError);
 public:
     Inspector::Protocol::Automation::ErrorMessage type;
     std::optional<String> message { std::nullopt };

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
@@ -29,6 +29,7 @@
 
 #import "APIAutomationClient.h"
 #import <JavaScriptCore/RemoteInspector.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKProcessPool;
@@ -38,7 +39,7 @@
 namespace WebKit {
 
 class AutomationClient final : public API::AutomationClient, Inspector::RemoteInspector::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AutomationClient);
 public:
     explicit AutomationClient(WKProcessPool *, id <_WKAutomationDelegate>);
     virtual ~AutomationClient();

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -40,6 +40,8 @@ using namespace Inspector;
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AutomationClient);
+
 AutomationClient::AutomationClient(WKProcessPool *processPool, id <_WKAutomationDelegate> delegate)
     : m_processPool(processPool)
     , m_delegate(delegate)

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h
@@ -29,6 +29,7 @@
 #import "WKFoundation.h"
 
 #import "APIAutomationSessionClient.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @protocol _WKAutomationSessionDelegate;
@@ -36,7 +37,7 @@
 namespace WebKit {
 
 class AutomationSessionClient final : public API::AutomationSessionClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AutomationSessionClient);
 public:
     explicit AutomationSessionClient(id <_WKAutomationSessionDelegate>);
 

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AutomationSessionClient);
+
 AutomationSessionClient::AutomationSessionClient(id <_WKAutomationSessionDelegate> delegate)
     : m_delegate(delegate)
 {

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h
@@ -27,6 +27,7 @@
 
 #import "APIDiagnosticLoggingClient.h"
 #import "WKFoundation.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKWebView;
@@ -35,7 +36,7 @@
 namespace WebKit {
 
 class DiagnosticLoggingClient final : public API::DiagnosticLoggingClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(DiagnosticLoggingClient);
 public:
     explicit DiagnosticLoggingClient(WKWebView *);
 

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DiagnosticLoggingClient);
+
 DiagnosticLoggingClient::DiagnosticLoggingClient(WKWebView *webView)
     : m_webView(webView)
 {

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
@@ -31,6 +31,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -43,7 +44,7 @@ class WebPageProxy;
 class WebProcessProxy;
 
 class ExtensionCapabilityGranter : public CanMakeWeakPtr<ExtensionCapabilityGranter> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ExtensionCapabilityGranter);
     WTF_MAKE_NONCOPYABLE(ExtensionCapabilityGranter);
 public:
     struct Client : public CanMakeCheckedPtr {

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
@@ -45,6 +45,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ExtensionCapabilityGranter);
+
 static WorkQueue& granterQueue()
 {
     static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("ExtensionCapabilityGranter Queue", WorkQueue::QOS::UserInitiated));

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.h
@@ -29,6 +29,7 @@
 #import "WKFoundation.h"
 
 #import "APIFindClient.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKWebView;
@@ -37,7 +38,7 @@
 namespace WebKit {
 
 class FindClient final : public API::FindClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(FindClient);
 public:
     explicit FindClient(WKWebView *);
     

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.mm
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FindClient);
+
 FindClient::FindClient(WKWebView *webView)
     : m_webView(webView)
 {

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
@@ -30,6 +30,7 @@
 #import "APIFullscreenClient.h"
 #import "WKWebView.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @protocol _WKFullscreenDelegate;
@@ -37,6 +38,7 @@
 namespace WebKit {
 
 class FullscreenClient : public API::FullscreenClient {
+    WTF_MAKE_WK_TZONE_ALLOCATED(FullscreenClient);
 public:
     explicit FullscreenClient(WKWebView *);
     ~FullscreenClient() { };

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FullscreenClient);
+
 FullscreenClient::FullscreenClient(WKWebView *webView)
     : m_webView(webView)
 {

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h
@@ -30,6 +30,7 @@
 #include "GroupActivitiesSession.h"
 #include "MediaSessionCoordinatorProxyPrivate.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS AVDelegatingPlaybackCoordinator;
 OBJC_CLASS AVDelegatingPlaybackCoordinatorPlayCommand;
@@ -42,7 +43,7 @@ OBJC_CLASS WKGroupActivitiesCoordinatorDelegate;
 namespace WebKit {
 
 class GroupActivitiesCoordinator final : public MediaSessionCoordinatorProxyPrivate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(GroupActivitiesCoordinator);
 public:
     static Ref<GroupActivitiesCoordinator> create(GroupActivitiesSession&);
     ~GroupActivitiesCoordinator();

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -104,6 +104,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(GroupActivitiesCoordinator);
+
 Ref<GroupActivitiesCoordinator> GroupActivitiesCoordinator::create(GroupActivitiesSession& session)
 {
     return adoptRef(*new GroupActivitiesCoordinator(session));

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h
@@ -31,6 +31,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakHashSet.h>
 
@@ -39,7 +40,7 @@ OBJC_CLASS WKGroupSession;
 namespace WebKit {
 
 class GroupActivitiesSession : public RefCounted<GroupActivitiesSession> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(GroupActivitiesSession);
 public:
     static Ref<GroupActivitiesSession> create(RetainPtr<WKGroupSession>&&);
     ~GroupActivitiesSession();

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.mm
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(GroupActivitiesSession);
+
 Ref<GroupActivitiesSession> GroupActivitiesSession::create(RetainPtr<WKGroupSession>&& session)
 {
     return adoptRef(*new GroupActivitiesSession(WTFMove(session)));

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h
@@ -29,6 +29,7 @@
 
 #include "GroupActivitiesSession.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
 
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class GroupActivitiesSessionNotifier : public CanMakeWeakPtr<GroupActivitiesSessionNotifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(GroupActivitiesSessionNotifier);
 public:
     static GroupActivitiesSessionNotifier& sharedNotifier();
 

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
@@ -40,6 +40,8 @@ namespace WebKit {
 using namespace PAL;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(GroupActivitiesSessionNotifier);
+
 GroupActivitiesSessionNotifier& GroupActivitiesSessionNotifier::sharedNotifier()
 {
     static NeverDestroyed<GroupActivitiesSessionNotifier> notifier;

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h
@@ -29,6 +29,8 @@
 
 #import "APIIconLoadingClient.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKWebView;
@@ -37,7 +39,7 @@
 namespace WebKit {
 
 class IconLoadingDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(IconLoadingDelegate);
 public:
     explicit IconLoadingDelegate(WKWebView *);
     ~IconLoadingDelegate();
@@ -49,7 +51,7 @@ public:
 
 private:
     class IconLoadingClient : public API::IconLoadingClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(IconLoadingClient);
     public:
         explicit IconLoadingClient(IconLoadingDelegate&);
         ~IconLoadingClient();

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(IconLoadingDelegate);
+
 IconLoadingDelegate::IconLoadingDelegate(WKWebView *webView)
     : m_webView(webView)
 {

--- a/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.h
@@ -29,6 +29,7 @@
 #import "LegacyCustomProtocolID.h"
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKCustomProtocolLoader;
 
@@ -41,6 +42,7 @@ namespace WebKit {
 class LegacyCustomProtocolManagerProxy;
 
 class LegacyCustomProtocolManagerClient final : public API::CustomProtocolManagerClient {
+    WTF_MAKE_WK_TZONE_ALLOCATED(LegacyCustomProtocolManagerClient);
 public:
     void startLoading(LegacyCustomProtocolManagerProxy&, LegacyCustomProtocolID, const WebCore::ResourceRequest&) final;
     void stopLoading(LegacyCustomProtocolManagerProxy&, LegacyCustomProtocolID) final;

--- a/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
@@ -138,6 +138,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LegacyCustomProtocolManagerClient);
+
 void LegacyCustomProtocolManagerClient::startLoading(LegacyCustomProtocolManagerProxy& manager, WebKit::LegacyCustomProtocolID customProtocolID, const ResourceRequest& coreRequest)
 {
     NSURLRequest *request = coreRequest.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h
@@ -27,6 +27,7 @@
 
 #import "APIDownloadClient.h"
 #import "WKFoundation.h"
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @protocol _WKDownloadDelegate;
@@ -39,7 +40,7 @@ class ResourceResponse;
 namespace WebKit {
 
 class LegacyDownloadClient final : public API::DownloadClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LegacyDownloadClient);
 public:
     explicit LegacyDownloadClient(id <_WKDownloadDelegate>);
     

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -47,6 +47,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LegacyDownloadClient);
+
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 LegacyDownloadClient::LegacyDownloadClient(id <_WKDownloadDelegate> delegate)

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -34,6 +34,8 @@
 #import "ProcessThrottler.h"
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMalloc.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/UniqueRef.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
@@ -55,7 +57,7 @@ namespace WebKit {
 struct WebNavigationDataStore;
 
 class NavigationState final : public PageLoadState::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NavigationState);
 public:
     explicit NavigationState(WKWebView *);
     ~NavigationState();
@@ -92,6 +94,7 @@ public:
 
 private:
     class NavigationClient final : public API::NavigationClient {
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NavigationClient);
     public:
         explicit NavigationClient(NavigationState&);
         ~NavigationClient();
@@ -158,6 +161,7 @@ private:
     };
     
     class HistoryClient final : public API::HistoryClient {
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(HistoryClient);
     public:
         explicit HistoryClient(NavigationState&);
         ~HistoryClient();

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -111,6 +111,8 @@ SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKMarketplaceKit)
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NavigationState);
+
 static WeakHashMap<WebPageProxy, WeakPtr<NavigationState>>& navigationStates()
 {
     static NeverDestroyed<WeakHashMap<WebPageProxy, WeakPtr<NavigationState>>> navigationStates;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -28,6 +28,7 @@
 #include "PageClient.h"
 #include <WebCore/PlatformTextAlternatives.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 
 @class PlatformTextAlternatives;
@@ -47,6 +48,7 @@ struct AppHighlight;
 namespace WebKit {
 
 class PageClientImplCocoa : public PageClient {
+    WTF_MAKE_WK_TZONE_ALLOCATED(PageClientImplCocoa);
 public:
     PageClientImplCocoa(WKWebView *);
     virtual ~PageClientImplCocoa();

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PageClientImplCocoa);
+
 PageClientImplCocoa::PageClientImplCocoa(WKWebView *webView)
     : m_webView { webView }
     , m_alternativeTextUIController { makeUnique<WebCore::AlternativeTextUIController>() }

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -38,6 +38,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
@@ -46,6 +47,7 @@ class WebPageProxy;
 class PlaybackSessionManagerProxy;
 
 class PlaybackSessionModelContext final: public RefCounted<PlaybackSessionModelContext>, public WebCore::PlaybackSessionModel  {
+    WTF_MAKE_WK_TZONE_ALLOCATED(PlaybackSessionModelContext);
 public:
     static Ref<PlaybackSessionModelContext> create(PlaybackSessionManagerProxy& manager, PlaybackSessionContextIdentifier contextId)
     {

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -44,6 +44,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PlaybackSessionModelContext);
+
 #pragma mark - PlaybackSessionModelContext
 
 PlaybackSessionModelContext::PlaybackSessionModelContext(PlaybackSessionManagerProxy& manager, PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h
@@ -27,6 +27,8 @@
 
 #import "APIResourceLoadClient.h"
 #import "WKFoundation.h"
+#import <wtf/TZoneMalloc.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKWebView;
@@ -40,7 +42,7 @@ class ResourceLoadClient;
 namespace WebKit {
 
 class ResourceLoadDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ResourceLoadDelegate);
 public:
     explicit ResourceLoadDelegate(WKWebView *);
     ~ResourceLoadDelegate();
@@ -52,7 +54,7 @@ public:
 
 private:
     class ResourceLoadClient : public API::ResourceLoadClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ResourceLoadClient);
     public:
         explicit ResourceLoadClient(ResourceLoadDelegate&);
         ~ResourceLoadClient();

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ResourceLoadDelegate);
+
 ResourceLoadDelegate::ResourceLoadDelegate(WKWebView *webView)
     : m_webView(webView)
 {

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
@@ -30,6 +30,7 @@
 #include "SOAuthorizationSession.h"
 #include "WebViewDidMoveToWindowObserver.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -41,6 +42,7 @@ namespace WebKit {
 // FSM: Idle => isInWindow => Active => Completed
 //      Idle => !isInWindow => Waiting => become isInWindow => Active => Completed
 class NavigationSOAuthorizationSession : public SOAuthorizationSession, private WebViewDidMoveToWindowObserver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NavigationSOAuthorizationSession);
 public:
     ~NavigationSOAuthorizationSession();
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NavigationSOAuthorizationSession);
+
 NavigationSOAuthorizationSession::NavigationSOAuthorizationSession(RetainPtr<WKSOAuthorizationDelegate> delegate, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, InitiatingAction action, Callback&& completionHandler)
     : SOAuthorizationSession(delegate, WTFMove(navigationAction), page, action)
     , m_callback(WTFMove(completionHandler))

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.h
@@ -29,6 +29,7 @@
 
 #include "SOAuthorizationSession.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKSOSecretDelegate;
 OBJC_CLASS WKWebView;
@@ -41,6 +42,7 @@ namespace WebKit {
 
 // FSM: Idle => Active => Completed
 class PopUpSOAuthorizationSession final : public SOAuthorizationSession {
+    WTF_MAKE_WK_TZONE_ALLOCATED(PopUpSOAuthorizationSession);
 public:
     using NewPageCallback = CompletionHandler<void(RefPtr<WebPageProxy>&&)>;
     using UIClientCallback = Function<void(Ref<API::NavigationAction>&&, NewPageCallback&&)>;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -97,6 +97,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PopUpSOAuthorizationSession);
+
 Ref<SOAuthorizationSession> PopUpSOAuthorizationSession::create(RetainPtr<WKSOAuthorizationDelegate> delegate, WebPageProxy& page, Ref<API::NavigationAction>&& navigationAction, NewPageCallback&& newPageCallback, UIClientCallback&& uiClientCallback)
 {
     return adoptRef(*new PopUpSOAuthorizationSession(delegate, page, WTFMove(navigationAction), WTFMove(newPageCallback), WTFMove(uiClientCallback)));

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.h
@@ -28,10 +28,12 @@
 #if HAVE(APP_SSO)
 
 #include "NavigationSOAuthorizationSession.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class RedirectSOAuthorizationSession final : public NavigationSOAuthorizationSession {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RedirectSOAuthorizationSession);
 public:
     using Callback = CompletionHandler<void(bool)>;
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
@@ -38,6 +38,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RedirectSOAuthorizationSession);
+
 Ref<SOAuthorizationSession> RedirectSOAuthorizationSession::create(RetainPtr<WKSOAuthorizationDelegate> delegate, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Callback&& completionHandler)
 {
     return adoptRef(*new RedirectSOAuthorizationSession(delegate, WTFMove(navigationAction), page, WTFMove(completionHandler)));

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS SOAuthorization;
 OBJC_CLASS WKSOAuthorizationDelegate;
@@ -47,7 +48,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class SOAuthorizationCoordinator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SOAuthorizationCoordinator);
     WTF_MAKE_NONCOPYABLE(SOAuthorizationCoordinator);
 public:
     SOAuthorizationCoordinator();

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -47,6 +47,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SOAuthorizationCoordinator);
+
 SOAuthorizationCoordinator::SOAuthorizationCoordinator()
 {
     m_hasAppSSO = !!PAL::getSOAuthorizationClass();

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -30,6 +30,7 @@
 #include <pal/spi/cocoa/AppSSOSPI.h>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
@@ -54,6 +55,7 @@ enum class SOAuthorizationLoadPolicy : bool;
 
 // A session will only be executed once.
 class SOAuthorizationSession : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SOAuthorizationSession, WTF::DestructionThread::MainRunLoop> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(SOAuthorizationSession);
 public:
     enum class InitiatingAction : uint8_t {
         Redirect,

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -54,6 +54,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SOAuthorizationSession);
+
 namespace {
 
 static const char* Redirect = "Redirect";

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -32,10 +32,12 @@
 #include "NavigationSOAuthorizationSession.h"
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class SubFrameSOAuthorizationSession final : public NavigationSOAuthorizationSession, public FrameLoadState::Observer {
+    WTF_MAKE_WK_TZONE_ALLOCATED(SubFrameSOAuthorizationSession);
 public:
     using Callback = CompletionHandler<void(bool)>;
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -39,6 +39,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SubFrameSOAuthorizationSession);
+
 #define AUTHORIZATIONSESSION_RELEASE_LOG(fmt, ...) RELEASE_LOG(AppSSO, "%p - [InitiatingAction=%s][State=%s] SubFrameSOAuthorizationSession::" fmt, this, initiatingActionString(), stateString(), ##__VA_ARGS__)
 
 namespace {

--- a/Source/WebKit/UIProcess/Cocoa/TextCheckingController.h
+++ b/Source/WebKit/UIProcess/Cocoa/TextCheckingController.h
@@ -30,6 +30,7 @@
 #import "EditingRange.h"
 #import <WebCore/FloatRect.h>
 #import <wtf/CompletionHandler.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSAttributedString;
 
@@ -38,7 +39,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class TextCheckingController final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(TextCheckingController);
     WTF_MAKE_NONCOPYABLE(TextCheckingController);
 public:
     explicit TextCheckingController(WebPageProxy&);

--- a/Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(TextCheckingController);
+
 TextCheckingController::TextCheckingController(WebPageProxy& webPageProxy)
     : m_page(webPageProxy)
 {

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -31,6 +31,8 @@
 #import "APIUIClient.h"
 #import <WebCore/PlatformViewController.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
@@ -53,7 +55,7 @@ namespace WebKit {
 enum class TapHandlingResult : uint8_t;
 
 class UIDelegate : public CanMakeWeakPtr<UIDelegate> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(UIDelegate);
 public:
     explicit UIDelegate(WKWebView *);
     ~UIDelegate();
@@ -69,6 +71,7 @@ public:
 private:
 #if ENABLE(CONTEXT_MENUS)
     class ContextMenuClient : public API::ContextMenuClient {
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ContextMenuClient);
     public:
         explicit ContextMenuClient(UIDelegate&);
         ~ContextMenuClient();
@@ -82,6 +85,7 @@ private:
 #endif
 
     class UIClient : public API::UIClient, public CanMakeWeakPtr<UIClient> {
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(UIClient);
     public:
         explicit UIClient(UIDelegate&);
         ~UIClient();

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -82,6 +82,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UIDelegate);
+
 UIDelegate::UIDelegate(WKWebView *webView)
     : m_webView(webView)
 {

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UIRemoteObjectRegistry);
+
 std::unique_ptr<ProcessThrottler::BackgroundActivity> UIRemoteObjectRegistry::backgroundActivity(ASCIILiteral name)
 {
     return protectedPage()->process().throttler().backgroundActivity(name).moveToUniquePtr();

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RemoteObjectRegistry.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
@@ -33,6 +34,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class UIRemoteObjectRegistry final : public RemoteObjectRegistry {
+    WTF_MAKE_WK_TZONE_ALLOCATED(UIRemoteObjectRegistry);
 public:
     UIRemoteObjectRegistry(_WKRemoteObjectRegistry *, WebPageProxy&);
     ~UIRemoteObjectRegistry();

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -52,11 +52,13 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UserMediaCaptureManagerProxy);
+
 class UserMediaCaptureManagerProxy::SourceProxy
     : public RealtimeMediaSource::Observer
     , private RealtimeMediaSource::AudioSampleObserver
     , private RealtimeMediaSource::VideoFrameObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(UserMediaCaptureManagerProxy);
 public:
     SourceProxy(RealtimeMediaSourceIdentifier id, Ref<IPC::Connection>&& connection, ProcessIdentity&& resourceOwner, Ref<RealtimeMediaSource>&& source, RefPtr<RemoteVideoFrameObjectHeap>&& videoFrameObjectHeap)
         : m_id(id)

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -38,6 +38,7 @@
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
 #include <pal/spi/cocoa/TCCSPI.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
@@ -51,7 +52,7 @@ namespace WebKit {
 class WebProcessProxy;
 
 class UserMediaCaptureManagerProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(UserMediaCaptureManagerProxy);
 public:
     class ConnectionProxy {
     public:

--- a/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h
@@ -27,6 +27,7 @@
 
 #include "WebURLSchemeHandler.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 @protocol WKURLSchemeHandler;
 
@@ -35,6 +36,7 @@ namespace WebKit {
 class WebURLSchemeTask;
 
 class WebURLSchemeHandlerCocoa : public WebURLSchemeHandler {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebURLSchemeHandlerCocoa);
 public:
     static Ref<WebURLSchemeHandlerCocoa> create(id <WKURLSchemeHandler>);
 

--- a/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebURLSchemeHandlerCocoa);
+
 Ref<WebURLSchemeHandlerCocoa> WebURLSchemeHandlerCocoa::create(id <WKURLSchemeHandler> apiHandler)
 {
     return adoptRef(*new WebURLSchemeHandlerCocoa(apiHandler));

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
@@ -28,6 +28,7 @@
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -44,6 +45,7 @@ class ProcessAndUIAssertion;
 // 2) On iOS, make the process runnable for the duration of the watchdog
 //    to ensure it has a chance to terminate cleanly.
 class XPCConnectionTerminationWatchdog {
+    WTF_MAKE_WK_TZONE_ALLOCATED(XPCConnectionTerminationWatchdog);
 public:
     static void startConnectionTerminationWatchdog(AuxiliaryProcessProxy&, Seconds interval);
 

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(XPCConnectionTerminationWatchdog);
+
 void XPCConnectionTerminationWatchdog::startConnectionTerminationWatchdog(AuxiliaryProcessProxy& process, Seconds interval)
 {
     new XPCConnectionTerminationWatchdog(process, interval);

--- a/Source/WebKit/UIProcess/DisplayLink.cpp
+++ b/Source/WebKit/UIProcess/DisplayLink.cpp
@@ -37,6 +37,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DisplayLink);
+
 constexpr unsigned maxFireCountWithoutObservers { 20 };
 
 DisplayLink::DisplayLink(PlatformDisplayID displayID)

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -34,6 +34,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(MAC)
 #include <CoreVideo/CVDisplayLink.h>
@@ -46,7 +47,7 @@
 namespace WebKit {
 
 class DisplayLink {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(DisplayLink);
 public:
     class Client : public CanMakeThreadSafeCheckedPtr {
     friend class DisplayLink;

--- a/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp
+++ b/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DisplayLinkProcessProxyClient);
+
 void DisplayLinkProcessProxyClient::setConnection(RefPtr<IPC::Connection>&& connection)
 {
     Locker locker { m_connectionLock };

--- a/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
+++ b/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
@@ -30,6 +30,7 @@
 #if HAVE(DISPLAY_LINK)
 
 #include "Connection.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -37,7 +38,7 @@ class WebProcessProxy;
 
 class DisplayLinkProcessProxyClient final : public DisplayLink::Client {
 public:
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(DisplayLinkProcessProxyClient);
 public:
     DisplayLinkProcessProxyClient() = default;
     ~DisplayLinkProcessProxyClient() = default;

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -50,6 +50,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DownloadProxy);
+
 DownloadProxy::DownloadProxy(DownloadProxyMap& downloadProxyMap, WebsiteDataStore& dataStore, API::DownloadClient& client, const ResourceRequest& resourceRequest, const FrameInfoData& frameInfoData, WebPageProxy* originatingPage)
     : m_downloadProxyMap(downloadProxyMap)
     , m_dataStore(&dataStore)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/ResourceRequest.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSProgress;
@@ -62,6 +63,7 @@ enum class AllowOverwrite : bool;
 struct FrameInfoData;
 
 class DownloadProxy : public API::ObjectImpl<API::Object::Type::Download>, public IPC::MessageReceiver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(DownloadProxy);
 public:
 
     template<typename... Args> static Ref<DownloadProxy> create(Args&&... args)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
@@ -44,6 +44,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DownloadProxyMap);
+
 DownloadProxyMap::DownloadProxyMap(NetworkProcessProxy& process)
     : m_process(process)
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -29,6 +29,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -53,9 +54,8 @@ class WebsiteDataStore;
 struct FrameInfoData;
 
 class DownloadProxyMap : public CanMakeWeakPtr<DownloadProxyMap> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(DownloadProxyMap);
     WTF_MAKE_NONCOPYABLE(DownloadProxyMap);
-
 public:
     explicit DownloadProxyMap(NetworkProcessProxy&);
     ~DownloadProxyMap();

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -40,6 +40,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DrawingAreaProxy);
+
 DrawingAreaProxy::DrawingAreaProxy(DrawingAreaType type, WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : m_type(type)
     , m_identifier(DrawingAreaIdentifier::generate())

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -37,6 +37,7 @@
 #include <stdint.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakRef.h>
 
@@ -64,7 +65,7 @@ struct UpdateInfo;
 #endif
 
 class DrawingAreaProxy : public IPC::MessageReceiver, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(DrawingAreaProxy);
     WTF_MAKE_NONCOPYABLE(DrawingAreaProxy);
 
 public:

--- a/Source/WebKit/UIProcess/EndowmentStateTracker.h
+++ b/Source/WebKit/UIProcess/EndowmentStateTracker.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakHashSet.h>
 
 OBJC_CLASS NSSet;
@@ -38,7 +39,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class EndowmentStateTracker {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(EndowmentStateTracker);
 public:
     static EndowmentStateTracker& singleton();
 

--- a/Source/WebKit/UIProcess/EndowmentStateTracker.mm
+++ b/Source/WebKit/UIProcess/EndowmentStateTracker.mm
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(EndowmentStateTracker);
+
 static NSString* visibilityEndowment = @"com.apple.frontboard.visibility";
 static NSString* userfacingEndowment = @"com.apple.launchservices.userfacing";
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3136,7 +3136,7 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         return;
 
     class InspectorExtensionClient : public API::InspectorExtensionClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(InspectorExtensionClient);
 
     public:
         explicit InspectorExtensionClient(API::InspectorExtension& inspectorExtension, WebExtensionContext& extensionContext)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -47,6 +47,8 @@ namespace WebKit {
 using namespace WTF;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionMatchPattern);
+
 static constexpr ASCIILiteral allURLsPattern = "<all_urls>"_s;
 static constexpr ASCIILiteral allHostsAndSchemesPattern = "*://*/*"_s;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
@@ -39,6 +39,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionMessagePort);
+
 NSError *toAPI(WebExtensionMessagePort::Error error)
 {
     if (!error)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -51,6 +51,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionTab);
+
 WebExtensionTab::WebExtensionTab(const WebExtensionContext& context, _WKWebExtensionTab *delegate)
     : m_identifier(WebExtensionTabIdentifier::generate())
     , m_extensionContext(context)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -50,6 +50,8 @@ namespace WebKit {
 
 class WebPageProxy;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionURLSchemeHandler);
+
 constexpr NSInteger noPermissionErrorCode = NSURLErrorNoPermissionsToReadFile;
 
 WebExtensionURLSchemeHandler::WebExtensionURLSchemeHandler(WebExtensionController& controller)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -33,6 +33,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -67,6 +68,7 @@ namespace WebKit {
 
 class WebExtension : public API::ObjectImpl<API::Object::Type::WebExtension>, public CanMakeWeakPtr<WebExtension> {
     WTF_MAKE_NONCOPYABLE(WebExtension);
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebExtension);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -30,6 +30,7 @@
 #include "APIObject.h"
 #include "CocoaImage.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -48,6 +49,7 @@ class WebExtensionWindow;
 
 class WebExtensionAction : public API::ObjectImpl<API::Object::Type::WebExtensionAction>, public CanMakeWeakPtr<WebExtensionAction> {
     WTF_MAKE_NONCOPYABLE(WebExtensionAction);
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebExtensionAction);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp
@@ -34,6 +34,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionAlarm);
+
 void WebExtensionAlarm::schedule()
 {
     m_parameters.nextScheduledTime = MonotonicTime::now() + initialInterval();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h
@@ -32,6 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -39,7 +40,7 @@ class WebExtensionContext;
 
 class WebExtensionAlarm : public RefCounted<WebExtensionAlarm> {
     WTF_MAKE_NONCOPYABLE(WebExtensionAlarm);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionAlarm);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionCommand);
+
 WebExtensionCommand::WebExtensionCommand(WebExtensionContext& extensionContext, const WebExtension::CommandData& data)
     : m_extensionContext(extensionContext)
     , m_identifier(data.identifier)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -30,6 +30,7 @@
 #include "APIObject.h"
 #include "WebExtension.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -68,6 +69,7 @@ struct WebExtensionCommandParameters;
 
 class WebExtensionCommand : public API::ObjectImpl<API::Object::Type::WebExtensionCommand>, public CanMakeWeakPtr<WebExtensionCommand> {
     WTF_MAKE_NONCOPYABLE(WebExtensionCommand);
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionCommand);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionContext);
+
 static HashMap<WebExtensionContextIdentifier, WeakRef<WebExtensionContext>>& webExtensionContexts()
 {
     static NeverDestroyed<HashMap<WebExtensionContextIdentifier, WeakRef<WebExtensionContext>>> contexts;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -65,6 +65,7 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 #include <wtf/UUID.h>
 #include <wtf/WeakHashCountedSet.h>
@@ -127,6 +128,7 @@ enum class WebExtensionContextInstallReason : uint8_t {
 
 class WebExtensionContext : public API::ObjectImpl<API::Object::Type::WebExtensionContext>, public IPC::MessageReceiver {
     WTF_MAKE_NONCOPYABLE(WebExtensionContext);
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionContext);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionController);
+
 constexpr auto freshlyCreatedTimeout = 5_s;
 
 static HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionController>>& webExtensionControllers()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -42,6 +42,8 @@
 #include "WebUserContentControllerProxy.h"
 #include <WebCore/Timer.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakHashSet.h>
 
@@ -70,6 +72,7 @@ class WebInspectorUIProxy;
 
 class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
     WTF_MAKE_NONCOPYABLE(WebExtensionController);
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionController);
 
 public:
     static Ref<WebExtensionController> create(Ref<WebExtensionControllerConfiguration> configuration) { return adoptRef(*new WebExtensionController(configuration)); }
@@ -204,7 +207,7 @@ private:
     void testFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
     class HTTPCookieStoreObserver : public API::HTTPCookieStore::Observer {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(HTTPCookieStoreObserver);
 
     public:
         explicit HTTPCookieStoreObserver(WebExtensionController& extensionController)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionControllerConfiguration);
+
 WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(IsPersistent persistent)
     : m_storageDirectory(persistent == IsPersistent::Yes ? createStorageDirectoryPath() : nullString())
 {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -32,6 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Markable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 
 OBJC_CLASS WKWebViewConfiguration;
@@ -41,6 +42,7 @@ namespace WebKit {
 
 class WebExtensionControllerConfiguration : public API::ObjectImpl<API::Object::Type::WebExtensionControllerConfiguration> {
     WTF_MAKE_NONCOPYABLE(WebExtensionControllerConfiguration);
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionControllerConfiguration);
 
 public:
     enum class IsPersistent : bool { No, Yes };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.cpp
@@ -32,6 +32,9 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionDataRecord);
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionDataRecordHolder);
+
 WebExtensionDataRecord::WebExtensionDataRecord(const String& displayName, const String& uniqueIdentifier)
     : m_displayName(displayName)
     , m_uniqueIdentifier(uniqueIdentifier)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
@@ -31,6 +31,7 @@
 #include "WebExtensionDataType.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 OBJC_CLASS _WKWebExtensionDataRecord;
@@ -39,6 +40,7 @@ namespace WebKit {
 
 class WebExtensionDataRecord : public API::ObjectImpl<API::Object::Type::WebExtensionDataRecord> {
     WTF_MAKE_NONCOPYABLE(WebExtensionDataRecord);
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionDataRecord);
 
 public:
     template<typename... Args>
@@ -76,7 +78,7 @@ private:
 
 class WebExtensionDataRecordHolder : public RefCounted<WebExtensionDataRecordHolder> {
     WTF_MAKE_NONCOPYABLE(WebExtensionDataRecordHolder);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionDataRecordHolder);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -36,6 +36,7 @@
 #include "WebExtensionScriptInjectionResultParameters.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 
 OBJC_CLASS WKWebView;
 OBJC_CLASS WKFrameInfo;
@@ -60,7 +61,7 @@ using UserStyleSheetVector = Vector<Ref<API::UserStyleSheet>>;
 
 class WebExtensionRegisteredScript : public RefCounted<WebExtensionRegisteredScript> {
     WTF_MAKE_NONCOPYABLE(WebExtensionRegisteredScript);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebExtensionRegisteredScript);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -32,6 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSArray;
 OBJC_CLASS NSError;
@@ -43,7 +44,8 @@ namespace WebKit {
 
 class WebExtensionMatchPattern : public API::ObjectImpl<API::Object::Type::WebExtensionMatchPattern> {
     WTF_MAKE_NONCOPYABLE(WebExtensionMatchPattern);
-
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionMatchPattern);
+    
 public:
     template<typename... Args>
     static RefPtr<WebExtensionMatchPattern> create(Args&&... args)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -45,7 +45,7 @@ namespace WebKit {
 class WebExtensionMatchPattern : public API::ObjectImpl<API::Object::Type::WebExtensionMatchPattern> {
     WTF_MAKE_NONCOPYABLE(WebExtensionMatchPattern);
     WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionMatchPattern);
-    
+
 public:
     template<typename... Args>
     static RefPtr<WebExtensionMatchPattern> create(Args&&... args)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebExtensionMenuItem);
+
 bool WebExtensionMenuItem::operator==(const WebExtensionMenuItem& other) const
 {
     return this == &other || (m_extensionContext == other.m_extensionContext && m_identifier == other.m_identifier);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -33,6 +33,7 @@
 #include "WebExtensionMenuItemContextType.h"
 #include "WebExtensionMenuItemType.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -67,7 +68,7 @@ struct WebExtensionMenuItemParameters;
 
 class WebExtensionMenuItem : public RefCounted<WebExtensionMenuItem>, public CanMakeWeakPtr<WebExtensionMenuItem> {
     WTF_MAKE_NONCOPYABLE(WebExtensionMenuItem);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionMenuItem);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
@@ -30,6 +30,7 @@
 #include "APIObject.h"
 #include "WebExtensionPortChannelIdentifier.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSError;
 OBJC_CLASS _WKWebExtensionMessagePort;
@@ -40,6 +41,7 @@ class WebExtensionContext;
 
 class WebExtensionMessagePort : public API::ObjectImpl<API::Object::Type::WebExtensionMessagePort> {
     WTF_MAKE_NONCOPYABLE(WebExtensionMessagePort);
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionMessagePort);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -33,6 +33,7 @@
 #include "WebExtensionTabIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS NSArray;
@@ -56,7 +57,7 @@ enum class WebExtensionTabImageFormat : uint8_t {
 
 class WebExtensionTab : public RefCounted<WebExtensionTab>, public CanMakeWeakPtr<WebExtensionTab> {
     WTF_MAKE_NONCOPYABLE(WebExtensionTab);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionTab);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionURLSchemeHandler.h
@@ -30,6 +30,7 @@
 #include "WebURLSchemeHandler.h"
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSBlockOperation;
@@ -39,6 +40,7 @@ namespace WebKit {
 class WebExtensionController;
 
 class WebExtensionURLSchemeHandler : public WebURLSchemeHandler {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebExtensionURLSchemeHandler);
 public:
     static Ref<WebExtensionURLSchemeHandler> create(WebExtensionController& controller)
     {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -31,6 +31,7 @@
 #include "WebExtensionWindowIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_PROTOCOL(_WKWebExtensionWindow);
@@ -61,7 +62,7 @@ static constexpr OptionSet<WebExtensionWindowTypeFilter> allWebExtensionWindowTy
 
 class WebExtensionWindow : public RefCounted<WebExtensionWindow>, public CanMakeWeakPtr<WebExtensionWindow> {
     WTF_MAKE_NONCOPYABLE(WebExtensionWindow);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebExtensionWindow);
 
 public:
     template<typename... Args>

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -84,6 +84,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(GPUProcessProxy);
+
 #if ENABLE(MEDIA_STREAM) && HAVE(AUDIT_TOKEN)
 static bool shouldCreateAppleCameraServiceSandboxExtension()
 {

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -37,6 +37,7 @@
 #include <WebCore/ShareableBitmap.h>
 #include <memory>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMalloc.h>
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 #include "LayerHostingContext.h"
@@ -67,7 +68,7 @@ struct GPUProcessCreationParameters;
 struct GPUProcessPreferencesForWebProcess;
 
 class GPUProcessProxy final : public AuxiliaryProcessProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(GPUProcessProxy);
     WTF_MAKE_NONCOPYABLE(GPUProcessProxy);
     friend LazyNeverDestroyed<GPUProcessProxy>;
 public:

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
@@ -34,6 +34,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UIGamepad);
+
 UIGamepad::UIGamepad(WebCore::PlatformGamepad& platformGamepad)
     : m_index(platformGamepad.index())
     , m_id(platformGamepad.id())

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.h
@@ -30,6 +30,7 @@
 #include <WebCore/GamepadHapticEffectType.h>
 #include <WebCore/SharedGamepadValue.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -42,7 +43,7 @@ namespace WebKit {
 class GamepadData;
 
 class UIGamepad {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(UIGamepad);
 public:
     UIGamepad(WebCore::PlatformGamepad&);
 

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -39,6 +39,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UIGamepadProvider);
+
 static const Seconds maximumGamepadUpdateInterval { 1_s / 120. };
 
 UIGamepadProvider& UIGamepadProvider::singleton()

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
@@ -30,6 +30,7 @@
 #include <WebCore/GamepadProviderClient.h>
 #include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
 
@@ -41,6 +42,7 @@ class WebProcessPool;
 class GamepadData;
 
 class UIGamepadProvider final : public WebCore::GamepadProviderClient {
+    WTF_MAKE_WK_TZONE_ALLOCATED(UIGamepadProvider);
 public:
     static UIGamepadProvider& singleton();
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
@@ -40,6 +40,8 @@ namespace WebKit {
 
 using namespace Inspector;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(InspectorBrowserAgent);
+
 InspectorBrowserAgent::InspectorBrowserAgent(WebPageAgentContext& context)
     : InspectorAgentBase("Browser"_s, context)
     , m_frontendDispatcher(makeUnique<Inspector::BrowserFrontendDispatcher>(context.frontendRouter))

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
@@ -37,7 +38,7 @@ class WebPageProxy;
 
 class InspectorBrowserAgent final : public InspectorAgentBase, public Inspector::BrowserBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorBrowserAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(InspectorBrowserAgent);
 public:
     InspectorBrowserAgent(WebPageAgentContext&);
     ~InspectorBrowserAgent();

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h
@@ -30,6 +30,7 @@
 #import "APIInspectorExtensionClient.h"
 #import "WKFoundation.h"
 #import <WebCore/FrameIdentifier.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class _WKInspectorExtension;
@@ -38,7 +39,7 @@
 namespace WebKit {
 
 class InspectorExtensionDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(InspectorExtensionDelegate);
 public:
     InspectorExtensionDelegate(_WKInspectorExtension *, id <_WKInspectorExtensionDelegate>);
     ~InspectorExtensionDelegate();
@@ -48,7 +49,7 @@ public:
 
 private:
     class InspectorExtensionClient final : public API::InspectorExtensionClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(InspectorExtensionClient);
     public:
         explicit InspectorExtensionClient(InspectorExtensionDelegate&);
         ~InspectorExtensionClient();

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(InspectorExtensionDelegate);
+
 InspectorExtensionDelegate::InspectorExtensionDelegate(_WKInspectorExtension *inspectorExtension, id <_WKInspectorExtensionDelegate> delegate)
     : m_inspectorExtension(inspectorExtension)
     , m_delegate(delegate)

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
@@ -38,6 +38,8 @@ namespace WebKit {
 
 using namespace Inspector;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(InspectorTargetProxy);
+
 std::unique_ptr<InspectorTargetProxy> InspectorTargetProxy::create(WebPageProxy& page, const String& targetId, Inspector::InspectorTargetType type)
 {
     return makeUnique<InspectorTargetProxy>(page, targetId, type);

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/InspectorTarget.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -38,7 +39,7 @@ class WebPageProxy;
 // any target -> frontend messages will be routed to the WebPageProxy with a targetId.
 
 class InspectorTargetProxy final : public Inspector::InspectorTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(InspectorTargetProxy);
     WTF_MAKE_NONCOPYABLE(InspectorTargetProxy);
 public:
     static std::unique_ptr<InspectorTargetProxy> create(WebPageProxy&, const String& targetId, Inspector::InspectorTargetType);

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
@@ -44,6 +44,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteWebInspectorUIProxy);
+
 RemoteWebInspectorUIProxy::RemoteWebInspectorUIProxy()
     : m_debuggableInfo(API::DebuggableInfo::create(DebuggableInfoData::empty()))
 {

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -73,6 +74,7 @@ public:
 };
 
 class RemoteWebInspectorUIProxy : public RefCounted<RemoteWebInspectorUIProxy>, public IPC::MessageReceiver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteWebInspectorUIProxy);
 public:
     static Ref<RemoteWebInspectorUIProxy> create()
     {

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -39,6 +39,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebInspectorUIExtensionControllerProxy);
+
 WebInspectorUIExtensionControllerProxy::WebInspectorUIExtensionControllerProxy(WebPageProxy& inspectorPage)
     : m_inspectorPage(inspectorPage)
 {

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -46,7 +47,7 @@ class WebPageProxy;
 class WebInspectorUIExtensionControllerProxy final
     : public RefCounted<WebInspectorUIExtensionControllerProxy>
     , public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebInspectorUIExtensionControllerProxy);
     WTF_MAKE_NONCOPYABLE(WebInspectorUIExtensionControllerProxy);
 public:
     static Ref<WebInspectorUIExtensionControllerProxy> create(WebPageProxy& inspectorPage);

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
@@ -36,6 +36,8 @@ namespace WebKit {
 
 using namespace Inspector;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPageDebuggable);
+
 WebPageDebuggable::WebPageDebuggable(WebPageProxy& page)
     : m_page(page)
 {

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
@@ -29,13 +29,14 @@
 
 #include <JavaScriptCore/RemoteInspectionTarget.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPageProxy;
 
 class WebPageDebuggable final : public Inspector::RemoteInspectionTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPageDebuggable);
     WTF_MAKE_NONCOPYABLE(WebPageDebuggable);
 public:
     WebPageDebuggable(WebPageProxy&);

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -44,6 +44,8 @@ namespace WebKit {
 
 using namespace Inspector;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPageInspectorController);
+
 static String getTargetID(const ProvisionalPageProxy& provisionalPage)
 {
     return WebPageInspectorTarget::toTargetID(provisionalPage.webPageID());

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -32,6 +32,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -47,7 +48,7 @@ struct WebPageAgentContext;
 
 class WebPageInspectorController {
     WTF_MAKE_NONCOPYABLE(WebPageInspectorController);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPageInspectorController);
 public:
     WebPageInspectorController(WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ProcessLauncher);
+
 ProcessLauncher::ProcessLauncher(Client* client, LaunchOptions&& launchOptions)
     : m_client(client)
     , m_launchOptions(WTFMove(launchOptions))

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Threading.h>
 #include <wtf/WeakPtr.h>
@@ -74,6 +75,7 @@ private:
 #endif
 
 class ProcessLauncher : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ProcessLauncher> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ProcessLauncher);
 public:
     class Client {
     public:

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
@@ -27,6 +27,7 @@
 
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 #if USE(EXTENSIONKIT)
 OBJC_CLASS BEWebContentProcess;
@@ -41,6 +42,7 @@ using ExtensionProcessVariant = std::variant<RetainPtr<BEWebContentProcess>, Ret
 namespace WebKit {
 
 class ExtensionProcess {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ExtensionProcess);
 public:
     ExtensionProcess(BEWebContentProcess *);
     ExtensionProcess(BENetworkingProcess *);

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ExtensionProcess);
+
 ExtensionProcess::ExtensionProcess(BEWebContentProcess *process)
     : m_process(process)
 {

--- a/Source/WebKit/UIProcess/LegacyGlobalSettings.cpp
+++ b/Source/WebKit/UIProcess/LegacyGlobalSettings.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LegacyGlobalSettings);
+
 LegacyGlobalSettings::LegacyGlobalSettings() = default;
 
 LegacyGlobalSettings& LegacyGlobalSettings::singleton()

--- a/Source/WebKit/UIProcess/LegacyGlobalSettings.h
+++ b/Source/WebKit/UIProcess/LegacyGlobalSettings.h
@@ -28,12 +28,13 @@
 #include "CacheModel.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class LegacyGlobalSettings {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LegacyGlobalSettings);
 public:
     static LegacyGlobalSettings& singleton();
 

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AudioSessionRoutingArbitratorProxy);
+
 #if !HAVE(AVAUDIO_ROUTING_ARBITER)
 
 AudioSessionRoutingArbitratorProxy::AudioSessionRoutingArbitratorProxy(WebProcessProxy& proxy)

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/AudioSession.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakPtr.h>
 
@@ -43,7 +44,7 @@ class WebProcessProxy;
 
 class AudioSessionRoutingArbitratorProxy
     : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AudioSessionRoutingArbitratorProxy);
 public:
     AudioSessionRoutingArbitratorProxy(WebProcessProxy&);
     virtual ~AudioSessionRoutingArbitratorProxy();

--- a/Source/WebKit/UIProcess/Media/MediaUsageManager.cpp
+++ b/Source/WebKit/UIProcess/Media/MediaUsageManager.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MediaUsageManager);
+
 #if !HAVE(MEDIA_USAGE_FRAMEWORK)
 std::unique_ptr<MediaUsageManager> MediaUsageManager::create()
 {

--- a/Source/WebKit/UIProcess/Media/MediaUsageManager.h
+++ b/Source/WebKit/UIProcess/Media/MediaUsageManager.h
@@ -27,11 +27,12 @@
 
 #include <WebCore/MediaUsageInfo.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class MediaUsageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(MediaUsageManager);
 public:
     static std::unique_ptr<MediaUsageManager> create();
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -47,6 +47,8 @@ extern WTFLogChannel LogMedia;
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteMediaSessionCoordinatorProxy);
+
 Ref<RemoteMediaSessionCoordinatorProxy> RemoteMediaSessionCoordinatorProxy::create(WebPageProxy& webPageProxy, Ref<MediaSessionCoordinatorProxyPrivate>&& privateCoordinator)
 {
     return adoptRef(*new RemoteMediaSessionCoordinatorProxy(webPageProxy, WTFMove(privateCoordinator)));

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct ExceptionData;
@@ -44,7 +45,7 @@ class RemoteMediaSessionCoordinatorProxy
     : private IPC::MessageReceiver
     , public RefCounted<RemoteMediaSessionCoordinatorProxy>
     , public WebCore::MediaSessionCoordinatorClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteMediaSessionCoordinatorProxy);
 public:
     static Ref<RemoteMediaSessionCoordinatorProxy> create(WebPageProxy&, Ref<MediaSessionCoordinatorProxyPrivate>&&);
     ~RemoteMediaSessionCoordinatorProxy();

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.h
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.h
@@ -28,14 +28,14 @@
 #if ENABLE(MEDIA_USAGE)
 
 #include "MediaUsageManager.h"
-#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 OBJC_CLASS USVideoUsage;
 
 namespace WebKit {
 
 class MediaUsageManagerCocoa : public MediaUsageManager {
-    WTF_MAKE_WK_TZONE_ALLOCATED(MediaUsageManagerCocoa);
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(MediaUsageManagerCocoa);
 public:
     MediaUsageManagerCocoa() = default;
     virtual ~MediaUsageManagerCocoa();

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.h
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.h
@@ -28,13 +28,14 @@
 #if ENABLE(MEDIA_USAGE)
 
 #include "MediaUsageManager.h"
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS USVideoUsage;
 
 namespace WebKit {
 
 class MediaUsageManagerCocoa : public MediaUsageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(MediaUsageManagerCocoa);
 public:
     MediaUsageManagerCocoa() = default;
     virtual ~MediaUsageManagerCocoa();

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -45,8 +45,6 @@ NS_ASSUME_NONNULL_END
 namespace WebKit {
 using namespace WebCore;
 
-WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MediaUsageManagerCocoa);
-
 static bool usageTrackingAvailable()
 {
     static bool available;

--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_END
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MediaUsageManagerCocoa);
+
 static bool usageTrackingAvailable()
 {
     static bool available;

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -45,6 +45,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MediaKeySystemPermissionRequestManagerProxy);
+
 #if !RELEASE_LOG_DISABLED
 static const char* logClassName()
 {

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class MediaKeySystemPermissionRequestManagerProxy : public CanMakeWeakPtr<MediaKeySystemPermissionRequestManagerProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(MediaKeySystemPermissionRequestManagerProxy);
 public:
     explicit MediaKeySystemPermissionRequestManagerProxy(WebPageProxy&);
     ~MediaKeySystemPermissionRequestManagerProxy();

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -54,6 +54,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ModelProcessProxy);
+
 static WeakPtr<ModelProcessProxy>& singleton()
 {
     static NeverDestroyed<WeakPtr<ModelProcessProxy>> singleton;

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -35,6 +35,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <memory>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMalloc.h>
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 #include "LayerHostingContext.h"
@@ -48,7 +49,7 @@ struct ModelProcessConnectionParameters;
 struct ModelProcessCreationParameters;
 
 class ModelProcessProxy final : public AuxiliaryProcessProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ModelProcessProxy);
     WTF_MAKE_NONCOPYABLE(ModelProcessProxy);
     friend LazyNeverDestroyed<ModelProcessProxy>;
 public:

--- a/Source/WebKit/UIProcess/ModelElementController.cpp
+++ b/Source/WebKit/UIProcess/ModelElementController.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ModelElementController);
+
 ModelElementController::ModelElementController(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
 {

--- a/Source/WebKit/UIProcess/ModelElementController.h
+++ b/Source/WebKit/UIProcess/ModelElementController.h
@@ -34,6 +34,7 @@
 #include <WebCore/ResourceError.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -48,7 +49,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class ModelElementController : public CanMakeWeakPtr<ModelElementController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ModelElementController);
 public:
     explicit ModelElementController(WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LegacyCustomProtocolManagerProxy);
+
 LegacyCustomProtocolManagerProxy::LegacyCustomProtocolManagerProxy(NetworkProcessProxy& networkProcessProxy)
     : m_networkProcessProxy(networkProcessProxy)
 {

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
@@ -28,6 +28,7 @@
 #include "LegacyCustomProtocolID.h"
 #include "MessageReceiver.h"
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
@@ -48,6 +49,7 @@ enum class CacheStoragePolicy : uint8_t;
 class NetworkProcessProxy;
 
 class LegacyCustomProtocolManagerProxy : public IPC::MessageReceiver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(LegacyCustomProtocolManagerProxy);
 public:
     LegacyCustomProtocolManagerProxy(NetworkProcessProxy&);
     ~LegacyCustomProtocolManagerProxy();

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -112,6 +112,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkProcessProxy);
+
 static constexpr Seconds networkProcessResponsivenessTimeout = 6_s;
 
 static WeakHashSet<NetworkProcessProxy>& networkProcessesSet()

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -42,6 +42,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <memory>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
@@ -109,7 +110,7 @@ struct WebsiteData;
 struct WebsiteDataStoreParameters;
 
 class NetworkProcessProxy final : public AuxiliaryProcessProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkProcessProxy);
 public:
     using RegistrableDomain = WebCore::RegistrableDomain;
     using TopFrameDomain = WebCore::RegistrableDomain;

--- a/Source/WebKit/UIProcess/Notifications/NotificationPermissionRequest.h
+++ b/Source/WebKit/UIProcess/Notifications/NotificationPermissionRequest.h
@@ -27,10 +27,12 @@
 
 #include "APIObject.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 class NotificationPermissionRequest : public API::ObjectImpl<API::Object::Type::NotificationPermissionRequest> {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NotificationPermissionRequest);
 public:
     static Ref<NotificationPermissionRequest> create(CompletionHandler<void(bool)>&& completionHandler)
     {

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ServiceWorkerNotificationHandler);
+
 ServiceWorkerNotificationHandler& ServiceWorkerNotificationHandler::singleton()
 {
     ASSERT(isMainRunLoop());

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
@@ -29,12 +29,14 @@
 #include <WebCore/PageIdentifier.h>
 #include <pal/SessionID.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebsiteDataStore;
 
 class ServiceWorkerNotificationHandler final : public NotificationManagerMessageHandler {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ServiceWorkerNotificationHandler);
 public:
     static ServiceWorkerNotificationHandler& singleton();
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebNotification);
+
 WebNotification::WebNotification(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection* sourceConnection)
     : m_data(data)
     , m_origin(API::SecurityOrigin::createFromString(data.originString))

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.h
@@ -32,6 +32,7 @@
 #include <WebCore/NotificationData.h>
 #include <wtf/Identified.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -42,6 +43,7 @@ struct NotificationData;
 namespace WebKit {
 
 class WebNotification : public API::ObjectImpl<API::Object::Type::Notification>, public Identified<WebNotification> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebNotification);
 public:
     static Ref<WebNotification> createNonPersistent(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, IPC::Connection& sourceConnection)
     {

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebNotificationManagerMessageHandler);
+
 WebNotificationManagerMessageHandler::WebNotificationManagerMessageHandler(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
 {

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -26,12 +26,14 @@
 #pragma once
 
 #include "NotificationManagerMessageHandler.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPageProxy;
 
 class WebNotificationManagerMessageHandler : public NotificationManagerMessageHandler {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebNotificationManagerMessageHandler);
     friend class WebPageProxy;
 private:
     explicit WebNotificationManagerMessageHandler(WebPageProxy&);

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -43,6 +43,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebNotificationManagerProxy);
+
 ASCIILiteral WebNotificationManagerProxy::supplementName()
 {
     return "WebNotificationManagerProxy"_s;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/NotificationClient.h>
 #include <pal/SessionID.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
 #include <wtf/text/StringHash.h>
 
@@ -54,6 +55,7 @@ class WebProcessPool;
 class WebsiteDataStore;
 
 class WebNotificationManagerProxy : public API::ObjectImpl<API::Object::Type::NotificationManager>, public WebContextSupplement {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebNotificationManagerProxy);
 public:
     static ASCIILiteral supplementName();
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebNotificationProvider);
+
 WebNotificationProvider::WebNotificationProvider(const WKNotificationProviderBase* provider)
 {
     initialize(provider);

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h
@@ -30,6 +30,7 @@
 #include "APINotificationProvider.h"
 #include "WKNotificationProvider.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 template<> struct ClientTraits<WKNotificationProviderBase> {
@@ -44,7 +45,7 @@ class WebNotificationManagerProxy;
 class WebPageProxy;
 
 class WebNotificationProvider : public API::NotificationProvider, public API::Client<WKNotificationProviderBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebNotificationProvider);
 public:
     explicit WebNotificationProvider(const WKNotificationProviderBase*);
 

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
@@ -36,6 +36,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PerActivityStateCPUUsageSampler);
+
 static const Seconds loggingInterval { 60_min };
 
 PerActivityStateCPUUsageSampler::PerActivityStateCPUUsageSampler(WebProcessPool& processPool)

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -28,6 +28,7 @@
 #include <WebCore/Page.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -35,7 +36,7 @@ class WebPageProxy;
 class WebProcessPool;
 
 class PerActivityStateCPUUsageSampler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(PerActivityStateCPUUsageSampler);
 public:
     explicit PerActivityStateCPUUsageSampler(WebProcessPool&);
     ~PerActivityStateCPUUsageSampler();

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ProcessAssertion);
+
 ASCIILiteral processAssertionTypeDescription(ProcessAssertionType type)
 {
     switch (type) {

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -28,6 +28,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/ProcessID.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -74,7 +75,7 @@ ASCIILiteral processAssertionTypeDescription(ProcessAssertionType);
 class AuxiliaryProcessProxy;
 
 class ProcessAssertion : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ProcessAssertion> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ProcessAssertion);
 public:
     enum class Mode : bool { Sync, Async };
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -42,13 +42,16 @@
 #define PROCESSTHROTTLER_RELEASE_LOG(msg, ...) RELEASE_LOG(ProcessSuspension, "%p - [PID=%d] ProcessThrottler::" msg, this, m_process->processID(), ##__VA_ARGS__)
 
 namespace WebKit {
-    
+
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ProcessThrottlerActivity);
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ProcessThrottlerTimedActivity);
+
 static constexpr Seconds processSuspensionTimeout { 20_s };
 static constexpr Seconds removeAllAssertionsTimeout { 8_min };
 static constexpr Seconds processAssertionCacheLifetime { 1_s };
 
 class ProcessThrottler::ProcessAssertionCache : public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ProcessThrottler::ProcessAssertionCache);
 public:
     void add(Ref<ProcessAssertion>&& assertion)
     {

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -31,6 +31,7 @@
 #include <wtf/ProcessID.h>
 #include <wtf/RefCounter.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -58,7 +59,7 @@ enum class ProcessThrottleState : uint8_t { Suspended, Background, Foreground };
 enum class ProcessThrottlerActivityType : bool { Background, Foreground };
 
 class ProcessThrottlerActivity : public CanMakeWeakPtr<ProcessThrottlerActivity> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ProcessThrottlerActivity);
     WTF_MAKE_NONCOPYABLE(ProcessThrottlerActivity);
 public:
     ProcessThrottlerActivity(ProcessThrottler&, ASCIILiteral name, ProcessThrottlerActivityType);
@@ -86,7 +87,7 @@ private:
 };
 
 class ProcessThrottlerTimedActivity {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ProcessThrottlerTimedActivity);
     WTF_MAKE_NONCOPYABLE(ProcessThrottlerTimedActivity);
     using Activity = ProcessThrottlerActivity;
     using ActivityVariant = std::variant<std::nullptr_t, UniqueRef<Activity>>;

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ProvisionalFrameProxy);
+
 ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, WebProcessProxy& process, RefPtr<RemotePageProxy>&& remotePageProxy)
     : m_frame(frame)
     , m_process(process)

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -28,6 +28,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/PageIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -38,7 +39,7 @@ class WebFrameProxy;
 class WebProcessProxy;
 
 class ProvisionalFrameProxy : public CanMakeWeakPtr<ProvisionalFrameProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ProvisionalFrameProxy);
 public:
     ProvisionalFrameProxy(WebFrameProxy&, WebProcessProxy&, RefPtr<RemotePageProxy>&&);
     ~ProvisionalFrameProxy();

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -65,6 +65,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ProvisionalPageProxy);
+
 #define PROVISIONALPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i, navigationID=%" PRIu64 "] ProvisionalPageProxy::" fmt, this, m_page->identifier().toUInt64(), m_webPageID.toUInt64(), m_process->processID(), m_navigationID, ##__VA_ARGS__)
 #define PROVISIONALPAGEPROXY_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i, navigationID=%" PRIu64 "] ProvisionalPageProxy::" fmt, this, m_page->identifier().toUInt64(), m_webPageID.toUInt64(), m_process->processID(), m_navigationID, ##__VA_ARGS__)
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -38,6 +38,7 @@
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/ResourceRequest.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace API {
@@ -81,7 +82,7 @@ using LayerHostingContextID = uint32_t;
 #endif
 
 class ProvisionalPageProxy : public IPC::MessageReceiver, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ProvisionalPageProxy);
 public:
     ProvisionalPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, std::unique_ptr<SuspendedPageProxy>, API::Navigation&, bool isServerRedirect, const WebCore::ResourceRequest&, ProcessSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies*, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
     ~ProvisionalPageProxy();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/FloatPoint.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/IntSize.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
 
 namespace WebKit {
@@ -44,6 +45,7 @@ class RemoteScrollingCoordinatorProxy;
 class RemoteScrollingCoordinatorTransaction;
 
 class RemoteLayerTreeDrawingAreaProxy : public DrawingAreaProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaProxy);
 public:
     RemoteLayerTreeDrawingAreaProxy(WebPageProxy&, WebProcessProxy&);
     virtual ~RemoteLayerTreeDrawingAreaProxy();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -56,6 +56,8 @@ namespace WebKit {
 using namespace IPC;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDrawingAreaProxy);
+
 RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy(WebPageProxy& pageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::RemoteLayerTree, pageProxy, webProcessProxy)
     , m_remoteLayerTreeHost(makeUnique<RemoteLayerTreeHost>(*this))

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -32,6 +32,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS CAAnimation;
 OBJC_CLASS WKAnimationDelegate;
@@ -42,7 +43,7 @@ class RemoteLayerTreeDrawingAreaProxy;
 class WebPageProxy;
 
 class RemoteLayerTreeHost {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteLayerTreeHost);
 public:
     explicit RemoteLayerTreeHost(RemoteLayerTreeDrawingAreaProxy&);
     ~RemoteLayerTreeHost();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -54,6 +54,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteLayerTreeHost);
+
 #define REMOTE_LAYER_TREE_HOST_RELEASE_LOG(...) RELEASE_LOG(ViewState, __VA_ARGS__)
 
 RemoteLayerTreeHost::RemoteLayerTreeHost(RemoteLayerTreeDrawingAreaProxy& drawingArea)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -33,6 +33,7 @@
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/ScrollTypes.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 OBJC_CLASS CALayer;
@@ -47,7 +48,7 @@ class RemoteLayerTreeHost;
 class RemoteLayerTreeScrollbars;
 
 class RemoteLayerTreeNode : public CanMakeWeakPtr<RemoteLayerTreeNode> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteLayerTreeNode);
 public:
     RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier, Markable<WebCore::LayerHostingContextIdentifier>, RetainPtr<CALayer>);
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -45,6 +45,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteLayerTreeNode);
+
 static NSString *const WKRemoteLayerTreeNodePropertyKey = @"WKRemoteLayerTreeNode";
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
 static NSString *const WKInteractionRegionContainerKey = @"WKInteractionRegionContainer";

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
@@ -28,13 +28,14 @@
 #import <WebCore/FloatRect.h>
 #import <wtf/Vector.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class RemoteLayerTreeDrawingAreaProxy;
 
 class RemoteLayerTreeScrollingPerformanceData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteLayerTreeScrollingPerformanceData);
 public:
     RemoteLayerTreeScrollingPerformanceData(RemoteLayerTreeDrawingAreaProxy&);
     ~RemoteLayerTreeScrollingPerformanceData();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteLayerTreeScrollingPerformanceData);
+
 RemoteLayerTreeScrollingPerformanceData::RemoteLayerTreeScrollingPerformanceData(RemoteLayerTreeDrawingAreaProxy& drawingArea)
     : m_drawingArea(drawingArea)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -47,6 +47,7 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteScrollingCoordinatorProxy);
 #define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, (webPageProxy().process().connection()), returnValue)
 
 RemoteScrollingCoordinatorProxy::RemoteScrollingCoordinatorProxy(WebPageProxy& webPageProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -37,6 +37,7 @@
 #include <WebCore/WheelEventTestMonitor.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS UIScrollView;
@@ -57,7 +58,7 @@ class WebPageProxy;
 class WebWheelEvent;
 
 class RemoteScrollingCoordinatorProxy : public CanMakeWeakPtr<RemoteScrollingCoordinatorProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxy);
     WTF_MAKE_NONCOPYABLE(RemoteScrollingCoordinatorProxy);
 public:
     explicit RemoteScrollingCoordinatorProxy(WebPageProxy&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -42,6 +42,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteScrollingTree);
+
 RemoteScrollingTree::RemoteScrollingTree(RemoteScrollingCoordinatorProxy& scrollingCoordinator)
     : m_scrollingCoordinatorProxy(WeakPtr { scrollingCoordinator })
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -30,9 +30,9 @@
 #include <WebCore/ScrollingConstraints.h>
 #include <WebCore/ScrollingCoordinatorTypes.h>
 #include <WebCore/ScrollingTree.h>
+#include <WebCore/WheelEventTestMonitor.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <WebCore/WheelEventTestMonitor.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -30,6 +30,8 @@
 #include <WebCore/ScrollingConstraints.h>
 #include <WebCore/ScrollingCoordinatorTypes.h>
 #include <WebCore/ScrollingTree.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <WebCore/WheelEventTestMonitor.h>
 #include <wtf/WeakPtr.h>
 
@@ -42,6 +44,7 @@ namespace WebKit {
 class RemoteScrollingCoordinatorProxy;
 
 class RemoteScrollingTree : public WebCore::ScrollingTree {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteScrollingTree);
 public:
     static Ref<RemoteScrollingTree> create(RemoteScrollingCoordinatorProxy&);
     virtual ~RemoteScrollingTree();
@@ -91,6 +94,7 @@ protected:
 };
 
 class RemoteLayerTreeHitTestLocker {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RemoteScrollingTree);
 public:
     RemoteLayerTreeHitTestLocker(RemoteScrollingTree& scrollingTree)
         : m_scrollingTree(scrollingTree)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RemoteLayerTreeDrawingAreaProxy.h"
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(IOS_FAMILY)
 
@@ -34,6 +35,7 @@ OBJC_CLASS WKDisplayLinkHandler;
 namespace WebKit {
 
 class RemoteLayerTreeDrawingAreaProxyIOS final : public RemoteLayerTreeDrawingAreaProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaProxyIOS);
 public:
     RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy&, WebProcessProxy&);
     virtual ~RemoteLayerTreeDrawingAreaProxyIOS();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -175,6 +175,8 @@ namespace WebKit {
 using namespace IPC;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDrawingAreaProxyIOS);
+
 RemoteLayerTreeDrawingAreaProxyIOS::RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy& pageProxy, WebProcessProxy& webProcessProxy)
     : RemoteLayerTreeDrawingAreaProxy(pageProxy, webProcessProxy)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(ASYNC_SCROLLING)
 
 #include "RemoteScrollingCoordinatorProxy.h"
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS UIScrollView;
 OBJC_CLASS WKBaseScrollView;
@@ -42,6 +43,7 @@ class RemoteLayerTreeDrawingAreaProxyIOS;
 class RemoteLayerTreeNode;
 
 class RemoteScrollingCoordinatorProxyIOS final : public RemoteScrollingCoordinatorProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxyIOS);
 public:
     explicit RemoteScrollingCoordinatorProxyIOS(WebPageProxy&);
     ~RemoteScrollingCoordinatorProxyIOS() = default;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -56,6 +56,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteScrollingCoordinatorProxyIOS);
+
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, webPageProxy().process().connection())
 
 RemoteScrollingCoordinatorProxyIOS::RemoteScrollingCoordinatorProxyIOS(WebPageProxy& webPageProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteScrollingTreeIOS);
+
 Ref<RemoteScrollingTree> RemoteScrollingTree::create(RemoteScrollingCoordinatorProxy& scrollingCoordinator)
 {
     return adoptRef(*new RemoteScrollingTreeIOS(scrollingCoordinator));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
@@ -28,12 +28,14 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
 
 #include "RemoteScrollingTree.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class RemoteScrollingCoordinatorProxy;
 
 class RemoteScrollingTreeIOS final : public RemoteScrollingTree {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteScrollingTreeIOS);
 public:
     explicit RemoteScrollingTreeIOS(RemoteScrollingCoordinatorProxy&);
     virtual ~RemoteScrollingTreeIOS();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
@@ -30,12 +30,14 @@
 OBJC_CLASS WKBaseScrollView;
 
 #include <WebCore/ScrollingTreeFrameScrollingNode.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ScrollingTreeScrollingNodeDelegateIOS;
 
 class ScrollingTreeFrameScrollingNodeRemoteIOS : public WebCore::ScrollingTreeFrameScrollingNode {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ScrollingTreeFrameScrollingNodeRemoteIOS);
 public:
     static Ref<ScrollingTreeFrameScrollingNodeRemoteIOS> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreeFrameScrollingNodeRemoteIOS();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ScrollingTreeFrameScrollingNodeRemoteIOS);
+
 Ref<ScrollingTreeFrameScrollingNodeRemoteIOS> ScrollingTreeFrameScrollingNodeRemoteIOS::create(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     return adoptRef(*new ScrollingTreeFrameScrollingNodeRemoteIOS(scrollingTree, nodeType, nodeID));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
@@ -28,6 +28,7 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(IOS_FAMILY)
 
 #include <WebCore/ScrollingTreeOverflowScrollingNode.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKBaseScrollView;
 
@@ -36,6 +37,7 @@ namespace WebKit {
 class ScrollingTreeScrollingNodeDelegateIOS;
 
 class ScrollingTreeOverflowScrollingNodeIOS final : public WebCore::ScrollingTreeOverflowScrollingNode {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ScrollingTreeOverflowScrollingNodeIOS);
 public:
     static Ref<ScrollingTreeOverflowScrollingNodeIOS> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreeOverflowScrollingNodeIOS();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
@@ -36,6 +36,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ScrollingTreeOverflowScrollingNodeIOS);
+
 Ref<ScrollingTreeOverflowScrollingNodeIOS> ScrollingTreeOverflowScrollingNodeIOS::create(WebCore::ScrollingTree& scrollingTree, WebCore::ScrollingNodeID nodeID)
 {
     return adoptRef(*new ScrollingTreeOverflowScrollingNodeIOS(scrollingTree, nodeID));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
@@ -28,6 +28,7 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(IOS_FAMILY)
 
 #include <WebCore/ScrollingTreePluginScrollingNode.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKBaseScrollView;
 
@@ -36,6 +37,7 @@ namespace WebKit {
 class ScrollingTreeScrollingNodeDelegateIOS;
 
 class ScrollingTreePluginScrollingNodeIOS final : public WebCore::ScrollingTreePluginScrollingNode {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ScrollingTreePluginScrollingNodeIOS);
 public:
     static Ref<ScrollingTreePluginScrollingNodeIOS> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreePluginScrollingNodeIOS();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
@@ -36,6 +36,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ScrollingTreePluginScrollingNodeIOS);
+
 Ref<ScrollingTreePluginScrollingNodeIOS> ScrollingTreePluginScrollingNodeIOS::create(WebCore::ScrollingTree& scrollingTree, WebCore::ScrollingNodeID nodeID)
 {
     return adoptRef(*new ScrollingTreePluginScrollingNodeIOS(scrollingTree, nodeID));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -30,6 +30,7 @@
 #import <WebCore/ScrollingCoordinator.h>
 #import <WebCore/ScrollingTreeScrollingNode.h>
 #import <WebCore/ScrollingTreeScrollingNodeDelegate.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
 @class CALayer;
@@ -51,7 +52,7 @@ class ScrollingTreeScrollingNode;
 namespace WebKit {
 
 class ScrollingTreeScrollingNodeDelegateIOS final : public WebCore::ScrollingTreeScrollingNodeDelegate, public CanMakeWeakPtr<ScrollingTreeScrollingNodeDelegateIOS> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ScrollingTreeScrollingNodeDelegateIOS);
 public:
     
     enum class AllowOverscrollToPreventScrollPropagation : bool { No, Yes };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -248,6 +248,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ScrollingTreeScrollingNodeDelegateIOS);
+
 ScrollingTreeScrollingNodeDelegateIOS::ScrollingTreeScrollingNodeDelegateIOS(ScrollingTreeScrollingNode& scrollingNode)
     : ScrollingTreeScrollingNodeDelegate(scrollingNode)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -31,6 +31,7 @@
 
 #include "DisplayLinkObserverID.h"
 #include <WebCore/AnimationFrameRate.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -41,6 +42,7 @@ class RemoteScrollingCoordinatorProxy;
 class RemoteScrollingCoordinatorTransaction;
 
 class RemoteLayerTreeDrawingAreaProxyMac final : public RemoteLayerTreeDrawingAreaProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaProxyMac);
 friend class RemoteScrollingCoordinatorProxyMac;
 public:
     RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy&, WebProcessProxy&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -49,13 +49,15 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDrawingAreaProxyMac);
+
 static NSString * const transientZoomAnimationKey = @"wkTransientZoomScale";
 static NSString * const transientZoomCommitAnimationKey = @"wkTransientZoomCommit";
 static NSString * const transientZoomScrollPositionOverrideAnimationKey = @"wkScrollPositionOverride";
 
 class RemoteLayerTreeDisplayLinkClient final : public DisplayLink::Client {
 public:
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RemoteLayerTreeDisplayLinkClient);
 public:
     explicit RemoteLayerTreeDisplayLinkClient(WebPageProxyIdentifier pageID)
         : m_pageIdentifier(pageID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -46,9 +46,11 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteLayerTreeEventDispatcher);
+
 class RemoteLayerTreeEventDispatcherDisplayLinkClient final : public DisplayLink::Client {
 public:
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RemoteLayerTreeEventDispatcherDisplayLinkClient);
 public:
     explicit RemoteLayerTreeEventDispatcherDisplayLinkClient(RemoteLayerTreeEventDispatcher& eventDispatcher)
         : m_eventDispatcher(&eventDispatcher)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -37,6 +37,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/threads/BinarySemaphore.h>
 
@@ -62,7 +63,7 @@ class RemoteLayerTreeEventDispatcherDisplayLinkClient;
 // This class exists to act as a threadsafe DisplayLink::Client client, allowing RemoteScrollingCoordinatorProxyMac to
 // be main-thread only. It's the UI-process analogue of WebPage/EventDispatcher.
 class RemoteLayerTreeEventDispatcher : public ThreadSafeRefCounted<RemoteLayerTreeEventDispatcher>, public MomentumEventDispatcher::Client {
-    WTF_MAKE_FAST_ALLOCATED();
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteLayerTreeEventDispatcher);
     friend class RemoteLayerTreeEventDispatcherDisplayLinkClient;
 public:
     static Ref<RemoteLayerTreeEventDispatcher> create(RemoteScrollingCoordinatorProxyMac&, WebCore::PageIdentifier);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -29,6 +29,7 @@
 
 #include "RemoteLayerTreeEventDispatcher.h"
 #include "RemoteScrollingCoordinatorProxy.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -37,6 +38,7 @@ class RemoteLayerTreeEventDispatcher;
 #endif
 
 class RemoteScrollingCoordinatorProxyMac final : public RemoteScrollingCoordinatorProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteScrollingCoordinatorProxyMac);
 public:
     explicit RemoteScrollingCoordinatorProxyMac(WebPageProxy&);
     ~RemoteScrollingCoordinatorProxyMac();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -47,6 +47,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteScrollingCoordinatorProxyMac);
+
 RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac(WebPageProxy& webPageProxy)
     : RemoteScrollingCoordinatorProxy(webPageProxy)
 #if ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -32,6 +32,7 @@
 #include "RemoteScrollingCoordinator.h"
 #include <WebCore/ScrollingConstraints.h>
 #include <WebCore/ScrollingTree.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class PlatformMouseEvent;
@@ -42,6 +43,7 @@ namespace WebKit {
 class RemoteScrollingCoordinatorProxy;
 
 class RemoteScrollingTreeMac final : public RemoteScrollingTree {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemoteScrollingTreeMac);
 public:
     explicit RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy&);
     virtual ~RemoteScrollingTreeMac();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -48,6 +48,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemoteScrollingTreeMac);
+
 Ref<RemoteScrollingTree> RemoteScrollingTree::create(RemoteScrollingCoordinatorProxy& scrollingCoordinator)
 {
     return adoptRef(*new RemoteScrollingTreeMac(scrollingCoordinator));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -33,6 +33,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ScrollingTreeFrameScrollingNodeRemoteMac);
+
 ScrollingTreeFrameScrollingNodeRemoteMac::ScrollingTreeFrameScrollingNodeRemoteMac(ScrollingTree& tree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
     : ScrollingTreeFrameScrollingNodeMac(tree, nodeType, nodeID)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
@@ -28,12 +28,14 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include <WebCore/ScrollingTreeFrameScrollingNodeMac.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ScrollerPairMac;
 
 class ScrollingTreeFrameScrollingNodeRemoteMac : public WebCore::ScrollingTreeFrameScrollingNodeMac {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ScrollingTreeFrameScrollingNodeRemoteMac);
 public:
     static Ref<ScrollingTreeFrameScrollingNodeRemoteMac> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreeFrameScrollingNodeRemoteMac();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -35,6 +35,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ScrollingTreeOverflowScrollingNodeRemoteMac);
+
 Ref<ScrollingTreeOverflowScrollingNodeRemoteMac> ScrollingTreeOverflowScrollingNodeRemoteMac::create(ScrollingTree& tree, ScrollingNodeID nodeID)
 {
     return adoptRef(*new ScrollingTreeOverflowScrollingNodeRemoteMac(tree, nodeID));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
@@ -28,12 +28,14 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include <WebCore/ScrollingTreeOverflowScrollingNodeMac.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ScrollerPairMac;
 
 class ScrollingTreeOverflowScrollingNodeRemoteMac : public WebCore::ScrollingTreeOverflowScrollingNodeMac {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ScrollingTreeOverflowScrollingNodeRemoteMac);
 public:
     static Ref<ScrollingTreeOverflowScrollingNodeRemoteMac> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreeOverflowScrollingNodeRemoteMac();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.cpp
@@ -35,6 +35,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ScrollingTreePluginScrollingNodeRemoteMac);
+
 Ref<ScrollingTreePluginScrollingNodeRemoteMac> ScrollingTreePluginScrollingNodeRemoteMac::create(ScrollingTree& tree, ScrollingNodeID nodeID)
 {
     return adoptRef(*new ScrollingTreePluginScrollingNodeRemoteMac(tree, nodeID));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreePluginScrollingNodeRemoteMac.h
@@ -28,12 +28,14 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include <WebCore/ScrollingTreePluginScrollingNodeMac.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ScrollerPairMac;
 
 class ScrollingTreePluginScrollingNodeRemoteMac : public WebCore::ScrollingTreePluginScrollingNodeMac {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ScrollingTreePluginScrollingNodeRemoteMac);
 public:
     static Ref<ScrollingTreePluginScrollingNodeRemoteMac> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreePluginScrollingNodeRemoteMac();

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemotePageDrawingAreaProxy);
+
 RemotePageDrawingAreaProxy::RemotePageDrawingAreaProxy(DrawingAreaProxy& drawingArea, WebProcessProxy& process)
     : m_drawingArea(drawingArea)
     , m_identifier(drawingArea.identifier())

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -28,6 +28,7 @@
 #include "DrawingAreaInfo.h"
 #include "MessageReceiver.h"
 #include "MessageReceiverMap.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -35,7 +36,7 @@ class DrawingAreaProxy;
 class WebProcessProxy;
 
 class RemotePageDrawingAreaProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemotePageDrawingAreaProxy);
 public:
     RemotePageDrawingAreaProxy(DrawingAreaProxy&, WebProcessProxy&);
     ~RemotePageDrawingAreaProxy();

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -45,6 +45,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RemotePageProxy);
+
 RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, const WebCore::RegistrableDomain& domain, WebPageProxyMessageReceiverRegistration* registrationToTransfer)
     : m_webPageID(page.webPageID())
     , m_process(process)

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace IPC {
@@ -68,7 +69,7 @@ struct FrameTreeCreationParameters;
 struct NavigationActionData;
 
 class RemotePageProxy : public RefCounted<RemotePageProxy>, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(RemotePageProxy);
 public:
     static Ref<RemotePageProxy> create(WebPageProxy& page, WebProcessProxy& process, const WebCore::RegistrableDomain& domain, WebPageProxyMessageReceiverRegistration* registrationToTransfer = nullptr) { return adoptRef(*new RemotePageProxy(page, process, domain, registrationToTransfer)); }
     ~RemotePageProxy();

--- a/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
+++ b/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
@@ -27,11 +27,12 @@
 
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 class RemotePageVisitedLinkStoreRegistration {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RemotePageVisitedLinkStoreRegistration);
 public:
     RemotePageVisitedLinkStoreRegistration(WebPageProxy& page, WebProcessProxy& process)
         : m_page(page)

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SpeechRecognitionPermissionManager);
+
 static SpeechRecognitionPermissionManager::CheckResult computeMicrophoneAccess()
 {
 #if HAVE(AVCAPTUREDEVICE)

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
@@ -27,6 +27,7 @@
 
 #include "SpeechRecognitionPermissionRequest.h"
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class SpeechRecognitionPermissionManager : public CanMakeWeakPtr<SpeechRecognitionPermissionManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SpeechRecognitionPermissionManager);
 public:
     enum class CheckResult { Denied, Granted, Unknown };
     explicit SpeechRecognitionPermissionManager(WebPageProxy&);

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SpeechRecognitionRemoteRealtimeMediaSourceManager);
+
 SpeechRecognitionRemoteRealtimeMediaSourceManager::SpeechRecognitionRemoteRealtimeMediaSourceManager(Ref<IPC::Connection>&& connection)
     : m_connection(WTFMove(connection))
 {

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"
@@ -48,7 +49,7 @@ namespace WebKit {
 class SpeechRecognitionRemoteRealtimeMediaSource;
 
 class SpeechRecognitionRemoteRealtimeMediaSourceManager final : public IPC::MessageReceiver, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SpeechRecognitionRemoteRealtimeMediaSourceManager);
 public:
     explicit SpeechRecognitionRemoteRealtimeMediaSourceManager(Ref<IPC::Connection>&&);
     void addSource(SpeechRecognitionRemoteRealtimeMediaSource&, const WebCore::CaptureDevice&);

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SpeechRecognitionServer);
+
 SpeechRecognitionServer::SpeechRecognitionServer(Ref<IPC::Connection>&& connection, SpeechRecognitionServerIdentifier identifier, SpeechRecognitionPermissionChecker&& permissionChecker, SpeechRecognitionCheckIfMockSpeechRecognitionEnabled&& checkIfEnabled
 #if ENABLE(MEDIA_STREAM)
     , RealtimeMediaSourceCreateFunction&& function

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -34,6 +34,7 @@
 #include <WebCore/SpeechRecognitionResultData.h>
 #include <WebCore/SpeechRecognizer.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 enum class SpeechRecognitionUpdateType : uint8_t;
@@ -50,7 +51,7 @@ using SpeechRecognitionPermissionChecker = Function<void(WebCore::SpeechRecognit
 using SpeechRecognitionCheckIfMockSpeechRecognitionEnabled = Function<bool()>;
 
 class SpeechRecognitionServer : public IPC::MessageReceiver, private IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SpeechRecognitionServer);
 public:
 #if ENABLE(MEDIA_STREAM)
     using RealtimeMediaSourceCreateFunction = Function<WebCore::CaptureSourceOrError()>;

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -46,6 +46,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SuspendedPageProxy);
+
 static const Seconds suspensionTimeout { 10_s };
 
 static WeakHashSet<SuspendedPageProxy>& allSuspendedPages()

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -33,6 +33,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -55,7 +56,7 @@ using LayerHostingContextID = uint32_t;
 enum class ShouldDelayClosingUntilFirstLayerFlush : bool { No, Yes };
 
 class SuspendedPageProxy final: public IPC::MessageReceiver, public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SuspendedPageProxy);
 public:
     SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&&, RemotePageProxyState&&, ShouldDelayClosingUntilFirstLayerFlush);
     ~SuspendedPageProxy();

--- a/Source/WebKit/UIProcess/SystemPreviewController.cpp
+++ b/Source/WebKit/UIProcess/SystemPreviewController.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SystemPreviewController);
+
 SystemPreviewController::SystemPreviewController(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
 {

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -32,6 +32,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/ResourceError.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
@@ -53,7 +54,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class SystemPreviewController : public CanMakeWeakPtr<SystemPreviewController> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SystemPreviewController);
 public:
     explicit SystemPreviewController(WebPageProxy&);
 

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebScriptMessageHandler);
+
 Ref<WebScriptMessageHandler> WebScriptMessageHandler::create(std::unique_ptr<Client> client, const String& name, API::ContentWorld& world)
 {
     return adoptRef(*new WebScriptMessageHandler(WTFMove(client), name, world));

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
@@ -30,6 +30,7 @@
 #include <wtf/Identified.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -49,6 +50,7 @@ class WebFrameProxy;
 struct FrameInfoData;
 
 class WebScriptMessageHandler : public RefCounted<WebScriptMessageHandler>, public Identified<WebScriptMessageHandler>  {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebScriptMessageHandler);
 public:
     class Client {
     public:

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -62,6 +62,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UserMediaPermissionRequestManagerProxy);
+
 #if ENABLE(MEDIA_STREAM)
 static const MediaProducerMediaStateFlags activeCaptureMask { MediaProducerMediaState::HasActiveAudioCaptureDevice, MediaProducerMediaState::HasActiveVideoCaptureDevice };
 #endif

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -61,7 +62,7 @@ class UserMediaPermissionRequestManagerProxy
     , private LoggerHelper
 #endif
 {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(UserMediaPermissionRequestManagerProxy);
 public:
     explicit UserMediaPermissionRequestManagerProxy(WebPageProxy&);
     ~UserMediaPermissionRequestManagerProxy();

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -55,6 +55,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ViewGestureController);
+
 static const Seconds swipeSnapshotRemovalWatchdogAfterFirstVisuallyNonEmptyLayoutDuration { 3_s };
 static const Seconds swipeSnapshotRemovalActiveLoadMonitoringInterval { 250_ms };
 static const Seconds swipeSnapshotRemovalWatchdogDuration = 3_s;

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -35,6 +35,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
@@ -100,7 +101,7 @@ class WebPageProxy;
 class WebProcessProxy;
 
 class ViewGestureController : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ViewGestureController);
     WTF_MAKE_NONCOPYABLE(ViewGestureController);
 public:
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(Authenticator);
+
 void Authenticator::handleRequest(const WebAuthenticationRequestData& data)
 {
     m_pendingRequestData = data;

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
@@ -33,6 +33,7 @@
 #include <WebCore/ExceptionData.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/spi/cocoa/SecuritySPI.h>
 
@@ -45,6 +46,7 @@ class AuthenticatorAssertionResponse;
 namespace WebKit {
 
 class Authenticator : public RefCounted<Authenticator>, public CanMakeWeakPtr<Authenticator> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(Authenticator);
 public:
     using Respond = std::variant<Ref<WebCore::AuthenticatorResponse>, WebCore::ExceptionData>;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -50,6 +50,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AuthenticatorManager);
+
 namespace {
 
 // Suggested by WebAuthN spec as of 7 August 2018.

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -37,6 +37,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 OBJC_CLASS LAContext;
@@ -48,7 +49,7 @@ class WebAuthenticationPanel;
 namespace WebKit {
 
 class AuthenticatorManager : public AuthenticatorTransportService::Observer, public Authenticator::Observer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AuthenticatorManager);
     WTF_MAKE_NONCOPYABLE(AuthenticatorManager);
 public:
     using Respond = std::variant<Ref<WebCore::AuthenticatorResponse>, WebCore::ExceptionData>;

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
@@ -40,6 +40,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AuthenticatorTransportService);
+
 UniqueRef<AuthenticatorTransportService> AuthenticatorTransportService::create(WebCore::AuthenticatorTransport transport, Observer& observer)
 {
     switch (transport) {

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
@@ -29,6 +29,8 @@
 
 #include "WebAuthenticationFlags.h"
 #include <WebCore/AuthenticatorTransport.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -41,10 +43,11 @@ namespace WebKit {
 class Authenticator;
 
 class AuthenticatorTransportService : public CanMakeWeakPtr<AuthenticatorTransportService> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AuthenticatorTransportService);
     WTF_MAKE_NONCOPYABLE(AuthenticatorTransportService);
 public:
     class Observer : public CanMakeWeakPtr<Observer> {
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(Observer);
     public:
         virtual ~Observer() = default;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h
@@ -34,6 +34,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS ASCAppleIDCredential;
@@ -49,7 +50,7 @@ namespace WebKit {
 class AuthenticatorManager;
 
 class AuthenticatorPresenterCoordinator : public CanMakeWeakPtr<AuthenticatorPresenterCoordinator> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AuthenticatorPresenterCoordinator);
     WTF_MAKE_NONCOPYABLE(AuthenticatorPresenterCoordinator);
 public:
     using TransportSet = HashSet<WebCore::AuthenticatorTransport, WTF::IntHash<WebCore::AuthenticatorTransport>, WTF::StrongEnumHashTraits<WebCore::AuthenticatorTransport>>;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AuthenticatorPresenterCoordinator);
+
 AuthenticatorPresenterCoordinator::AuthenticatorPresenterCoordinator(const AuthenticatorManager& manager, const String& rpId, const TransportSet& transports, ClientDataType type, const String& username)
     : m_manager(manager)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h
@@ -30,6 +30,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS TKSmartCard;
@@ -40,6 +41,7 @@ class CcidService;
 using DataReceivedCallback = Function<void(Vector<uint8_t>&&)>;
 
 class CcidConnection : public RefCounted<CcidConnection>, public CanMakeWeakPtr<CcidConnection> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CcidConnection);
 public:
     static Ref<CcidConnection> create(RetainPtr<TKSmartCard>&&, CcidService&);
     ~CcidConnection();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -36,6 +36,8 @@
 namespace WebKit {
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CcidConnection);
+
 namespace {
 
 // FIXME: This is duplicate code with compareVersion in NfcConnection.mm.

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
@@ -30,6 +30,7 @@
 #include "FidoService.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSArray;
 OBJC_CLASS TKSmartCardSlot;
@@ -42,6 +43,7 @@ namespace WebKit {
 class CcidConnection;
 
 class CcidService : public FidoService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CcidService);
 public:
     explicit CcidService(Observer&);
     ~CcidService();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
@@ -55,6 +55,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CcidService);
+
 CcidService::CcidService(Observer& observer)
     : FidoService(observer)
     , m_restartTimer(RunLoop::main(), this, &CcidService::platformStartDiscovery)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h
@@ -34,11 +34,12 @@
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class HidConnection {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(HidConnection);
     WTF_MAKE_NONCOPYABLE(HidConnection);
 public:
     enum class DataSent : bool { No, Yes };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -35,6 +35,8 @@
 namespace WebKit {
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(HidConnection);
+
 // FIXME(191518)
 static void reportReceived(void* context, IOReturn status, void*, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.h
@@ -30,6 +30,7 @@
 #include "FidoService.h"
 #include <pal/spi/cocoa/IOKitSPI.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
@@ -37,6 +38,7 @@ namespace WebKit {
 class HidConnection;
 
 class HidService : public FidoService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(HidService);
 public:
     explicit HidService(Observer&);
     ~HidService();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
@@ -34,6 +34,8 @@
 namespace WebKit {
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(HidService);
+
 // FIXME(191518)
 static void deviceAddedCallback(void* context, IOReturn, void*, IOHIDDeviceRef device)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
@@ -29,6 +29,7 @@
 
 #include "Authenticator.h"
 #include "LocalConnection.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 OBJC_CLASS LAContext;
@@ -41,6 +42,7 @@ class AuthenticatorAssertionResponse;
 namespace WebKit {
 
 class LocalAuthenticator final : public Authenticator {
+    WTF_MAKE_WK_TZONE_ALLOCATED(LocalAuthenticator);
 public:
     // Here is the FSM.
     // MakeCredential: Init => RequestReceived => PolicyDecided => UserVerified => (Attested) => End

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -80,6 +80,8 @@ using namespace WebCore;
 using namespace WebAuthn;
 using CBOR = cbor::CBORValue;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LocalAuthenticator);
+
 namespace LocalAuthenticatorInternal {
 
 // Credential ID is currently SHA-1 of the corresponding public key.

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
@@ -30,6 +30,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -49,7 +50,7 @@ namespace WebKit {
 // that are not allowed in auto test environment such that some mocking
 // mechnism can override them.
 class LocalConnection {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LocalConnection);
     WTF_MAKE_NONCOPYABLE(LocalConnection);
 public:
     enum class UserVerification : uint8_t {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -46,6 +46,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LocalConnection);
+
 namespace {
 #if PLATFORM(MAC)
 static inline String bundleName()

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.h
@@ -28,12 +28,14 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "AuthenticatorTransportService.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class LocalConnection;
 
 class LocalService : public AuthenticatorTransportService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(LocalService);
 public:
     explicit LocalService(Observer&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
@@ -42,6 +42,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LocalService);
+
 LocalService::LocalService(Observer& observer)
     : AuthenticatorTransportService(observer)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.h
@@ -30,6 +30,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS NFReaderSession;
@@ -41,6 +42,7 @@ namespace WebKit {
 class NfcService;
 
 class NfcConnection : public RefCounted<NfcConnection>, public CanMakeWeakPtr<NfcConnection> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NfcConnection);
 public:
     static Ref<NfcConnection> create(RetainPtr<NFReaderSession>&&, NfcService&);
     ~NfcConnection();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NfcConnection);
+
 namespace {
 inline bool compareVersion(NSData *data, const uint8_t version[], size_t versionSize)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h
@@ -29,6 +29,7 @@
 
 #include "FidoService.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NFReaderSession;
 
@@ -37,6 +38,7 @@ namespace WebKit {
 class NfcConnection;
 
 class NfcService : public FidoService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NfcService);
 public:
     explicit NfcService(Observer&);
     ~NfcService();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
@@ -39,6 +39,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NfcService);
+
 NfcService::NfcService(Observer& observer)
     : FidoService(observer)
     , m_restartTimer(RunLoop::main(), this, &NfcService::platformStartDiscovery)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.h
@@ -31,6 +31,7 @@
 
 #import "APIWebAuthenticationPanelClient.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
@@ -40,6 +41,7 @@
 namespace WebKit {
 
 class WebAuthenticationPanelClient final : public API::WebAuthenticationPanelClient, public CanMakeWeakPtr<WebAuthenticationPanelClient> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebAuthenticationPanelClient);
 public:
     WebAuthenticationPanelClient(_WKWebAuthenticationPanel *, id <_WKWebAuthenticationPanelDelegate>);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -41,6 +41,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebAuthenticationPanelClient);
+
 WebAuthenticationPanelClient::WebAuthenticationPanelClient(_WKWebAuthenticationPanel *panel, id <_WKWebAuthenticationPanelDelegate> delegate)
     : m_panel(panel)
     , m_delegate(delegate)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MockAuthenticatorManager);
+
 MockAuthenticatorManager::MockAuthenticatorManager(WebCore::MockWebAuthenticationConfiguration&& configuration)
     : m_testConfiguration(WTFMove(configuration))
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.h
@@ -29,10 +29,12 @@
 
 #include "AuthenticatorManager.h"
 #include <WebCore/MockWebAuthenticationConfiguration.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class MockAuthenticatorManager final : public AuthenticatorManager {
+    WTF_MAKE_WK_TZONE_ALLOCATED(MockAuthenticatorManager);
 public:
     explicit MockAuthenticatorManager(WebCore::MockWebAuthenticationConfiguration&&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h
@@ -29,12 +29,14 @@
 
 #include "CcidService.h"
 #include <WebCore/MockWebAuthenticationConfiguration.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSData;
 
 namespace WebKit {
 
 class MockCcidService final : public CcidService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(MockCcidService);
 public:
     MockCcidService(Observer&, const WebCore::MockWebAuthenticationConfiguration&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
@@ -67,6 +67,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MockCcidService);
+
 MockCcidService::MockCcidService(Observer& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
     : CcidService(observer)
     , m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
@@ -44,6 +44,8 @@ using namespace WebCore;
 using namespace cbor;
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MockHidConnection);
+
 MockHidConnection::MockHidConnection(IOHIDDeviceRef device, const MockWebAuthenticationConfiguration& configuration)
     : HidConnection(device)
     , m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.h
@@ -30,6 +30,7 @@
 #include "HidConnection.h"
 #include <WebCore/FidoHidMessage.h>
 #include <WebCore/MockWebAuthenticationConfiguration.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -44,6 +45,7 @@ namespace WebKit {
 // FSM: Info::Init => Info::Msg => [Request::Init => Request::Msg]+
 // According to different combinations of error and stages, error will manifest differently.
 class MockHidConnection final : public CanMakeWeakPtr<MockHidConnection>, public HidConnection {
+    WTF_MAKE_WK_TZONE_ALLOCATED(MockHidConnection);
 public:
     MockHidConnection(IOHIDDeviceRef, const WebCore::MockWebAuthenticationConfiguration&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MockHidService);
+
 MockHidService::MockHidService(Observer& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
     : HidService(observer)
     , m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidService.h
@@ -29,10 +29,12 @@
 
 #include "HidService.h"
 #include <WebCore/MockWebAuthenticationConfiguration.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class MockHidService final : public HidService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(MockHidService);
 public:
     MockHidService(Observer&, const WebCore::MockWebAuthenticationConfiguration&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
@@ -30,10 +30,12 @@
 #include "LocalConnection.h"
 #include <WebCore/AuthenticatorAssertionResponse.h>
 #include <WebCore/MockWebAuthenticationConfiguration.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class MockLocalConnection final : public LocalConnection {
+    WTF_MAKE_WK_TZONE_ALLOCATED(MockLocalConnection);
 public:
     explicit MockLocalConnection(const WebCore::MockWebAuthenticationConfiguration&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
@@ -42,6 +42,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MockLocalConnection);
+
 MockLocalConnection::MockLocalConnection(const MockWebAuthenticationConfiguration& configuration)
     : m_configuration(configuration)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.h
@@ -29,10 +29,12 @@
 
 #include "LocalService.h"
 #include <WebCore/MockWebAuthenticationConfiguration.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class MockLocalService final : public LocalService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(MockLocalService);
 public:
     MockLocalService(Observer&, const WebCore::MockWebAuthenticationConfiguration&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
@@ -39,6 +39,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MockLocalService);
+
 MockLocalService::MockLocalService(Observer& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
     : LocalService(observer)
     , m_configuration(configuration)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.h
@@ -29,12 +29,14 @@
 
 #include "NfcService.h"
 #include <WebCore/MockWebAuthenticationConfiguration.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSData;
 
 namespace WebKit {
 
 class MockNfcService final : public NfcService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(MockNfcService);
 public:
     MockNfcService(Observer&, const WebCore::MockWebAuthenticationConfiguration&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -128,6 +128,8 @@ namespace WebKit {
 using namespace fido;
 using Mock = WebCore::MockWebAuthenticationConfiguration;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MockNfcService);
+
 #if HAVE(NEAR_FIELD)
 
 namespace {

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
@@ -35,6 +35,8 @@ namespace WebKit {
 
 struct VirtualCredential;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(VirtualAuthenticatorManager);
+
 VirtualAuthenticatorManager::VirtualAuthenticatorManager()
     : AuthenticatorManager()
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h
@@ -30,12 +30,14 @@
 #include "AuthenticatorManager.h"
 #include "VirtualAuthenticatorConfiguration.h"
 #include "VirtualCredential.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
 struct VirtualCredential;
 
 class VirtualAuthenticatorManager final : public AuthenticatorManager {
+    WTF_MAKE_WK_TZONE_ALLOCATED(VirtualAuthenticatorManager);
 public:
     explicit VirtualAuthenticatorManager();
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
@@ -43,6 +43,8 @@ using namespace cbor;
 using namespace fido;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(VirtualHidConnection);
+
 const size_t CtapChannelIdSize = 4;
 
 VirtualHidConnection::VirtualHidConnection(const String& authenticatorId, const VirtualAuthenticatorConfiguration& configuration, const WeakPtr<VirtualAuthenticatorManager>& manager)

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.h
@@ -30,6 +30,7 @@
 #include "HidConnection.h"
 #include "VirtualAuthenticatorConfiguration.h"
 #include <WebCore/FidoHidMessage.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -37,6 +38,7 @@ struct VirtualAuthenticatorConfiguration;
 class VirtualAuthenticatorManager;
 
 class VirtualHidConnection final : public CanMakeWeakPtr<VirtualHidConnection>, public HidConnection {
+    WTF_MAKE_WK_TZONE_ALLOCATED(VirtualHidConnection);
 public:
     explicit VirtualHidConnection(const String& authenticatorId, const VirtualAuthenticatorConfiguration&, const WeakPtr<VirtualAuthenticatorManager>&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.h
@@ -29,12 +29,14 @@
 
 #include "LocalConnection.h"
 #include "VirtualAuthenticatorConfiguration.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
 struct VirtualAuthenticatorConfiguration;
 
 class VirtualLocalConnection final : public CanMakeWeakPtr<VirtualLocalConnection>, public LocalConnection {
+    WTF_MAKE_WK_TZONE_ALLOCATED(VirtualLocalConnection);
 public:
     explicit VirtualLocalConnection(const VirtualAuthenticatorConfiguration&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm
@@ -44,6 +44,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(VirtualLocalConnection);
+
 VirtualLocalConnection::VirtualLocalConnection(const VirtualAuthenticatorConfiguration& configuration)
     : m_configuration(configuration)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.h
@@ -30,6 +30,7 @@
 #include "AuthenticatorTransportService.h"
 #include "VirtualAuthenticatorConfiguration.h"
 #include "VirtualCredential.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -37,6 +38,7 @@ namespace WebKit {
 class VirtualAuthenticatorManager;
 
 class VirtualService : public AuthenticatorTransportService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(VirtualService);
 public:
     explicit VirtualService(Observer&, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
@@ -43,6 +43,8 @@ namespace WebKit {
 using namespace fido;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(VirtualService);
+
 VirtualService::VirtualService(Observer& observer, Vector<std::pair<String, VirtualAuthenticatorConfiguration>>& authenticators)
     : AuthenticatorTransportService(observer), m_authenticators(authenticators)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
@@ -47,6 +47,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebAuthenticatorCoordinatorProxy);
+
 WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -34,6 +34,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 #if HAVE(WEB_AUTHN_AS_MODERN)
 OBJC_CLASS _WKASDelegate;
@@ -71,7 +72,7 @@ using CapabilitiesCompletionHandler = CompletionHandler<void(Vector<KeyValuePair
 using RequestCompletionHandler = CompletionHandler<void(const WebCore::AuthenticatorResponseData&, WebCore::AuthenticatorAttachment, const WebCore::ExceptionData&)>;
 
 class WebAuthenticatorCoordinatorProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebAuthenticatorCoordinatorProxy);
     WTF_MAKE_NONCOPYABLE(WebAuthenticatorCoordinatorProxy);
 public:
     explicit WebAuthenticatorCoordinatorProxy(WebPageProxy&);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -50,6 +50,8 @@ namespace WebKit {
 using namespace WebCore;
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CtapAuthenticator);
+
 using UVAvailability = AuthenticatorSupportedOptions::UserVerificationAvailability;
 
 namespace {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -29,6 +29,7 @@
 
 #include "FidoAuthenticator.h"
 #include <WebCore/AuthenticatorGetInfoResponse.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace fido {
 namespace pin {
@@ -45,6 +46,7 @@ namespace WebKit {
 class CtapDriver;
 
 class CtapAuthenticator final : public FidoAuthenticator {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CtapAuthenticator);
 public:
     static Ref<CtapAuthenticator> create(std::unique_ptr<CtapDriver>&& driver, fido::AuthenticatorGetInfoResponse&& info)
     {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
@@ -36,6 +36,8 @@ namespace WebKit {
 using namespace apdu;
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CtapCcidDriver);
+
 CtapCcidDriver::CtapCcidDriver(Ref<CcidConnection>&& connection, WebCore::AuthenticatorTransport transport)
     : CtapDriver(transport)
     , m_connection(WTFMove(connection))

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h
@@ -29,6 +29,7 @@
 
 #include "CcidConnection.h"
 #include "CtapDriver.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
@@ -36,6 +37,7 @@ namespace WebKit {
 // The following implements the CTAP NFC protocol:
 // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc
 class CtapCcidDriver : public CtapDriver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CtapCcidDriver);
 public:
     explicit CtapCcidDriver(Ref<CcidConnection>&&, WebCore::AuthenticatorTransport);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
@@ -32,12 +32,13 @@
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
 class CtapDriver : public CanMakeWeakPtr<CtapDriver> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(CtapDriver);
     WTF_MAKE_NONCOPYABLE(CtapDriver);
 public:
     using ResponseCallback = Function<void(Vector<uint8_t>&&)>;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CtapHidDriver);
+
 CtapHidDriver::Worker::Worker(UniqueRef<HidConnection>&& connection)
     : m_connection(WTFMove(connection))
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h
@@ -30,6 +30,8 @@
 #include "CtapDriver.h"
 #include "HidConnection.h"
 #include <WebCore/FidoHidMessage.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
@@ -38,6 +40,7 @@ namespace WebKit {
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#usb
 // FSM: Idle => AllocateChannel => Ready
 class CtapHidDriver final : public CtapDriver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CtapHidDriver);
 public:
     enum class State : uint8_t {
         Idle,
@@ -57,7 +60,7 @@ private:
     // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#arbitration
     // FSM: Idle => Write => Read.
     class Worker : public CanMakeWeakPtr<Worker> {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(Worker);
         WTF_MAKE_NONCOPYABLE(Worker);
     public:
         using MessageCallback = Function<void(std::optional<fido::FidoHidMessage>&&)>;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
@@ -36,6 +36,8 @@ namespace WebKit {
 using namespace apdu;
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CtapNfcDriver);
+
 CtapNfcDriver::CtapNfcDriver(Ref<NfcConnection>&& connection)
     : CtapDriver(WebCore::AuthenticatorTransport::Nfc)
     , m_connection(WTFMove(connection))

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.h
@@ -29,6 +29,7 @@
 
 #include "CtapDriver.h"
 #include "NfcConnection.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
@@ -36,6 +37,7 @@ namespace WebKit {
 // The following implements the CTAP NFC protocol:
 // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc
 class CtapNfcDriver : public CtapDriver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CtapNfcDriver);
 public:
     explicit CtapNfcDriver(Ref<NfcConnection>&&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FidoAuthenticator);
+
 FidoAuthenticator::FidoAuthenticator(std::unique_ptr<CtapDriver>&& driver)
     : m_driver(WTFMove(driver))
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
@@ -28,12 +28,14 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "Authenticator.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class CtapDriver;
 
 class FidoAuthenticator : public Authenticator {
+    WTF_MAKE_WK_TZONE_ALLOCATED(FidoAuthenticator);
 public:
     ~FidoAuthenticator() override;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
@@ -41,6 +41,8 @@
 namespace WebKit {
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FidoService);
+
 FidoService::FidoService(Observer& observer)
     : AuthenticatorTransportService(observer)
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
@@ -30,11 +30,13 @@
 #include "AuthenticatorTransportService.h"
 #include "CtapDriver.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
 
 class FidoService : public AuthenticatorTransportService {
+    WTF_MAKE_WK_TZONE_ALLOCATED(FidoService);
 public:
     explicit FidoService(Observer&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -41,6 +41,8 @@ using namespace WebCore;
 using namespace apdu;
 using namespace fido;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(U2fAuthenticator);
+
 namespace {
 const unsigned retryTimeOutValueMs = 200;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h
@@ -29,6 +29,7 @@
 
 #include "FidoAuthenticator.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace apdu {
 class ApduResponse;
@@ -39,6 +40,7 @@ namespace WebKit {
 class CtapDriver;
 
 class U2fAuthenticator final : public FidoAuthenticator {
+    WTF_MAKE_WK_TZONE_ALLOCATED(U2fAuthenticator);
 public:
     static Ref<U2fAuthenticator> create(std::unique_ptr<CtapDriver>&& driver)
     {

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebBackForwardCache);
+
 WebBackForwardCache::WebBackForwardCache(WebProcessPool& processPool)
     : m_processPool(processPool)
 {

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -29,6 +29,7 @@
 #include <pal/SessionID.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
@@ -41,7 +42,7 @@ class WebProcessPool;
 class WebProcessProxy;
 
 class WebBackForwardCache : public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebBackForwardCache);
 public:
     explicit WebBackForwardCache(WebProcessPool&);
     ~WebBackForwardCache();

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -36,6 +36,8 @@ namespace WebKit {
 
 static const Seconds expirationDelay { 30_min };
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebBackForwardCacheEntry);
+
 WebBackForwardCacheEntry::WebBackForwardCacheEntry(WebBackForwardCache& backForwardCache, WebCore::BackForwardItemIdentifier backForwardItemID, WebCore::ProcessIdentifier processIdentifier, std::unique_ptr<SuspendedPageProxy>&& suspendedPage)
     : m_backForwardCache(backForwardCache)
     , m_processIdentifier(processIdentifier)

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -29,6 +29,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -37,7 +38,7 @@ class WebBackForwardCache;
 class WebProcessProxy;
 
 class WebBackForwardCacheEntry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebBackForwardCacheEntry);
 public:
     WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, std::unique_ptr<SuspendedPageProxy>&& = nullptr);
     ~WebBackForwardCacheEntry();

--- a/Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebContextInjectedBundleClient);
+
 WebContextInjectedBundleClient::WebContextInjectedBundleClient(const WKContextInjectedBundleClientBase* client)
 {
     initialize(client);

--- a/Source/WebKit/UIProcess/WebContextInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/WebContextInjectedBundleClient.h
@@ -29,6 +29,7 @@
 #include "APIInjectedBundleClient.h"
 #include "WKContextInjectedBundleClient.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 class Object;
@@ -43,7 +44,7 @@ namespace WebKit {
 class WebProcessPool;
 
 class WebContextInjectedBundleClient : public API::InjectedBundleClient, public API::Client<WKContextInjectedBundleClientBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebContextInjectedBundleClient);
 public:
     explicit WebContextInjectedBundleClient(const WKContextInjectedBundleClientBase*);
 

--- a/Source/WebKit/UIProcess/WebFormClient.cpp
+++ b/Source/WebKit/UIProcess/WebFormClient.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebFormClient);
+
 WebFormClient::WebFormClient(const WKPageFormClientBase* wkClient)
 {
     initialize(wkClient);

--- a/Source/WebKit/UIProcess/WebFormClient.h
+++ b/Source/WebKit/UIProcess/WebFormClient.h
@@ -28,6 +28,7 @@
 #include "APIClient.h"
 #include "APIFormClient.h"
 #include "WKPageFormClient.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 template<> struct ClientTraits<WKPageFormClientBase> {
@@ -38,7 +39,7 @@ template<> struct ClientTraits<WKPageFormClientBase> {
 namespace WebKit {
 
 class WebFormClient : public API::FormClient, API::Client<WKPageFormClientBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebFormClient);
 public:
     explicit WebFormClient(const WKPageFormClientBase*);
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -43,6 +43,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebFullScreenManagerProxy);
+
 WebFullScreenManagerProxy::WebFullScreenManagerProxy(WebPageProxy& page, WebFullScreenManagerProxyClient& client)
     : m_page(page)
     , m_client(client)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -34,6 +34,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -70,7 +71,7 @@ public:
 };
 
 class WebFullScreenManagerProxy : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebFullScreenManagerProxy);
 public:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
     virtual ~WebFullScreenManagerProxy();

--- a/Source/WebKit/UIProcess/WebGeolocationProvider.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationProvider.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebGeolocationProvider);
+
 WebGeolocationProvider::WebGeolocationProvider(const WKGeolocationProviderBase* provider)
 {
     initialize(provider);

--- a/Source/WebKit/UIProcess/WebGeolocationProvider.h
+++ b/Source/WebKit/UIProcess/WebGeolocationProvider.h
@@ -30,6 +30,7 @@
 #include "APIGeolocationProvider.h"
 #include "WKGeolocationManager.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 template<> struct ClientTraits<WKGeolocationProviderBase> {
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebGeolocationManagerProxy;
 
 class WebGeolocationProvider : public API::GeolocationProvider, API::Client<WKGeolocationProviderBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebGeolocationProvider);
 public:
     explicit WebGeolocationProvider(const WKGeolocationProviderBase*);
 

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebLockRegistryProxy);
+
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_process.connection())
 
 WebLockRegistryProxy::WebLockRegistryProxy(WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.h
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.h
@@ -29,6 +29,7 @@
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/WebLockIdentifier.h>
 #include <WebCore/WebLockMode.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct ClientOrigin;
@@ -40,7 +41,7 @@ namespace WebKit {
 class WebProcessProxy;
 
 class WebLockRegistryProxy final : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebLockRegistryProxy);
 public:
     explicit WebLockRegistryProxy(WebProcessProxy&);
     ~WebLockRegistryProxy();

--- a/Source/WebKit/UIProcess/WebNavigationState.cpp
+++ b/Source/WebKit/UIProcess/WebNavigationState.cpp
@@ -33,6 +33,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebNavigationState);
+
 WebNavigationState::WebNavigationState()
 {
 }

--- a/Source/WebKit/UIProcess/WebNavigationState.h
+++ b/Source/WebKit/UIProcess/WebNavigationState.h
@@ -28,6 +28,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace API {
@@ -47,7 +48,7 @@ class WebPageProxy;
 class WebBackForwardListItem;
 
 class WebNavigationState : public CanMakeWeakPtr<WebNavigationState> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebNavigationState);
 public:
     explicit WebNavigationState();
     ~WebNavigationState();

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
@@ -35,6 +35,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPageInjectedBundleClient);
+
 void WebPageInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, API::Object* messageBody)
 {
     if (!m_client.didReceiveMessageFromInjectedBundle)

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
@@ -28,6 +28,7 @@
 #include "APIClient.h"
 #include "WKPage.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace API {
 class Object;
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class WebPageInjectedBundleClient : public API::Client<WKPageInjectedBundleClientBase> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPageInjectedBundleClient);
 public:
     void didReceiveMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*);
     void didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -413,7 +413,8 @@ static WorkQueue& sharedFileQueue()
 #endif
 
 class StorageRequests {
-    WTF_MAKE_NONCOPYABLE(StorageRequests); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(StorageRequests);
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(StorageRequests);
     friend NeverDestroyed<StorageRequests>;
 public:
     static StorageRequests& singleton();
@@ -455,7 +456,7 @@ StorageRequests& StorageRequests::singleton()
 
 class WebPageProxyFrameLoadStateObserver final : public FrameLoadState::Observer {
     WTF_MAKE_NONCOPYABLE(WebPageProxyFrameLoadStateObserver);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebPageProxyFrameLoadStateObserver);
 public:
     static constexpr size_t maxVisitedDomainsSize = 6;
 

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
@@ -41,6 +41,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPermissionControllerProxy);
+
 WebPermissionControllerProxy::WebPermissionControllerProxy(WebProcessProxy& process)
     : m_process(process)
 {

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include "WebPageProxyIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 enum class PermissionQuerySource : uint8_t;
@@ -42,7 +43,7 @@ class WebPageProxy;
 class WebProcessProxy;
 
 class WebPermissionControllerProxy final : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPermissionControllerProxy);
 public:
     explicit WebPermissionControllerProxy(WebProcessProxy&);
     ~WebPermissionControllerProxy();

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebProcessCache);
+
 #if PLATFORM(COCOA)
 Seconds WebProcessCache::cachedProcessLifetime { 30_min };
 Seconds WebProcessCache::clearingDelayAfterApplicationResignsActive { 5_min };

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -32,6 +32,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -40,7 +41,7 @@ class WebProcessPool;
 class WebsiteDataStore;
 
 class WebProcessCache : public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebProcessCache);
 public:
     explicit WebProcessCache(WebProcessPool&);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -254,7 +254,7 @@ Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType wo
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 class UIProxyForCapture final : public UserMediaCaptureManagerProxy::ConnectionProxy {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(UIProxyForCapture);
 public:
     explicit UIProxyForCapture(WebProcessProxy& process)
         : m_process(process)

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebScreenOrientationManagerProxy);
+
 WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy(WebPageProxy& page, WebCore::ScreenOrientationType orientation)
     : m_page(page)
     , m_currentOrientation(orientation)

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -29,6 +29,7 @@
 #include <WebCore/ScreenOrientationLockType.h>
 #include <WebCore/ScreenOrientationType.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class Exception;
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class WebScreenOrientationManagerProxy final : public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebScreenOrientationManagerProxy);
 public:
     WebScreenOrientationManagerProxy(WebPageProxy&, WebCore::ScreenOrientationType);
     ~WebScreenOrientationManagerProxy();

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
@@ -37,6 +37,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebDeviceOrientationAndMotionAccessController);
+
 void WebDeviceOrientationAndMotionAccessController::shouldAllowAccess(WebPageProxy& page, WebFrameProxy& frame, FrameInfoData&& frameInfo, bool mayPrompt, CompletionHandler<void(DeviceOrientationOrMotionPermissionState)>&& completionHandler)
 {
     auto originData = SecurityOrigin::createFromString(page.pageLoadState().activeURL())->data();

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.h
@@ -30,6 +30,7 @@
 #include <WebCore/DeviceOrientationOrMotionPermissionState.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -39,6 +40,7 @@ class WebFrameProxy;
 struct FrameInfoData;
 
 class WebDeviceOrientationAndMotionAccessController : public CanMakeWeakPtr<WebDeviceOrientationAndMotionAccessController> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebDeviceOrientationAndMotionAccessController);
 public:
     WebDeviceOrientationAndMotionAccessController() = default;
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -98,6 +98,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebsiteDataStore);
+
 static bool allowsWebsiteDataRecordsForAllOrigins;
 void WebsiteDataStore::allowWebsiteDataRecordsForAllOrigins()
 {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -48,6 +48,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -120,6 +121,7 @@ struct WebsiteDataRecord;
 struct WebsiteDataStoreParameters;
 
 class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public Identified<WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebsiteDataStore);
 public:
     static Ref<WebsiteDataStore> defaultDataStore();
     static bool defaultDataStoreExists();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -32,6 +32,7 @@
 #include <WebCore/NotificationData.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 enum class WindowProxyProperty : uint8_t;
@@ -46,7 +47,7 @@ class WebPageProxy;
 class WebsiteDataStore;
 
 class WebsiteDataStoreClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebsiteDataStoreClient);
 public:
     virtual ~WebsiteDataStoreClient() { }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebsiteDataStoreConfiguration);
+
 WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(IsPersistent isPersistent, ShouldInitializePaths shouldInitializePaths)
     : m_isPersistent(isPersistent)
     , m_unifiedOriginStorageLevel(WebsiteDataStore::defaultUnifiedOriginStorageLevel())

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include <wtf/Markable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 #include <wtf/UUID.h>
 #include <wtf/text/WTFString.h>
@@ -42,6 +43,7 @@ struct WebPushDaemonConnectionConfiguration;
 enum class IsPersistent : bool { No, Yes };
 
 class WebsiteDataStoreConfiguration : public API::ObjectImpl<API::Object::Type::WebsiteDataStoreConfiguration> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebsiteDataStoreConfiguration);
 public:
     enum class ShouldInitializePaths : bool { No, Yes };
     static Ref<WebsiteDataStoreConfiguration> create(IsPersistent isPersistent) { return adoptRef(*new WebsiteDataStoreConfiguration(isPersistent, ShouldInitializePaths::Yes)); }

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -39,6 +39,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PlatformXRSystem);
+
 PlatformXRSystem::PlatformXRSystem(WebPageProxy& page)
     : m_page(page)
 {

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -32,6 +32,7 @@
 #include "ProcessThrottler.h"
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/PlatformXR.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class SecurityOriginData;
@@ -45,7 +46,7 @@ class WebPageProxy;
 struct XRDeviceInfo;
 
 class PlatformXRSystem : public IPC::MessageReceiver, public PlatformXRCoordinator::SessionEventClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(PlatformXRSystem);
 public:
     PlatformXRSystem(WebPageProxy&);
     virtual ~PlatformXRSystem();

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -31,6 +31,7 @@
 #import "PlatformXRCoordinator.h"
 
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Threading.h>
 #import <wtf/threads/BinarySemaphore.h>
 
@@ -40,7 +41,7 @@
 namespace WebKit {
 
 class ARKitCoordinator final : public PlatformXRCoordinator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ARKitCoordinator);
     struct RenderState;
 public:
     ARKitCoordinator();

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -40,6 +40,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ARKitCoordinator);
+
 struct ARKitCoordinator::RenderState {
     RetainPtr<id<WKARPresentationSession>> presentationSession;
     PlatformXR::Device::RequestFrameCallback onFrameUpdate;

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h
@@ -29,13 +29,15 @@
 
 #import <UIKit/UIKit.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 
 @class WKCompactContextMenuPresenterButton;
 
 namespace WebKit {
 
 class CompactContextMenuPresenter {
-    WTF_MAKE_NONCOPYABLE(CompactContextMenuPresenter); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CompactContextMenuPresenter);
+    WTF_MAKE_WK_TZONE_ALLOCATED(CompactContextMenuPresenter);
 public:
     CompactContextMenuPresenter(UIView *rootView, id<UIContextMenuInteractionDelegate>);
     ~CompactContextMenuPresenter();

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
@@ -80,6 +80,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CompactContextMenuPresenter);
+
 CompactContextMenuPresenter::CompactContextMenuPresenter(UIView *rootView, id<UIContextMenuInteractionDelegate> delegate)
     : m_rootView(rootView)
     , m_button([WKCompactContextMenuPresenterButton buttonWithType:UIButtonTypeSystem])

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
@@ -35,6 +35,7 @@
 #import <WebCore/WebItemProviderPasteboard.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/URL.h>
 #import <wtf/Vector.h>
 
@@ -64,6 +65,7 @@ using DragItemToPreviewMap = HashMap<RetainPtr<UIDragItem>, RetainPtr<UITargeted
 enum class AddPreviewViewToContainer : bool;
 
 class DragDropInteractionState {
+    WTF_MAKE_WK_TZONE_ALLOCATED(DragDropInteractionState);
 public:
     bool anyActiveDragSourceContainsSelection() const;
 

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -38,6 +38,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DragDropInteractionState);
+
 enum class AddPreviewViewToContainer : bool { No, Yes };
 
 static UIDragItem *dragItemMatchingIdentifier(id <UIDragSession> session, NSInteger identifier)

--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
@@ -31,6 +31,7 @@
 #import <wtf/Noncopyable.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKContentView;
@@ -39,7 +40,7 @@
 namespace WebKit {
 
 class GestureRecognizerConsistencyEnforcer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(GestureRecognizerConsistencyEnforcer);
     WTF_MAKE_NONCOPYABLE(GestureRecognizerConsistencyEnforcer);
 public:
     GestureRecognizerConsistencyEnforcer(WKContentView *);

--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(GestureRecognizerConsistencyEnforcer);
+
 GestureRecognizerConsistencyEnforcer::GestureRecognizerConsistencyEnforcer(WKContentView *view)
     : m_view(view)
     , m_timer(RunLoop::main(), this, &GestureRecognizerConsistencyEnforcer::timerFired)

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
@@ -29,13 +29,14 @@
 
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS RBSProcessMonitor;
 
 namespace WebKit {
 
 class ProcessStateMonitor : public CanMakeWeakPtr<ProcessStateMonitor> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ProcessStateMonitor);
 public:
     ProcessStateMonitor(Function<void(bool)>&& becomeSuspendedHandler);
     ~ProcessStateMonitor();

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ProcessStateMonitor);
+
 static constexpr double maxPrepareForSuspensionDelayInSecond = 15;
 
 ProcessStateMonitor::ProcessStateMonitor(Function<void(bool)>&& becomeSuspendedHandler)

--- a/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.h
+++ b/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.h
@@ -29,6 +29,7 @@
 
 #import <wtf/OptionSet.h>
 #import <wtf/RefCounted.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class WKContentView;
@@ -42,6 +43,7 @@ enum class RevealFocusedElementDeferralReason : uint8_t {
 };
 
 class RevealFocusedElementDeferrer final : public RefCounted<RevealFocusedElementDeferrer> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RevealFocusedElementDeferrer);
 public:
     static Ref<RevealFocusedElementDeferrer> create(WKContentView *, OptionSet<RevealFocusedElementDeferralReason>);
     void fulfill(RevealFocusedElementDeferralReason);

--- a/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.mm
+++ b/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.mm
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RevealFocusedElementDeferrer);
+
 RevealFocusedElementDeferrer::RevealFocusedElementDeferrer(WKContentView *view, OptionSet<RevealFocusedElementDeferralReason> reasons)
     : m_view(view)
     , m_reasons(reasons)

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/FloatRect.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKContentView;
 OBJC_CLASS UIScrollView;
@@ -39,7 +40,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class SmartMagnificationController : private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SmartMagnificationController);
     WTF_MAKE_NONCOPYABLE(SmartMagnificationController);
 public:
     SmartMagnificationController(WKContentView *);

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
@@ -50,6 +50,8 @@ static const double smartMagnificationMinimumScale = 0;
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SmartMagnificationController);
+
 SmartMagnificationController::SmartMagnificationController(WKContentView *contentView)
     : m_webPageProxy(*contentView.page)
     , m_contentView(contentView)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -452,6 +452,7 @@ TextStream& operator<<(TextStream& stream, const WKSelectionDrawingInfo& info)
 #if ENABLE(IMAGE_ANALYSIS)
 
 class ImageAnalysisGestureDeferralToken final : public RefCounted<ImageAnalysisGestureDeferralToken> {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(RevealFocusedElementDeferrer);
 public:
     static RefPtr<ImageAnalysisGestureDeferralToken> create(WKContentView *view)
     {

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
@@ -53,7 +53,7 @@ OBJC_CLASS WKContentView;
 namespace WebKit {
 
 class WebDataListSuggestionsDropdownIOS : public WebDataListSuggestionsDropdown {
-    WTF_MAKE_WK_TZONE_ALLOCATED(RevealFocusedElementDeferrer);
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebDataListSuggestionsDropdownIOS);
 public:
     static Ref<WebDataListSuggestionsDropdownIOS> create(WebPageProxy&, WKContentView *);
 

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
@@ -30,6 +30,7 @@
 #import "WebDataListSuggestionsDropdown.h"
 #import <pal/spi/ios/BrowserEngineKitSPI.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
 
 OBJC_CLASS WKContentView;
@@ -52,6 +53,7 @@ OBJC_CLASS WKContentView;
 namespace WebKit {
 
 class WebDataListSuggestionsDropdownIOS : public WebDataListSuggestionsDropdown {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RevealFocusedElementDeferrer);
 public:
     static Ref<WebDataListSuggestionsDropdownIOS> create(WebPageProxy&, WKContentView *);
 

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -96,6 +96,8 @@ static NSString * const suggestionCellReuseIdentifier = @"WKDataListSuggestionCe
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RevealFocusedElementDeferrer);
+
 Ref<WebDataListSuggestionsDropdownIOS> WebDataListSuggestionsDropdownIOS::create(WebPageProxy& page, WKContentView *view)
 {
     return adoptRef(*new WebDataListSuggestionsDropdownIOS(page, view));

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -96,7 +96,7 @@ static NSString * const suggestionCellReuseIdentifier = @"WKDataListSuggestionCe
 
 namespace WebKit {
 
-WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RevealFocusedElementDeferrer);
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebDataListSuggestionsDropdownIOS);
 
 Ref<WebDataListSuggestionsDropdownIOS> WebDataListSuggestionsDropdownIOS::create(WebPageProxy& page, WKContentView *view)
 {

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -29,13 +29,14 @@
 
 #include "MessageReceiver.h"
 #include <WebCore/MotionManagerClient.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebPageProxy;
 
 class WebDeviceOrientationUpdateProviderProxy : public WebCore::MotionManagerClient, private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebDeviceOrientationUpdateProviderProxy);
 public:
     WebDeviceOrientationUpdateProviderProxy(WebPageProxy&);
     ~WebDeviceOrientationUpdateProviderProxy();

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebDeviceOrientationUpdateProviderProxy);
+
 WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy(WebPageProxy& page)
     : m_page(page)
 {

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FullscreenTouchSecheuristic);
+
 double FullscreenTouchSecheuristic::scoreOfNextTouch(CGPoint location)
 {
     Seconds now = MonotonicTime::now().secondsSinceEpoch();

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
@@ -28,10 +28,12 @@
 #ifdef __cplusplus
 
 #include <WebKit/FullscreenTouchSecheuristicParameters.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class FullscreenTouchSecheuristic {
+    WTF_MAKE_WK_TZONE_ALLOCATED(FullscreenTouchSecheuristic);
 public:
     WK_EXPORT double scoreOfNextTouch(CGPoint location);
     WK_EXPORT double scoreOfNextTouch(CGPoint location, const Seconds& deltaTime);

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.h
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 class FullscreenTouchSecheuristic {
-    WTF_MAKE_WK_TZONE_ALLOCATED(FullscreenTouchSecheuristic);
+    WTF_MAKE_WK_TZONE_ALLOCATED_EXPORT(FullscreenTouchSecheuristic, WK_EXPORT);
 public:
     WK_EXPORT double scoreOfNextTouch(CGPoint location);
     WK_EXPORT double scoreOfNextTouch(CGPoint location, const Seconds& deltaTime);

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -44,6 +44,7 @@
 #import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/MonotonicTime.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
 
 #if PLATFORM(VISION)
@@ -58,6 +59,7 @@ static const Seconds bannerMinimumHideDelay = 1_s;
 @class WKFullscreenStackView;
 
 class WKFullScreenViewControllerPlaybackSessionModelClient : WebCore::PlaybackSessionModelClient {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WKFullScreenViewControllerPlaybackSessionModelClient);
 public:
     void setParent(WKFullScreenViewController *parent) { m_parent = parent; }
 

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.h
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.h
@@ -33,12 +33,14 @@
 #import <AppKit/NSSpellChecker.h>
 #import <WebCore/AlternativeTextClient.h>
 #import <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class WebViewImpl;
 
 class CorrectionPanel {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CorrectionPanel);
 public:
     CorrectionPanel();
     ~CorrectionPanel();

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CorrectionPanel);
+
 CorrectionPanel::CorrectionPanel()
     : m_wasDismissedExternally(false)
     , m_reasonForDismissing(ReasonForDismissingAlternativeText::Ignored)

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
@@ -31,6 +31,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -40,6 +41,7 @@ class SecurityOrigin;
 namespace WebKit {
 
 class DisplayCaptureSessionManager {
+    WTF_MAKE_WK_TZONE_ALLOCATED(DisplayCaptureSessionManager);
 public:
     static DisplayCaptureSessionManager& singleton();
     static bool isAvailable();

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -50,6 +50,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DisplayCaptureSessionManager);
+
 #if HAVE(SCREEN_CAPTURE_KIT)
 void DisplayCaptureSessionManager::alertForGetDisplayMedia(WebPageProxy& page, const WebCore::SecurityOriginData& origin, CompletionHandler<void(DisplayCaptureSessionManager::CaptureSessionType)>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/mac/HighPerformanceGPUManager.h
+++ b/Source/WebKit/UIProcess/mac/HighPerformanceGPUManager.h
@@ -30,6 +30,7 @@
 #include <OpenGL/CGLTypes.h>
 #include <WebCore/Timer.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
@@ -37,6 +38,7 @@ namespace WebKit {
 class WebProcessProxy;
 
 class HighPerformanceGPUManager {
+    WTF_MAKE_WK_TZONE_ALLOCATED(HighPerformanceGPUManager);
     friend NeverDestroyed<HighPerformanceGPUManager>;
 public:
     static HighPerformanceGPUManager& singleton();

--- a/Source/WebKit/UIProcess/mac/HighPerformanceGPUManager.mm
+++ b/Source/WebKit/UIProcess/mac/HighPerformanceGPUManager.mm
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(HighPerformanceGPUManager);
+
 // FIXME: This class is using OpenGL to control the muxing of GPUs. Ultimately
 // we want to use Metal, but currently there isn't a way to "release" a
 // discrete MTLDevice, such that the process muxes back to an integrated GPU.

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -31,6 +31,7 @@
 #include <mutex>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/MallocPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/cf/TypeCastsCF.h>
 #include <wtf/text/StringView.h>
 
@@ -77,6 +78,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(HistoryEntryDataEncoder, WTF_I
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HistoryEntryDataEncoder);
 
 class HistoryEntryDataEncoder {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(HistoryEntryDataEncoder);
 public:
     HistoryEntryDataEncoder()
         : m_bufferSize(0)
@@ -530,6 +532,7 @@ RefPtr<API::Data> encodeLegacySessionState(const SessionState& sessionState)
 }
 
 class HistoryEntryDataDecoder {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(HistoryEntryDataDecoder);
 public:
     HistoryEntryDataDecoder(const uint8_t* buffer, size_t bufferSize)
         : m_buffer(buffer)

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SecItemShimProxy);
+
 #define MESSAGE_CHECK_COMPLETION(assertion, connection, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, &connection, completion)
 
 // We received these dictionaries over IPC so they shouldn't contain any "in-memory" objects (rdar://104253249).

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
@@ -29,6 +29,7 @@
 
 #include "Connection.h"
 #include "WorkQueueMessageReceiver.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -36,7 +37,8 @@ class SecItemRequestData;
 class SecItemResponseData;
 
 class SecItemShimProxy final : private IPC::MessageReceiver {
-WTF_MAKE_NONCOPYABLE(SecItemShimProxy);
+    WTF_MAKE_NONCOPYABLE(SecItemShimProxy);
+    WTF_MAKE_WK_TZONE_ALLOCATED(SecItemShimProxy);
 public:
     static SecItemShimProxy& singleton();
 

--- a/Source/WebKit/UIProcess/mac/ServicesController.h
+++ b/Source/WebKit/UIProcess/mac/ServicesController.h
@@ -31,11 +31,13 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ServicesController {
     WTF_MAKE_NONCOPYABLE(ServicesController);
+    WTF_MAKE_WK_TZONE_ALLOCATED(ServicesController);
     friend NeverDestroyed<ServicesController>;
 public:
     static ServicesController& singleton();

--- a/Source/WebKit/UIProcess/mac/ServicesController.mm
+++ b/Source/WebKit/UIProcess/mac/ServicesController.mm
@@ -38,6 +38,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ServicesController);
+
 ServicesController& ServicesController::singleton()
 {
     static NeverDestroyed<ServicesController> sharedController;

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
@@ -28,10 +28,12 @@
 #if !PLATFORM(IOS_FAMILY)
 
 #include "DrawingAreaProxy.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class TiledCoreAnimationDrawingAreaProxy final : public DrawingAreaProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(TiledCoreAnimationDrawingAreaProxy);
 public:
     TiledCoreAnimationDrawingAreaProxy(WebPageProxy&, WebProcessProxy&);
     virtual ~TiledCoreAnimationDrawingAreaProxy();

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -43,6 +43,8 @@ namespace WebKit {
 using namespace IPC;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(TiledCoreAnimationDrawingAreaProxy);
+
 TiledCoreAnimationDrawingAreaProxy::TiledCoreAnimationDrawingAreaProxy(WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::TiledCoreAnimation, webPageProxy, webProcessProxy)
 {

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.h
@@ -27,10 +27,12 @@
 
 #include "UserMediaPermissionRequestProxy.h"
 #include <WebCore/SecurityOrigin.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class UserMediaPermissionRequestProxyMac final : public UserMediaPermissionRequestProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(UserMediaPermissionRequestProxyMac);
 public:
     ~UserMediaPermissionRequestProxyMac() final;
 

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
@@ -33,6 +33,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(UserMediaPermissionRequestProxyMac);
+
 Ref<UserMediaPermissionRequestProxy> UserMediaPermissionRequestProxy::create(UserMediaPermissionRequestManagerProxy& manager, UserMediaRequestIdentifier userMediaID, FrameIdentifier mainFrameID, FrameIdentifier frameID, Ref<SecurityOrigin>&& userMediaDocumentOrigin, Ref<SecurityOrigin>&& topLevelDocumentOrigin, Vector<CaptureDevice>&& audioDevices, Vector<CaptureDevice>&& videoDevices, MediaStreamRequest&& request, CompletionHandler<void(bool)>&& decisionCompletionHandler)
 {
     return adoptRef(*new UserMediaPermissionRequestProxyMac(manager, userMediaID, mainFrameID, frameID, WTFMove(userMediaDocumentOrigin), WTFMove(topLevelDocumentOrigin), WTFMove(audioDevices), WTFMove(videoDevices), WTFMove(request), WTFMove(decisionCompletionHandler)));

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -61,7 +61,7 @@ namespace WebKit {
 using namespace WebCore;
 
 class TextFinderFindClient : public API::FindMatchesClient, public API::FindClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(TextFinderFindClient);
 public:
     explicit TextFinderFindClient(WKTextFinderClient *textFinderClient)
         : m_textFinderClient(textFinderClient)

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.h
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.h
@@ -34,6 +34,7 @@
 #import "WebColorPicker.h"
 #import <WebCore/IntRect.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
 
 namespace WebCore {
@@ -54,7 +55,8 @@ class WebColorPickerMac;
 namespace WebKit {
     
 class WebColorPickerMac final : public WebColorPicker {
-public:        
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebColorPickerMac);
+public:
     static Ref<WebColorPickerMac> create(WebColorPicker::Client*, const WebCore::Color&, const WebCore::IntRect&, Vector<WebCore::Color>&&, NSView *);
     virtual ~WebColorPickerMac();
 

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -75,6 +75,8 @@ static const CGFloat colorPickerMatrixSwatchWidth = 13.0;
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebColorPickerMac);
+
 Ref<WebColorPickerMac> WebColorPickerMac::create(WebColorPicker::Client* client, const WebCore::Color& initialColor, const WebCore::IntRect& rect, Vector<WebCore::Color>&& suggestions, NSView *view)
 {
     return adoptRef(*new WebColorPickerMac(client, initialColor, rect, WTFMove(suggestions), view));

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -29,6 +29,7 @@
 
 #include "WebContextMenuProxy.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS NSMenu;
@@ -42,6 +43,7 @@ namespace WebKit {
 class WebContextMenuItemData;
 
 class WebContextMenuProxyMac final : public WebContextMenuProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebContextMenuProxyMac);
 public:
     static auto create(NSView *webView, WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
     {

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -198,6 +198,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebContextMenuProxyMac);
+
 WebContextMenuProxyMac::WebContextMenuProxyMac(NSView *webView, WebPageProxy& page, ContextMenuContextData&& context, const UserData& userData)
     : WebContextMenuProxy(page, WTFMove(context), userData)
     , m_webView(webView)

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h
@@ -29,12 +29,14 @@
 
 #import "WebDataListSuggestionsDropdown.h"
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKDataListSuggestionsController;
 
 namespace WebKit {
 
 class WebDataListSuggestionsDropdownMac final : public WebDataListSuggestionsDropdown {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebDataListSuggestionsDropdownMac);
 public:
     static Ref<WebDataListSuggestionsDropdownMac> create(WebPageProxy&, NSView *);
     ~WebDataListSuggestionsDropdownMac();

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -68,6 +68,8 @@ static NSString * const suggestionCellReuseIdentifier = @"WKDataListSuggestionVi
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebDataListSuggestionsDropdownMac);
+
 Ref<WebDataListSuggestionsDropdownMac> WebDataListSuggestionsDropdownMac::create(WebPageProxy& page, NSView *view)
 {
     return adoptRef(*new WebDataListSuggestionsDropdownMac(page, view));

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.h
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.h
@@ -30,6 +30,7 @@
 #import "WebDateTimePicker.h"
 #import <WebCore/DateTimeChooserParameters.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMalloc.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/text/StringView.h>
 
@@ -38,6 +39,7 @@
 namespace WebKit {
 
 class WebDateTimePickerMac final : public WebDateTimePicker {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebDateTimePickerMac);
 public:
     static Ref<WebDateTimePickerMac> create(WebPageProxy&, NSView *);
     ~WebDateTimePickerMac();

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
@@ -59,6 +59,8 @@ constexpr NSString * kDefaultTimeZoneIdentifier = @"UTC";
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebDateTimePickerMac);
+
 Ref<WebDateTimePickerMac> WebDateTimePickerMac::create(WebPageProxy& page, NSView *view)
 {
     return adoptRef(*new WebDateTimePickerMac(page, view));

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
@@ -30,6 +30,7 @@
 
 #include "WebPopupMenuProxy.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSPopUpButtonCell;
 OBJC_CLASS WKView;
@@ -39,6 +40,7 @@ namespace WebKit {
 class WebPageProxy;
 
 class WebPopupMenuProxyMac : public WebPopupMenuProxy {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebPopupMenuProxyMac);
 public:
     static Ref<WebPopupMenuProxyMac> create(NSView *webView, WebPopupMenuProxy::Client& client)
     {

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -42,6 +42,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebPopupMenuProxyMac);
+
 WebPopupMenuProxyMac::WebPopupMenuProxyMac(NSView *webView, WebPopupMenuProxy::Client& client)
     : WebPopupMenuProxy(client)
     , m_webView(webView)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -45,6 +45,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/WorkQueue.h>
@@ -183,7 +184,7 @@ typedef Vector<RetainPtr<ValidationItem>> ValidationVector;
 typedef HashMap<String, ValidationVector> ValidationMap;
 
 class WebViewImpl : public CanMakeWeakPtr<WebViewImpl>, public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebViewImpl);
     WTF_MAKE_NONCOPYABLE(WebViewImpl);
 public:
     WebViewImpl(NSView <WebViewImplDelegate> *, WKWebView *outerWebView, WebProcessPool&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1135,6 +1135,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebViewImpl);
+
 static NSTrackingAreaOptions trackingAreaOptions()
 {
     // Legacy style scrollbars have design details that rely on tracking the mouse all the time.

--- a/Source/WebKit/UIProcess/mac/WindowServerConnection.h
+++ b/Source/WebKit/UIProcess/mac/WindowServerConnection.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/mac/WindowServerConnection.h
+++ b/Source/WebKit/UIProcess/mac/WindowServerConnection.h
@@ -23,9 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <wtf/TZoneMalloc.h>
+
 namespace WebKit {
 
 class WindowServerConnection {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WindowServerConnection);
 public:
     static WindowServerConnection& singleton();
 

--- a/Source/WebKit/UIProcess/mac/WindowServerConnection.mm
+++ b/Source/WebKit/UIProcess/mac/WindowServerConnection.mm
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WindowServerConnection);
+
 #if PLATFORM(MAC)
 void WindowServerConnection::applicationWindowModificationsStopped(bool stopped)
 {

--- a/Source/WebKit/config.h
+++ b/Source/WebKit/config.h
@@ -40,7 +40,7 @@
 #undef new
 #undef delete
 #include <wtf/FastMalloc.h>
-
+#include <wtf/TZoneMallocInlines.h>
 #endif
 
 // ENABLE_WEBDRIVER_ACTIONS_API represents whether mouse, keyboard, touch or wheel interactions are defined

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -393,7 +393,7 @@
 #endif
 
 #if BUSE(LIBPAS) && BOS(DARWIN) && BCPU(ARM64)
-#define BUSE_TZONE 0
+#define BUSE_TZONE 1
 #else
 #define BUSE_TZONE 0
 #endif


### PR DESCRIPTION
#### 93466125094e0f5f1120250f89d5a9147540f6a7
<pre>
[UI] test tzone on
</pre>
----------------------------------------------------------------------
#### 153a995c679d2d6aa7caef5e7b22dfe62883db2e
<pre>
Start adopting TZone within WebKit/UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=269575">https://bugs.webkit.org/show_bug.cgi?id=269575</a>
<a href="https://rdar.apple.com/123091415">rdar://123091415</a>

Reviewed by NOBODY (OOPS!).

Adopts the TZone allocator throughout the WebKit/UIProcess directory.

* Source/WebKit/UIProcess/API/APIAutomationClient.h:
* Source/WebKit/UIProcess/API/APIAutomationSessionClient.h:
* Source/WebKit/UIProcess/API/APIContextMenuClient.h:
* Source/WebKit/UIProcess/API/APICustomProtocolManagerClient.h:
* Source/WebKit/UIProcess/API/APIDataTaskClient.h:
* Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h:
* Source/WebKit/UIProcess/API/APIDownloadClient.h:
* Source/WebKit/UIProcess/API/APIFindClient.h:
* Source/WebKit/UIProcess/API/APIFindMatchesClient.h:
* Source/WebKit/UIProcess/API/APIFormClient.h:
* Source/WebKit/UIProcess/API/APIFullscreenClient.h:
* Source/WebKit/UIProcess/API/APIGeolocationProvider.h:
* Source/WebKit/UIProcess/API/APIHistoryClient.h:
* Source/WebKit/UIProcess/API/APIIconDatabaseClient.h:
* Source/WebKit/UIProcess/API/APIIconLoadingClient.h:
* Source/WebKit/UIProcess/API/APIInjectedBundleClient.h:
* Source/WebKit/UIProcess/API/APIInspectorClient.h:
* Source/WebKit/UIProcess/API/APIInspectorExtensionClient.h:
* Source/WebKit/UIProcess/API/APILegacyContextHistoryClient.h:
* Source/WebKit/UIProcess/API/APILoaderClient.h:
* Source/WebKit/UIProcess/API/APINavigationClient.h:
* Source/WebKit/UIProcess/API/APINotificationProvider.h:
* Source/WebKit/UIProcess/API/APIPolicyClient.h:
* Source/WebKit/UIProcess/API/APIUIClient.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanelClient.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
* Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setInputDelegate:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _createMediaSessionCoordinatorForTesting:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm:
* Source/WebKit/UIProcess/ApplicationStateTracker.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm:
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h:
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm:
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h:
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
* Source/WebKit/UIProcess/Cocoa/FindClient.h:
* Source/WebKit/UIProcess/Cocoa/FindClient.mm:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.mm:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm:
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.h:
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm:
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h:
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.h:
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
* Source/WebKit/UIProcess/Cocoa/TextCheckingController.h:
* Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/DisplayLink.cpp:
* Source/WebKit/UIProcess/DisplayLink.h:
* Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp:
* Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp:
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/EndowmentStateTracker.h:
* Source/WebKit/UIProcess/EndowmentStateTracker.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp:
* Source/WebKit/UIProcess/Gamepad/UIGamepad.h:
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp:
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h:
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h:
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/LegacyGlobalSettings.cpp:
* Source/WebKit/UIProcess/LegacyGlobalSettings.h:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
* Source/WebKit/UIProcess/Media/MediaUsageManager.cpp:
* Source/WebKit/UIProcess/Media/MediaUsageManager.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.h:
* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
* Source/WebKit/UIProcess/ModelElementController.cpp:
* Source/WebKit/UIProcess/ModelElementController.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp:
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/ProcessAssertion.cpp:
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/SystemPreviewController.cpp:
* Source/WebKit/UIProcess/SystemPreviewController.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
(WebKit::WebCore::bundleName): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp:
* Source/WebKit/UIProcess/WebContextInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebFormClient.cpp:
* Source/WebKit/UIProcess/WebFormClient.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebGeolocationProvider.cpp:
* Source/WebKit/UIProcess/WebGeolocationProvider.h:
* Source/WebKit/UIProcess/WebLockRegistryProxy.cpp:
* Source/WebKit/UIProcess/WebLockRegistryProxy.h:
* Source/WebKit/UIProcess/WebNavigationState.cpp:
* Source/WebKit/UIProcess/WebNavigationState.h:
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp:
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h:
* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm:
* Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h:
* Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm:
* Source/WebKit/UIProcess/ios/ProcessStateMonitor.h:
* Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.h:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
* Source/WebKit/config.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93466125094e0f5f1120250f89d5a9147540f6a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40892 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36983 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33891 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41466 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16850 "Found 60 new test failures: accessibility/accessibility-node-reparent.html, accessibility/ancestor-computation.html, accessibility/announcement-notification.html, accessibility/aria-checked-mixed-value.html, accessibility/aria-current-state-changed-notification.html, accessibility/aria-describedby-on-input.html, accessibility/aria-description.html, accessibility/aria-invalid.html, accessibility/aria-labelledby-targeting-slot.html, accessibility/display-contents/aria-hidden.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35251 "6 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14514 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14619 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html, imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html, imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-in-worker.worker.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44745 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34345 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37104 "Found 2539 new API test failures: TestWebKitAPI.ProcessSwap.NavigatingSameOriginFromCOOPSameOriginToCOOPSameOrigin, TestWebKitAPI.URLSchemeHandler.Frames, TestWebKitAPI.SampledPageTopColor.HitTestHTMLCanvasWithoutRenderingContext, TestWebKitAPI.WKWebExtensionAPIRuntime.GetFrameId, TestWebKitAPI.SafeBrowsing.GoBack, TestWebKitAPI.ElementActionTests.OpenLinkWithHoverMenu, TestWebKitAPI.WKWebView.PageZoomAfterPDF, TestWebKitAPI.WKWebExtensionAPIRuntime.SendMessageFromContentScriptWithNoReply, TestWebKitAPI.RequestTextInputContext.Iframe, TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsForPopup ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36552 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-crash-with-dynamic-inline-content.html, accessibility/accessibility-node-reparent.html, accessibility/accessibility-object-detached.html, accessibility/custom-elements/autocomplete.html, accessibility/custom-elements/controls-shadow.html, accessibility/custom-elements/controls.html, accessibility/custom-elements/current.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40300 "Passed tests") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40518 "Found 4 new JSC binary failures: testair, testb3, testdfg, testmasm, Found 19473 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/ArrayBtreeBadCodeGen.js.default, ChakraCore.yaml/ChakraCore/test/Array/ArrayElementMissingValueSetToZero.js.default, ChakraCore.yaml/ChakraCore/test/Array/InlineArrayPopWithIntConstSrc.js.default, ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/SegmentMapFlagResetInJSArrayConstructor.js.default, ChakraCore.yaml/ChakraCore/test/Array/TryGrowHeadSegmentBug.js.default, ChakraCore.yaml/ChakraCore/test/Array/arr_bailout.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_apply.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15707 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12898 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-crash-with-dynamic-inline-content.html, accessibility/accessibility-node-reparent.html, accessibility/accessibility-object-detached.html, accessibility/custom-elements/autocomplete.html, accessibility/custom-elements/controls-shadow.html, accessibility/custom-elements/controls.html, accessibility/display-contents/aria-grid.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38668 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17326 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47529 "Built successfully") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17377 "Hash 93466125 for PR 24618 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9760 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->