### PR TITLE
Sync `transition-end-event-nested.html` test from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2087,8 +2087,6 @@ webkit.org/b/221017 media/modern-media-controls/media-controller/media-controlle
 
 webkit.org/b/226600 imported/w3c/web-platform-tests/navigation-timing/test_navigate_within_document.html [ Pass Failure ]
 
-webkit.org/b/228002 transitions/transition-end-event-nested.html [ Pass Failure ]
-
 webkit.org/b/227877 imported/w3c/web-platform-tests/navigation-timing/test_timing_attributes_order.html [ Pass Failure ]
 
 webkit.org/b/222385 imported/w3c/web-platform-tests/xhr/event-upload-progress-crossorigin.any.worker.html [ Pass Failure ]

--- a/LayoutTests/transitions/transition-end-event-helpers.js
+++ b/LayoutTests/transitions/transition-end-event-helpers.js
@@ -136,6 +136,7 @@ function runTransitionTest(expected, callback)
 
   function startTest(expected, callback, maxTime)
   {
+    document.body.offsetHeight; // Force style recalc
     if (callback)
       callback();
     

--- a/LayoutTests/transitions/transition-end-event-nested-expected.txt
+++ b/LayoutTests/transitions/transition-end-event-nested-expected.txt
@@ -1,6 +1,6 @@
 Initiating transitions on various properties of all boxes.
 
-PASS --- [Expected] Property: background-color Target: box2 Elapsed Time: 0.2
-PASS --- [Expected] Property: left Target: box1 Elapsed Time: 0.2
-PASS --- [Expected] Property: width Target: box3 Elapsed Time: 0.3
+PASS --- [Expected] Property: background-color Target: box2 Elapsed Time: 0.06
+PASS --- [Expected] Property: left Target: box1 Elapsed Time: 0.06
+PASS --- [Expected] Property: width Target: box3 Elapsed Time: 0.1
 

--- a/LayoutTests/transitions/transition-end-event-nested.html
+++ b/LayoutTests/transitions/transition-end-event-nested.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <style>
@@ -8,8 +9,8 @@
       width: 100px;
       margin: 10px;
       background-color: blue;
-      -webkit-transition-property: width, left, background-color, height, top;
-      -webkit-transition-duration: 0.2s;
+      transition-property: width, left, background-color, height, top;
+      transition-duration: 0.06s;
     }
     
     .box1 {
@@ -22,7 +23,7 @@
     
     .box3 {
       width: 150px;
-      -webkit-transition-duration: 0.3s;
+      transition-duration: 0.1s;
     }
     
   </style>
@@ -31,20 +32,22 @@
     
     var expectedEndEvents = [
       // [property-name, element-id, elapsed-time, listen]
-      ["background-color", "box2", 0.2, false],
-      ["left", "box1", 0.2, false],
-      ["width", "box3", 0.3, false],
+      ["background-color", "box2", 0.06, false],
+      ["left", "box1", 0.06, false],
+      ["width", "box3", 0.1, false],
     ];
     
-    function handleEndEvent2(event)
+    function handleEndEvent3(event)
     {
       recordTransitionEndEvent(event);
     }
 
-    function startTransition2()
+    function handleEndEvent2(event)
     {
+      recordTransitionEndEvent(event);
+
       var box = document.getElementById("box3");
-      box.addEventListener("webkitTransitionEnd", handleEndEvent2, false);
+      box.addEventListener("transitionend", handleEndEvent3, false);
       box.className = "box box3";
     }
 
@@ -52,27 +55,15 @@
     {
       recordTransitionEndEvent(event);
       
-      setTimeout(startTransition2, 100);
-    }
-
-    function startTransition1()
-    {
       var box = document.getElementById("box2");
-      box.addEventListener("webkitTransitionEnd", handleEndEvent1, false);
+      box.addEventListener("transitionend", handleEndEvent2, false);
       box.className = "box box2";
-    }
-
-    function handleEndEvent(event)
-    {
-      recordTransitionEndEvent(event);
-      
-      setTimeout(startTransition1, 100);
     }
 
     function setupTest()
     {
       var box = document.getElementById("box1");
-      box.addEventListener("webkitTransitionEnd", handleEndEvent, false);
+      box.addEventListener("transitionend", handleEndEvent1, false);
       box.className = "box box1";
     }
     


### PR DESCRIPTION
#### 7c57e3d7752e11a23e1ec87a9bfb523c65da4228
<pre>
Sync `transition-end-event-nested.html` test from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=228002">https://bugs.webkit.org/show_bug.cgi?id=228002</a>
<a href="https://rdar.apple.com/problem/80647736">rdar://problem/80647736</a>

Reviewed by Antoine Quint.

This patch is to sync `transition-end-event-nested.html` from Blink / Chromium upstream
as per below commit:

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/854380e3ef0dc2d5cfdc171bb7b49ef7d46fe725">https://source.chromium.org/chromium/chromium/src/+/854380e3ef0dc2d5cfdc171bb7b49ef7d46fe725</a>

* LayoutTests/transitions/transition-end-event-nested.html: Update Test Case
* LayoutTests/transitions/transition-end-event-nested-expected.txt: Update Test Case Expectation
* LayoutTests/transitions/transition-end-event-helpers.js: Update Helper Script
* LayoutTests/platform/mac/TestExpectations: Remove [ Pass Failure ] Expectation

Canonical link: <a href="https://commits.webkit.org/274921@main">https://commits.webkit.org/274921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88378d7c693fd898f52bb2f8c08aa1a09feaed31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42926 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36469 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33493 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14077 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39845 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38121 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35062 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16863 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5348 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->