### PR TITLE
Add plumbing for PRF

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
@@ -28,6 +28,8 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "BufferSource.h"
+#include <wtf/KeyValuePair.h>
+#include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -39,9 +41,20 @@ struct AuthenticationExtensionsClientInputs {
         std::optional<BufferSource> write;
     };
 
+    struct PRFValues {
+        BufferSource first;
+        std::optional<BufferSource> second;
+    };
+
+    struct PRFInputs {
+        std::optional<AuthenticationExtensionsClientInputs::PRFValues> eval;
+        std::optional<Vector<KeyValuePair<String, AuthenticationExtensionsClientInputs::PRFValues>>> evalByCredential;
+    };
+
     String appid;
     bool credProps; // Not serialized but probably should be. Don't re-introduce rdar://101057340 though.
     std::optional<AuthenticationExtensionsClientInputs::LargeBlobInputs> largeBlob;
+    std::optional<AuthenticationExtensionsClientInputs::PRFInputs> prf;
 
     WEBCORE_EXPORT Vector<uint8_t> toCBOR() const;
     WEBCORE_EXPORT static std::optional<AuthenticationExtensionsClientInputs> fromCBOR(std::span<const uint8_t>);

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
@@ -33,9 +33,24 @@
 
 [
     Conditional=WEB_AUTHN,
+] dictionary AuthenticationExtensionsPRFValues {
+    required BufferSource first;
+    BufferSource second;
+};
+
+[
+    Conditional=WEB_AUTHN,
+] dictionary AuthenticationExtensionsPRFInputs {
+    AuthenticationExtensionsPRFValues eval;
+    record<USVString, AuthenticationExtensionsPRFValues> evalByCredential;
+};
+
+[
+    Conditional=WEB_AUTHN,
 ] dictionary AuthenticationExtensionsClientInputs {
     USVString appid;
     // For Google to turn off the legacy AppID support.
     boolean credProps;
     AuthenticationExtensionsLargeBlobInputs largeBlob;
+    AuthenticationExtensionsPRFInputs prf;
 };

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.h
@@ -45,9 +45,20 @@ struct AuthenticationExtensionsClientOutputs {
         std::optional<bool> written;
     };
 
+    struct PRFValues {
+        RefPtr<ArrayBuffer> first;
+        RefPtr<ArrayBuffer> second;
+    };
+
+    struct PRFOutputs {
+        std::optional<bool> enabled;
+        std::optional<AuthenticationExtensionsClientOutputs::PRFValues> results;
+    };
+
     std::optional<bool> appid;
     std::optional<CredentialPropertiesOutput> credProps;
     std::optional<LargeBlobOutputs> largeBlob;
+    std::optional<PRFOutputs> prf;
 
     WEBCORE_EXPORT Vector<uint8_t> toCBOR() const;
     WEBCORE_EXPORT static std::optional<AuthenticationExtensionsClientOutputs> fromCBOR(const Vector<uint8_t>&);

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.idl
@@ -41,8 +41,25 @@
 [
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
+] dictionary AuthenticationExtensionsPRFValues {
+    required ArrayBuffer first;
+    ArrayBuffer second;
+};
+
+[
+    Conditional=WEB_AUTHN,
+    JSGenerateToJSObject,
+] dictionary AuthenticationExtensionsPRFOutputs {
+    boolean enabled;
+    AuthenticationExtensionsPRFValues results;
+};
+
+[
+    Conditional=WEB_AUTHN,
+    JSGenerateToJSObject,
 ] dictionary AuthenticationExtensionsClientOutputs {
     boolean appid;
     CredentialPropertiesOutput credProps;
     AuthenticationExtensionsLargeBlobOutputs largeBlob;
+    AuthenticationExtensionsPRFOutputs prf;
 };

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -153,12 +153,14 @@ void AuthenticatorCoordinator::create(const Document& document, CredentialCreati
     AuthenticationExtensionsClientInputs extensionInputs = {
         String(),
         false,
+        std::nullopt,
         std::nullopt
     };
 
     if (auto extensions = options.extensions) {
         extensionInputs.credProps = extensions->credProps;
         extensionInputs.largeBlob = extensions->largeBlob;
+        extensionInputs.prf = extensions->prf;
     }
 
     options.extensions = extensionInputs;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1495,12 +1495,23 @@ struct WebCore::AuthenticatorResponseData {
     String support;
     std::optional<bool> read;
     std::optional<WebCore::BufferSource> write;
-}
+};
+
+[Nested] struct WebCore::AuthenticationExtensionsClientInputs::PRFValues {
+    WebCore::BufferSource first;
+    std::optional<WebCore::BufferSource> second;
+};
+
+[Nested] struct WebCore::AuthenticationExtensionsClientInputs::PRFInputs {
+    std::optional<WebCore::AuthenticationExtensionsClientInputs::PRFValues> eval;
+    std::optional<Vector<KeyValuePair<String, WebCore::AuthenticationExtensionsClientInputs::PRFValues>>> evalByCredential;
+};
 
 [LegacyPopulateFromEmptyConstructor] struct WebCore::AuthenticationExtensionsClientInputs {
     String appid;
     [NotSerialized] bool credProps;
     std::optional<WebCore::AuthenticationExtensionsClientInputs::LargeBlobInputs> largeBlob;
+    std::optional<WebCore::AuthenticationExtensionsClientInputs::PRFInputs> prf;
 }
 
 [Nested] struct WebCore::AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput {
@@ -1513,10 +1524,21 @@ struct WebCore::AuthenticatorResponseData {
     std::optional<bool> written;
 };
 
+[Nested] struct WebCore::AuthenticationExtensionsClientOutputs::PRFValues {
+    RefPtr<JSC::ArrayBuffer> first;
+    RefPtr<JSC::ArrayBuffer> second;
+};
+
+[Nested] struct WebCore::AuthenticationExtensionsClientOutputs::PRFOutputs {
+    std::optional<bool> enabled;
+    std::optional<WebCore::AuthenticationExtensionsClientOutputs::PRFValues> results;
+};
+
 struct WebCore::AuthenticationExtensionsClientOutputs {
     std::optional<bool> appid;
     std::optional<WebCore::AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput> credProps;
     std::optional<WebCore::AuthenticationExtensionsClientOutputs::LargeBlobOutputs> largeBlob;
+    std::optional<WebCore::AuthenticationExtensionsClientOutputs::PRFOutputs> prf;
 }
 
 [Nested] struct WebCore::PublicKeyCredentialCreationOptions::Parameters {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -231,7 +231,7 @@ void U2fAuthenticator::continueSignCommandAfterResponseReceived(ApduResponse&& a
             return;
         }
         if (m_isAppId)
-            response->setExtensions({ m_isAppId, std::nullopt, std::nullopt });
+            response->setExtensions({ m_isAppId, std::nullopt, std::nullopt, std::nullopt });
 
         receiveRespond(response.releaseNonNull());
         return;


### PR DESCRIPTION
#### d0abae280688756cccd287674a25211f84f18834
<pre>
Add plumbing for PRF
<a href="https://rdar.apple.com/121687418">rdar://121687418</a> (Adopt PRF extension in WebKit)

Reviewed by Pascoe.

Update the IDLs/serializations for PRF and add some plumbing.

* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.h:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.idl:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toNSData):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForAssertion):
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):

Canonical link: <a href="https://commits.webkit.org/274930@main">https://commits.webkit.org/274930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e95ec4a833d30ccd6221ce4d07978e0aa6a94d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36480 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16732 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14091 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39854 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38128 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16874 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5355 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->