### PR TITLE
[Wasm-GC] Fix error cases in Table.set/grow in JS API

### DIFF
--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -160,7 +160,7 @@ ALWAYS_INLINE JSValue defaultValueForReferenceType(const Wasm::Type type)
     ASSERT(Wasm::isRefType(type));
     if (Wasm::isExternref(type))
         return jsUndefined();
-    ASSERT(Wasm::isFuncref(type));
+    ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), Wasm::isFuncref(type));
     return jsNull();
 }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
@@ -95,13 +95,21 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncGrow, (JSGlobalObject* globalO
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
     JSValue defaultValue = jsNull();
-    if (callFrame->argumentCount() < 2)
+    if (callFrame->argumentCount() < 2) {
+        if (!table->table()->wasmType().isNullable())
+            return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.grow requires the second argument for non-defaultable table type"_s);
         defaultValue = defaultValueForReferenceType(table->table()->wasmType());
-    else
+    } else
         defaultValue = callFrame->uncheckedArgument(1);
 
     if (table->table()->isFuncrefTable() && !defaultValue.isNull() && !isWebAssemblyHostFunction(defaultValue))
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.grow expects the second argument to be null or an instance of WebAssembly.Function"_s);
+    else if (table->table()->isExternrefTable() && !isExternref(table->table()->wasmType())) {
+        RELEASE_ASSERT(Options::useWebAssemblyGC());
+        JSValue internalValue = Wasm::internalizeExternref(defaultValue);
+        if (!Wasm::TypeInformation::castReference(internalValue, true, table->table()->wasmType().index))
+            return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.grow failed to cast the second argument to the table's element type"_s);
+    }
     uint32_t oldLength = table->length();
 
     if (!table->grow(delta, defaultValue))
@@ -141,8 +149,11 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncSet, (JSGlobalObject* globalOb
         return throwVMRangeError(globalObject, throwScope, "WebAssembly.Table.prototype.set expects an integer less than the length of the table"_s);
 
     JSValue value = callFrame->argument(1);
-    if (callFrame->argumentCount() < 2)
+    if (callFrame->argumentCount() < 2) {
         value = defaultValueForReferenceType(table->table()->wasmType());
+        if (!table->table()->wasmType().isNullable())
+            return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.set requires the second argument for non-defaultable table type"_s);
+    }
 
     if (table->table()->asFuncrefTable()) {
         WebAssemblyFunction* wasmFunction = nullptr;
@@ -161,7 +172,6 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncSet, (JSGlobalObject* globalOb
                 table->set(index, wasmWrapperFunction);
         }
     } else {
-        // FIXME: Once non-defaultable table types are allowed, this will need to check for null if a non-null table type is used.
         if (isExternref(table->table()->wasmType()))
             table->set(index, value);
         else {


### PR DESCRIPTION
#### e4308dcc1bbede74e9defcd8ae815ca98ab6a969
<pre>
[Wasm-GC] Fix error cases in Table.set/grow in JS API
<a href="https://bugs.webkit.org/show_bug.cgi?id=269578">https://bugs.webkit.org/show_bug.cgi?id=269578</a>

Reviewed by Justin Michaud.

Fixes error cases for these JS API operations to match the latest GC proposal
JS API spec. Also ensure assertions are accurate.

* JSTests/wasm/gc/js-api.js:
(testTable):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::defaultValueForReferenceType):
* Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/275014@main">https://commits.webkit.org/275014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90e6cf616241c0ce2a6b080e8e3986fc71f2f5ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43182 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36718 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33707 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14301 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44457 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34082 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40063 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40255 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38397 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17063 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47265 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9106 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17114 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9714 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->