### PR TITLE
Sync `no-clipping-overflow-hidden-added-after-transform.html` test from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/fast/layers/no-clipping-overflow-hidden-added-after-transform-expected.html
+++ b/LayoutTests/fast/layers/no-clipping-overflow-hidden-added-after-transform-expected.html
@@ -9,12 +9,12 @@ div {
 
 #overflowHidden {
     overflow: hidden;
-    background: white;
+    background: purple;
 }
 
 #transformed {
-    -webkit-transform: rotate(45deg) translate3d(0, 0, 0);
-    background: black;
+    transform: rotate(45deg) translate3d(0, 0, 0);
+    background: green;
 }
 </style>
 </head>

--- a/LayoutTests/fast/layers/no-clipping-overflow-hidden-added-after-transform.html
+++ b/LayoutTests/fast/layers/no-clipping-overflow-hidden-added-after-transform.html
@@ -9,17 +9,17 @@ div {
 
 #overflowHidden {
     overflow: hidden;
-    background: white;
+    background: purple;
 }
 
 #transformed {
-    -webkit-transform: rotate(0deg) translate3d(0, 0, 0);
-    -webkit-transition: -webkit-transform linear 1ms;
-    background: black;
+    transform: rotate(0deg) translate3d(0, 0, 0);
+    transition: transform linear 0s;
+    background: green;
 }
 
 #transformed:hover {
-    -webkit-transform: rotate(45deg) translate3d(0, 0, 0);
+    transform: rotate(45deg) translate3d(0, 0, 0);
 }
 </style>
 </head>
@@ -30,21 +30,14 @@ div {
     <div id="transformed"></div>
 </div>
 <script>
-    function transitionFinished() {
-        if (window.testRunner)
-            window.testRunner.notifyDone();
-    }
-
     if (!window.eventSender)
         alert("To manually test, hover over the green div. The overflow should be properly clipped.");
 
-    if (window.testRunner)
-      window.testRunner.waitUntilDone();
-
+    document.body.offsetTop; // Force layout. The mouse is not tracked before first layout.
     var transformed = document.getElementById("transformed");
     transformed.parentNode.setAttribute("id", "overflowHidden");
-    transformed.addEventListener("webkitTransitionEnd", transitionFinished, true);
-    eventSender.mouseMoveTo(transformed.offsetLeft + 10, transformed.offsetTop + 10);
+    eventSender.mouseMoveTo(transformed.offsetLeft + 50, transformed.offsetTop + 50);
+    document.body.offsetTop; // Update layout for hovered state.
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1547,8 +1547,6 @@ fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html [ Skip ]
 fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html [ Skip ]
 http/tests/download/convert-cached-load-to-download.html [ Skip ]
 
-webkit.org/b/157007 fast/layers/no-clipping-overflow-hidden-added-after-transform.html [ Pass ImageOnlyFailure ]
-
 # dumpPolicyDelegateCallbacks is not supported in DumpRenderTree
 fast/loader/iframe-src-invalid-url.html [ Skip ]
 


### PR DESCRIPTION
#### f07572f71508530dbd75f5c1178b8fad02e0bf83
<pre>
Sync `no-clipping-overflow-hidden-added-after-transform.html` test from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=157007">https://bugs.webkit.org/show_bug.cgi?id=157007</a>

Reviewed by Antoine Quint.

This patch is to sync `no-clipping-overflow-hidden-added-after-transform.html` from Blink / Chromium
upstream as per below commit:

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/7dcf0801857f3fc64f066c5c20738a54889ae835">https://source.chromium.org/chromium/chromium/src/+/7dcf0801857f3fc64f066c5c20738a54889ae835</a>

* LayoutTests/fast/layers/no-clipping-overflow-hidden-added-after-transform.html: Updated Test Case
* LayoutTests/fast/layers/no-clipping-overflow-hidden-added-after-transform-expected.html: Updated Test Case Expectation
* LayoutTests/platform/mac-wk1/TestExpectations: Remove [ Pass ImageOnlyFailure ] Expectation

Canonical link: <a href="https://commits.webkit.org/274922@main">https://commits.webkit.org/274922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27e5536bff17cc8e8094b63c41893468dd505870

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36467 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44201 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39842 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38116 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35061 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16861 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5349 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->