### PR TITLE
[WebGPU] https://webgpu.github.io/webgpu-samples/samples/deferredRendering has an error in Queue::submit

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -854,7 +854,7 @@ static BindGroupEntryUsage usageForBuffer(WGPUBufferBindingType bufferBindingTyp
 
 static BindGroupEntryUsageData makeBindGroupEntryUsageData(BindGroupEntryUsage usage, uint32_t bindingIndex, auto& resource)
 {
-    return BindGroupEntryUsageData { .usage = usage, .binding = bindingIndex, .resource = resource };
+    return BindGroupEntryUsageData { .usage = usage, .binding = bindingIndex, .resource = &resource };
 }
 
 Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor)

--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -27,8 +27,8 @@
 
 #import <Metal/Metal.h>
 #import <wtf/OptionSet.h>
+#import <wtf/RefPtr.h>
 #import <wtf/Vector.h>
-#import <wtf/WeakPtr.h>
 
 namespace WebGPU {
 
@@ -58,7 +58,7 @@ static constexpr auto isTextureBindGroupEntryUsage(OptionSet<BindGroupEntryUsage
 struct BindGroupEntryUsageData {
     OptionSet<BindGroupEntryUsage> usage { BindGroupEntryUsage::Undefined };
     uint32_t binding { 0 };
-    using Resource = std::variant<WeakPtr<const Buffer>, WeakPtr<const TextureView>, WeakPtr<const ExternalTexture>>;
+    using Resource = std::variant<RefPtr<const Buffer>, RefPtr<const TextureView>, RefPtr<const ExternalTexture>>;
     Resource resource;
     static constexpr uint32_t invalidBindingIndex = INT_MAX;
     static constexpr BindGroupEntryUsage invalidBindGroupUsage = static_cast<BindGroupEntryUsage>(std::numeric_limits<std::underlying_type<BindGroupEntryUsage>::type>::max());

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -83,7 +83,7 @@ private:
     bool validatePopDebugGroup() const;
 
     void makeInvalid(NSString* = nil);
-    void executePreDispatchCommands(id<MTLBuffer> = nil);
+    void executePreDispatchCommands(const Buffer* = nullptr);
     id<MTLBuffer> runPredispatchIndirectCallValidation(const Buffer&, uint64_t);
 
     id<MTLComputeCommandEncoder> m_computeCommandEncoder { nil };

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -33,6 +33,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebGPU {
 class RenderPipeline;

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -239,7 +239,7 @@ void RenderBundleEncoder::addResource(RenderBundle::ResourcesContainer* resource
 
 void RenderBundleEncoder::addResource(RenderBundle::ResourcesContainer* container, id<MTLResource> mtlResource, MTLRenderStages stage)
 {
-    WeakPtr<const Buffer> placeholderBuffer = nullptr;
+    RefPtr<const Buffer> placeholderBuffer;
     addResource(container, mtlResource, stage, placeholderBuffer);
 }
 
@@ -559,7 +559,7 @@ void RenderBundleEncoder::drawIndexedIndirect(const Buffer& indirectBuffer, uint
             return;
 
         ASSERT(m_indexBufferOffset == contents->indexStart);
-        addResource(m_resources, indirectBuffer.buffer(), MTLRenderStageVertex, indirectBuffer);
+        addResource(m_resources, indirectBuffer.buffer(), MTLRenderStageVertex, &indirectBuffer);
         [icbCommand drawIndexedPrimitives:m_primitiveType indexCount:contents->indexCount indexType:m_indexType indexBuffer:indexBuffer indexBufferOffset:m_indexBufferOffset instanceCount:contents->instanceCount baseVertex:contents->baseVertex baseInstance:contents->baseInstance];
     } else {
         if (!isValidToUseWith(indirectBuffer, *this)) {
@@ -607,7 +607,7 @@ void RenderBundleEncoder::drawIndirect(const Buffer& indirectBuffer, uint64_t in
         if (!contents || !contents->instanceCount || !contents->vertexCount)
             return;
 
-        addResource(m_resources, indirectBuffer.buffer(), MTLRenderStageVertex, indirectBuffer);
+        addResource(m_resources, indirectBuffer.buffer(), MTLRenderStageVertex, &indirectBuffer);
         [icbCommand drawPrimitives:m_primitiveType vertexStart:contents->vertexStart vertexCount:contents->vertexCount instanceCount:contents->instanceCount baseInstance:contents->baseInstance];
     } else {
         m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDraw;
@@ -907,7 +907,7 @@ void RenderBundleEncoder::setIndexBuffer(const Buffer& buffer, WGPUIndexFormat f
         return;
     }
 
-    addResource(m_resources, indexBuffer, MTLRenderStageVertex, buffer);
+    addResource(m_resources, indexBuffer, MTLRenderStageVertex, &buffer);
 }
 
 bool RenderBundleEncoder::icbNeedsToBeSplit(const RenderPipeline& a, const RenderPipeline& b)
@@ -1038,7 +1038,7 @@ void RenderBundleEncoder::setVertexBuffer(uint32_t slot, const Buffer* optionalB
 
         auto& buffer = *optionalBuffer;
         m_utilizedBufferIndices.add(slot, size);
-        addResource(m_resources, buffer.buffer(), MTLRenderStageVertex, buffer);
+        addResource(m_resources, buffer.buffer(), MTLRenderStageVertex, &buffer);
         m_vertexBuffers[slot] = { .buffer = buffer.buffer(), .offset = offset, .dynamicOffsetCount = 0, .dynamicOffsets = nullptr, .size = size };
         if (m_renderPassEncoder)
             buffer.setCommandEncoder(m_renderPassEncoder->parentEncoder());

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -34,6 +34,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakPtr.h>
 
 @class TextureAndClearColor;
 
@@ -105,12 +106,12 @@ private:
     RenderPassEncoder(CommandEncoder&, Device&, NSString*);
 
     bool validatePopDebugGroup() const;
-    bool executePreDrawCommands(id<MTLBuffer> = nil);
+    bool executePreDrawCommands(const Buffer* = nullptr);
     bool runIndexBufferValidation(uint32_t firstInstance, uint32_t instanceCount);
     void runVertexBufferValidation(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
     void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>);
     void addResourceToActiveResources(const TextureView&, OptionSet<BindGroupEntryUsage>, WGPUTextureAspect);
-    void addResourceToActiveResources(id<MTLResource>, OptionSet<BindGroupEntryUsage>, uint32_t baseMipLevel = 0, uint32_t baseArrayLayer = 0, WGPUTextureAspect = WGPUTextureAspect_DepthOnly);
+    void addResourceToActiveResources(const void*, id<MTLResource>, OptionSet<BindGroupEntryUsage>, uint32_t baseMipLevel = 0, uint32_t baseArrayLayer = 0, WGPUTextureAspect = WGPUTextureAspect_DepthOnly);
 
     NSString* errorValidatingAndBindingBuffers();
     NSString* errorValidatingDrawIndexed() const;
@@ -148,7 +149,7 @@ private:
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
     using EntryUsage = OptionSet<BindGroupEntryUsage>;
     using EntryMap = HashMap<uint64_t, EntryUsage, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
-    HashMap<void*, EntryMap> m_usagesForResource;
+    HashMap<const void*, EntryMap> m_usagesForResource;
     float m_minDepth { 0.f };
     float m_maxDepth { 1.f };
     HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_queryBufferIndicesToClear;

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -83,6 +83,7 @@ public:
     bool isDestroyed() const;
     void destroy();
     void setCommandEncoder(CommandEncoder&) const;
+    const Texture& apiParentTexture() const { return m_parentTexture; }
 
 private:
     TextureView(id<MTLTexture>, const WGPUTextureViewDescriptor&, const std::optional<WGPUExtent3D>&, Texture&, Device&);


### PR DESCRIPTION
#### 2216a54223af1e12f2e64dc08c74fc09c86b5016
<pre>
[WebGPU] <a href="https://webgpu.github.io/webgpu-samples/samples/deferredRendering">https://webgpu.github.io/webgpu-samples/samples/deferredRendering</a> has an error in Queue::submit
<a href="https://bugs.webkit.org/show_bug.cgi?id=269600">https://bugs.webkit.org/show_bug.cgi?id=269600</a>
&lt;radar://123106092&gt;

Reviewed by Cameron McCormack.

274518@main used the address of the MTLResource as a handle,
the problem appears to be that multiple MTLBuffers can share
the same address when bridged-casted.

Instead of relying on that behavior, use the address of the
WebGPU resource which we know to be unique.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::makeBindGroupEntryUsageData):
* Source/WebGPU/WebGPU/BindableResource.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::addResourceToActiveResources):
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
(WebGPU::ComputePassEncoder::dispatchIndirect):
(WebGPU::setCommandEncoder):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::addResource):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::setIndexBuffer):
(WebGPU::RenderBundleEncoder::setVertexBuffer):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::addResourceToActiveResources):
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::drawIndexedIndirect):
(WebGPU::RenderPassEncoder::drawIndirect):
(WebGPU::RenderPassEncoder::setCommandEncoder):
(WebGPU::RenderPassEncoder::setIndexBuffer):
(WebGPU::RenderPassEncoder::setVertexBuffer):
* Source/WebGPU/WebGPU/TextureView.h:
(WebGPU::TextureView::apiParentTexture const):

Canonical link: <a href="https://commits.webkit.org/274902@main">https://commits.webkit.org/274902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c706e7933deb32eaeca12df1a23a557bbf6c1da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42849 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16645 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16261 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44127 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36534 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12386 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16738 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9049 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->