### PR TITLE
[MSE] Intermittent crash with imported/w3c/web-platform-tests/media-source/URL-createObjectURL-null.html

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1337,11 +1337,10 @@ void MediaSource::notifyElementUpdateMediaState() const
 void MediaSource::ensureWeakOnHTMLMediaElementContext(Function<void(HTMLMediaElement&)>&& task) const
 {
     ensureOnMainThread([weakMediaElement = m_mediaElement, task = WTFMove(task)]() mutable {
-        if (RefPtr mediaElement = weakMediaElement.get())
+        if (RefPtrAllowingPartiallyDestroyed<HTMLMediaElement> mediaElement = weakMediaElement.get())
             task(*mediaElement);
     });
 }
-
 
 void MediaSource::sourceBufferBufferedChanged()
 {


### PR DESCRIPTION
#### a691187c506e9f19e2a61adbf52585560d704d12
<pre>
[MSE] Intermittent crash with imported/w3c/web-platform-tests/media-source/URL-createObjectURL-null.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=269656">https://bugs.webkit.org/show_bug.cgi?id=269656</a>
<a href="https://rdar.apple.com/123171059">rdar://123171059</a>

Reviewed by Chris Dumez.

`MediaSource::ensureWeakOnHTMLMediaElementContext` took a strong ref to the HTMLMediaElement but this code can be called while the HTMLMediaElement is being destructed.

`ASSERT(!deletionHasBegun());`

We use a RefPtrAllowingPartiallyDestroyed instead which avoid the problem for now.

Ideally the logic should be refactored to avoid calling the method in the first place
if the HTMLMediaElement has gone away.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::ensureWeakOnHTMLMediaElementContext const):

Canonical link: <a href="https://commits.webkit.org/274942@main">https://commits.webkit.org/274942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50d0ad0cff08d03a80c39af5b72b76149e84f9f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33561 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44276 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39914 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12508 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38212 "Found 272 new API test failures: /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/cookies-changed, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestFrame:/webkit/WebKitFrame/javascript-values, /WebKitGTK/TestDownloads:/webkit/Downloads/remote-file-error, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16885 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9068 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->