### PR TITLE
Revert 274308@main - Broke discord.com login button

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt
@@ -1,5 +1,5 @@
 
-PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGPathElement
+FAIL When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGPathElement assert_throws_dom: function "function() { pathElement.getPointAtLength(700) }" did not throw
 PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGRectElement
 PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGCircleElement
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
@@ -1,15 +1,15 @@
 
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none The current element is a non-rendered element.
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style The current element is a non-rendered element.
+PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style assert_approx_equals: expected 50 +/- 0.00001 but got 0
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none The current element is a non-rendered element.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none The object is in an invalid state.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: none The current element is a non-rendered element.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: none The object is in an invalid state.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: none The current element is a non-rendered element.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: none The object is in an invalid state.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: none The current element is a non-rendered element.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: none The object is in an invalid state.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: none The current element is a non-rendered element.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: none The object is in an invalid state.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
-PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: none and an empty path
+FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: none and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
 FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: none and an empty path
 FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, circle with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw

--- a/LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html
+++ b/LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html
@@ -6,8 +6,8 @@ if (window.testRunner)
 
 function go() {
     var oSVGPolygon = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
-    var svgRoot = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    var oSVGPoint1 = svgRoot.createSVGPoint();
+    var oSVGPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    var oSVGPoint1 = oSVGPath.getPointAtLength(0);
     oSVGPolygon.points.initialize(oSVGPoint1);
     oSVGPolygon.points.removeItem(-9223372036854775802);
     alert("Accessing old oSVGPoint1.x: " + oSVGPoint1.x);

--- a/LayoutTests/svg/dom/path-pointAtLength-expected.txt
+++ b/LayoutTests/svg/dom/path-pointAtLength-expected.txt
@@ -3,10 +3,10 @@ This tests getPointAtLength of SVG path.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS pointAtLengthOfPath('M0,20 L400,20 L640,20') threw exception InvalidStateError: The current element is a non-rendered element..
-PASS pointAtLengthOfPath('M0,20 L400,20 L640,20 z') threw exception InvalidStateError: The current element is a non-rendered element..
-PASS pointAtLengthOfPath('M0,20 L400,20 z M 320,20 L640,20') threw exception InvalidStateError: The current element is a non-rendered element..
-PASS pointAtLengthOfPath('M0,20 L20,40') threw exception InvalidStateError: The current element is a non-rendered element..
+PASS pointAtLengthOfPath('M0,20 L400,20 L640,20') is '(640, 20)'
+PASS pointAtLengthOfPath('M0,20 L400,20 L640,20 z') is '(580, 20)'
+PASS pointAtLengthOfPath('M0,20 L400,20 z M 320,20 L640,20') is '(100, 20)'
+PASS pointAtLengthOfPath('M0,20 L20,40') is '(20, 40)'
 PASS pathElement.getPointAtLength(Math.NaN) threw exception TypeError: The provided value is non-finite.
 PASS pathElement.getPointAtLength() threw exception TypeError: Not enough arguments.
 PASS pathElement.getPointAtLength(Math.Infinity) threw exception TypeError: The provided value is non-finite.

--- a/LayoutTests/svg/dom/path-pointAtLength.html
+++ b/LayoutTests/svg/dom/path-pointAtLength.html
@@ -18,10 +18,10 @@ function pointAtLengthOfPath(string) {
     return "(" + Math.round(point.x) + ", " + Math.round(point.y) + ")";
 }
 
-shouldThrow("pointAtLengthOfPath('M0,20 L400,20 L640,20')");
-shouldThrow("pointAtLengthOfPath('M0,20 L400,20 L640,20 z')");
-shouldThrow("pointAtLengthOfPath('M0,20 L400,20 z M 320,20 L640,20')");
-shouldThrow("pointAtLengthOfPath('M0,20 L20,40')");
+shouldBe("pointAtLengthOfPath('M0,20 L400,20 L640,20')", "'(640, 20)'");
+shouldBe("pointAtLengthOfPath('M0,20 L400,20 L640,20 z')", "'(580, 20)'");
+shouldBe("pointAtLengthOfPath('M0,20 L400,20 z M 320,20 L640,20')", "'(100, 20)'");
+shouldBe("pointAtLengthOfPath('M0,20 L20,40')", "'(20, 40)'");
 shouldThrow("pathElement.getPointAtLength(Math.NaN)");
 shouldThrow("pathElement.getPointAtLength()");
 shouldThrow("pathElement.getPointAtLength(Math.Infinity)");

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -76,7 +76,7 @@ ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) 
     auto* renderer = this->renderer();
     // Spec: If current element is a non-rendered element, throw an InvalidStateError.
     if (!renderer)
-        return Exception { ExceptionCode::InvalidStateError, "The current element is a non-rendered element."_s };
+        return Exception { ExceptionCode::InvalidStateError };
 
     // Spec: Return a newly created, detached SVGPoint object.
     if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -180,14 +180,8 @@ float SVGPathElement::getTotalLength() const
 
 ExceptionOr<Ref<SVGPoint>> SVGPathElement::getPointAtLength(float distance) const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
-
     // Spec: Clamp distance to [0, length].
     distance = clampTo<float>(distance, 0, getTotalLength());
-
-    // Spec: If current element is a non-rendered element, throw an InvalidStateError.
-    if (!renderer())
-        return Exception { ExceptionCode::InvalidStateError, "The current element is a non-rendered element."_s };
 
     // Spec: Return a newly created, detached SVGPoint object.
     return SVGPoint::create(getPointAtLengthOfSVGPathByteStream(pathByteStream(), distance));


### PR DESCRIPTION
#### 5b92efd47caab72297ba516a095b517d629bb56b
<pre>
Revert 274308@main - Broke discord.com login button

<a href="https://bugs.webkit.org/show_bug.cgi?id=269647">https://bugs.webkit.org/show_bug.cgi?id=269647</a>

Reviewed by Simon Fraser.

This patch reverts 274308@main as title states manually.

&gt; Reverted Changes:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt:
* LayoutTests/svg/dom/path-pointAtLength-expected.txt:
* LayoutTests/svg/dom/path-pointAtLength.html:
* LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html:
* Source/WebCore/svg/SVGGeometryElement.cpp:
(SVGGeometryElement::getPointAtLength):
* Source/WebCore/svg/SVGPathElement.cpp:
(SVGPathElement::getPointAtLength):

Canonical link: <a href="https://commits.webkit.org/274929@main">https://commits.webkit.org/274929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/766f97c9a608405ee3a092e4be348adba434a76b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42967 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16761 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33529 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16385 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14178 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44243 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36646 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39882 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15235 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16854 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/35100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16903 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5354 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->