### PR TITLE
[pre-push] Make version regex more permissive

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -36,7 +36,7 @@ class InstallHooks(Command):
     help = 'Re-install all hooks from this repository into this checkout'
 
     REMOTE_RE = re.compile(r'(?P<protcol>[^@:]+://)?(?P<user>[^:@]+@)?(?P<host>[^:/@]+)(/|:)(?P<path>[^\.]+[^\./])(\.git)?/?')
-    VERSION_RE = re.compile(r'^VERSION\s+=\s+\'(?P<number>\d+(\.\d+)*)\'$')
+    VERSION_RE = re.compile(r'^VERSION\s*=\s*[\'"](?P<number>\d+(\.\d+)*)[\'"]$')
     MODES = ('default', 'publish', 'no-radar')
 
     @classmethod

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py
@@ -94,6 +94,13 @@ class TestInstallHooks(testing.PathTestCase):
                 'example.org:project/project-security': 1,
             }, program.InstallHooks._security_levels(local.Git(self.path)))
 
+    def test_version_re(self):
+        self.assertEqual(program.InstallHooks.VERSION_RE.match("VERSION = '1.2.3'").group('number'), '1.2.3')
+        self.assertEqual(program.InstallHooks.VERSION_RE.match("VERSION='1.2.3'").group('number'), '1.2.3')
+        self.assertEqual(program.InstallHooks.VERSION_RE.match('VERSION = "1.2.3"').group('number'), '1.2.3')
+
+        self.assertEqual(program.InstallHooks.VERSION_RE.match('import os'), None)
+
     def test_install_hook(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path, remote='git@example.org:project/project'), mocks.local.Svn():
             self.write_hook(os.path.join(self.path, 'hooks', 'pre-commit'))


### PR DESCRIPTION
#### afa81e7deccf5a4b1c0c0717e489fc9c0da50991
<pre>
[pre-push] Make version regex more permissive
<a href="https://bugs.webkit.org/show_bug.cgi?id=269599">https://bugs.webkit.org/show_bug.cgi?id=269599</a>
<a href="https://rdar.apple.com/123106227">rdar://123106227</a>

Reviewed by Dewei Zhu.

There exist versions of the pre-push hook which relies on linters to format
Python code slightly different than WebKit&apos;s current style. Our version regex
should be permissive enough to read such files.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks): Make version regex more permissive.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py:
(TestInstallHooks.test_version_re):

Canonical link: <a href="https://commits.webkit.org/274872@main">https://commits.webkit.org/274872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12ef76b46bd6d899c30df22254c0c59e437a184b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42772 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16568 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16202 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/40095 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44050 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33680 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36483 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/40274 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5323 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->