### PR TITLE
[Skia] Cleanup / refactor AcceleratedBufferPool

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -12,6 +12,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/graphics/skia/GraphicsContextSkia.h
     platform/graphics/skia/ImageBufferSkiaBackend.h
+    platform/graphics/skia/SkiaAcceleratedBufferPool.h
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h
 )

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -46,6 +46,7 @@ platform/graphics/skia/PathSkia.cpp
 platform/graphics/skia/PatternSkia.cpp
 platform/graphics/skia/PlatformDisplaySkia.cpp
 platform/graphics/skia/ShareableBitmapSkia.cpp
+platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp
 platform/graphics/skia/SkiaHarfBuzzFontCache.cpp
 

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "SkiaAcceleratedBufferPool.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "GLContext.h"
+#include "PlatformDisplay.h"
+#include <skia/gpu/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
+#include <skia/gpu/gl/GrGLInterface.h>
+#include <skia/gpu/gl/GrGLTypes.h>
+
+namespace WebCore {
+
+SkiaAcceleratedBufferPool::SkiaAcceleratedBufferPool()
+    : m_releaseUnusedBuffersTimer(RunLoop::main(), this, &SkiaAcceleratedBufferPool::releaseUnusedBuffersTimerFired)
+{
+}
+
+SkiaAcceleratedBufferPool::~SkiaAcceleratedBufferPool()
+{
+    if (m_buffers.isEmpty())
+        return;
+
+    auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
+    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+    m_buffers.clear();
+}
+
+Ref<Nicosia::Buffer> SkiaAcceleratedBufferPool::acquireBuffer(const IntSize& size, bool supportsAlpha)
+{
+    Entry* selectedEntry = std::find_if(m_buffers.begin(), m_buffers.end(), [&](Entry& entry) {
+        return entry.m_buffer->refCount() == 1 && entry.m_buffer->size() == size && entry.m_buffer->supportsAlpha() == supportsAlpha;
+    });
+
+    if (selectedEntry == m_buffers.end()) {
+        m_buffers.append(Entry(createAcceleratedBuffer(size, supportsAlpha)));
+        selectedEntry = &m_buffers.last();
+    }
+
+    scheduleReleaseUnusedBuffers();
+    selectedEntry->markIsInUse();
+    return selectedEntry->m_buffer.copyRef();
+}
+
+Ref<Nicosia::Buffer> SkiaAcceleratedBufferPool::createAcceleratedBuffer(const IntSize& size, bool supportsAlpha)
+{
+    auto* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+    auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height());
+    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, nullptr);
+    return Nicosia::AcceleratedBuffer::create(WTFMove(surface), supportsAlpha ? Nicosia::Buffer::SupportsAlpha : Nicosia::Buffer::NoFlags);
+}
+
+void SkiaAcceleratedBufferPool::scheduleReleaseUnusedBuffers()
+{
+    if (m_releaseUnusedBuffersTimer.isActive())
+        return;
+
+    static const Seconds releaseUnusedBuffersTimerInterval { 500_ms };
+    m_releaseUnusedBuffersTimer.startOneShot(releaseUnusedBuffersTimerInterval);
+}
+
+void SkiaAcceleratedBufferPool::releaseUnusedBuffersTimerFired()
+{
+    if (m_buffers.isEmpty())
+        return;
+
+    // Delete entries, which have been unused in releaseUnusedSecondsTolerance.
+    static const Seconds releaseUnusedSecondsTolerance { 3_s };
+    MonotonicTime minUsedTime = MonotonicTime::now() - releaseUnusedSecondsTolerance;
+
+    {
+        auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
+        GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+        m_buffers.removeAllMatching([&minUsedTime](const Entry& entry) {
+            return entry.canBeReleased(minUsedTime);
+        });
+    }
+
+    if (!m_buffers.isEmpty())
+        scheduleReleaseUnusedBuffers();
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "NicosiaBuffer.h"
+#include <wtf/FastMalloc.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/RunLoop.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class SkiaAcceleratedBufferPool {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(SkiaAcceleratedBufferPool);
+public:
+    SkiaAcceleratedBufferPool();
+    ~SkiaAcceleratedBufferPool();
+
+    Ref<Nicosia::Buffer> acquireBuffer(const IntSize&, bool supportsAlpha);
+
+private:
+    struct Entry {
+        explicit Entry(Ref<Nicosia::Buffer>&& buffer)
+            : m_buffer(WTFMove(buffer))
+        {
+        }
+
+        void markIsInUse() { m_lastUsedTime = MonotonicTime::now(); }
+        bool canBeReleased (MonotonicTime minUsedTime) const { return m_lastUsedTime < minUsedTime && m_buffer->refCount() == 1; }
+
+        Ref<Nicosia::Buffer> m_buffer;
+        MonotonicTime m_lastUsedTime;
+    };
+
+    Ref<Nicosia::Buffer> createAcceleratedBuffer(const IntSize&, bool supportsAlpha);
+    void scheduleReleaseUnusedBuffers();
+
+    void releaseUnusedBuffersTimerFired();
+
+    Vector<Entry> m_buffers;
+    RunLoop::Timer m_releaseUnusedBuffersTimer;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -40,6 +40,7 @@
 #if USE(SKIA)
 namespace WebCore {
 class BitmapTexture;
+class SkiaAcceleratedBufferPool;
 }
 #endif
 
@@ -60,6 +61,8 @@ public:
     virtual void attachLayer(CoordinatedGraphicsLayer*) = 0;
 #if USE(CAIRO)
     virtual Nicosia::PaintingEngine& paintingEngine() = 0;
+#elif USE(SKIA)
+    virtual SkiaAcceleratedBufferPool* skiaAcceleratedBufferPool() const = 0;
 #endif
     virtual RefPtr<Nicosia::ImageBackingStore> imageBackingStore(uint64_t, Function<RefPtr<Nicosia::Buffer>()>) = 0;
 };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -49,6 +49,7 @@ namespace WebCore {
 class GraphicsContext;
 class GraphicsLayer;
 class Image;
+class SkiaAcceleratedBufferPool;
 }
 
 namespace WebKit {
@@ -97,6 +98,8 @@ private:
     void attachLayer(WebCore::CoordinatedGraphicsLayer*) override;
 #if USE(CAIRO)
     Nicosia::PaintingEngine& paintingEngine() override;
+#elif USE(SKIA)
+    SkiaAcceleratedBufferPool* skiaAcceleratedBufferPool() const override { return m_skiaAcceleratedBufferPool.get(); }
 #endif
     RefPtr<Nicosia::ImageBackingStore> imageBackingStore(uint64_t, Function<RefPtr<Nicosia::Buffer>()>) override;
 
@@ -129,6 +132,8 @@ private:
 
 #if USE(CAIRO)
     std::unique_ptr<Nicosia::PaintingEngine> m_paintingEngine;
+#elif USE(SKIA)
+    std::unique_ptr<SkiaAcceleratedBufferPool> m_skiaAcceleratedBufferPool;
 #endif
     HashMap<uint64_t, Ref<Nicosia::ImageBackingStore>> m_imageBackingStores;
 


### PR DESCRIPTION
#### 0c499e9e1049c4d57593a538d5f0ebfb3f74a687
<pre>
[Skia] Cleanup / refactor AcceleratedBufferPool
<a href="https://bugs.webkit.org/show_bug.cgi?id=269650">https://bugs.webkit.org/show_bug.cgi?id=269650</a>

Reviewed by Carlos Garcia Campos.

Move AcceleratedBufferPool out of CoordinatedGraphicsLayerSkia.cpp into
Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.* -
rename the class to SkiaAcceleratedBufferPool.

AcceleratedBufferPools destructor contains code to cleanup the GL
resources - this was never called as the class was managed as a
singleton. SkiaAcceleratedBufferPool is instead owned by
CopositingCoordinator. It allocates the pool if GPU rendering is used
and properly destructs it in the invalidate() method, which is called
during LayerTreeHost destruction. This ensures that we don&apos;t leave
around unclaimed resources.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp: Added.
(WebCore::SkiaAcceleratedBufferPool::SkiaAcceleratedBufferPool):
(WebCore::SkiaAcceleratedBufferPool::~SkiaAcceleratedBufferPool):
(WebCore::SkiaAcceleratedBufferPool::acquireBuffer):
(WebCore::SkiaAcceleratedBufferPool::createAcceleratedBuffer):
(WebCore::SkiaAcceleratedBufferPool::scheduleReleaseUnusedBuffers):
(WebCore::SkiaAcceleratedBufferPool::releaseUnusedBuffersTimerFired):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.h: Added.
(WebCore::SkiaAcceleratedBufferPool::Entry::Entry):
(WebCore::SkiaAcceleratedBufferPool::Entry::markIsInUse):
(WebCore::SkiaAcceleratedBufferPool::Entry::canBeReleased const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
(WebCore::AcceleratedBufferPool::singleton): Deleted.
(WebCore::AcceleratedBufferPool::AcceleratedBufferPool): Deleted.
(WebCore::AcceleratedBufferPool::~AcceleratedBufferPool): Deleted.
(WebCore::AcceleratedBufferPool::acquireBuffer): Deleted.
(WebCore::AcceleratedBufferPool::Entry::Entry): Deleted.
(WebCore::AcceleratedBufferPool::Entry::markIsInUse): Deleted.
(WebCore::AcceleratedBufferPool::Entry::canBeReleased const): Deleted.
(WebCore::AcceleratedBufferPool::createAcceleratedBuffer): Deleted.
(WebCore::AcceleratedBufferPool::scheduleReleaseUnusedBuffers): Deleted.
(WebCore::AcceleratedBufferPool::releaseUnusedBuffersTimerFired): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::skiaForceUseCpuRendering):
(WebKit::CompositingCoordinator::CompositingCoordinator):
(WebKit::CompositingCoordinator::invalidate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/274990@main">https://commits.webkit.org/274990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3a9b3f3426b76cb250163048219f1a3edeb1b8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43174 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22596 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/16965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/41195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/16569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/44449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/16965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35270 "Build is in progress. Recent messages:") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17106 "Build is in progress. Recent messages:") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5390 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->