### PR TITLE
Fix and check using statements in serialization.in files

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
@@ -257,7 +257,7 @@ enum class WebCore::WebGPU::ColorWrite : uint8_t {
     All,
 };
 
-using WebCore::WebGPU::ColorWriteFlags = std::underlying_type<WebCore::WebGPU::ColorWrite>;
+using WebCore::WebGPU::ColorWriteFlags = uint32_t;
 
 header: <WebCore/WebGPUSamplerBindingType.h>
 enum class WebCore::WebGPU::SamplerBindingType : uint8_t {

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1320,6 +1320,14 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
     result.extend(output_sorted_headers(sorted(header_set)))
 
     result.append('')
+    for using_statement in using_statements:
+        if using_statement.condition is not None:
+            result.append('#if ' + using_statement.condition)
+        result.append('static_assert(std::is_same_v<' + using_statement.name + ', ' + using_statement.alias + '>);')
+        if using_statement.condition is not None:
+            result.append('#endif')
+
+    result.append('')
     result.append('#if ENABLE(IPC_TESTING_API)')
     result.append('')
     result.append('namespace WebKit {')

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -80,6 +80,15 @@
 #include <wtf/CreateUsingClass.h>
 #include <wtf/Seconds.h>
 
+static_asssert(std::is_same_v<WebCore::SharedStringHash, uint32_t>);
+static_asssert(std::is_same_v<WebCore::UsingWithSemicolon, uint32_t>);
+#if OS(WINDOWS)
+static_asssert(std::is_same_v<WTF::ProcessID, int>);
+#endif
+#if !(OS(WINDOWS))
+static_asssert(std::is_same_v<WTF::ProcessID, pid_t>);
+#endif
+
 #if ENABLE(IPC_TESTING_API)
 
 namespace WebKit {

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -80,7 +80,7 @@ enum class webrtc::WebKitEncodedVideoRotation : uint8_t {
     kVideoRotation_270
 };
 
-using WebKitEncodedFrameTiming = webrtc::EncodedImage::Timing
+using webrtc::WebKitEncodedFrameTiming = webrtc::EncodedImage::Timing
 
 [Nested] struct webrtc::EncodedImage::Timing {
     uint8_t flags

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1485,7 +1485,7 @@ struct WebCore::WebLockManagerSnapshot {
     RefPtr<JSC::ArrayBuffer> userHandle;
 };
 
-using WebCore::AuthenticatorResponseDataSerializableForm = std::variant<std::nullptr_t, WebCore::AuthenticatorResponseDataBase, WebCore::AuthenticatorAttestationResponseData, WebCore::AuthenticatorAssertionResponseData>;
+using WebCore::AuthenticatorResponseDataSerializableForm = std::variant<std::nullptr_t, WebCore::AuthenticatorResponseBaseData, WebCore::AuthenticatorAttestationResponseData, WebCore::AuthenticatorAssertionResponseData>;
 
 struct WebCore::AuthenticatorResponseData {
     WebCore::AuthenticatorResponseDataSerializableForm getSerializableForm();
@@ -6520,9 +6520,9 @@ struct WebCore::PrewarmInformation {
     WebCore::FontCachePrewarmInformation fontCache;
 };
 
-using WebCore::ScrollingNodeID = ProcessQualified<ObjectIdentifier<WebCore::ScrollingNodeIDType>>;
-using WebCore::PlatformLayerIdentifier = ProcessQualified<ObjectIdentifier<WebCore::PlatformLayerIdentifierType>>;
-using WebCore::ScriptExecutionContextIdentifier = ProcessQualified<WTF::UUID>;
+using WebCore::ScrollingNodeID = WebCore::ProcessQualified<ObjectIdentifier<WebCore::ScrollingNodeIDType>>;
+using WebCore::PlatformLayerIdentifier = WebCore::ProcessQualified<ObjectIdentifier<WebCore::PlatformLayerIdentifierType>>;
+using WebCore::ScriptExecutionContextIdentifier = WebCore::ProcessQualified<WTF::UUID>;
 
 header: <WebCore/FontSelectionAlgorithm.h>
 using WebCore::FontSelectionValue::BackingType = int16_t;


### PR DESCRIPTION
#### 6303dc5ac35a183593e52eb8a2409f3057dd179a
<pre>
Fix and check using statements in serialization.in files
<a href="https://bugs.webkit.org/show_bug.cgi?id=269616">https://bugs.webkit.org/show_bug.cgi?id=269616</a>
<a href="https://rdar.apple.com/123118176">rdar://123118176</a>

Reviewed by Brady Eidson.

Some of them were wrong.
I added static_asserts so it won&apos;t compile if any of them are wrong.

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in:
* Source/WebKit/Scripts/generate-serializers.py:
(generate_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
* Source/WebKit/Shared/RTCNetwork.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/274903@main">https://commits.webkit.org/274903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a725ccc545f73752a6f33148dd2381fa86e08720

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42842 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34769 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/40165 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44120 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36052 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16780 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5340 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->