### PR TITLE
[GStreamer] Crash after 10 seconds on watchdog thread do to loop when destroying ~ImageDecoderGStreamerSample

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -38,6 +38,17 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_image_decoder_debug);
 #define GST_CAT_DEFAULT webkit_image_decoder_debug
 
+static Lock s_decoderLock;
+static Vector<RefPtr<ImageDecoderGStreamer>> s_imageDecoders;
+
+void teardownGStreamerImageDecoders()
+{
+    Locker lock { s_decoderLock };
+    for (auto& decoder : s_imageDecoders)
+        decoder->tearDown();
+    s_imageDecoders.clear();
+}
+
 class ImageDecoderGStreamerSample final : public MediaSampleGStreamer {
 public:
     static Ref<ImageDecoderGStreamerSample> create(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize)
@@ -51,7 +62,11 @@ public:
             return nullptr;
         return m_image->image().nativeImage()->platformImage();
     }
-    void dropImage() { m_image = nullptr; }
+    void dropImage()
+    {
+        m_image = nullptr;
+        m_frame = nullptr;
+    }
 
     SampleFlags flags() const override
     {
@@ -62,7 +77,7 @@ private:
     ImageDecoderGStreamerSample(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize)
         : MediaSampleGStreamer(WTFMove(sample), presentationSize, { })
     {
-        m_frame = VideoFrameGStreamer::createWrappedSample(platformSample().sample.gstSample);
+        m_frame = VideoFrameGStreamer::create(GRefPtr(platformSample().sample.gstSample), presentationSize);
         m_image = m_frame->convertToImage();
     }
 
@@ -83,7 +98,12 @@ ImageDecoderGStreamerSample* toSample(Iterator iter)
 
 RefPtr<ImageDecoderGStreamer> ImageDecoderGStreamer::create(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
 {
-    return adoptRef(*new ImageDecoderGStreamer(data, mimeType, alphaOption, gammaAndColorProfileOption));
+    RefPtr decoder = adoptRef(*new ImageDecoderGStreamer(data, mimeType, alphaOption, gammaAndColorProfileOption));
+    {
+        Locker lock { s_decoderLock };
+        s_imageDecoders.append(decoder);
+    }
+    return decoder;
 }
 
 ImageDecoderGStreamer::ImageDecoderGStreamer(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption, GammaAndColorProfileOption)
@@ -121,11 +141,23 @@ ImageDecoderGStreamer::ImageDecoderGStreamer(FragmentedSharedBuffer& data, const
         configureVideoDecoderForHarnessing(element);
         m_decoderHarness = GStreamerElementHarness::create(WTFMove(element), [this](auto&, auto&& outputSample) {
             storeDecodedSample(WTFMove(outputSample));
-        }, { });
+        });
         return m_decoderHarness;
     });
 
     pushEncodedData(data);
+}
+
+ImageDecoderGStreamer::~ImageDecoderGStreamer()
+{
+    tearDown();
+}
+
+void ImageDecoderGStreamer::tearDown()
+{
+    m_sampleData.clear();
+    m_decoderHarness = nullptr;
+    m_parserHarness = nullptr;
 }
 
 bool ImageDecoderGStreamer::supportsContainerType(const String& type)
@@ -316,7 +348,7 @@ void ImageDecoderGStreamer::pushEncodedData(const FragmentedSharedBuffer& shared
         }
     }
 
-    m_decoderHarness->flush();
+    m_decoderHarness->reset();
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h
@@ -35,13 +35,15 @@ namespace WebCore {
 class ContentType;
 class ImageDecoderGStreamerSample;
 
+void teardownGStreamerImageDecoders();
+
 class ImageDecoderGStreamer final : public ImageDecoder {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ImageDecoderGStreamer);
 public:
     static RefPtr<ImageDecoderGStreamer> create(FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption);
     ImageDecoderGStreamer(FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption);
-    virtual ~ImageDecoderGStreamer() = default;
+    ~ImageDecoderGStreamer();
 
     static bool supportsMediaType(MediaType type) { return type == MediaType::Video; }
     static bool supportsContainerType(const String&);
@@ -73,6 +75,8 @@ public:
     void setData(const FragmentedSharedBuffer&, bool allDataReceived) final;
     bool isAllDataReceived() const final { return m_eos; }
     void clearFrameBufferCache(size_t) final;
+
+    void tearDown();
 
 private:
     void pushEncodedData(const FragmentedSharedBuffer&);

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -61,7 +61,7 @@ public:
         Stream(GRefPtr<GstPad>&&, RefPtr<GStreamerElementHarness>&&);
 
         GstFlowReturn chainSample(GRefPtr<GstSample>&&);
-        bool sinkEvent(GstEvent*);
+        bool sinkEvent(GRefPtr<GstEvent>&&);
 
         GRefPtr<GstPad> m_pad;
         RefPtr<GStreamerElementHarness> m_downstreamHarness;
@@ -111,7 +111,7 @@ private:
     GstFlowReturn pushBufferFull(GRefPtr<GstBuffer>&&);
 
     bool srcQuery(GstPad*, GstObject*, GstQuery*);
-    bool srcEvent(GstEvent*);
+    bool srcEvent(GRefPtr<GstEvent>&&);
 
     void pushStickyEvents(GRefPtr<GstCaps>&&, std::optional<const GstSegment*>&& = { });
     void pushSegmentEvent(std::optional<const GstSegment*>&& = { });


### PR DESCRIPTION
#### e653f5a19d03b41d53edcfa7d4ca1372f37f262b
<pre>
[GStreamer] Crash after 10 seconds on watchdog thread do to loop when destroying ~ImageDecoderGStreamerSample
<a href="https://bugs.webkit.org/show_bug.cgi?id=264824">https://bugs.webkit.org/show_bug.cgi?id=264824</a>

Reviewed by Xabier Rodriguez-Calvar.

The WebProcess was deadlocking at shutdown when the disposal of the element harness of the image
decoder was triggering disposal of chained harnesses, within the same thread, through the
pad-removed signal emission. The proposed solution is to use a recursive mutex for active pipelines
storage protection.

This patch also fixes a few more leaks in ImageDecoder and the element harness.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::deinitializeGStreamer):
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
(WebCore::teardownGStreamerImageDecoders):
(WebCore::ImageDecoderGStreamer::create):
(WebCore::ImageDecoderGStreamer::ImageDecoderGStreamer):
(WebCore::ImageDecoderGStreamer::tearDown):
(WebCore::ImageDecoderGStreamer::pushEncodedData):
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h:
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::GStreamerElementHarness):
(WebCore::GStreamerElementHarness::~GStreamerElementHarness):
(WebCore::GStreamerElementHarness::Stream::Stream):
(WebCore::GStreamerElementHarness::Stream::~Stream):
(WebCore::GStreamerElementHarness::Stream::sinkEvent):
(WebCore::GStreamerElementHarness::srcEvent):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:

Canonical link: <a href="https://commits.webkit.org/275032@main">https://commits.webkit.org/275032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c30302484c24a10e5648d24dd8c90ef5b3d0d6c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33496 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14079 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44205 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38122 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16816 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9118 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->