### PR TITLE
Allow determining if an SVG value has been specified to enable animation

### DIFF
--- a/LayoutTests/svg/animations/no-attr-lineargradient-gradienttransform-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-gradienttransform-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-gradienttransform.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-gradienttransform.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <linearGradient id="gradient">
+    <stop stop-color="#008000" offset="0.5"/>
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <animateTransform attributeName="gradientTransform" type="scale" dur="0.001s" from="2" to="2" fill="freeze"/>
+  </linearGradient>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-gradientunits-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-gradientunits-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-gradientunits.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-gradientunits.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <linearGradient id="gradient" x1="0" x2="0.5">
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <stop stop-color="#008000" offset="0.5"/>
+    <set attributeName="gradientUnits" to="userSpaceOnUse" fill="freeze"/>
+  </linearGradient>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-spreadmethod-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-spreadmethod-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-spreadmethod.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-spreadmethod.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1-128; totalPixels=3829-4399" />
+  <linearGradient id="gradient" x2="50%">
+    <stop stop-color="#008000" offset="0"/>
+    <!-- 0.99 rather than 1 to counter a bug with pad -->
+    <stop stop-color="#008000" offset="0.99"/>
+    <stop stop-color="#ff0000" offset="1"/>
+    <set attributeName="spreadMethod" to="repeat" fill="freeze"/>
+  </linearGradient>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-x1-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-x1-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-x1.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-x1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <linearGradient id="gradient">
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <stop stop-color="#008000" offset="0.5"/>
+    <set attributeName="x1" to="-100%" fill="freeze"/>
+  </linearGradient>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-x2-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-x2-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-x2.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-x2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <linearGradient id="gradient">
+    <stop stop-color="#008000" offset="0.5"/>
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <set attributeName="x2" to="200%" fill="freeze"/>
+  </linearGradient>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-y1-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-y1-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-y1.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-y1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <linearGradient id="gradient" x2="0%" y2="100%">
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <stop stop-color="#008000" offset="0.5"/>
+    <set attributeName="y1" to="-100%" fill="freeze"/>
+  </linearGradient>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-y2-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-y2-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-lineargradient-y2.svg
+++ b/LayoutTests/svg/animations/no-attr-lineargradient-y2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <linearGradient id="gradient" x2="0%" y1="100%">
+    <stop stop-color="#008000" offset="0.5"/>
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <set attributeName="y2" to="200%" fill="freeze"/>
+  </linearGradient>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-height-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-height-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-height.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-height.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" patternUnits="userSpaceOnUse" width="100">
+    <rect width="100" height="100" fill="#008000"/>
+    <set attributeName="height" to="100" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-par-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-par-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-par.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-par.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" patternUnits="userSpaceOnUse" viewBox="0 0 100 50" width="100" height="100">
+    <rect width="100" height="50" fill="#008000"/>
+    <set attributeName="preserveAspectRatio" to="none" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-patterncontentunits-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-patterncontentunits-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-patterncontentunits.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-patterncontentunits.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" patternUnits="userSpaceOnUse" width="100" height="100">
+    <rect width="1" height="1" fill="#008000"/>
+    <set attributeName="patternContentUnits" to="objectBoundingBox" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-patterntransform-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-patterntransform-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-patterntransform.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-patterntransform.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" patternUnits="userSpaceOnUse" width="100" height="100">
+    <rect width="50" height="50" fill="#008000"/>
+    <animateTransform attributeName="patternTransform" type="scale" dur="0.001s" from="2" to="2" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-patternunits-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-patternunits-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-patternunits.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-patternunits.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" width="50" height="50">
+    <rect width="50" height="50" fill="#008000"/>
+    <set attributeName="patternUnits" to="userSpaceOnUse" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-viewbox-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-viewbox-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-viewbox.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-viewbox.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" patternUnits="userSpaceOnUse" width="100" height="100">
+    <rect x="50" y="50" width="50" height="50" fill="#008000"/>
+    <set attributeName="viewBox" to="50 50 50 50" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-width-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-width-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-width.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-width.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" patternUnits="userSpaceOnUse" height="100">
+    <rect width="100" height="100" fill="#008000"/>
+    <set attributeName="width" to="100" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="#ff0000"/>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-x-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-x-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-x.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-x.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" patternUnits="userSpaceOnUse" width="200" height="100">
+    <rect x="0" width="100" height="100" fill="#ff0000"/>
+    <rect x="100" width="100" height="100" fill="#008000"/>
+    <set attributeName="x" to="100" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-y-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-y-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-pattern-y.svg
+++ b/LayoutTests/svg/animations/no-attr-pattern-y.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <pattern id="pattern" patternUnits="userSpaceOnUse" width="100" height="200">
+    <rect y="0" width="100" height="100" fill="#ff0000"/>
+    <rect y="100" width="100" height="100" fill="#008000"/>
+    <set attributeName="y" to="100" fill="freeze"/>
+  </pattern>
+  <rect width="100" height="100" fill="url(#pattern)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-cx-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-cx-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-cx.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-cx.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <radialGradient id="gradient">
+    <stop stop-color="#ff0000" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+    <set attributeName="cx" to="-50%" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-cy-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-cy-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-cy.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-cy.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <radialGradient id="gradient">
+    <stop stop-color="#ff0000" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+    <set attributeName="cy" to="-50%" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-fr-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-fr-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <radialGradient id="gradient" fr="25%">
+    <stop stop-color="#000080" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-fr.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-fr.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <radialGradient id="gradient">
+    <stop stop-color="#000080" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+    <set attributeName="fr" to="25%" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-fx-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-fx-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <radialGradient id="gradient" fx="25%">
+    <stop stop-color="#000080" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-fx.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-fx.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <radialGradient id="gradient">
+    <stop stop-color="#000080" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+    <set attributeName="fx" to="25%" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-fy-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-fy-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <radialGradient id="gradient" fy="25%">
+    <stop stop-color="#000080" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-fy.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-fy.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <radialGradient id="gradient">
+    <stop stop-color="#000080" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+    <set attributeName="fy" to="25%" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-gradienttransform-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-gradienttransform-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-gradienttransform.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-gradienttransform.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <radialGradient id="gradient">
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <stop stop-color="#008000" offset="0.5"/>
+    <animateTransform attributeName="gradientTransform" type="scale" dur="0.001s" from="4" to="4" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-gradientunits-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-gradientunits-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-gradientunits.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-gradientunits.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <radialGradient id="gradient">
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <stop stop-color="#008000" offset="0.5"/>
+    <set attributeName="gradientUnits" to="userSpaceOnUse" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-r-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-r-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#008000"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-r.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-r.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=3829-4344" />
+  <radialGradient id="gradient">
+    <stop stop-color="#008000" offset="0.5"/>
+    <stop stop-color="#ff0000" offset="0.5"/>
+    <set attributeName="r" to="400%" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-spreadmethod-expected.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-spreadmethod-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <radialGradient id="gradient" r="25%" spreadMethod="repeat">
+    <stop stop-color="#000080" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/LayoutTests/svg/animations/no-attr-radialgradient-spreadmethod.svg
+++ b/LayoutTests/svg/animations/no-attr-radialgradient-spreadmethod.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <radialGradient id="gradient" r="25%">
+    <stop stop-color="#000080" offset="0"/>
+    <stop stop-color="#008000" offset="1"/>
+    <set attributeName="spreadMethod" to="repeat" fill="freeze"/>
+  </radialGradient>
+  <rect width="100" height="100" fill="url(#gradient)"/>
+</svg>

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -613,6 +613,11 @@ bool SVGElement::isAnimatedStyleAttribute(const QualifiedName& attributeName) co
     return SVGPropertyAnimatorFactory::isKnownAttribute(attributeName) || propertyRegistry().isAnimatedStylePropertyAttribute(attributeName);
 }
 
+bool SVGElement::hasAttributeOrIsAnimatingProperty(const QualifiedName& attributeName) const
+{
+    return hasAttribute(attributeName) || propertyRegistry().isAnimatingProperty(attributeName);
+}
+
 RefPtr<SVGAttributeAnimator> SVGElement::createAnimator(const QualifiedName& attributeName, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive)
 {
     // Property animator, e.g. "fill" or "fill-opacity".

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -163,6 +163,7 @@ public:
     bool isAnimatedPropertyAttribute(const QualifiedName&) const;
     bool isAnimatedAttribute(const QualifiedName&) const;
     bool isAnimatedStyleAttribute(const QualifiedName&) const;
+    bool hasAttributeOrIsAnimatingProperty(const QualifiedName&) const;
 
     void synchronizeAttribute(const QualifiedName&);
     void synchronizeAllAttributes();

--- a/Source/WebCore/svg/SVGFitToViewBox.h
+++ b/Source/WebCore/svg/SVGFitToViewBox.h
@@ -56,7 +56,13 @@ public:
     String viewBoxString() const { return SVGPropertyTraits<FloatRect>::toString(viewBox()); }
     String preserveAspectRatioString() const { return preserveAspectRatio().valueAsString(); }
 
-    bool hasValidViewBox() const { return m_isViewBoxValid && viewBox().width() >= 0 && viewBox().height() >= 0; }
+    bool hasValidViewBox() const
+    {
+        auto& viewBox = this->viewBox();
+        if (m_viewBox->isAnimating())
+            return viewBox.width() >= 0 && viewBox.height() >= 0;
+        return m_isViewBoxValid && viewBox.width() >= 0 && viewBox.height() >= 0;
+    }
     bool hasEmptyViewBox() const { return hasValidViewBox() && viewBox().isEmpty(); }
 
 protected:

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -112,13 +112,13 @@ RenderPtr<RenderElement> SVGLinearGradientElement::createElementRenderer(RenderS
 
 static void setGradientAttributes(SVGGradientElement& element, LinearGradientAttributes& attributes, bool isLinear = true)
 {
-    if (!attributes.hasSpreadMethod() && element.hasAttribute(SVGNames::spreadMethodAttr))
+    if (!attributes.hasSpreadMethod() && element.hasAttributeOrIsAnimatingProperty(SVGNames::spreadMethodAttr))
         attributes.setSpreadMethod(element.spreadMethod());
 
-    if (!attributes.hasGradientUnits() && element.hasAttribute(SVGNames::gradientUnitsAttr))
+    if (!attributes.hasGradientUnits() && element.hasAttributeOrIsAnimatingProperty(SVGNames::gradientUnitsAttr))
         attributes.setGradientUnits(element.gradientUnits());
 
-    if (!attributes.hasGradientTransform() && element.hasAttribute(SVGNames::gradientTransformAttr))
+    if (!attributes.hasGradientTransform() && element.hasAttributeOrIsAnimatingProperty(SVGNames::gradientTransformAttr))
         attributes.setGradientTransform(element.gradientTransform().concatenate().value_or(identity));
 
     if (!attributes.hasStops())
@@ -127,16 +127,16 @@ static void setGradientAttributes(SVGGradientElement& element, LinearGradientAtt
     if (isLinear) {
         SVGLinearGradientElement& linear = downcast<SVGLinearGradientElement>(element);
 
-        if (!attributes.hasX1() && element.hasAttribute(SVGNames::x1Attr))
+        if (!attributes.hasX1() && element.hasAttributeOrIsAnimatingProperty(SVGNames::x1Attr))
             attributes.setX1(linear.x1());
 
-        if (!attributes.hasY1() && element.hasAttribute(SVGNames::y1Attr))
+        if (!attributes.hasY1() && element.hasAttributeOrIsAnimatingProperty(SVGNames::y1Attr))
             attributes.setY1(linear.y1());
 
-        if (!attributes.hasX2() && element.hasAttribute(SVGNames::x2Attr))
+        if (!attributes.hasX2() && element.hasAttributeOrIsAnimatingProperty(SVGNames::x2Attr))
             attributes.setX2(linear.x2());
 
-        if (!attributes.hasY2() && element.hasAttribute(SVGNames::y2Attr))
+        if (!attributes.hasY2() && element.hasAttributeOrIsAnimatingProperty(SVGNames::y2Attr))
             attributes.setY2(linear.y2());
     }
 }

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -161,31 +161,31 @@ RenderPtr<RenderElement> SVGPatternElement::createElementRenderer(RenderStyle&& 
 
 void SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes) const
 {
-    if (!attributes.hasX() && hasAttribute(SVGNames::xAttr))
+    if (!attributes.hasX() && hasAttributeOrIsAnimatingProperty(SVGNames::xAttr))
         attributes.setX(x());
 
-    if (!attributes.hasY() && hasAttribute(SVGNames::yAttr))
+    if (!attributes.hasY() && hasAttributeOrIsAnimatingProperty(SVGNames::yAttr))
         attributes.setY(y());
 
-    if (!attributes.hasWidth() && hasAttribute(SVGNames::widthAttr))
+    if (!attributes.hasWidth() && hasAttributeOrIsAnimatingProperty(SVGNames::widthAttr))
         attributes.setWidth(width());
 
-    if (!attributes.hasHeight() && hasAttribute(SVGNames::heightAttr))
+    if (!attributes.hasHeight() && hasAttributeOrIsAnimatingProperty(SVGNames::heightAttr))
         attributes.setHeight(height());
 
-    if (!attributes.hasViewBox() && hasAttribute(SVGNames::viewBoxAttr) && hasValidViewBox())
+    if (!attributes.hasViewBox() && hasAttributeOrIsAnimatingProperty(SVGNames::viewBoxAttr) && hasValidViewBox())
         attributes.setViewBox(viewBox());
 
-    if (!attributes.hasPreserveAspectRatio() && hasAttribute(SVGNames::preserveAspectRatioAttr))
+    if (!attributes.hasPreserveAspectRatio() && hasAttributeOrIsAnimatingProperty(SVGNames::preserveAspectRatioAttr))
         attributes.setPreserveAspectRatio(preserveAspectRatio());
 
-    if (!attributes.hasPatternUnits() && hasAttribute(SVGNames::patternUnitsAttr))
+    if (!attributes.hasPatternUnits() && hasAttributeOrIsAnimatingProperty(SVGNames::patternUnitsAttr))
         attributes.setPatternUnits(patternUnits());
 
-    if (!attributes.hasPatternContentUnits() && hasAttribute(SVGNames::patternContentUnitsAttr))
+    if (!attributes.hasPatternContentUnits() && hasAttributeOrIsAnimatingProperty(SVGNames::patternContentUnitsAttr))
         attributes.setPatternContentUnits(patternContentUnits());
 
-    if (!attributes.hasPatternTransform() && hasAttribute(SVGNames::patternTransformAttr))
+    if (!attributes.hasPatternTransform() && hasAttributeOrIsAnimatingProperty(SVGNames::patternTransformAttr))
         attributes.setPatternTransform(patternTransform().concatenate().value_or(identity));
 
     if (!attributes.hasPatternContentElement() && childElementCount())

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -119,13 +119,13 @@ RenderPtr<RenderElement> SVGRadialGradientElement::createElementRenderer(RenderS
 
 static void setGradientAttributes(SVGGradientElement& element, RadialGradientAttributes& attributes, bool isRadial = true)
 {
-    if (!attributes.hasSpreadMethod() && element.hasAttribute(SVGNames::spreadMethodAttr))
+    if (!attributes.hasSpreadMethod() && element.hasAttributeOrIsAnimatingProperty(SVGNames::spreadMethodAttr))
         attributes.setSpreadMethod(element.spreadMethod());
 
-    if (!attributes.hasGradientUnits() && element.hasAttribute(SVGNames::gradientUnitsAttr))
+    if (!attributes.hasGradientUnits() && element.hasAttributeOrIsAnimatingProperty(SVGNames::gradientUnitsAttr))
         attributes.setGradientUnits(element.gradientUnits());
 
-    if (!attributes.hasGradientTransform() && element.hasAttribute(SVGNames::gradientTransformAttr))
+    if (!attributes.hasGradientTransform() && element.hasAttributeOrIsAnimatingProperty(SVGNames::gradientTransformAttr))
         attributes.setGradientTransform(element.gradientTransform().concatenate().value_or(identity));
 
     if (!attributes.hasStops())
@@ -134,22 +134,22 @@ static void setGradientAttributes(SVGGradientElement& element, RadialGradientAtt
     if (isRadial) {
         SVGRadialGradientElement& radial = downcast<SVGRadialGradientElement>(element);
 
-        if (!attributes.hasCx() && element.hasAttribute(SVGNames::cxAttr))
+        if (!attributes.hasCx() && element.hasAttributeOrIsAnimatingProperty(SVGNames::cxAttr))
             attributes.setCx(radial.cx());
 
-        if (!attributes.hasCy() && element.hasAttribute(SVGNames::cyAttr))
+        if (!attributes.hasCy() && element.hasAttributeOrIsAnimatingProperty(SVGNames::cyAttr))
             attributes.setCy(radial.cy());
 
-        if (!attributes.hasR() && element.hasAttribute(SVGNames::rAttr))
+        if (!attributes.hasR() && element.hasAttributeOrIsAnimatingProperty(SVGNames::rAttr))
             attributes.setR(radial.r());
 
-        if (!attributes.hasFx() && element.hasAttribute(SVGNames::fxAttr))
+        if (!attributes.hasFx() && element.hasAttributeOrIsAnimatingProperty(SVGNames::fxAttr))
             attributes.setFx(radial.fx());
 
-        if (!attributes.hasFy() && element.hasAttribute(SVGNames::fyAttr))
+        if (!attributes.hasFy() && element.hasAttributeOrIsAnimatingProperty(SVGNames::fyAttr))
             attributes.setFy(radial.fy());
 
-        if (!attributes.hasFr() && element.hasAttribute(SVGNames::frAttr))
+        if (!attributes.hasFr() && element.hasAttributeOrIsAnimatingProperty(SVGNames::frAttr))
             attributes.setFr(radial.fr());
     }
 }

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAccessor.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAccessor.h
@@ -46,6 +46,7 @@ public:
 
 private:
     bool isAnimatedProperty() const override { return true; }
+    bool isAnimating(const OwnerType& owner) const override { return property(owner)->isAnimating(); }
 };
 
 }

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
@@ -51,6 +51,7 @@ protected:
     }
 
     bool isAnimatedProperty() const override { return true; }
+    bool isAnimating(const OwnerType& owner) const override { return property1(owner)->isAnimating() || property2(owner)->isAnimating(); }
 
     const Ref<AnimatedPropertyType1>& property1(OwnerType& owner) const { return m_accessor1.property(owner); }
     const Ref<AnimatedPropertyType1>& property1(const OwnerType& owner) const { return m_accessor1.property(owner); }

--- a/Source/WebCore/svg/properties/SVGMemberAccessor.h
+++ b/Source/WebCore/svg/properties/SVGMemberAccessor.h
@@ -42,6 +42,7 @@ public:
     virtual void detach(const OwnerType&) const { }
     virtual bool isAnimatedProperty() const { return false; }
     virtual bool isAnimatedLength() const { return false; }
+    virtual bool isAnimating(const OwnerType&) const { return false; }
 
     virtual bool matches(const OwnerType&, const SVGProperty&) const { return false; }
     virtual bool matches(const OwnerType&, const SVGAnimatedPropertyBase&) const { return false; }

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -298,7 +298,7 @@ public:
 
     bool isAnimatedPropertyAttribute(const QualifiedName& attributeName) const override
     {
-        if (auto* property = fastAnimatedPropertyLookup(m_owner, attributeName))
+        if (RefPtr property = fastAnimatedPropertyLookup(m_owner, attributeName))
             return true;
 
         bool isAnimatedPropertyAttribute = false;
@@ -306,6 +306,18 @@ public:
             isAnimatedPropertyAttribute = accessor.isAnimatedProperty();
         });
         return isAnimatedPropertyAttribute;
+    }
+
+    bool isAnimatingProperty(const QualifiedName& attributeName) const override
+    {
+        if (RefPtr property = fastAnimatedPropertyLookup(m_owner, attributeName))
+            return property->isAnimating();
+
+        bool result = false;
+        lookupRecursivelyAndApply(attributeName, [&](auto& accessor) {
+            result = accessor.isAnimating(m_owner);
+        });
+        return result;
     }
 
     bool isAnimatedStylePropertyAttribute(const QualifiedName& attributeName) const override

--- a/Source/WebCore/svg/properties/SVGPropertyRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyRegistry.h
@@ -43,6 +43,7 @@ public:
     virtual HashMap<QualifiedName, String> synchronizeAllAttributes() const = 0;
 
     virtual bool isAnimatedPropertyAttribute(const QualifiedName&) const = 0;
+    virtual bool isAnimatingProperty(const QualifiedName&) const = 0;
     virtual bool isAnimatedStylePropertyAttribute(const QualifiedName&) const = 0;
     virtual RefPtr<SVGAttributeAnimator> createAnimator(const QualifiedName&, AnimationMode, CalcMode, bool isAccumulated, bool isAdditive) const = 0;
     virtual void appendAnimatedInstance(const QualifiedName& attributeName, SVGAttributeAnimator&) const = 0;


### PR DESCRIPTION
#### a6a8ca738974cb312892566f4d9c1f824056bc03
<pre>
Allow determining if an SVG value has been specified to enable animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=269481">https://bugs.webkit.org/show_bug.cgi?id=269481</a>
<a href="https://rdar.apple.com/problem/123457088">rdar://problem/123457088</a>

Reviewed by Nikolas Zimmermann.

When collecting attributes for pattern/gradient rendering, hasAttribute()
was used to check whether a property value should be included. This only
checks for the presence of a DOM attribute on the element, missing the case
where a value is produced solely by SMIL animation (animVal without a
corresponding baseVal attribute). The animated value was correctly computed
and reflected in the DOM API (animVal), but the rendering codepath never
read it.

Fix this by adding SVGElement::hasAttributeOrIsAnimatingProperty() which
combines hasAttribute() with a new registry query that checks whether the
animated property for a given attribute is currently being driven by an
animator. The plumbing goes through SVGMemberAccessor::isAnimating() →
SVGAnimatedPropertyAccessor (delegates to SVGAnimatedPropertyBase::isAnimating())
→ SVGPropertyOwnerRegistry::isAnimatingProperty() → SVGElement convenience
method. This preserves attribute inheritance semantics for paint servers
referencing other paint servers via href, since the check is false when
neither an attribute nor an animation is present.

Additionally, fix SVGFitToViewBox::hasValidViewBox() which suffered from a
similar issue: m_isViewBoxValid is only set when the viewBox DOM attribute
is parsed, so an animated viewBox without an explicit attribute was always
considered invalid. Now when the viewBox property is being animated, the
validity check bypasses the m_isViewBoxValid flag and directly validates
the animated value&apos;s dimensions.

Affects &lt;pattern&gt;, &lt;linearGradient&gt;, and &lt;radialGradient&gt; — all attributes
collected for rendering are now covered and fixes for both LegacySVG and
LBSE.

Inspired by (&amp; Tests): <a href="https://chromium.googlesource.com/chromium/blink/+/9102ba31c8dbaf5bd47d67a4c6450fbbaf75d43d">https://chromium.googlesource.com/chromium/blink/+/9102ba31c8dbaf5bd47d67a4c6450fbbaf75d43d</a>

* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::hasAttributeOrIsAnimatingProperty const):
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGFitToViewBox.h:
(WebCore::SVGFitToViewBox::hasValidViewBox):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::setGradientAttributes):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::collectPatternAttributes const):
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::setGradientAttributes):
* Source/WebCore/svg/properties/SVGAnimatedPropertyAccessor.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h:
* Source/WebCore/svg/properties/SVGMemberAccessor.h:
(WebCore::SVGMemberAccessor::isAnimating const):
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
* Source/WebCore/svg/properties/SVGPropertyRegistry.h:

&gt; Add Test Case &amp; Expectations:
NOTE: Due to gradient noise, all gradient tests have `fuzziness` meta tag.
* LayoutTests/svg/animations/no-attr-radialgradient-spreadmethod.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-spreadmethod-expected.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-r.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-r-expected.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-gradientunits.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-gradientunits-expected.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-gradienttransform.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-gradienttransform-expected.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-fy.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-fy-expected.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-fx.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-fx-expected.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-fr.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-fr-expected.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-cy.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-cy-expected.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-cx.svg:
* LayoutTests/svg/animations/no-attr-radialgradient-cx-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-y.svg:
* LayoutTests/svg/animations/no-attr-pattern-y-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-x.svg:
* LayoutTests/svg/animations/no-attr-pattern-x-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-width.svg:
* LayoutTests/svg/animations/no-attr-pattern-width-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-viewbox.svg:
* LayoutTests/svg/animations/no-attr-pattern-viewbox-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-patternunits.svg:
* LayoutTests/svg/animations/no-attr-pattern-patternunits-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-patterntransform.svg:
* LayoutTests/svg/animations/no-attr-pattern-patterntransform-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-patterncontentunits.svg:
* LayoutTests/svg/animations/no-attr-pattern-patterncontentunits-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-par.svg:
* LayoutTests/svg/animations/no-attr-pattern-par-expected.svg:
* LayoutTests/svg/animations/no-attr-pattern-height.svg:
* LayoutTests/svg/animations/no-attr-pattern-height-expected.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-y2.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-y2-expected.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-y1.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-y1-expected.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-x2.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-x2-expected.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-x1.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-x1-expected.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-spreadmethod.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-spreadmethod-expected.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-gradientunits.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-gradientunits-expected.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-gradienttransform.svg:
* LayoutTests/svg/animations/no-attr-lineargradient-gradienttransform-expected.svg:

Canonical link: <a href="https://commits.webkit.org/310257@main">https://commits.webkit.org/310257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65a1b84a1f0f220c232213aba97f77ca0eb2a9e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/25859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106535 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed4b70c6-3130-4d2f-8c87-9d7f36fc7393) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/154950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118321 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83773 "3 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11d99040-7845-4e95-a3c7-22bb416c6dc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99034 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91b5c611-c1e4-4837-93e5-b40e2717f1d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19630 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17572 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPINamespace.NoWebNavigationObjectWithoutPermission (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9657 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164295 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7431 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126383 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126541 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34367 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137091 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82302 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13870 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89561 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/24967 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25125 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->