### PR TITLE
Implement AXExpanded handling for command buttons

### DIFF
--- a/LayoutTests/accessibility/mac/expanded-notification-commandfor-popover-expected.txt
+++ b/LayoutTests/accessibility/mac/expanded-notification-commandfor-popover-expected.txt
@@ -1,0 +1,46 @@
+This tests that expanded notifications will be sent correctly for command buttons and popovers.
+PASS: showPopoverCommandButton.isExpanded === false
+PASS: hidePopoverCommandButton.isExpanded === false
+PASS: togglePopoverCommandButton.isExpanded === false
+PASS: showPopoverCommandButton.isAttributeSupported('AXExpanded') === true
+PASS: hidePopoverCommandButton.isAttributeSupported('AXExpanded') === true
+PASS: togglePopoverCommandButton.isAttributeSupported('AXExpanded') === true
+PASS: customCommandButton.isExpanded === false
+PASS: invalidCommandButton.isExpanded === false
+PASS: customCommandButton.isAttributeSupported('AXExpanded') === false
+PASS: invalidCommandButton.isAttributeSupported('AXExpanded') === false
+document.getElementById('show-popover-command-btn').click()
+PASS: showPopoverCommandButton.isExpanded === true
+PASS: hidePopoverCommandButton.isExpanded === true
+PASS: togglePopoverCommandButton.isExpanded === true
+PASS: customCommandButton.isExpanded === false
+PASS: invalidCommandButton.isExpanded === false
+PASS: customCommandButton.isAttributeSupported('AXExpanded') === false
+PASS: invalidCommandButton.isAttributeSupported('AXExpanded') === false
+document.getElementById('hide-popover-command-btn').click()
+PASS: showPopoverCommandButton.isExpanded === false
+PASS: hidePopoverCommandButton.isExpanded === false
+PASS: togglePopoverCommandButton.isExpanded === false
+document.getElementById('show-popover-command-btn').setAttribute('commandfor', 'non-existent')
+PASS: showPopoverCommandButton.isExpanded === false
+PASS: showPopoverCommandButton.isAttributeSupported('AXExpanded') === false
+document.getElementById('show-popover-command-btn').setAttribute('commandfor', 'mypopover')
+PASS: showPopoverCommandButton.isExpanded === false
+PASS: showPopoverCommandButton.isAttributeSupported('AXExpanded') === true
+document.getElementById('show-popover-command-btn').setAttribute('command', 'invalid')
+PASS: showPopoverCommandButton.isExpanded === false
+PASS: showPopoverCommandButton.isAttributeSupported('AXExpanded') === false
+document.getElementById('show-popover-command-btn').setAttribute('command', 'show-popover')
+document.getElementById('mypopover').removeAttribute('popover')
+PASS: showPopoverCommandButton.isExpanded === false
+PASS: hidePopoverCommandButton.isExpanded === false
+PASS: togglePopoverCommandButton.isExpanded === false
+PASS: showPopoverCommandButton.isAttributeSupported('AXExpanded') === false
+PASS: hidePopoverCommandButton.isAttributeSupported('AXExpanded') === false
+PASS: togglePopoverCommandButton.isAttributeSupported('AXExpanded') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Show popover Hide popover Toggle popover  Custom Command Button Invalid Command Button
+Popover content

--- a/LayoutTests/accessibility/mac/expanded-notification-commandfor-popover.html
+++ b/LayoutTests/accessibility/mac/expanded-notification-commandfor-popover.html
@@ -1,0 +1,103 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<button type="button" id="show-popover-command-btn" commandfor="mypopover" command="show-popover">Show popover</button>
+<button type="button" id="hide-popover-command-btn" commandfor="mypopover" command="hide-popover">Hide popover</button>
+<button type="button" id="toggle-popover-command-btn" commandfor="mypopover" command="toggle-popover">Toggle popover</button>
+
+<button type="button" id="custom-command-btn" commandfor="mypopover" command="--custom">Custom Command Button</button>
+<button type="button" id="invalid-command-btn" commandfor="mypopover" command="invalid">Invalid Command Button</button>
+
+<div id="mypopover" popover>Popover content</div>
+
+<script>
+let output = "This tests that expanded notifications will be sent correctly for command buttons and popovers.\n";
+
+let notificationCount = 0;
+function notificationCallback(element, notification) {
+    if (notification == "AXExpandedChanged") {
+        notificationCount++;
+
+        output += `Received ${notification} for #${element.domIdentifier}\n`;
+        output += `element.isExpanded: ${element.isExpanded}\n`;
+    }
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notificationCallback);
+    var showPopoverCommandButton = accessibilityController.accessibleElementById("show-popover-command-btn");
+    var hidePopoverCommandButton = accessibilityController.accessibleElementById("hide-popover-command-btn");
+    var togglePopoverCommandButton = accessibilityController.accessibleElementById("toggle-popover-command-btn");
+    var customCommandButton = accessibilityController.accessibleElementById("custom-command-btn");
+    var invalidCommandButton = accessibilityController.accessibleElementById("invalid-command-btn");
+    setTimeout(async () => {
+        // Command buttons that are linked to closed popovers should not be considered expanded, but should still support the expanded state.
+        output += expect("showPopoverCommandButton.isExpanded", "false");
+        output += expect("hidePopoverCommandButton.isExpanded", "false");
+        output += expect("togglePopoverCommandButton.isExpanded", "false");
+        output += expect("showPopoverCommandButton.isAttributeSupported('AXExpanded')", "true");
+        output += expect("hidePopoverCommandButton.isAttributeSupported('AXExpanded')", "true");
+        output += expect("togglePopoverCommandButton.isAttributeSupported('AXExpanded')", "true");
+
+        // Custom or invalid commands should not support the expanded state.
+        output += expect("customCommandButton.isExpanded", "false");
+        output += expect("invalidCommandButton.isExpanded", "false");
+        output += expect("customCommandButton.isAttributeSupported('AXExpanded')", "false");
+        output += expect("invalidCommandButton.isAttributeSupported('AXExpanded')", "false");
+
+        output += evalAndReturn("document.getElementById('show-popover-command-btn').click()");
+        // We expanded the popover via #show-popover-command-btn, but #hide-popover-command-btn and #toggle-popover-command-btn (which are also linked to the popover) should be considered expanded now as well.
+        output += await expectAsync("showPopoverCommandButton.isExpanded", "true");
+        output += await expectAsync("hidePopoverCommandButton.isExpanded", "true");
+        output += await expectAsync("togglePopoverCommandButton.isExpanded", "true");
+        // Custom or invalid commands should still not support the expanded state.
+        output += await expectAsync("customCommandButton.isExpanded", "false");
+        output += await expectAsync("invalidCommandButton.isExpanded", "false");
+        output += await expectAsync("customCommandButton.isAttributeSupported('AXExpanded')", "false");
+        output += await expectAsync("invalidCommandButton.isAttributeSupported('AXExpanded')", "false");
+
+        output += evalAndReturn("document.getElementById('hide-popover-command-btn').click()");
+        output += await expectAsync("showPopoverCommandButton.isExpanded", "false");
+        output += await expectAsync("hidePopoverCommandButton.isExpanded", "false");
+        output += await expectAsync("togglePopoverCommandButton.isExpanded", "false");
+
+        // Point commandfor at non-existent ID.
+        output += evalAndReturn("document.getElementById('show-popover-command-btn').setAttribute('commandfor', 'non-existent')");
+        output += await expectAsync("showPopoverCommandButton.isExpanded", "false");
+        output += await expectAsync("showPopoverCommandButton.isAttributeSupported('AXExpanded')", "false");
+
+        output += evalAndReturn("document.getElementById('show-popover-command-btn').setAttribute('commandfor', 'mypopover')");
+        output += await expectAsync("showPopoverCommandButton.isExpanded", "false");
+        output += await expectAsync("showPopoverCommandButton.isAttributeSupported('AXExpanded')", "true");
+
+        // Change command attribute to invalid.
+        output += evalAndReturn("document.getElementById('show-popover-command-btn').setAttribute('command', 'invalid')");
+        output += await expectAsync("showPopoverCommandButton.isExpanded", "false");
+        output += await expectAsync("showPopoverCommandButton.isAttributeSupported('AXExpanded')", "false");
+
+        output += evalAndReturn("document.getElementById('show-popover-command-btn').setAttribute('command', 'show-popover')");
+
+        // Make #mypopover not a popover.
+        output += evalAndReturn("document.getElementById('mypopover').removeAttribute('popover')");
+        output += await expectAsync("showPopoverCommandButton.isExpanded", "false");
+        output += await expectAsync("hidePopoverCommandButton.isExpanded", "false");
+        output += await expectAsync("togglePopoverCommandButton.isExpanded", "false");
+        output += await expectAsync("showPopoverCommandButton.isAttributeSupported('AXExpanded')", "false");
+        output += await expectAsync("hidePopoverCommandButton.isAttributeSupported('AXExpanded')", "false");
+        output += await expectAsync("togglePopoverCommandButton.isAttributeSupported('AXExpanded')", "false");
+
+        debug(output);
+        accessibilityController.removeNotificationListener();
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -165,6 +165,8 @@ protected:
     macro(ColumnCountChanged) \
     macro(ColumnIndexChanged) \
     macro(ColumnSpanChanged) \
+    macro(CommandChanged) \
+    macro(CommandForChanged) \
     macro(ContentEditableAttributeChanged) \
     macro(ControlledObjectsChanged) \
     macro(CurrentStateChanged) \

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -49,6 +49,7 @@
 #include "FrameLoader.h"
 #include "FrameSelection.h"
 #include "HTMLAudioElement.h"
+#include "HTMLButtonElement.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLDetailsElement.h"
 #include "HTMLFieldSetElement.h"
@@ -1181,6 +1182,18 @@ RefPtr<Element> AccessibilityNodeObject::popoverTargetElement() const
 {
     WeakPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(node());
     return formControlElement ? formControlElement->popoverTargetElement() : nullptr;
+}
+
+RefPtr<Element> AccessibilityNodeObject::commandForElement() const
+{
+    RefPtr element = dynamicDowncast<HTMLButtonElement>(node());
+    return element ? element->commandForElement() : nullptr;
+}
+
+CommandType AccessibilityNodeObject::commandType() const
+{
+    RefPtr element = dynamicDowncast<HTMLButtonElement>(node());
+    return element ? element->commandType() : CommandType::Invalid;
 }
 
 AccessibilityObject* AccessibilityNodeObject::internalLinkElement() const

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -116,6 +116,8 @@ public:
     Element* actionElement() const override;
     Element* anchorElement() const override;
     RefPtr<Element> popoverTargetElement() const final;
+    RefPtr<Element> commandForElement() const final;
+    CommandType commandType() const final;
     AccessibilityObject* internalLinkElement() const final;
     AccessibilityChildrenVector radioButtonGroup() const final;
    

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -61,6 +61,8 @@ class IntPoint;
 class IntSize;
 class ScrollableArea;
 
+enum class CommandType: uint8_t;
+
 class AccessibilityObject : public AXCoreObject, public CanMakeWeakPtr<AccessibilityObject> {
 public:
     virtual ~AccessibilityObject();
@@ -442,6 +444,7 @@ public:
     static AccessibilityObject* headingElementForNode(Node*);
     virtual Element* anchorElement() const { return nullptr; }
     virtual RefPtr<Element> popoverTargetElement() const { return nullptr; }
+    virtual RefPtr<Element> commandForElement() const { return nullptr; }
     Element* actionElement() const override { return nullptr; }
     virtual LayoutRect boundingBoxRect() const { return { }; }
     LayoutRect elementRect() const override = 0;
@@ -931,6 +934,8 @@ private:
 
     // Special handling of click point for links.
     IntPoint linkClickPoint();
+
+    virtual CommandType commandType() const;
 
 protected: // FIXME: Make the data members private.
     AccessibilityChildrenVector m_children;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6025,6 +6025,11 @@ bool Element::isPopoverShowing() const
     return popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing;
 }
 
+PopoverState Element::popoverState() const
+{
+    return popoverData() ? popoverData()->popoverState() : PopoverState::None;
+}
+
 // https://drafts.csswg.org/css-contain/#relevant-to-the-user
 bool Element::isRelevantToUser() const
 {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -102,6 +102,7 @@ enum class FullscreenNavigationUI : uint8_t;
 enum class FullscreenKeyboardLock : uint8_t;
 enum class IsSyntheticClick : bool { No, Yes };
 enum class ParserContentPolicy : uint8_t;
+enum class PopoverState : uint8_t { None, Auto, Manual };
 enum class ResolveURLs : uint8_t { No, NoExcludingURLsForPrivacy, Yes, YesExcludingURLsForPrivacy };
 enum class SelectionRestorationMode : uint8_t;
 enum class ShadowRootDelegatesFocus : bool { No, Yes };
@@ -676,6 +677,7 @@ public:
     PopoverData& ensurePopoverData();
     void clearPopoverData();
     bool isPopoverShowing() const;
+    PopoverState popoverState() const;
 
     Element* invokedPopover() const;
     void setInvokedPopover(RefPtr<Element>&&);

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -44,6 +44,7 @@ public:
     void setCommand(const AtomString&);
 
     RefPtr<Element> commandForElement() const;
+    CommandType commandType() const;
 
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 
@@ -68,7 +69,6 @@ private:
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void defaultEventHandler(Event&) final;
 
-    CommandType commandType() const;
     void handleCommand();
 
     bool appendFormData(DOMFormData&) final;

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1345,11 +1345,6 @@ const AtomString& HTMLElement::popover() const
     return nullAtom();
 }
 
-PopoverState HTMLElement::popoverState() const
-{
-    return popoverData() ? popoverData()->popoverState() : PopoverState::None;
-}
-
 #if PLATFORM(IOS_FAMILY)
 
 SelectionRenderingBehavior HTMLElement::selectionRenderingBehavior(const Node* node)

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -46,7 +46,6 @@ struct TextRecognitionResult;
 
 enum class EnterKeyHint : uint8_t;
 enum class PageIsEditable : bool;
-enum class PopoverVisibilityState : bool;
 enum class ToggleState : bool;
 
 #if PLATFORM(IOS_FAMILY)
@@ -55,11 +54,6 @@ enum class SelectionRenderingBehavior : bool;
 
 enum class FireEvents : bool { No, Yes };
 enum class FocusPreviousElement : bool { No, Yes };
-enum class PopoverState : uint8_t {
-    None,
-    Auto,
-    Manual,
-};
 
 class HTMLElement : public StyledElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLElement);
@@ -163,7 +157,6 @@ public:
     ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents);
     ExceptionOr<bool> togglePopover(std::optional<std::variant<WebCore::HTMLElement::TogglePopoverOptions, bool>>);
 
-    PopoverState popoverState() const;
     const AtomString& popover() const;
     void setPopover(const AtomString& value) { setAttributeWithoutSynchronization(HTMLNames::popoverAttr, value); };
     void popoverAttributeChanged(const AtomString& value);


### PR DESCRIPTION
#### 362e1d2e9abae57701df04c5bee563bcbb4be833
<pre>
Implement AXExpanded handling for command buttons
<a href="https://bugs.webkit.org/show_bug.cgi?id=269672">https://bugs.webkit.org/show_bug.cgi?id=269672</a>

Reviewed by Tyler Wilcock and Darin Adler.

This patch updates WebKit to handle exposing the expanded state on command buttons.

Specifically when the command button is linked with a popover,
and has a valid command for popover it will expose the expanded state.

See <a href="https://github.com/w3c/aria/pull/2354">https://github.com/w3c/aria/pull/2354</a>

* LayoutTests/accessibility/mac/expanded-notification-commandfor-popover-expected.txt: Added.
* LayoutTests/accessibility/mac/expanded-notification-commandfor-popover.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::updateIsolatedTree):
(WebCore::AXObjectCache::relationAttributes):
(WebCore::AXObjectCache::attributeToRelationType):
(WebCore::AXObjectCache::updateRelations):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::commandForElement const):
(WebCore::AccessibilityNodeObject::commandType const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::commandType const):
(WebCore::AccessibilityObject::supportsExpanded const):
(WebCore::AccessibilityObject::isExpanded const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::commandForElement const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::popoverState const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLButtonElement.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::popoverState const): Deleted.
* Source/WebCore/html/HTMLElement.h:

Canonical link: <a href="https://commits.webkit.org/292067@main">https://commits.webkit.org/292067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8549b740a43a60f07223bca4ad11759559bd3db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72317 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29620 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3320 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44637 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101867 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80696 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20171 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15069 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26933 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->