### PR TITLE
Fix Windows and Linux GPU process build after 274801@main

### DIFF
--- a/Source/WebKit/GPUProcess/glib/GPUProcessMainGLib.cpp
+++ b/Source/WebKit/GPUProcess/glib/GPUProcessMainGLib.cpp
@@ -34,7 +34,7 @@
 namespace WebKit {
 
 #if ENABLE(GPU_PROCESS) && (PLATFORM(GTK) || PLATFORM(WPE))
-class GPUProcessMainGStreamer final: public AuxiliaryProcessMainBaseNoSingleton<GPUProcess> {
+class GPUProcessMainGStreamer final: public AuxiliaryProcessMainBase<GPUProcess> {
 };
 #endif
 

--- a/Source/WebKit/GPUProcess/win/GPUProcessMainWin.cpp
+++ b/Source/WebKit/GPUProcess/win/GPUProcessMainWin.cpp
@@ -38,7 +38,7 @@ SOFT_LINK_OPTIONAL(user32, SetProcessDpiAwarenessContext, BOOL, STDAPICALLTYPE, 
 
 namespace WebKit {
 
-class GPUProcessMainWin final: public AuxiliaryProcessMainBaseNoSingleton<GPUProcess> {
+class GPUProcessMainWin final: public AuxiliaryProcessMainBase<GPUProcess> {
 public:
     bool platformInitialize() override
     {


### PR DESCRIPTION
#### c7e6ce586dfa3d5790f7feb2c3c8c0fc6a8ba893
<pre>
Fix Windows and Linux GPU process build after 274801@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=269583">https://bugs.webkit.org/show_bug.cgi?id=269583</a>

Unreviewed.

The GPU process was changed to a singleton.

* Source/WebKit/GPUProcess/glib/GPUProcessMainGLib.cpp:
* Source/WebKit/GPUProcess/win/GPUProcessMainWin.cpp:

Canonical link: <a href="https://commits.webkit.org/274836@main">https://commits.webkit.org/274836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3036a2a01b8189d4f8d68b67da543c0cffd908a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40184 "Failed to checkout and rebase branch from PR 24623") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/19196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42562 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16525 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40758 "Failed to checkout and rebase branch from PR 24623") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/44007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5302 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->