### PR TITLE
Adopt more smart pointers in WebFrameProxy.cpp

### DIFF
--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -86,6 +86,7 @@ public:
 
     WebCore::FrameIdentifier frameID() const { return m_frameID; }
     WebPageProxy* page() const;
+    RefPtr<WebPageProxy> protectedPage() const;
 
     bool pageIsClosed() const { return !m_page; } // Needs to be thread-safe.
 
@@ -160,13 +161,13 @@ public:
     FrameTreeCreationParameters frameTreeCreationParameters() const;
 
     WebFrameProxy* parentFrame() const { return m_parentFrame.get(); }
-    Ref<WebFrameProxy> rootFrame();
+    WebFrameProxy& rootFrame();
     WebProcessProxy& process() const { return m_process.get(); }
     Ref<WebProcessProxy> protectedProcess() const { return process(); }
     void setProcess(WebProcessProxy& process) { m_process = process; }
     ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
     std::unique_ptr<ProvisionalFrameProxy> takeProvisionalFrame();
-    RefPtr<RemotePageProxy> remotePageProxy();
+    RemotePageProxy* remotePageProxy() const;
     void remoteProcessDidTerminate();
     std::optional<WebCore::PageIdentifier> webPageIDInCurrentProcess();
     void notifyParentOfLoadCompletion(WebProcessProxy&);
@@ -188,11 +189,11 @@ private:
 
     std::optional<WebCore::PageIdentifier> pageIdentifier() const;
 
-    RefPtr<WebFrameProxy> deepLastChild();
-    RefPtr<WebFrameProxy> firstChild() const;
-    RefPtr<WebFrameProxy> lastChild() const;
-    RefPtr<WebFrameProxy> nextSibling() const;
-    RefPtr<WebFrameProxy> previousSibling() const;
+    WebFrameProxy* deepLastChild();
+    WebFrameProxy* firstChild() const;
+    WebFrameProxy* lastChild() const;
+    WebFrameProxy* nextSibling() const;
+    WebFrameProxy* previousSibling() const;
 
     WeakPtr<WebPageProxy> m_page;
     Ref<WebProcessProxy> m_process;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -862,6 +862,11 @@ PAL::SessionID WebPageProxy::sessionID() const
     return m_websiteDataStore->sessionID();
 }
 
+RefPtr<WebFrameProxy> WebPageProxy::protectedMainFrame() const
+{
+    return m_mainFrame;
+}
+
 DrawingAreaProxy* WebPageProxy::provisionalDrawingArea() const
 {
     if (m_provisionalPage && m_provisionalPage->drawingArea())
@@ -8409,7 +8414,7 @@ void WebPageProxy::setTextIndicatorFromFrame(FrameIdentifier frameID, TextIndica
     if (!frame)
         return;
 
-    RefPtr rootFrameParent = frame->rootFrame()->parentFrame();
+    RefPtr rootFrameParent = frame->rootFrame().parentFrame();
     if (!rootFrameParent) {
         setTextIndicator(WTFMove(indicatorData), lifetime);
         return;
@@ -8421,7 +8426,7 @@ void WebPageProxy::setTextIndicatorFromFrame(FrameIdentifier frameID, TextIndica
     auto textBoundingRect = indicatorData.textBoundingRectInRootViewCoordinates;
     sendToProcessContainingFrame(parentFrameID, Messages::WebPage::RemoteViewRectToRootView(frameID, textBoundingRect), [protectedThis = Ref { *this }, indicatorData = WTFMove(indicatorData), rootFrameParent = WTFMove(rootFrameParent), lifetime](FloatRect rect) mutable {
         indicatorData.textBoundingRectInRootViewCoordinates = rect;
-        protectedThis->setTextIndicatorFromFrame(rootFrameParent->rootFrame()->frameID(), WTFMove(indicatorData), lifetime);
+        protectedThis->setTextIndicatorFromFrame(rootFrameParent->rootFrame().frameID(), WTFMove(indicatorData), lifetime);
     });
 }
 
@@ -8579,7 +8584,7 @@ void WebPageProxy::showContextMenuFromFrame(FrameIdentifier frameID, ContextMenu
     if (!frame)
         return;
 
-    RefPtr rootFrameParent = frame->rootFrame()->parentFrame();
+    RefPtr rootFrameParent = frame->rootFrame().parentFrame();
     if (!rootFrameParent) {
         showContextMenu(WTFMove(contextMenuContextData), userData);
         return;
@@ -8591,7 +8596,7 @@ void WebPageProxy::showContextMenuFromFrame(FrameIdentifier frameID, ContextMenu
     auto menuLocation = contextMenuContextData.menuLocation();
     sendToProcessContainingFrame(parentFrameID, Messages::WebPage::RemoteViewPointToRootView(frameID, menuLocation), [protectedThis = Ref { *this }, contextMenuContextData = WTFMove(contextMenuContextData), userData = WTFMove(userData), rootFrameParent = WTFMove(rootFrameParent)](FloatPoint point) mutable {
         contextMenuContextData.setMenuLocation(IntPoint(point));
-        protectedThis->showContextMenuFromFrame(rootFrameParent->rootFrame()->frameID(), WTFMove(contextMenuContextData), WTFMove(userData));
+        protectedThis->showContextMenuFromFrame(rootFrameParent->rootFrame().frameID(), WTFMove(contextMenuContextData), WTFMove(userData));
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -569,6 +569,7 @@ public:
     PAL::SessionID sessionID() const;
 
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
+    RefPtr<WebFrameProxy> protectedMainFrame() const;
     WebFrameProxy* openerFrame() const { return m_openerFrame.get(); }
     WebPageProxy* openerPage() const;
     WebFrameProxy* focusedFrame() const { return m_focusedFrame.get(); }


### PR DESCRIPTION
#### af34d92a2f7f2c772006b4ef840dda1b89c814f3
<pre>
Adopt more smart pointers in WebFrameProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=269658">https://bugs.webkit.org/show_bug.cgi?id=269658</a>

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::protectedPage const):
(WebKit::WebFrameProxy::navigateServiceWorkerClient):
(WebKit::WebFrameProxy::loadURL):
(WebKit::WebFrameProxy::loadData):
(WebKit::WebFrameProxy::getWebArchive):
(WebKit::WebFrameProxy::getMainResourceData):
(WebKit::WebFrameProxy::getResourceData):
(WebKit::WebFrameProxy::didHandleContentFilterUnblockNavigation):
(WebKit::WebFrameProxy::collapseSelection):
(WebKit::WebFrameProxy::disconnect):
(WebKit::WebFrameProxy::didCreateSubframe):
(WebKit::WebFrameProxy::prepareForProvisionalNavigationInProcess):
(WebKit::WebFrameProxy::commitProvisionalFrame):
(WebKit::WebFrameProxy::getFrameInfo):
(WebKit::WebFrameProxy::remotePageProxy const):
(WebKit::WebFrameProxy::isFocused const):
(WebKit::WebFrameProxy::remoteProcessDidTerminate):
(WebKit::WebFrameProxy::traverseNext const):
(WebKit::WebFrameProxy::traversePrevious):
(WebKit::WebFrameProxy::deepLastChild const):
(WebKit::WebFrameProxy::firstChild const):
(WebKit::WebFrameProxy::lastChild const):
(WebKit::WebFrameProxy::nextSibling const):
(WebKit::WebFrameProxy::previousSibling const):
(WebKit::WebFrameProxy::rootFrame const):
(WebKit::WebFrameProxy::remotePageProxy): Deleted.
(WebKit::WebFrameProxy::deepLastChild): Deleted.
(WebKit::WebFrameProxy::rootFrame): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:

Canonical link: <a href="https://commits.webkit.org/274995@main">https://commits.webkit.org/274995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb389073bb8f16c8d8f6f888a38879e5b600f890

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43156 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36692 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16947 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14272 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44430 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34056 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36817 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40043 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40229 "Build is in progress. Recent messages:") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38375 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17037 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17088 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5392 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->