### PR TITLE
HTMLPreloadScanner should only use valid `base` urls

### DIFF
--- a/LayoutTests/fast/parser/badurl-base-preloader-crash-expected.txt
+++ b/LayoutTests/fast/parser/badurl-base-preloader-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS: if scanning this document with preloader doesn't crash in debug builds

--- a/LayoutTests/fast/parser/badurl-base-preloader-crash.html
+++ b/LayoutTests/fast/parser/badurl-base-preloader-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<base href="gopher:��&#279%�:0"></base>
+<script src=":"></script>
+<script>
+if (window.testRunner) testRunner.dumpAsText();
+</script>
+<p>PASS: if scanning this document with preloader doesn't crash in debug builds</p>

--- a/LayoutTests/http/tests/loading/preload-ignore-invalid-base-expected.txt
+++ b/LayoutTests/http/tests/loading/preload-ignore-invalid-base-expected.txt
@@ -1,0 +1,11 @@
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+PASS internals.isPreloaded("resources/fail.js") is false
+PASS window.fail is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/loading/preload-ignore-invalid-base.html
+++ b/LayoutTests/http/tests/loading/preload-ignore-invalid-base.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+window.fail = false;
+</script>
+<base href="gopher:???:"></base>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100"></script>
+<script>
+shouldBeFalse('internals.isPreloaded("resources/fail.js")')
+</script>
+<!-- The resource should not be read, as the baseUrl is now set to empty from reading invalid url -->
+<script src="resources/fail.js"></script>
+<script>
+shouldBeFalse('window.fail')
+</script>

--- a/LayoutTests/http/tests/loading/resources/fail.js
+++ b/LayoutTests/http/tests/loading/resources/fail.js
@@ -1,0 +1,1 @@
+window.fail=true;

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -510,7 +510,7 @@ void TokenPreloadScanner::updatePredictedBaseURL(const HTMLToken& token, bool sh
         return;
     URL temp { m_documentURL, StringImpl::create8BitIfPossible(hrefAttribute->value) };
     if (!shouldRestrictBaseURLSchemes || SecurityPolicy::isBaseURLSchemeAllowed(temp))
-        m_predictedBaseElementURL = WTFMove(temp).isolatedCopy();
+        m_predictedBaseElementURL = WTFMove(temp).isValid() ? WTFMove(temp).isolatedCopy() : URL();
 }
 
 HTMLPreloadScanner::HTMLPreloadScanner(const HTMLParserOptions& options, const URL& documentURL, float deviceScaleFactor)


### PR DESCRIPTION
#### 393573035d7ef055e27d29da79d2f8ce5833f783
<pre>
HTMLPreloadScanner should only use valid `base` urls

<a href="https://bugs.webkit.org/show_bug.cgi?id=269643">https://bugs.webkit.org/show_bug.cgi?id=269643</a>

Reviewed by Ryosuke Niwa.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/754b22f62f6fa5f0b938a90c0e92502eb7f5a7c3">https://chromium.googlesource.com/chromium/blink/+/754b22f62f6fa5f0b938a90c0e92502eb7f5a7c3</a>

Before this patch, HTMLPreloadScanner accepted invalid `base` urls and
used it to resolve urls encountered later in the scan.
This patch ensures that only valid urls specified in `base href` are
actually used as base urls.

* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(TokenPreloadScanner::updatePredictedBaseURL):
* LayoutTests/fast/parser/badurl-base-preloader-crash.html: Add Test Case
* LayoutTests/fast/parser/badurl-base-preloader-crash-expected.txt: Add Test Case Expectation
* LayoutTests/http/tests/loading/preload-ignore-invalid-base.html: Add Test Case
* LayoutTests/http/tests/loading/resources/fail.js: Add Test Case Helper Script
* LayoutTests/http/tests/loading/preload-ignore-invalid-base-expected.txt: Add Test Expectation

Canonical link: <a href="https://commits.webkit.org/274963@main">https://commits.webkit.org/274963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d05518f8788ba6b1234f4775de399de373a1d01f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33519 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39867 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38161 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35089 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->