### PR TITLE
[Cocoa] Add more PlatformColor tests

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@ WTF_EXTERN_C_END
 
 #if USE(APPLE_INTERNAL_SDK)
 
+#import <UIKit/NSColor.h>
 #import <UIKit/NSParagraphStyle_Private.h>
 #import <UIKit/NSTextAlternatives.h>
 #import <UIKit/NSTextAttachment_Private.h>
@@ -137,6 +138,11 @@ static const UIUserInterfaceIdiom UIUserInterfaceIdiomWatch = (UIUserInterfaceId
 
 @end
 
+@interface NSColor : UIColor
++ (id)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
++ (id)colorWithCalibratedWhite:(CGFloat)white alpha:(CGFloat)alpha;
+@end
+
 @interface UIFont ()
 
 + (UIFont *)fontWithFamilyName:(NSString *)familyName traits:(UIFontTrait)traits size:(CGFloat)fontSize;
@@ -220,10 +226,6 @@ typedef NS_ENUM(NSUInteger, NSTextTabType) {
     NSCenterTabStopType,
     NSDecimalTabStopType
 };
-
-@interface NSColor : UIColor
-+ (id)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
-@end
 
 @interface NSTextTab ()
 - (id)initWithType:(NSTextTabType)type location:(CGFloat)loc;

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -38,7 +38,8 @@
 #define PlatformFont                    NSFont
 #define PlatformFontClass               NSFont.class
 #define PlatformImageClass              NSImage
-#define PlatformNSColorClass            NSColor
+#define PlatformNSColor                 NSColor
+#define PlatformNSColorClass            NSColor.class
 #define PlatformNSParagraphStyle        NSParagraphStyle.class
 #define PlatformNSPresentationIntent    NSPresentationIntent.class
 #define PlatformNSShadow                NSShadow.class
@@ -53,7 +54,8 @@
 #define PlatformFont                    UIFont
 #define PlatformFontClass               PAL::getUIFontClass()
 #define PlatformImageClass              PAL::getUIImageClass()
-#define PlatformNSColorClass            getNSColorClass()
+#define PlatformNSColor                 NSColor
+#define PlatformNSColorClass            WebCore::getNSColorClass()
 #define PlatformNSParagraphStyle        PAL::getNSParagraphStyleClass()
 #define PlatformNSPresentationIntent    PAL::getNSPresentationIntentClass()
 #define PlatformNSShadow                PAL::getNSShadowClass()
@@ -72,6 +74,9 @@ OBJC_CLASS NSPresentationIntent;
 OBJC_CLASS NSShadow;
 OBJC_CLASS NSTextAttachment;
 OBJC_CLASS PlatformColor;
+#if PLATFORM(IOS_FAMILY)
+OBJC_CLASS PlatformNSColor;
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/ios/UIFoundationSoftLink.mm
+++ b/Source/WebCore/platform/ios/UIFoundationSoftLink.mm
@@ -33,7 +33,7 @@
 // FIXME: Remove SOFT_LINK_PRIVATE_FRAMEWORK(UIFoundation) and move symbols from NSAttributedStringSPI.h to here.
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE(WebCore, UIFoundation)
 
-SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSColor)
+SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(WebCore, UIFoundation, NSColor, WEBCORE_EXPORT)
 SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextAttachment)
 SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSMutableParagraphStyle)
 SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextList)

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -65,6 +65,9 @@ OBJC_CLASS PKShippingMethod;
 #endif
 
 OBJC_CLASS PlatformColor;
+#if PLATFORM(IOS_FAMILY)
+OBJC_CLASS PlatformNSColor;
+#endif
 OBJC_CLASS NSShadow;
 
 namespace IPC {
@@ -142,6 +145,9 @@ template<> Class getClass<PKSecureElementPass>();
 #endif
 
 template<> Class getClass<PlatformColor>();
+#if PLATFORM(IOS_FAMILY)
+template<> Class getClass<PlatformNSColor>();
+#endif
 template<> Class getClass<NSShadow>();
 
 template<typename T> void encodeObjectDirectly(Encoder&, T *);

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -49,7 +49,7 @@
 #import <wtf/text/StringHash.h>
 
 #if PLATFORM(IOS_FAMILY)
-#import <UIKit/UIColor.h>
+#import <WebCore/UIFoundationSoftLink.h>
 #import <UIKit/UIFont.h>
 #import <UIKit/UIFontDescriptor.h>
 #import <UIKit/UIKit.h>
@@ -334,6 +334,13 @@ template<> Class getClass<PlatformColor>()
 {
     return PlatformColorClass;
 }
+
+#if PLATFORM(IOS_FAMILY)
+template<> Class getClass<PlatformNSColor>()
+{
+    return PlatformNSColorClass;
+}
+#endif
 
 template<> Class getClass<NSShadow>()
 {
@@ -734,6 +741,9 @@ ENCODE_WITH_COREIPC_WRAPPER(NSValue);
 ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSPersonNameComponents, CoreIPCPersonNameComponents);
 ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSDateComponents, CoreIPCDateComponents);
 ENCODE_WITH_COREIPC_WRAPPER_NAMED(PlatformColor, CoreIPCColor);
+#if PLATFORM(IOS_FAMILY)
+ENCODE_WITH_COREIPC_WRAPPER_NAMED(PlatformNSColor, CoreIPCColor);
+#endif
 ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSData, CoreIPCData);
 ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSURL, CoreIPCURL);
 ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSNull, CoreIPCNull);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		41E67A8525D16E83007B0A4C /* STUNMessageParsingTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41E67A8425D16E83007B0A4C /* STUNMessageParsingTest.cpp */; };
 		41EBA9F228ABA06700953013 /* ImageRotationSessionVT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */; };
 		44077BB123144B5000179E2D /* DataDetectorsTestIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44077BB0231449D200179E2D /* DataDetectorsTestIOS.mm */; };
+		441A29E12B7EE84B00010BED /* CocoaColorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 441A29D92B7EE84B00010BED /* CocoaColorTests.mm */; };
 		4433A396208044140091ED57 /* SynchronousTimeoutTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4433A395208044130091ED57 /* SynchronousTimeoutTests.mm */; };
 		44449DC12718B4B700E821B5 /* OSObjectPtrCocoaARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44449DBF2718B4B600E821B5 /* OSObjectPtrCocoaARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		44449DC22718B4B700E821B5 /* OSObjectPtrCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44449DC02718B4B700E821B5 /* OSObjectPtrCocoa.mm */; };
@@ -2380,6 +2381,7 @@
 		41E9EE1A28B4DBF8006A2298 /* PermissionsAPI.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PermissionsAPI.mm; sourceTree = "<group>"; };
 		41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageRotationSessionVT.cpp; sourceTree = "<group>"; };
 		44077BB0231449D200179E2D /* DataDetectorsTestIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DataDetectorsTestIOS.mm; sourceTree = "<group>"; };
+		441A29D92B7EE84B00010BED /* CocoaColorTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaColorTests.mm; sourceTree = "<group>"; };
 		442BBF681C91CAD90017087F /* RefLogger.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RefLogger.cpp; sourceTree = "<group>"; };
 		4433A395208044130091ED57 /* SynchronousTimeoutTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SynchronousTimeoutTests.mm; sourceTree = "<group>"; };
 		44449DBF2718B4B600E821B5 /* OSObjectPtrCocoaARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSObjectPtrCocoaARC.mm; sourceTree = "<group>"; };
@@ -5785,6 +5787,7 @@
 			children = (
 				7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */,
 				0711DF51226A95FB003DD2F7 /* AVFoundationSoftLinkTest.mm */,
+				441A29D92B7EE84B00010BED /* CocoaColorTests.mm */,
 				31F865E526701E73003BFC6D /* CoreCryptoSPI.h */,
 				510A667A27D2FC7A00D22629 /* CoreMediaUtilities.mm */,
 				751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */,
@@ -6466,6 +6469,7 @@
 				7CCE7EE51A411AE600447C4C /* CloseThenTerminate.cpp in Sources */,
 				F43CAB1D278A326500C8D0A2 /* CloseWhileCommittingLoad.mm in Sources */,
 				6B306106218A372900F5A802 /* ClosingWebView.mm in Sources */,
+				441A29E12B7EE84B00010BED /* CocoaColorTests.mm in Sources */,
 				E51A740E2B0442180047FEB1 /* ColorInputTests.mm in Sources */,
 				7C3965061CDD74F90094DBB8 /* ColorTests.cpp in Sources */,
 				1C9EB8411E380DA1005C6442 /* ComplexTextController.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CocoaColorTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CocoaColorTests.mm
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Test.h"
+#import <WebCore/AttributedString.h>
+#import <WebCore/ColorCocoa.h>
+
+#import <WebCore/UIFoundationSoftLink.h>
+#import <pal/ios/UIKitSoftLink.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+static void testPlatformColor(const RetainPtr<id>& platformColor)
+{
+    Color color = colorFromCocoaColor(platformColor.get());
+    RetainPtr<PlatformColor> convertedPlatformColor = cocoaColor(color);
+    // Passing -isEqual: test for Objective-C color objects is a non-goal
+    // since there are many subclasses and none test for color equality
+    // between different subclasses.
+
+    Color convertedColor = colorFromCocoaColor(convertedPlatformColor.get());
+    EXPECT_EQ(color, convertedColor);
+}
+
+TEST(Color, Platform_Color)
+{
+    RetainPtr<PlatformColor> colorWithWhiteAlpha = [PlatformColorClass colorWithWhite:0.3 alpha:0.7];
+    testPlatformColor(colorWithWhiteAlpha);
+
+    RetainPtr<PlatformColor> colorWithHueSaturationBrightnessAlpha = [PlatformColorClass colorWithHue:0.2 saturation:0.4 brightness:0.6 alpha:0.8];
+    testPlatformColor(colorWithHueSaturationBrightnessAlpha);
+
+    RetainPtr<PlatformColor> colorWithRedGreenBlueAlpha = [PlatformColorClass colorWithRed:0.2 green:0.4 blue:0.6 alpha:0.8];
+    testPlatformColor(colorWithRedGreenBlueAlpha);
+
+    RetainPtr<PlatformColor> colorWithDisplayP3RedGreenBlueAlpha = [PlatformColorClass colorWithDisplayP3Red:0.2 green:0.4 blue:0.6 alpha:0.8];
+    testPlatformColor(colorWithDisplayP3RedGreenBlueAlpha);
+
+    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    constexpr CGFloat testComponents[4] = { 1, .75, .5, .25 };
+    auto cgColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), testComponents));
+    RetainPtr<PlatformColor> colorWithCGColor = [PlatformColorClass colorWithCGColor:cgColor.get()];
+    testPlatformColor(colorWithCGColor);
+}
+
+TEST(Color, Platform_NSColor)
+{
+    @autoreleasepool {
+        RetainPtr<PlatformNSColor> colorWithCalibratedRedGreenBlueAlpha = [PlatformNSColorClass colorWithCalibratedRed:0.75 green:0.25 blue:0.50 alpha:0.88];
+        testPlatformColor(colorWithCalibratedRedGreenBlueAlpha);
+
+        RetainPtr<PlatformNSColor> colorWithCalibratedWhiteAlpha = [PlatformNSColorClass colorWithCalibratedWhite:0.67 alpha:0.88];
+        testPlatformColor(colorWithCalibratedWhiteAlpha);
+    }
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 08bdf5fdda05b53667bcb83687dc17aceb254048
<pre>
[Cocoa] Add more PlatformColor tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=269652">https://bugs.webkit.org/show_bug.cgi?id=269652</a>
&lt;<a href="https://rdar.apple.com/123166372">rdar://123166372</a>&gt;

Reviewed by NOBODY (OOPS!).

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
- Switch to use private header to define methods on internal SDKs.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
- Make UIFoundationSoftLink.h a private header for use in TestWebKitAPI
  project.
* Source/WebCore/editing/cocoa/AttributedString.h:
(PlatformNSColor): Add.
(PlatformNSColorClass):
- Fix definition of PlatformNSColorClass and add PlatformNSColor.  These
  are identical to PlatformColor[Class] on macOS, but different on iOS
  Family.
* Source/WebCore/platform/ios/UIFoundationSoftLink.mm:
- Export WebCore::getNSColorClass() for use in TestWebKitAPI.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;PlatformNSColor&gt;):
- Add support for PlatformNSColor on PLATFORM(IOS_FAMILY).

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
- Add CocoaColorTests.mm.
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(wkCocoaPlatformColor_isEqual): Add.
(wkNSShadow_isEqual): Add.
(operator==):
- Add/swizzle -isEqual: methods for PlatformColor, PlatformNSColor and
  NSShadow to properly handle comparison of the many subclasses of
  PlatformColor and PlatformNSColor.
(TEST(IPCSerialization, NSShadow)):
- Add more tests with different PlatformColor and PlatformNSColor
  variations.
(TEST(IPCSerialization, Platform_CocoaColor)): Add.
(TEST(IPCSerialization, Platform_NSColor_calibrated)): Add.
- Add serialization tests for PlatformColor and PlatformNSColor.
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CocoaColorTests.mm: Add.
(TEST(Color, Platform_Color)):
(TEST(Color, Platform_NSColor)):
- Add tests to convert from PlatformColor and PlatformNSColor to
  WebCore::Color to PlatformColor and back to WebCore::Color.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08bdf5fdda05b53667bcb83687dc17aceb254048

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43032 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33589 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14172 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14249 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44307 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39940 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38243 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->