### PR TITLE
[UnifedPDF] Hook up accessibility for Unified PDF

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
@@ -116,6 +116,11 @@
 - (PDFDestination *)namedDestination:(NSString *)name;
 @end
 
+// FIXME: Move this declaration inside the !USE(APPLE_INTERNAL_SDK) block once rdar://problem/118903435 is in builds.
+@interface PDFDocument (AX)
+- (NSArray *)accessibilityChildren:(id)parent;
+@end
+
 @interface PDFPage (IPI)
 - (CGPDFPageLayoutRef) pageLayout;
 @end

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -46,7 +46,9 @@ class RemoteLayerWithInProcessRenderingBackingStore;
 class RemoteLayerTreeContext;
 class RemoteLayerTreeTransaction;
 class RemoteImageBufferSetProxy;
+class ThreadSafeImageBufferSetFlusher;
 
+enum class BufferInSetType : uint8_t;
 enum class SwapBuffersDisplayRequirement : uint8_t;
 
 class RemoteLayerBackingStoreCollection : public CanMakeWeakPtr<RemoteLayerBackingStoreCollection> {

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -696,6 +696,7 @@ WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
 WebProcess/Plugins/PDF/PDFPluginPasswordForm.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
 WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
+WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4889,6 +4889,8 @@
 		3311023E2B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIDeclarativeNetRequest.mm; sourceTree = "<group>"; };
 		3311023F2B17B99800B21C8C /* JSWebExtensionAPIDeclarativeNetRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIDeclarativeNetRequest.h; sourceTree = "<group>"; };
 		331102462B17CFE300B21C8C /* WebExtensionContextAPIDeclarativeNetRequestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIDeclarativeNetRequestCocoa.mm; sourceTree = "<group>"; };
+		33238F5D2B7EFD3B0014AE88 /* WKAccessibilityPDFDocumentObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKAccessibilityPDFDocumentObject.h; path = PDF/WKAccessibilityPDFDocumentObject.h; sourceTree = "<group>"; };
+		33238F5E2B7EFD6A0014AE88 /* WKAccessibilityPDFDocumentObject.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKAccessibilityPDFDocumentObject.mm; path = PDF/WKAccessibilityPDFDocumentObject.mm; sourceTree = "<group>"; };
 		3326F2612B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionDeclarativeNetRequestRule.mm; sourceTree = "<group>"; };
 		3326F2622B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionDeclarativeNetRequestRule.h; sourceTree = "<group>"; };
 		3326F2632B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionDeclarativeNetRequestTranslator.h; sourceTree = "<group>"; };
@@ -15395,6 +15397,8 @@
 				2D2ADF0616362DC700197E47 /* PDFPluginTextAnnotation.mm */,
 				2DC2515E2AFE0E8F00EB4EC5 /* PDFScriptEvaluator.h */,
 				2DC2515F2AFE0E9000EB4EC5 /* PDFScriptEvaluator.mm */,
+				33238F5D2B7EFD3B0014AE88 /* WKAccessibilityPDFDocumentObject.h */,
+				33238F5E2B7EFD6A0014AE88 /* WKAccessibilityPDFDocumentObject.mm */,
 			);
 			name = PDF;
 			sourceTree = "<group>";

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -109,7 +109,6 @@ public:
 
     bool showContextMenuAtPoint(const WebCore::IntPoint&);
 
-    PDFPluginAnnotation* activeAnnotation() const { return m_activeAnnotation.get(); }
     WebCore::AXObjectCache* axObjectCache() const;
 
     WebCore::IntPoint convertFromPluginToPDFView(const WebCore::IntPoint&) const;
@@ -181,7 +180,6 @@ private:
 
     id accessibilityHitTest(const WebCore::IntPoint&) const override;
     id accessibilityObject() const override;
-    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
 
     NSEvent *nsEventForWebMouseEvent(const WebMouseEvent&);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1594,17 +1594,6 @@ NSData *PDFPlugin::liveData() const
     return originalData();
 }
 
-id PDFPlugin::accessibilityAssociatedPluginParentForElement(WebCore::Element* element) const
-{
-    if (!m_activeAnnotation)
-        return nil;
-
-    if (m_activeAnnotation->element() != element)
-        return nil;
-
-    return [m_activeAnnotation->annotation() accessibilityNode];
-}
-
 id PDFPlugin::accessibilityHitTest(const WebCore::IntPoint& point) const
 {
     return [m_accessibilityObject accessibilityHitTestIntPoint:point];

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -47,6 +47,9 @@ OBJC_CLASS NSDictionary;
 OBJC_CLASS PDFAnnotation;
 OBJC_CLASS PDFDocument;
 OBJC_CLASS PDFSelection;
+#if PLATFORM(MAC)
+OBJC_CLASS WKAccessibilityPDFDocumentObject;
+#endif
 
 namespace WebCore {
 class FragmentedSharedBuffer;
@@ -116,7 +119,6 @@ public:
     bool isLocked() const;
 
     RetainPtr<PDFDocument> pdfDocument() const { return m_pdfDocument; }
-    RetainPtr<PDFDocument> pdfDocumentForPrinting() const { return m_pdfDocument; }
     WebCore::FloatSize pdfDocumentSizeForPrinting() const;
 
     virtual bool geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform);
@@ -159,7 +161,7 @@ public:
 
     virtual id accessibilityHitTest(const WebCore::IntPoint&) const = 0;
     virtual id accessibilityObject() const = 0;
-    virtual id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const = 0;
+    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const;
 
     bool isBeingDestroyed() const { return m_isBeingDestroyed; }
 
@@ -176,13 +178,19 @@ public:
     WebCore::IntPoint convertFromPluginToRootView(const WebCore::IntPoint&) const;
     WebCore::IntRect convertFromPluginToRootView(const WebCore::IntRect&) const;
     WebCore::IntRect boundsOnScreen() const;
+    WebCore::FloatRect convertFromPDFViewToScreenForAccessibility(const WebCore::FloatRect&) const;
+    WebCore::IntPoint convertFromPDFViewToRootView(const WebCore::IntPoint&) const;
+    WebCore::IntPoint convertFromRootViewToPDFView(const WebCore::IntPoint&) const;
+
+    bool showContextMenuAtPoint(const WebCore::IntPoint&);
+    WebCore::AXObjectCache* axObjectCache() const;
 
     WebCore::ScrollPosition scrollPositionForTesting() const { return scrollPosition(); }
     WebCore::Scrollbar* horizontalScrollbar() const override { return m_horizontalScrollbar.get(); }
     WebCore::Scrollbar* verticalScrollbar() const override { return m_verticalScrollbar.get(); }
+    void setScrollOffset(const WebCore::ScrollOffset&) final;
 
     virtual void didAttachScrollingNode() { }
-
     virtual void didChangeSettings() { }
 
     // HUD Actions.
@@ -197,6 +205,9 @@ public:
 
     WebCore::ScrollPosition scrollPosition() const final;
 
+#if PLATFORM(MAC)
+    PDFPluginAnnotation* activeAnnotation() const { return m_activeAnnotation.get(); }
+#endif
     virtual void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) = 0;
     void didMutatePDFDocument() { m_pdfDocumentWasMutated = true; }
 
@@ -272,7 +283,6 @@ protected:
     bool isScrollableOrRubberbandable() final { return true; }
     bool hasScrollableOrRubberbandableAncestor() final { return true; }
     WebCore::IntRect scrollableAreaBoundingBox(bool* = nullptr) const final;
-    void setScrollOffset(const WebCore::ScrollOffset&) final;
     bool isActive() const final;
     bool isScrollCornerVisible() const final { return false; }
     WebCore::ScrollPosition minimumScrollPosition() const final;
@@ -329,6 +339,9 @@ protected:
     uint64_t m_streamedBytes { 0 };
 
     RetainPtr<PDFDocument> m_pdfDocument;
+#if PLATFORM(MAC)
+    RetainPtr<WKAccessibilityPDFDocumentObject> m_accessibilityDocumentObject;
+#endif
 
     String m_suggestedFilename;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -33,6 +33,7 @@
 #import "PDFIncrementalLoader.h"
 #import "PDFKitSPI.h"
 #import "PluginView.h"
+#import "WKAccessibilityPDFDocumentObject.h"
 #import "WebEventConversion.h"
 #import "WebFrame.h"
 #import "WebLoaderStrategy.h"
@@ -104,6 +105,12 @@ PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
     , m_incrementalPDFLoadingEnabled(element.document().settings().incrementalPDFLoadingEnabled())
 #endif
 {
+#if PLATFORM(MAC)
+    m_accessibilityDocumentObject = adoptNS([[WKAccessibilityPDFDocumentObject alloc] initWithPDFDocument:m_pdfDocument andElement:&element]);
+    [m_accessibilityDocumentObject setPDFPlugin:this];
+    if (this->isFullFramePlugin() && m_frame && m_frame->page() && m_frame->isMainFrame())
+        [m_accessibilityDocumentObject setParent:dynamic_objc_cast<NSObject>(m_frame->protectedPage()->accessibilityRemoteObject())];
+#endif
 }
 
 PDFPluginBase::~PDFPluginBase()
@@ -932,6 +939,50 @@ bool PDFPluginBase::supportsForms()
     return isFullFramePlugin();
 }
 
+bool PDFPluginBase::showContextMenuAtPoint(const IntPoint& point)
+{
+    auto* frameView = m_frame ? m_frame->coreLocalFrame()->view() : nullptr;
+    if (!frameView)
+        return false;
+    IntPoint contentsPoint = frameView->contentsToRootView(point);
+    WebMouseEvent event({ WebEventType::MouseDown, OptionSet<WebEventModifier> { }, WallTime::now() }, WebMouseEventButton::Right, 0, contentsPoint, contentsPoint, 0, 0, 0, 1, WebCore::ForceAtClick);
+    return handleContextMenuEvent(event);
+}
+
+IntPoint PDFPluginBase::convertFromPDFViewToRootView(const IntPoint& point) const
+{
+    // FIXME fix the coordinate space
+    IntPoint pointInPluginCoordinates(point.x(), size().height() - point.y());
+    return valueOrDefault(m_rootViewToPluginTransform.inverse()).mapPoint(pointInPluginCoordinates);
+}
+
+FloatRect PDFPluginBase::convertFromPDFViewToScreenForAccessibility(const FloatRect& rect) const
+{
+    return WebCore::Accessibility::retrieveValueFromMainThread<WebCore::FloatRect>([&] () -> WebCore::FloatRect {
+        FloatRect updatedRect = rect;
+        updatedRect.setLocation(convertFromPDFViewToRootView(IntPoint(updatedRect.location())));
+        RefPtr page = this->page();
+        if (!page)
+            return { };
+        return page->chrome().rootViewToScreen(enclosingIntRect(updatedRect));
+    });
+}
+
+WebCore::AXObjectCache* PDFPluginBase::axObjectCache() const
+{
+    ASSERT(isMainRunLoop());
+    if (!m_frame || !m_frame->coreLocalFrame() || !m_frame->coreLocalFrame()->document())
+        return nullptr;
+    return m_frame->coreLocalFrame()->document()->axObjectCache();
+}
+
+IntPoint PDFPluginBase::convertFromRootViewToPDFView(const IntPoint& point) const
+{
+    ASSERT(isMainRunLoop());
+    IntPoint pointInPluginCoordinates = m_rootViewToPluginTransform.mapPoint(point);
+    return IntPoint(pointInPluginCoordinates.x(), size().height() - pointInPluginCoordinates.y());
+}
+
 WebCore::IntPoint PDFPluginBase::lastKnownMousePositionInView() const
 {
     if (m_lastMouseEvent)
@@ -954,6 +1005,23 @@ void PDFPluginBase::navigateToURL(const URL& url)
         coreEvent = MouseEvent::create(eventNames().clickEvent, &frame->windowProxy(), platform(*m_lastMouseEvent), 0, 0);
 
     frame->loader().changeLocation(url, emptyAtom(), coreEvent.get(), ReferrerPolicy::NoReferrer, ShouldOpenExternalURLsPolicy::ShouldAllow);
+}
+
+id PDFPluginBase::accessibilityAssociatedPluginParentForElement(Element* element) const
+{
+    ASSERT(isMainRunLoop());
+
+#if PLATFORM(MAC)
+    if (!m_activeAnnotation)
+        return nil;
+
+    if (m_activeAnnotation->element() != element)
+        return nil;
+
+    return [m_activeAnnotation->annotation() accessibilityNode];
+#endif
+
+    return nil;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -274,7 +274,9 @@ private:
 
     id accessibilityHitTest(const WebCore::IntPoint&) const override;
     id accessibilityObject() const override;
-    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
+#if PLATFORM(MAC)
+    id accessibilityHitTestIntPoint(const WebCore::IntPoint&) const;
+#endif
 
     void paint(WebCore::GraphicsContext&, const WebCore::IntRect&) override;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -38,6 +38,7 @@
 #include "PDFPluginPasswordForm.h"
 #include "PasteboardTypes.h"
 #include "PluginView.h"
+#include "WKAccessibilityPDFDocumentObject.h"
 #include "WebEventConversion.h"
 #include "WebEventModifier.h"
 #include "WebEventType.h"
@@ -84,7 +85,7 @@
 
 @implementation WKPDFFormMutationObserver
 
-- (id)initWithPlguin:(WebKit::UnifiedPDFPlugin *)plugin
+- (id)initWithPlugin:(WebKit::UnifiedPDFPlugin *)plugin
 {
     if (!(self = [super init]))
         return nil;
@@ -118,7 +119,7 @@ Ref<UnifiedPDFPlugin> UnifiedPDFPlugin::create(HTMLPlugInElement& pluginElement)
 
 UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
     : PDFPluginBase(element)
-    , m_pdfMutationObserver(adoptNS([[WKPDFFormMutationObserver alloc] initWithPlguin:this]))
+    , m_pdfMutationObserver(adoptNS([[WKPDFFormMutationObserver alloc] initWithPlugin:this]))
 {
     this->setVerticalScrollElasticity(ScrollElasticity::Automatic);
     this->setHorizontalScrollElasticity(ScrollElasticity::Automatic);
@@ -2653,18 +2654,28 @@ LookupTextResult UnifiedPDFPlugin::lookupTextAtLocation(const FloatPoint& rootVi
     return { lookupText, m_currentSelection };
 }
 
-id UnifiedPDFPlugin::accessibilityHitTest(const IntPoint&) const
+#if PLATFORM(MAC)
+id UnifiedPDFPlugin::accessibilityHitTestIntPoint(const WebCore::IntPoint& point) const
 {
+    auto convertedPoint =  convertFromRootViewToPDFView(point);
+    return [m_accessibilityDocumentObject accessibilityHitTest:convertedPoint];
+}
+#endif
+
+id UnifiedPDFPlugin::accessibilityHitTest(const WebCore::IntPoint& point) const
+{
+#if PLATFORM(MAC)
+    return accessibilityHitTestIntPoint(point);
+#endif
+    UNUSED_PARAM(point);
     return nil;
 }
 
 id UnifiedPDFPlugin::accessibilityObject() const
 {
-    return nil;
-}
-
-id UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement(Element*) const
-{
+#if PLATFORM(MAC)
+    return m_accessibilityDocumentObject.get();
+#endif
     return nil;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+
+#include "PDFPluginBase.h"
+#include <PDFKit/PDFKit.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WeakObjCPtr.h>
+
+namespace WebCore {
+class HTMLPlugInElement;
+class WeakPtrImplWithEventTargetData;
+}
+
+@interface WKAccessibilityPDFDocumentObject: NSObject {
+    RetainPtr<PDFDocument> _pdfDocument;
+    WeakObjCPtr<NSObject> _parent;
+    ThreadSafeWeakPtr<WebKit::PDFPluginBase> _pdfPlugin;
+}
+
+@property (assign) WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> pluginElement;
+
+- (id)initWithPDFDocument:(RetainPtr<PDFDocument>)document andElement:(WebCore::HTMLPlugInElement*)element;
+- (void)setParent:(NSObject *)parent;
+- (void)setPDFDocument:(RetainPtr<PDFDocument>)document;
+- (void)setPDFPlugin:(WebKit::PDFPluginBase*)plugin;
+- (PDFDocument *)document;
+- (NSObject *)parent;
+- (id)accessibilityHitTest:(NSPoint)point;
+- (void)gotoDestination:(PDFDestination *)destination;
+
+@end
+
+#endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WKAccessibilityPDFDocumentObject.h"
+
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+
+#include "PDFKitSPI.h"
+#include "PDFPluginAnnotation.h"
+#include "PDFPluginBase.h"
+#include <PDFKit/PDFKit.h>
+#include <WebCore/AXObjectCache.h>
+#include <WebCore/HTMLPlugInElement.h>
+#include <WebCore/WebAccessibilityObjectWrapperMac.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WeakObjCPtr.h>
+
+@implementation WKAccessibilityPDFDocumentObject
+
+@synthesize pluginElement = _pluginElement;
+
+- (id)initWithPDFDocument:(RetainPtr<PDFDocument>)document andElement:(WebCore::HTMLPlugInElement*)element
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _pdfDocument = document;
+    _pluginElement = element;
+    return self;
+}
+
+- (void)setPDFPlugin:(WebKit::PDFPluginBase*)plugin
+{
+    _pdfPlugin = plugin;
+}
+
+- (void)setPDFDocument:(RetainPtr<PDFDocument>)document
+{
+    _pdfDocument = document;
+}
+
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
+- (id)accessibilityFocusedUIElement
+{
+    RefPtr plugin = _pdfPlugin.get();
+    if (plugin) {
+        if (RefPtr activeAnnotation = plugin->activeAnnotation()) {
+            if (WebCore::AXObjectCache* existingCache = plugin->axObjectCache()) {
+                if (RefPtr object = existingCache->getOrCreate(activeAnnotation->element())) {
+                ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+                    return [object->wrapper() accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
+                ALLOW_DEPRECATED_DECLARATIONS_END
+                }
+            }
+        }
+    }
+    for (id page in [self accessibilityChildren]) {
+        id focusedElement = [page accessibilityFocusedUIElement];
+        if (!focusedElement)
+            return focusedElement;
+    }
+    return nil;
+}
+
+- (PDFDocument*)document
+{
+    return _pdfDocument.get();
+}
+
+- (NSArray *)accessibilityVisibleChildren
+{
+    RetainPtr<NSMutableArray> visiblePageElements = adoptNS([[NSMutableArray alloc] init]);
+    for (id page in [self accessibilityChildren]) {
+        id focusedElement = [page accessibilityFocusedUIElement];
+        if (!focusedElement)
+            [visiblePageElements addObject:page];
+    }
+    return visiblePageElements.autorelease();
+}
+
+- (NSObject *)parent
+{
+    RetainPtr protectedSelf = self;
+    if (!protectedSelf->_parent) {
+        callOnMainRunLoopAndWait([protectedSelf] {
+            if (CheckedPtr axObjectCache = protectedSelf->_pdfPlugin.get()->axObjectCache()) {
+                if (RefPtr pluginAxObject = axObjectCache->getOrCreate(protectedSelf->_pluginElement.get()))
+                    protectedSelf->_parent = pluginAxObject->wrapper();
+            }
+        });
+    }
+    return protectedSelf->_parent.get().get();
+}
+
+- (void)setParent:(NSObject *)parent
+{
+    _parent = parent;
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (id)accessibilityAttributeValue:(NSString *)attribute
+{
+    if ([attribute isEqualToString:NSAccessibilityParentAttribute])
+        return [self parent];
+    if ([attribute isEqualToString:NSAccessibilityChildrenAttribute])
+        return [self accessibilityChildren];
+    if ([attribute isEqualToString:NSAccessibilityVisibleChildrenAttribute])
+        return [self accessibilityVisibleChildren];
+    if ([attribute isEqualToString:NSAccessibilityTopLevelUIElementAttribute])
+        return [[self parent] accessibilityAttributeValue:NSAccessibilityTopLevelUIElementAttribute];
+    if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
+        return [[self parent] accessibilityAttributeValue:NSAccessibilityWindowAttribute];
+    if ([attribute isEqualToString:NSAccessibilityEnabledAttribute])
+        return [[self parent] accessibilityAttributeValue:NSAccessibilityEnabledAttribute];
+    if ([attribute isEqualToString:NSAccessibilityRoleAttribute])
+        return NSAccessibilityGroupRole;
+    if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
+        return [[self parent] accessibilityAttributeValue:NSAccessibilityPrimaryScreenHeightAttribute];
+    if ([attribute isEqualToString:NSAccessibilitySubroleAttribute])
+        return @"AXPDFPluginSubrole";
+    if ([attribute isEqualToString:NSAccessibilitySizeAttribute]) {
+        RefPtr plugin = _pdfPlugin.get();
+        if (plugin)
+            return [NSValue valueWithSize:plugin->boundsOnScreen().size()];
+    }
+    if ([attribute isEqualToString:NSAccessibilityPositionAttribute]) {
+        RefPtr plugin = _pdfPlugin.get();
+        if (plugin)
+            return [NSValue valueWithPoint:plugin->boundsOnScreen().location()];
+    }
+    return nil;
+}
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (NSArray *)accessibilityAttributeNames
+{
+    static NeverDestroyed<RetainPtr<NSArray>> attributeNames = @[
+        NSAccessibilityParentAttribute,
+        NSAccessibilityWindowAttribute,
+        NSAccessibilityTopLevelUIElementAttribute,
+        NSAccessibilityRoleDescriptionAttribute,
+        NSAccessibilitySizeAttribute,
+        NSAccessibilityEnabledAttribute,
+        NSAccessibilityPositionAttribute,
+        NSAccessibilityFocusedAttribute,
+        NSAccessibilityChildrenAttribute,
+        NSAccessibilityPrimaryScreenHeightAttribute,
+        NSAccessibilitySubroleAttribute
+    ];
+    return attributeNames.get().get();
+}
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+
+- (BOOL)accessibilityShouldUseUniqueId
+{
+    return YES;
+}
+
+- (NSUInteger)accessibilityArrayAttributeCount:(NSString *)attribute
+{
+    if (!_pdfDocument) {
+        RefPtr plugin = _pdfPlugin.get();
+        if (plugin)
+            _pdfDocument = plugin->pdfDocument();
+    }
+    if ([attribute isEqualToString:NSAccessibilityChildrenAttribute])
+        return [_pdfDocument.get() pageCount];
+    if ([attribute isEqualToString:NSAccessibilityVisibleChildrenAttribute])
+        return [self accessibilityVisibleChildren].count;
+    return [super accessibilityArrayAttributeCount:attribute];
+}
+
+- (NSArray*)accessibilityChildren
+{
+    if (!_pdfDocument) {
+        RefPtr plugin = _pdfPlugin.get();
+        if (plugin)
+            _pdfDocument = plugin->pdfDocument();
+    }
+
+    if ([_pdfDocument respondsToSelector:@selector(accessibilityChildren:)])
+        return [_pdfDocument accessibilityChildren:self];
+
+    return nil;
+}
+
+- (id)accessibilityHitTest:(NSPoint)point
+{
+    for (id element in [self accessibilityChildren]) {
+        id result = [element accessibilityHitTest:point];
+        if (!result)
+            return result;
+    }
+    return self;
+}
+
+// this function allows VoiceOver to scroll to the current page with VO cursor
+- (void)gotoDestination:(PDFDestination *)destination
+{
+    RefPtr plugin = _pdfPlugin.get();
+    if (!plugin)
+        return;
+
+    NSInteger pageIndex = [_pdfDocument indexForPage:[destination page]];
+    NSRect rect = [[self accessibilityChildren][0] accessibilityFrame];
+    WebCore::IntPoint point = { 0, static_cast<int>(rect.size.height * pageIndex) + 1 };
+
+    callOnMainRunLoopAndWait([protectedPlugin = plugin, &point] {
+        protectedPlugin->setScrollOffset(point);
+    });
+}
+@end
+
+#endif

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -952,7 +952,7 @@ bool PluginView::isBeingDestroyed() const
 
 RetainPtr<PDFDocument> PluginView::pdfDocumentForPrinting() const
 {
-    return protectedPlugin()->pdfDocumentForPrinting();
+    return protectedPlugin()->pdfDocument();
 }
 
 WebCore::FloatSize PluginView::pdfDocumentSizeForPrinting() const


### PR DESCRIPTION
<pre>
[UnifedPDF] Hook up accessibility for Unified PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=269565">https://bugs.webkit.org/show_bug.cgi?id=269565</a>
<a href="https://rdar.apple.com/123056248">rdar://123056248</a>

Patch originally by Elina Ding.
Reviewed by Simon Fraser.

This commit adds support so that UnifiedPDF is accessible.
This commit creates WKAccessibilityPDFDocumentObject as a UnifedPDF accessibility
wrapper, which is different from WKPDFPluginAccessibilityObject in that this
object does not depend on any layer code.

Previously, the accessibility communication point between WebKit and PDFKit was via
PDFLayerController. I moved the communication point to PDFDocument for better
code reuse and less dependency.

Some Todos:
    1. Stop accessing the plugin on the accessibility thread.
    2. Move WKAccessibilityPDFDocumentObject to its own file.
    3. Resolve coordinate space for better visual experience.

* Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::accessibilityAssociatedPluginParentForElement const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::pdfDocument const):
(WebKit::PDFPluginBase::didAttachScrollingNode):
(WebKit::PDFPluginBase::activeAnnotation const):
(WebKit::PDFPluginBase::pdfDocumentForPrinting const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::showContextMenuAtPoint):
(WebKit::PDFPluginBase::convertFromPDFViewToRootView const):
(WebKit::PDFPluginBase::convertFromPDFViewToScreenForAccessibility const):
(WebKit::PDFPluginBase::axObjectCache const):
(WebKit::PDFPluginBase::convertFromRootViewToPDFView const):
(WebKit::PDFPluginBase::accessibilityAssociatedPluginParentForElement const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(-[WKPDFFormMutationObserver initWithPlugin:]):
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::UnifiedPDFPlugin::accessibilityHitTestIntPoint const):
(WebKit::UnifiedPDFPlugin::accessibilityHitTest const):
(WebKit::UnifiedPDFPlugin::accessibilityObject const):
(-[WKPDFFormMutationObserver initWithPlguin:]): Deleted.
(WebKit::UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h: Added.
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm: Added.
(-[WKAccessibilityPDFDocumentObject initWithPDFDocument:andElement:]):
(-[WKAccessibilityPDFDocumentObject setPDFPlugin:]):
(-[WKAccessibilityPDFDocumentObject setPDFDocument:]):
(-[WKAccessibilityPDFDocumentObject isAccessibilityElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityFocusedUIElement]):
(-[WKAccessibilityPDFDocumentObject document]):
(-[WKAccessibilityPDFDocumentObject accessibilityVisibleChildren]):
(-[WKAccessibilityPDFDocumentObject parent]):
(-[WKAccessibilityPDFDocumentObject setParent:]):
(-[WKAccessibilityPDFDocumentObject accessibilityAttributeValue:]):
(-[WKAccessibilityPDFDocumentObject accessibilityAttributeNames]):
(-[WKAccessibilityPDFDocumentObject accessibilityShouldUseUniqueId]):
(-[WKAccessibilityPDFDocumentObject accessibilityArrayAttributeCount:]):
(-[WKAccessibilityPDFDocumentObject accessibilityChildren]):
(-[WKAccessibilityPDFDocumentObject accessibilityHitTest:]):
(-[WKAccessibilityPDFDocumentObject gotoDestination:]):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::pdfDocumentForPrinting const):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cac12777613920998a3db50bb54f0c9937cdce7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19240 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22166 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16569 "Hash cac12777 for PR 24631 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/42773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40802 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/16201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/42773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/44051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/16569 "Hash cac12777 for PR 24631 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->