### PR TITLE
Sync `video-display-aspect-ratio.html` test from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/media/video-display-aspect-ratio-expected.txt
+++ b/LayoutTests/media/video-display-aspect-ratio-expected.txt
@@ -1,8 +1,4 @@
 
-EXPECTED (video.videoWidth == '0') OK
-EXPECTED (video.videoHeight == '0') OK
-EVENT(loadedmetadata)
-EXPECTED (video.videoWidth == '426') OK
-EXPECTED (video.videoHeight == '240') OK
-END OF TEST
+
+PASS Test video dimension aspect ratio.
 

--- a/LayoutTests/media/video-display-aspect-ratio.html
+++ b/LayoutTests/media/video-display-aspect-ratio.html
@@ -1,15 +1,19 @@
-<video controls></video>
-<script src=media-file.js></script>
-<script src=video-test.js></script>
+<!DOCTYPE html>
+<title>Test video dimension aspect ratio.</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<video></video>
 <script>
-    testExpected("video.videoWidth", 0, "==");
-    testExpected("video.videoHeight", 0, "==");
+async_test(function(t) {
+    var video = document.querySelector("video");
+    assert_equals(video.videoWidth, 0);
+    assert_equals(video.videoHeight, 0);
 
-    waitForEvent('loadedmetadata', function () {
-        testExpected("video.videoWidth", 426, "==");
-        testExpected("video.videoHeight", 240, "==");
-        endTest();
-    } );
+    video.onloadedmetadata = t.step_func_done(function() {
+        assert_equals(video.videoWidth, 426);
+        assert_equals(video.videoHeight, 240);
+    });
 
-    video.src = findMediaFile("video", "content/test-par-16-9");
+    video.src = "content/test-par-16-9.mp4";
+});
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2486,7 +2486,6 @@ media/video-webkit-playsinline.html
 
 webkit.org/b/103926 media/track/opera
 
-webkit.org/b/35297 media/video-display-aspect-ratio.html [ Pass Failure ]
 webkit.org/b/112659 media/video-playing-and-pause.html [ Skip ]
 
 webkit.org/b/112492 media/track/track-prefer-captions.html

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -712,7 +712,6 @@ webkit.org/b/137368 media/video-controls-no-scripting.html [ Pass Failure ]
 
 ## --- Start flaky media tests ---
 webkit.org/b/34331 http/tests/media/video-referer.html [ Pass Timeout ]
-webkit.org/b/35297 media/video-display-aspect-ratio.html [ Pass Failure ]
 webkit.org/b/82976 media/W3C/video/networkState/networkState_during_progress.html [ Pass Failure ]
 webkit.org/b/85525 media/video-played-reset.html [ Pass Failure ]
 webkit.org/b/112659 media/video-playing-and-pause.html [ Failure Timeout ]


### PR DESCRIPTION
#### 85c396bcfe9d798ee3cb60acbd0f62b04a1ef393
<pre>
Sync `video-display-aspect-ratio.html` test from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=35297">https://bugs.webkit.org/show_bug.cgi?id=35297</a>

Reviewed by Eric Carlson.

This patch is to sync `video-display-aspect-ratio.html` from Blink / Chromium upstream as per below commit:

Partial Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/fb4997976e1c1db6712d1a1b8be871f041eeaf4e">https://source.chromium.org/chromium/chromium/src/+/fb4997976e1c1db6712d1a1b8be871f041eeaf4e</a>

* LayoutTests/media/video-display-aspect-ratio.html: Updated
* LayoutTests/media/video-display-aspect-ratio-expected.txt: Rebaselined
* LayoutTests/platform/ios/TestExpectations: Remove &apos;fail&apos; expectation
* LayoutTests/platform/mac/TestExpectations: Ditto

Canonical link: <a href="https://commits.webkit.org/274947@main">https://commits.webkit.org/274947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a234bcf17b050eca978a7d68b5a9cf27385fce92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36545 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33566 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44282 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39919 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38230 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35133 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9071 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->