### PR TITLE
Re-import invoker WPT tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2836,6 +2836,12 @@ http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-css-i
 # text-spacing: These tests generate a bunch of render tree dumps
 imported/w3c/web-platform-tests/css/css-text/text-spacing-trim [ Skip ]
 
+# invokers v2: These tests cover additions to the invokers API which aren't specced yet
+imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html [ Skip ]
+
 # text-transform: full-width
 # no full width mapping for characters ( and )
 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-001.xht [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
@@ -5,4 +5,5 @@ PASS event action is set to invokeAction
 PASS event action is set to invokeaction attribute
 PASS event does not dispatch if click:preventDefault is called
 PASS event does not dispatch if invoker is disabled
+FAIL event dispatches if invoker is non-HTML Element assert_true: event was called expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
@@ -78,6 +78,7 @@
   }, "event does not dispatch if click:preventDefault is called");
 
   promise_test(async function (t) {
+    t.add_cleanup(() => invokerbutton.removeAttribute('disabled'));
     let called = false;
     invokee.addEventListener(
       "invoke",
@@ -90,4 +91,29 @@
     await clickOn(invokerbutton);
     assert_false(called, "event was not called");
   }, "event does not dispatch if invoker is disabled");
+
+  promise_test(async function (t) {
+    svgInvokee = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    t.add_cleanup(() => {
+      invokerbutton.invokeTargetElement = invokee;
+      svgInvokee.remove();
+    });
+    document.body.append(svgInvokee);
+    let called = false;
+    assert_false(svgInvokee instanceof HTMLElement);
+    assert_true(svgInvokee instanceof Element);
+    let eventInvoker = null;
+    svgInvokee.addEventListener(
+      "invoke",
+      (event) => {
+        eventInvoker = event.invoker;
+        called = true;
+      },
+      { once: true },
+    );
+    invokerbutton.invokeTargetElement = svgInvokee;
+    await clickOn(invokerbutton);
+    assert_true(called, "event was called");
+    assert_true(eventInvoker == svgInvokee, "event invoker is set to right element");
+  }, "event dispatches if invoker is non-HTML Element");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative-expected.txt
@@ -2,6 +2,7 @@ Fullscreen content
 
 PASS invoking div with auto action is no-op
 FAIL invoking div with toggleFullscreen action makes div fullscreen assert_true: expected true got false
+PASS invoking div with toggleFullscreen action (without user activation) is a no-op
 PASS invoking div with toggleFullscreen action and preventDefault is a no-op
 FAIL invoking fullscreen div with toggleFullscreen action exits fullscreen assert_false: expected false got true
 FAIL invoking fullscreen div with toggleFullscreen (case-insensitive) action exits fullscreen assert_false: expected false got true

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html
@@ -44,6 +44,17 @@
       invokerbutton.removeAttribute("invokeaction");
       if (document.fullscreenElement) await document.exitFullscreen();
     });
+    assert_false(invokee.matches(":fullscreen"));
+    invokerbutton.setAttribute("invokeaction", "toggleFullscreen");
+    invokerbutton.click();
+    assert_false(invokee.matches(":fullscreen"));
+  }, "invoking div with toggleFullscreen action (without user activation) is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      if (document.fullscreenElement) await document.exitFullscreen();
+    });
     invokee.addEventListener("invoke", (e) => e.preventDefault(), {
       once: true,
     });

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-generic-eventtarget-crash.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-generic-eventtarget-crash.tentative.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<div id="invoker"></div>
+
+<script type="module">
+  const invokeEvent = new InvokeEvent('invoke', { bubbles: true });
+  document.body.addEventListener('invoke', e => {
+    e.invoker.toString();
+  });
+  invoker.addEventListener('invoke', e => {
+    e.invoker.toString();
+  });
+  invoker.dispatchEvent(invokeEvent);
+  await Promise.resolve();
+  invokeEvent.invoker.toString();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative-expected.txt
@@ -1,0 +1,18 @@
+
+
+PASS invoking audio with auto action is no-op
+FAIL invoking audio with playpause action makes audio play assert_false: expected false got true
+FAIL invoking audio with playpause action (without user activation) is a no-op assert_false: expected false got true
+PASS invoking audio with playpause action and preventDefault is a no-op
+FAIL invoking playing audio with playpause action pauses it assert_true: expected true got false
+FAIL invoking audio with play action makes audio play assert_false: expected false got true
+FAIL invoking audio with play action (without user activation) is a no-op assert_false: expected false got true
+PASS invoking audio with play action and preventDefault is a no-op
+PASS invoking playing audio with play action is a no-op
+PASS invoking audio with pause action is a no-op
+PASS invoking audio with pause action and preventDefault is a no-op
+FAIL invoking playing audio with pause action makes it pause assert_true: expected true got false
+FAIL invoking audio with toggleMuted action mutes it assert_true: expected true got false
+PASS invoking audio with toggleMuted action and preventDefault is a no-op
+FAIL invoking muted audio with toggleMuted action unmutes it assert_false: expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<audio controls id="invokee" src="/media/sound_5.mp3"></audio>
+<button id="invokerbutton" invoketarget="invokee"></button>
+
+<script>
+  // auto
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking audio with auto action is no-op");
+
+  // playpause
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "playpause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.paused);
+  }, "invoking audio with playpause action makes audio play");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "playpause");
+    invokerbutton.click();
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.paused);
+  }, "invoking audio with playpause action (without user activation) is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "playpause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking audio with playpause action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    await test_driver.bless('play audio');
+    invokee.play();
+    assert_false(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "playpause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking playing audio with playpause action pauses it");
+
+  // play
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "play");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.paused);
+  }, "invoking audio with play action makes audio play");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "play");
+    invokerbutton.click();
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.paused);
+  }, "invoking audio with play action (without user activation) is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "play");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking audio with play action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    await test_driver.bless('play audio');
+    invokee.play();
+    assert_false(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "play");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.paused);
+  }, "invoking playing audio with play action is a no-op");
+
+  // pause
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "pause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+        requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking audio with pause action is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "pause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking audio with pause action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    await test_driver.bless('play audio');
+    invokee.play();
+    assert_false(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "pause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking playing audio with pause action makes it pause");
+
+  // mute
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_false(invokee.muted);
+    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.muted);
+  }, "invoking audio with toggleMuted action mutes it");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_false(invokee.muted);
+    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.muted);
+  }, "invoking audio with toggleMuted action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.muted = true;
+    assert_true(invokee.muted);
+    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.muted);
+  }, "invoking muted audio with toggleMuted action unmutes it");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative-expected.txt
@@ -2,8 +2,10 @@
 
 FAIL invoking closed details with auto action opens assert_true: expected true got false
 PASS invoking closed details with auto action and preventDefault does not open
-FAIL invoking open details with auto action opens assert_false: expected false got true
+FAIL invoking open details with auto action closes assert_false: expected false got true
 PASS invoking open details with auto action and preventDefault does not close
+FAIL invoking details with auto action where event listener opens leads to a closed details assert_false: expected false got true
+FAIL invoking open details with auto action where event listener closes leads to an open details assert_true: expected true got false
 FAIL invoking closed details with toggle action opens assert_true: expected true got false
 FAIL invoking closed details with toggle (case-insensitive) action opens assert_true: expected true got false
 PASS invoking closed details with toggle action and preventDefault does not open

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html
@@ -10,7 +10,7 @@
 <script src="resources/invoker-utils.js"></script>
 
 <details id="invokee">
-  Details Contents
+    Details Contents
 </details>
 <button id="invokerbutton" invoketarget="invokee"></button>
 
@@ -27,7 +27,7 @@
   promise_test(async function (t) {
     assert_false(invokee.matches("[open]"));
     invokee.addEventListener("invoke", (e) => e.preventDefault(), {
-      once: true,
+        once: true,
     });
     await clickOn(invokerbutton);
     t.add_cleanup(() => invokee.removeAttribute('open'));
@@ -39,18 +39,43 @@
     assert_true(invokee.matches("[open]"));
     await clickOn(invokerbutton);
     assert_false(invokee.matches("[open]"));
-  }, "invoking open details with auto action opens");
+  }, "invoking open details with auto action closes");
 
   promise_test(async function (t) {
     invokee.setAttribute('open', '');
     t.add_cleanup(() => invokee.removeAttribute('open'));
     invokee.addEventListener("invoke", (e) => e.preventDefault(), {
-      once: true,
+        once: true,
     });
     assert_true(invokee.matches("[open]"));
     await clickOn(invokerbutton);
     assert_true(invokee.matches("[open]"));
   }, "invoking open details with auto action and preventDefault does not close");
+
+  promise_test(async function (t) {
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    invokee.addEventListener("invoke", (e) => {
+        invokee.setAttribute('open', '');
+    }, {
+        once: true,
+    });
+    assert_false(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    assert_false(invokee.matches("[open]"));
+  }, "invoking details with auto action where event listener opens leads to a closed details");
+
+  promise_test(async function (t) {
+    invokee.setAttribute('open', '');
+    t.add_cleanup(() => invokee.removeAttribute('open'));
+    invokee.addEventListener("invoke", (e) => {
+        invokee.removeAttribute('open');
+    }, {
+        once: true,
+    });
+    assert_true(invokee.matches("[open]"));
+    await clickOn(invokerbutton);
+    assert_true(invokee.matches("[open]"));
+  }, "invoking open details with auto action where event listener closes leads to an open details");
 
   // toggle
 
@@ -77,7 +102,7 @@
     invokerbutton.setAttribute("invokeaction", "toggle");
     t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
     invokee.addEventListener("invoke", (e) => e.preventDefault(), {
-      once: true,
+        once: true,
     });
     await clickOn(invokerbutton);
     t.add_cleanup(() => invokee.removeAttribute('open'));
@@ -99,7 +124,7 @@
     invokerbutton.setAttribute("invokeaction", "toggle");
     t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
     invokee.addEventListener("invoke", (e) => e.preventDefault(), {
-      once: true,
+        once: true,
     });
     assert_true(invokee.matches("[open]"));
     await clickOn(invokerbutton);
@@ -141,7 +166,7 @@
     t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
     assert_false(invokee.matches("[open]"));
     invokee.addEventListener("invoke", (e) => e.preventDefault(), {
-      once: true,
+        once: true,
     });
     await clickOn(invokerbutton);
     t.add_cleanup(() => invokee.removeAttribute('open'));
@@ -185,7 +210,7 @@
     t.add_cleanup(() => invokee.removeAttribute('open'));
     assert_true(invokee.matches("[open]"));
     invokee.addEventListener("invoke", (e) => e.preventDefault(), {
-      once: true,
+        once: true,
     });
     await clickOn(invokerbutton);
     assert_true(invokee.matches("[open]"));

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
@@ -2,12 +2,14 @@
 
 FAIL invoking (as auto) closed popover opens assert_true: expected true got false
 PASS invoking (as auto) closed popover with preventDefault does not open
-FAIL invoking (as auto) open popover closes assert_false: expected false got true
+PASS invoking (as auto) open popover closes
+FAIL invoking (as auto) from within open popover closes assert_false: expected false got true
 PASS invoking (as auto) open popover with preventDefault does not close
 FAIL invoking (as togglepopover) closed popover opens assert_true: expected true got false
 FAIL invoking (as togglepopover - case insensitive) closed popover opens assert_true: expected true got false
 PASS invoking (as togglepopover) closed popover with preventDefault does not open
-FAIL invoking (as togglepopover) open popover closes assert_false: expected false got true
+PASS invoking (as togglepopover) open popover closes
+FAIL invoking (as togglepopover) from within open popover closes assert_false: expected false got true
 PASS invoking (as togglepopover) open popover with preventDefault does not close
 FAIL invoking (as showpopover) closed popover opens assert_true: expected true got false
 FAIL invoking (as showpopover - case insensitive) closed popover opens assert_true: expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
@@ -37,9 +37,16 @@
   promise_test(async function (t) {
     invokee.showPopover();
     assert_true(invokee.matches(":popover-open"));
-    await clickOn(invokerbutton2);
+    await clickOn(invokerbutton);
     assert_false(invokee.matches(":popover-open"));
   }, "invoking (as auto) open popover closes");
+
+  promise_test(async function (t) {
+    invokee.showPopover();
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton2);
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as auto) from within open popover closes");
 
   promise_test(async function (t) {
     invokee.showPopover();
@@ -89,9 +96,18 @@
     invokerbutton2.setAttribute("invokeaction", "togglepopover");
     t.add_cleanup(() => invokerbutton2.removeAttribute("invokeaction"));
     assert_true(invokee.matches(":popover-open"));
-    await clickOn(invokerbutton2);
+    await clickOn(invokerbutton);
     assert_false(invokee.matches(":popover-open"));
   }, "invoking (as togglepopover) open popover closes");
+
+  promise_test(async function (t) {
+    invokee.showPopover();
+    invokerbutton2.setAttribute("invokeaction", "togglepopover");
+    t.add_cleanup(() => invokerbutton2.removeAttribute("invokeaction"));
+    assert_true(invokee.matches(":popover-open"));
+    await clickOn(invokerbutton2);
+    assert_false(invokee.matches(":popover-open"));
+  }, "invoking (as togglepopover) from within open popover closes");
 
   promise_test(async function (t) {
     invokee.showPopover();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative-expected.txt
@@ -1,0 +1,16 @@
+
+
+FAIL invoking video with auto action is no-op assert_true: expected true got false
+FAIL invoking video with playpause action makes video play assert_false: expected false got true
+PASS invoking video with playpause action and preventDefault is a no-op
+FAIL invoking playing video with playpause action pauses it assert_true: expected true got false
+FAIL invoking video with play action makes video play assert_false: expected false got true
+PASS invoking video with play action and preventDefault is a no-op
+PASS invoking playing video with play action is a no-op
+PASS invoking video with pause action is a no-op
+PASS invoking video with pause action and preventDefault is a no-op
+FAIL invoking playing video with pause action makes it pause assert_true: expected true got false
+FAIL invoking video with toggleMuted action mutes it assert_true: expected true got false
+PASS invoking video with toggleMuted action and preventDefault is a no-op
+FAIL invoking muted video with toggleMuted action unmutes it assert_false: expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<video controls id="invokee" src="/media/movie_5.mp4"></video>
+<button id="invokerbutton" invoketarget="invokee"></button>
+
+<script>
+  // auto
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking video with auto action is no-op");
+
+  // playpause
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "playpause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.paused);
+  }, "invoking video with playpause action makes video play");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+      once: true,
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "playpause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking video with playpause action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    await test_driver.bless('play video');
+    invokee.play();
+    assert_false(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "playpause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking playing video with playpause action pauses it");
+
+  // play
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "play");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.paused);
+  }, "invoking video with play action makes video play");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+        once: true,
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "play");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking video with play action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    await test_driver.bless('play video');
+    invokee.play();
+    assert_false(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "play");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.paused);
+  }, "invoking playing video with play action is a no-op");
+
+  // pause
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "pause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking video with pause action is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+        once: true,
+    });
+    assert_true(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "pause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking video with pause action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    await test_driver.bless('play video');
+    invokee.play();
+    assert_false(invokee.paused);
+    invokerbutton.setAttribute("invokeaction", "pause");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.paused);
+  }, "invoking playing video with pause action makes it pause");
+
+  // mute
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    assert_false(invokee.muted);
+    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_true(invokee.muted);
+  }, "invoking video with toggleMuted action mutes it");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+        once: true,
+    });
+    assert_false(invokee.muted);
+    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.muted);
+  }, "invoking video with toggleMuted action and preventDefault is a no-op");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      invokerbutton.removeAttribute("invokeaction");
+      invokee.pause();
+      invokee.currentTime = 0;
+      invokee.muted = false;
+    });
+    invokee.muted = true;
+    assert_true(invokee.muted);
+    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    await clickOn(invokerbutton);
+    await new Promise(resolve => {
+      requestAnimationFrame(resolve);
+    });
+    assert_false(invokee.muted);
+  }, "invoking muted video with toggleMuted action unmutes it");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
@@ -20,5 +20,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-generic-eventtarget-crash.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
@@ -3,11 +3,13 @@
 FAIL invoking (as auto) closed popover opens assert_true: expected true got false
 PASS invoking (as auto) closed popover with preventDefault does not open
 FAIL invoking (as auto) open popover closes assert_false: expected false got true
+FAIL invoking (as auto) from within open popover closes assert_false: expected false got true
 PASS invoking (as auto) open popover with preventDefault does not close
 FAIL invoking (as togglepopover) closed popover opens assert_true: expected true got false
 FAIL invoking (as togglepopover - case insensitive) closed popover opens assert_true: expected true got false
 PASS invoking (as togglepopover) closed popover with preventDefault does not open
 FAIL invoking (as togglepopover) open popover closes assert_false: expected false got true
+FAIL invoking (as togglepopover) from within open popover closes assert_false: expected false got true
 PASS invoking (as togglepopover) open popover with preventDefault does not close
 FAIL invoking (as showpopover) closed popover opens assert_true: expected true got false
 FAIL invoking (as showpopover - case insensitive) closed popover opens assert_true: expected true got false

--- a/Source/WebCore/dom/InvokeEvent.cpp
+++ b/Source/WebCore/dom/InvokeEvent.cpp
@@ -69,6 +69,9 @@ bool InvokeEvent::isInvokeEvent() const
 RefPtr<Element> InvokeEvent::invoker() const
 {
     auto* invoker = m_invoker.get();
+    if (!invoker)
+        return nullptr;
+
     if (RefPtr target = dynamicDowncast<Node>(currentTarget())) {
         auto& treeScope = target->treeScope();
         auto node = treeScope.retargetToScope(*invoker);


### PR DESCRIPTION
#### c186a833cb69d41564ab234631537684365c1501
<pre>
Re-import invoker WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=269670">https://bugs.webkit.org/show_bug.cgi?id=269670</a>

Reviewed by Tim Nguyen.

Upstream commit: web-platform-tests/wpt@32864fa

Also fixes an issue where null invokers would be retargeted causing a crash.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-generic-eventtarget-crash.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt:
* Source/WebCore/dom/InvokeEvent.cpp:
(WebCore::InvokeEvent::invoker const):

Canonical link: <a href="https://commits.webkit.org/274953@main">https://commits.webkit.org/274953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d3ae5c117f20a7c62872f237da1a723487e9641

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36563 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33583 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14166 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44300 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38236 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35145 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16958 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5367 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->