### PR TITLE
[Network] test tzone on

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -326,7 +326,7 @@
 #if CPU(ARM64) && OS(DARWIN)
 // Only MacroAssemblerARM64 is known to build.
 // Building with TZONE_MALLOC currently disabled for all platforms.
-#define USE_TZONE_MALLOC 0
+#define USE_TZONE_MALLOC 1
 #else
 #define USE_TZONE_MALLOC 0
 #endif

--- a/Source/WTF/wtf/TZoneMallocInitialization.h
+++ b/Source/WTF/wtf/TZoneMallocInitialization.h
@@ -39,11 +39,11 @@
 
 #include <bmalloc/TZoneHeapManager.h>
 
-#if USE(DARWIN_TZONE_SEED)
-#include <WebKitAdditions/TZoneAdditions.h>
-#else
+//#if USE(DARWIN_TZONE_SEED)
+//#include <WebKitAdditions/TZoneAdditions.h>
+//#else
 #define GET_TZONE_SEED_FROM_ENV(x) nullptr
-#endif
+//#endif
 
 #if !BUSE(TZONE)
 #error "TZones enabled in WTF, but not enabled in bmalloc"

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -42,6 +42,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(BackgroundFetchLoad);
+
 BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::SessionID sessionID, Client& client, const BackgroundFetchRequest& request, size_t responseDataSize, const ClientOrigin& clientOrigin)
     : m_sessionID(WTFMove(sessionID))
     , m_client(client)

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -31,6 +31,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -47,7 +48,7 @@ class NetworkLoadChecker;
 class NetworkProcess;
 
 class BackgroundFetchLoad final : public WebCore::BackgroundFetchRecordLoader, public NetworkDataTaskClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(BackgroundFetchLoad);
 public:
     BackgroundFetchLoad(NetworkProcess&, PAL::SessionID, Client&, const WebCore::BackgroundFetchRequest&, size_t responseDataSize, const WebCore::ClientOrigin&);
     ~BackgroundFetchLoad();

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -61,6 +61,9 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(OperatingDate);
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ResourceLoadStatisticsStore);
+
 #define ITP_RELEASE_LOG(sessionID, fmt, ...) RELEASE_LOG(Network, "%p - ResourceLoadStatisticsStore::" fmt, this, ##__VA_ARGS__)
 #define ITP_RELEASE_LOG_ERROR(sessionID, fmt, ...) RELEASE_LOG_ERROR(Network, "%p - ResourceLoadStatisticsStore::" fmt, this, ##__VA_ARGS__)
 

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -33,6 +33,7 @@
 #include <pal/SessionID.h>
 #include <wtf/Forward.h>
 #include <wtf/StdSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if HAVE(CORE_PREDICTION)
@@ -53,6 +54,7 @@ namespace WebKit {
 enum class DidFilterKnownLinkDecoration : bool;
 
 class OperatingDate {
+    WTF_MAKE_WK_TZONE_ALLOCATED(OperatingDate);
 public:
     OperatingDate() = default;
     
@@ -86,7 +88,7 @@ enum class DataRemovalFrequency : uint8_t { Never, Short, Long };
 
 // This is always constructed / used / destroyed on the WebResourceLoadStatisticsStore's statistics queue.
 class ResourceLoadStatisticsStore final : public DatabaseUtilities, public CanMakeWeakPtr<ResourceLoadStatisticsStore> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ResourceLoadStatisticsStore);
 public:
     using ResourceLoadStatistics = WebCore::ResourceLoadStatistics;
     using RegistrableDomain = WebCore::RegistrableDomain;

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -59,6 +59,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebResourceLoadStatisticsStore);
+
 const OptionSet<WebsiteDataType>& WebResourceLoadStatisticsStore::monitoredDataTypes()
 {
     static NeverDestroyed<OptionSet<WebsiteDataType>> dataTypes(std::initializer_list<WebsiteDataType>({

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -43,6 +43,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 #include <wtf/WallTime.h>
@@ -94,6 +95,7 @@ struct RegistrableDomainsToDeleteOrRestrictWebsiteDataFor {
 };
 
 class WebResourceLoadStatisticsStore final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebResourceLoadStatisticsStore, WTF::DestructionThread::Main> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebResourceLoadStatisticsStore);
 public:
     using ResourceLoadStatistics = WebCore::ResourceLoadStatistics;
     using RegistrableDomain = WebCore::RegistrableDomain;

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -43,6 +43,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebCookieManager);
+
 ASCIILiteral WebCookieManager::supplementName()
 {
     return "WebCookieManager"_s;

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakRef.h>
 
@@ -50,7 +51,7 @@ namespace WebKit {
 class NetworkProcess;
 
 class WebCookieManager : public NetworkProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebCookieManager);
     WTF_MAKE_NONCOPYABLE(WebCookieManager);
 public:
     WebCookieManager(NetworkProcess&);

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LegacyCustomProtocolManager);
+
 ASCIILiteral LegacyCustomProtocolManager::supplementName()
 {
     return "LegacyCustomProtocolManager"_s;

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -54,7 +55,7 @@ class NetworkProcess;
 struct NetworkProcessCreationParameters;
 
 class LegacyCustomProtocolManager : public NetworkProcessSupplement, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LegacyCustomProtocolManager);
     WTF_MAKE_NONCOPYABLE(LegacyCustomProtocolManager);
 public:
     explicit LegacyCustomProtocolManager(NetworkProcess&);

--- a/Source/WebKit/NetworkProcess/DatabaseUtilities.cpp
+++ b/Source/WebKit/NetworkProcess/DatabaseUtilities.cpp
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DatabaseUtilities);
+
 DatabaseUtilities::DatabaseUtilities(String&& storageFilePath)
     : m_storageFilePath(WTFMove(storageFilePath))
     , m_transaction(m_database)

--- a/Source/WebKit/NetworkProcess/DatabaseUtilities.h
+++ b/Source/WebKit/NetworkProcess/DatabaseUtilities.h
@@ -29,6 +29,7 @@
 #include <WebCore/SQLiteTransaction.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/Scope.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class PrivateClickMeasurement;
@@ -43,6 +44,7 @@ enum class PrivateClickMeasurementAttributionType : bool;
 using TableAndIndexPair = std::pair<String, std::optional<String>>;
 
 class DatabaseUtilities {
+    WTF_MAKE_WK_TZONE_ALLOCATED(DatabaseUtilities);
 protected:
     DatabaseUtilities(String&& storageFilePath);
     ~DatabaseUtilities();

--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -50,6 +50,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(Download);
+
 Download::Download(DownloadManager& downloadManager, DownloadID downloadID, NetworkDataTask& download, NetworkSession& session, const String& suggestedName)
     : m_downloadManager(downloadManager)
     , m_downloadID(downloadID)

--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -37,6 +37,7 @@
 #include <pal/SessionID.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
@@ -61,7 +62,8 @@ class NetworkSession;
 class WebPage;
 
 class Download : public IPC::MessageSender, public CanMakeWeakPtr<Download> {
-    WTF_MAKE_NONCOPYABLE(Download); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(Download);
+    WTF_MAKE_WK_TZONE_ALLOCATED(Download);
 public:
     Download(DownloadManager&, DownloadID, NetworkDataTask&, NetworkSession&, const String& suggestedFilename = { });
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
@@ -40,6 +40,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DownloadManager);
+
 DownloadManager::DownloadManager(Client& client)
     : m_client(client)
 {

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -36,6 +36,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace PAL {
 class SessionID;
@@ -63,7 +64,7 @@ enum class CallDownloadDidStart : bool { No, Yes };
 
 class DownloadManager {
     WTF_MAKE_NONCOPYABLE(DownloadManager);
-
+    WTF_MAKE_WK_TZONE_ALLOCATED(DownloadManager);
 public:
     class Client : public CanMakeCheckedPtr {
     public:

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMap.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMap.cpp
@@ -33,6 +33,7 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DownloadMap);
 
 Download* DownloadMap::get(DownloadID downloadID) const
 {

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMap.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMap.h
@@ -28,6 +28,7 @@
 #include "DownloadID.h"
 #include "ProcessAssertion.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -38,6 +39,7 @@ typedef HashMap<DownloadID, std::unique_ptr<Download>> DownloadMap;
 #else
 
 class DownloadMap {
+    WTF_MAKE_WK_TZONE_ALLOCATED(DownloadMap);
 public:
     typedef HashMap<DownloadID, std::unique_ptr<Download>> DownloadMapType;
 

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DownloadMonitor);
+
 constexpr uint64_t operator"" _kbps(unsigned long long kilobytesPerSecond)
 {
     return kilobytesPerSecond * 1024;

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
@@ -27,13 +27,15 @@
 
 #include <WebCore/Timer.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class Download;
 
 class DownloadMonitor {
-    WTF_MAKE_NONCOPYABLE(DownloadMonitor); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(DownloadMonitor);
+    WTF_MAKE_WK_TZONE_ALLOCATED(DownloadMonitor);
 public:
     DownloadMonitor(Download&);
     

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -36,6 +36,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PendingDownload);
+
 PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, NetworkLoadParameters&& parameters, DownloadID downloadID, NetworkSession& networkSession, const String& suggestedName)
     : m_networkLoad(makeUnique<NetworkLoad>(*this, WTFMove(parameters), networkSession))
     , m_parentProcessConnection(parentProcessConnection)

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -29,6 +29,7 @@
 #include "MessageSender.h"
 #include "NetworkLoadClient.h"
 #include "SandboxExtension.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Connection;
@@ -46,7 +47,7 @@ class NetworkLoadParameters;
 class NetworkSession;
 
 class PendingDownload : public NetworkLoadClient, public IPC::MessageSender, public CanMakeWeakPtr<PendingDownload> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(PendingDownload);
 public:
     PendingDownload(IPC::Connection*, NetworkLoadParameters&&, DownloadID, NetworkSession&, const String& suggestedName);
     PendingDownload(IPC::Connection*, std::unique_ptr<NetworkLoad>&&, ResponseCompletionHandler&&, DownloadID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -40,6 +40,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(EarlyHintsResourceLoader);
+
 EarlyHintsResourceLoader::EarlyHintsResourceLoader(NetworkResourceLoader& loader)
     : m_loader(&loader)
 {

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "NetworkResourceLoader.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class LinkHeader;
@@ -35,7 +36,7 @@ namespace WebKit {
 
 class EarlyHintsResourceLoader
     : public WebCore::ContentSecurityPolicyClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(EarlyHintsResourceLoader);
     WTF_MAKE_NONCOPYABLE(EarlyHintsResourceLoader);
 public:
     explicit EarlyHintsResourceLoader(NetworkResourceLoader&);

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkBroadcastChannelRegistry);
+
 #define REGISTRY_MESSAGE_CHECK(assertion) REGISTRY_MESSAGE_CHECK_COMPLETION(assertion, (void)0)
 #define REGISTRY_MESSAGE_CHECK_COMPLETION(assertion, completion) do { \
     ASSERT(assertion); \

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
@@ -29,6 +29,7 @@
 #include <WebCore/BroadcastChannelIdentifier.h>
 #include <WebCore/ClientOrigin.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct MessageWithMessagePorts;
@@ -39,7 +40,7 @@ namespace WebKit {
 class NetworkProcess;
 
 class NetworkBroadcastChannelRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkBroadcastChannelRegistry);
 public:
     explicit NetworkBroadcastChannelRegistry(NetworkProcess&);
 

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -42,6 +42,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkCORSPreflightChecker);
+
 NetworkCORSPreflightChecker::NetworkCORSPreflightChecker(NetworkProcess& networkProcess, NetworkResourceLoader* networkResourceLoader, Parameters&& parameters, bool shouldCaptureExtraNetworkLoadMetrics, CompletionCallback&& completionCallback)
     : m_parameters(WTFMove(parameters))
     , m_networkProcess(networkProcess)

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -33,6 +33,7 @@
 #include <WebCore/StoredCredentialsPolicy.h>
 #include <pal/SessionID.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class ResourceError;
@@ -47,7 +48,7 @@ class NetworkProcess;
 class NetworkResourceLoader;
 
 class NetworkCORSPreflightChecker final : private NetworkDataTaskClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkCORSPreflightChecker);
 public:
     struct Parameters {
         WebCore::ResourceRequest originalRequest;

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
@@ -35,6 +35,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkContentRuleListManager);
+
 NetworkContentRuleListManager::NetworkContentRuleListManager(NetworkProcess& networkProcess)
     : m_networkProcess(networkProcess)
 {

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
@@ -30,6 +30,7 @@
 #include "UserContentControllerIdentifier.h"
 #include "WebCompiledContentRuleListData.h"
 #include <WebCore/ContentExtensionsBackend.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
 namespace IPC {
@@ -42,6 +43,7 @@ namespace WebKit {
 class NetworkProcess;
 
 class NetworkContentRuleListManager {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkContentRuleListManager);
 public:
     NetworkContentRuleListManager(NetworkProcess&);
     ~NetworkContentRuleListManager();

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -51,6 +51,9 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkDataTaskClient);
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkDataTask);
+
 Ref<NetworkDataTask> NetworkDataTask::create(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
 {
     ASSERT(!parameters.request.url().protocolIsBlob());

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -36,6 +36,7 @@
 #include <WebCore/StoredCredentialsPolicy.h>
 #include <pal/SessionID.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -60,6 +61,7 @@ using ChallengeCompletionHandler = CompletionHandler<void(AuthenticationChalleng
 using ResponseCompletionHandler = CompletionHandler<void(WebCore::PolicyAction)>;
 
 class NetworkDataTaskClient : public CanMakeWeakPtr<NetworkDataTaskClient> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkDataTaskClient);
 public:
     virtual void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) = 0;
     virtual void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) = 0;
@@ -87,6 +89,7 @@ public:
 };
 
 class NetworkDataTask : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NetworkDataTask, WTF::DestructionThread::Main> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkDataTask);
 public:
     static Ref<NetworkDataTask> create(NetworkSession&, NetworkDataTaskClient&, const NetworkLoadParameters&);
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -52,6 +52,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkDataTaskBlob);
+
 static const unsigned bufferSize = 512 * 1024;
 
 static const int httpOK = 200;

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
@@ -34,6 +34,7 @@
 #include "NetworkDataTask.h"
 #include <WebCore/FileStreamClient.h>
 #include <wtf/FileSystem.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class AsyncFileStream;
@@ -47,6 +48,7 @@ namespace WebKit {
 class NetworkProcess;
 
 class NetworkDataTaskBlob final : public NetworkDataTask, public WebCore::FileStreamClient {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkDataTaskBlob);
 public:
     static Ref<NetworkDataTask> create(NetworkSession& session, NetworkDataTaskClient& client, const WebCore::ResourceRequest& request, const Vector<RefPtr<WebCore::BlobDataFileReference>>& fileReferences, const RefPtr<WebCore::SecurityOrigin>& topOrigin)
     {

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -46,6 +46,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkLoad);
+
 NetworkLoad::NetworkLoad(NetworkLoadClient& client, NetworkLoadParameters&& parameters, NetworkSession& networkSession)
     : m_client(client)
     , m_networkProcess(networkSession.networkProcess())

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -28,6 +28,7 @@
 #include "DownloadID.h"
 #include "NetworkDataTask.h"
 #include "NetworkLoadParameters.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ class NetworkLoadScheduler;
 class NetworkProcess;
 
 class NetworkLoad final : public NetworkDataTaskClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkLoad);
 public:
     NetworkLoad(NetworkLoadClient&, NetworkLoadParameters&&, NetworkSession&);
     NetworkLoad(NetworkLoadClient&, NetworkSession&, const Function<RefPtr<NetworkDataTask>(NetworkDataTaskClient&)>&);

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -50,6 +50,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkLoadChecker);
+
 NetworkLoadChecker::NetworkLoadChecker(NetworkProcess& networkProcess, NetworkResourceLoader* networkResourceLoader, NetworkSchemeRegistry* schemeRegistry, FetchOptions&& options, PAL::SessionID sessionID, WebPageProxyIdentifier webPageProxyID, HTTPHeaderMap&& originalRequestHeaders, URL&& url, DocumentURL&& documentURL, RefPtr<SecurityOrigin>&& sourceOrigin, RefPtr<SecurityOrigin>&& topOrigin, RefPtr<SecurityOrigin>&& parentOrigin, PreflightPolicy preflightPolicy, String&& referrer, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, bool shouldCaptureExtraNetworkLoadMetrics, LoadType requestLoadType)
     : m_options(WTFMove(options))
     , m_allowPrivacyProxy(allowPrivacyProxy)

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -33,6 +33,7 @@
 #include <WebCore/NetworkLoadInformation.h>
 #include <pal/SessionID.h>
 #include <variant>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -57,7 +58,7 @@ class NetworkSchemeRegistry;
 using DocumentURL = URL;
 
 class NetworkLoadChecker : public CanMakeWeakPtr<NetworkLoadChecker> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkLoadChecker);
 public:
     enum class LoadType : bool { MainFrame, Other };
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -38,12 +38,14 @@
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/ProcessID.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 enum class PreconnectOnly : bool { No, Yes };
 
 class NetworkLoadParameters {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NetworkLoadParameters);
 public:
     NetworkLoadParameters() = default;
     NetworkLoadParameters(WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, WebCore::FrameIdentifier webFrameID, RefPtr<WebCore::SecurityOrigin>&& topOrigin, RefPtr<WebCore::SecurityOrigin>&& sourceOrigin, WTF::ProcessID parentPID, WebCore::ResourceRequest&& request, WebCore::ContentSniffingPolicy contentSniffingPolicy, WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, WebCore::ClientCredentialPolicy clientCredentialPolicy, bool shouldClearReferrerOnHTTPSToHTTPRedirect, bool needsCertificateInfo, bool isMainFrameNavigation, std::optional<NavigationActionData>&& mainResourceNavigationDataForAnyFrame, WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, PreconnectOnly shouldPreconnectOnly, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections)

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
@@ -34,11 +34,13 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkLoadScheduler);
+
 static constexpr size_t maximumActiveCountForLowPriority = 2;
 static constexpr size_t maximumTrackedHTTP1XOrigins = 128;
 
 class NetworkLoadScheduler::HostContext {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NetworkLoadScheduler::HostContext);
 public:
     HostContext() = default;
     ~HostContext();

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
@@ -31,6 +31,7 @@
 #include <tuple>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakListHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -43,7 +44,7 @@ namespace WebKit {
 class NetworkLoad;
 
 class NetworkLoadScheduler : public CanMakeWeakPtr<NetworkLoadScheduler> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkLoadScheduler);
 public:
     NetworkLoadScheduler();
     ~NetworkLoadScheduler();

--- a/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkOriginAccessPatterns);
+
 void NetworkOriginAccessPatterns::allowAccessTo(const WebCore::UserContentURLPattern& pattern)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.h
+++ b/Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.h
@@ -27,12 +27,13 @@
 
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/UserContentURLPattern.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 
 class NetworkOriginAccessPatterns final : public WebCore::OriginAccessPatterns {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkOriginAccessPatterns);
 public:
     void allowAccessTo(const WebCore::UserContentURLPattern&);
 private:

--- a/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp
@@ -32,6 +32,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkProcessPlatformStrategies);
+
 void NetworkProcessPlatformStrategies::initialize()
 {
     static NeverDestroyed<NetworkProcessPlatformStrategies> platformStrategies;

--- a/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.h
@@ -27,10 +27,12 @@
 
 #include <WebCore/LoaderStrategy.h>
 #include <WebCore/PlatformStrategies.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class NetworkProcessPlatformStrategies : public WebCore::PlatformStrategies {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkProcessPlatformStrategies);
 public:
     static void initialize();
     

--- a/Source/WebKit/NetworkProcess/NetworkProcessSupplement.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessSupplement.h
@@ -26,12 +26,14 @@
 #pragma once
 
 #include "AuxiliaryProcessSupplement.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 struct NetworkProcessCreationParameters;
 
 class NetworkProcessSupplement : public AuxiliaryProcessSupplement {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NetworkProcessSupplement);
 public:
     virtual void initialize(const NetworkProcessCreationParameters&)
     {

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp
@@ -29,6 +29,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkResourceLoadMap);
+
 NetworkResourceLoadMap::NetworkResourceLoadMap(Function<void(bool hasUpload)>&& hasUploadChangeListener)
     : m_hasUploadChangeListener(WTFMove(hasUploadChangeListener))
 {

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.h
@@ -28,6 +28,7 @@
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(TAKE_UNBOUNDED_NETWORKING_ASSERTION)
 #include "ProcessAssertion.h"
@@ -39,6 +40,7 @@ class NetworkResourceLoader;
 class NetworkConnectionToWebProcess;
 
 class NetworkResourceLoadMap {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkResourceLoadMap);
 public:
     using MapType = HashMap<WebCore::ResourceLoaderIdentifier, Ref<NetworkResourceLoader>>;
     NetworkResourceLoadMap(Function<void(bool hasUpload)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -31,6 +31,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkResourceLoadParameters);
+
 NetworkResourceLoadParameters::NetworkResourceLoadParameters(
     NetworkLoadParameters&& networkLoadParameters
     , WebCore::ResourceLoaderIdentifier identifier

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -37,6 +37,7 @@
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/SecurityContext.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Decoder;
@@ -46,6 +47,7 @@ class Encoder;
 namespace WebKit {
 
 class NetworkResourceLoadParameters : public NetworkLoadParameters {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkResourceLoadParameters);
 public:
     NetworkResourceLoadParameters() = default;
     NetworkResourceLoadParameters(

--- a/Source/WebKit/NetworkProcess/NetworkSchemeRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSchemeRegistry.cpp
@@ -28,6 +28,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkSchemeRegistry);
+
 void NetworkSchemeRegistry::registerURLSchemeAsCORSEnabled(String&& scheme)
 {
     m_corsEnabledSchemes.add(WTFMove(scheme));

--- a/Source/WebKit/NetworkProcess/NetworkSchemeRegistry.h
+++ b/Source/WebKit/NetworkProcess/NetworkSchemeRegistry.h
@@ -27,12 +27,14 @@
 
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class NetworkSchemeRegistry : public RefCounted<NetworkSchemeRegistry> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkSchemeRegistry);
 public:
     static Ref<NetworkSchemeRegistry> create() { return adoptRef(*new NetworkSchemeRegistry); }
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -72,6 +72,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkSession);
+
 constexpr Seconds cachedNetworkResourceLoaderLifetime { 30_s };
 
 std::unique_ptr<NetworkSession> NetworkSession::create(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -49,6 +49,8 @@
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
@@ -102,7 +104,7 @@ class Cache;
 }
 
 class NetworkSession : public WebCore::SWServerDelegate, public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkSession);
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess&, const NetworkSessionCreationParameters&);
     virtual ~NetworkSession();
@@ -311,7 +313,7 @@ protected:
     HashSet<Ref<NetworkResourceLoader>> m_keptAliveLoads;
 
     class CachedNetworkResourceLoader {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(CachedNetworkResourceLoader);
     public:
         explicit CachedNetworkResourceLoader(Ref<NetworkResourceLoader>&&);
         RefPtr<NetworkResourceLoader> takeLoader();

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -37,6 +37,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkSocketChannel);
+
 std::unique_ptr<NetworkSocketChannel> NetworkSocketChannel::create(NetworkConnectionToWebProcess& connection, PAL::SessionID sessionID, const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, const WebCore::ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 {
     auto result = makeUnique<NetworkSocketChannel>(connection, connection.networkProcess().networkSession(sessionID), request, protocol, identifier, webPageProxyID, frameID, pageID, clientOrigin, hadMainFrameMainResourcePrivateRelayed, allowPrivacyProxy, advancedPrivacyProtections, shouldRelaxThirdPartyCookieBlocking, storedCredentialsPolicy);

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -35,6 +35,7 @@
 #include <WebCore/WebSocketIdentifier.h>
 #include <pal/SessionID.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -58,7 +59,7 @@ class NetworkProcess;
 class NetworkSession;
 
 class NetworkSocketChannel : public IPC::MessageSender, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkSocketChannel);
 public:
     static std::unique_ptr<NetworkSocketChannel> create(NetworkConnectionToWebProcess&, PAL::SessionID, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
 

--- a/Source/WebKit/NetworkProcess/NetworkStorageSessionProvider.h
+++ b/Source/WebKit/NetworkProcess/NetworkStorageSessionProvider.h
@@ -29,11 +29,13 @@
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/StorageSessionProvider.h>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
 class NetworkStorageSessionProvider final : public WebCore::StorageSessionProvider {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NetworkStorageSessionProvider);
 public:
     static Ref<NetworkStorageSessionProvider> create(NetworkProcess& networkProcess, PAL::SessionID sessionID) { return adoptRef(*new NetworkStorageSessionProvider(networkProcess, sessionID)); }
     

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -40,6 +40,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkNotificationManager);
+
 NetworkNotificationManager::NetworkNotificationManager(NetworkSession& networkSession, const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration)
     : m_networkSession(networkSession)
 {

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -34,6 +34,7 @@
 #include <WebCore/ExceptionData.h>
 #include <WebCore/NotificationDirection.h>
 #include <WebCore/PushSubscriptionData.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -50,7 +51,7 @@ enum class MessageType : uint8_t;
 class NetworkSession;
 
 class NetworkNotificationManager : public NotificationManagerMessageHandler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkNotificationManager);
     friend class NetworkSession;
 public:
     NetworkSession& networkSession() const { return m_networkSession; }

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit::WebPushD {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(Connection);
+
 Connection::Connection(CString&& machServiceName, NetworkNotificationManager& manager, WebPushDaemonConnectionConfiguration&& configuration)
     : Daemon::ConnectionToMachService<ConnectionTraits>(WTFMove(machServiceName))
     , m_notificationManager(manager)

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -31,6 +31,7 @@
 #include "MessageSender.h"
 #include "WebPushDaemonConnectionConfiguration.h"
 #include "WebPushDaemonConstants.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class Decoder;
@@ -52,7 +53,7 @@ struct ConnectionTraits {
 };
 
 class Connection : public Daemon::ConnectionToMachService<ConnectionTraits>, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(Connection);
 public:
     Connection(CString&& machServiceName, NetworkNotificationManager&, WebPushDaemonConnectionConfiguration&&);
 

--- a/Source/WebKit/NetworkProcess/PingLoad.cpp
+++ b/Source/WebKit/NetworkProcess/PingLoad.cpp
@@ -40,6 +40,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PingLoad);
+
 PingLoad::PingLoad(NetworkProcess& networkProcess, PAL::SessionID sessionID, NetworkResourceLoadParameters&& parameters, CompletionHandler<void(const ResourceError&, const ResourceResponse&)>&& completionHandler)
     : m_sessionID(sessionID)
     , m_parameters(WTFMove(parameters))

--- a/Source/WebKit/NetworkProcess/PingLoad.h
+++ b/Source/WebKit/NetworkProcess/PingLoad.h
@@ -30,6 +30,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceResponse.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -41,6 +42,7 @@ class NetworkProcess;
 class NetworkSchemeRegistry;
 
 class PingLoad final : public NetworkDataTaskClient {
+    WTF_MAKE_WK_TZONE_ALLOCATED(PingLoad);
 public:
     PingLoad(NetworkProcess&, PAL::SessionID, NetworkResourceLoadParameters&&, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse&)>&&);
     PingLoad(NetworkConnectionToWebProcess&, NetworkResourceLoadParameters&&, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse&)>&&);

--- a/Source/WebKit/NetworkProcess/PreconnectTask.cpp
+++ b/Source/WebKit/NetworkProcess/PreconnectTask.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PreconnectTask);
+
 PreconnectTask::PreconnectTask(NetworkSession& networkSession, NetworkLoadParameters&& parameters, CompletionHandler<void(const ResourceError&, const WebCore::NetworkLoadMetrics&)>&& completionHandler)
     : m_completionHandler(WTFMove(completionHandler))
     , m_timeout(60_s)

--- a/Source/WebKit/NetworkProcess/PreconnectTask.h
+++ b/Source/WebKit/NetworkProcess/PreconnectTask.h
@@ -30,6 +30,7 @@
 #include "NetworkLoadClient.h"
 #include <WebCore/Timer.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -40,6 +41,7 @@ class NetworkProcess;
 class NetworkSession;
 
 class PreconnectTask final : public NetworkLoadClient {
+    WTF_MAKE_WK_TZONE_ALLOCATED(PreconnectTask);
 public:
     PreconnectTask(NetworkSession&, NetworkLoadParameters&&, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&)>&&);
     ~PreconnectTask();

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit::PCM {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ClientImpl);
+
 ClientImpl::ClientImpl(NetworkSession& session, NetworkProcess& networkProcess)
     : m_networkSession(session)
     , m_networkProcess(networkProcess) { }

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h
@@ -28,6 +28,7 @@
 #include "PrivateClickMeasurementClient.h"
 #include <pal/SessionID.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -38,7 +39,7 @@ class NetworkProcess;
 namespace PCM {
 
 class ClientImpl : public Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ClientImpl);
 public:
     ClientImpl(NetworkSession&, NetworkProcess&);
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit::PCM {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(DaemonClient);
+
 void DaemonClient::broadcastConsoleMessage(JSC::MessageLevel level, const String& message)
 {
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.h
@@ -27,12 +27,13 @@
 
 #include "PrivateClickMeasurementClient.h"
 #include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit::PCM {
 
 class DaemonClient : public Client, public CanMakeWeakPtr<DaemonClient> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(DaemonClient);
     void broadcastConsoleMessage(JSC::MessageLevel, const String&) final;
     bool featureEnabled() const final;
     bool debugModeEnabled() const final;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -36,6 +36,8 @@
 
 namespace WebKit::PCM {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(Database);
+
 constexpr auto setUnattributedPrivateClickMeasurementAsExpiredQuery = "UPDATE UnattributedPrivateClickMeasurement SET timeOfAdClick = -1.0"_s;
 constexpr auto insertUnattributedPrivateClickMeasurementQuery = "INSERT OR REPLACE INTO UnattributedPrivateClickMeasurement (sourceSiteDomainID, destinationSiteDomainID, "
     "sourceID, timeOfAdClick, token, signature, keyID, sourceApplicationBundleID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"_s;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
@@ -27,6 +27,7 @@
 
 #include "DatabaseUtilities.h"
 #include <WebCore/PrivateClickMeasurement.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -36,7 +37,7 @@ struct DebugInfo;
 
 // This is created, used, and destroyed on the Store's queue.
 class Database : public DatabaseUtilities, public CanMakeWeakPtr<Database> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(Database);
 public:
     Database(const String& storageDirectory);
     virtual ~Database();

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit::PCM {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(EphemeralStore);
+
 EphemeralStore::EphemeralStore() = default;
 EphemeralStore::~EphemeralStore() = default;
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "PrivateClickMeasurementStore.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -37,6 +38,7 @@ class Database;
 struct DebugInfo;
 
 class EphemeralStore : public Store {
+    WTF_MAKE_WK_TZONE_ALLOCATED(EphemeralStore);
 public:
     static Ref<Store> create()
     {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -47,6 +47,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PrivateClickMeasurementManager);
+
 using SourceSite = WebCore::PCM::SourceSite;
 using AttributionDestinationSite = WebCore::PCM::AttributionDestinationSite;
 using AttributionTriggerData = WebCore::PCM::AttributionTriggerData;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
@@ -33,13 +33,14 @@
 #include <WebCore/Timer.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class PrivateClickMeasurementManager : public PCM::ManagerInterface, public CanMakeWeakPtr<PrivateClickMeasurementManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(PrivateClickMeasurementManager);
 public:
 
     explicit PrivateClickMeasurementManager(UniqueRef<PCM::Client>&&, const String& storageDirectory);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/RegistrableDomain.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class CertificateInfo;
@@ -45,6 +46,7 @@ class PrivateClickMeasurementManager;
 namespace PCM {
 
 class ManagerInterface {
+    WTF_MAKE_WK_TZONE_ALLOCATED(ManagerInterface);
 public:
     virtual ~ManagerInterface() { };
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit::PCM {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ManagerProxy);
+
 template<MessageType messageType, typename... Args>
 void ManagerProxy::sendMessage(Args&&... args) const
 {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h
@@ -28,6 +28,7 @@
 #include "PrivateClickMeasurementConnection.h"
 #include "PrivateClickMeasurementManagerInterface.h"
 #include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
 namespace WebKit {
@@ -37,7 +38,7 @@ class NetworkSession;
 namespace PCM {
 
 class ManagerProxy : public ManagerInterface {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ManagerProxy);
 public:
     ManagerProxy(const String& machServiceName, NetworkSession&);
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit::PCM {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkLoader);
+
 #if !PLATFORM(COCOA)
 void NetworkLoader::start(URL&&, RefPtr<JSON::Object>&&, WebCore::PrivateClickMeasurement::PcmDataCarried, Callback&& completionHandler)
 {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h
@@ -28,6 +28,7 @@
 #include <WebCore/PrivateClickMeasurement.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class CertificateInfo;
@@ -38,7 +39,7 @@ class ResourceResponse;
 namespace WebKit::PCM {
 
 class NetworkLoader {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkLoader);
 public:
     using Callback = CompletionHandler<void(const String&, const RefPtr<JSON::Object>&)>;
     static void start(URL&&, RefPtr<JSON::Object>&&, WebCore::PrivateClickMeasurement::PcmDataCarried, Callback&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -40,6 +40,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ServiceWorkerDownloadTask);
+
 static WorkQueue& sharedServiceWorkerDownloadTaskQueue()
 {
     static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("Shared ServiceWorkerDownloadTask Queue"));

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -32,6 +32,7 @@
 #include <WebCore/FetchIdentifier.h>
 #include <wtf/FileSystem.h>
 #include <wtf/FunctionDispatcher.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace IPC {
 class FormDataReference;
@@ -46,7 +47,7 @@ class SandboxExtension;
 class WebSWServerToContextConnection;
 
 class ServiceWorkerDownloadTask : public NetworkDataTask, private FunctionDispatcher, private IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ServiceWorkerDownloadTask);
 public:
     static Ref<ServiceWorkerDownloadTask> create(NetworkSession& session, NetworkDataTaskClient& client, WebSWServerToContextConnection& connection, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::FetchIdentifier fetchIdentifier, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, DownloadID downloadID)
     {

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -52,6 +52,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ServiceWorkerFetchTask);
+
 Ref<ServiceWorkerFetchTask> ServiceWorkerFetchTask::create(WebSWServerConnection& connection, NetworkResourceLoader& loader, WebCore::ResourceRequest&& request, WebCore::SWServerConnectionIdentifier connectionIdentifier, WebCore::ServiceWorkerIdentifier workerIdentifier, WebCore::SWServerRegistration& registration, NetworkSession* session, bool isWorkerReady)
 {
     return adoptRef(*new ServiceWorkerFetchTask(connection, loader, WTFMove(request), connectionIdentifier, workerIdentifier, registration, session, isWorkerReady));

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -32,6 +32,7 @@
 #include <WebCore/ServiceWorkerTypes.h>
 #include <WebCore/Timer.h>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -61,7 +62,7 @@ class WebSWServerConnection;
 class WebSWServerToContextConnection;
 
 class ServiceWorkerFetchTask : public RefCounted<ServiceWorkerFetchTask>, public CanMakeWeakPtr<ServiceWorkerFetchTask> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ServiceWorkerFetchTask);
 public:
     static RefPtr<ServiceWorkerFetchTask> fromNavigationPreloader(WebSWServerConnection&, NetworkResourceLoader&, const WebCore::ResourceRequest&, NetworkSession*);
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ServiceWorkerNavigationPreloader);
+
 ServiceWorkerNavigationPreloader::ServiceWorkerNavigationPreloader(NetworkSession& session, NetworkLoadParameters&& parameters, const WebCore::NavigationPreloadState& state, bool shouldCaptureExtraNetworkLoadMetric)
     : m_session(session)
     , m_parameters(WTFMove(parameters))

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
@@ -31,6 +31,7 @@
 #include "NetworkLoadParameters.h"
 #include <WebCore/NavigationPreloadState.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -45,7 +46,7 @@ class NetworkLoad;
 class NetworkSession;
 
 class ServiceWorkerNavigationPreloader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerNavigationPreloader>, public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ServiceWorkerNavigationPreloader);
 public:
     ServiceWorkerNavigationPreloader(NetworkSession&, NetworkLoadParameters&&, const WebCore::NavigationPreloadState&, bool shouldCaptureExtraNetworkLoadMetrics);
     ~ServiceWorkerNavigationPreloader();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -41,6 +41,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ServiceWorkerSoftUpdateLoader);
+
 ServiceWorkerSoftUpdateLoader::ServiceWorkerSoftUpdateLoader(NetworkSession& session, ServiceWorkerJobData&& jobData, bool shouldRefreshCache, ResourceRequest&& request, Handler&& completionHandler)
     : m_completionHandler(WTFMove(completionHandler))
     , m_jobData(WTFMove(jobData))

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
@@ -33,6 +33,7 @@
 #include <WebCore/ServiceWorkerJobData.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -47,7 +48,7 @@ class NetworkLoad;
 class NetworkSession;
 
 class ServiceWorkerSoftUpdateLoader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerSoftUpdateLoader>, public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ServiceWorkerSoftUpdateLoader);
 public:
     using Handler = CompletionHandler<void(WebCore::WorkerFetchResult&&)>;
     ServiceWorkerSoftUpdateLoader(NetworkSession&, WebCore::ServiceWorkerJobData&&, bool shouldRefreshCache, WebCore::ResourceRequest&&, Handler&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -35,6 +35,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSWOriginStore);
+
 WebSWOriginStore::WebSWOriginStore()
     : m_store(*this)
 {

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.h
@@ -27,6 +27,7 @@
 
 #include "SharedStringHashStore.h"
 #include <WebCore/SWOriginStore.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebKit {
@@ -34,6 +35,7 @@ namespace WebKit {
 class WebSWServerConnection;
 
 class WebSWOriginStore final : public WebCore::SWOriginStore, private SharedStringHashStore::Client {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSWOriginStore);
 public:
     WebSWOriginStore();
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSWRegistrationStore);
+
 WebSWRegistrationStore::WebSWRegistrationStore(WebCore::SWServer& server, NetworkStorageManager& manager)
     : m_server(server)
     , m_manager(manager)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -29,6 +29,7 @@
 #include <WebCore/ServiceWorkerContextData.h>
 #include <WebCore/Timer.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class SWServer;
@@ -39,6 +40,7 @@ namespace WebKit {
 class NetworkStorageManager;
 
 class WebSWRegistrationStore final : public WebCore::SWRegistrationStore, public CanMakeWeakPtr<WebSWRegistrationStore> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSWRegistrationStore);
 public:
     WebSWRegistrationStore(WebCore::SWServer&, NetworkStorageManager&);
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -63,6 +63,8 @@ namespace WebKit {
 using namespace PAL;
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSWServerConnection);
+
 #define SWSERVERCONNECTION_RELEASE_LOG(fmt, ...) RELEASE_LOG(ServiceWorker, "%p - WebSWServerConnection::" fmt, this, ##__VA_ARGS__)
 #define SWSERVERCONNECTION_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(ServiceWorker, "%p - WebSWServerConnection::" fmt, this, ##__VA_ARGS__)
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -39,6 +39,7 @@
 #include <WebCore/SWServer.h>
 #include <pal/SessionID.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -67,6 +68,7 @@ class NetworkResourceLoader;
 class ServiceWorkerFetchTask;
 
 class WebSWServerConnection final : public WebCore::SWServer::Connection, public IPC::MessageSender, public IPC::MessageReceiver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSWServerConnection);
 public:
     WebSWServerConnection(NetworkConnectionToWebProcess&, WebCore::SWServer&, IPC::Connection&, WebCore::ProcessIdentifier);
     WebSWServerConnection(const WebSWServerConnection&) = delete;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -46,6 +46,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSWServerToContextConnection);
+
 WebSWServerToContextConnection::WebSWServerToContextConnection(NetworkConnectionToWebProcess& connection, WebPageProxyIdentifier webPageProxyID, RegistrableDomain&& registrableDomain, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, SWServer& server)
     : SWServerToContextConnection(server, WTFMove(registrableDomain), serviceWorkerPageIdentifier)
     , m_connection(connection)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -31,6 +31,7 @@
 #include "ServiceWorkerFetchTask.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/SWServerToContextConnection.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
@@ -57,6 +58,7 @@ class ServiceWorkerDownloadTask;
 class WebSWServerConnection;
 
 class WebSWServerToContextConnection final: public WebCore::SWServerToContextConnection, public IPC::MessageSender, public IPC::MessageReceiver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSWServerToContextConnection);
 public:
     using WebCore::SWServerToContextConnection::weakPtrFactory;
     using WebCore::SWServerToContextConnection::WeakValueType;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSharedWorker);
+
 static HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>& allWorkers()
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -34,6 +34,7 @@
 #include <WebCore/WorkerOptions.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ class WebSharedWorkerServer;
 class WebSharedWorkerServerToContextConnection;
 
 class WebSharedWorker : public CanMakeWeakPtr<WebSharedWorker> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSharedWorker);
 public:
     WebSharedWorker(WebSharedWorkerServer&, const WebCore::SharedWorkerKey&, const WebCore::WorkerOptions&);
     ~WebSharedWorker();

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -41,6 +41,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSharedWorkerServer);
+
 WebSharedWorkerServer::WebSharedWorkerServer(NetworkSession& session)
     : m_session(session)
 {

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -33,6 +33,7 @@
 #include <WebCore/SharedWorkerObjectIdentifier.h>
 #include <WebCore/TransferredMessagePort.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace PAL {
@@ -55,7 +56,7 @@ class WebSharedWorkerServerConnection;
 class WebSharedWorkerServerToContextConnection;
 
 class WebSharedWorkerServer : public CanMakeWeakPtr<WebSharedWorkerServer> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSharedWorkerServer);
 public:
     explicit WebSharedWorkerServer(NetworkSession&);
     ~WebSharedWorkerServer();

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -40,6 +40,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSharedWorkerServerConnection);
+
 #define CONNECTION_MESSAGE_CHECK(assertion) CONNECTION_MESSAGE_CHECK_COMPLETION(assertion, (void)0)
 #define CONNECTION_MESSAGE_CHECK_COMPLETION(assertion, completion) do { \
     ASSERT(assertion); \

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -32,6 +32,7 @@
 #include <WebCore/TransferredMessagePort.h>
 #include <WebCore/WorkerInitializationData.h>
 #include <pal/SessionID.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class ResourceError;
@@ -50,7 +51,7 @@ class WebSharedWorkerServerToContextConnection;
 class NetworkSession;
 
 class WebSharedWorkerServerConnection : public IPC::MessageSender, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSharedWorkerServerConnection);
 public:
     WebSharedWorkerServerConnection(NetworkProcess&, WebSharedWorkerServer&, IPC::Connection&, WebCore::ProcessIdentifier);
     ~WebSharedWorkerServerConnection();

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -43,6 +43,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSharedWorkerServerToContextConnection);
+
 #define CONTEXT_CONNECTION_RELEASE_LOG(fmt, ...) RELEASE_LOG(SharedWorker, "%p - [webProcessIdentifier=%" PRIu64 "] WebSharedWorkerServerToContextConnection::" fmt, this, webProcessIdentifier().toUInt64(), ##__VA_ARGS__)
 
 // We terminate the context connection after 5 seconds if it is no longer used by any SharedWorker objects,

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -34,6 +34,7 @@
 #include <WebCore/Timer.h>
 #include <WebCore/TransferredMessagePort.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class RegistrableDomain;
@@ -50,7 +51,7 @@ class WebSharedWorker;
 class WebSharedWorkerServer;
 
 class WebSharedWorkerServerToContextConnection final : public IPC::MessageSender, public IPC::MessageReceiver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSharedWorkerServerToContextConnection);
 public:
     WebSharedWorkerServerToContextConnection(NetworkConnectionToWebProcess&, const WebCore::RegistrableDomain&, WebSharedWorkerServer&);
     ~WebSharedWorkerServerToContextConnection();

--- a/Source/WebKit/NetworkProcess/WebSocketTask.h
+++ b/Source/WebKit/NetworkProcess/WebSocketTask.h
@@ -32,13 +32,14 @@
 #elif USE(CURL)
 #include "WebSocketTaskCurl.h"
 #else
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 struct SessionSet;
 
 class WebSocketTask : public CanMakeWeakPtr<WebSocketTask> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(WebSocketTask);
 public:
     typedef uint64_t TaskIdentifier;
 

--- a/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
+++ b/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
@@ -33,6 +33,8 @@
 namespace WebKit {
 namespace NetworkCache {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(AsyncRevalidation);
+
 static inline WebCore::ResourceRequest constructRevalidationRequest(const Key& key, const WebCore::ResourceRequest& request, const Entry& entry)
 {
     WebCore::ResourceRequest revalidationRequest = request;

--- a/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.h
+++ b/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.h
@@ -31,6 +31,7 @@
 #include "NetworkCacheEntry.h"
 #include "NetworkCacheSpeculativeLoad.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -45,7 +46,7 @@ class SpeculativeLoad;
 namespace NetworkCache {
 
 class AsyncRevalidation : public CanMakeWeakPtr<AsyncRevalidation> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(AsyncRevalidation);
 public:
     enum class Result {
         Failure,

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -56,6 +56,8 @@
 namespace WebKit {
 namespace NetworkCache {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(Cache);
+
 using namespace FileSystem;
 
 static const AtomString& resourceType()

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -39,6 +39,7 @@
 #include <wtf/Hasher.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -151,6 +152,7 @@ enum class CacheOption : uint8_t {
 };
 
 class Cache : public RefCounted<Cache> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(Cache);
 public:
     ~Cache();
     static RefPtr<Cache> open(NetworkProcess&, const String& cachePath, OptionSet<CacheOption>, PAL::SessionID);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
@@ -41,6 +41,8 @@
 namespace WebKit {
 namespace NetworkCache {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(BlobStorage);
+
 BlobStorage::BlobStorage(const String& blobDirectoryPath, Salt salt)
     : m_blobDirectoryPath(blobDirectoryPath)
     , m_salt(salt)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.h
@@ -29,6 +29,7 @@
 #include "NetworkCacheData.h"
 #include "NetworkCacheKey.h"
 #include <wtf/SHA1.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 namespace NetworkCache {
@@ -36,6 +37,7 @@ namespace NetworkCache {
 // BlobStorage deduplicates the data using SHA1 hash computed over the blob bytes.
 class BlobStorage {
     WTF_MAKE_NONCOPYABLE(BlobStorage);
+    WTF_MAKE_WK_TZONE_ALLOCATED(BlobStorage);
 public:
     BlobStorage(const String& blobDirectoryPath, Salt);
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
@@ -38,6 +38,8 @@
 namespace WebKit {
 namespace NetworkCache {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(Data);
+
 Data Data::mapToFile(const String& path) const
 {
     FileSystem::PlatformFileHandle handle;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -28,6 +28,7 @@
 #include <span>
 #include <wtf/FileSystem.h>
 #include <wtf/SHA1.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -53,6 +54,7 @@ namespace WebKit {
 namespace NetworkCache {
 
 class Data {
+    WTF_MAKE_WK_TZONE_ALLOCATED(Data);
 public:
     Data() { }
     Data(const uint8_t*, size_t);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
@@ -32,6 +32,7 @@
 #include <WebCore/ShareableResource.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ class FragmentedSharedBuffer;
 namespace WebKit::NetworkCache {
 
 class Entry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(Entry);
 public:
     Entry(const Key&, const WebCore::ResourceResponse&, PrivateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&&, const Vector<std::pair<String, String>>& varyingRequestHeaders);
     Entry(const Key&, const WebCore::ResourceResponse&, const WebCore::ResourceRequest& redirectRequest, const Vector<std::pair<String, String>>& varyingRequestHeaders);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
@@ -36,6 +36,8 @@
 namespace WebKit {
 namespace NetworkCache {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(Key);
+
 Key::Key(const Key& o)
     : m_partition(o.m_partition.isolatedCopy())
     , m_type(o.m_type.isolatedCopy())

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -27,6 +27,7 @@
 
 #include "NetworkCacheData.h"
 #include <wtf/SHA1.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF::Persistence {
@@ -52,6 +53,7 @@ struct DataKey {
 };
 
 class Key {
+    WTF_MAKE_WK_TZONE_ALLOCATED(Key);
 public:
     typedef SHA1::Digest HashType;
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -43,6 +43,8 @@ namespace NetworkCache {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SpeculativeLoad);
+
 SpeculativeLoad::SpeculativeLoad(Cache& cache, const GlobalFrameID& globalFrameID, const ResourceRequest& request, std::unique_ptr<NetworkCache::Entry> cacheEntryForValidation, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, RevalidationCompletionHandler&& completionHandler)
     : m_cache(cache)
     , m_completionHandler(WTFMove(completionHandler))

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h
@@ -36,6 +36,7 @@
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 enum class AdvancedPrivacyProtections : uint16_t;
@@ -48,7 +49,7 @@ class NetworkLoad;
 namespace NetworkCache {
 
 class SpeculativeLoad final : public NetworkLoadClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SpeculativeLoad);
 public:
     using RevalidationCompletionHandler = CompletionHandler<void(std::unique_ptr<NetworkCache::Entry>)>;
     SpeculativeLoad(Cache&, const GlobalFrameID&, const WebCore::ResourceRequest&, std::unique_ptr<NetworkCache::Entry>, std::optional<NavigatingToAppBoundDomain>, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, RevalidationCompletionHandler&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -49,6 +49,8 @@ namespace NetworkCache {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SpeculativeLoadManager);
+
 static const Seconds preloadedEntryLifetime { 10_s };
 
 #if !LOG_DISABLED
@@ -127,7 +129,7 @@ static bool responseNeedsRevalidation(const ResourceResponse& response, WallTime
 }
 
 class SpeculativeLoadManager::ExpiringEntry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(SpeculativeLoadManager::ExpiringEntry);
 public:
     explicit ExpiringEntry(WTF::Function<void()>&& expirationHandler)
         : m_lifetimeTimer(WTFMove(expirationHandler))
@@ -140,7 +142,7 @@ private:
 };
 
 class SpeculativeLoadManager::PreloadedEntry : private ExpiringEntry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(SpeculativeLoadManager::PreloadedEntry);
 public:
     PreloadedEntry(std::unique_ptr<Entry> entry, std::optional<ResourceRequest>&& speculativeValidationRequest, WTF::Function<void()>&& lifetimeReachedHandler)
         : ExpiringEntry(WTFMove(lifetimeReachedHandler))

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
@@ -32,6 +32,7 @@
 #include "NetworkCacheStorage.h"
 #include <WebCore/ResourceRequest.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -49,7 +50,7 @@ class SubresourceInfo;
 class SubresourcesEntry;
 
 class SpeculativeLoadManager : public CanMakeWeakPtr<SpeculativeLoadManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SpeculativeLoadManager);
 public:
     explicit SpeculativeLoadManager(Cache&, Storage&);
     ~SpeculativeLoadManager();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -46,6 +46,8 @@
 namespace WebKit {
 namespace NetworkCache {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(Storage);
+
 static constexpr auto saltFileName = "salt"_s;
 static constexpr auto versionDirectoryPrefix = "Version "_s;
 static constexpr auto recordsDirectoryName = "Records"_s;
@@ -66,7 +68,7 @@ static uint64_t nextReadOperationOrdinal()
 }
 
 struct Storage::ReadOperation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(Storage::ReadOperation);
 public:
     ReadOperation(Storage& storage, const Key& key, unsigned priority, RetrieveCompletionHandler&& completionHandler)
         : storage(storage)
@@ -130,7 +132,7 @@ bool Storage::ReadOperation::finish()
 }
 
 struct Storage::WriteOperation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(Storage::WriteOperation);
 public:
     WriteOperation(Storage& storage, const Record& record, MappedBodyHandler&& mappedBodyHandler, CompletionHandler<void(int)>&& completionHandler)
         : storage(storage)
@@ -149,7 +151,7 @@ public:
 };
 
 struct Storage::TraverseOperation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(Storage::TraverseOperation);
 public:
     TraverseOperation(Ref<Storage>&& storage, const String& type, OptionSet<TraverseFlag> flags, TraverseHandler&& handler)
         : storage(WTFMove(storage))

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -36,6 +36,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/PriorityQueue.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/WTFString.h>
@@ -46,6 +47,7 @@ namespace NetworkCache {
 class IOChannel;
 
 class Storage : public ThreadSafeRefCounted<Storage, WTF::DestructionThread::Main> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(Storage);
 public:
     enum class Mode { Normal, AvoidRandomness };
     static RefPtr<Storage> open(const String& cachePath, Mode, size_t capacity);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
@@ -36,6 +36,10 @@
 namespace WebKit {
 namespace NetworkCache {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SubresourceInfo);
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SubresourceLoad);
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SubresourcesEntry);
+
 bool SubresourceInfo::isFirstParty() const
 {
     WebCore::RegistrableDomain firstPartyDomain { m_firstPartyForCookies };

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h
@@ -29,12 +29,13 @@
 
 #include "NetworkCacheStorage.h"
 #include <WebCore/ResourceRequest.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 
 namespace WebKit::NetworkCache {
 
 class SubresourceInfo {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SubresourceInfo);
 public:
     SubresourceInfo(Key&& key, WallTime lastSeen, WallTime firstSeen)
         : m_key(WTFMove(key))
@@ -85,7 +86,8 @@ private:
 };
 
 struct SubresourceLoad {
-    WTF_MAKE_NONCOPYABLE(SubresourceLoad); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(SubresourceLoad);
+    WTF_MAKE_WK_TZONE_ALLOCATED(SubresourceLoad);
 public:
     SubresourceLoad(const WebCore::ResourceRequest& request, const Key& key)
         : request(request)
@@ -97,7 +99,8 @@ public:
 };
 
 class SubresourcesEntry {
-    WTF_MAKE_NONCOPYABLE(SubresourcesEntry); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(SubresourcesEntry);
+    WTF_MAKE_WK_TZONE_ALLOCATED(SubresourcesEntry);
 public:
     SubresourcesEntry(Key&&, const Vector<std::unique_ptr<SubresourceLoad>>&);
     explicit SubresourcesEntry(const Storage::Record&);

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(PrefetchCache);
+
 PrefetchCache::Entry::Entry(WebCore::ResourceResponse&& response, PrivateRelayed privateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&& buffer)
     : response(WTFMove(response))
     , privateRelayed(privateRelayed)

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.h
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.h
@@ -32,6 +32,7 @@
 #include <WebCore/Timer.h>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URLHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -39,7 +40,7 @@ namespace WebKit {
 
 class PrefetchCache {
     WTF_MAKE_NONCOPYABLE(PrefetchCache);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(PrefetchCache);
 public:
     PrefetchCache();
     ~PrefetchCache();

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -31,11 +31,12 @@
 #include <wtf/Lock.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class LaunchServicesDatabaseObserver : public WebKit::XPCEndpoint, public NetworkProcessSupplement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LaunchServicesDatabaseObserver);
 public:
     LaunchServicesDatabaseObserver(NetworkProcess&);
     virtual ~LaunchServicesDatabaseObserver();

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LaunchServicesDatabaseObserver);
+
 LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
 {
 #if HAVE(LSDATABASECONTEXT) && !HAVE(SYSTEM_CONTENT_LS_DATABASE)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -32,6 +32,7 @@
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSHTTPCookieStorage;
 OBJC_CLASS NSURLSessionDataTask;
@@ -50,6 +51,7 @@ class NetworkSessionCocoa;
 struct SessionWrapper;
 
 class NetworkDataTaskCocoa final : public NetworkDataTask, public NetworkTaskCocoa {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkDataTaskCocoa);
 public:
     static Ref<NetworkDataTask> create(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
     {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -63,6 +63,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkDataTaskCocoa);
+
 #if HAVE(SYSTEM_SUPPORT_FOR_ADVANCED_PRIVACY_PROTECTIONS)
 
 inline static bool shouldBlockTrackersForThirdPartyCloaking(NSURLRequest *request)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -46,6 +46,8 @@ OBJC_CLASS NSURLCredentialStorage;
 #include <WebCore/RegistrableDomain.h>
 #include <wtf/HashMap.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 enum class AdvancedPrivacyProtections : uint16_t;
@@ -70,7 +72,7 @@ struct SessionWrapper : public CanMakeWeakPtr<SessionWrapper> {
 };
 
 struct IsolatedSession {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(IsolatedSession);
 public:
     SessionWrapper sessionWithCredentialStorage;
     WallTime lastUsed;
@@ -99,6 +101,7 @@ private:
 };
 
 class NetworkSessionCocoa final : public NetworkSession {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkSessionCocoa);
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess&, const NetworkSessionCreationParameters&);
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1206,6 +1206,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkSessionCocoa);
+
 #if ASSERT_ENABLED
 static bool sessionsCreated = false;
 #endif
@@ -1964,7 +1966,7 @@ void NetworkSessionCocoa::addWebPageNetworkParameters(WebPageProxyIdentifier pag
 // Make NetworkLoad's redirection and challenge handling code pass everything to the NetworkLoadClient
 // and use NetworkLoad and a new NetworkLoadClient instead of BlobDataTaskClient and WKURLSessionTaskDelegate.
 class NetworkSessionCocoa::BlobDataTaskClient final : public NetworkDataTaskClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NetworkSessionCocoa::BlobDataTaskClient);
 public:
     BlobDataTaskClient(WebCore::ResourceRequest&& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, NetworkSessionCocoa& session, IPC::Connection* connection, DataTaskIdentifier identifier)
         : m_task(NetworkDataTaskBlob::create(session, *this, request, session.blobRegistry().filesInBlob(request.url(), topOrigin), topOrigin ? topOrigin->securityOrigin().ptr() : nullptr))

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h
@@ -31,6 +31,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSURLSessionWebSocketTask;
@@ -48,7 +49,7 @@ class NetworkSocketChannel;
 struct SessionSet;
 
 class WebSocketTask : public CanMakeWeakPtr<WebSocketTask>, public NetworkTaskCocoa {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(WebSocketTask);
 public:
     WebSocketTask(NetworkSocketChannel&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WeakPtr<SessionSet>&&, const WebCore::ResourceRequest&, const WebCore::ClientOrigin&, RetainPtr<NSURLSessionWebSocketTask>&&, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
     ~WebSocketTask() = default;

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(WebSocketTask);
+
 WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifier webProxyPageID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, WeakPtr<SessionSet>&& sessionSet, const WebCore::ResourceRequest& request, const WebCore::ClientOrigin& clientOrigin, RetainPtr<NSURLSessionWebSocketTask>&& task, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
     : NetworkTaskCocoa(*channel.session(), shouldRelaxThirdPartyCookieBlocking)
     , m_channel(channel)

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
@@ -46,6 +46,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(BackgroundFetchStoreImpl);
+
 // FIXME: Handle quota.
 
 BackgroundFetchStoreImpl::BackgroundFetchStoreImpl(WeakPtr<NetworkStorageManager>&& manager, WeakPtr<WebCore::SWServer>&& server)

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -28,6 +28,7 @@
 #include <WebCore/ClientOrigin.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 class WorkQueue;
@@ -43,6 +44,7 @@ class NetworkStorageManager;
 struct BackgroundFetchState;
 
 class BackgroundFetchStoreImpl :  public WebCore::BackgroundFetchStore {
+    WTF_MAKE_WK_TZONE_ALLOCATED(BackgroundFetchStoreImpl);
 public:
     static Ref<BackgroundFetchStoreImpl> create(WeakPtr<NetworkStorageManager>&& manager, WeakPtr<WebCore::SWServer>&& server) { return adoptRef(*new BackgroundFetchStoreImpl(WTFMove(manager), WTFMove(server))); }
     ~BackgroundFetchStoreImpl();

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -39,6 +39,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(BackgroundFetchStoreManager);
+
 static constexpr auto fetchSuffix = "-backgroundfetch"_s;
 
 static bool shouldUseFileMapping(uint64_t fileSize)

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
@@ -28,6 +28,7 @@
 #include <WebCore/SharedBuffer.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -38,7 +39,7 @@ class WorkQueue;
 namespace WebKit {
 
 class BackgroundFetchStoreManager : public CanMakeWeakPtr<BackgroundFetchStoreManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(BackgroundFetchStoreManager);
 public:
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
     BackgroundFetchStoreManager(const String&, Ref<WTF::WorkQueue>&&, QuotaCheckFunction&&);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -38,6 +38,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CacheStorageCache);
+
 static String computeKeyURL(const URL& url)
 {
     RELEASE_ASSERT(url.isValid());

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -29,6 +29,7 @@
 #include "CacheStorageStore.h"
 #include "NetworkCacheKey.h"
 #include <WebCore/RetrieveRecordsOptions.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebKit {
@@ -36,7 +37,7 @@ namespace WebKit {
 class CacheStorageManager;
 
 class CacheStorageCache : public CanMakeWeakPtr<CacheStorageCache> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(CacheStorageCache);
 public:
     CacheStorageCache(CacheStorageManager&, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&&);
     ~CacheStorageCache();

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -39,6 +39,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CacheStorageDiskStore);
+
 static constexpr auto saltFileName = "salt"_s;
 static constexpr auto versionDirectoryPrefix = "Version "_s;
 static constexpr auto recordsDirectoryName = "Records"_s;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
@@ -28,12 +28,14 @@
 #include "CacheStorageStore.h"
 #include "NetworkCacheKey.h"
 #include <wtf/FileSystem.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class CacheStorageDiskStore final : public CacheStorageStore {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CacheStorageDiskStore);
 public:
     static Ref<CacheStorageDiskStore> create(const String& cacheName, const String& path, Ref<WorkQueue>&&);
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CacheStorageManager);
+
 static constexpr auto cachesListFileName = "cacheslist"_s;
 static constexpr auto sizeFileName = "estimatedsize"_s;
 static constexpr auto originFileName = "origin"_s;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include <WebCore/DOMCacheEngine.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ struct CacheStorageRecordInformation;
 
 
 class CacheStorageManager : public CanMakeWeakPtr<CacheStorageManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(CacheStorageManager);
 public:
     static String cacheStorageOriginDirectory(const String& rootDirectory, const WebCore::ClientOrigin&);
     static void copySaltFileToOriginDirectory(const String& rootDirectory, const String& originDirectory);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CacheStorageMemoryStore);
+
 Ref<CacheStorageMemoryStore> CacheStorageMemoryStore::create()
 {
     return adoptRef(*new CacheStorageMemoryStore);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.h
@@ -28,11 +28,13 @@
 #include "CacheStorageRecord.h"
 #include "CacheStorageStore.h"
 #include "NetworkCacheKey.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class CacheStorageMemoryStore final : public CacheStorageStore {
+    WTF_MAKE_WK_TZONE_ALLOCATED(CacheStorageMemoryStore);
 public:
     static Ref<CacheStorageMemoryStore> create();
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(CacheStorageRegistry);
+
 CacheStorageRegistry::CacheStorageRegistry() = default;
 
 void CacheStorageRegistry::registerCache(WebCore::DOMCacheIdentifier identifier, CacheStorageCache& cache)

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/DOMCacheIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -33,7 +34,7 @@ namespace WebKit {
 class CacheStorageCache;
 
 class CacheStorageRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(CacheStorageRegistry);
 public:
     CacheStorageRegistry();
     void registerCache(WebCore::DOMCacheIdentifier, CacheStorageCache&);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FileSystemStorageHandle);
+
 #if OS(WINDOWS)
 constexpr char pathSeparator = '\\';
 #else

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -29,6 +29,7 @@
 #include "FileSystemSyncAccessHandleInfo.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -41,7 +42,7 @@ class FileSystemStorageManager;
 enum class FileSystemStorageError : uint8_t;
 
 class FileSystemStorageHandle : public CanMakeWeakPtr<FileSystemStorageHandle, WeakPtrFactoryInitialization::Eager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(FileSystemStorageHandle);
 public:
     enum class Type : uint8_t { File, Directory, Any };
     static std::unique_ptr<FileSystemStorageHandle> create(FileSystemStorageManager&, Type, String&& path, String&& name);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FileSystemStorageHandleRegistry);
+
 FileSystemStorageHandleRegistry::FileSystemStorageHandleRegistry() = default;
 
 void FileSystemStorageHandleRegistry::registerHandle(WebCore::FileSystemHandleIdentifier identifier, FileSystemStorageHandle& handle)

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 class FileSystemStorageHandle;
 
 class FileSystemStorageHandleRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(FileSystemStorageHandleRegistry);
 public:
     FileSystemStorageHandleRegistry();
     void registerHandle(WebCore::FileSystemHandleIdentifier, FileSystemStorageHandle&);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(FileSystemStorageManager);
+
 FileSystemStorageManager::FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry& registry, QuotaCheckFunction&& quotaCheckFunction)
     : m_path(WTFMove(path))
     , m_registry(registry)

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -27,6 +27,7 @@
 
 #include "FileSystemStorageHandle.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -34,7 +35,7 @@ class FileSystemStorageHandle;
 class FileSystemStorageHandleRegistry;
 
 class FileSystemStorageManager : public CanMakeWeakPtr<FileSystemStorageManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(FileSystemStorageManager);
 public:
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
     FileSystemStorageManager(String&& path, FileSystemStorageHandleRegistry&, QuotaCheckFunction&&);

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(IDBStorageConnectionToClient);
+
 IDBStorageConnectionToClient::IDBStorageConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)
     : m_connection(connection)
     , m_identifier(identifier)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
@@ -28,11 +28,12 @@
 #include "Connection.h"
 #include <WebCore/IDBConnectionToClient.h>
 #include <WebCore/IDBConnectionToClientDelegate.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class IDBStorageConnectionToClient final : public WebCore::IDBServer::IDBConnectionToClientDelegate {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(IDBStorageConnectionToClient);
 public:
     IDBStorageConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);
     ~IDBStorageConnectionToClient();

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(IDBStorageManager);
+
 static bool migrateOriginDataImpl(const String& oldOriginDirectory, const String& newOriginDirectory, Function<String(const String&)>&& createFileNameFunction)
 {
     if (oldOriginDirectory.isEmpty() || !FileSystem::fileExists(oldOriginDirectory))

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/UniqueIDBDatabase.h>
 #include <WebCore/UniqueIDBDatabaseManager.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class IDBRequestData;
@@ -45,6 +46,7 @@ namespace WebKit {
 class IDBStorageRegistry;
 
 class IDBStorageManager final : public WebCore::IDBServer::UniqueIDBDatabaseManager {
+    WTF_MAKE_WK_TZONE_ALLOCATED(IDBStorageManager);
 public:
     static String idbStorageOriginDirectory(const String& rootDirectory, const WebCore::ClientOrigin&);
     static uint64_t idbStorageSize(const String& originDirectory);

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(IDBStorageRegistry);
+
 IDBStorageRegistry::IDBStorageRegistry() = default;
 
 WebCore::IDBServer::IDBConnectionToClient& IDBStorageRegistry::ensureConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include <WebCore/IDBResourceIdentifier.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ namespace WebKit {
 class IDBStorageConnectionToClient;
 
 class IDBStorageRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(IDBStorageRegistry);
 public:
     IDBStorageRegistry();
     WebCore::IDBServer::IDBConnectionToClient& ensureConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
@@ -34,6 +34,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LocalStorageManager);
+
 // Suggested by https://www.w3.org/TR/webstorage/#disk-space
 constexpr unsigned localStorageQuotaInBytes = 5 * MB;
 constexpr auto s_fileSuffix = ".localstorage"_s;

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.h
@@ -28,6 +28,7 @@
 #include "Connection.h"
 #include "StorageAreaIdentifier.h"
 #include "StorageAreaMapIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ class StorageAreaBase;
 class StorageAreaRegistry;
 
 class LocalStorageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LocalStorageManager);
 public:
     static Vector<WebCore::SecurityOriginData> originsOfLocalStorageData(const String& path);
     static String localStorageFilePath(const String& directory, const WebCore::ClientOrigin&);

--- a/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.cpp
@@ -28,6 +28,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(MemoryStorageArea);
+
 MemoryStorageArea::MemoryStorageArea(const WebCore::ClientOrigin& origin, StorageAreaBase::StorageType type)
     : StorageAreaBase(WebCore::StorageMap::noQuota, origin)
     , m_map(WebCore::StorageMap(WebCore::StorageMap::noQuota))

--- a/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/MemoryStorageArea.h
@@ -27,6 +27,7 @@
 
 #include "StorageAreaBase.h"
 #include <WebCore/StorageMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class StorageMap;
@@ -35,6 +36,7 @@ class StorageMap;
 namespace WebKit {
 
 class MemoryStorageArea final : public StorageAreaBase {
+    WTF_MAKE_WK_TZONE_ALLOCATED(MemoryStorageArea);
 public:
     explicit MemoryStorageArea(const WebCore::ClientOrigin&, StorageAreaBase::StorageType = StorageAreaBase::StorageType::Session);
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -61,6 +61,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkStorageManager);
+
 #if PLATFORM(IOS_FAMILY)
 static const Seconds defaultBackupExclusionPeriod { 24_h };
 #endif

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -46,6 +46,7 @@
 #include <pal/SessionID.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 
 namespace IPC {
@@ -84,6 +85,7 @@ class StorageAreaBase;
 class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver, public CanMakeCheckedPtr {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkStorageManager);
 public:
     static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(OriginQuotaManager);
+
 static constexpr double defaultReportedQuotaIncreaseFactor = 2.0;
 
 Ref<OriginQuotaManager> OriginQuotaManager::create(Parameters&& parameters, GetUsageFunction&& getUsageFunction)

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -28,12 +28,13 @@
 #include "QuotaIncreaseRequestIdentifier.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebKit {
 
 class OriginQuotaManager : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<OriginQuotaManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(OriginQuotaManager);
 public:
     using GetUsageFunction = Function<uint64_t()>;
     using IncreaseQuotaFunction = Function<void(QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t requestedIncrease)>;

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -47,11 +47,13 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(OriginStorageManager);
+
 static constexpr auto originFileName = "origin"_s;
 enum class OriginStorageManager::StorageBucketMode : bool { BestEffort, Persistent };
 
 class OriginStorageManager::StorageBucket {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(OriginStorageManager::StorageBucket);
 public:
     enum class StorageType : uint8_t {
         FileSystem,

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -28,6 +28,7 @@
 #include "Connection.h"
 #include "OriginQuotaManager.h"
 #include "WebsiteDataType.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -53,7 +54,7 @@ enum class UnifiedOriginStorageLevel : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
 class OriginStorageManager : public CanMakeWeakPtr<OriginStorageManager> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(OriginStorageManager);
 public:
     static String originFileIdentifier();
 

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SQLiteStorageArea);
+
 constexpr Seconds transactionDuration { 500_ms };
 constexpr unsigned maximumSizeForValuesKeptInMemory { 1 * KB };
 constexpr auto createItemTableStatementAlternative = "CREATE TABLE IF NOT EXISTS ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB NOT NULL ON CONFLICT FAIL)"_s;

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "StorageAreaBase.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 class SQLiteDatabase;
@@ -37,6 +38,7 @@ class SQLiteTransaction;
 namespace WebKit {
 
 class SQLiteStorageArea final : public StorageAreaBase {
+    WTF_MAKE_WK_TZONE_ALLOCATED(SQLiteStorageArea);
 public:
     SQLiteStorageArea(unsigned quota, const WebCore::ClientOrigin&, const String& path, Ref<WorkQueue>&&);
     ~SQLiteStorageArea();

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(ServiceWorkerStorageManager);
+
 ServiceWorkerStorageManager::ServiceWorkerStorageManager(const String& path)
     : m_path(path)
 {

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h
@@ -27,11 +27,12 @@
 
 #include <WebCore/SWRegistrationDatabase.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class ServiceWorkerStorageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(ServiceWorkerStorageManager);
 public:
     explicit ServiceWorkerStorageManager(const String& path);
 

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp
@@ -31,6 +31,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(SessionStorageManager);
+
 SessionStorageManager::SessionStorageManager(StorageAreaRegistry& registry)
     : m_registry(registry)
 {

--- a/Source/WebKit/NetworkProcess/storage/SessionStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/SessionStorageManager.h
@@ -29,6 +29,7 @@
 #include "StorageAreaIdentifier.h"
 #include "StorageAreaMapIdentifier.h"
 #include "StorageNamespaceIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 struct ClientOrigin;
@@ -40,7 +41,7 @@ class MemoryStorageArea;
 class StorageAreaRegistry;
 
 class SessionStorageManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(SessionStorageManager);
 public:
     explicit SessionStorageManager(StorageAreaRegistry&);
     bool isActive() const;

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(StorageAreaBase);
+
 uint64_t StorageAreaBase::nextMessageIdentifier()
 {
     static std::atomic<uint64_t> currentIdentifier;

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
@@ -30,6 +30,7 @@
 #include "StorageAreaImplIdentifier.h"
 #include "StorageAreaMapIdentifier.h"
 #include <WebCore/ClientOrigin.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ enum class StorageError : uint8_t {
 
 class StorageAreaBase : public CanMakeWeakPtr<StorageAreaBase> {
     WTF_MAKE_NONCOPYABLE(StorageAreaBase);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(StorageAreaBase);
 public:
     static uint64_t nextMessageIdentifier();
     virtual ~StorageAreaBase();

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(StorageAreaRegistry);
+
 StorageAreaRegistry::StorageAreaRegistry() = default;
 
 void StorageAreaRegistry::registerStorageArea(StorageAreaIdentifier identifier, StorageAreaBase& storageArea)

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "StorageAreaIdentifier.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -33,7 +34,7 @@ namespace WebKit {
 class StorageAreaBase;
 
 class StorageAreaRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(StorageAreaRegistry);
 public:
     StorageAreaRegistry();
     void registerStorageArea(StorageAreaIdentifier, StorageAreaBase&);

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(LibWebRTCSocketClient);
+
 LibWebRTCSocketClient::LibWebRTCSocketClient(WebCore::LibWebRTCSocketIdentifier identifier, NetworkRTCProvider& rtcProvider, std::unique_ptr<rtc::AsyncPacketSocket>&& socket, Type type, Ref<IPC::Connection>&& connection)
     : m_identifier(identifier)
     , m_type(type)

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h
@@ -28,6 +28,7 @@
 #if USE(LIBWEBRTC)
 
 #include "NetworkRTCProvider.h"
+#include <wtf/TZoneMalloc.h>
 
 ALLOW_COMMA_BEGIN
 
@@ -44,7 +45,7 @@ typedef int64_t PacketTime;
 namespace WebKit {
 
 class LibWebRTCSocketClient final : public NetworkRTCProvider::Socket, public sigslot::has_slots<> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(LibWebRTCSocketClient);
 public:
     LibWebRTCSocketClient(WebCore::LibWebRTCSocketIdentifier, NetworkRTCProvider&, std::unique_ptr<rtc::AsyncPacketSocket>&&, Type, Ref<IPC::Connection>&&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -37,6 +37,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkMDNSRegister);
+
 #define MDNS_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - NetworkMDNSRegister::" fmt, this, ##__VA_ARGS__)
 #define MDNS_RELEASE_LOG_IN_CALLBACK(sessionID, fmt, ...) RELEASE_LOG(Network, "NetworkMDNSRegister callback - " fmt, ##__VA_ARGS__)
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
@@ -34,6 +34,7 @@
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(COCOA) && defined __has_include && __has_include(<dns_sd.h>)
 #define ENABLE_MDNS 1
@@ -63,6 +64,7 @@ namespace WebKit {
 class NetworkConnectionToWebProcess;
 
 class NetworkMDNSRegister {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkMDNSRegister);
 public:
     NetworkMDNSRegister(NetworkConnectionToWebProcess&);
     ~NetworkMDNSRegister();

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -44,9 +44,12 @@ ALLOW_COMMA_END
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkRTCMonitor);
+
 #define RTC_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - NetworkRTCMonitor::" fmt, this, ##__VA_ARGS__)
 
 class NetworkManagerWrapper final : public sigslot::has_slots<> {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NetworkManagerWrapper);
 public:
     void addListener(NetworkRTCMonitor&);
     void removeListener(NetworkRTCMonitor&);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -29,6 +29,7 @@
 
 #include "RTCNetwork.h"
 #include <WebCore/LibWebRTCMacros.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 ALLOW_COMMA_BEGIN
@@ -49,6 +50,7 @@ namespace WebKit {
 class NetworkRTCProvider;
 
 class NetworkRTCMonitor final : public CanMakeWeakPtr<NetworkRTCMonitor> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkRTCMonitor);
 public:
     explicit NetworkRTCMonitor(NetworkRTCProvider& rtcProvider) : m_rtcProvider(rtcProvider) { }
     ~NetworkRTCMonitor();

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -37,6 +37,8 @@
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/HashMap.h>
 #include <wtf/StdMap.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/text/WTFString.h>
@@ -76,6 +78,7 @@ struct SocketComparator {
 };
 
 class NetworkRTCProvider : private FunctionDispatcher, private IPC::MessageReceiver, public ThreadSafeRefCounted<NetworkRTCProvider, WTF::DestructionThread::MainRunLoop> {
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkRTCProvider);
 public:
     static Ref<NetworkRTCProvider> create(NetworkConnectionToWebProcess& connection)
     {
@@ -88,6 +91,7 @@ public:
     void didReceiveNetworkRTCMonitorMessage(IPC::Connection& connection, IPC::Decoder& decoder) { m_rtcMonitor.didReceiveMessage(connection, decoder); }
 
     class Socket {
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(Socket);
     public:
         virtual ~Socket() = default;
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.mm
@@ -36,6 +36,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkRTCProvider);
+
 static inline bool isEnabled(CFDictionaryRef proxy, CFStringRef key)
 {
     auto enabled = static_cast<CFNumberRef>(CFDictionaryGetValue(proxy, key));

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
@@ -29,6 +29,7 @@
 
 #include "NetworkRTCProvider.h"
 #include <Network/Network.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace rtc {
@@ -38,7 +39,7 @@ class SocketAddress;
 namespace WebKit {
 
 class NetworkRTCTCPSocketCocoa final : public NetworkRTCProvider::Socket, public CanMakeWeakPtr<NetworkRTCTCPSocketCocoa> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkRTCTCPSocketCocoa);
 public:
     static std::unique_ptr<NetworkRTCProvider::Socket> createClientTCPSocket(WebCore::LibWebRTCSocketIdentifier, NetworkRTCProvider&, const rtc::SocketAddress&, int options, const String& attributedBundleIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain&, Ref<IPC::Connection>&&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -40,6 +40,8 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkRTCTCPSocketCocoa);
+
 static dispatch_queue_t tcpSocketQueue()
 {
     static dispatch_queue_t queue;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h
@@ -32,6 +32,7 @@
 #include <limits>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace rtc {
 class SocketAddress;
@@ -58,7 +59,7 @@ namespace WebKit {
 class NetworkRTCUDPSocketCocoaConnections;
 
 class NetworkRTCUDPSocketCocoa final : public NetworkRTCProvider::Socket {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkRTCUDPSocketCocoa);
 public:
     static std::unique_ptr<NetworkRTCProvider::Socket> createUDPSocket(WebCore::LibWebRTCSocketIdentifier, NetworkRTCProvider&, const rtc::SocketAddress&, uint16_t minPort, uint16_t maxPort, Ref<IPC::Connection>&&, String&& attributedBundleIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -46,7 +46,10 @@ namespace WebKit {
 
 using namespace WebCore;
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkRTCUDPSocketCocoa);
+
 class NetworkRTCUDPSocketCocoaConnections : public ThreadSafeRefCounted<NetworkRTCUDPSocketCocoaConnections> {
+    WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(NetworkRTCUDPSocketCocoaConnections);
 public:
     static Ref<NetworkRTCUDPSocketCocoaConnections> create(WebCore::LibWebRTCSocketIdentifier identifier, NetworkRTCProvider& provider, const rtc::SocketAddress& address, Ref<IPC::Connection>&& connection, String&& attributedBundleIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain& domain) { return adoptRef(*new NetworkRTCUDPSocketCocoaConnections(identifier, provider, address, WTFMove(connection), WTFMove(attributedBundleIdentifier), isFirstParty, isRelayDisabled, domain)); }
 
@@ -56,6 +59,7 @@ public:
     void setListeningPort(int);
 
     class ConnectionStateTracker : public ThreadSafeRefCounted<ConnectionStateTracker> {
+        WTF_MAKE_WK_TZONE_ALLOCATED_INLINE(ConnectionStateTracker);
     public:
         static Ref<ConnectionStateTracker> create() { return adoptRef(*new ConnectionStateTracker()); }
         void markAsStopped() { m_isStopped = true; }

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(RTCDataChannelRemoteManagerProxy);
+
 RTCDataChannelRemoteManagerProxy::RTCDataChannelRemoteManagerProxy()
     : m_queue(WorkQueue::create("RTCDataChannelRemoteManagerProxy"))
 {

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
@@ -30,6 +30,7 @@
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/RTCDataChannelRemoteHandlerConnection.h>
 #include <WebCore/RTCDataChannelRemoteSourceConnection.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebKit {
@@ -37,6 +38,7 @@ namespace WebKit {
 class NetworkConnectionToWebProcess;
 
 class RTCDataChannelRemoteManagerProxy final : public IPC::WorkQueueMessageReceiver {
+    WTF_MAKE_WK_TZONE_ALLOCATED(RTCDataChannelRemoteManagerProxy);
 public:
     static Ref<RTCDataChannelRemoteManagerProxy> create() { return adoptRef(*new RTCDataChannelRemoteManagerProxy); }
 

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.cpp
@@ -28,6 +28,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkTransportBidirectionalStream);
+
 NetworkTransportBidirectionalStream::NetworkTransportBidirectionalStream(NetworkTransportSession& session)
     : NetworkTransportReceiveStream(session) { }
 

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.h
@@ -27,11 +27,12 @@
 
 #include "NetworkTransportReceiveStream.h"
 #include "NetworkTransportSendStream.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class NetworkTransportBidirectionalStream : public NetworkTransportSendStream, public NetworkTransportReceiveStream {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkTransportBidirectionalStream);
 public:
     NetworkTransportBidirectionalStream(NetworkTransportSession&);
 };

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkTransportReceiveStream);
+
 NetworkTransportReceiveStream::NetworkTransportReceiveStream(NetworkTransportSession& session)
     : m_session(session) { }
 

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -32,7 +33,7 @@ namespace WebKit {
 class NetworkTransportSession;
 
 class NetworkTransportReceiveStream {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkTransportReceiveStream);
 public:
     NetworkTransportReceiveStream(NetworkTransportSession&);
 private:

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.cpp
@@ -28,6 +28,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkTransportSendStream);
+
 void NetworkTransportSendStream::sendBytes(std::span<const uint8_t>, bool)
 {
     // FIXME: Implement.

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.h
@@ -27,11 +27,12 @@
 
 #include <span>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class NetworkTransportSendStream {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkTransportSendStream);
 public:
     void sendBytes(std::span<const uint8_t>, bool withFin);
 };

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -35,6 +35,8 @@
 
 namespace WebKit {
 
+WTF_MAKE_WK_TZONE_ALLOCATED_IMPL(NetworkTransportSession);
+
 void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connection, URL&&, CompletionHandler<void(std::unique_ptr<NetworkTransportSession>&&)>&& completionHandler)
 {
     completionHandler(makeUnique<NetworkTransportSession>(connection));

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -29,6 +29,7 @@
 #include "MessageSender.h"
 #include <WebCore/ProcessQualified.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
@@ -44,7 +45,7 @@ using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdenti
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
 class NetworkTransportSession : public IPC::MessageReceiver, public IPC::MessageSender {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_WK_TZONE_ALLOCATED(NetworkTransportSession);
 public:
     static void initialize(NetworkConnectionToWebProcess&, URL&&, CompletionHandler<void(std::unique_ptr<NetworkTransportSession>&&)>&&);
 

--- a/Source/WebKit/config.h
+++ b/Source/WebKit/config.h
@@ -40,7 +40,7 @@
 #undef new
 #undef delete
 #include <wtf/FastMalloc.h>
-
+#include <wtf/TZoneMallocInlines.h>
 #endif
 
 // ENABLE_WEBDRIVER_ACTIONS_API represents whether mouse, keyboard, touch or wheel interactions are defined

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -393,7 +393,7 @@
 #endif
 
 #if BUSE(LIBPAS) && BOS(DARWIN) && BCPU(ARM64)
-#define BUSE_TZONE 0
+#define BUSE_TZONE 1
 #else
 #define BUSE_TZONE 0
 #endif


### PR DESCRIPTION
#### 8f29cc7c51bd26660a75a94880ca52f9206c7cfd
<pre>
[Network] test tzone on
</pre>
----------------------------------------------------------------------
#### 2c3e47d2d330d651168fca4145e876512fa41693
<pre>
Start adopting TZone within WebKit/NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=269588">https://bugs.webkit.org/show_bug.cgi?id=269588</a>
<a href="https://rdar.apple.com/123101529">rdar://123101529</a>

Reviewed by NOBODY (OOPS!).

Adopts the TZone allocator throughout the WebKit/NetworkProcess directory.

* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/Downloads/Download.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.h:
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp:
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp:
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h:
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h:
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
* Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp:
* Source/WebKit/NetworkProcess/NetworkLoadScheduler.h:
* Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.cpp:
* Source/WebKit/NetworkProcess/NetworkOriginAccessPatterns.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp:
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDaemonClient.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.cpp:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementNetworkLoader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/NetworkProcess/WebSocketTask.h:
* Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp:
* Source/WebKit/NetworkProcess/cache/AsyncRevalidation.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h:
* Source/WebKit/NetworkProcess/cache/PrefetchCache.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp:
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h:
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.cpp:
* Source/WebKit/NetworkProcess/storage/SessionStorageManager.h:
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp:
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.h:
* Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.cpp:
* Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h:
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp:
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportBidirectionalStream.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportReceiveStream.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSendStream.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/config.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f29cc7c51bd26660a75a94880ca52f9206c7cfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40759 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43317 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36849 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22758 "Hash 8f29cc7c for PR 24638 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33804 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41333 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/22758 "Hash 8f29cc7c for PR 24638 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14409 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/22758 "Hash 8f29cc7c for PR 24638 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44589 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34212 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/22758 "Hash 8f29cc7c for PR 24638 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40172 "Passed tests") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40385 "Found 4 new JSC binary failures: testair, testb3, testdfg, testmasm, Found 18838 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/ArrayElementMissingValueSetToZero.js.default, ChakraCore.yaml/ChakraCore/test/Array/InlineArrayPopWithIntConstSrc.js.default, ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/SegmentMapFlagResetInJSArrayConstructor.js.default, ChakraCore.yaml/ChakraCore/test/Array/TryGrowHeadSegmentBug.js.default, ChakraCore.yaml/ChakraCore/test/Array/arr_bailout.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_forin.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38513 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17193 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47395 "Built successfully") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17244 "Hash 8f29cc7c for PR 24638 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9737 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->