### PR TITLE
Use WYHash widely

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -831,6 +831,7 @@
 		E361DB69289115D000B2A2B8 /* bigint.h in Headers */ = {isa = PBXBuildFile; fileRef = E361DB60289115D000B2A2B8 /* bigint.h */; };
 		E36BA9DE29E275DB00300057 /* WTFProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36BA9DC29E275DB00300057 /* WTFProcess.cpp */; };
 		E36BA9DF29E275DB00300057 /* WTFProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = E36BA9DD29E275DB00300057 /* WTFProcess.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E370B8322B773C460008687B /* StreamingWYHash.h in Headers */ = {isa = PBXBuildFile; fileRef = E370B8312B773C460008687B /* StreamingWYHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E37E96542702AD0B00E1C36A /* ApproximateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E37E96522702AD0700E1C36A /* ApproximateTime.cpp */; };
 		E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */ = {isa = PBXBuildFile; fileRef = E383AAC82B6C730B00058E60 /* AdaptiveStringSearcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E388886F20C9095100E632BC /* WorkerPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E388886D20C9095100E632BC /* WorkerPool.cpp */; };
@@ -841,6 +842,7 @@
 		E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3BE09A724A5854D009DF2B4 /* ICUHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BE09A624A58545009DF2B4 /* ICUHelpers.cpp */; };
 		E3DA37E7287AD1A10066808F /* StringCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DA37E6287AD1A10066808F /* StringCommon.cpp */; };
+		E3E629302B77468000EC599E /* HasherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = E3E6292F2B77467F00EC599E /* HasherHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E4A0AD391A96245500536DF6 /* WorkQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD371A96245500536DF6 /* WorkQueue.cpp */; };
 		E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */; };
 		EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */; };
@@ -1768,6 +1770,7 @@
 		E36895CC23A445EE008DD4C8 /* PackedRefPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PackedRefPtr.h; sourceTree = "<group>"; };
 		E36BA9DC29E275DB00300057 /* WTFProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WTFProcess.cpp; sourceTree = "<group>"; };
 		E36BA9DD29E275DB00300057 /* WTFProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFProcess.h; sourceTree = "<group>"; };
+		E370B8312B773C460008687B /* StreamingWYHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamingWYHash.h; sourceTree = "<group>"; };
 		E37E96522702AD0700E1C36A /* ApproximateTime.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ApproximateTime.cpp; sourceTree = "<group>"; };
 		E37E96532702AD0700E1C36A /* ApproximateTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApproximateTime.h; sourceTree = "<group>"; };
 		E38020DB2401C0930037CA9E /* CompactRefPtrTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactRefPtrTuple.h; sourceTree = "<group>"; };
@@ -1788,6 +1791,7 @@
 		E3DA37E6287AD1A10066808F /* StringCommon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringCommon.cpp; sourceTree = "<group>"; };
 		E3E0F04F26197157004640FC /* FixedVector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FixedVector.h; sourceTree = "<group>"; };
 		E3E158251EADA53C004A079D /* SystemFree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemFree.h; sourceTree = "<group>"; };
+		E3E6292F2B77467F00EC599E /* HasherHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HasherHelpers.h; sourceTree = "<group>"; };
 		E3E64F0B22813428001E55B4 /* Nonmovable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Nonmovable.h; sourceTree = "<group>"; };
 		E3E8162F2764799300BAA45B /* RefCountedFixedVector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RefCountedFixedVector.h; sourceTree = "<group>"; };
 		E3FD6D6627A1F6AD00935000 /* GenericHashKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GenericHashKey.h; sourceTree = "<group>"; };
@@ -2552,12 +2556,14 @@
 				50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */,
 				50DE35F4215BB01500B979C7 /* ExternalStringImpl.h */,
 				461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */,
+				E3E6292F2B77467F00EC599E /* HasherHelpers.h */,
 				26147B0815DDCCDC00DDB907 /* IntegerToStringConversion.h */,
 				93AC91A718942FC400244939 /* LChar.h */,
 				C2BCFC531F621F3F00C9222C /* LineEnding.cpp */,
 				C2BCFC541F621F3F00C9222C /* LineEnding.h */,
 				DD4901ED27B474D900D7E50D /* NullTextBreakIterator.h */,
 				14E785E71DFB330100209BD1 /* OrdinalNumber.h */,
+				E370B8312B773C460008687B /* StreamingWYHash.h */,
 				0F95B63620CB5EFD00479635 /* StringBuffer.cpp */,
 				A8A47323151A825B004123FF /* StringBuffer.h */,
 				A8A47324151A825B004123FF /* StringBuilder.cpp */,
@@ -3185,6 +3191,7 @@
 				DD3DC8F927A4BF8E007E5B61 /* GregorianDateTime.h in Headers */,
 				DD3DC8E427A4BF8E007E5B61 /* HashCountedSet.h in Headers */,
 				DD3DC91227A4BF8E007E5B61 /* Hasher.h in Headers */,
+				E3E629302B77468000EC599E /* HasherHelpers.h in Headers */,
 				DD3DC97927A4BF8E007E5B61 /* HashFunctions.h in Headers */,
 				DD3DC86427A4BF8E007E5B61 /* HashIterators.h in Headers */,
 				DD3DC85F27A4BF8E007E5B61 /* HashMap.h in Headers */,
@@ -3405,6 +3412,7 @@
 				DD3DC93427A4BF8E007E5B61 /* StdUnorderedSet.h in Headers */,
 				DD3DC98027A4BF8E007E5B61 /* Stopwatch.h in Headers */,
 				DD3DC8A527A4BF8E007E5B61 /* StreamBuffer.h in Headers */,
+				E370B8322B773C460008687B /* StreamingWYHash.h in Headers */,
 				DDF307D827C086DF006A526F /* StringBuffer.h in Headers */,
 				DDF307CC27C086DF006A526F /* StringBuilder.h in Headers */,
 				DDF307D927C086DF006A526F /* StringBuilderInternals.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -405,11 +405,13 @@ set(WTF_PUBLIC_HEADERS
     text/EscapedFormsForJSON.h
     text/ExternalStringImpl.h
     text/FastCharacterComparison.h
+    text/HasherHelpers.h
     text/IntegerToStringConversion.h
     text/LChar.h
     text/LineEnding.h
     text/NullTextBreakIterator.h
     text/OrdinalNumber.h
+    text/StreamingWYHash.h
     text/StringBuffer.h
     text/StringBuilder.h
     text/StringBuilderInternals.h

--- a/Source/WTF/wtf/Hasher.h
+++ b/Source/WTF/wtf/Hasher.h
@@ -28,7 +28,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 #include <wtf/text/AtomString.h>
-#include <wtf/text/SuperFastHash.h>
+#include <wtf/text/StreamingWYHash.h>
 
 namespace WTF {
 
@@ -69,7 +69,7 @@ public:
     }
 
 private:
-    SuperFastHash m_underlyingHasher;
+    StreamingWYHash m_underlyingHasher;
 };
 
 template<typename UnsignedInteger> std::enable_if_t<std::is_unsigned<UnsignedInteger>::value && sizeof(UnsignedInteger) == sizeof(uint64_t), void> add(Hasher& hasher, UnsignedInteger integer)

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -31,7 +31,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/StdLibExtras.h>
-#include <wtf/text/SuperFastHash.h>
+#include <wtf/text/WYHash.h>
 
 OBJC_CLASS NSString;
 
@@ -112,9 +112,7 @@ inline unsigned ASCIILiteral::hash() const
 {
     if (isNull())
         return 0;
-    SuperFastHash hasher;
-    hasher.addCharacters(characters(), length());
-    return hasher.hash();
+    return WYHash::computeHash(characters(), length());
 }
 
 struct ASCIILiteralHash {

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -31,7 +31,7 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringCommon.h>
-#include <wtf/text/SuperFastHash.h>
+#include <wtf/text/WYHash.h>
 
 namespace WTF {
 
@@ -137,10 +137,7 @@ unsigned CString::hash() const
 {
     if (isNull())
         return 0;
-    SuperFastHash hasher;
-    for (const char* ptr = data(); *ptr; ++ptr)
-        hasher.addCharacter(*ptr);
-    return hasher.hash();
+    return WYHash::computeHash(data(), length());
 }
 
 bool operator<(const CString& a, const CString& b)

--- a/Source/WTF/wtf/text/HasherHelpers.h
+++ b/Source/WTF/wtf/text/HasherHelpers.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2010 Patrick Gansterer <paroga@paroga.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <unicode/utypes.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/text/LChar.h>
+
+namespace WTF {
+
+class StringHasher;
+
+namespace HasherHelpers {
+
+static constexpr unsigned flagCount = 8; // Save 8 bits for StringImpl to use as flags.
+static constexpr unsigned maskHash = (1U << (sizeof(unsigned) * 8 - flagCount)) - 1;
+
+// This avoids ever returning a hash code of 0, since that is used to
+// signal "hash not computed yet". Setting the high bit maintains
+// reasonable fidelity to a hash code of 0 because it is likely to yield
+// exactly 0 when hash lookup masks out the high bits.
+ALWAYS_INLINE static constexpr unsigned avoidZero(unsigned hash)
+{
+    if (hash)
+        return hash;
+    return 0x80000000 >> flagCount;
+}
+
+ALWAYS_INLINE static constexpr unsigned finalize(unsigned hash)
+{
+    return avoidZero(hash);
+}
+
+ALWAYS_INLINE static constexpr unsigned finalizeAndMaskTop8Bits(unsigned hash)
+{
+    // Reserving space from the high bits for flags preserves most of the hash's
+    // value, since hash lookup typically masks out the high bits anyway.
+    return avoidZero(hash & maskHash);
+}
+
+struct DefaultConverter {
+    template<typename CharType>
+    static constexpr UChar convert(CharType character)
+    {
+        return static_cast<std::make_unsigned_t<CharType>>((character));
+    }
+};
+
+} // namespace HasherHelpers
+} // namespace WTF

--- a/Source/WTF/wtf/text/StreamingWYHash.h
+++ b/Source/WTF/wtf/text/StreamingWYHash.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WYHash.h>
+
+namespace WTF {
+
+class StreamingWYHash {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static constexpr unsigned numberOfCharactersInLargestBulkForWYHash = 24; // Don't change this value. It's fixed for WYhash algorithm.
+
+    // Things need to do to update this threshold:
+    // 1. This threshold must stay in sync with the threshold in the scripts create_hash_table, Hasher.pm, and hasher.py.
+    // 2. Run script `run-bindings-tests --reset-results` to update all CompactHashIndex's under path `WebCore/bindings/scripts/test/JS/`.
+    // 3. Manually update all CompactHashIndex's in JSDollarVM.cpp by using createHashTable in hasher.py.
+    static constexpr unsigned smallStringThreshold = numberOfCharactersInLargestBulkForWYHash * 2;
+
+    void addCharactersAssumingAligned(UChar a, UChar b)
+    {
+        addCharacter(a);
+        addCharacter(b);
+    }
+
+    void addCharacter(UChar character)
+    {
+        if (m_bufferSize == smallStringThreshold) {
+            // This algorithm must stay in sync with WYHash::hash function.
+            if (!m_pendingHashValue) {
+                m_see1 = m_see2 = m_seed = WYHash::initSeed();
+                m_pendingHashValue = true;
+            }
+            UChar* p = m_buffer.data();
+            while (m_bufferSize >= 24) {
+                WYHash::consume24Characters(p, WYHash::Reader16Bit<UChar>::wyr8, m_seed, m_see1, m_see2);
+                p += 24;
+                m_bufferSize -= 24;
+            }
+            ASSERT(!m_bufferSize);
+            m_numberOfProcessedCharacters += smallStringThreshold;
+        }
+
+        ASSERT(m_bufferSize < smallStringThreshold);
+        m_buffer[m_bufferSize++] = character;
+    }
+
+    unsigned finalize() const
+    {
+        unsigned hashValue;
+        if (!m_pendingHashValue) {
+            ASSERT(m_bufferSize <= smallStringThreshold);
+            hashValue = WYHash::computeHash<UChar>(m_buffer.data(), m_bufferSize);
+        } else {
+            // This algorithm must stay in sync with WYHash::hash function.
+            auto wyr8 = WYHash::Reader16Bit<UChar>::wyr8;
+            unsigned i = m_bufferSize;
+            uint64_t seed = m_seed;
+            uint64_t see1 = m_see1;
+            uint64_t see2 = m_see2;
+            if (i <= 24)
+                seed ^= see1 ^ see2;
+            const UChar* p = m_buffer.data();
+            WYHash::handleGreaterThan8CharactersCase(p, i, wyr8, seed, see1, see2);
+
+            uint64_t a = 0;
+            uint64_t b = 0;
+            if (m_bufferSize >= 8) {
+                a = wyr8(p + i - 8);
+                b = wyr8(p + i - 4);
+            } else {
+                UChar tmp[8];
+                unsigned bufferIndex = smallStringThreshold - (8 - i);
+                for (unsigned tmpIndex = 0; tmpIndex < 8; tmpIndex++) {
+                    tmp[tmpIndex] = m_buffer[bufferIndex];
+                    bufferIndex = (bufferIndex + 1) % smallStringThreshold;
+                }
+
+                UChar* tmpPtr = tmp;
+                a = wyr8(tmpPtr);
+                b = wyr8(tmpPtr + 4);
+            }
+
+            const uint64_t totalByteCount = (static_cast<uint64_t>(m_numberOfProcessedCharacters) + static_cast<uint64_t>(m_bufferSize)) << 1;
+            hashValue = WYHash::handleEndCase(a, b, seed, totalByteCount);
+        }
+        return hashValue;
+    }
+
+    unsigned hash() const
+    {
+        return HasherHelpers::finalize(finalize());
+    }
+
+private:
+    uint64_t m_seed { 0 };
+    uint64_t m_see1 { 0 };
+    uint64_t m_see2 { 0 };
+    unsigned m_numberOfProcessedCharacters { 0 };
+    unsigned m_bufferSize { 0 };
+    bool m_pendingHashValue { false };
+    std::array<UChar, smallStringThreshold> m_buffer;
+};
+
+} // namespace WTF
+
+using WTF::StreamingWYHash;

--- a/Source/WTF/wtf/text/StringHasherInlines.h
+++ b/Source/WTF/wtf/text/StringHasherInlines.h
@@ -115,7 +115,7 @@ inline unsigned StringHasher::hashWithTop8BitsMasked()
         }
 
         const uint64_t totalByteCount = (static_cast<uint64_t>(m_numberOfProcessedCharacters) + static_cast<uint64_t>(m_bufferSize)) << 1;
-        hashValue = StringHasher::avoidZero(WYHash::handleEndCase(a, b, m_seed, totalByteCount) & StringHasher::maskHash);
+        hashValue = HasherHelpers::finalizeAndMaskTop8Bits(WYHash::handleEndCase(a, b, m_seed, totalByteCount));
 
         m_pendingHashValue = false;
         m_numberOfProcessedCharacters = m_seed = m_see1 = m_see2 = 0;
@@ -126,7 +126,7 @@ inline unsigned StringHasher::hashWithTop8BitsMasked()
     unsigned hashValue = SuperFastHash::hashWithTop8BitsMaskedImpl(m_hasPendingCharacter, m_pendingCharacter, m_hash);
     m_hasPendingCharacter = false;
     m_pendingCharacter = 0;
-    m_hash = stringHashingStartValue;
+    m_hash = SuperFastHash::stringHashingStartValue;
     return hashValue;
 #endif
 }

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -72,7 +72,7 @@ struct TextEncodingNameHash {
     // http://burtleburtle.net/bob/hash/doobs.html
     static unsigned hash(const char* s)
     {
-        unsigned h = WTF::stringHashingStartValue;
+        unsigned h = WTF::SuperFastHash::stringHashingStartValue;
         for (;;) {
             char c = *s++;
             if (!c) {

--- a/Source/WebCore/contentextensions/DFAMinimizer.cpp
+++ b/Source/WebCore/contentextensions/DFAMinimizer.cpp
@@ -34,6 +34,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Hasher.h>
 #include <wtf/Vector.h>
+#include <wtf/text/WYHash.h>
 
 namespace WebCore {
 namespace ContentExtensions {
@@ -400,9 +401,7 @@ struct ActionKey {
         , actionsLength(actionsLength)
         , state(Valid)
     {
-        SuperFastHash hasher;
-        hasher.addCharactersAssumingAligned(reinterpret_cast<const UChar*>(&dfa->actions[actionsStart]), actionsLength * sizeof(uint64_t) / sizeof(UChar));
-        hash = hasher.hash();
+        hash = WYHash::computeHash(reinterpret_cast<const UChar*>(&dfa->actions[actionsStart]), actionsLength * sizeof(uint64_t) / sizeof(UChar));
     }
 
     bool isEmptyValue() const { return state == Empty; }

--- a/Source/WebCore/contentextensions/HashableActionList.h
+++ b/Source/WebCore/contentextensions/HashableActionList.h
@@ -45,9 +45,7 @@ struct HashableActionList {
         , state(Valid)
     {
         std::sort(actions.begin(), actions.end());
-        SuperFastHash hasher;
-        hasher.addCharactersAssumingAligned(reinterpret_cast<const UChar*>(actions.data()), actions.size() * sizeof(uint64_t) / sizeof(UChar));
-        hash = hasher.hash();
+        hash = WYHash::computeHash(reinterpret_cast<const UChar*>(actions.data()), actions.size() * sizeof(uint64_t) / sizeof(UChar));
     }
 
     bool isEmptyValue() const { return state == Empty; }

--- a/Source/WebCore/dom/DocumentSharedObjectPool.cpp
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.cpp
@@ -30,6 +30,7 @@
 #include "Element.h"
 #include "ElementData.h"
 #include <wtf/UnalignedAccess.h>
+#include <wtf/text/WYHash.h>
 
 namespace WebCore {
 
@@ -62,7 +63,7 @@ ALWAYS_INLINE bool equalAttributes(const uint8_t* a, const uint8_t* b, unsigned 
 struct DocumentSharedObjectPool::ShareableElementDataHash {
     static unsigned hash(const Ref<ShareableElementData>& data)
     {
-        return computeHash(std::span<const Attribute> { data->m_attributeArray, data->length() });
+        return WYHash::computeHash(reinterpret_cast<const uint8_t*>(data->m_attributeArray), data->length() * sizeof(Attribute));
     }
     static bool equal(const Ref<ShareableElementData>& a, const Ref<ShareableElementData>& b)
     {
@@ -76,7 +77,7 @@ struct DocumentSharedObjectPool::ShareableElementDataHash {
 struct AttributeSpanTranslator {
     static unsigned hash(std::span<const Attribute> attributes)
     {
-        return computeHash(attributes);
+        return WYHash::computeHash(reinterpret_cast<const uint8_t*>(attributes.data()), attributes.size() * sizeof(Attribute));
     }
 
     static bool equal(const Ref<ShareableElementData>& a, std::span<const Attribute> b)


### PR DESCRIPTION
#### ec5e35ae3f97a574c4369333e8f73dac21bd9615
<pre>
Use WYHash widely
<a href="https://bugs.webkit.org/show_bug.cgi?id=269640">https://bugs.webkit.org/show_bug.cgi?id=269640</a>
<a href="https://rdar.apple.com/123140857">rdar://123140857</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/Hasher.h:
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::ASCIILiteral::hash const):
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::hash const):
* Source/WTF/wtf/text/HasherHelpers.h: Added.
(WTF::HasherHelpers::avoidZero):
(WTF::HasherHelpers::finalize):
(WTF::HasherHelpers::finalizeAndMaskTop8Bits):
(WTF::HasherHelpers::DefaultConverter::convert):
* Source/WTF/wtf/text/StreamingWYHash.h: Added.
(WTF::StreamingWYHash::addCharactersAssumingAligned):
(WTF::StreamingWYHash::addCharacter):
(WTF::StreamingWYHash::finalize const):
(WTF::StreamingWYHash::hash const):
* Source/WTF/wtf/text/StringHasher.h:
(WTF::StringHasher::DefaultConverter::convert): Deleted.
(WTF::StringHasher::avalancheBits): Deleted.
(WTF::StringHasher::finalize): Deleted.
(WTF::StringHasher::finalizeAndMaskTop8Bits): Deleted.
(WTF::StringHasher::avoidZero): Deleted.
* Source/WTF/wtf/text/StringHasherInlines.h:
(WTF::StringHasher::hashWithTop8BitsMasked):
* Source/WTF/wtf/text/SuperFastHash.h:
(WTF::SuperFastHash::hash const):
(WTF::SuperFastHash::computeHashAndMaskTop8Bits):
(WTF::SuperFastHash::computeHash):
(WTF::SuperFastHash::hashWithTop8BitsMaskedImpl):
(WTF::SuperFastHash::avalancheBits):
* Source/WTF/wtf/text/WYHash.h:
(WTF::WYHash::computeHash):
(WTF::WYHash::computeHashAndMaskTop8Bits):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::TextEncodingNameHash::hash):
* Source/WebCore/contentextensions/DFAMinimizer.cpp:
* Source/WebCore/contentextensions/HashableActionList.h:
(WebCore::ContentExtensions::HashableActionList::HashableActionList):
* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
(WebCore::DocumentSharedObjectPool::ShareableElementDataHash::hash):
(WebCore::AttributeSpanTranslator::hash):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec5e35ae3f97a574c4369333e8f73dac21bd9615

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16342 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34808 "Found 5 new API test failures: TestWTF.WTF.Hasher_integer, TestWTF.WTF.Hasher_floatingPoint, TestWTF.WTF.Hasher_multiple, TestWTF.WTF.Hasher_custom, TestWTF.WTF.Hasher_tupleLike (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14070 "Found 5 new API test failures: /TestWTF:WTF.Hasher_multiple, /TestWTF:WTF.Hasher_integer, /TestWTF:WTF.Hasher_floatingPoint, /TestWTF:WTF.Hasher_tupleLike, /TestWTF:WTF.Hasher_custom (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44190 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33820 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36604 "Found 5 new API test failures: TestWTF.WTF.Hasher_integer, TestWTF.WTF.Hasher_floatingPoint, TestWTF.WTF.Hasher_multiple, TestWTF.WTF.Hasher_custom, TestWTF.WTF.Hasher_tupleLike (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39833 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39993 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12431 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38108 "Found 5 new API test failures: /TestWTF:WTF.Hasher_multiple, /TestWTF:WTF.Hasher_integer, /TestWTF:WTF.Hasher_floatingPoint, /TestWTF:WTF.Hasher_tupleLike, /TestWTF:WTF.Hasher_custom (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16801 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47003 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16850 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9673 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->