### PR TITLE
Restrict types serialized in an NSDictionary and NSArray

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -400,6 +400,12 @@ class MemberVariable(object):
             return value
         return value + ' *'
 
+    def type_check(self):
+        value = self.ns_type()
+        if value == 'SecTrustRef':
+            return '(m_' + self.type + ' && CFGetTypeID((CFTypeRef)m_' + self.type + '.get()) == SecTrustGetTypeID())'
+        return '[m_' + self.type + ' isKindOfClass:IPC::getClass<' + value + '>()]'
+
     def id_cast(self):
         value = self.ns_type()
         if value == 'SecTrustRef':
@@ -1743,13 +1749,9 @@ def generate_webkit_secure_coding_impl(serialized_types, headers):
                         result.append('    m_' + member.type + ' = vectorFromArray<' + member.array_contents() + '>((' + member.ns_type_pointer() + ')[dictionary objectForKey:@"' + member.type + '"]);')
             else:
                 result.append('    m_' + member.type + ' = (' + member.ns_type_pointer() + ')[dictionary objectForKey:@"' + member.type + '"];')
-                if member.value_is_optional():
-                    result.append('    if (m_' + member.type + ' && IPC::typeFromObject(' + member.id_cast() + 'm_' + member.type + '.get()) != IPC::NSType::' + member.ns_type_enum_value() + ') {')
-                else:
-                    result.append('    if (!m_' + member.type + ' || IPC::typeFromObject(' + member.id_cast() + 'm_' + member.type + '.get()) != IPC::NSType::' + member.ns_type_enum_value() + ') {')
+                result.append('    if (!' + member.type_check() + ')')
                 result.append('        m_' + member.type + ' = nullptr;')
                 # FIXME: We ought to be able to ASSERT_NOT_REACHED() here once all the question marks are in the right places.
-                result.append('    }')
                 result.append('')
         result.append('}')
         result.append('')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
@@ -126,14 +126,12 @@ CoreIPCAVOutputContext::CoreIPCAVOutputContext(AVOutputContext *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
     m_AVOutputContextSerializationKeyContextID = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextID"];
-    if (!m_AVOutputContextSerializationKeyContextID || IPC::typeFromObject(m_AVOutputContextSerializationKeyContextID.get()) != IPC::NSType::String) {
+    if (![m_AVOutputContextSerializationKeyContextID isKindOfClass:IPC::getClass<NSString>()])
         m_AVOutputContextSerializationKeyContextID = nullptr;
-    }
 
     m_AVOutputContextSerializationKeyContextType = (NSString *)[dictionary objectForKey:@"AVOutputContextSerializationKeyContextType"];
-    if (!m_AVOutputContextSerializationKeyContextType || IPC::typeFromObject(m_AVOutputContextSerializationKeyContextType.get()) != IPC::NSType::String) {
+    if (![m_AVOutputContextSerializationKeyContextType isKindOfClass:IPC::getClass<NSString>()])
         m_AVOutputContextSerializationKeyContextType = nullptr;
-    }
 
 }
 
@@ -175,39 +173,32 @@ CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType(NSSomeFoundationType *o
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
     m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
-    if (!m_StringKey || IPC::typeFromObject(m_StringKey.get()) != IPC::NSType::String) {
+    if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
         m_StringKey = nullptr;
-    }
 
     m_NumberKey = (NSNumber *)[dictionary objectForKey:@"NumberKey"];
-    if (!m_NumberKey || IPC::typeFromObject(m_NumberKey.get()) != IPC::NSType::Number) {
+    if (![m_NumberKey isKindOfClass:IPC::getClass<NSNumber>()])
         m_NumberKey = nullptr;
-    }
 
     m_OptionalNumberKey = (NSNumber *)[dictionary objectForKey:@"OptionalNumberKey"];
-    if (m_OptionalNumberKey && IPC::typeFromObject(m_OptionalNumberKey.get()) != IPC::NSType::Number) {
+    if (![m_OptionalNumberKey isKindOfClass:IPC::getClass<NSNumber>()])
         m_OptionalNumberKey = nullptr;
-    }
 
     m_ArrayKey = (NSArray *)[dictionary objectForKey:@"ArrayKey"];
-    if (!m_ArrayKey || IPC::typeFromObject(m_ArrayKey.get()) != IPC::NSType::Array) {
+    if (![m_ArrayKey isKindOfClass:IPC::getClass<NSArray>()])
         m_ArrayKey = nullptr;
-    }
 
     m_OptionalArrayKey = (NSArray *)[dictionary objectForKey:@"OptionalArrayKey"];
-    if (m_OptionalArrayKey && IPC::typeFromObject(m_OptionalArrayKey.get()) != IPC::NSType::Array) {
+    if (![m_OptionalArrayKey isKindOfClass:IPC::getClass<NSArray>()])
         m_OptionalArrayKey = nullptr;
-    }
 
     m_DictionaryKey = (NSDictionary *)[dictionary objectForKey:@"DictionaryKey"];
-    if (!m_DictionaryKey || IPC::typeFromObject(m_DictionaryKey.get()) != IPC::NSType::Dictionary) {
+    if (![m_DictionaryKey isKindOfClass:IPC::getClass<NSDictionary>()])
         m_DictionaryKey = nullptr;
-    }
 
     m_OptionalDictionaryKey = (NSDictionary *)[dictionary objectForKey:@"OptionalDictionaryKey"];
-    if (m_OptionalDictionaryKey && IPC::typeFromObject(m_OptionalDictionaryKey.get()) != IPC::NSType::Dictionary) {
+    if (![m_OptionalDictionaryKey isKindOfClass:IPC::getClass<NSDictionary>()])
         m_OptionalDictionaryKey = nullptr;
-    }
 
 }
 
@@ -260,19 +251,16 @@ CoreIPCDDScannerResult::CoreIPCDDScannerResult(DDScannerResult *object)
 {
     auto dictionary = dictionaryForWebKitSecureCodingType(object);
     m_StringKey = (NSString *)[dictionary objectForKey:@"StringKey"];
-    if (!m_StringKey || IPC::typeFromObject(m_StringKey.get()) != IPC::NSType::String) {
+    if (![m_StringKey isKindOfClass:IPC::getClass<NSString>()])
         m_StringKey = nullptr;
-    }
 
     m_NumberKey = (NSNumber *)[dictionary objectForKey:@"NumberKey"];
-    if (!m_NumberKey || IPC::typeFromObject(m_NumberKey.get()) != IPC::NSType::Number) {
+    if (![m_NumberKey isKindOfClass:IPC::getClass<NSNumber>()])
         m_NumberKey = nullptr;
-    }
 
     m_OptionalNumberKey = (NSNumber *)[dictionary objectForKey:@"OptionalNumberKey"];
-    if (m_OptionalNumberKey && IPC::typeFromObject(m_OptionalNumberKey.get()) != IPC::NSType::Number) {
+    if (![m_OptionalNumberKey isKindOfClass:IPC::getClass<NSNumber>()])
         m_OptionalNumberKey = nullptr;
-    }
 
     m_ArrayKey = vectorFromArray<DDScannerResult>((NSArray *)[dictionary objectForKey:@"ArrayKey"]);
     m_OptionalArrayKey = optionalVectorFromArray<DDScannerResult>((NSArray *)[dictionary objectForKey:@"OptionalArrayKey"]);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -67,31 +67,9 @@ class CoreIPNSCURLProtectionSpace;
 
 using ObjectValue = std::variant<
     std::nullptr_t,
-#if USE(AVFOUNDATION)
-    CoreIPCAVOutputContext,
-#endif
     CoreIPCArray,
     CoreIPCCFType,
-#if USE(PASSKIT)
-    CoreIPCCNContact,
-    CoreIPCCNPhoneNumber,
-    CoreIPCCNPostalAddress,
-    CoreIPCDateComponents,
-    CoreIPCPKContact,
-    CoreIPCPKPaymentMerchantSession,
-    CoreIPCPKPayment,
-    CoreIPCPKPaymentToken,
-    CoreIPCPKShippingMethod,
-    CoreIPCPKDateComponentsRange,
-    CoreIPCPKPaymentMethod,
-#endif
     CoreIPCColor,
-#if ENABLE(DATA_DETECTION)
-#if PLATFORM(MAC)
-    CoreIPCDDActionContext,
-#endif
-    CoreIPCDDScannerResult,
-#endif
     CoreIPCData,
     CoreIPCDate,
     CoreIPCDictionary,
@@ -102,12 +80,9 @@ using ObjectValue = std::variant<
     CoreIPCNSValue,
     CoreIPCNumber,
     CoreIPCNull,
-    CoreIPCPersonNameComponents,
-    CoreIPCPresentationIntent,
     CoreIPCSecureCoding,
     CoreIPCString,
-    CoreIPCURL,
-    CoreIPCNSURLProtectionSpace
+    CoreIPCURL
 >;
 
 class CoreIPCNSCFObject {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -35,68 +35,16 @@
 
 namespace WebKit {
 
-// This method helps us bridge the gap between classic NSSecureCoding types and new WebKit coding types
-// as we get more and more support in various classes.
-// The eventual goal is to remove the CoreIPCSecureCoding wrapper altogether, but for now this runtime
-// fork in behavior is necessary.
-template <typename WebKitSecureCodingWrapper, typename ObjCType> ObjectValue secureCodingValueFromID(ObjCType object)
-{
-    if (CoreIPCSecureCoding::conformsToWebKitSecureCoding(object))
-        return WebKitSecureCodingWrapper(object);
-    if (CoreIPCSecureCoding::conformsToSecureCoding(object))
-        return CoreIPCSecureCoding(object);
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 static ObjectValue valueFromID(id object)
 {
     if (!object)
         return nullptr;
 
     switch (IPC::typeFromObject(object)) {
-#if USE(AVFOUNDATION)
-    case IPC::NSType::AVOutputContext:
-        return CoreIPCAVOutputContext((AVOutputContext *)object);
-#endif
     case IPC::NSType::Array:
         return CoreIPCArray((NSArray *)object);
-#if USE(PASSKIT)
-    case IPC::NSType::CNContact:
-        return CoreIPCCNContact((CNContact *)object);
-    case IPC::NSType::CNPhoneNumber:
-        return CoreIPCCNPhoneNumber((CNPhoneNumber *)object);
-    case IPC::NSType::CNPostalAddress:
-        return CoreIPCCNPostalAddress((CNPostalAddress *)object);
-    case IPC::NSType::NSDateComponents:
-        return CoreIPCDateComponents((NSDateComponents *)object);
-    case IPC::NSType::PKContact:
-        return CoreIPCPKContact((PKContact *)object);
-    case IPC::NSType::PKPaymentMerchantSession:
-        return CoreIPCPKPaymentMerchantSession((PKPaymentMerchantSession *)object);
-    case IPC::NSType::PKPayment:
-        return CoreIPCPKPayment((PKPayment *)object);
-    case IPC::NSType::PKPaymentToken:
-        return CoreIPCPKPaymentToken((PKPaymentToken *)object);
-    case IPC::NSType::PKSecureElementPass:
-        // FIXME: Serialize PKSecureElementPass directly instead of relying on secure coding.
-        return CoreIPCSecureCoding(object);
-    case IPC::NSType::PKShippingMethod:
-        return CoreIPCPKShippingMethod((PKShippingMethod *)object);
-    case IPC::NSType::PKDateComponentsRange:
-        return CoreIPCPKDateComponentsRange((PKDateComponentsRange *)object);
-    case IPC::NSType::PKPaymentMethod:
-        return CoreIPCPKPaymentMethod((PKPaymentMethod *)object);
-#endif
     case IPC::NSType::Color:
         return CoreIPCColor((WebCore::CocoaColor *)object);
-#if ENABLE(DATA_DETECTION)
-#if PLATFORM(MAC)
-    case IPC::NSType::DDActionContext:
-        return secureCodingValueFromID<CoreIPCDDActionContext>((DDActionContext *)object);
-#endif
-    case IPC::NSType::DDScannerResult:
-        return secureCodingValueFromID<CoreIPCDDScannerResult>((DDScannerResult *)object);
-#endif
     case IPC::NSType::Data:
         return CoreIPCData((NSData *)object);
     case IPC::NSType::Date:
@@ -109,26 +57,18 @@ static ObjectValue valueFromID(id object)
         return CoreIPCLocale((NSLocale *)object);
     case IPC::NSType::Font:
         return CoreIPCFont((WebCore::CocoaFont *)object);
-    case IPC::NSType::NSShadow:
-        return CoreIPCNSShadow((NSShadow *)object);
     case IPC::NSType::NSValue:
         return CoreIPCNSValue((NSValue *)object);
     case IPC::NSType::Number:
         return CoreIPCNumber(bridge_cast((NSNumber *)object));
     case IPC::NSType::Null:
         return CoreIPCNull((NSNull *)object);
-    case IPC::NSType::PersonNameComponents:
-        return CoreIPCPersonNameComponents((NSPersonNameComponents *)object);
-    case IPC::NSType::PresentationIntent:
-        return CoreIPCPresentationIntent((NSPresentationIntent *)object);
     case IPC::NSType::SecureCoding:
         return CoreIPCSecureCoding((NSObject<NSSecureCoding> *)object);
     case IPC::NSType::String:
         return CoreIPCString((NSString *)object);
     case IPC::NSType::URL:
         return CoreIPCURL((NSURL *)object);
-    case IPC::NSType::NSURLProtectionSpace:
-        return CoreIPCNSURLProtectionSpace((NSURLProtectionSpace *)object);
     case IPC::NSType::CF:
         return CoreIPCCFType((CFTypeRef)object);
     case IPC::NSType::Unknown:


### PR DESCRIPTION
#### 3eb7fa3d34df30dc1066f15dd1f6137865df49b8
<pre>
Restrict types serialized in an NSDictionary and NSArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=269613">https://bugs.webkit.org/show_bug.cgi?id=269613</a>
<a href="https://rdar.apple.com/122817546">rdar://122817546</a>

Reviewed by Brady Eidson.

When we used CoreIPCDictionary for serialization of all types that used WKKeyedCoder,
when we increased the number of types that used WKKeyedCoder we increased the number of
types that could be serialized in any NSDictionary or NSArray.

Now that we are using generated structures for serialization of types using WKKeyedCoder,
we can separate the coders and bring the number of types allowed in NSDictionary and NSArray
back down.

* Source/WebKit/Scripts/generate-serializers.py:
(MemberVariable.type_check):
(generate_webkit_secure_coding_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
(WebKit::CoreIPCNSSomeFoundationType::CoreIPCNSSomeFoundationType):
(WebKit::CoreIPCDDScannerResult::CoreIPCDDScannerResult):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
(IPC::decodeRequiringAllowedClasses):
(IPC::ArgumentCoder&lt;T::encode):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
(IPC::encodeObjectWithWrapper): Deleted.
(IPC::decodeObjectFromWrapper): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):

Canonical link: <a href="https://commits.webkit.org/274933@main">https://commits.webkit.org/274933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a53171950ecc6a3e762a9aa9cf670da983019d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36505 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16757 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33526 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 20 flakes 178 failures 1 missing results; Uploaded test results; 24 flakes 150 failures 1 missing results; Compiled WebKit (cancelled)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16382 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14108 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/40287 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14174 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44239 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36643 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38164 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16899 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5358 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->