### PR TITLE
Invokers should work on non-html elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
@@ -5,5 +5,5 @@ PASS event action is set to invokeAction
 PASS event action is set to invokeaction attribute
 PASS event does not dispatch if click:preventDefault is called
 PASS event does not dispatch if invoker is disabled
-FAIL event dispatches if invoker is non-HTML Element assert_true: event was called expected true got false
+PASS event dispatches if invokee is non-HTML Element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
@@ -107,6 +107,7 @@
       "invoke",
       (event) => {
         eventInvoker = event.invoker;
+        eventTarget = event.target;
         called = true;
       },
       { once: true },
@@ -114,6 +115,7 @@
     invokerbutton.invokeTargetElement = svgInvokee;
     await clickOn(invokerbutton);
     assert_true(called, "event was called");
-    assert_true(eventInvoker == svgInvokee, "event invoker is set to right element");
-  }, "event dispatches if invoker is non-HTML Element");
+    assert_equals(eventInvoker, invokerbutton, "event.invoker is set to right element");
+    assert_equals(eventTarget, svgInvokee, "event.target is set to right element");
+  }, "event dispatches if invokee is non-HTML Element");
 </script>

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -620,6 +620,8 @@ public:
     void clearPopoverData();
     bool isPopoverShowing() const;
 
+    virtual void handleInvokeInternal(const AtomString&) { }
+
     ExceptionOr<void> setPointerCapture(int32_t);
     ExceptionOr<void> releasePointerCapture(int32_t);
     bool hasPointerCapture(int32_t);

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -162,8 +162,6 @@ public:
     void setPopover(const AtomString& value) { setAttributeWithoutSynchronization(HTMLNames::popoverAttr, value); };
     void popoverAttributeChanged(const AtomString& value);
 
-    virtual void handleInvokeInternal(const AtomString&) { }
-
 #if PLATFORM(IOS_FAMILY)
     static SelectionRenderingBehavior selectionRenderingBehavior(const Node*);
 #endif

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -410,7 +410,7 @@ void HTMLFormControlElement::handlePopoverTargetAction() const
         target->showPopover(this);
 }
 
-RefPtr<HTMLElement> HTMLFormControlElement::invokeTargetElement() const
+RefPtr<Element> HTMLFormControlElement::invokeTargetElement() const
 {
     auto canInvoke = [](const HTMLFormControlElement& element) -> bool {
         if (!element.document().settings().invokerAttributesEnabled())
@@ -423,7 +423,7 @@ RefPtr<HTMLElement> HTMLFormControlElement::invokeTargetElement() const
     if (!canInvoke(*this))
         return nullptr;
 
-    return dynamicDowncast<HTMLElement>(getElementAttribute(invoketargetAttr));
+    return getElementAttribute(invoketargetAttr);
 }
 
 const AtomString& HTMLFormControlElement::invokeAction() const

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -102,7 +102,7 @@ public:
     const AtomString& popoverTargetAction() const;
     void setPopoverTargetAction(const AtomString& value);
 
-    RefPtr<HTMLElement> invokeTargetElement() const;
+    RefPtr<Element> invokeTargetElement() const;
     const AtomString& invokeAction() const;
     void setInvokeAction(const AtomString& value);
 


### PR DESCRIPTION
#### b1c3165a6c3bfac437737539fdbc51cfb395dbae
<pre>
Invokers should work on non-html elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=269673">https://bugs.webkit.org/show_bug.cgi?id=269673</a>

Reviewed by Tim Nguyen.

This changes invokers to work on non-HTML elements by changing code to reference Element instead of HTMLElement.

This patch also fixes the relevant test as it was wrong.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html:
* Source/WebCore/dom/Element.h:
(WebCore::Element::handleInvokeInternal):
* Source/WebCore/html/HTMLElement.h:
(WebCore::HTMLElement::handleInvokeInternal): Deleted.
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::invokeTargetElement const):
* Source/WebCore/html/HTMLFormControlElement.h:

Canonical link: <a href="https://commits.webkit.org/274954@main">https://commits.webkit.org/274954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a902bc0b42be19f55061e9b03b208548f1bf831

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43037 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14246 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44312 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39950 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38253 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35159 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16970 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5368 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->