### PR TITLE
Crash under SQLiteDatabase::~SQLiteDatabase

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -28,12 +28,13 @@
 
 #include <functional>
 #include <sqlite3.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Expected.h>
 #include <wtf/Lock.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Threading.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
@@ -49,7 +50,7 @@ class DatabaseAuthorizer;
 class SQLiteStatement;
 class SQLiteTransaction;
 
-class SQLiteDatabase : public CanMakeThreadSafeCheckedPtr {
+class SQLiteDatabase : public CanMakeWeakPtr<SQLiteDatabase>, public CanMakeThreadSafeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(SQLiteDatabase);
     friend class SQLiteTransaction;

--- a/Source/WebCore/platform/sql/SQLiteStatement.h
+++ b/Source/WebCore/platform/sql/SQLiteStatement.h
@@ -28,7 +28,7 @@
 #include "SQLValue.h"
 #include "SQLiteDatabase.h"
 #include <span>
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 struct sqlite3_stmt;
 
@@ -93,7 +93,7 @@ private:
     template<typename T, typename... Args> bool bindImpl(int i, T first, Args&&... args);
     template<typename T> bool bindImpl(int, T);
 
-    CheckedRef<SQLiteDatabase> m_database;
+    WeakRef<SQLiteDatabase> m_database;
     sqlite3_stmt* m_statement;
 };
 

--- a/Source/WebCore/platform/sql/SQLiteTransaction.h
+++ b/Source/WebCore/platform/sql/SQLiteTransaction.h
@@ -26,9 +26,9 @@
 #ifndef SQLiteTransaction_h
 #define SQLiteTransaction_h
 
-#include <wtf/CheckedRef.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -51,7 +51,7 @@ public:
     SQLiteDatabase& database() const { return m_db.get(); }
 
 private:
-    CheckedRef<SQLiteDatabase> m_db;
+    WeakRef<SQLiteDatabase> m_db;
     bool m_inProgress;
     bool m_readOnly;
 };

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -455,9 +455,8 @@ bool SQLiteStorageArea::handleDatabaseCorruptionIfNeeded(int databaseError)
     if (databaseError != SQLITE_CORRUPT && databaseError != SQLITE_NOTADB)
         return false;
 
-    m_database = nullptr;
-    m_cache = std::nullopt;
-    m_cacheSize = std::nullopt;
+    close();
+
     RELEASE_LOG(Storage, "SQLiteStorageArea::handleDatabaseCorruption deletes corrupted database file '%s'", m_path.utf8().data());
     WebCore::SQLiteFileSystem::deleteDatabaseFile(m_path);
     return true;


### PR DESCRIPTION
#### f6305e2e3567e25d0565bf39f66c00433c3252a0
<pre>
Crash under SQLiteDatabase::~SQLiteDatabase
<a href="https://bugs.webkit.org/show_bug.cgi?id=269648">https://bugs.webkit.org/show_bug.cgi?id=269648</a>
<a href="https://rdar.apple.com/123160407">rdar://123160407</a>

Reviewed by David Kilzer.

The crash was occurring because SQLiteStorageArea::handleDatabaseCorruptionIfNeeded()
was destroying the SQLiteDatabase object (m_database) but was failing to destroy the
potential transaction (m_transaction) and cached statements (m_cachedStatements), all
of which have a CheckedRef pointing to the database.

Update handleDatabaseCorruptionIfNeeded() to call close(), which clears m_cache,
m_cacheSize, m_transaction, m_cachedStatements and m_database.

Also update SQLiteStatement / SQLiteTransaction to keep a WeakRef to the database
instead of a CheckedRef, as per our updated smart pointer guidelines. Using
CheckedPtr/CheckedRef for database members is no longer recommended.

* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebCore/platform/sql/SQLiteStatement.h:
* Source/WebCore/platform/sql/SQLiteTransaction.h:
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::handleDatabaseCorruptionIfNeeded):

Canonical link: <a href="https://commits.webkit.org/274937@main">https://commits.webkit.org/274937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28be005bf19c7eebf6a8fb0a8d44e5250d5ac083

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16765 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33533 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39886 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38172 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16907 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5360 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->