### PR TITLE
[Skia] Implement outset drop shadows

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -42,6 +42,7 @@
 #include <skia/core/SkRegion.h>
 #include <skia/core/SkTileMode.h>
 #include <skia/effects/SkDashPathEffect.h>
+#include <skia/effects/SkImageFilters.h>
 #include <wtf/MathExtras.h>
 
 #if USE(THEME_ADWAITA)
@@ -304,6 +305,21 @@ SkPaint GraphicsContextSkia::createFillPaint(std::optional<Color> fillColor) con
             color = color.colorWithAlphaMultipliedBy(globalAlpha);
         auto [r, g, b, a] = color.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
         paint.setColor(SkColorSetARGB(a, r, g, b));
+    }
+
+    // Outset shadow
+    // FIXME: Don't add the effect if the shadow is inset
+    if (hasDropShadow()) {
+        const auto shadow = dropShadow();
+        ASSERT(shadow);
+
+        const auto sigma = shadow->radius / 2.0;
+        auto globalAlpha = state.alpha();
+        auto shadowColor = shadow->color;
+        if (globalAlpha < 1)
+            shadowColor = shadowColor.colorWithAlphaMultipliedBy(globalAlpha);
+        auto [r, g, b, a] = shadowColor.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+        paint.setImageFilter(SkImageFilters::DropShadow(shadow->offset.width(), shadow->offset.height(), sigma, sigma, SkColorSetARGB(a, r, g, b), nullptr));
     }
 
     return paint;


### PR DESCRIPTION
#### f5c941fbf0500ebfc89755fb40d972d2f226cea6
<pre>
[Skia] Implement outset drop shadows
<a href="https://bugs.webkit.org/show_bug.cgi?id=269596">https://bugs.webkit.org/show_bug.cgi?id=269596</a>

Reviewed by Nikolas Zimmermann.

Whenever the GraphicsContext has a drop shadow set, use that to create
and set a SkImageFilters::DropShadow() image effect to the fill paint.
Stroke paints are unaffected.

The SkImageFilters::DropShadow() receives a blur sigma instead of radius
and the formal definition of that [1] states that sigma is half of the
blur radius, so convert between these values.

This only implements outset shadows. Inset shadows won&apos;t be rendered
anyway because GraphicsContextSkia::fillRectWithRoundedHole() is not
implemented yet.

[1] <a href="https://html.spec.whatwg.org/multipage/canvas.html#shadows">https://html.spec.whatwg.org/multipage/canvas.html#shadows</a>

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::createFillPaint const):

Canonical link: <a href="https://commits.webkit.org/274928@main">https://commits.webkit.org/274928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9a468702111e3639560f024e271c7d19e1c88b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36304 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33425 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13994 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44038 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38031 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16649 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9064 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->