### PR TITLE
Reduce invalidation necessity for NodeList

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2183,6 +2183,7 @@ private:
 
     HashSet<LiveNodeList*> m_listsInvalidatedAtDocument;
     HashSet<HTMLCollection*> m_collectionsInvalidatedAtDocument;
+    unsigned m_nodeListAndCollectionCountForAttributeChangeInvalidation { 0 };
     unsigned m_nodeListAndCollectionCounts[numNodeListInvalidationTypes] { 0 };
 
     RefPtr<XPathEvaluator> m_xpathEvaluator;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1026,7 +1026,7 @@ unsigned Node::computeNodeIndex() const
 }
 
 template<unsigned type>
-bool shouldInvalidateNodeListCachesForAttr(const unsigned nodeListCounts[], const QualifiedName& attrName)
+bool shouldInvalidateNodeListCachesForAttr(const unsigned* nodeListCounts, const QualifiedName& attrName)
 {
     if constexpr (type >= numNodeListInvalidationTypes)
         return false;
@@ -1039,15 +1039,13 @@ bool shouldInvalidateNodeListCachesForAttr(const unsigned nodeListCounts[], cons
 
 inline bool Document::shouldInvalidateNodeListAndCollectionCaches() const
 {
-    for (int type = 0; type < numNodeListInvalidationTypes; ++type) {
-        if (m_nodeListAndCollectionCounts[type])
-            return true;
-    }
-    return false;
+    return m_nodeListAndCollectionCountForAttributeChangeInvalidation || m_nodeListAndCollectionCounts[static_cast<unsigned>(NodeListInvalidationType::DoNotInvalidateOnAttributeChanges)];
 }
 
 inline bool Document::shouldInvalidateNodeListAndCollectionCachesForAttribute(const QualifiedName& attrName) const
 {
+    if (!m_nodeListAndCollectionCountForAttributeChangeInvalidation)
+        return false;
     return shouldInvalidateNodeListCachesForAttr<enumToUnderlyingType(NodeListInvalidationType::DoNotInvalidateOnAttributeChanges) + 1>(m_nodeListAndCollectionCounts, attrName);
 }
 


### PR DESCRIPTION
#### 1bcbb87dade0c5b7699d37392b1ad20866d00fcb
<pre>
Reduce invalidation necessity for NodeList
<a href="https://bugs.webkit.org/show_bug.cgi?id=269642">https://bugs.webkit.org/show_bug.cgi?id=269642</a>
<a href="https://rdar.apple.com/123146571">rdar://123146571</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebCore/bindings/js/JSDOMAbstractOperations.h:
(WebCore::accessVisibleNamedProperty):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::registerNodeListForInvalidation):
(WebCore::Document::unregisterNodeListForInvalidation):
(WebCore::Document::registerCollection):
(WebCore::Document::unregisterCollection):
(WebCore::Document::collectionCachedIdNameMap):
(WebCore::Document::collectionWillClearIdNameMap):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Document::shouldInvalidateNodeListAndCollectionCaches const):
(WebCore::Document::shouldInvalidateNodeListAndCollectionCachesForAttribute const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bcbb87dade0c5b7699d37392b1ad20866d00fcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33570 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44288 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39924 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38227 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16946 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->