### PR TITLE
[UnifiedPDF] Clean up the coordinate system code

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -70,16 +70,18 @@ public:
 
     RetainPtr<PDFPage> pageAtIndex(PageIndex) const;
     std::optional<unsigned> indexForPage(RetainPtr<PDFPage>) const;
-    PDFDocumentLayout::PageIndex nearestPageIndexForDocumentPoint(WebCore::IntPoint) const;
+    PDFDocumentLayout::PageIndex nearestPageIndexForDocumentPoint(WebCore::FloatPoint) const;
 
     // This is not scaled by scale().
     WebCore::FloatRect layoutBoundsForPageAtIndex(PageIndex) const;
     // Returns 0, 90, 180, 270.
     WebCore::IntDegrees rotationForPageAtIndex(PageIndex) const;
 
-    WebCore::FloatPoint documentPointToPDFPagePoint(WebCore::FloatPoint documentPoint, PageIndex) const;
-    WebCore::FloatPoint pdfPagePointToDocumentPoint(WebCore::FloatPoint pagePoint, PageIndex) const;
-    WebCore::FloatRect pdfPageRectToDocumentRect(WebCore::FloatRect pageRect, PageIndex) const;
+    WebCore::FloatPoint documentToPDFPage(WebCore::FloatPoint documentPoint, PageIndex) const;
+    WebCore::FloatRect documentToPDFPage(WebCore::FloatRect documentRect, PageIndex) const;
+
+    WebCore::FloatPoint pdfPageToDocument(WebCore::FloatPoint pagePoint, PageIndex) const;
+    WebCore::FloatRect pdfPageToDocument(WebCore::FloatRect pageRect, PageIndex) const;
 
     // This is the scale that scales the largest page or pair of pages up or down to fit the available width.
     float scale() const { return m_scale; }


### PR DESCRIPTION
#### 625cdc03e3b236e872f37780ff2fde4272524459
<pre>
[UnifiedPDF] Clean up the coordinate system code
<a href="https://bugs.webkit.org/show_bug.cgi?id=269657">https://bugs.webkit.org/show_bug.cgi?id=269657</a>
<a href="https://rdar.apple.com/123173348">rdar://123173348</a>

Reviewed by Tim Horton.

Replace the panoply of coordinate conversion functions with two template functions, capable
of converting FloatPoints and FloatRects. These are `convertUp()` and `convertDown()`, where
the former converts to enclosing coordinate systems, and the latter to inner coordinate
systems. An enum describes the available coordinate systems.

It was a purposeful choice to have convertUp() and convertDown() only do conversions within
the Plugin; outside the Plugin boundary (e.g. to/from RootView), functions on PDFPluginBase
can be used, albeit with the minor annoyance that conversions between integer and float
types are necessary.

Generally, staying in FloatPoint/FloatRect are preferred to converting using integer types

Minor other cleanups.

The only thing I can find that doesn&apos;t seem to use the correct conversions is painting the
yellow Find highlight, which continues to give incorrect results.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::nearestPageIndexForDocumentPoint const):
(WebKit::PDFDocumentLayout::layoutBoundsForPageAtIndex const):
(WebKit::PDFDocumentLayout::scaledContentsSize const):
(WebKit::PDFDocumentLayout::documentToPDFPage const):
(WebKit::PDFDocumentLayout::pdfPageToDocument const):
(WebKit::PDFDocumentLayout::documentPointToPDFPagePoint const): Deleted.
(WebKit::PDFDocumentLayout::pdfPagePointToDocumentPoint const): Deleted.
(WebKit::PDFDocumentLayout::pdfPageRectToDocumentRect const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setNeedsRepaintInDocumentRect):
(WebKit::UnifiedPDFPlugin::paintHoveredAnnotationOnPage):
(WebKit::UnifiedPDFPlugin::updateScrollingExtents):
(WebKit::UnifiedPDFPlugin::pageIndexForDocumentPoint const):
(WebKit::UnifiedPDFPlugin::indexForCurrentPageInView const):
(WebKit::UnifiedPDFPlugin::annotationForRootViewPoint const):
(WebKit::UnifiedPDFPlugin::convertUp const):
(WebKit::UnifiedPDFPlugin::convertDown const):
(WebKit::UnifiedPDFPlugin::pdfElementTypesForPluginPoint const):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::documentRectForAnnotation const):
(WebKit::UnifiedPDFPlugin::scrollToPDFDestination):
(WebKit::UnifiedPDFPlugin::scrollToPointInPage):
(WebKit::UnifiedPDFPlugin::scrollToPage):
(WebKit::UnifiedPDFPlugin::beginTrackingSelection):
(WebKit::UnifiedPDFPlugin::updateCurrentSelectionForContextMenuEventIfNeeded):
(WebKit::computeMarqueeSelectionRect):
(WebKit::UnifiedPDFPlugin::continueTrackingSelection):
(WebKit::UnifiedPDFPlugin::existingSelectionContainsPoint const):
(WebKit::UnifiedPDFPlugin::rectForSelectionInRootView const):
(WebKit::UnifiedPDFPlugin::countFindMatches):
(WebKit::UnifiedPDFPlugin::findString):
(WebKit::UnifiedPDFPlugin::collectFindMatchRects):
(WebKit::UnifiedPDFPlugin::rectsForTextMatchesInRect const):
(WebKit::UnifiedPDFPlugin::textIndicatorForSelection):
(WebKit::UnifiedPDFPlugin::performDictionaryLookupAtLocation):
(WebKit::UnifiedPDFPlugin::selectionBoundsForFirstPageInDocumentSpace const):
(WebKit::UnifiedPDFPlugin::showDefinitionForAttributedString):
(WebKit::UnifiedPDFPlugin::lookupTextAtLocation):
(WebKit::UnifiedPDFPlugin::pluginBoundsForAnnotation const):
(WebKit::UnifiedPDFPlugin::convertFromRootViewToDocument const): Deleted.
(WebKit::UnifiedPDFPlugin::convertFromPluginToDocument const): Deleted.
(WebKit::UnifiedPDFPlugin::convertFromDocumentToPlugin const): Deleted.
(WebKit::UnifiedPDFPlugin::convertFromPageToRootView const): Deleted.
(WebKit::UnifiedPDFPlugin::convertFromDocumentToPage const): Deleted.
(WebKit::UnifiedPDFPlugin::convertFromPageToDocument const): Deleted.
(WebKit::UnifiedPDFPlugin::convertFromPageToContents const): Deleted.
(WebKit::UnifiedPDFPlugin::convertFromDocumentToContents const): Deleted.
(WebKit::UnifiedPDFPlugin::offsetContentsSpacePointByPageMargins const): Deleted.

Canonical link: <a href="https://commits.webkit.org/274950@main">https://commits.webkit.org/274950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da75b60b4e09890ba3fbc304691c6cce880bcc6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43027 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36565 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16818 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14236 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44302 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39935 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38237 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16910 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9073 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->