### PR TITLE
[MSE] `ASSERT(canSafelyBeUsed());` ASSERTION when using webm with MSE in a worker

### DIFF
--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -68,14 +68,15 @@ AudioTrack::AudioTrack(ScriptExecutionContext* context, AudioTrackPrivate& track
     , m_enabled(trackPrivate.enabled())
     , m_configuration(AudioTrackConfiguration::create())
 {
-    m_private->setClient(*this);
+    addClientToTrackPrivateBase(*this, trackPrivate);
+
     updateKindFromPrivate();
     updateConfigurationFromPrivate();
 }
 
 AudioTrack::~AudioTrack()
 {
-    m_private->clearClient();
+    removeClientFromTrackPrivateBase(Ref { m_private });
 }
 
 void AudioTrack::setPrivate(AudioTrackPrivate& trackPrivate)
@@ -83,10 +84,11 @@ void AudioTrack::setPrivate(AudioTrackPrivate& trackPrivate)
     if (m_private.ptr() == &trackPrivate)
         return;
 
-    m_private->clearClient();
+    removeClientFromTrackPrivateBase(Ref { m_private });
     m_private = trackPrivate;
     m_private->setEnabled(m_enabled);
-    m_private->setClient(*this);
+    addClientToTrackPrivateBase(*this, trackPrivate);
+
 #if !RELEASE_LOG_DISABLED
     m_private->setLogger(logger(), logIdentifier());
 #endif

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -60,13 +60,13 @@ InbandTextTrack::InbandTextTrack(ScriptExecutionContext& context, InbandTextTrac
     : TextTrack(&context, emptyAtom(), trackPrivate.id(), trackPrivate.label(), trackPrivate.language(), InBand)
     , m_private(trackPrivate)
 {
-    m_private->setClient(*this);
+    addClientToTrackPrivateBase(*this, trackPrivate);
     updateKindFromPrivate();
 }
 
 InbandTextTrack::~InbandTextTrack()
 {
-    m_private->clearClient();
+    removeClientFromTrackPrivateBase(Ref { m_private });
 }
 
 void InbandTextTrack::setPrivate(InbandTextTrackPrivate& trackPrivate)
@@ -74,9 +74,9 @@ void InbandTextTrack::setPrivate(InbandTextTrackPrivate& trackPrivate)
     if (m_private.ptr() == &trackPrivate)
         return;
 
-    m_private->clearClient();
+    removeClientFromTrackPrivateBase(Ref { m_private });
     m_private = trackPrivate;
-    m_private->setClient(*this);
+    addClientToTrackPrivateBase(*this, trackPrivate);
 
     setModeInternal(mode());
     updateKindFromPrivate();

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -29,6 +29,8 @@
 #include "ContextDestructionObserverInlines.h"
 #include "Logging.h"
 #include "TrackListBase.h"
+#include "TrackPrivateBase.h"
+#include "TrackPrivateBaseClient.h"
 #include <wtf/Language.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -181,6 +183,20 @@ WTFLogChannel& TrackBase::logChannel() const
     return LogMedia;
 }
 #endif
+
+void TrackBase::addClientToTrackPrivateBase(TrackPrivateBaseClient& client, TrackPrivateBase& track)
+{
+    if (auto context = scriptExecutionContext()) {
+        m_clientRegistrationId = track.addClient([contextIdentifier = context->identifier()](auto&& task) {
+            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, WTFMove(task));
+        }, client);
+    }
+}
+
+void TrackBase::removeClientFromTrackPrivateBase(TrackPrivateBase& track)
+{
+    track.removeClient(m_clientRegistrationId);
+}
 
 MediaTrackBase::MediaTrackBase(ScriptExecutionContext* context, Type type, const std::optional<AtomString>& id, TrackID trackId, const AtomString& label, const AtomString& language)
     : TrackBase(context, type, id, trackId, label, language)

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -37,6 +37,8 @@ namespace WebCore {
 
 class SourceBuffer;
 class TrackListBase;
+class TrackPrivateBase;
+class TrackPrivateBaseClient;
 using TrackID = uint64_t;
 
 class TrackBase
@@ -94,6 +96,9 @@ protected:
     SourceBuffer* m_sourceBuffer { nullptr };
 #endif
 
+    void addClientToTrackPrivateBase(TrackPrivateBaseClient&, TrackPrivateBase&);
+    void removeClientFromTrackPrivateBase(TrackPrivateBase&);
+
 private:
     Type m_type;
     int m_uniqueId;
@@ -107,6 +112,7 @@ private:
     const void* m_logIdentifier { nullptr };
 #endif
     WeakPtr<TrackListBase, WeakPtrImplWithEventTargetData> m_trackList;
+    size_t m_clientRegistrationId;
 };
 
 class MediaTrackBase : public TrackBase {

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -60,14 +60,14 @@ VideoTrack::VideoTrack(ScriptExecutionContext* context, VideoTrackPrivate& track
     , m_configuration(VideoTrackConfiguration::create())
     , m_selected(trackPrivate.selected())
 {
-    m_private->setClient(*this);
+    addClientToTrackPrivateBase(*this, trackPrivate);
     updateKindFromPrivate();
     updateConfigurationFromPrivate();
 }
 
 VideoTrack::~VideoTrack()
 {
-    m_private->clearClient();
+    removeClientFromTrackPrivateBase(Ref { m_private });
 }
 
 void VideoTrack::setPrivate(VideoTrackPrivate& trackPrivate)
@@ -75,9 +75,9 @@ void VideoTrack::setPrivate(VideoTrackPrivate& trackPrivate)
     if (m_private.ptr() == &trackPrivate)
         return;
 
-    m_private->clearClient();
+    removeClientFromTrackPrivateBase(Ref { m_private });
     m_private = trackPrivate;
-    m_private->setClient(*this);
+    addClientToTrackPrivateBase(*this, trackPrivate);
 #if !RELEASE_LOG_DISABLED
     m_private->setLogger(logger(), logIdentifier());
 #endif

--- a/Source/WebCore/platform/graphics/AudioTrackPrivateClient.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivateClient.h
@@ -36,10 +36,15 @@ struct PlatformAudioTrackConfiguration;
 
 class AudioTrackPrivateClient : public TrackPrivateBaseClient {
 public:
+    constexpr Type type() const final { return Type::Audio; }
     virtual void enabledChanged(bool) = 0;
     virtual void configurationChanged(const PlatformAudioTrackConfiguration&) = 0;
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AudioTrackPrivateClient)
+static bool isType(const WebCore::TrackPrivateBaseClient& track) { return track.type() == WebCore::TrackPrivateBaseClient::Type::Audio; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
@@ -47,10 +47,6 @@ public:
     static Ref<InbandTextTrackPrivate> create(CueFormat format) { return adoptRef(*new InbandTextTrackPrivate(format)); }
     virtual ~InbandTextTrackPrivate() = default;
 
-    InbandTextTrackPrivateClient* client() const override { return m_client.get(); }
-    virtual void setClient(InbandTextTrackPrivateClient& client) { m_client = client; }
-    void clearClient() { m_client = nullptr; }
-
     using Mode = InbandTextTrackPrivateMode;
     virtual void setMode(Mode mode) { m_mode = mode; };
     virtual InbandTextTrackPrivate::Mode mode() const { return m_mode; }
@@ -107,7 +103,6 @@ protected:
 
 private:
     CueFormat m_format;
-    WeakPtr<InbandTextTrackPrivateClient> m_client { nullptr };
     Mode m_mode { Mode::Disabled };
 };
 

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h
@@ -46,6 +46,8 @@ class InbandTextTrackPrivateClient : public TrackPrivateBaseClient {
 public:
     virtual ~InbandTextTrackPrivateClient() = default;
 
+    constexpr Type type() const final { return Type::Text; }
+
     virtual void addDataCue(const MediaTime& start, const MediaTime& end, const void*, unsigned) = 0;
 
 #if ENABLE(DATACUE_VALUE)
@@ -64,5 +66,9 @@ public:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::InbandTextTrackPrivateClient)
+static bool isType(const WebCore::TrackPrivateBaseClient& track) { return track.type() == WebCore::TrackPrivateBaseClient::Type::Text; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "TrackPrivateBase.h"
+#include <wtf/SharedTask.h>
 
 #if ENABLE(VIDEO)
 
@@ -51,6 +52,76 @@ bool TrackPrivateBase::operator==(const TrackPrivateBase& track) const
         && trackUID() == track.trackUID()
         && defaultEnabled() == track.defaultEnabled()
         && startTimeVariance() == track.startTimeVariance();
+}
+
+void TrackPrivateBase::notifyClients(Task&& task)
+{
+    Ref sharedTask = createSharedTask<void(TrackPrivateBaseClient&)>(WTFMove(task));
+    // We ensure not to hold the lock for too long by making a copy (which are cheap)
+    // as we could potentially get a re-entrant call which would cause a deadlock.
+    Vector<ClientRecord> clients;
+    {
+        Locker locker { m_lock };
+        clients = m_clients;
+    }
+    for (auto& tuple : clients) {
+        auto& [dispatcher, weakClient, mainThread] = tuple;
+        if (dispatcher) {
+            dispatcher->get()([weakClient = WTFMove(weakClient), sharedTask] {
+                if (weakClient)
+                    sharedTask->run(*weakClient);
+            });
+        }
+    }
+}
+
+void TrackPrivateBase::notifyMainThreadClient(Task&& task)
+{
+    // There will only ever be one main thread client.
+    // We call the first one found.
+    Vector<ClientRecord> clients;
+    {
+        Locker locker { m_lock };
+        clients = m_clients;
+    }
+    for (auto& tuple : clients) {
+        auto& [dispatcher, weakClient, mainThread] = tuple;
+        if (dispatcher && mainThread) {
+            dispatcher->get()([weakClient = WTFMove(weakClient), task = WTFMove(task)] {
+                if (weakClient)
+                    task(*weakClient);
+            });
+            break;
+        }
+    }
+}
+
+size_t TrackPrivateBase::addClient(TrackPrivateBaseClient::Dispatcher&& dispatcher, TrackPrivateBaseClient& client)
+{
+    Locker locker { m_lock };
+    size_t index = m_clients.size();
+    m_clients.append(std::make_tuple(SharedDispatcher::create(WTFMove(dispatcher)), WeakPtr { client }, isMainThread()));
+    return index;
+}
+
+void TrackPrivateBase::removeClient(uint32_t index)
+{
+    Locker locker { m_lock };
+    if (m_clients.size() > index)
+        return;
+    m_clients[index] = std::make_tuple<RefPtr<SharedDispatcher>, WeakPtr<TrackPrivateBaseClient>, bool>({ }, { }, false);
+}
+
+bool TrackPrivateBase::hasClients() const
+{
+    Locker locker { m_lock };
+    return m_clients.size();
+}
+
+bool TrackPrivateBase::hasOneClient() const
+{
+    Locker locker { m_lock };
+    return m_clients.size() == 1;
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -29,10 +29,13 @@
 
 #if ENABLE(VIDEO)
 
+#include "ScriptExecutionContextIdentifier.h"
 #include "TrackPrivateBaseClient.h"
+#include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -50,7 +53,8 @@ class WEBCORE_EXPORT TrackPrivateBase
 public:
     virtual ~TrackPrivateBase() = default;
 
-    virtual TrackPrivateBaseClient* client() const = 0;
+    size_t addClient(TrackPrivateBaseClient::Dispatcher&&, TrackPrivateBaseClient&);
+    void removeClient(uint32_t); // Can be called multiple times with the same id.
 
     virtual TrackID id() const { return 0; }
     virtual AtomString label() const { return emptyAtom(); }
@@ -64,8 +68,9 @@ public:
 
     void willBeRemoved()
     {
-        if (auto* client = this->client())
-            client->willRemove();
+        notifyClients([](auto& client) {
+            client.willRemove();
+        });
     }
 
     bool operator==(const TrackPrivateBase&) const;
@@ -80,8 +85,33 @@ public:
     WTFLogChannel& logChannel() const final;
 #endif
 
+    using Task = Function<void(TrackPrivateBaseClient&)>;
+    void notifyClients(Task&&);
+    void notifyMainThreadClient(Task&&);
+
 protected:
     TrackPrivateBase() = default;
+
+    template <typename T>
+    class Shared final : public ThreadSafeRefCounted<Shared<T>> {
+    public:
+        static Ref<Shared> create(T&& obj) { return adoptRef(*new Shared(WTFMove(obj))); }
+
+        T& get() { return m_obj; };
+    private:
+        Shared(T&& obj)
+            : m_obj(WTFMove(obj))
+        {
+        }
+        T m_obj;
+    };
+    using SharedDispatcher = Shared<TrackPrivateBaseClient::Dispatcher>;
+
+    bool hasClients() const;
+    bool hasOneClient() const;
+    mutable Lock m_lock;
+    using ClientRecord = std::tuple<RefPtr<SharedDispatcher>, WeakPtr<TrackPrivateBaseClient>, bool>;
+    Vector<ClientRecord> m_clients WTF_GUARDED_BY_LOCK(m_lock);
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;

--- a/Source/WebCore/platform/graphics/TrackPrivateBaseClient.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBaseClient.h
@@ -36,7 +36,12 @@ using TrackID = uint64_t;
 
 class TrackPrivateBaseClient : public CanMakeWeakPtr<TrackPrivateBaseClient> {
 public:
+    using Task = Function<void()>;
+    using Dispatcher = Function<void(Task&&)>;
+
     virtual ~TrackPrivateBaseClient() = default;
+    enum Type { Text, Audio, Video };
+    virtual constexpr Type type() const = 0;
     virtual void idChanged(TrackID) = 0;
     virtual void labelChanged(const AtomString&) = 0;
     virtual void languageChanged(const AtomString&) = 0;

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -38,17 +38,15 @@ struct VideoInfo;
 
 class VideoTrackPrivate : public TrackPrivateBase {
 public:
-    void setClient(VideoTrackPrivateClient& client) { m_client = client; }
-    void clearClient() { m_client = nullptr; }
-    VideoTrackPrivateClient* client() const override { return m_client.get(); }
-
     virtual void setSelected(bool selected)
     {
         if (m_selected == selected)
             return;
         m_selected = selected;
-        if (m_client)
-            m_client->selectedChanged(m_selected);
+        notifyClients([selected](auto& client) {
+            ASSERT(is<VideoTrackPrivateClient>(client));
+            downcast<VideoTrackPrivateClient>(client).selectedChanged(selected);
+        });
         if (m_selectedChangedCallback)
             m_selectedChangedCallback(*this, m_selected);
     }
@@ -70,8 +68,10 @@ public:
         if (configuration == m_configuration)
             return;
         m_configuration = WTFMove(configuration);
-        if (m_client)
-            m_client->configurationChanged(m_configuration);
+        notifyClients([configuration = m_configuration](auto& client) {
+            ASSERT(is<VideoTrackPrivateClient>(client));
+            downcast<VideoTrackPrivateClient>(client).configurationChanged(configuration);
+        });
     }
     
     bool operator==(const VideoTrackPrivate& track) const
@@ -89,7 +89,6 @@ protected:
     VideoTrackPrivate() = default;
 
 private:
-    WeakPtr<VideoTrackPrivateClient> m_client { nullptr };
     bool m_selected { false };
     PlatformVideoTrackConfiguration m_configuration;
 

--- a/Source/WebCore/platform/graphics/VideoTrackPrivateClient.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivateClient.h
@@ -35,10 +35,15 @@ struct PlatformVideoTrackConfiguration;
 
 class VideoTrackPrivateClient : public TrackPrivateBaseClient {
 public:
+    constexpr Type type() const final { return Type::Video; }
     virtual void selectedChanged(bool) = 0;
     virtual void configurationChanged(const PlatformVideoTrackConfiguration&) = 0;
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::VideoTrackPrivateClient)
+static bool isType(const WebCore::TrackPrivateBaseClient& track) { return track.type() == WebCore::TrackPrivateBaseClient::Type::Video; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
@@ -50,13 +50,14 @@ InbandChapterTrackPrivateAVFObjC::InbandChapterTrackPrivateAVFObjC(RetainPtr<NSL
 
 void InbandChapterTrackPrivateAVFObjC::processChapters(RetainPtr<NSArray<AVTimedMetadataGroup *>> chapters)
 {
-    if (!client())
+    if (!hasClients())
         return;
 
     auto identifier = LOGIDENTIFIER;
     auto createChapterCue = ([this, identifier] (AVMetadataItem *item, int chapterNumber) mutable {
-        if (!client())
+        if (!hasClients())
             return;
+        ASSERT(hasOneClient());
         ChapterData chapterData = { PAL::toMediaTime([item time]), PAL::toMediaTime([item duration]), [item stringValue] };
         if (m_processedChapters.contains(chapterData))
             return;
@@ -64,7 +65,10 @@ void InbandChapterTrackPrivateAVFObjC::processChapters(RetainPtr<NSArray<AVTimed
 
         ISOWebVTTCue cueData = ISOWebVTTCue(PAL::toMediaTime([item time]), PAL::toMediaTime([item duration]), AtomString::number(chapterNumber), [item stringValue]);
         INFO_LOG(identifier, "created cue ", cueData);
-        client()->parseWebVTTCueData(WTFMove(cueData));
+        notifyMainThreadClient([cueData = WTFMove(cueData)](TrackPrivateBaseClient& client) mutable {
+            ASSERT(is<InbandTextTrackPrivateClient>(client));
+            downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(WTFMove(cueData));
+        });
     });
 
     int chapterNumber = 0;

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -101,7 +101,9 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromTags(GRefPtr<GstTagList>
             m_trackID = *trackID;
             GST_DEBUG_OBJECT(objectForLogging(), "Audio track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_trackID);
             m_stringId = AtomString::number(static_cast<unsigned long long>(*m_trackID));
-            client()->idChanged(*m_trackID);
+            notifyClients([trackID = *m_trackID](auto& client) {
+                client.idChanged(trackID);
+            });
         }
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandMetadataTextTrackPrivateGStreamer.h
@@ -47,14 +47,21 @@ public:
 
     void addDataCue(const MediaTime& start, const MediaTime& end, const void* data, unsigned length)
     {
+        ASSERT(isMainThread());
         ASSERT(cueFormat() == CueFormat::Data);
-        client()->addDataCue(start, end, data, length);
+
+        notifyMainThreadClient([&](auto& client) {
+            downcast<InbandTextTrackPrivateClient>(client).addDataCue(start, end, data, length);
+        });
     }
 
     void addGenericCue(InbandGenericCue& data)
     {
+        ASSERT(isMainThread());
         ASSERT(cueFormat() == CueFormat::Generic);
-        client()->addGenericCue(data);
+        notifyMainThreadClient([&](auto& client) {
+            downcast<InbandTextTrackPrivateClient>(client).addGenericCue(data);
+        });
     }
 
 private:

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -102,7 +102,9 @@ void VideoTrackPrivateGStreamer::updateConfigurationFromTags(GRefPtr<GstTagList>
             m_trackID = *trackID;
             GST_DEBUG_OBJECT(objectForLogging(), "Video track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_trackID);
             m_stringId = AtomString::number(static_cast<unsigned long long>(*m_trackID));
-            client()->idChanged(*m_trackID);
+            notifyClients([trackID = *m_trackID](auto& client) {
+                client.idChanged(trackID);
+            });
         }
     }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
@@ -45,13 +45,16 @@ RemoteAudioTrackProxy::RemoteAudioTrackProxy(GPUConnectionToWebProcess& connecti
     , m_id(trackPrivate.id())
     , m_mediaPlayerIdentifier(mediaPlayerIdentifier)
 {
-    m_trackPrivate->setClient(*this);
+    m_clientId = trackPrivate.addClient([](auto&& task) {
+        ensureOnMainThread(WTFMove(task));
+    }, *this);
+
     m_connectionToWebProcess->connection().send(Messages::MediaPlayerPrivateRemote::AddRemoteAudioTrack(configuration()), m_mediaPlayerIdentifier);
 }
 
 RemoteAudioTrackProxy::~RemoteAudioTrackProxy()
 {
-    m_trackPrivate->clearClient();
+    m_trackPrivate->removeClient(m_clientId);
 }
 
 AudioTrackPrivateRemoteConfiguration RemoteAudioTrackProxy::configuration()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -47,7 +47,7 @@ struct AudioTrackPrivateRemoteConfiguration;
 
 class RemoteAudioTrackProxy final
     : public ThreadSafeRefCounted<RemoteAudioTrackProxy, WTF::DestructionThread::Main>
-    , private WebCore::AudioTrackPrivateClient {
+    , public WebCore::AudioTrackPrivateClient {
 public:
     static Ref<RemoteAudioTrackProxy> create(GPUConnectionToWebProcess& connectionToWebProcess, WebCore::AudioTrackPrivate& trackPrivate, WebCore::MediaPlayerIdentifier mediaPlayerIdentifier)
     {
@@ -85,6 +85,7 @@ private:
     WebCore::TrackID m_id;
     WebCore::MediaPlayerIdentifier m_mediaPlayerIdentifier;
     bool m_enabled { false };
+    size_t m_clientId { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -48,13 +48,15 @@ RemoteTextTrackProxy::RemoteTextTrackProxy(GPUConnectionToWebProcess& connection
     , m_id(trackPrivate.id())
     , m_mediaPlayerIdentifier(mediaPlayerIdentifier)
 {
-    m_trackPrivate->setClient(*this);
+    m_clientId = trackPrivate.addClient([](auto&& task) {
+        ensureOnMainThread(WTFMove(task));
+    }, *this);
     m_connectionToWebProcess->connection().send(Messages::MediaPlayerPrivateRemote::AddRemoteTextTrack(configuration()), m_mediaPlayerIdentifier);
 }
 
 RemoteTextTrackProxy::~RemoteTextTrackProxy()
 {
-    m_trackPrivate->clearClient();
+    m_trackPrivate->removeClient(m_clientId);
 }
 
 TextTrackPrivateRemoteConfiguration& RemoteTextTrackProxy::configuration()

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -93,6 +93,7 @@ private:
     Ref<WebCore::InbandTextTrackPrivate> m_trackPrivate;
     WebCore::TrackID m_id;
     WebCore::MediaPlayerIdentifier m_mediaPlayerIdentifier;
+    size_t m_clientId { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
@@ -45,13 +45,15 @@ RemoteVideoTrackProxy::RemoteVideoTrackProxy(GPUConnectionToWebProcess& connecti
     , m_id(trackPrivate.id())
     , m_mediaPlayerIdentifier(mediaPlayerIdentifier)
 {
-    m_trackPrivate->setClient(*this);
+    m_clientRegistrationId = trackPrivate.addClient([](auto&& task) {
+        ensureOnMainThread(WTFMove(task));
+    }, *this);
     m_connectionToWebProcess->connection().send(Messages::MediaPlayerPrivateRemote::AddRemoteVideoTrack(configuration()), m_mediaPlayerIdentifier);
 }
 
 RemoteVideoTrackProxy::~RemoteVideoTrackProxy()
 {
-    m_trackPrivate->clearClient();
+    m_trackPrivate->removeClient(m_clientRegistrationId);
 }
 
 VideoTrackPrivateRemoteConfiguration RemoteVideoTrackProxy::configuration()

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -85,6 +85,7 @@ private:
     WebCore::TrackID m_id;
     WebCore::MediaPlayerIdentifier m_mediaPlayerIdentifier;
     bool m_selected { false };
+    size_t m_clientRegistrationId { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h
@@ -35,9 +35,9 @@ namespace WebKit {
 
 struct TextTrackPrivateRemoteConfiguration {
     WebCore::TrackID trackId;
-    AtomString label;
-    AtomString language;
-    AtomString inBandMetadataTrackDispatchType;
+    String label;
+    String language;
+    String inBandMetadataTrackDispatchType;
     MediaTime startTimeVariance { MediaTime::zeroTime() };
     int trackIndex;
 

--- a/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
@@ -24,9 +24,9 @@
 
 struct WebKit::TextTrackPrivateRemoteConfiguration {
     WebCore::TrackID trackId;
-    AtomString label;
-    AtomString language;
-    AtomString inBandMetadataTrackDispatchType;
+    String label;
+    String language;
+    String inBandMetadataTrackDispatchType;
     MediaTime startTimeVariance;
     int trackIndex;
 

--- a/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h
@@ -34,8 +34,8 @@ namespace WebKit {
 
 struct TrackPrivateRemoteConfiguration {
     WebCore::TrackID trackId;
-    AtomString label;
-    AtomString language;
+    String label;
+    String language;
     MediaTime startTimeVariance { MediaTime::zeroTime() };
     int trackIndex;
 };

--- a/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in
@@ -24,8 +24,8 @@
 
 struct WebKit::TrackPrivateRemoteConfiguration {
     WebCore::TrackID trackId;
-    AtomString label;
-    AtomString language;
+    String label;
+    String language;
     MediaTime startTimeVariance;
     int trackIndex;
 }

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
@@ -53,8 +53,8 @@ private:
 
     using AudioTrackKind = WebCore::AudioTrackPrivate::Kind;
     AudioTrackKind kind() const final { return m_kind; }
-    AtomString label() const final { return m_label; }
-    AtomString language() const final { return m_language; }
+    AtomString label() const final { return AtomString { m_label }; }
+    AtomString language() const final { return AtomString { m_language }; }
     int trackIndex() const final { return m_trackIndex; }
     void setEnabled(bool) final;
     MediaTime startTimeVariance() const final { return m_startTimeVariance; }
@@ -62,8 +62,8 @@ private:
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     AudioTrackKind m_kind { AudioTrackKind::None };
     WebCore::TrackID m_id;
-    AtomString m_label;
-    AtomString m_language;
+    String m_label;
+    String m_language;
     int m_trackIndex { -1 };
 
     MediaTime m_startTimeVariance { MediaTime::zeroTime() };

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -32,6 +32,7 @@
 #include "GPUProcessConnection.h"
 #include "MediaPlayerPrivateRemote.h"
 #include "RemoteMediaPlayerProxyMessages.h"
+#include <wtf/CrossThreadCopier.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -62,22 +63,29 @@ void TextTrackPrivateRemote::updateConfiguration(TextTrackPrivateRemoteConfigura
 {
     if (configuration.trackId != m_id) {
         m_id = configuration.trackId;
-        if (client())
-            client()->idChanged(m_id);
+        notifyClients([id = m_id](auto& client) {
+            client.idChanged(id);
+        });
     }
 
     if (configuration.label != m_label) {
         auto changed = !m_label.isEmpty();
         m_label = configuration.label;
-        if (changed && client())
-            client()->labelChanged(m_label);
+        if (changed) {
+            notifyClients([label = crossThreadCopy(m_label)](auto& client) {
+                client.labelChanged(AtomString { label });
+            });
+        }
     }
 
     if (configuration.language != m_language) {
         auto changed = !m_language.isEmpty();
         m_language = configuration.language;
-        if (changed && client())
-            client()->languageChanged(m_language);
+        if (changed) {
+            notifyClients([language = crossThreadCopy(m_language)](auto& client) {
+                client.languageChanged(AtomString { language });
+            });
+        }
     }
 
     m_trackIndex = configuration.trackIndex;
@@ -95,73 +103,83 @@ void TextTrackPrivateRemote::updateConfiguration(TextTrackPrivateRemoteConfigura
 
 void TextTrackPrivateRemote::addGenericCue(Ref<InbandGenericCue> cue)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->addGenericCue(cue);
+    ASSERT(hasClients());
+    notifyClients([cue](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).addGenericCue(cue);
+    });
 }
 
 void TextTrackPrivateRemote::updateGenericCue(Ref<InbandGenericCue> cue)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->updateGenericCue(cue);
+    ASSERT(hasClients());
+    notifyClients([cue](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).updateGenericCue(cue);
+    });
 }
 
 void TextTrackPrivateRemote::removeGenericCue(Ref<InbandGenericCue> cue)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->removeGenericCue(cue);
+    ASSERT(hasClients());
+    notifyClients([cue](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).removeGenericCue(cue);
+    });
 }
 
 void TextTrackPrivateRemote::parseWebVTTFileHeader(String&& header)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->parseWebVTTFileHeader(WTFMove(header));
+    ASSERT(hasOneClient());
+    notifyMainThreadClient([&](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).parseWebVTTFileHeader(WTFMove(header));
+    });
 }
 
 void TextTrackPrivateRemote::parseWebVTTCueData(std::span<const uint8_t> data)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->parseWebVTTCueData(data.data(), data.size());
+    ASSERT(hasOneClient());
+    notifyMainThreadClient([&](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(data.data(), data.size());
+    });
 }
 
 void TextTrackPrivateRemote::parseWebVTTCueDataStruct(ISOWebVTTCue&& cueData)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->parseWebVTTCueData(WTFMove(cueData));
+    ASSERT(hasOneClient());
+    notifyMainThreadClient([&](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(WTFMove(cueData));
+    });
 }
 
 void TextTrackPrivateRemote::addDataCue(MediaTime&& start, MediaTime&& end, std::span<const uint8_t> data)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->addDataCue(WTFMove(start), WTFMove(end), data.data(), data.size());
+    ASSERT(hasOneClient());
+    notifyMainThreadClient([&](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).addDataCue(WTFMove(start), WTFMove(end), data.data(), data.size());
+    });
 }
 
 #if ENABLE(DATACUE_VALUE)
 void TextTrackPrivateRemote::addDataCueWithType(MediaTime&& start, MediaTime&& end, SerializedPlatformDataCueValue&& dataValue, String&& type)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->addDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)), type);
+    ASSERT(hasOneClient());
+    notifyMainThreadClient([&](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).addDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)), type);
+    });
 }
 
 void TextTrackPrivateRemote::updateDataCue(MediaTime&& start, MediaTime&& end, SerializedPlatformDataCueValue&& dataValue)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->updateDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)));
+    ASSERT(hasOneClient());
+    notifyMainThreadClient([&](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).updateDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)));
+    });
 }
 
 void TextTrackPrivateRemote::removeDataCue(MediaTime&& start, MediaTime&& end, SerializedPlatformDataCueValue&& dataValue)
 {
-    ASSERT(client());
-    if (auto* client = this->client())
-        client->removeDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)));
+    ASSERT(hasOneClient());
+    notifyMainThreadClient([&](auto& client) {
+        downcast<InbandTextTrackPrivateClient>(client).removeDataCue(WTFMove(start), WTFMove(end), WebCore::SerializedPlatformDataCue::create(WTFMove(dataValue)));
+    });
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
@@ -73,10 +73,10 @@ public:
     void updateConfiguration(TextTrackPrivateRemoteConfiguration&&);
 
     WebCore::TrackID id() const final { return m_id; }
-    AtomString label() const final { return m_label; }
-    AtomString language() const final { return m_language; }
+    AtomString label() const final { return AtomString { m_label }; }
+    AtomString language() const final { return AtomString { m_language }; }
     int trackIndex() const final { return m_trackIndex; }
-    AtomString inBandMetadataTrackDispatchType() const final { return m_inBandMetadataTrackDispatchType; }
+    AtomString inBandMetadataTrackDispatchType() const final { return AtomString { m_inBandMetadataTrackDispatchType }; }
 
     using TextTrackKind = WebCore::InbandTextTrackPrivate::Kind;
     TextTrackKind kind() const final { return m_kind; }
@@ -96,10 +96,10 @@ private:
     TextTrackPrivateRemote(GPUProcessConnection&, WebCore::MediaPlayerIdentifier, TextTrackPrivateRemoteConfiguration&&);
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
-    AtomString m_label;
-    AtomString m_language;
+    String m_label;
+    String m_language;
     int m_trackIndex { -1 };
-    AtomString m_inBandMetadataTrackDispatchType;
+    String m_inBandMetadataTrackDispatchType;
     MediaTime m_startTimeVariance { MediaTime::zeroTime() };
     WebCore::TrackID m_id;
     WebCore::MediaPlayerIdentifier m_playerIdentifier;

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
@@ -33,6 +33,7 @@
 #include "MediaPlayerPrivateRemote.h"
 #include "RemoteMediaPlayerProxyMessages.h"
 #include "VideoTrackPrivateRemoteConfiguration.h"
+#include <wtf/CrossThreadCopier.h>
 
 namespace WebKit {
 
@@ -60,22 +61,29 @@ void VideoTrackPrivateRemote::updateConfiguration(VideoTrackPrivateRemoteConfigu
 {
     if (configuration.trackId != m_id) {
         m_id = configuration.trackId;
-        if (client())
-            client()->idChanged(m_id);
+        notifyClients([id = m_id](auto& client) {
+            client.idChanged(id);
+        });
     }
 
     if (configuration.label != m_label) {
         auto changed = !m_label.isEmpty();
         m_label = configuration.label;
-        if (changed && client())
-            client()->labelChanged(m_label);
+        if (changed && hasClients()) {
+            notifyClients([label = crossThreadCopy(m_label)](auto& client) {
+                client.labelChanged(AtomString { label });
+            });
+        }
     }
 
     if (configuration.language != m_language) {
         auto changed = !m_language.isEmpty();
         m_language = configuration.language;
-        if (changed && client())
-            client()->languageChanged(m_language);
+        if (changed && hasClients()) {
+            notifyClients([language = crossThreadCopy(m_language)](auto& client) {
+                client.languageChanged(AtomString { language });
+            });
+        }
     }
 
     m_trackIndex = configuration.trackIndex;

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
@@ -51,8 +51,8 @@ public:
     using VideoTrackKind = WebCore::VideoTrackPrivate::Kind;
     VideoTrackKind kind() const final { return m_kind; }
     WebCore::TrackID id() const final { return m_id; }
-    AtomString label() const final { return m_label; }
-    AtomString language() const final { return m_language; }
+    AtomString label() const final { return AtomString { m_label }; }
+    AtomString language() const final { return AtomString { m_language }; }
     int trackIndex() const final { return m_trackIndex; }
     MediaTime startTimeVariance() const final { return m_startTimeVariance; }
 
@@ -63,8 +63,8 @@ private:
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     VideoTrackKind m_kind { VideoTrackKind::None };
-    AtomString m_label;
-    AtomString m_language;
+    String m_label;
+    String m_language;
     int m_trackIndex { -1 };
     MediaTime m_startTimeVariance { MediaTime::zeroTime() };
     WebCore::TrackID m_id;


### PR DESCRIPTION
#### de9e3d6bc4880dab143d3f4e3643adf588078dd9
<pre>
[MSE] `ASSERT(canSafelyBeUsed());` ASSERTION when using webm with MSE in a worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=269638">https://bugs.webkit.org/show_bug.cgi?id=269638</a>
<a href="https://rdar.apple.com/123134428">rdar://123134428</a>

Reviewed by Eric Carlson.

With a MediaSource running in a DedicatedWorker, a TrackPrivate may be referenced by two Tracks:
- The canonical track living in the SourceBuffer
- Its mirror that is sent to the HTMLMediaElement on the main thread.

The interface between the Track and the TrackPrivate is done via the TrackPrivateBaseClient
which inherit from CanMakeWeakPtr. A WeakPtr was used to store the TrackPrivateClient
in the TrackPrivate.
As the TrackPrivate could only track one client, it was the last caller to TrackPrivate::setClient
that won. So you could end up having the TrackPrivate attempting to use the WeakPtr created on the
worker thread while the TrackPrivate is being used in the main thread.

We add support for multiple clients, and to ensure that the client will only ever be called
on the right thread, TrackPrivate::addClient now takes a dispatcher that will ensure the
task to run and the WeakPtr will always be accessed on the right thread.
TrackPrivate::addClient|removeClient are thread safe.

Previously, {Audio|Video|InbandTrack}PrivateTrack each managed their respective client.
We move the logic to the base TrackPrivateBase class to remove mostly duplicated code.

Move semantics with the client&apos;s callback is no longer possible, this is fine for
Audio and Video tracks as their message is only to enable/select them; however for
InbandTextTrack it becomes problematic as the WebVTT parser API and Cues all require
move semantics.
However, InbandTextTracks aren&apos;t currently supported with our MediaSource implementation
(no User-Agent does), so there will only ever be one client to those tracks, and the
client will be running in the main thread.
We add assertions for methods were moved semantics is required, and to prevent unexpected
failures, only the first client will be called, and only if on the main thread.

The Remote{Audio|Video|InbandText}PrivateTrack which are the only tracks used when MSE in
a worker is active, were using AtomString which can&apos;t be transferred across thread.
We change the type of their strings from AtomString to String, and ensure that
the string copied are isolated copies.

For non-MSE, no change in observable behaviour.
A test will be added in a follow-up change: <a href="https://webkit.org/b/269564)">https://webkit.org/b/269564)</a>

* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::AudioTrack):
(WebCore::AudioTrack::~AudioTrack):
(WebCore::AudioTrack::setPrivate):
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::InbandTextTrack):
(WebCore::InbandTextTrack::~InbandTextTrack):
(WebCore::InbandTextTrack::setPrivate):
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::addClientToTrackPrivateBase):
(WebCore::TrackBase::removeClientFromTrackPrivateBase):
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::VideoTrack):
(WebCore::VideoTrack::~VideoTrack):
(WebCore::VideoTrack::setPrivate):
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
(WebCore::AudioTrackPrivate::setEnabled):
(WebCore::AudioTrackPrivate::setConfiguration):
(WebCore::AudioTrackPrivate::setClient): Deleted.
(WebCore::AudioTrackPrivate::clearClient): Deleted.
* Source/WebCore/platform/graphics/AudioTrackPrivateClient.h:
(isType):
* Source/WebCore/platform/graphics/InbandTextTrackPrivate.h:
(WebCore::InbandTextTrackPrivate::setClient): Deleted.
(WebCore::InbandTextTrackPrivate::clearClient): Deleted.
* Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h:
(isType):
* Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
(WebCore::TrackPrivateBase::notifyClients):
(WebCore::TrackPrivateBase::notifyMainThreadClient):
(WebCore::TrackPrivateBase::addClient):
(WebCore::TrackPrivateBase::removeClient):
(WebCore::TrackPrivateBase::hasClients const):
(WebCore::TrackPrivateBase::hasOneClient const):
* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/TrackPrivateBaseClient.h:
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
(WebCore::VideoTrackPrivate::setSelected):
(WebCore::VideoTrackPrivate::setConfiguration):
(WebCore::VideoTrackPrivate::setClient): Deleted.
(WebCore::VideoTrackPrivate::clearClient): Deleted.
* Source/WebCore/platform/graphics/VideoTrackPrivateClient.h:
(isType):
* Source/WebCore/platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp:
(WebCore::InbandMetadataTextTrackPrivateAVF::addDataCue):
(WebCore::InbandMetadataTextTrackPrivateAVF::updatePendingCueEndTimes):
(WebCore::InbandMetadataTextTrackPrivateAVF::flushPartialCues):
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processCue):
(WebCore::InbandTextTrackPrivateAVF::processAttributedStrings):
(WebCore::InbandTextTrackPrivateAVF::removeCompletedCues):
(WebCore::InbandTextTrackPrivateAVF::resetCueValues):
(WebCore::InbandTextTrackPrivateAVF::processNativeSamples):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm:
(WebCore::InbandChapterTrackPrivateAVFObjC::processChapters):
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromTags):
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp:
(WebCore::InbandTextTrackPrivateGStreamer::tagsChanged):
(WebCore::InbandTextTrackPrivateGStreamer::notifyTrackOfSample):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromTags):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp:
(WebKit::RemoteAudioTrackProxy::RemoteAudioTrackProxy):
(WebKit::RemoteAudioTrackProxy::~RemoteAudioTrackProxy):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
(WebKit::RemoteTextTrackProxy::RemoteTextTrackProxy):
(WebKit::RemoteTextTrackProxy::~RemoteTextTrackProxy):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp:
(WebKit::RemoteVideoTrackProxy::RemoteVideoTrackProxy):
(WebKit::RemoteVideoTrackProxy::~RemoteVideoTrackProxy):
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:
* Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h:
* Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in: Change data type to AtomString
* Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h:
* Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in: Change data type to AtomString
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp:
(WebKit::AudioTrackPrivateRemote::updateConfiguration):
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp:
(WebKit::TextTrackPrivateRemote::updateConfiguration):
(WebKit::TextTrackPrivateRemote::addGenericCue):
(WebKit::TextTrackPrivateRemote::updateGenericCue):
(WebKit::TextTrackPrivateRemote::removeGenericCue):
(WebKit::TextTrackPrivateRemote::parseWebVTTFileHeader):
(WebKit::TextTrackPrivateRemote::parseWebVTTCueData):
(WebKit::TextTrackPrivateRemote::parseWebVTTCueDataStruct):
(WebKit::TextTrackPrivateRemote::addDataCue):
(WebKit::TextTrackPrivateRemote::addDataCueWithType):
(WebKit::TextTrackPrivateRemote::updateDataCue):
(WebKit::TextTrackPrivateRemote::removeDataCue):
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp:
(WebKit::VideoTrackPrivateRemote::updateConfiguration):
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/274956@main">https://commits.webkit.org/274956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be3ba6d538d0d3f425a3c27ad1f8bbd40c18e3fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33568 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39921 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38222 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16894 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9074 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->