### PR TITLE
Adopt more smart pointers in WebCore/html

### DIFF
--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -63,10 +63,8 @@ RefPtr<PaintRenderingContext2D> CustomPaintCanvas::getContext()
     if (m_context)
         return &downcast<PaintRenderingContext2D>(*m_context);
 
-    auto context = PaintRenderingContext2D::create(*this);
-    auto* contextPtr = context.get();
-    m_context = WTFMove(context);
-    return contextPtr;
+    m_context = PaintRenderingContext2D::create(*this);
+    return static_cast<PaintRenderingContext2D*>(m_context.get());
 }
 
 void CustomPaintCanvas::replayDisplayList(GraphicsContext& target)

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -88,12 +88,12 @@ ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, co
     ASSERT(!m_element->needsLayout());
     ASSERT(!m_element->element()->document().needsStyleRecalc());
 
-    JSCSSPaintCallback& callback = static_cast<JSCSSPaintCallback&>(m_paintDefinition->paintCallback.get());
-    auto* scriptExecutionContext = callback.scriptExecutionContext();
+    Ref callback = static_cast<JSCSSPaintCallback&>(m_paintDefinition->paintCallback.get());
+    RefPtr scriptExecutionContext = callback->scriptExecutionContext();
     if (!scriptExecutionContext)
         return ImageDrawResult::DidNothing;
 
-    auto canvas = CustomPaintCanvas::create(*scriptExecutionContext, destSize.width(), destSize.height());
+    Ref canvas = CustomPaintCanvas::create(*scriptExecutionContext, destSize.width(), destSize.height());
     RefPtr context = canvas->getContext();
 
     HashMap<AtomString, RefPtr<CSSValue>> propertyValues;
@@ -120,7 +120,7 @@ ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, co
         return ImageDrawResult::DidNothing;
     }
 
-    auto result = callback.handleEvent(WTFMove(thisObject), *context, size, propertyMap, m_arguments);
+    auto result = callback->handleEvent(WTFMove(thisObject), *context, size, propertyMap, m_arguments);
     if (result.type() != CallbackResultType::Success)
         return ImageDrawResult::DidNothing;
 

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -40,6 +40,7 @@
 #include "Text.h"
 #include <wtf/GregorianDateTime.h>
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -107,12 +108,12 @@ FTPDirectoryDocumentParser::FTPDirectoryDocumentParser(HTMLDocument& document)
 
 void FTPDirectoryDocumentParser::appendEntry(String&& filename, String&& size, String&& date, bool isDirectory)
 {
-    auto& document = *this->document();
+    Ref document = *this->document();
 
-    auto rowElement = m_tableElement->insertRow(-1).releaseReturnValue();
+    Ref rowElement = m_tableElement->insertRow(-1).releaseReturnValue();
     rowElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "ftpDirectoryEntryRow"_s);
 
-    auto typeElement = HTMLTableCellElement::create(tdTag, document);
+    Ref typeElement = HTMLTableCellElement::create(tdTag, document);
     typeElement->appendChild(Text::create(document, String(&noBreakSpace, 1)));
     if (isDirectory)
         typeElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "ftpDirectoryIcon ftpDirectoryTypeDirectory"_s);
@@ -120,38 +121,38 @@ void FTPDirectoryDocumentParser::appendEntry(String&& filename, String&& size, S
         typeElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "ftpDirectoryIcon ftpDirectoryTypeFile"_s);
     rowElement->appendChild(typeElement);
 
-    auto nameElement = createTDForFilename(WTFMove(filename));
+    Ref nameElement = createTDForFilename(WTFMove(filename));
     nameElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "ftpDirectoryFileName"_s);
     rowElement->appendChild(nameElement);
 
-    auto dateElement = HTMLTableCellElement::create(tdTag, document);
+    Ref dateElement = HTMLTableCellElement::create(tdTag, document);
     dateElement->appendChild(Text::create(document, WTFMove(date)));
     dateElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "ftpDirectoryFileDate"_s);
     rowElement->appendChild(dateElement);
 
-    auto sizeElement = HTMLTableCellElement::create(tdTag, document);
+    Ref sizeElement = HTMLTableCellElement::create(tdTag, document);
     sizeElement->appendChild(Text::create(document, WTFMove(size)));
     sizeElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "ftpDirectoryFileSize"_s);
     rowElement->appendChild(sizeElement);
-    document.setHasVisuallyNonEmptyCustomContent();
+    document->setHasVisuallyNonEmptyCustomContent();
 }
 
 Ref<Element> FTPDirectoryDocumentParser::createTDForFilename(String&& filename)
 {
-    auto& document = *this->document();
+    Ref document = *this->document();
 
-    auto baseURL = document.baseURL().string();
+    auto baseURL = document->baseURL().string();
     AtomString fullURL;
     if (baseURL.endsWith('/'))
         fullURL = makeAtomString(baseURL, filename);
     else
         fullURL = makeAtomString(baseURL, '/', filename);
 
-    auto anchorElement = HTMLAnchorElement::create(document);
+    Ref anchorElement = HTMLAnchorElement::create(document);
     anchorElement->setAttributeWithoutSynchronization(HTMLNames::hrefAttr, WTFMove(fullURL));
     anchorElement->appendChild(Text::create(document, WTFMove(filename)));
 
-    auto tdElement = HTMLTableCellElement::create(tdTag, document);
+    Ref tdElement = HTMLTableCellElement::create(tdTag, document);
     tdElement->appendChild(anchorElement);
 
     return tdElement;
@@ -288,20 +289,20 @@ static inline RefPtr<SharedBuffer> createTemplateDocumentData(const Settings& se
     
 bool FTPDirectoryDocumentParser::loadDocumentTemplate()
 {
-    static SharedBuffer* templateDocumentData = createTemplateDocumentData(document()->settings()).leakRef();
+    static NeverDestroyed<RefPtr<SharedBuffer>> templateDocumentData = createTemplateDocumentData(document()->settings());
     // FIXME: Instead of storing the data, it would be more efficient if we could parse the template data into the
     // template Document once, store that document, then "copy" it whenever we get an FTP directory listing.
     
-    if (!templateDocumentData) {
+    if (!templateDocumentData.get()) {
         LOG_ERROR("Could not load templateData");
         return false;
     }
 
-    HTMLDocumentParser::insert(String(templateDocumentData->data(), templateDocumentData->size()));
+    HTMLDocumentParser::insert(String(templateDocumentData.get()->data(), templateDocumentData.get()->size()));
 
-    auto& document = *this->document();
+    Ref document = *this->document();
 
-    RefPtr foundElement = document.getElementById(StringView { "ftpDirectoryTable"_s });
+    RefPtr foundElement = document->getElementById(StringView { "ftpDirectoryTable"_s });
     if (!foundElement)
         LOG_ERROR("Unable to find element by id \"ftpDirectoryTable\" in the template document.");
     else if (RefPtr tableElement = dynamicDowncast<HTMLTableElement>(*foundElement)) {
@@ -310,15 +311,16 @@ bool FTPDirectoryDocumentParser::loadDocumentTemplate()
     } else
         LOG_ERROR("Element of id \"ftpDirectoryTable\" is not a table element");
 
-    m_tableElement = HTMLTableElement::create(document);
-    m_tableElement->setAttributeWithoutSynchronization(HTMLNames::idAttr, "ftpDirectoryTable"_s);
+    Ref tableElement = HTMLTableElement::create(document);
+    m_tableElement = tableElement.copyRef();
+    tableElement->setAttributeWithoutSynchronization(HTMLNames::idAttr, "ftpDirectoryTable"_s);
 
     // If we didn't find the table element, lets try to append our own to the body.
     // If that fails for some reason, cram it on the end of the document as a last ditch effort.
-    if (RefPtr body = document.bodyOrFrameset())
-        body->appendChild(*m_tableElement);
+    if (RefPtr body = document->bodyOrFrameset())
+        body->appendChild(tableElement);
     else
-        document.appendChild(*m_tableElement);
+        document->appendChild(tableElement);
 
     return true;
 }
@@ -327,18 +329,19 @@ void FTPDirectoryDocumentParser::createBasicDocument()
 {
     LOG(FTP, "Creating a basic FTP document structure as no template was loaded");
 
-    auto& document = *this->document();
+    Ref document = *this->document();
 
-    auto bodyElement = HTMLBodyElement::create(document);
-    document.appendChild(bodyElement);
+    Ref bodyElement = HTMLBodyElement::create(document);
+    document->appendChild(bodyElement);
 
-    m_tableElement = HTMLTableElement::create(document);
-    m_tableElement->setAttributeWithoutSynchronization(HTMLNames::idAttr, "ftpDirectoryTable"_s);
-    m_tableElement->setAttribute(HTMLNames::styleAttr, "width:100%"_s);
+    Ref tableElement = HTMLTableElement::create(document);
+    m_tableElement = tableElement.copyRef();
+    tableElement->setAttributeWithoutSynchronization(HTMLNames::idAttr, "ftpDirectoryTable"_s);
+    tableElement->setAttribute(HTMLNames::styleAttr, "width:100%"_s);
 
-    bodyElement->appendChild(*m_tableElement);
+    bodyElement->appendChild(tableElement);
 
-    document.processViewport("width=device-width"_s, ViewportArguments::Type::ViewportMeta);
+    document->processViewport("width=device-width"_s, ViewportArguments::Type::ViewportMeta);
 }
 
 void FTPDirectoryDocumentParser::append(RefPtr<StringImpl>&& inputSource)

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -228,9 +228,9 @@ FormControlState FormAssociatedCustomElement::saveFormControlState() const
     // https://bugs.webkit.org/show_bug.cgi?id=249895
     bool didLogMessage = false;
     auto logUnsupportedFileWarning = [&](RefPtr<File>) {
-        auto& document = asHTMLElement().document();
-        if (document.frame() && !didLogMessage) {
-            document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "File isn't currently supported when saving / restoring state."_s);
+        Ref document = asHTMLElement().document();
+        if (document->frame() && !didLogMessage) {
+            document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "File isn't currently supported when saving / restoring state."_s);
             didLogMessage = true;
         }
     };

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -255,7 +255,7 @@ Vector<AtomString> FormController::formElementsState(const Document& document) c
         // FIXME: We should be saving the state of form controls in shadow trees, too.
         FormKeyGenerator keyGenerator;
         for (auto& element : descendantsOfType<Element>(document)) {
-            auto* control = const_cast<Element&>(element).asValidatedFormListedElement();
+            RefPtr control = const_cast<Element&>(element).asValidatedFormListedElement();
             if (!control || !control->isCandidateForSavingAndRestoringState())
                 continue;
 
@@ -263,7 +263,7 @@ Vector<AtomString> FormController::formElementsState(const Document& document) c
             auto& vector = formKeyToControlsMap.ensure(formKey, [] {
                 return Vector<Ref<const ValidatedFormListedElement>> { };
             }).iterator->value;
-            vector.append(*control);
+            vector.append(control.releaseNonNull());
         }
     }
 

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -188,7 +188,7 @@ void FormListedElement::parseFormAttribute(const AtomString& value)
         setForm(HTMLFormElement::findClosestFormAncestor(element));
         auto* newForm = form();
         if (newForm && newForm != originalForm && newForm->isConnected())
-            element.document().didAssociateFormControl(element);
+            element.protectedDocument()->didAssociateFormControl(element);
         m_formAttributeTargetObserver = nullptr;
     } else {
         resetFormOwner();

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -292,14 +292,14 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
         auto attributes = convert<IDLDictionary<WebGLContextAttributes>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
         RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
 
-        auto context = createContextWebGL(toWebGLVersion(contextId), WTFMove(attributes));
+        RefPtr context = createContextWebGL(toWebGLVersion(contextId), WTFMove(attributes));
         if (!context)
             return std::optional<RenderingContext> { std::nullopt };
 
         if (auto* webGLContext = dynamicDowncast<WebGLRenderingContext>(*context))
             return std::optional<RenderingContext> { RefPtr { webGLContext } };
 
-        return std::optional<RenderingContext> { RefPtr { &downcast<WebGL2RenderingContext>(*context) } };
+        return std::optional<RenderingContext> { downcast<WebGL2RenderingContext>(WTFMove(context)) };
     }
 #endif
 

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -134,13 +134,13 @@ std::optional<std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLColl
         return std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { RefPtr<HTMLCollection> { WTFMove(collection) } };
     }
 
-    auto& element = *documentNamedItem(name);
-    if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element); UNLIKELY(iframe)) {
+    Ref element = *documentNamedItem(name);
+    if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element.get()); UNLIKELY(iframe)) {
         if (RefPtr domWindow = iframe->contentWindow())
             return std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { WTFMove(domWindow) };
     }
 
-    return std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { RefPtr<Element> { &element } };
+    return std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { RefPtr<Element> { WTFMove(element) } };
 }
 
 bool HTMLDocument::isSupportedPropertyName(const AtomString& name) const

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -116,9 +116,8 @@ HTMLFormElement::~HTMLFormElement()
 
     m_defaultButton = nullptr;
     for (auto& weakElement : m_listedElements) {
-        RefPtr element { weakElement.get() };
-        ASSERT(element);
-        auto* listedElement = element->asFormListedElement();
+        ASSERT(weakElement);
+        RefPtr listedElement = weakElement->asFormListedElement();
         ASSERT(listedElement);
         listedElement->formWillBeDestroyed();
     }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1398,7 +1398,7 @@ ExceptionOr<void> HTMLInputElement::showPicker()
     // https://github.com/whatwg/html/issues/6909#issuecomment-917138991
     if (!m_inputType->allowsShowPickerAcrossFrames()) {
         auto* localTopFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
-        if (!localTopFrame || !frame->document()->securityOrigin().isSameOriginAs(localTopFrame->document()->securityOrigin()))
+        if (!localTopFrame || !frame->document()->protectedSecurityOrigin()->isSameOriginAs(localTopFrame->document()->protectedSecurityOrigin()))
             return Exception { ExceptionCode::SecurityError, "Input showPicker() called from cross-origin iframe."_s };
     }
 

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -123,14 +123,14 @@ void HTMLLabelElement::setHovered(bool over, Style::InvalidationScope invalidati
 
 bool HTMLLabelElement::isEventTargetedAtInteractiveDescendants(Event& event) const
 {
-    auto* node = dynamicDowncast<Node>(*event.target());
+    RefPtr node = dynamicDowncast<Node>(*event.target());
     if (!node)
         return false;
 
-    if (!containsIncludingShadowDOM(node))
+    if (!containsIncludingShadowDOM(node.get()))
         return false;
 
-    for (const auto* it = node; it && it != this; it = it->parentElementInComposedTree()) {
+    for (const auto* it = node.get(); it && it != this; it = it->parentElementInComposedTree()) {
         auto* element = dynamicDowncast<HTMLElement>(*it);
         if (element && element->isInteractiveContent())
             return true;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4795,7 +4795,7 @@ MediaElementAudioSourceNode* HTMLMediaElement::audioSourceNode()
 }
 #endif
 
-ExceptionOr<TextTrack&> HTMLMediaElement::addTextTrack(const AtomString& kind, const AtomString& label, const AtomString& language)
+ExceptionOr<Ref<TextTrack>> HTMLMediaElement::addTextTrack(const AtomString& kind, const AtomString& label, const AtomString& language)
 {
     // 4.8.10.12.4 Text track API
     // The addTextTrack(kind, label, language) method of media elements, when invoked, must run the following steps:
@@ -4811,24 +4811,23 @@ ExceptionOr<TextTrack&> HTMLMediaElement::addTextTrack(const AtomString& kind, c
     // 5. Create a new text track corresponding to the new object, and set its text track kind to kind, its text
     // track label to label, its text track language to language...
     Ref track = TextTrack::create(protectedDocument().ptr(), kind, emptyAtom(), label, language);
-    auto& trackReference = track.get();
 #if !RELEASE_LOG_DISABLED
-    trackReference.setLogger(protectedLogger(), logIdentifier());
+    track->setLogger(protectedLogger(), logIdentifier());
 #endif
 
     // Note, due to side effects when changing track parameters, we have to
     // first append the track to the text track list.
 
     // 6. Add the new text track to the media element's list of text tracks.
-    addTextTrack(WTFMove(track));
+    addTextTrack(track.copyRef());
 
     // ... its text track readiness state to the text track loaded state ...
-    trackReference.setReadinessState(TextTrack::Loaded);
+    track->setReadinessState(TextTrack::Loaded);
 
     // ... its text track mode to the text track hidden mode, and its text track list of cues to an empty list ...
-    trackReference.setMode(TextTrack::Mode::Hidden);
+    track->setMode(TextTrack::Mode::Hidden);
 
-    return trackReference;
+    return track;
 }
 
 AudioTrackList& HTMLMediaElement::ensureAudioTracks()
@@ -5168,11 +5167,11 @@ void HTMLMediaElement::setSelectedTextTrack(TextTrack* trackToSelect)
             return;
 
         for (int i = 0, length = trackList->length(); i < length; ++i) {
-            auto& track = *trackList->item(i);
-            if (&track != trackToSelect)
-                track.setMode(TextTrack::Mode::Disabled);
+            Ref track = *trackList->item(i);
+            if (track.ptr() != trackToSelect)
+                track->setMode(TextTrack::Mode::Disabled);
             else
-                track.setMode(TextTrack::Mode::Showing);
+                track->setMode(TextTrack::Mode::Showing);
         }
     }
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -367,7 +367,7 @@ public:
 
     bool shouldForceControlsDisplay() const;
 
-    ExceptionOr<TextTrack&> addTextTrack(const AtomString& kind, const AtomString& label, const AtomString& language);
+    ExceptionOr<Ref<TextTrack>> addTextTrack(const AtomString& kind, const AtomString& label, const AtomString& language);
 
     AudioTrackList& ensureAudioTracks();
     TextTrackList& ensureTextTracks();

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -157,10 +157,10 @@ bool HTMLSelectElement::hasPlaceholderLabelOption() const
 
     int listIndex = optionToListIndex(0);
     ASSERT(listIndex >= 0);
-    if (listIndex < 0)
+    if (listIndex)
         return false;
-    HTMLOptionElement& option = downcast<HTMLOptionElement>(*listItems()[listIndex]);
-    return !listIndex && option.value().isEmpty();
+    Ref option = downcast<HTMLOptionElement>(*listItems()[listIndex]);
+    return option->value().isEmpty();
 }
 
 String HTMLSelectElement::validationMessage() const
@@ -1647,8 +1647,7 @@ void HTMLSelectElement::accessKeySetSelectedIndex(int index)
     auto& items = listItems();
     int listIndex = optionToListIndex(index);
     if (listIndex >= 0) {
-        auto& element = *items[listIndex];
-        if (RefPtr option = dynamicDowncast<HTMLOptionElement>(element)) {
+        if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*items[listIndex])) {
             if (option->selected())
                 option->setSelectedState(false);
             else

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -125,16 +125,15 @@ static void flattenAssignedNodes(Vector<Ref<Node>>& nodes, const HTMLSlotElement
         }
         return;
     }
-    for (auto& nodeWeakPtr : *assignedNodes) {
-        auto* node = nodeWeakPtr.get();
-        if (UNLIKELY(!node)) {
+    for (auto& weakNode : *assignedNodes) {
+        if (UNLIKELY(!weakNode)) {
             ASSERT_NOT_REACHED();
             continue;
         }
-        if (auto* slot = dynamicDowncast<HTMLSlotElement>(*node); slot && slot->containingShadowRoot())
+        if (RefPtr slot = dynamicDowncast<HTMLSlotElement>(*weakNode); slot && slot->containingShadowRoot())
             flattenAssignedNodes(nodes, *slot);
         else
-            nodes.append(*node);
+            nodes.append(Ref { *weakNode });
     }
 }
 

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -42,6 +42,7 @@
 #include "NodeRareData.h"
 #include "RenderTable.h"
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {
@@ -446,14 +447,14 @@ void HTMLTableElement::attributeChanged(const QualifiedName& name, const AtomStr
     }
 }
 
-static MutableStyleProperties* leakBorderStyle(CSSValueID value)
+static Ref<MutableStyleProperties> createBorderStyle(CSSValueID value)
 {
-    auto style = MutableStyleProperties::create();
+    Ref style = MutableStyleProperties::create();
     style->setProperty(CSSPropertyBorderTopStyle, value);
     style->setProperty(CSSPropertyBorderBottomStyle, value);
     style->setProperty(CSSPropertyBorderLeftStyle, value);
     style->setProperty(CSSPropertyBorderRightStyle, value);
-    return &style.leakRef();
+    return style;
 }
 
 const MutableStyleProperties* HTMLTableElement::additionalPresentationalHintStyle() const
@@ -465,14 +466,14 @@ const MutableStyleProperties* HTMLTableElement::additionalPresentationalHintStyl
         // Setting the border to 'hidden' allows it to win over any border
         // set on the table's cells during border-conflict resolution.
         if (m_rulesAttr != UnsetRules) {
-            static auto* solidBorderStyle = leakBorderStyle(CSSValueHidden);
-            return solidBorderStyle;
+            static NeverDestroyed<Ref<MutableStyleProperties>> solidBorderStyle = createBorderStyle(CSSValueHidden);
+            return solidBorderStyle.get().ptr();
         }
         return nullptr;
     }
 
-    static auto* outsetBorderStyle = leakBorderStyle(CSSValueOutset);
-    return outsetBorderStyle;
+    static NeverDestroyed<Ref<MutableStyleProperties>> outsetBorderStyle = createBorderStyle(CSSValueOutset);
+    return outsetBorderStyle.get().ptr();
 }
 
 HTMLTableElement::CellBorders HTMLTableElement::cellBorders() const

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -64,8 +64,7 @@ static inline RefPtr<HTMLTableElement> findTable(const HTMLTableRowElement& row)
     if (auto* table = dynamicDowncast<HTMLTableElement>(parent))
         return table;
     if (is<HTMLTableSectionElement>(parent)) {
-        auto* grandparent = parent->parentNode();
-        if (auto* table = dynamicDowncast<HTMLTableElement>(grandparent))
+        if (auto* table = dynamicDowncast<HTMLTableElement>(parent->parentNode()))
             return table;
     }
     return nullptr;

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -417,7 +417,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
         return;
     }
 
-    auto imageForRenderer = cachedImage->imageForRenderer(renderer);
+    RefPtr imageForRenderer = cachedImage->imageForRenderer(renderer);
     if (!imageForRenderer) {
         completionHandler(Exception { ExceptionCode::InvalidStateError, "Cannot create ImageBitmap from image that can't be rendered"_s });
         return;
@@ -525,7 +525,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
         return;
     }
 
-    auto imageForRender = canvas.copiedImage();
+    RefPtr imageForRender = canvas.copiedImage();
     if (!imageForRender) {
         completionHandler(Exception { ExceptionCode::InvalidStateError, "Cannot create ImageBitmap from canvas that can't be rendered"_s });
         return;
@@ -663,7 +663,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
         return;
     }
 
-    auto imageForRender = BitmapImage::create(existingImageBitmap->buffer()->copyNativeImage());
+    RefPtr imageForRender = BitmapImage::create(existingImageBitmap->buffer()->copyNativeImage());
 
     FloatRect destRect(FloatPoint(), outputSize);
     bitmapData->context().drawImage(*imageForRender, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::Orientation::None) });
@@ -870,7 +870,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
     }
 
     auto outputSize = outputSizeForSourceRectangle(sourceRectangle.returnValue(), options);
-    auto bitmapData = createImageBuffer(scriptExecutionContext, outputSize, bufferRenderingMode, toDestinationColorSpace(imageData->colorSpace()));
+    RefPtr bitmapData = createImageBuffer(scriptExecutionContext, outputSize, bufferRenderingMode, toDestinationColorSpace(imageData->colorSpace()));
 
     const bool originClean = true;
     if (!bitmapData) {
@@ -892,7 +892,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
 
     // 6.3. Set imageBitmap's bitmap data to image's image data, cropped to the
     //      source rectangle with formatting.
-    auto tempBitmapData = createImageBuffer(scriptExecutionContext, imageData->size(), bufferRenderingMode, toDestinationColorSpace(imageData->colorSpace()));
+    RefPtr tempBitmapData = createImageBuffer(scriptExecutionContext, imageData->size(), bufferRenderingMode, toDestinationColorSpace(imageData->colorSpace()));
     if (!tempBitmapData) {
         completionHandler(createBlankImageBuffer(scriptExecutionContext, true));
         return;
@@ -902,7 +902,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
     bitmapData->context().drawImageBuffer(*tempBitmapData, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::Orientation::None) });
 
     // 6.4.1. Resolve p with ImageBitmap.
-    auto imageBitmap = create(bitmapData.releaseNonNull(), originClean, premultiplyAlpha);
+    Ref imageBitmap = create(bitmapData.releaseNonNull(), originClean, premultiplyAlpha);
 
     // The result is implicitly origin-clean, and alpha premultiplication has already been handled.
     completionHandler(WTFMove(imageBitmap));

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -411,6 +411,7 @@ protected:
     }
 
     HTMLInputElement* element() const { return m_element.get(); }
+    RefPtr<HTMLInputElement> protectedElement() const { return m_element.get(); }
     Chrome* chrome() const;
     Decimal parseToNumberOrNaN(const String&) const;
 

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -83,35 +83,35 @@ private:
     
 void MediaDocumentParser::createDocumentStructure()
 {
-    auto& document = *this->document();
+    Ref document = *this->document();
 
-    auto rootElement = HTMLHtmlElement::create(document);
-    document.appendChild(rootElement);
-    document.setCSSTarget(rootElement.ptr());
+    Ref rootElement = HTMLHtmlElement::create(document);
+    document->appendChild(rootElement);
+    document->setCSSTarget(rootElement.ptr());
     rootElement->insertedByParser();
 
-    if (document.frame())
-        document.frame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);
+    if (RefPtr frame = document->frame())
+        frame->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 
 #if PLATFORM(IOS_FAMILY)
-    auto headElement = HTMLHeadElement::create(document);
+    Ref headElement = HTMLHeadElement::create(document);
     rootElement->appendChild(headElement);
 
-    auto metaElement = HTMLMetaElement::create(document);
+    Ref metaElement = HTMLMetaElement::create(document);
     metaElement->setAttributeWithoutSynchronization(nameAttr, "viewport"_s);
     metaElement->setAttributeWithoutSynchronization(contentAttr, "width=device-width,initial-scale=1"_s);
     headElement->appendChild(metaElement);
 #endif
 
-    auto body = HTMLBodyElement::create(document);
+    Ref body = HTMLBodyElement::create(document);
     rootElement->appendChild(body);
 
-    auto videoElement = HTMLVideoElement::create(document);
+    Ref videoElement = HTMLVideoElement::create(document);
     m_mediaElement = videoElement.get();
     videoElement->setAttributeWithoutSynchronization(controlsAttr, emptyAtom());
     videoElement->setAttributeWithoutSynchronization(autoplayAttr, emptyAtom());
-    videoElement->setAttributeWithoutSynchronization(srcAttr, AtomString { document.url().string() });
-    if (RefPtr loader = document.loader())
+    videoElement->setAttributeWithoutSynchronization(srcAttr, AtomString { document->url().string() });
+    if (RefPtr loader = document->loader())
         videoElement->setAttributeWithoutSynchronization(typeAttr, AtomString { loader->responseMIMEType() });
 
 #if !ENABLE(MODERN_MEDIA_CONTROLS)
@@ -119,14 +119,14 @@ void MediaDocumentParser::createDocumentStructure()
 #endif // !ENABLE(MODERN_MEDIA_CONTROLS)
 
     body->appendChild(videoElement);
-    document.setHasVisuallyNonEmptyCustomContent();
+    document->setHasVisuallyNonEmptyCustomContent();
 
-    RefPtr frame = document.frame();
+    RefPtr frame = document->frame();
     if (!frame)
         return;
 
-    frame->loader().activeDocumentLoader()->setMainResourceDataBufferingPolicy(DataBufferingPolicy::DoNotBufferData);
-    frame->loader().setOutgoingReferrer(document.completeURL(m_outgoingReferrer));
+    frame->loader().protectedActiveDocumentLoader()->setMainResourceDataBufferingPolicy(DataBufferingPolicy::DoNotBufferData);
+    frame->checkedLoader()->setOutgoingReferrer(document->completeURL(m_outgoingReferrer));
 }
 
 void MediaDocumentParser::appendBytes(DocumentWriter&, const uint8_t*, size_t)

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -378,14 +378,14 @@ Expected<void, MediaPlaybackDenialReason> MediaElementSession::playbackStateChan
         return makeUnexpected(MediaPlaybackDenialReason::InvalidState);
     }
 
-    auto& document = m_element.document();
-    auto* page = document.page();
+    Ref document = m_element.document();
+    RefPtr page = document->page();
     if (!page || page->mediaPlaybackIsSuspended()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Returning FALSE because media playback is suspended");
         return makeUnexpected(MediaPlaybackDenialReason::PageConsentRequired);
     }
 
-    if (document.isMediaDocument() && !document.ownerElement())
+    if (document->isMediaDocument() && !document->ownerElement())
         return { };
 
     if (pageExplicitlyAllowsElementToAutoplayInline(m_element))
@@ -401,32 +401,32 @@ Expected<void, MediaPlaybackDenialReason> MediaElementSession::playbackStateChan
 
 #if ENABLE(MEDIA_STREAM)
     if (m_element.hasMediaStreamSrcObject()) {
-        if (document.isCapturing())
+        if (document->isCapturing())
             return { };
-        if (document.mediaState() & MediaProducerMediaState::IsPlayingAudio)
+        if (document->mediaState() & MediaProducerMediaState::IsPlayingAudio)
             return { };
     }
 #endif
 
     // FIXME: Why are we checking top-level document only for PerDocumentAutoplayBehavior?
-    const auto& topDocument = document.topDocument();
-    if (topDocument.quirks().requiresUserGestureToPauseInPictureInPicture()
+    Ref topDocument = document->topDocument();
+    if (topDocument->quirks().requiresUserGestureToPauseInPictureInPicture()
         && m_element.fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModePictureInPicture
         && !m_element.paused() && state == MediaPlaybackState::Paused
-        && !document.processingUserGestureForMedia()) {
+        && !document->processingUserGestureForMedia()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Returning FALSE because a quirk requires a user gesture to pause while in Picture-in-Picture");
         return makeUnexpected(MediaPlaybackDenialReason::UserGestureRequired);
     }
 
-    if (topDocument.mediaState() & MediaProducerMediaState::HasUserInteractedWithMediaElement && topDocument.quirks().needsPerDocumentAutoplayBehavior())
+    if (topDocument->mediaState() & MediaProducerMediaState::HasUserInteractedWithMediaElement && topDocument->quirks().needsPerDocumentAutoplayBehavior())
         return { };
 
-    if (m_restrictions & RequireUserGestureForVideoRateChange && m_element.isVideo() && !document.processingUserGestureForMedia()) {
+    if (m_restrictions & RequireUserGestureForVideoRateChange && m_element.isVideo() && !document->processingUserGestureForMedia()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Returning FALSE because a user gesture is required for video rate change restriction");
         return makeUnexpected(MediaPlaybackDenialReason::UserGestureRequired);
     }
 
-    if (m_restrictions & RequireUserGestureForAudioRateChange && (!m_element.isVideo() || m_element.hasAudio()) && !m_element.muted() && m_element.volume() && !document.processingUserGestureForMedia()) {
+    if (m_restrictions & RequireUserGestureForAudioRateChange && (!m_element.isVideo() || m_element.hasAudio()) && !m_element.muted() && m_element.volume() && !document->processingUserGestureForMedia()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Returning FALSE because a user gesture is required for audio rate change restriction");
         return makeUnexpected(MediaPlaybackDenialReason::UserGestureRequired);
     }
@@ -436,7 +436,7 @@ Expected<void, MediaPlaybackDenialReason> MediaElementSession::playbackStateChan
         return makeUnexpected(MediaPlaybackDenialReason::UserGestureRequired);
     }
 
-    if (m_restrictions & RequireUserGestureForVideoDueToLowPowerMode && m_element.isVideo() && !document.processingUserGestureForMedia()) {
+    if (m_restrictions & RequireUserGestureForVideoDueToLowPowerMode && m_element.isVideo() && !document->processingUserGestureForMedia()) {
         ALWAYS_LOG(LOGIDENTIFIER, "Returning FALSE because of video low power mode restriction");
         return makeUnexpected(MediaPlaybackDenialReason::UserGestureRequired);
     }
@@ -446,10 +446,10 @@ Expected<void, MediaPlaybackDenialReason> MediaElementSession::playbackStateChan
 
 bool MediaElementSession::autoplayPermitted() const
 {
-    const Document& document = m_element.document();
-    if (document.backForwardCacheState() != Document::NotInBackForwardCache)
+    Ref document = m_element.document();
+    if (document->backForwardCacheState() != Document::NotInBackForwardCache)
         return false;
-    if (document.activeDOMObjectsAreSuspended())
+    if (document->activeDOMObjectsAreSuspended())
         return false;
 
     if (!hasBehaviorRestriction(MediaElementSession::InvisibleAutoplayNotPermitted))
@@ -459,7 +459,7 @@ bool MediaElementSession::autoplayPermitted() const
     if ((!m_element.isVideo() || m_element.hasAudio()) && !m_element.muted() && m_element.volume())
         return true;
 
-    auto* renderer = m_element.renderer();
+    CheckedPtr renderer = m_element.renderer();
     if (!renderer) {
         ALWAYS_LOG(LOGIDENTIFIER, "Returning FALSE because element has no renderer");
         return false;
@@ -626,7 +626,7 @@ bool MediaElementSession::canShowControlsManager(PlaybackControlsPurpose purpose
 #if ENABLE(FULLSCREEN_API)
     // Elements which are not descendants of the current fullscreen element cannot be main content.
     if (CheckedPtr fullsreenManager = m_element.document().fullscreenManagerIfExists()) {
-        auto* fullscreenElement = fullsreenManager->currentFullscreenElement();
+        RefPtr fullscreenElement = fullsreenManager->currentFullscreenElement();
         if (fullscreenElement && !m_element.isDescendantOf(*fullscreenElement)) {
             INFO_LOG(LOGIDENTIFIER, "returning FALSE: outside of full screen");
             return false;
@@ -696,13 +696,13 @@ void MediaElementSession::showPlaybackTargetPicker()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    auto& document = m_element.document();
-    if (m_restrictions & RequireUserGestureToShowPlaybackTargetPicker && !document.processingUserGestureForMedia()) {
+    Ref document = m_element.document();
+    if (m_restrictions & RequireUserGestureToShowPlaybackTargetPicker && !document->processingUserGestureForMedia()) {
         ALWAYS_LOG(LOGIDENTIFIER, "returning early because of permissions");
         return;
     }
 
-    if (!document.page()) {
+    if (!document->page()) {
         ALWAYS_LOG(LOGIDENTIFIER, "returning early because page is NULL");
         return;
     }
@@ -715,7 +715,7 @@ void MediaElementSession::showPlaybackTargetPicker()
 #endif
 
     auto& audioSession = AudioSession::sharedSession();
-    document.showPlaybackTargetPicker(*this, is<HTMLVideoElement>(m_element), audioSession.routeSharingPolicy(), audioSession.routingContextUID());
+    document->showPlaybackTargetPicker(*this, is<HTMLVideoElement>(m_element), audioSession.routeSharingPolicy(), audioSession.routingContextUID());
 }
 
 bool MediaElementSession::hasWirelessPlaybackTargets() const
@@ -939,7 +939,7 @@ void MediaElementSession::resumeBuffering()
 
 bool MediaElementSession::bufferingSuspended() const
 {
-    if (auto* page = m_element.document().page())
+    if (RefPtr page = m_element.document().page())
         return page->mediaBufferingIsSuspended();
     return true;
 }
@@ -958,59 +958,56 @@ bool MediaElementSession::requiresPlaybackTargetRouteMonitoring() const
 
 static bool isElementMainContentForPurposesOfAutoplay(const HTMLMediaElement& element, bool shouldHitTestMainFrame)
 {
-    Document& document = element.document();
-    if (!document.hasLivingRenderTree() || document.activeDOMObjectsAreStopped() || element.isSuspended() || !element.hasAudio() || !element.hasVideo())
+    Ref document = element.document();
+    if (!document->hasLivingRenderTree() || document->activeDOMObjectsAreStopped() || element.isSuspended() || !element.hasAudio() || !element.hasVideo())
         return false;
 
     // Elements which have not yet been laid out, or which are not yet in the DOM, cannot be main content.
-    auto* renderer = element.renderer();
-    if (!renderer)
-        return false;
+    {
+        CheckedPtr renderer = element.renderer();
+        if (!renderer)
+            return false;
 
-    if (!isElementLargeEnoughForMainContent(element, MediaSessionMainContentPurpose::Autoplay))
-        return false;
+        if (!isElementLargeEnoughForMainContent(element, MediaSessionMainContentPurpose::Autoplay))
+            return false;
 
-    // Elements which are hidden by style, or have been scrolled out of view, cannot be main content.
-    // But elements which have audio & video and are already playing should not stop playing because
-    // they are scrolled off the page.
-    if (renderer->style().visibility() != Visibility::Visible)
-        return false;
-    if (renderer->visibleInViewportState() != VisibleInViewportState::Yes && !element.isPlaying())
-        return false;
+        // Elements which are hidden by style, or have been scrolled out of view, cannot be main content.
+        // But elements which have audio & video and are already playing should not stop playing because
+        // they are scrolled off the page.
+        if (renderer->style().visibility() != Visibility::Visible)
+            return false;
+        if (renderer->visibleInViewportState() != VisibleInViewportState::Yes && !element.isPlaying())
+            return false;
+    }
 
     // Main content elements must be in the main frame.
-    if (!document.frame() || !document.frame()->isMainFrame())
+    if (!document->frame() || !document->frame()->isMainFrame())
         return false;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(document.frame()->mainFrame());
-    if (!localFrame)
+    RefPtr mainFrame = dynamicDowncast<LocalFrame>(document->frame()->mainFrame());
+    if (!mainFrame)
         return false;
 
-    auto& mainFrame = *localFrame;
-    if (!mainFrame.view() || !mainFrame.view()->renderView())
+    if (!mainFrame->view() || !mainFrame->view()->renderView())
         return false;
 
     if (!shouldHitTestMainFrame)
         return true;
 
-    if (!mainFrame.document())
+    if (!mainFrame->document())
         return false;
 
     // Hit test the area of the main frame where the element appears, to determine if the element is being obscured.
     // Elements which are obscured by other elements cannot be main content.
     IntRect rectRelativeToView = element.boundingBoxInRootViewCoordinates();
-    ScrollPosition scrollPosition = mainFrame.view()->documentScrollPositionRelativeToViewOrigin();
+    ScrollPosition scrollPosition = mainFrame->view()->documentScrollPositionRelativeToViewOrigin();
     IntRect rectRelativeToTopDocument(rectRelativeToView.location() + scrollPosition, rectRelativeToView.size());
     OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent, HitTestRequest::Type::IgnoreClipping, HitTestRequest::Type::DisallowUserAgentShadowContent };
     HitTestResult result(rectRelativeToTopDocument.center());
 
-    mainFrame.document()->hitTest(hitType, result);
+    mainFrame->protectedDocument()->hitTest(hitType, result);
     result.setToNonUserAgentShadowAncestor();
-    RefPtr<Element> hitElement = result.targetElement();
-    if (hitElement != &element)
-        return false;
-
-    return true;
+    return result.targetElement() == &element;
 }
 
 static bool isElementRectMostlyInMainFrame(const HTMLMediaElement& element)
@@ -1040,7 +1037,7 @@ static bool isElementRectMostlyInMainFrame(const HTMLMediaElement& element)
 static bool isElementLargeRelativeToMainFrame(const HTMLMediaElement& element)
 {
     static const double minimumPercentageOfMainFrameAreaForMainContent = 0.9;
-    auto* renderer = element.renderer();
+    CheckedPtr renderer = element.renderer();
     if (!renderer)
         return false;
 
@@ -1065,7 +1062,7 @@ static bool isElementLargeEnoughForMainContent(const HTMLMediaElement& element, 
     static const double minimumAspectRatio = .5; // Slightly smaller than 9:16.
 
     // Elements which have not yet been laid out, or which are not yet in the DOM, cannot be main content.
-    auto* renderer = element.renderer();
+    CheckedPtr renderer = element.renderer();
     if (!renderer)
         return false;
 
@@ -1127,13 +1124,13 @@ bool MediaElementSession::allowsPlaybackControlsForAutoplayingAudio() const
 static bool isDocumentPlayingSeveralMediaStreamsAndCapturing(Document& document)
 {
     // We restrict to capturing document for now, until we have a good way to state to the UIProcess application that audio rendering is muted from here.
-    auto* page = document.page();
+    RefPtr page = document.page();
     return document.activeMediaElementsWithMediaStreamCount() > 1 && page && MediaProducer::isCapturing(page->mediaState());
 }
 
 static bool processRemoteControlCommandIfPlayingMediaStreams(Document& document, PlatformMediaSession::RemoteControlCommandType commandType)
 {
-    auto* page = document.page();
+    RefPtr page = document.page();
     if (!page)
         return false;
 
@@ -1168,7 +1165,7 @@ static bool processRemoteControlCommandIfPlayingMediaStreams(Document& document,
 
 void MediaElementSession::didReceiveRemoteControlCommand(RemoteControlCommandType commandType, const RemoteCommandArgument& argument)
 {
-    auto* session = mediaSession();
+    RefPtr session = mediaSession();
     if (!session || !session->hasActiveActionHandlers()) {
 #if ENABLE(MEDIA_STREAM)
         if (processRemoteControlCommandIfPlayingMediaStreams(m_element.document(), commandType))
@@ -1238,7 +1235,7 @@ void MediaElementSession::didReceiveRemoteControlCommand(RemoteControlCommandTyp
 
 std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
 {
-    auto* page = m_element.document().page();
+    RefPtr page = m_element.document().page();
 
 #if ENABLE(MEDIA_SESSION)
     auto* session = mediaSession();
@@ -1276,8 +1273,7 @@ std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
     }
     if (currentPosition)
         currentTime = *currentPosition;
-    auto* sessionMetadata = session ? session->metadata() : nullptr;
-    if (sessionMetadata) {
+    if (RefPtr sessionMetadata = session ? session->metadata() : nullptr) {
         std::optional<NowPlayingInfoArtwork> artwork;
         if (sessionMetadata->artworkImage()) {
             ASSERT(sessionMetadata->artworkImage()->data(), "An image must always have associated data");
@@ -1292,8 +1288,8 @@ std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
 
 void MediaElementSession::updateMediaUsageIfChanged()
 {
-    auto& document = m_element.document();
-    auto* page = document.page();
+    Ref document = m_element.document();
+    RefPtr page = document->page();
     if (!page || page->sessionID().isEphemeral())
         return;
 
@@ -1305,14 +1301,14 @@ void MediaElementSession::updateMediaUsageIfChanged()
 
     bool isOutsideOfFullscreen = false;
 #if ENABLE(FULLSCREEN_API)
-    if (CheckedPtr fullscreenManager = document.fullscreenManagerIfExists()) {
-        if (auto* fullscreenElement = document.fullscreenManager().currentFullscreenElement())
+    if (CheckedPtr fullscreenManager = document->fullscreenManagerIfExists()) {
+        if (RefPtr fullscreenElement = document->fullscreenManager().currentFullscreenElement())
             isOutsideOfFullscreen = m_element.isDescendantOf(*fullscreenElement);
     }
 #endif
     bool isAudio = client().presentationType() == MediaType::Audio;
     bool isVideo = client().presentationType() == MediaType::Video;
-    bool processingUserGesture = document.processingUserGestureForMedia();
+    bool processingUserGesture = document->processingUserGestureForMedia();
     bool isPlaying = m_element.isPlaying();
 
     MediaUsageInfo usage = {
@@ -1325,7 +1321,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
         m_element.inActiveDocument(),
         m_element.isFullscreen(),
         m_element.muted(),
-        document.isMediaDocument() && (document.frame() && document.frame()->isMainFrame()),
+        document->isMediaDocument() && (document->frame() && document->frame()->isMainFrame()),
         isVideo,
         isAudio,
         m_element.hasVideo(),
@@ -1336,7 +1332,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
         isElementRectMostlyInMainFrame(m_element),
         !!playbackStateChangePermitted(MediaPlaybackState::Playing),
         page->mediaPlaybackIsSuspended(),
-        document.isMediaDocument() && !document.ownerElement(),
+        document->isMediaDocument() && !document->ownerElement(),
         pageExplicitlyAllowsElementToAutoplayInline(m_element),
         requiresFullscreenForVideoPlayback() && !fullscreenPermitted(),
         isVideo && hasBehaviorRestriction(RequireUserGestureForVideoRateChange) && !processingUserGesture,
@@ -1385,7 +1381,7 @@ MediaSession* MediaElementSession::mediaSession() const
     auto* window = m_element.document().domWindow();
     if (!window)
         return nullptr;
-    return &NavigatorMediaSession::mediaSession(window->navigator());
+    return &NavigatorMediaSession::mediaSession(window->protectedNavigator());
 #else
     return nullptr;
 #endif

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -244,7 +244,7 @@ bool RadioInputType::matchesIndeterminatePseudoClass() const
     ASSERT(element());
     auto& element = *this->element();
     if (auto* radioButtonGroups = element.radioButtonGroups())
-        return !radioButtonGroups->hasCheckedButton(element);
+        return !radioButtonGroups->hasCheckedButton(Ref { element });
     return !element.checked();
 }
 

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -252,7 +252,7 @@ void ValidatedFormListedElement::updateValidity()
     bool newIsValid = this->computeValidity();
 
     if (newIsValid != m_isValid) {
-        HTMLElement& element = asHTMLElement();
+        SUPPRESS_UNCOUNTED_LOCAL auto& element = asHTMLElement();
         Style::PseudoClassChangeInvalidation styleInvalidation(element, {
             { CSSSelector::PseudoClass::Valid, newIsValid },
             { CSSSelector::PseudoClass::Invalid, !newIsValid },

--- a/Source/WebCore/html/ValidationMessage.cpp
+++ b/Source/WebCore/html/ValidationMessage.cpp
@@ -134,7 +134,7 @@ void ValidationMessage::setMessageDOMAndStartTimer()
     m_messageHeading->removeChildren();
     m_messageBody->removeChildren();
 
-    auto& document = m_messageHeading->document();
+    Ref document = m_messageHeading->document();
     auto lines = StringView(m_message).split('\n');
     auto it = lines.begin();
     if (it != lines.end()) {
@@ -147,7 +147,7 @@ void ValidationMessage::setMessageDOMAndStartTimer()
         }
     }
 
-    int magnification = document.page() ? document.page()->settings().validationMessageTimerMagnification() : -1;
+    int magnification = document->page() ? document->page()->settings().validationMessageTimerMagnification() : -1;
     if (magnification <= 0)
         m_timer = nullptr;
     else {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -272,10 +272,8 @@ bool CanvasRenderingContext2DBase::hasDeferredOperations() const
 void CanvasRenderingContext2DBase::flushDeferredOperations()
 {
     m_hasDeferredOperations = false;
-    auto* buffer = canvasBase().buffer();
-    if (!buffer)
-        return;
-    buffer->flushDrawingContextAsync();
+    if (RefPtr buffer = canvasBase().buffer())
+        buffer->flushDrawingContextAsync();
 }
 
 void CanvasRenderingContext2DBase::reset()
@@ -2077,11 +2075,11 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(C
     if (cachedImage.image()->drawsSVGImage())
         originClean = false;
 
-    auto* image = cachedImage.imageForRenderer(renderer);
+    RefPtr image = cachedImage.imageForRenderer(renderer);
     if (!image)
         return Exception { ExceptionCode::InvalidStateError };
 
-    auto nativeImage = image->nativeImage();
+    RefPtr nativeImage = image->nativeImage();
     if (!nativeImage)
         return Exception { ExceptionCode::InvalidStateError };
 
@@ -2090,7 +2088,7 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(C
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(HTMLImageElement& imageElement, bool repeatX, bool repeatY)
 {
-    auto* cachedImage = imageElement.cachedImage();
+    CachedResourceHandle cachedImage = imageElement.cachedImage();
     
     // If the image loading hasn't started or the image is not complete, it is not fully decodable.
     if (!cachedImage || !imageElement.complete())
@@ -2112,7 +2110,7 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(H
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(SVGImageElement& imageElement, bool repeatX, bool repeatY)
 {
-    auto* cachedImage = imageElement.cachedImage();
+    CachedResourceHandle cachedImage = imageElement.cachedImage();
 
     // The image loading hasn't started.
     if (!cachedImage)

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -798,9 +798,9 @@ RefPtr<HTMLElement> HTMLConstructionSite::createHTMLElementOrFindCustomElementIn
     // have to pass the current form element.  We should rework form association
     // to occur after construction to allow better code sharing here.
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/tree-construction.html#create-an-element-for-the-token
-    Document& ownerDocument = ownerDocumentForCurrentNode();
-    bool insideTemplateElement = !ownerDocument.frame();
-    auto element = HTMLElementFactory::createKnownElement(token.tagName(), ownerDocument, insideTemplateElement ? nullptr : form(), true);
+    Ref ownerDocument = ownerDocumentForCurrentNode();
+    bool insideTemplateElement = !ownerDocument->frame();
+    RefPtr element = HTMLElementFactory::createKnownElement(token.tagName(), ownerDocument, insideTemplateElement ? nullptr : form(), true);
     if (UNLIKELY(!element)) {
         if (auto* elementInterface = findCustomElementInterface(ownerDocument, token.name())) {
             if (!m_isParsingFragment) {

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -252,13 +252,13 @@ void DateTimeEditElement::layout(const LayoutParameters& layoutParameters)
         element->setUserAgentPart(UserAgentParts::webkitDatetimeEditFieldsWrapper());
     }
 
-    Element& fieldsWrapper = fieldsWrapperElement();
-    auto* focusedField = focusedFieldElement();
+    Ref fieldsWrapper = fieldsWrapperElement();
+    RefPtr focusedField = focusedFieldElement();
 
     DateTimeEditBuilder builder(*this, layoutParameters);
-    Node* lastChildToBeRemoved = fieldsWrapper.lastChild();
+    RefPtr lastChildToBeRemoved = fieldsWrapper->lastChild();
     if (!builder.build(layoutParameters.dateTimeFormat) || m_fields.isEmpty()) {
-        lastChildToBeRemoved = fieldsWrapper.lastChild();
+        lastChildToBeRemoved = fieldsWrapper->lastChild();
         builder.build(layoutParameters.fallbackDateTimeFormat);
     }
 
@@ -279,8 +279,8 @@ void DateTimeEditElement::layout(const LayoutParameters& layoutParameters)
     }
 
     if (lastChildToBeRemoved) {
-        while (auto* childNode = fieldsWrapper.firstChild()) {
-            fieldsWrapper.removeChild(*childNode);
+        while (RefPtr childNode = fieldsWrapper->firstChild()) {
+            fieldsWrapper->removeChild(*childNode);
             if (childNode == lastChildToBeRemoved)
                 break;
         }

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -102,7 +102,7 @@ void MediaControlTextTrackContainerElement::updateDisplay()
         return;
 
     // 2. Let video be the media element or other playback mechanism.
-    auto* video = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
+    RefPtr video = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
     if (!video)
         return;
 
@@ -275,9 +275,9 @@ void MediaControlTextTrackContainerElement::updateTextStrokeStyle()
     // FIXME: Since it is possible to have more than one text track enabled, the following code may not find the correct language.
     // The default UI only allows a user to enable one track at a time, so it should be OK for now, but we should consider doing
     // this differently, see <https://bugs.webkit.org/show_bug.cgi?id=169875>.
-    if (auto* tracks = m_mediaElement->textTracks()) {
+    if (RefPtr tracks = m_mediaElement->textTracks()) {
         for (unsigned i = 0; i < tracks->length(); ++i) {
-            auto track = tracks->item(i);
+            RefPtr track = tracks->item(i);
             if (track && track->mode() == TextTrack::Mode::Showing) {
                 language = track->validBCP47Language();
                 break;

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1444,17 +1444,17 @@ void VTTCue::prepareToSpeak(SpeechSynthesis& speechSynthesis, double rate, doubl
         return;
     }
 
-    auto& track = *this->track();
+    Ref track = *this->track();
     m_speechSynthesis = &speechSynthesis;
-    m_speechUtterance = SpeechSynthesisUtterance::create(*track.scriptExecutionContext(), m_content, [protectedThis = Ref { *this }, completion = WTFMove(completion)](const SpeechSynthesisUtterance&) {
+    m_speechUtterance = SpeechSynthesisUtterance::create(Ref { *track->scriptExecutionContext() }, m_content, [protectedThis = Ref { *this }, completion = WTFMove(completion)](const SpeechSynthesisUtterance&) {
         protectedThis->m_speechUtterance = nullptr;
         protectedThis->m_speechSynthesis = nullptr;
         completion(protectedThis.get());
     });
 
-    auto trackLanguage = track.validBCP47Language();
+    auto trackLanguage = track->validBCP47Language();
     if (trackLanguage.isEmpty())
-        trackLanguage = track.language();
+        trackLanguage = track->language();
 
     m_speechUtterance->setLang(trackLanguage);
     m_speechUtterance->setVolume(volume);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -770,6 +770,11 @@ Navigator& LocalDOMWindow::navigator()
     return *m_navigator;
 }
 
+Ref<Navigator> LocalDOMWindow::protectedNavigator()
+{
+    return navigator();
+}
+
 Performance& LocalDOMWindow::performance() const
 {
     if (!m_performance) {

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -168,6 +168,7 @@ public:
     BarProp& statusbar();
     BarProp& toolbar();
     WEBCORE_EXPORT Navigator& navigator();
+    Ref<Navigator> protectedNavigator();
     Navigator* optionalNavigator() const { return m_navigator.get(); }
 
     WEBCORE_EXPORT static void overrideTransientActivationDurationForTesting(std::optional<Seconds>&&);


### PR DESCRIPTION
#### df78abde6c530518547912af228f691c75a35176
<pre>
Adopt more smart pointers in WebCore/html
<a href="https://bugs.webkit.org/show_bug.cgi?id=269636">https://bugs.webkit.org/show_bug.cgi?id=269636</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::getContext):
* Source/WebCore/html/CustomPaintImage.cpp:
(WebCore::CustomPaintImage::doCustomPaint):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::appendEntry):
(WebCore::FTPDirectoryDocumentParser::createTDForFilename):
(WebCore::FTPDirectoryDocumentParser::loadDocumentTemplate):
(WebCore::FTPDirectoryDocumentParser::createBasicDocument):
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::saveFormControlState const):
* Source/WebCore/html/FormController.cpp:
(WebCore::FormController::formElementsState const):
* Source/WebCore/html/FormListedElement.cpp:
(WebCore::FormListedElement::parseFormAttribute):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::attributionDestinationURLForPCM const):
(WebCore::HTMLAnchorElement::mainDocumentRegistrableDomainForPCM const):
(WebCore::HTMLAnchorElement::attributionSourceNonceForPCM const):
(WebCore::HTMLAnchorElement::parsePrivateClickMeasurement const):
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
* Source/WebCore/html/HTMLDocument.cpp:
(WebCore::HTMLDocument::namedItem):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::~HTMLFormElement):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::showPicker):
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::isEventTargetedAtInteractiveDescendants const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::addTextTrack):
(WebCore::HTMLMediaElement::setSelectedTextTrack):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::hasPlaceholderLabelOption const):
(WebCore::HTMLSelectElement::accessKeySetSelectedIndex):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::flattenAssignedNodes):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::createBorderStyle):
(WebCore::HTMLTableElement::additionalPresentationalHintStyle const):
(WebCore::leakBorderStyle): Deleted.
* Source/WebCore/html/HTMLTableRowElement.cpp:
(WebCore::findTable):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::setContainerAndOffsetForRange):
(WebCore::HTMLTextFormControlElement::selection const):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createCompletionHandler):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::dispatchSimulatedClickIfActive const):
(WebCore::InputType::accessKeyAction):
(WebCore::InputType::setValue):
* Source/WebCore/html/InputType.h:
(WebCore::InputType::protectedElement const):
* Source/WebCore/html/MediaDocument.cpp:
(WebCore::MediaDocumentParser::createDocumentStructure):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::playbackStateChangePermitted const):
(WebCore::MediaElementSession::autoplayPermitted const):
(WebCore::MediaElementSession::canShowControlsManager const):
(WebCore::MediaElementSession::showPlaybackTargetPicker):
(WebCore::MediaElementSession::bufferingSuspended const):
(WebCore::isElementMainContentForPurposesOfAutoplay):
(WebCore::isElementLargeRelativeToMainFrame):
(WebCore::isElementLargeEnoughForMainContent):
(WebCore::isDocumentPlayingSeveralMediaStreamsAndCapturing):
(WebCore::processRemoteControlCommandIfPlayingMediaStreams):
(WebCore::MediaElementSession::didReceiveRemoteControlCommand):
(WebCore::MediaElementSession::nowPlayingInfo const):
(WebCore::MediaElementSession::updateMediaUsageIfChanged):
(WebCore::MediaElementSession::mediaSession const):
* Source/WebCore/html/RadioInputType.cpp:
(WebCore::RadioInputType::matchesIndeterminatePseudoClass const):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::updateValidity):
* Source/WebCore/html/ValidationMessage.cpp:
(WebCore::ValidationMessage::setMessageDOMAndStartTimer):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::flushDeferredOperations):
(WebCore::CanvasRenderingContext2DBase::createPattern):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::addActivityStateChangeObserverIfNecessary):
(WebCore::WebGLRenderingContextBase::removeActivityStateChangeObserver):
(WebCore::WebGLRenderingContextBase::maybeRestoreContextSoon):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditElement::layout):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::updateTextStrokeStyle):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::prepareToSpeak):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::protectedNavigator):
* Source/WebCore/page/LocalDOMWindow.h:

Canonical link: <a href="https://commits.webkit.org/275067@main">https://commits.webkit.org/275067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72f5fc571859d105c2e5972cc299253f5608d53f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33522 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14104 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44232 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39870 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38159 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16843 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16892 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5419 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->