### PR TITLE
[Site Isolation][iOS] Remove hosted layer as subview instead of sublayer

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -183,13 +183,8 @@ bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& tran
             return HashSet<WebCore::PlatformLayerIdentifier>();
         }).iterator->value.add(rootNode->layerID());
         rootNode->setRemoteContextHostedIdentifier(*contextHostedID);
-        if (auto* remoteRootNode = nodeForID(m_hostingLayers.get(*contextHostedID))) {
-#if PLATFORM(IOS_FAMILY)
-            [remoteRootNode->uiView() addSubview:rootNode->uiView()];
-#else
-            [remoteRootNode->layer() addSublayer:rootNode->layer()];
-#endif
-        }
+        if (auto* remoteRootNode = nodeForID(m_hostingLayers.get(*contextHostedID)))
+            rootNode->addToHostingNode(*remoteRootNode);
     }
 
     for (auto& changedLayer : transaction.changedLayerProperties()) {
@@ -384,11 +379,7 @@ void RemoteLayerTreeHost::createLayer(const RemoteLayerTreeTransaction::LayerCre
     if (auto* hostIdentifier = std::get_if<WebCore::LayerHostingContextIdentifier>(&properties.additionalData)) {
         m_hostingLayers.set(*hostIdentifier, properties.layerID);
         if (auto* hostedNode = nodeForID(m_hostedLayers.get(*hostIdentifier)))
-#if PLATFORM(IOS_FAMILY)
-            [node->uiView() addSubview:hostedNode->uiView()];
-#else
-            [node->layer() addSublayer:hostedNode->layer()];
-#endif
+            hostedNode->addToHostingNode(*node);
     }
 
     m_nodes.add(properties.layerID, WTFMove(node));
@@ -501,7 +492,8 @@ MonotonicTime RemoteLayerTreeHost::animationCurrentTime() const
 void RemoteLayerTreeHost::remotePageProcessCrashed(WebCore::ProcessIdentifier processIdentifier)
 {
     for (auto layerID : m_hostedLayersInProcess.take(processIdentifier)) {
-        [layerForID(layerID) removeFromSuperlayer];
+        if (auto* node = nodeForID(layerID))
+            node->removeFromHostingNode();
         layerWillBeRemoved(processIdentifier, layerID);
     }
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -110,6 +110,8 @@ public:
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostingIdentifier() const { return m_remoteContextHostingIdentifier; }
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier() const { return m_remoteContextHostedIdentifier; }
     void setRemoteContextHostedIdentifier(WebCore::LayerHostingContextIdentifier identifier) { m_remoteContextHostedIdentifier = identifier; }
+    void addToHostingNode(RemoteLayerTreeNode&);
+    void removeFromHostingNode();
 
     // A cached CAIOSurface object to retain CA render resources.
     struct CachedContentsBuffer {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -247,6 +247,24 @@ NSString *RemoteLayerTreeNode::appendLayerDescription(NSString *description, CAL
     return [description stringByAppendingString:layerDescription];
 }
 
+void RemoteLayerTreeNode::addToHostingNode(RemoteLayerTreeNode& hostingNode)
+{
+#if PLATFORM(IOS_FAMILY)
+    [hostingNode.uiView() addSubview:uiView()];
+#else
+    [hostingNode.layer() addSublayer:layer()];
+#endif
+}
+
+void RemoteLayerTreeNode::removeFromHostingNode()
+{
+#if PLATFORM(IOS_FAMILY)
+    [uiView() removeFromSuperview];
+#else
+    [layer() removeFromSuperlayer];
+#endif
+}
+
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects& effects, const WebCore::AcceleratedEffectValues& baseValues, RemoteLayerTreeHost& host)
 {


### PR DESCRIPTION
#### 93760c4cbf98e14ebf2f588b5f1a1ebe03de4689
<pre>
[Site Isolation][iOS] Remove hosted layer as subview instead of sublayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=269610">https://bugs.webkit.org/show_bug.cgi?id=269610</a>
<a href="https://rdar.apple.com/123113647">rdar://123113647</a>

Reviewed by Alex Christensen.

On iOS, RemoteLayerTreeNode is backed by UIView, so we should modify remote layer tree by updating
the hierachy of UIView. This patch also adds a helper function to avoid this issue in the future.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::createLayer):
(WebKit::RemoteLayerTreeHost::remotePageProcessCrashed):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::addToHostingNode):
(WebKit::RemoteLayerTreeNode::removeFromHostingNode):

Canonical link: <a href="https://commits.webkit.org/275004@main">https://commits.webkit.org/275004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b3a3c4689daee8bf9f179972cd83dd53c3c9d1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43161 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36697 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33690 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14277 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14353 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44435 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40048 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38380 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17042 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17093 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5399 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->