### PR TITLE
Make Skia use bmalloc/fastMalloc

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -844,7 +844,6 @@ add_library(Skia STATIC
     src/ports/SkFontMgr_fontconfig.cpp
     src/ports/SkGlobalInitialization_default.cpp
     src/ports/SkImageGenerator_skia.cpp
-    src/ports/SkMemory_malloc.cpp
     src/ports/SkOSFile_posix.cpp
     src/ports/SkOSFile_stdio.cpp
 
@@ -856,6 +855,20 @@ add_library(Skia STATIC
     modules/skcms/src/skcms_TransformHsw.cc
     modules/skcms/src/skcms_TransformSkx.cc
 )
+
+if (USE_SYSTEM_MALLOC)
+    target_sources(Skia PRIVATE src/ports/SkMemory_malloc.cpp)
+else ()
+    # Using WTF headers needs including Source/WTF/config.h first, and
+    # in turn that needs cmakeconfig.h from the top build directory, so
+    # arrange the include directories accordingly.
+    target_sources(Skia PRIVATE ${WEBCORE_DIR}/platform/skia/SkiaAllocatorFastMalloc.cpp)
+    set_property(
+        SOURCE ${WEBCORE_DIR}/platform/skia/SkiaAllocatorFastMalloc.cpp
+        APPEND PROPERTY INCLUDE_DIRECTORIES ${WTF_DIR} ${CMAKE_BINARY_DIR}
+    )
+    target_link_libraries(Skia PRIVATE WebKit::WTF)
+endif ()
 
 set_target_properties(Skia PROPERTIES
     CXX_STANDARD 17

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -44,7 +44,6 @@ std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnaccelerate
         return nullptr;
 
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
-    // FIXME: use SkSurfaces::WrapPixels() to allocate pixels with bmalloc?
     auto surface = SkSurfaces::Raster(imageInfo, nullptr);
     return std::unique_ptr<ImageBufferSkiaUnacceleratedBackend>(new ImageBufferSkiaUnacceleratedBackend(parameters, WTFMove(surface)));
 }

--- a/Source/WebCore/platform/skia/SkiaAllocatorFastMalloc.cpp
+++ b/Source/WebCore/platform/skia/SkiaAllocatorFastMalloc.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <algorithm>
+#include <wtf/Assertions.h>
+#include <wtf/FastMalloc.h>
+#include "../../../ThirdParty/skia/include/private/base/SkMalloc.h"
+
+void sk_abort_no_print()
+{
+    CRASH();
+}
+
+void sk_out_of_memory(void)
+{
+    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("sk_out_of_memory");
+}
+
+void sk_free(void* p)
+{
+    WTF::fastFree(p);
+}
+
+void* sk_realloc_throw(void* addr, size_t size)
+{
+    return WTF::fastRealloc(addr, size);
+}
+
+void* sk_malloc_flags(size_t size, unsigned flags)
+{
+    if (flags & SK_MALLOC_ZERO_INITIALIZE) {
+        if (flags & SK_MALLOC_THROW)
+            return WTF::fastZeroedMalloc(size);
+
+        auto result = WTF::tryFastZeroedMalloc(size);
+        void* ptr;
+        if (result.getValue(ptr))
+            return ptr;
+        return nullptr;
+    }
+
+    if (flags & SK_MALLOC_THROW)
+        return WTF::fastMalloc(size);
+
+    auto result = WTF::tryFastMalloc(size);
+    void* ptr;
+    if (result.getValue(ptr))
+        return ptr;
+    return nullptr;
+}
+
+size_t sk_malloc_size(void *ptr, size_t size)
+{
+    // bmalloc/fastMalloc may be disabled either at build time or run
+    // time, and in both cases WTF::fastMallocSize() will return 1.
+    return std::max(WTF::fastMallocSize(ptr), size);
+}

--- a/Tools/ImageDiff/Skia.cmake
+++ b/Tools/ImageDiff/Skia.cmake
@@ -2,6 +2,28 @@ list(APPEND ImageDiff_SOURCES
     skia/PlatformImageSkia.cpp
 )
 
+if (NOT USE_SYSTEM_MALLOC)
+    #
+    # Skia is built to use bmalloc/fastMalloc, but ImageDiff should not
+    # link to WTF. Adding the malloc allocator source will make the linker
+    # skip the memory allocator symbols from the Skia static library, thus
+    # avoiding the need to link to WTF.
+    #
+    list(APPEND ImageDiff_SOURCES
+        ${THIRDPARTY_DIR}/skia/src/ports/SkMemory_malloc.cpp
+    )
+
+    if (NOT DEFINED CXX_COMPILER_SUPPORTS_-Wno-unused-parameter)
+        check_cxx_compiler_flag(-Wno-unused-parameter CXX_COMPILER_SUPPORTS_-Wno-unused-parameter)
+    endif ()
+    if (CXX_COMPILER_SUPPORTS_-Wno-unused-parameter)
+        set_property(
+            SOURCE ${THIRDPARTY_DIR}/skia/src/ports/SkMemory_malloc.cpp
+            APPEND PROPERTY COMPILE_OPTIONS -Wno-unused-parameter
+        )
+    endif ()
+endif ()
+
 list(APPEND ImageDiff_LIBRARIES
     Skia
 )

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -276,6 +276,12 @@ _PATH_RULES_SPECIFIER = [
       os.path.join('Source', 'WebKit', 'NetworkProcess', 'soup', 'WebKitDirectoryInputStream.h')],
      ["-readability/naming",
       "-readability/enum_casing"]),
+    ([
+      # This file needs to define symbols with underscores to integrate
+      # with the rest of Skia, and does not have a corresponding header.
+      os.path.join('Source', 'WebCore', 'platform', 'skia', 'SkiaAllocatorFastMalloc.cpp')],
+     ["-build/include_order",
+      "-readability/naming/underscores"]),
 
     # For third-party code, keep only the following checks--
     #


### PR DESCRIPTION
#### 8722ec73f50ceaf96717b811b489bf3819db90a9
<pre>
Make Skia use bmalloc/fastMalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=269572">https://bugs.webkit.org/show_bug.cgi?id=269572</a>

Reviewed by Carlos Garcia Campos.

Implement functions used by Skia to handle memory allocations in terms
of WTF::fastMalloc() and friends.

* Source/ThirdParty/skia/CMakeLists.txt: Build the fastMalloc allocator
instead of the system-wide one when USE_SYSTEM_MALLOC is disabled.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp:
(WebCore::ImageBufferSkiaUnacceleratedBackend::create): Remove FIXME
comment, allocations done by Skia now go through bmalloc/fastMalloc.
* Source/WebCore/platform/skia/SkiaAllocatorFastMalloc.cpp: Added.
(sk_abort_no_print):
(sk_out_of_memory):
(sk_free):
(sk_realloc_throw):
(sk_malloc_flags):
(sk_malloc_size):
* Tools/Scripts/webkitpy/style/checker.py: Ignore lints for include
headers and underscores in identifiers for SkiaAllocatorFastMalloc.cpp
* Tools/ImageDiff/Skia.cmake: Add logic to avoid linking ImageDiff to
WTF when Skia has the bmalloc/fastMalloc allocator support built.

Canonical link: <a href="https://commits.webkit.org/275315@main">https://commits.webkit.org/275315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8411cb33e0ce38a1f0a545b37048889b251ba4e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41520 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37612 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/43827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17864 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42094 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35761 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/41390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45457 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37086 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16335 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17954 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18010 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5546 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->