### PR TITLE
[build.webkit.org] Support multiple hostnames for production instance

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -45,7 +45,7 @@ if 'dev' in CURRENT_HOSTNAME:
 if 'uat' in CURRENT_HOSTNAME:
     custom_suffix = '-uat'
 
-BUILD_WEBKIT_HOSTNAME = 'build.webkit.org'
+BUILD_WEBKIT_HOSTNAMES = ['build.webkit.org', 'build']
 COMMITS_INFO_URL = 'https://commits.webkit.org/'
 RESULTS_WEBKIT_URL = 'https://results.webkit.org'
 RESULTS_SERVER_API_KEY = 'RESULTS_SERVER_API_KEY'
@@ -581,7 +581,7 @@ class DownloadBuiltProduct(shell.ShellCommandNewStyle):
     @defer.inlineCallbacks
     def run(self):
         # Only try to download from S3 on the official deployment <https://webkit.org/b/230006>
-        if CURRENT_HOSTNAME != BUILD_WEBKIT_HOSTNAME:
+        if CURRENT_HOSTNAME not in BUILD_WEBKIT_HOSTNAMES:
             self.build.addStepsAfterCurrentStep([DownloadBuiltProductFromMaster()])
             defer.returnValue(SKIPPED)
 
@@ -1367,7 +1367,7 @@ class TransferToS3(master.MasterShellCommandNewStyle):
         defer.returnValue(rc)
 
     def doStepIf(self, step):
-        return CURRENT_HOSTNAME == BUILD_WEBKIT_HOSTNAME
+        return CURRENT_HOSTNAME in BUILD_WEBKIT_HOSTNAMES
 
 
 class ExtractTestResults(master.MasterShellCommandNewStyle):


### PR DESCRIPTION
#### 70f3a29f11a7ab9d3d4cc0deee46b20e505f5af9
<pre>
[build.webkit.org] Support multiple hostnames for production instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=269579">https://bugs.webkit.org/show_bug.cgi?id=269579</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/build-webkit-org/steps.py:
(DownloadBuiltProduct.run):
(TransferToS3.doStepIf):

Canonical link: <a href="https://commits.webkit.org/274852@main">https://commits.webkit.org/274852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34c563d5f7c089f8a6000b99d8161407d2a884d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40175 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/19187 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42553 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42720 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42482 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/22110 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/16516 "Build was cancelled. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 24621") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40749 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/22110 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42553 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/22110 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42553 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43998 "Build was cancelled. Recent messages:Printed configuration") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/22110 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42553 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/43998 "Build was cancelled. Recent messages:Printed configuration") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/16516 "Build was cancelled. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 24621") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/43998 "Build was cancelled. Recent messages:Printed configuration") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/40222 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16609 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42553 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5313 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->