### PR TITLE
[WebGPU] GPUCanvasContext.configure(Rgba16float) crashes in IOSurface creation

### DIFF
--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -58,11 +58,13 @@ private:
     NSArray<IOSurface *> *m_ioSurfaces { nil };
     struct RenderBuffer {
         Ref<Texture> texture;
-        Ref<TextureView> textureView;
+        RefPtr<Texture> luminanceClampTexture;
     };
     Vector<RenderBuffer> m_renderBuffers;
     RefPtr<Device> m_device;
     size_t m_currentIndex { 0 };
+    id<MTLFunction> m_luminanceClampFunction;
+    id<MTLComputePipelineState> m_computePipelineState;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -117,6 +117,7 @@ public:
     void recreateIfNeeded();
     void makeCanvasBacking();
     void setCommandEncoder(CommandEncoder&) const;
+    static const char* formatToString(WGPUTextureFormat);
 
 private:
     Texture(id<MTLTexture>, const WGPUTextureDescriptor&, Vector<WGPUTextureFormat>&& viewFormats, Device&);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2963,7 +2963,7 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
 
 void Texture::recreateIfNeeded()
 {
-    RELEASE_ASSERT(m_texture.iosurface && m_canvasBacking);
+    RELEASE_ASSERT(m_canvasBacking);
     m_destroyed = false;
 }
 
@@ -2979,6 +2979,206 @@ void Texture::setCommandEncoder(CommandEncoder& commandEncoder) const
         commandEncoder.makeSubmitInvalid();
 }
 
+const char* Texture::formatToString(WGPUTextureFormat format)
+{
+    switch (format) {
+    case WGPUTextureFormat_Undefined:
+        return "undefined";
+    case WGPUTextureFormat_R8Unorm:
+        return "r8unorm";
+    case WGPUTextureFormat_R8Snorm:
+        return "r8snorm";
+    case WGPUTextureFormat_R8Uint:
+        return "r8uint";
+    case WGPUTextureFormat_R8Sint:
+        return "r8sint";
+    case WGPUTextureFormat_R16Uint:
+        return "r16uint";
+    case WGPUTextureFormat_R16Sint:
+        return "r16sint";
+    case WGPUTextureFormat_R16Float:
+        return "r16float";
+    case WGPUTextureFormat_RG8Unorm:
+        return "rg8unorm";
+    case WGPUTextureFormat_RG8Snorm:
+        return "rg8snorm";
+    case WGPUTextureFormat_RG8Uint:
+        return "rg8uint";
+    case WGPUTextureFormat_RG8Sint:
+        return "rg8sint";
+    case WGPUTextureFormat_R32Float:
+        return "r32float";
+    case WGPUTextureFormat_R32Uint:
+        return "r32uint";
+    case WGPUTextureFormat_R32Sint:
+        return "r32sint";
+    case WGPUTextureFormat_RG16Uint:
+        return "rg16uint";
+    case WGPUTextureFormat_RG16Sint:
+        return "rg16sint";
+    case WGPUTextureFormat_RG16Float:
+        return "rg16float";
+    case WGPUTextureFormat_RGBA8Unorm:
+        return "rgba8unorm";
+    case WGPUTextureFormat_RGBA8UnormSrgb:
+        return "rgba8unorm-srgb";
+    case WGPUTextureFormat_RGBA8Snorm:
+        return "rgba8snorm";
+    case WGPUTextureFormat_RGBA8Uint:
+        return "rgba8uint";
+    case WGPUTextureFormat_RGBA8Sint:
+        return "rgba8sint";
+    case WGPUTextureFormat_BGRA8Unorm:
+        return "bgra8unorm";
+    case WGPUTextureFormat_BGRA8UnormSrgb:
+        return "bgra8unorm-srgb";
+    case WGPUTextureFormat_RGB10A2Uint:
+        return "rgb10a2uint";
+    case WGPUTextureFormat_RGB10A2Unorm:
+        return "rgb10a2unorm";
+    case WGPUTextureFormat_RG11B10Ufloat:
+        return "rg11b10ufloat";
+    case WGPUTextureFormat_RGB9E5Ufloat:
+        return "rgb9e5ufloat";
+    case WGPUTextureFormat_RG32Float:
+        return "rg32float";
+    case WGPUTextureFormat_RG32Uint:
+        return "rg32uint";
+    case WGPUTextureFormat_RG32Sint:
+        return "rg32sint";
+    case WGPUTextureFormat_RGBA16Uint:
+        return "rgba16uint";
+    case WGPUTextureFormat_RGBA16Sint:
+        return "rgba16sint";
+    case WGPUTextureFormat_RGBA16Float:
+        return "rgba16float";
+    case WGPUTextureFormat_RGBA32Float:
+        return "rgba32float";
+    case WGPUTextureFormat_RGBA32Uint:
+        return "rgba32uint";
+    case WGPUTextureFormat_RGBA32Sint:
+        return "rgba32sint";
+    case WGPUTextureFormat_Stencil8:
+        return "stencil8";
+    case WGPUTextureFormat_Depth16Unorm:
+        return "depth16unorm";
+    case WGPUTextureFormat_Depth24Plus:
+        return "depth24plus";
+    case WGPUTextureFormat_Depth24PlusStencil8:
+        return "depth24plus-stencil8";
+    case WGPUTextureFormat_Depth32Float:
+        return "depth32float";
+    case WGPUTextureFormat_Depth32FloatStencil8:
+        return "depth32float-stencil8";
+    case WGPUTextureFormat_BC1RGBAUnorm:
+        return "bc1-rgba-unorm";
+    case WGPUTextureFormat_BC1RGBAUnormSrgb:
+        return "bc1-rgba-unorm-srgb";
+    case WGPUTextureFormat_BC2RGBAUnorm:
+        return "bc2-rgba-unorm";
+    case WGPUTextureFormat_BC2RGBAUnormSrgb:
+        return "bc2-rgba-unorm-srgb";
+    case WGPUTextureFormat_BC3RGBAUnorm:
+        return "bc3-rgba-unorm";
+    case WGPUTextureFormat_BC3RGBAUnormSrgb:
+        return "bc3-rgba-unorm-srgb";
+    case WGPUTextureFormat_BC4RUnorm:
+        return "bc4-r-unorm";
+    case WGPUTextureFormat_BC4RSnorm:
+        return "bc4-r-snorm";
+    case WGPUTextureFormat_BC5RGUnorm:
+        return "bc5-rg-unorm";
+    case WGPUTextureFormat_BC5RGSnorm:
+        return "bc5-rg-snorm";
+    case WGPUTextureFormat_BC6HRGBUfloat:
+        return "bc6h-rgb-ufloat";
+    case WGPUTextureFormat_BC6HRGBFloat:
+        return "bc6h-rgb-float";
+    case WGPUTextureFormat_BC7RGBAUnorm:
+        return "bc7-rgba-unorm";
+    case WGPUTextureFormat_BC7RGBAUnormSrgb:
+        return "bc7-rgba-unorm-srgb";
+    case WGPUTextureFormat_ETC2RGB8Unorm:
+        return "etc2-rgb8unorm";
+    case WGPUTextureFormat_ETC2RGB8UnormSrgb:
+        return "etc2-rgb8unorm-srgb";
+    case WGPUTextureFormat_ETC2RGB8A1Unorm:
+        return "etc2-rgb8a1unorm";
+    case WGPUTextureFormat_ETC2RGB8A1UnormSrgb:
+        return "etc2-rgb8a1unorm-srgb";
+    case WGPUTextureFormat_ETC2RGBA8Unorm:
+        return "etc2-rgba8unorm";
+    case WGPUTextureFormat_ETC2RGBA8UnormSrgb:
+        return "etc2-rgba8unorm-srgb";
+    case WGPUTextureFormat_EACR11Unorm:
+        return "eac-r11unorm";
+    case WGPUTextureFormat_EACR11Snorm:
+        return "eac-r11snorm";
+    case WGPUTextureFormat_EACRG11Unorm:
+        return "eac-rg11unorm";
+    case WGPUTextureFormat_EACRG11Snorm:
+        return "eac-rg11snorm";
+    case WGPUTextureFormat_ASTC4x4Unorm:
+        return "astc-4x4-unorm";
+    case WGPUTextureFormat_ASTC4x4UnormSrgb:
+        return "astc-4x4-unorm-srgb";
+    case WGPUTextureFormat_ASTC5x4Unorm:
+        return "astc-5x4-unorm";
+    case WGPUTextureFormat_ASTC5x4UnormSrgb:
+        return "astc-5x4-unorm-srgb";
+    case WGPUTextureFormat_ASTC5x5Unorm:
+        return "astc-5x5-unorm";
+    case WGPUTextureFormat_ASTC5x5UnormSrgb:
+        return "astc-5x5-unorm-srgb";
+    case WGPUTextureFormat_ASTC6x5Unorm:
+        return "astc-6x5-unorm";
+    case WGPUTextureFormat_ASTC6x5UnormSrgb:
+        return "astc-6x5-unorm-srgb";
+    case WGPUTextureFormat_ASTC6x6Unorm:
+        return "astc-6x6-unorm";
+    case WGPUTextureFormat_ASTC6x6UnormSrgb:
+        return "astc-6x6-unorm-srgb";
+    case WGPUTextureFormat_ASTC8x5Unorm:
+        return "astc-8x5-unorm";
+    case WGPUTextureFormat_ASTC8x5UnormSrgb:
+        return "astc-8x5-unorm-srgb";
+    case WGPUTextureFormat_ASTC8x6Unorm:
+        return "astc-8x6-unorm";
+    case WGPUTextureFormat_ASTC8x6UnormSrgb:
+        return "astc-8x6-unorm-srgb";
+    case WGPUTextureFormat_ASTC8x8Unorm:
+        return "astc-8x8-unorm";
+    case WGPUTextureFormat_ASTC8x8UnormSrgb:
+        return "astc-8x8-unorm-srgb";
+    case WGPUTextureFormat_ASTC10x5Unorm:
+        return "astc-10x5-unorm";
+    case WGPUTextureFormat_ASTC10x5UnormSrgb:
+        return "astc-10x5-unorm-srgb";
+    case WGPUTextureFormat_ASTC10x6Unorm:
+        return "astc-10x6-unorm";
+    case WGPUTextureFormat_ASTC10x6UnormSrgb:
+        return "astc-10x6-unorm-srgb";
+    case WGPUTextureFormat_ASTC10x8Unorm:
+        return "astc-10x8-unorm";
+    case WGPUTextureFormat_ASTC10x8UnormSrgb:
+        return "astc-10x8-unorm-srgb";
+    case WGPUTextureFormat_ASTC10x10Unorm:
+        return "astc-10x10-unorm";
+    case WGPUTextureFormat_ASTC10x10UnormSrgb:
+        return "astc-10x10-unorm-srgb";
+    case WGPUTextureFormat_ASTC12x10Unorm:
+        return "astc-12x10-unorm";
+    case WGPUTextureFormat_ASTC12x10UnormSrgb:
+        return "astc-12x10-unorm-srgb";
+    case WGPUTextureFormat_ASTC12x12Unorm:
+        return "astc-12x12-unorm";
+    case WGPUTextureFormat_ASTC12x12UnormSrgb:
+        return "astc-12x12-unorm-srgb";
+    case WGPUTextureFormat_Force32:
+    default:
+        return "invalid format";
+    }
+}
 void Texture::destroy()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy


### PR DESCRIPTION
#### 303744063b76f8bcf0335164bd86adae36fe28ab
<pre>
[WebGPU] GPUCanvasContext.configure(Rgba16float) crashes in IOSurface creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=269582">https://bugs.webkit.org/show_bug.cgi?id=269582</a>
&lt;radar://123096556&gt;

Reviewed by Dan Glastonbury.

rgba16float is a supported GPUCanvasContext format according to the specification,
but HTMLCanvas doesn&apos;t support rgba16float yet. So according to the WebGPU specification,
we are supposed to clamp the luminance to [0,1], leaving the chroma unchanged.

Do so with a custom compute shader.

* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::recreateIfNeeded):
(WebGPU::Texture::formatToString):

Canonical link: <a href="https://commits.webkit.org/274994@main">https://commits.webkit.org/274994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcc496cd25d4f50f2ed8630ef443c6ff84477ef5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36693 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16948 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14273 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36816 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40044 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38376 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17038 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9096 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->