### PR TITLE
[Skia] Implement stroke gradients

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -343,11 +343,9 @@ SkPaint GraphicsContextSkia::createStrokePaint(std::optional<Color> strokeColor)
         // FIXME: Implement stroke patterns.
         UNUSED_PARAM(strokePattern);
         notImplemented();
-    } else if (auto strokeGradient = state.strokeBrush().gradient()) {
-        // FIXME: Implement stroke gradients.
-        UNUSED_PARAM(strokeGradient);
-        notImplemented();
-    } else {
+    } else if (auto strokeGradient = state.strokeBrush().gradient())
+        paint.setShader(strokeGradient->shader(state.alpha(), state.strokeBrush().gradientSpaceTransform()));
+    else {
         auto [r, g, b, a] = strokeColor.value_or(state.strokeBrush().color()).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
         paint.setColor(SkColorSetARGB(a, r, g, b));
     }


### PR DESCRIPTION
#### 8a94dff5de5a1852323be73786aee08e71f0a8f7
<pre>
[Skia] Implement stroke gradients
<a href="https://bugs.webkit.org/show_bug.cgi?id=269664">https://bugs.webkit.org/show_bug.cgi?id=269664</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::createStrokePaint const):

Canonical link: <a href="https://commits.webkit.org/274970@main">https://commits.webkit.org/274970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdcd0881e2cbb53684a2c36eaf8af12a4e9e249c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36611 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33622 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39977 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12572 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38292 "Found 270 new API test failures: /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/cookies-changed, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestFrame:/webkit/WebKitFrame/javascript-values, /WebKitGTK/TestDownloads:/webkit/Downloads/remote-file-error, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16956 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17007 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5380 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16600 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->