### PR TITLE
Add invoke defaults for dialogs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt
@@ -1,72 +1,72 @@
 
 
-FAIL invoking (with invokeaction property as auto) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as auto) closed dialog opens as modal
 PASS invoking (with invokeaction property as auto) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction property as auto) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction attribute as auto) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as auto) while changing action still opens as modal
+PASS invoking (with invokeaction attribute as auto) closed dialog opens as modal
 PASS invoking (with invokeaction attribute as auto) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction attribute as auto) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction property as explicit empty) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction attribute as auto) while changing action still opens as modal
+PASS invoking (with invokeaction property as explicit empty) closed dialog opens as modal
 PASS invoking (with invokeaction property as explicit empty) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction property as explicit empty) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction attribute as explicit empty) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as explicit empty) while changing action still opens as modal
+PASS invoking (with invokeaction attribute as explicit empty) closed dialog opens as modal
 PASS invoking (with invokeaction attribute as explicit empty) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction attribute as explicit empty) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction property as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction attribute as explicit empty) while changing action still opens as modal
+PASS invoking (with invokeaction property as showmodal) closed dialog opens as modal
 PASS invoking (with invokeaction property as showmodal) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction property as showmodal) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction attribute as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as showmodal) while changing action still opens as modal
+PASS invoking (with invokeaction attribute as showmodal) closed dialog opens as modal
 PASS invoking (with invokeaction attribute as showmodal) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction attribute as showmodal) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction property as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction attribute as showmodal) while changing action still opens as modal
+PASS invoking (with invokeaction property as sHoWmOdAl) closed dialog opens as modal
 PASS invoking (with invokeaction property as sHoWmOdAl) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction property as sHoWmOdAl) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction attribute as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as sHoWmOdAl) while changing action still opens as modal
+PASS invoking (with invokeaction attribute as sHoWmOdAl) closed dialog opens as modal
 PASS invoking (with invokeaction attribute as sHoWmOdAl) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction attribute as sHoWmOdAl) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking to close (with invokeaction property as auto) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking (with invokeaction attribute as sHoWmOdAl) while changing action still opens as modal
+PASS invoking to close (with invokeaction property as auto) open dialog closes
 PASS invoking to close (with invokeaction property as auto) open dialog with preventDefault is no-op
 PASS invoking to close (with invokeaction property as auto) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction property as auto) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as auto) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as auto) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction property as auto) open dialog while changing action still closes
+PASS invoking to close (with invokeaction property as auto) open modal dialog while changing action still closes
+PASS invoking to close (with invokeaction attribute as auto) open dialog closes
 PASS invoking to close (with invokeaction attribute as auto) open dialog with preventDefault is no-op
 PASS invoking to close (with invokeaction attribute as auto) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction attribute as auto) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as auto) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as explicit empty) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction attribute as auto) open dialog while changing action still closes
+PASS invoking to close (with invokeaction attribute as auto) open modal dialog while changing action still closes
+PASS invoking to close (with invokeaction property as explicit empty) open dialog closes
 PASS invoking to close (with invokeaction property as explicit empty) open dialog with preventDefault is no-op
 PASS invoking to close (with invokeaction property as explicit empty) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction property as explicit empty) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as explicit empty) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as explicit empty) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction property as explicit empty) open dialog while changing action still closes
+PASS invoking to close (with invokeaction property as explicit empty) open modal dialog while changing action still closes
+PASS invoking to close (with invokeaction attribute as explicit empty) open dialog closes
 PASS invoking to close (with invokeaction attribute as explicit empty) open dialog with preventDefault is no-op
 PASS invoking to close (with invokeaction attribute as explicit empty) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction attribute as explicit empty) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as explicit empty) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as close) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction attribute as explicit empty) open dialog while changing action still closes
+PASS invoking to close (with invokeaction attribute as explicit empty) open modal dialog while changing action still closes
+PASS invoking to close (with invokeaction property as close) open dialog closes
 PASS invoking to close (with invokeaction property as close) open dialog with preventDefault is no-op
 PASS invoking to close (with invokeaction property as close) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction property as close) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as close) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as close) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction property as close) open dialog while changing action still closes
+PASS invoking to close (with invokeaction property as close) open modal dialog while changing action still closes
+PASS invoking to close (with invokeaction attribute as close) open dialog closes
 PASS invoking to close (with invokeaction attribute as close) open dialog with preventDefault is no-op
 PASS invoking to close (with invokeaction attribute as close) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction attribute as close) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as close) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as cLoSe) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction attribute as close) open dialog while changing action still closes
+PASS invoking to close (with invokeaction attribute as close) open modal dialog while changing action still closes
+PASS invoking to close (with invokeaction property as cLoSe) open dialog closes
 PASS invoking to close (with invokeaction property as cLoSe) open dialog with preventDefault is no-op
 PASS invoking to close (with invokeaction property as cLoSe) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction property as cLoSe) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as cLoSe) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as cLoSe) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction property as cLoSe) open dialog while changing action still closes
+PASS invoking to close (with invokeaction property as cLoSe) open modal dialog while changing action still closes
+PASS invoking to close (with invokeaction attribute as cLoSe) open dialog closes
 PASS invoking to close (with invokeaction attribute as cLoSe) open dialog with preventDefault is no-op
 PASS invoking to close (with invokeaction attribute as cLoSe) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction attribute as cLoSe) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as cLoSe) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction attribute as cLoSe) open dialog while changing action still closes
+PASS invoking to close (with invokeaction attribute as cLoSe) open modal dialog while changing action still closes
 PASS invoking (as showmodal) open dialog is noop
 PASS invoking (as showmodal) open modal, while changing action still a no-op
-FAIL invoking (as showmodal) closed popover dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (as showmodal) closed popover dialog opens as modal
 PASS invoking (as close) already closed dialog is noop
 PASS invoking (as showmodal) dialog as open popover=manual is noop
 PASS invoking (as showmodal) dialog as open popover=auto is noop

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt
@@ -1,0 +1,86 @@
+
+
+FAIL invoking (with invokeaction property as auto) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as auto) closed dialog with preventDefault is noop
+FAIL invoking (with invokeaction property as auto) while changing action still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with invokeaction attribute as auto) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction attribute as auto) closed dialog with preventDefault is noop
+FAIL invoking (with invokeaction attribute as auto) while changing action still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with invokeaction property as explicit empty) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as explicit empty) closed dialog with preventDefault is noop
+FAIL invoking (with invokeaction property as explicit empty) while changing action still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with invokeaction attribute as explicit empty) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction attribute as explicit empty) closed dialog with preventDefault is noop
+FAIL invoking (with invokeaction attribute as explicit empty) while changing action still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with invokeaction property as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as showmodal) closed dialog with preventDefault is noop
+FAIL invoking (with invokeaction property as showmodal) while changing action still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with invokeaction attribute as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction attribute as showmodal) closed dialog with preventDefault is noop
+FAIL invoking (with invokeaction attribute as showmodal) while changing action still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with invokeaction property as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction property as sHoWmOdAl) closed dialog with preventDefault is noop
+FAIL invoking (with invokeaction property as sHoWmOdAl) while changing action still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with invokeaction attribute as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with invokeaction attribute as sHoWmOdAl) closed dialog with preventDefault is noop
+FAIL invoking (with invokeaction attribute as sHoWmOdAl) while changing action still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking to close (with invokeaction property as auto) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction property as auto) open dialog with preventDefault is no-op
+PASS invoking to close (with invokeaction property as auto) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with invokeaction property as auto) open dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction property as auto) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction attribute as auto) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction attribute as auto) open dialog with preventDefault is no-op
+PASS invoking to close (with invokeaction attribute as auto) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with invokeaction attribute as auto) open dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction attribute as auto) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction property as explicit empty) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction property as explicit empty) open dialog with preventDefault is no-op
+PASS invoking to close (with invokeaction property as explicit empty) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with invokeaction property as explicit empty) open dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction property as explicit empty) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction attribute as explicit empty) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction attribute as explicit empty) open dialog with preventDefault is no-op
+PASS invoking to close (with invokeaction attribute as explicit empty) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with invokeaction attribute as explicit empty) open dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction attribute as explicit empty) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction property as close) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction property as close) open dialog with preventDefault is no-op
+PASS invoking to close (with invokeaction property as close) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with invokeaction property as close) open dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction property as close) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction attribute as close) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction attribute as close) open dialog with preventDefault is no-op
+PASS invoking to close (with invokeaction attribute as close) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with invokeaction attribute as close) open dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction attribute as close) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction property as cLoSe) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction property as cLoSe) open dialog with preventDefault is no-op
+PASS invoking to close (with invokeaction property as cLoSe) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with invokeaction property as cLoSe) open dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction property as cLoSe) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction attribute as cLoSe) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with invokeaction attribute as cLoSe) open dialog with preventDefault is no-op
+PASS invoking to close (with invokeaction attribute as cLoSe) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with invokeaction attribute as cLoSe) open dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with invokeaction attribute as cLoSe) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+PASS invoking (as showmodal) open dialog is noop
+PASS invoking (as showmodal) open modal, while changing action still a no-op
+FAIL invoking (as showmodal) closed popover dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (as close) already closed dialog is noop
+PASS invoking (as showmodal) dialog as open popover=manual is noop
+PASS invoking (as showmodal) dialog as open popover=auto is noop
+PASS invoking (as close) dialog as open popover=manual is noop
+PASS invoking (as close) dialog as open popover=auto is noop
+PASS invoking (as explicit empty) dialog as open popover=manual is noop
+PASS invoking (as explicit empty) dialog as open popover=auto is noop
+PASS invoking (as showmodal) dialog that is removed is noop
+PASS invoking (as showmodal) dialog from a detached invoker
+PASS invoking (as showmodal) detached dialog from a detached invoker
+PASS invoking (as close) dialog that is removed is noop
+PASS invoking (as close) dialog from a detached invoker
+PASS invoking (as close) detached dialog from a detached invoker
+PASS invoking (as explicit empty) dialog that is removed is noop
+PASS invoking (as explicit empty) dialog from a detached invoker
+PASS invoking (as explicit empty) detached dialog from a detached invoker
+

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -117,6 +117,9 @@ enum class InvokeAction: uint8_t {
     TogglePopover,
     HidePopover,
     ShowPopover,
+
+    ShowModal,
+    Close,
 };
 
 struct CheckVisibilityOptions;

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -135,6 +135,36 @@ void HTMLDialogElement::close(const String& result)
     queueTaskToDispatchEvent(TaskSource::UserInteraction, Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
+bool HTMLDialogElement::isValidInvokeAction(const InvokeAction action)
+{
+    return HTMLElement::isValidInvokeAction(action) || action == InvokeAction::ShowModal || action == InvokeAction::Close;
+}
+
+bool HTMLDialogElement::handleInvokeInternal(const HTMLFormControlElement& invoker, const InvokeAction& action)
+{
+    if (HTMLElement::handleInvokeInternal(invoker, action))
+        return true;
+
+    if (isPopoverShowing())
+        return false;
+
+    if (isOpen()) {
+        auto shouldClose = action == InvokeAction::Auto || action == InvokeAction::Close;
+        if (shouldClose) {
+            close(nullString());
+            return true;
+        }
+    } else {
+        auto shouldOpen = action == InvokeAction::Auto || action == InvokeAction::ShowModal;
+        if (shouldOpen) {
+            showModal();
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void HTMLDialogElement::queueCancelTask()
 {
     queueTaskKeepingThisNodeAlive(TaskSource::UserInteraction, [this] {

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -49,6 +49,9 @@ public:
 
     void runFocusingSteps();
 
+    bool isValidInvokeAction(const InvokeAction) final;
+    bool handleInvokeInternal(const HTMLFormControlElement& invoker, const InvokeAction&) final;
+
 private:
     HTMLDialogElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -160,8 +160,8 @@ public:
     void setPopover(const AtomString& value) { setAttributeWithoutSynchronization(HTMLNames::popoverAttr, value); };
     void popoverAttributeChanged(const AtomString& value);
 
-    bool isValidInvokeAction(const InvokeAction) final;
-    bool handleInvokeInternal(const HTMLFormControlElement& invoker, const InvokeAction&) final;
+    bool isValidInvokeAction(const InvokeAction) override;
+    bool handleInvokeInternal(const HTMLFormControlElement& invoker, const InvokeAction&) override;
 
 #if PLATFORM(IOS_FAMILY)
     static SelectionRenderingBehavior selectionRenderingBehavior(const Node*);

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -429,6 +429,8 @@ RefPtr<Element> HTMLFormControlElement::invokeTargetElement() const
 constexpr ASCIILiteral togglePopoverLiteral = "togglepopover"_s;
 constexpr ASCIILiteral showPopoverLiteral = "showpopover"_s;
 constexpr ASCIILiteral hidePopoverLiteral = "hidepopover"_s;
+constexpr ASCIILiteral showModalLiteral = "showmodal"_s;
+constexpr ASCIILiteral closeLiteral = "close"_s;
 InvokeAction HTMLFormControlElement::invokeAction() const
 {
     auto action = attributeWithoutSynchronization(HTMLNames::invokeactionAttr);
@@ -443,6 +445,12 @@ InvokeAction HTMLFormControlElement::invokeAction() const
 
     if (equalLettersIgnoringASCIICase(action, hidePopoverLiteral))
         return InvokeAction::HidePopover;
+
+    if (equalLettersIgnoringASCIICase(action, showModalLiteral))
+        return InvokeAction::ShowModal;
+
+    if (equalLettersIgnoringASCIICase(action, closeLiteral))
+        return InvokeAction::Close;
 
     if (action.contains('-'))
         return InvokeAction::Custom;


### PR DESCRIPTION
#### dbcbbe87dd98b259cf8815a53c9bc7276892de6f
<pre>
Add invoke defaults for dialogs
<a href="https://bugs.webkit.org/show_bug.cgi?id=270602">https://bugs.webkit.org/show_bug.cgi?id=270602</a>

Reviewed by Anne van Kesteren.

This adds the `handleInvokeInternal` logic for HTMLDialogElement showmodal/close
a dialog.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt.
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::isValidInvokeAction):
(WebCore::HTMLDialogElement::handleInvokeInternal):
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::invokeAction const):

Canonical link: <a href="https://commits.webkit.org/278970@main">https://commits.webkit.org/278970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26243fa2e9282c7396e5eaeff79c1d9782144e31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42398 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1797 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2230 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/984 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56972 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49798 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49059 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11404 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->