### PR TITLE
Use Expected for error reporting in Web Extensions completionHandlers.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1000,6 +1000,7 @@ def headers_for_type(type):
         'WebKit::WebEventType': ['"WebEvent.h"'],
         'WebKit::WebExtensionContext::InstallReason': ['"WebExtensionContext.h"'],
         'WebKit::WebExtensionCookieFilterParameters': ['"WebExtensionCookieParameters.h"'],
+        'WebKit::WebExtensionError': ['"WebExtensionError.h"'],
         'WebKit::WebExtensionTab::ImageFormat': ['"WebExtensionTab.h"'],
         'WebKit::WebGPU::BindGroupDescriptor': ['"WebGPUBindGroupDescriptor.h"'],
         'WebKit::WebGPU::BindGroupEntry': ['"WebGPUBindGroupEntry.h"'],

--- a/Source/WebKit/Shared/Extensions/WebExtensionConstants.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionConstants.h
@@ -29,12 +29,16 @@
 
 namespace WebKit {
 
-// MARK: Declarative Net Request constants.
+// MARK: Message Passing
+/// This matches the maximum message length enforced by Chromium in its `MessageFromJSONString()` function.
+constexpr size_t webExtensionMaxMessageLength = 1024 * 1024 * 64;
+
+// MARK: Declarative Net Request
 static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfStaticRulesets = 100;
 static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets = 50;
 static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules = 5000;
 
-// MARK: Storage constants.
+// MARK: Storage
 static constexpr double webExtensionUnlimitedStorageQuotaBytes = std::numeric_limits<double>::max();
 
 static constexpr size_t webExtensionStorageAreaLocalQuotaBytes = 5 * 1024 * 1024;

--- a/Source/WebKit/Shared/Extensions/WebExtensionError.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-messages -> WebExtensionController {
+#include <wtf/text/WTFString.h>
 
-    DidStartProvisionalLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
-    DidCommitLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
-    DidFinishLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
-    DidFailLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebKit::WebExtensionFrameIdentifier frameID, WebKit::WebExtensionFrameIdentifier parentFrameID, URL targetURL, WallTime timestamp)
+namespace WebKit {
 
-    // Test APIs
-    TestResult(bool result, String message, String sourceURL, unsigned lineNumber)
-    TestEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber)
-    TestMessage(String message, String sourceURL, unsigned lineNumber)
-    TestYielded(String message, String sourceURL, unsigned lineNumber)
-    TestFinished(bool result, String message, String sourceURL, unsigned lineNumber)
+using WebExtensionError = String;
 
-}
+} // namespace WTF
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -89,10 +89,10 @@ inline WebCore::FrameIdentifier toWebCoreFrameIdentifier(const WebExtensionFrame
 
 inline bool matchesFrame(const WebExtensionFrameIdentifier& identifier, const WebFrame& frame)
 {
-    if (auto* coreFrame = frame.coreFrame(); coreFrame->isMainFrame() && isMainFrame(identifier))
+    if (RefPtr coreFrame = frame.coreFrame(); coreFrame && coreFrame->isMainFrame() && isMainFrame(identifier))
         return true;
 
-    if (auto* page = frame.page(); &page->mainWebFrame() == &frame && isMainFrame(identifier))
+    if (RefPtr page = frame.page(); page && &page->mainWebFrame() == &frame && isMainFrame(identifier))
         return true;
 
     return frame.frameID().object().toUInt64() == identifier.toUInt64();
@@ -107,10 +107,10 @@ inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(WebCore::FrameI
 
 inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame& frame)
 {
-    if (auto* coreFrame = frame.coreFrame(); coreFrame->isMainFrame())
+    if (RefPtr coreFrame = frame.coreFrame(); coreFrame && coreFrame->isMainFrame())
         return WebExtensionFrameConstants::MainFrameIdentifier;
 
-    if (auto* page = frame.page(); &page->mainWebFrame() == &frame)
+    if (RefPtr page = frame.page(); page && &page->mainWebFrame() == &frame)
         return WebExtensionFrameConstants::MainFrameIdentifier;
 
     return toWebExtensionFrameIdentifier(frame.frameID());

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -27,9 +27,17 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "WebExtensionError.h"
 #import <JavaScriptCore/JSBase.h>
 
+#ifdef __OBJC__
+#import <wtf/RetainPtr.h>
+#import <wtf/cocoa/VectorCocoa.h>
+#endif
+
 namespace WebKit {
+
+#ifdef __OBJC__
 
 /// Verifies that a dictionary:
 ///  - Contains a required set of string keys, as listed in `requiredKeys`, all other types specified in `keyTypes` are optional keys.
@@ -59,9 +67,6 @@ JSObjectRef toJSError(JSContextRef, NSString *callingAPIName, NSString *sourceKe
 
 NSString *toWebAPI(NSLocale *);
 
-/// This matches the maximum message length enforced by Chromium in its `MessageFromJSONString()` function.
-constexpr size_t webExtensionMaxMessageLength = 1024 * 1024 * 64;
-
 /// Returns the storage size of a string.
 size_t storageSizeOf(NSString *);
 
@@ -70,6 +75,38 @@ size_t storageSizeOf(NSDictionary<NSString *, NSString *> *);
 
 /// Returns true if the size of any item in the dictionary exceeds the given quota.
 bool anyItemsExceedQuota(NSDictionary *, size_t quota, NSString **outKeyWithError = nullptr);
+
+enum class UseNullValue : bool { No, Yes };
+
+template<typename T>
+id toWebAPI(const std::optional<T>& result, UseNullValue useNull = UseNullValue::Yes)
+{
+    if (!result)
+        return useNull == UseNullValue::Yes ? NSNull.null : nil;
+    return toWebAPI(result.value());
+}
+
+template<typename T>
+NSArray *toWebAPI(const Vector<T>& items)
+{
+    return createNSArray(items, [](const T& item) {
+        return toWebAPI(item);
+    }).get();
+}
+
+inline NSNumber *toWebAPI(size_t index)
+{
+    return index != notFound ? @(index) : @(std::numeric_limits<double>::quiet_NaN());
+}
+
+/// Returns an error for Expected results in CompletionHandler.
+template<typename... Args>
+Unexpected<WebExtensionError> toWebExtensionError(NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString, Args&&... args)
+{
+    return makeUnexpected(String(toErrorString(callingAPIName, sourceKey, underlyingErrorString, std::forward<Args>(args)...)));
+}
+
+#endif // __OBJC__
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
@@ -44,9 +44,9 @@ void WebExtensionContext::alarmsCreate(const String& name, Seconds initialInterv
     }));
 }
 
-void WebExtensionContext::alarmsGet(const String& name, CompletionHandler<void(std::optional<WebExtensionAlarmParameters>)>&& completionHandler)
+void WebExtensionContext::alarmsGet(const String& name, CompletionHandler<void(std::optional<WebExtensionAlarmParameters>&&)>&& completionHandler)
 {
-    if (auto* alarm = m_alarmMap.get(name))
+    if (RefPtr alarm = m_alarmMap.get(name))
         completionHandler(alarm->parameters());
     else
         completionHandler(std::nullopt);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -45,7 +45,7 @@ static NSString * const displayBlockedResourceCountAsBadgeTextStateKey = @"Displ
 
 namespace WebKit {
 
-void WebExtensionContext::declarativeNetRequestGetEnabledRulesets(CompletionHandler<void(const Vector<String>&)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestGetEnabledRulesets(CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
     Vector<String> enabledRulesets;
     for (auto& ruleset : extension().declarativeNetRequestRulesets()) {
@@ -53,7 +53,7 @@ void WebExtensionContext::declarativeNetRequestGetEnabledRulesets(CompletionHand
             enabledRulesets.append(ruleset.rulesetID);
     }
 
-    completionHandler(enabledRulesets);
+    completionHandler(WTFMove(enabledRulesets));
 }
 
 void WebExtensionContext::loadDeclarativeNetRequestRulesetStateFromStorage()
@@ -102,10 +102,10 @@ WebExtensionContext::DeclarativeNetRequestValidatedRulesets WebExtensionContext:
         }
 
         if (!found)
-            return { std::nullopt, toErrorString(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"Failed to apply rules. Invalid ruleset id: %@.", (NSString *)identifier) };
+            return toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"Failed to apply rules. Invalid ruleset id: %@.", (NSString *)identifier);
     }
 
-    return { validatedRulesets, std::nullopt };
+    return WTFMove(validatedRulesets);
 }
 
 size_t WebExtensionContext::declarativeNetRequestEnabledRulesetCount()
@@ -134,27 +134,27 @@ void WebExtensionContext::declarativeNetRequestToggleRulesets(const Vector<Strin
     }
 }
 
-void WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets(const Vector<String>& rulesetIdentifiersToEnable, const Vector<String>& rulesetIdentifiersToDisable, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets(const Vector<String>& rulesetIdentifiersToEnable, const Vector<String>& rulesetIdentifiersToDisable, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
     if (rulesetIdentifiersToEnable.isEmpty() && rulesetIdentifiersToDisable.isEmpty()) {
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     auto validatedRulesetsToEnable = declarativeNetRequestValidateRulesetIdentifiers(rulesetIdentifiersToEnable);
-    if (validatedRulesetsToEnable.second) {
-        completionHandler(validatedRulesetsToEnable.second);
+    if (!validatedRulesetsToEnable) {
+        completionHandler(makeUnexpected(validatedRulesetsToEnable.error()));
         return;
     }
 
     auto validatedRulesetsToDisable = declarativeNetRequestValidateRulesetIdentifiers(rulesetIdentifiersToDisable);
-    if (validatedRulesetsToDisable.second) {
-        completionHandler(validatedRulesetsToDisable.second);
+    if (!validatedRulesetsToDisable) {
+        completionHandler(makeUnexpected(validatedRulesetsToDisable.error()));
         return;
     }
 
     if (declarativeNetRequestEnabledRulesetCount() - rulesetIdentifiersToDisable.size() + rulesetIdentifiersToEnable.size() > webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets) {
-        completionHandler(toErrorString(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"The number of enabled static rulesets exceeds the limit. Only %lu rulesets can be enabled at once.", webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets));
+        completionHandler(toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"The number of enabled static rulesets exceeds the limit. Only %lu rulesets can be enabled at once.", webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets));
         return;
     }
 
@@ -165,7 +165,7 @@ void WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets(const Vecto
     loadDeclarativeNetRequestRules([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), rulesetIdentifiersToEnable, rulesetIdentifiersToDisable, rulesetIdentifiersToEnabledState = RetainPtr { rulesetIdentifiersToEnabledState }](bool success) mutable {
         if (success) {
             saveDeclarativeNetRequestRulesetStateToStorage(rulesetIdentifiersToEnabledState.get());
-            completionHandler(std::nullopt);
+            completionHandler({ });
             return;
         }
 
@@ -174,7 +174,7 @@ void WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets(const Vecto
         declarativeNetRequestToggleRulesets(rulesetIdentifiersToDisable, true, rulesetIdentifiersToEnabledState.get());
         declarativeNetRequestToggleRulesets(rulesetIdentifiersToEnable, false, rulesetIdentifiersToEnabledState.get());
 
-        completionHandler(toErrorString(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"Failed to apply rules."));
+        completionHandler(toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"Failed to apply rules."));
     });
 }
 
@@ -198,10 +198,10 @@ void WebExtensionContext::incrementActionCountForTab(WebExtensionTab& tab, ssize
     tabAction->incrementBlockedResourceCount(incrementAmount);
 }
 
-void WebExtensionContext::declarativeNetRequestDisplayActionCountAsBadgeText(bool displayActionCountAsBadgeText, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestDisplayActionCountAsBadgeText(bool displayActionCountAsBadgeText, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
     if (shouldDisplayBlockedResourceCountAsBadgeText() == displayActionCountAsBadgeText) {
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
@@ -211,28 +211,28 @@ void WebExtensionContext::declarativeNetRequestDisplayActionCountAsBadgeText(boo
             entry.value->clearBlockedResourceCount();
     }
 
-    completionHandler(std::nullopt);
+    completionHandler({ });
 }
 
-void WebExtensionContext::declarativeNetRequestIncrementActionCount(WebExtensionTabIdentifier tabIdentifier, double increment, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestIncrementActionCount(WebExtensionTabIdentifier tabIdentifier, double increment, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toErrorString(@"declarativeNetRequest.setExtensionActionOptions()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"declarativeNetRequest.setExtensionActionOptions()", nil, @"tab not found"));
         return;
     }
 
     incrementActionCountForTab(*tab, increment);
-    completionHandler(std::nullopt);
+    completionHandler({ });
 }
 
-void WebExtensionContext::declarativeNetRequestGetMatchedRules(std::optional<WebExtensionTabIdentifier> tabIdentifier, std::optional<WallTime> minTimeStamp, CompletionHandler<void(std::optional<Vector<WebExtensionMatchedRuleParameters>> matchedRules, std::optional<String>)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestGetMatchedRules(std::optional<WebExtensionTabIdentifier> tabIdentifier, std::optional<WallTime> minTimeStamp, CompletionHandler<void(Expected<Vector<WebExtensionMatchedRuleParameters>, WebExtensionError>&&)>&& completionHandler)
 {
     RefPtr tab = tabIdentifier ? getTab(tabIdentifier.value()) : nullptr;
 
     static NSString * const apiName = @"declarativeNetRequest.getMatchedRules()";
     if (tabIdentifier && !tab) {
-        completionHandler(std::nullopt, toErrorString(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
         return;
     }
 
@@ -240,7 +240,7 @@ void WebExtensionContext::declarativeNetRequestGetMatchedRules(std::optional<Web
         ASSERT(hasPermission(_WKWebExtensionPermissionActiveTab));
 
         if (!hasPermission(_WKWebExtensionPermissionTabs, tab.get())) {
-            completionHandler(std::nullopt, toErrorString(apiName, nil, @"The 'activeTab' permission has not been granted by the user for the specified tab."));
+            completionHandler(toWebExtensionError(apiName, nil, @"The 'activeTab' permission has not been granted by the user for the specified tab."));
             return;
         }
     }
@@ -262,7 +262,7 @@ void WebExtensionContext::declarativeNetRequestGetMatchedRules(std::optional<Web
         filteredMatchedRules.append(matchedRule);
     }
 
-    completionHandler(filteredMatchedRules, std::nullopt);
+    completionHandler(WTFMove(filteredMatchedRules));
 }
 
 _WKWebExtensionDeclarativeNetRequestSQLiteStore *WebExtensionContext::declarativeNetRequestDynamicRulesStore()
@@ -281,44 +281,49 @@ _WKWebExtensionDeclarativeNetRequestSQLiteStore *WebExtensionContext::declarativ
     return m_declarativeNetRequestSessionRulesStore.get();
 }
 
-void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtensionDeclarativeNetRequestSQLiteStore *storage, NSString *storageType, NSArray *rulesToAdd, NSArray *ruleIDsToRemove, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtensionDeclarativeNetRequestSQLiteStore *storage, NSString *storageType, NSString *apiName, NSArray *rulesToAdd, NSArray *ruleIDsToRemove, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    [storage createSavepointWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storage, storageType, rulesToAdd, ruleIDsToRemove](NSUUID *savepointIdentifier, NSString *errorMessage) mutable {
+    [storage createSavepointWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storage, storageType, apiName, rulesToAdd, ruleIDsToRemove](NSUUID *savepointIdentifier, NSString *errorMessage) mutable {
         if (errorMessage)
             RELEASE_LOG_ERROR(Extensions, "Unable to create %{public}@ rules savepoint for extension %{private}@. Error: %{private}@", storageType, (NSString *)uniqueIdentifier(), errorMessage);
 
         if (errorMessage.length) {
-            completionHandler(errorMessage);
+            completionHandler(toWebExtensionError(apiName, nil, errorMessage));
             return;
         }
 
-        [storage updateRulesByRemovingIDs:ruleIDsToRemove addRules:rulesToAdd completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storage, storageType, savepointIdentifier](NSString *errorMessage) mutable {
+        [storage updateRulesByRemovingIDs:ruleIDsToRemove addRules:rulesToAdd completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storage, storageType, apiName, savepointIdentifier](NSString *errorMessage) mutable {
             if (errorMessage)
                 RELEASE_LOG_ERROR(Extensions, "Unable to update %{public}@ rules for extension %{private}@. Error: %{private}@", storageType, (NSString *)uniqueIdentifier(), errorMessage);
 
             if (errorMessage.length) {
                 // Update was unsucessful, rollback the changes to the database.
-                [storage rollbackToSavepoint:savepointIdentifier completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType, errorMessage](NSString *savepointErrorMessage) mutable {
+                [storage rollbackToSavepoint:savepointIdentifier completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType, apiName, errorMessage](NSString *savepointErrorMessage) mutable {
                     if (savepointErrorMessage)
                         RELEASE_LOG_ERROR(Extensions, "Unable to rollback to %{public}@ rules savepoint for extension %{private}@. Error: %{private}@", storageType, (NSString *)uniqueIdentifier(), savepointErrorMessage);
 
-                    completionHandler(errorMessage);
+                    completionHandler(toWebExtensionError(apiName, nil, errorMessage));
                 }).get()];
 
                 return;
             }
 
             // Update was sucessful, load the new rules.
-            loadDeclarativeNetRequestRules([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType, storage, savepointIdentifier](bool success) mutable {
+            loadDeclarativeNetRequestRules([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType, apiName, storage, savepointIdentifier](bool success) mutable {
                 if (!success) {
                     // Load was unsucessful, rollback the changes to the database.
-                    [storage rollbackToSavepoint:savepointIdentifier completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType](NSString *savepointErrorMessage) mutable {
+                    [storage rollbackToSavepoint:savepointIdentifier completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), storageType, apiName](NSString *savepointErrorMessage) mutable {
                         if (savepointErrorMessage)
                             RELEASE_LOG_ERROR(Extensions, "Unable to rollback to %{public}@ rules savepoint for extension %{private}@. Error: %{private}@", storageType, (NSString *)uniqueIdentifier(), savepointErrorMessage);
 
                         // Load the declarativeNetRequest rules again after rolling back the dynamic update.
-                        loadDeclarativeNetRequestRules([completionHandler = WTFMove(completionHandler)](bool success) mutable {
-                            completionHandler(success ? nil : @"Unable to load declarativeNetRequest rules.");
+                        loadDeclarativeNetRequestRules([completionHandler = WTFMove(completionHandler), apiName](bool success) mutable {
+                            if (!success) {
+                                completionHandler(toWebExtensionError(apiName, nil, @"unable to load declarativeNetRequest rules"));
+                                return;
+                            }
+
+                            completionHandler({ });
                         });
                     }).get()];
                 }
@@ -328,89 +333,87 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
                     if (savepointErrorMessage)
                         RELEASE_LOG_ERROR(Extensions, "Unable to commit %{public}@ rules savepoint for extension %{private}@. Error: %{private}@", storageType, (NSString *)uniqueIdentifier(), savepointErrorMessage);
 
-                    completionHandler(std::nullopt);
+                    completionHandler({ });
                 }).get()];
             });
         }).get()];
     }).get()];
 }
 
-void WebExtensionContext::declarativeNetRequestGetDynamicRules(CompletionHandler<void(std::optional<String> rulesJSON, std::optional<String> error)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestGetDynamicRules(CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
 {
     [declarativeNetRequestDynamicRulesStore() getRulesWithCompletionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSArray *rules, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(std::nullopt, errorMessage);
+            completionHandler(toWebExtensionError(@"declarativeNetRequest.getDynamicRules()", nil, errorMessage));
             return;
         }
 
-        completionHandler(encodeJSONString(rules, JSONOptions::FragmentsAllowed), std::nullopt);
+        completionHandler(String(encodeJSONString(rules, JSONOptions::FragmentsAllowed)));
     }).get()];
 }
 
-void WebExtensionContext::declarativeNetRequestUpdateDynamicRules(std::optional<String> rulesToAddJSON, std::optional<Vector<double>> ruleIDsToDeleteVector, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestUpdateDynamicRules(String&& rulesToAddJSON, Vector<double>&& ruleIDsToDeleteVector, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    auto *ruleIDsToDelete = @[ ];
-    if (ruleIDsToDeleteVector) {
-        ruleIDsToDelete = createNSArray(ruleIDsToDeleteVector.value(), [this, protectedThis = Ref { *this }](double ruleID) -> NSNumber * {
-            if (!m_dynamicRulesIDs.contains(ruleID))
-                return nil;
-            return @(ruleID);
-        }).get();
-    }
+    static NSString * const apiName = @"declarativeNetRequest.updateDynamicRules()";
 
-    NSArray *rulesToAdd = rulesToAddJSON ? parseJSON(rulesToAddJSON.value(), JSONOptions::FragmentsAllowed) : @[ ];
+    auto *ruleIDsToDelete = createNSArray(ruleIDsToDeleteVector, [this](double ruleID) -> NSNumber * {
+        if (!m_dynamicRulesIDs.contains(ruleID))
+            return nil;
+        return @(ruleID);
+    }).get();
+
+    auto *rulesToAdd = dynamic_objc_cast<NSArray>(parseJSON(rulesToAddJSON, JSONOptions::FragmentsAllowed)) ?: @[ ];
 
     if (!ruleIDsToDelete.count && !rulesToAdd.count) {
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     auto updatedDynamicRulesCount = m_dynamicRulesIDs.size() + rulesToAdd.count - ruleIDsToDelete.count;
     if (updatedDynamicRulesCount + m_sessionRulesIDs.size() > webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules) {
-        completionHandler(toErrorString(@"declarativeNetRequest.updateDynamicRules()", nil, @"Failed to add dynamic rules. Maximum number of dynamic and session rules exceeded."));
+        completionHandler(toWebExtensionError(apiName, nil, @"Failed to add dynamic rules. Maximum number of dynamic and session rules exceeded."));
         return;
     }
 
-    updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestDynamicRulesStore(), @"dynamic", rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
+    updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestDynamicRulesStore(), @"dynamic", apiName, rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
 }
 
-void WebExtensionContext::declarativeNetRequestGetSessionRules(CompletionHandler<void(std::optional<String> rulesJSON, std::optional<String> error)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestGetSessionRules(CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
 {
     [declarativeNetRequestSessionRulesStore() getRulesWithCompletionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSArray *rules, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(std::nullopt, errorMessage);
+            completionHandler(toWebExtensionError(@"declarativeNetRequest.getSessionRules()", nil, errorMessage));
             return;
         }
 
-        completionHandler(encodeJSONString(rules, JSONOptions::FragmentsAllowed), std::nullopt);
+        completionHandler(String(encodeJSONString(rules, JSONOptions::FragmentsAllowed)));
     }).get()];
 }
 
-void WebExtensionContext::declarativeNetRequestUpdateSessionRules(std::optional<String> rulesToAddJSON, std::optional<Vector<double>> ruleIDsToDeleteVector, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+void WebExtensionContext::declarativeNetRequestUpdateSessionRules(String&& rulesToAddJSON, Vector<double>&& ruleIDsToDeleteVector, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    auto *ruleIDsToDelete = @[ ];
-    if (ruleIDsToDeleteVector) {
-        ruleIDsToDelete = createNSArray(ruleIDsToDeleteVector.value(), [this, protectedThis = Ref { *this }](double ruleID) -> NSNumber * {
-            if (!m_sessionRulesIDs.contains(ruleID))
-                return nil;
-            return @(ruleID);
-        }).get();
-    }
+    static NSString * const apiName = @"declarativeNetRequest.updateSessionRules()";
 
-    NSArray *rulesToAdd = rulesToAddJSON ? parseJSON(rulesToAddJSON.value(), JSONOptions::FragmentsAllowed) : @[ ];
+    auto *ruleIDsToDelete = createNSArray(ruleIDsToDeleteVector, [this](double ruleID) -> NSNumber * {
+        if (!m_sessionRulesIDs.contains(ruleID))
+            return nil;
+        return @(ruleID);
+    }).get();
+
+    auto *rulesToAdd = dynamic_objc_cast<NSArray>(parseJSON(rulesToAddJSON, JSONOptions::FragmentsAllowed)) ?: @[ ];
 
     if (!ruleIDsToDelete.count && !rulesToAdd.count) {
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     auto updatedSessionRulesCount = m_sessionRulesIDs.size() + rulesToAdd.count - ruleIDsToDelete.count;
     if (updatedSessionRulesCount + m_dynamicRulesIDs.size() > webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules) {
-        completionHandler(toErrorString(@"declarativeNetRequest.updateSessionRules()", nil, @"Failed to add session rules. Maximum number of dynamic and session rules exceeded."));
+        completionHandler(toWebExtensionError(apiName, nil, @"Failed to add session rules. Maximum number of dynamic and session rules exceeded."));
         return;
     }
 
-    updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestSessionRulesStore(), @"session", rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
+    updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestSessionRulesStore(), @"session", apiName, rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm
@@ -38,21 +38,21 @@
 
 namespace WebKit {
 
-void WebExtensionContext::devToolsPanelsCreate(WebPageProxyIdentifier webPageProxyIdentifier, const String& title, const String& iconPath, const String& pagePath, CompletionHandler<void(Expected<Inspector::ExtensionTabID, String>)>&& completionHandler)
+void WebExtensionContext::devToolsPanelsCreate(WebPageProxyIdentifier webPageProxyIdentifier, const String& title, const String& iconPath, const String& pagePath, CompletionHandler<void(Expected<Inspector::ExtensionTabID, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const apiName = @"devtools.panels.create()";
 
     RefPtr extension = inspectorExtension(webPageProxyIdentifier);
     if (!extension) {
         RELEASE_LOG_ERROR(Extensions, "Inspector extension not found for page %llu", webPageProxyIdentifier.toUInt64());
-        completionHandler(makeUnexpected(toErrorString(apiName, nil, @"Web Inspector not found")));
+        completionHandler(toWebExtensionError(apiName, nil, @"Web Inspector not found"));
         return;
     }
 
-    extension->createTab(title, { baseURL(), iconPath }, { baseURL(), pagePath }, [completionHandler = WTFMove(completionHandler)](Expected<Inspector::ExtensionTabID, Inspector::ExtensionError> result) mutable {
+    extension->createTab(title, { baseURL(), iconPath }, { baseURL(), pagePath }, [completionHandler = WTFMove(completionHandler)](Expected<Inspector::ExtensionTabID, Inspector::ExtensionError>&& result) mutable {
         if (!result) {
             RELEASE_LOG_ERROR(Extensions, "Inspector could not create panel (%{public}@)", (NSString *)extensionErrorToString(result.error()));
-            completionHandler(makeUnexpected(toErrorString(apiName, nil, @"Web Inspector could not create the panel")));
+            completionHandler(toWebExtensionError(apiName, nil, @"Web Inspector could not create the panel"));
             return;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
@@ -45,48 +45,48 @@
 
 namespace WebKit {
 
-void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const Vector<String>& keys, CompletionHandler<void(std::optional<String> dataJSON, ErrorString)>&& completionHandler)
+void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const Vector<String>& keys, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.get()", (NSString *)toAPIPrefixString(dataType)];
 
     if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(std::nullopt, toErrorString(callingAPIName, nil, @"access not allowed"));
+        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
     auto storage = storageForType(dataType);
     [storage getValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([&, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *values, NSString *errorMessage) mutable {
         if (errorMessage)
-            completionHandler(std::nullopt, toErrorString(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
         else
-            completionHandler(encodeJSONString(values), std::nullopt);
+            completionHandler(String(encodeJSONString(values)));
     }).get()];
 }
 
-void WebExtensionContext::storageGetBytesInUse(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const Vector<String>& keys, CompletionHandler<void(std::optional<size_t> size, ErrorString)>&& completionHandler)
+void WebExtensionContext::storageGetBytesInUse(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const Vector<String>& keys, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.getBytesInUse()", (NSString *)toAPIPrefixString(dataType)];
 
     if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(std::nullopt, toErrorString(callingAPIName, nil, @"access not allowed"));
+        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
     auto storage = storageForType(dataType);
     [storage getStorageSizeForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([&, completionHandler = WTFMove(completionHandler)](size_t size, NSString *errorMessage) mutable {
         if (errorMessage)
-            completionHandler(std::nullopt, toErrorString(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
         else
-            completionHandler(size, std::nullopt);
+            completionHandler(size);
     }).get()];
 }
 
-void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const String& dataJSON, CompletionHandler<void(ErrorString)>&& completionHandler)
+void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const String& dataJSON, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.set()", (NSString *)toAPIPrefixString(dataType)];
 
     if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toErrorString(callingAPIName, nil, @"access not allowed"));
+        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
@@ -94,25 +94,25 @@ void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifi
 
     [storageForType(dataType) getStorageSizeForAllKeysIncludingKeyedData:data withCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, dataType, retainData = RetainPtr { data }, completionHandler = WTFMove(completionHandler)](size_t size, NSUInteger numberOfKeys, NSDictionary<NSString *, NSString *> *existingKeysAndValues, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toErrorString(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
             return;
         }
 
         if (size > quoataForStorageType(dataType)) {
-            completionHandler(toErrorString(callingAPIName, nil, @"exceeded storage quota"));
+            completionHandler(toWebExtensionError(callingAPIName, nil, @"exceeded storage quota"));
             return;
         }
 
         if (dataType == WebExtensionDataType::Sync && numberOfKeys > webExtensionStorageAreaSyncMaximumItems) {
-            completionHandler(toErrorString(callingAPIName, nil, @"exceeded maximum number of items"));
+            completionHandler(toWebExtensionError(callingAPIName, nil, @"exceeded maximum number of items"));
             return;
         }
 
         [storageForType(dataType) setKeyedData:retainData.get() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, retainData, dataType, existingKeysAndValues = RetainPtr { existingKeysAndValues }, completionHandler = WTFMove(completionHandler)](NSArray *keysSuccessfullySet, NSString *errorMessage) mutable {
             if (errorMessage)
-                completionHandler(toErrorString(callingAPIName, nil, errorMessage));
+                completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
             else
-                completionHandler(std::nullopt);
+                completionHandler({ });
 
             // Only fire an onChanged event for the keys that were successfully set.
             if (!keysSuccessfullySet.count)
@@ -127,72 +127,74 @@ void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifi
     }).get()];
 }
 
-void WebExtensionContext::storageRemove(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const Vector<String>& keys, CompletionHandler<void(ErrorString)>&& completionHandler)
+void WebExtensionContext::storageRemove(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const Vector<String>& keys, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.remove()", (NSString *)toAPIPrefixString(dataType)];
 
     if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toErrorString(callingAPIName, nil, @"access not allowed"));
+        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
     [storageForType(dataType) getValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, keys, dataType, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *oldValuesAndKeys, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toErrorString(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
             return;
         }
 
         [storageForType(dataType) deleteValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, dataType, oldValuesAndKeys = RetainPtr { oldValuesAndKeys }, completionHandler = WTFMove(completionHandler)](NSString *errorMessage) mutable {
             if (errorMessage) {
-                completionHandler(toErrorString(callingAPIName, nil, errorMessage));
+                completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
                 return;
             }
 
             fireStorageChangedEventIfNeeded(oldValuesAndKeys.get(), nil, dataType);
-            completionHandler(std::nullopt);
+
+            completionHandler({ });
         }).get()];
     }).get()];
 }
 
-void WebExtensionContext::storageClear(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, CompletionHandler<void(ErrorString)>&& completionHandler)
+void WebExtensionContext::storageClear(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.clear()", (NSString *)toAPIPrefixString(dataType)];
 
     if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toErrorString(callingAPIName, nil, @"access not allowed"));
+        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
     [storageForType(dataType) getValuesForKeys:@[ ] completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, dataType, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *oldValuesAndKeys, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toErrorString(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
             return;
         }
 
         [storageForType(dataType) deleteDatabaseWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, oldValuesAndKeys = RetainPtr { oldValuesAndKeys }, dataType, completionHandler = WTFMove(completionHandler)](NSString *errorMessage) mutable {
             if (errorMessage) {
-                completionHandler(toErrorString(callingAPIName, nil, errorMessage));
+                completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
                 return;
             }
 
             fireStorageChangedEventIfNeeded(oldValuesAndKeys.get(), nil, dataType);
-            completionHandler(std::nullopt);
+
+            completionHandler({ });
         }).get()];
     }).get()];
 }
 
-void WebExtensionContext::storageSetAccessLevel(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const WebExtensionStorageAccessLevel accessLevel, CompletionHandler<void(ErrorString)>&& completionHandler)
+void WebExtensionContext::storageSetAccessLevel(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionDataType dataType, const WebExtensionStorageAccessLevel accessLevel, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const callingAPIName = @"browser.session.setAccessLevel()";
 
     if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
-        completionHandler(toErrorString(callingAPIName, nil, @"access not allowed"));
+        completionHandler(toWebExtensionError(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
     setSessionStorageAllowedInContentScripts(accessLevel == WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts);
 
-    completionHandler(std::nullopt);
+    completionHandler({ });
 }
 
 void WebExtensionContext::fireStorageChangedEventIfNeeded(NSDictionary *oldKeysAndValues, NSDictionary *newKeysAndValues, WebExtensionDataType dataType)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
@@ -46,21 +46,14 @@ namespace WebKit {
 
 static WebExtensionFrameParameters frameParametersForFrame(_WKFrameTreeNode *frame, _WKFrameTreeNode *parentFrame, WebExtensionTab* tab, WebExtensionContext* extensionContext, bool includeFrameIdentifier)
 {
-    WKFrameInfo *frameInfo = frame.info;
-    NSURL *frameURL = frameInfo.request.URL;
+    auto *frameInfo = frame.info;
+    auto *frameURL = frameInfo.request.URL;
 
     return {
-        // errorOccured
         (bool)frameInfo._errorOccurred,
-
-        // url
-        extensionContext->hasPermission(frameURL, tab) ? std::optional { frameURL } : std::nullopt,
-
-        // parentFrameIdentifier
+        extensionContext->hasPermission(frameURL, tab) ? std::optional(frameURL) : std::nullopt,
         parentFrame ? toWebExtensionFrameIdentifier(parentFrame.info) : WebExtensionFrameConstants::NoneIdentifier,
-
-        // frameIdentifier
-        includeFrameIdentifier ? std::optional { toWebExtensionFrameIdentifier(frameInfo) } : std::nullopt
+        includeFrameIdentifier ? std::optional(toWebExtensionFrameIdentifier(frameInfo)) : std::nullopt
     };
 }
 
@@ -85,46 +78,47 @@ std::optional<WebExtensionFrameParameters> WebExtensionContext::webNavigationFin
     return std::nullopt;
 }
 
-void WebExtensionContext::webNavigationGetFrame(WebExtensionTabIdentifier tabIdentifier, WebExtensionFrameIdentifier frameIdentifier, CompletionHandler<void(std::optional<WebExtensionFrameParameters>, std::optional<String> error)>&& completionHandler)
+void WebExtensionContext::webNavigationGetFrame(WebExtensionTabIdentifier tabIdentifier, WebExtensionFrameIdentifier frameIdentifier, CompletionHandler<void(Expected<std::optional<WebExtensionFrameParameters>, WebExtensionError>&&)>&& completionHandler)
 {
-    auto tab = getTab(tabIdentifier);
+    RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(std::nullopt, toErrorString(@"webNavigation.getFrame()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"tab not found"));
         return;
     }
 
-    auto webView = tab->mainWebView();
+    auto *webView = tab->mainWebView();
     if (!webView) {
-        completionHandler(std::nullopt, toErrorString(@"webNavigation.getFrame()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"tab not found"));
         return;
     }
 
-    [webView _frames:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), tab, frameIdentifier] (_WKFrameTreeNode *mainFrame) mutable {
+    [webView _frames:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), tab, frameIdentifier](_WKFrameTreeNode *mainFrame) mutable {
         if (auto frameParameters = webNavigationFindFrameIdentifierInFrameTree(mainFrame, nil, tab.get(), frameIdentifier))
-            completionHandler(frameParameters, std::nullopt);
+            completionHandler(WTFMove(frameParameters));
         else
-            completionHandler(std::nullopt, toErrorString(@"webNavigation.getFrame()", nil, @"frame not found"));
+            completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"frame not found"));
     }).get()];
 }
 
-void WebExtensionContext::webNavigationGetAllFrames(WebExtensionTabIdentifier tabIdentifier, CompletionHandler<void(std::optional<Vector<WebExtensionFrameParameters>>, std::optional<String> error)>&& completionHandler)
+void WebExtensionContext::webNavigationGetAllFrames(WebExtensionTabIdentifier tabIdentifier, CompletionHandler<void(Expected<Vector<WebExtensionFrameParameters>, WebExtensionError>&&)>&& completionHandler)
 {
-    auto tab = getTab(tabIdentifier);
+    RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(std::nullopt, toErrorString(@"webNavigation.getFrame()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"tab not found"));
         return;
     }
 
-    auto webView = tab->mainWebView();
+    auto *webView = tab->mainWebView();
     if (!webView) {
-        completionHandler(std::nullopt, toErrorString(@"webNavigation.getFrame()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"tab not found"));
         return;
     }
 
-    [webView _frames:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), tab] (_WKFrameTreeNode *mainFrame) mutable {
+    [webView _frames:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), tab](_WKFrameTreeNode *mainFrame) mutable {
         Vector<WebExtensionFrameParameters> frameParameters;
         webNavigationTraverseFrameTreeForFrame(mainFrame, nil, tab.get(), frameParameters);
-        completionHandler(frameParameters, std::nullopt);
+
+        completionHandler(WTFMove(frameParameters));
     }).get()];
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -43,11 +43,13 @@
 
 namespace WebKit {
 
-void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& creationParameters, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&& completionHandler)
+void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& creationParameters, CompletionHandler<void(Expected<std::optional<WebExtensionWindowParameters>, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"windows.create()";
+
     auto delegate = extensionController()->delegate();
     if (![delegate respondsToSelector:@selector(webExtensionController:openNewWindowWithOptions:forExtensionContext:completionHandler:)]) {
-        completionHandler(std::nullopt, toErrorString(@"windows.create()", nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
         return;
     }
 
@@ -84,9 +86,9 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
     if (creationParameters.tabs) {
         for (auto& tabParameters : creationParameters.tabs.value()) {
             if (tabParameters.identifier) {
-                auto tab = getTab(tabParameters.identifier.value());
+                RefPtr tab = getTab(tabParameters.identifier.value());
                 if (!tab) {
-                    completionHandler(std::nullopt, toErrorString(@"windows.create()", nil, @"tab '%llu' was not found", tabParameters.identifier.value().toUInt64()));
+                    completionHandler(toWebExtensionError(apiName, nil, @"tab '%llu' was not found", tabParameters.identifier.value().toUInt64()));
                     return;
                 }
 
@@ -102,60 +104,60 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
     [delegate webExtensionController:extensionController()->wrapper() openNewWindowWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionWindow> newWindow, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for open new window: %{private}@", error);
-            completionHandler(std::nullopt, error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
         if (!newWindow) {
-            completionHandler(std::nullopt, std::nullopt);
+            completionHandler({ });
             return;
         }
 
         THROW_UNLESS([newWindow conformsToProtocol:@protocol(_WKWebExtensionWindow)], @"Object returned by webExtensionController:openNewWindowWithOptions:forExtensionContext:completionHandler: does not conform to the _WKWebExtensionWindow protocol");
 
-        auto window = getOrCreateWindow(newWindow);
+        RefPtr window = getOrCreateWindow(newWindow);
 
-        completionHandler(window->extensionHasAccess() ? std::optional(window->parameters()) : std::nullopt, std::nullopt);
+        completionHandler(window->extensionHasAccess() ? std::optional(window->parameters()) : std::nullopt);
     }).get()];
 }
 
-void WebExtensionContext::windowsGet(WebPageProxyIdentifier, WebExtensionWindowIdentifier windowIdentifier, OptionSet<WindowTypeFilter> filter, PopulateTabs populate, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&& completionHandler)
+void WebExtensionContext::windowsGet(WebPageProxyIdentifier, WebExtensionWindowIdentifier windowIdentifier, OptionSet<WindowTypeFilter> filter, PopulateTabs populate, CompletionHandler<void(Expected<WebExtensionWindowParameters, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const apiName = @"windows.get()";
 
-    auto window = getWindow(windowIdentifier);
+    RefPtr window = getWindow(windowIdentifier);
     if (!window) {
-        completionHandler(std::nullopt, toErrorString(apiName, nil, @"window not found"));
+        completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
         return;
     }
 
     if (!window->matches(filter)) {
-        completionHandler(std::nullopt, toErrorString(apiName, nil, @"window does not match requested 'windowTypes'"));
+        completionHandler(toWebExtensionError(apiName, nil, @"window does not match requested 'windowTypes'"));
         return;
     }
 
-    completionHandler(window->parameters(populate), std::nullopt);
+    completionHandler(window->parameters(populate));
 }
 
-void WebExtensionContext::windowsGetLastFocused(OptionSet<WindowTypeFilter> filter, PopulateTabs populate, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&& completionHandler)
+void WebExtensionContext::windowsGetLastFocused(OptionSet<WindowTypeFilter> filter, PopulateTabs populate, CompletionHandler<void(Expected<WebExtensionWindowParameters, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const apiName = @"windows.getLastFocused()";
 
-    auto window = frontmostWindow();
+    RefPtr window = frontmostWindow();
     if (!window) {
-        completionHandler(std::nullopt, toErrorString(apiName, nil, @"window not found"));
+        completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
         return;
     }
 
     if (!window->matches(filter)) {
-        completionHandler(std::nullopt, toErrorString(apiName, nil, @"window does not match requested 'windowTypes'"));
+        completionHandler(toWebExtensionError(apiName, nil, @"window does not match requested 'windowTypes'"));
         return;
     }
 
-    completionHandler(window->parameters(populate), std::nullopt);
+    completionHandler(window->parameters(populate));
 }
 
-void WebExtensionContext::windowsGetAll(OptionSet<WindowTypeFilter> filter, PopulateTabs populate, CompletionHandler<void(Vector<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&& completionHandler)
+void WebExtensionContext::windowsGetAll(OptionSet<WindowTypeFilter> filter, PopulateTabs populate, CompletionHandler<void(Expected<Vector<WebExtensionWindowParameters>, WebExtensionError>&&)>&& completionHandler)
 {
     Vector<WebExtensionWindowParameters> result;
     for (auto& window : openWindows()) {
@@ -165,46 +167,46 @@ void WebExtensionContext::windowsGetAll(OptionSet<WindowTypeFilter> filter, Popu
         result.append(window->parameters(populate));
     }
 
-    completionHandler(result, std::nullopt);
+    completionHandler(WTFMove(result));
 }
 
-void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdentifier, WebExtensionWindowParameters updateParameters, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&& completionHandler)
+void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdentifier, WebExtensionWindowParameters updateParameters, CompletionHandler<void(Expected<WebExtensionWindowParameters, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const apiName = @"windows.update()";
 
-    auto window = getWindow(windowIdentifier);
+    RefPtr window = getWindow(windowIdentifier);
     if (!window) {
-        completionHandler(std::nullopt, toErrorString(apiName, nil, @"window not found"));
+        completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
         return;
     }
 
-    auto updateState = [&](CompletionHandler<void(WebExtensionWindow::Error)>&& stepCompletionHandler) {
+    auto updateState = [&](CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
         if (!updateParameters.state || updateParameters.state == window->state()) {
-            stepCompletionHandler(std::nullopt);
+            stepCompletionHandler({ });
             return;
         }
 
         window->setState(updateParameters.state.value(), WTFMove(stepCompletionHandler));
     };
 
-    auto updateFocus = [&](CompletionHandler<void(WebExtensionWindow::Error)>&& stepCompletionHandler) {
+    auto updateFocus = [&](CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
         if (!updateParameters.focused || !updateParameters.focused.value()) {
-            stepCompletionHandler(std::nullopt);
+            stepCompletionHandler({ });
             return;
         }
 
         window->focus(WTFMove(stepCompletionHandler));
     };
 
-    auto updateFrame = [&](CompletionHandler<void(WebExtensionWindow::Error)>&& stepCompletionHandler) {
+    auto updateFrame = [&](CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
         if (!updateParameters.frame || window->state() != WebExtensionWindow::State::Normal) {
-            stepCompletionHandler(std::nullopt);
+            stepCompletionHandler({ });
             return;
         }
 
         CGRect currentFrame = window->frame();
         if (CGRectIsNull(currentFrame)) {
-            stepCompletionHandler(toErrorString(apiName, nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
+            stepCompletionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
             return;
         }
 
@@ -222,7 +224,7 @@ void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdent
         // coordinates with the origin in the top-left corner.
         CGRect screenFrame = window->screenFrame();
         if (CGRectIsEmpty(screenFrame)) {
-            stepCompletionHandler(toErrorString(apiName, nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
+            stepCompletionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
             return;
         }
 
@@ -247,7 +249,7 @@ void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdent
 #endif
 
         if (CGRectEqualToRect(currentFrame, desiredFrame)) {
-            stepCompletionHandler(std::nullopt);
+            stepCompletionHandler({ });
             return;
         }
 
@@ -260,35 +262,35 @@ void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdent
         updateParameters.state = WebExtensionWindow::State::Normal;
     }
 
-    updateState([&](WebExtensionWindow::Error stateError) {
-        if (stateError) {
-            completionHandler(std::nullopt, stateError);
+    updateState([&](Expected<void, WebExtensionError>&& stateResult) {
+        if (!stateResult) {
+            completionHandler(makeUnexpected(stateResult.error()));
             return;
         }
 
-        updateFocus([&](WebExtensionWindow::Error focusError) {
-            if (focusError) {
-                completionHandler(std::nullopt, focusError);
+        updateFocus([&](Expected<void, WebExtensionError>&& focusResult) {
+            if (!focusResult) {
+                completionHandler(makeUnexpected(focusResult.error()));
                 return;
             }
 
-            updateFrame([&](WebExtensionWindow::Error frameError) {
-                if (frameError) {
-                    completionHandler(std::nullopt, frameError);
+            updateFrame([&](Expected<void, WebExtensionError>&& frameResult) {
+                if (!frameResult) {
+                    completionHandler(makeUnexpected(frameResult.error()));
                     return;
                 }
 
-                completionHandler(window->parameters(), std::nullopt);
+                completionHandler(window->parameters());
             });
         });
     });
 }
 
-void WebExtensionContext::windowsRemove(WebExtensionWindowIdentifier windowIdentifier, CompletionHandler<void(WebExtensionWindow::Error)>&& completionHandler)
+void WebExtensionContext::windowsRemove(WebExtensionWindowIdentifier windowIdentifier, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    auto window = getWindow(windowIdentifier);
+    RefPtr window = getWindow(windowIdentifier);
     if (!window) {
-        completionHandler(toErrorString(@"windows.remove()", nil, @"window not found"));
+        completionHandler(toWebExtensionError(@"windows.remove()", nil, @"window not found"));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1592,13 +1592,13 @@ void WebExtensionContext::forgetTab(WebExtensionTabIdentifier identifier) const
 
 void WebExtensionContext::openNewTab(const WebExtensionTabParameters& parameters, CompletionHandler<void(RefPtr<WebExtensionTab>)>&& completionHandler)
 {
-    tabsCreate(std::nullopt, parameters, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](std::optional<WebExtensionTabParameters> newTabParameters, WebExtensionTab::Error) mutable {
-        if (!newTabParameters || !newTabParameters.value().identifier) {
+    tabsCreate(std::nullopt, parameters, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) mutable {
+        if (!result || !result.value()) {
             completionHandler(nullptr);
             return;
         }
 
-        completionHandler(getTab(newTabParameters.value().identifier.value()));
+        completionHandler(getTab(result.value()->identifier.value()));
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -101,11 +101,27 @@ SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParamet
     return { SourcePair { parameters.code.value_or(parameters.function.value_or(parameters.css.value_or(""_s))), std::nullopt } };
 }
 
-void executeScript(std::optional<SourcePairs> scriptPairs, WKWebView *webView, API::ContentWorld& executionWorld, WebExtensionTab *tab, const WebExtensionScriptInjectionParameters& parameters, WebExtensionContext& context, CompletionHandler<void(InjectionResultHolder&)>&& completionHandler)
+class InjectionResultHolder : public RefCounted<InjectionResultHolder> {
+    WTF_MAKE_NONCOPYABLE(InjectionResultHolder);
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    template<typename... Args>
+    static Ref<InjectionResultHolder> create(Args&&... args)
+    {
+        return adoptRef(*new InjectionResultHolder(std::forward<Args>(args)...));
+    }
+
+    InjectionResultHolder() = default;
+
+    InjectionResults results;
+};
+
+void executeScript(std::optional<SourcePairs> scriptPairs, WKWebView *webView, API::ContentWorld& executionWorld, WebExtensionTab *tab, const WebExtensionScriptInjectionParameters& parameters, WebExtensionContext& context, CompletionHandler<void(InjectionResults&&)>&& completionHandler)
 {
     auto injectionResults = InjectionResultHolder::create();
     auto aggregator = MainRunLoopCallbackAggregator::create([injectionResults, completionHandler = WTFMove(completionHandler)]() mutable {
-        completionHandler(injectionResults);
+        completionHandler(WTFMove(injectionResults->results));
     });
 
     [webView _frames:makeBlockPtr([webView = RetainPtr { webView }, tab, context = Ref { context }, scriptPairs, executionWorld = Ref { executionWorld }, injectionResults, aggregator, parameters](_WKFrameTreeNode *mainFrame) mutable {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -298,21 +298,23 @@ RefPtr<WebExtensionTab> WebExtensionTab::parentTab() const
     return m_extensionContext->getOrCreateTab(parentTab);
 }
 
-void WebExtensionTab::setParentTab(RefPtr<WebExtensionTab> parentTab, CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::setParentTab(RefPtr<WebExtensionTab> parentTab, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToSetParentTab) {
-        completionHandler(toErrorString(@"tabs.update()", nil, @"it is not implemented for 'openerTabId'"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'openerTabId'"));
         return;
     }
 
     [m_delegate setParentTab:(parentTab ? parentTab->delegate() : nil) forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for setParentTab: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
@@ -393,39 +395,43 @@ bool WebExtensionTab::isSelected() const
     return [m_delegate isSelectedForWebExtensionContext:m_extensionContext->wrapper()];
 }
 
-void WebExtensionTab::pin(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::pin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToPin) {
-        completionHandler(toErrorString(@"tabs.update()", nil, @"it is not implemented for 'pinned' set to `true`"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'pinned' set to `true`"));
         return;
     }
 
     [m_delegate pinForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for pin: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::unpin(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::unpin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToUnpin) {
-        completionHandler(toErrorString(@"tabs.update()", nil, @"it is not implemented for 'pinned' set to `false`"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'pinned' set to `false`"));
         return;
     }
 
     [m_delegate unpinForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for unpin: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
@@ -456,21 +462,23 @@ bool WebExtensionTab::isPrivate() const
     return m_private;
 }
 
-void WebExtensionTab::toggleReaderMode(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::toggleReaderMode(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.toggleReaderMode()";
+
     if (!isValid() || !m_respondsToToggleReaderMode) {
-        completionHandler(toErrorString(@"tabs.toggleReaderMode()", nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
         return;
     }
 
     [m_delegate toggleReaderModeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for toggleReaderMode: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
@@ -490,39 +498,43 @@ bool WebExtensionTab::isShowingReaderMode() const
     return [m_delegate isShowingReaderModeForWebExtensionContext:m_extensionContext->wrapper()];
 }
 
-void WebExtensionTab::mute(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::mute(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToMute) {
-        completionHandler(toErrorString(@"tabs.update()", nil, @"it is not implemented for 'muted' set to `true`"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'muted' set to `true`"));
         return;
     }
 
     [m_delegate muteForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for mute: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::unmute(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::unmute(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToUnmute) {
-        completionHandler(toErrorString(@"tabs.update()", nil, @"it is not implemented for 'muted' set to `false`"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'muted' set to `false`"));
         return;
     }
 
     [m_delegate unmuteForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for unmute: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
@@ -558,22 +570,24 @@ double WebExtensionTab::zoomFactor() const
     return [m_delegate zoomFactorForWebExtensionContext:m_extensionContext->wrapper()];
 }
 
-void WebExtensionTab::setZoomFactor(double zoomFactor, CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::setZoomFactor(double zoomFactor, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.setZoom()";
+
     if (!isValid() || !m_respondsToSetZoomFactor) {
         mainWebView().pageZoom = zoomFactor;
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     [m_delegate setZoomFactor:zoomFactor forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for setZoomFactor: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
@@ -607,44 +621,48 @@ bool WebExtensionTab::isLoadingComplete() const
     return [m_delegate isLoadingCompleteForWebExtensionContext:m_extensionContext->wrapper()];
 }
 
-void WebExtensionTab::detectWebpageLocale(CompletionHandler<void(NSLocale *, Error)>&& completionHandler)
+void WebExtensionTab::detectWebpageLocale(CompletionHandler<void(Expected<NSLocale *, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.detectLanguage()";
+
     if (!isValid() || !m_respondsToDetectWebpageLocale) {
-        completionHandler(nil, toErrorString(@"tabs.detectLanguage()", nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
         return;
     }
 
     [m_delegate detectWebpageLocaleForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSLocale *locale, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for detectWebpageLocale: %{private}@", error);
-            completionHandler(nil, error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
         THROW_UNLESS(!locale || [locale isKindOfClass:NSLocale.class], @"Object passed to completionHandler of detectWebpageLocaleForWebExtensionContext:completionHandler: is not an NSLocale");
-        completionHandler(locale, std::nullopt);
+        completionHandler(locale);
     }).get()];
 }
 
-void WebExtensionTab::captureVisibleWebpage(CompletionHandler<void(CocoaImage *, Error)>&& completionHandler)
+void WebExtensionTab::captureVisibleWebpage(CompletionHandler<void(Expected<CocoaImage *, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.captureVisibleTab()";
+
     bool delegateIsUnavailable = !isValid() || !m_respondsToCaptureVisibleWebpage;
     WKWebView *mainWebView = delegateIsUnavailable ? this->mainWebView() : nil;
 
     if (delegateIsUnavailable && !mainWebView) {
-        completionHandler(nil, toErrorString(@"tabs.captureVisibleTab()", nil, @"capture is unavailable for this tab"));
+        completionHandler(toWebExtensionError(apiName, nil, @"capture is unavailable for this tab"));
         return;
     }
 
     auto internalCompletionHandler = makeBlockPtr([completionHandler = WTFMove(completionHandler)](CocoaImage *image, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for captureVisibleWebpage: %{private}@", error);
-            completionHandler(nil, error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
         THROW_UNLESS(!image || [image isKindOfClass:[CocoaImage class]], @"Object passed to completionHandler of captureVisibleWebpageForWebExtensionContext:completionHandler: is not an image");
-        completionHandler(image, std::nullopt);
+        completionHandler(image);
     });
 
     if (delegateIsUnavailable) {
@@ -663,156 +681,172 @@ void WebExtensionTab::captureVisibleWebpage(CompletionHandler<void(CocoaImage *,
     [m_delegate captureVisibleWebpageForWebExtensionContext:m_extensionContext->wrapper() completionHandler:internalCompletionHandler.get()];
 }
 
-void WebExtensionTab::loadURL(URL url, CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::loadURL(URL url, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToLoadURL) {
         [mainWebView() loadRequest:[NSURLRequest requestWithURL:url]];
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     [m_delegate loadURL:url forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for loadURL: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::reload(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::reload(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.reload()";
+
     if (!isValid() || !m_respondsToReload) {
         [mainWebView() reload];
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     [m_delegate reloadForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for reload: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::reloadFromOrigin(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::reloadFromOrigin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.reload()";
+
     if (!isValid() || !m_respondsToReloadFromOrigin) {
         [mainWebView() reloadFromOrigin];
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     [m_delegate reloadFromOriginForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for reloadFromOrigin: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::goBack(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::goBack(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.goBack()";
+
     if (!isValid() || !m_respondsToGoBack) {
         [mainWebView() goBack];
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     [m_delegate goBackForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for goBack: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::goForward(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::goForward(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.goForward()";
+
     if (!isValid() || !m_respondsToGoForward) {
         [mainWebView() goForward];
-        completionHandler(std::nullopt);
+        completionHandler({ });
         return;
     }
 
     [m_delegate goForwardForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for goForward: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::activate(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::activate(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToActivate) {
-        completionHandler(toErrorString(@"tabs.update()", nil, @"it is not implemented for 'active' set to `true`"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'active' set to `true`"));
         return;
     }
 
     [m_delegate activateForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for activate: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::select(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::select(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToSelect) {
-        completionHandler(toErrorString(@"tabs.update()", nil, @"it is not implemented for 'highlighted' or 'selected' set to `true`"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'highlighted' or 'selected' set to `true`"));
         return;
     }
 
     [m_delegate selectForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for select: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::deselect(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::deselect(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.update()";
+
     if (!isValid() || !m_respondsToDeselect) {
-        completionHandler(toErrorString(@"tabs.update()", nil, @"it is not implemented for 'highlighted' or 'selected' set to `false`"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'highlighted' or 'selected' set to `false`"));
         return;
     }
 
     [m_delegate deselectForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for deselect: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
-void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, CompletionHandler<void(RefPtr<WebExtensionTab>, Error)>&& completionHandler)
+void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, CompletionHandler<void(Expected<RefPtr<WebExtensionTab>, WebExtensionError>&&)>&& completionHandler)
 {
     ASSERT(!parameters.audible);
     ASSERT(!parameters.loading);
@@ -826,8 +860,10 @@ void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, Com
     ASSERT(!parameters.title);
     ASSERT(!parameters.url);
 
+    static NSString * const apiName = @"tabs.duplicate()";
+
     if (!isValid() || !m_respondsToDuplicate) {
-        completionHandler(nullptr, toErrorString(@"tabs.duplicate()", nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
         return;
     }
 
@@ -848,35 +884,37 @@ void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, Com
     [m_delegate duplicateForWebExtensionContext:m_extensionContext->wrapper() withOptions:duplicateOptions completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionTab> duplicatedTab, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for duplicate: %{private}@", error);
-            completionHandler(nullptr, error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
         if (!duplicatedTab) {
-            completionHandler(nullptr, std::nullopt);
+            completionHandler({ });
             return;
         }
 
         THROW_UNLESS([duplicatedTab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object passed to completionHandler of duplicateForWebExtensionContext:withOptions:completionHandler: does not conform to the _WKWebExtensionTab protocol");
-        completionHandler(m_extensionContext->getOrCreateTab(duplicatedTab), std::nullopt);
+        completionHandler(RefPtr { m_extensionContext->getOrCreateTab(duplicatedTab).ptr() });
     }).get()];
 }
 
-void WebExtensionTab::close(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionTab::close(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"tabs.remove()";
+
     if (!isValid() || !m_respondsToClose) {
-        completionHandler(toErrorString(@"tabs.remove()", nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
         return;
     }
 
     [m_delegate closeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for tab close: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -281,21 +281,23 @@ _WKWebExtensionWindowState toAPI(WebExtensionWindow::State state)
     return _WKWebExtensionWindowStateNormal;
 }
 
-void WebExtensionWindow::setState(WebExtensionWindow::State state, CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionWindow::setState(WebExtensionWindow::State state, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"windows.update()";
+
     if (!isValid() || !m_respondsToSetWindowState || !m_respondsToWindowState) {
-        completionHandler(toErrorString(@"windows.update()", nil, @"it is not implemented for 'state'"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'state'"));
         return;
     }
 
     [m_delegate setWindowState:toAPI(state) forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for setWindowState: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
@@ -320,21 +322,23 @@ bool WebExtensionWindow::isFrontmost() const
     return this == m_extensionContext->frontmostWindow();
 }
 
-void WebExtensionWindow::focus(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionWindow::focus(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"windows.update()";
+
     if (!isValid() || !m_respondsToFocus) {
-        completionHandler(toErrorString(@"windows.update()", nil, @"it is not implemented for 'focused'"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'focused'"));
         return;
     }
 
     [m_delegate focusForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for window focus: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
@@ -376,15 +380,17 @@ CGRect WebExtensionWindow::frame() const
     return CGRectStandardize([m_delegate frameForWebExtensionContext:m_extensionContext->wrapper()]);
 }
 
-void WebExtensionWindow::setFrame(CGRect frame, CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionWindow::setFrame(CGRect frame, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"windows.update()";
+
 #if PLATFORM(MAC)
     if (!isValid() || !m_respondsToSetFrame || !m_respondsToFrame || !m_respondsToScreenFrame)
 #else
     if (!isValid() || !m_respondsToSetFrame || !m_respondsToFrame)
 #endif
     {
-        completionHandler(toErrorString(@"windows.update()", nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
         return;
     }
 
@@ -395,11 +401,11 @@ void WebExtensionWindow::setFrame(CGRect frame, CompletionHandler<void(Error)>&&
     [m_delegate setFrame:frame forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for setFrame: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 
@@ -411,21 +417,23 @@ CGRect WebExtensionWindow::screenFrame() const
     return CGRectStandardize([m_delegate screenFrameForWebExtensionContext:m_extensionContext->wrapper()]);
 }
 
-void WebExtensionWindow::close(CompletionHandler<void(Error)>&& completionHandler)
+void WebExtensionWindow::close(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"windows.remove()";
+
     if (!isValid() || !m_respondsToClose) {
-        completionHandler(toErrorString(@"windows.remove()", nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
         return;
     }
 
     [m_delegate closeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for window close: %{private}@", error);
-            completionHandler(error.localizedDescription);
+            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
 
-        completionHandler(std::nullopt);
+        completionHandler({ });
     }).get()];
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -27,136 +27,136 @@
 
 messages -> WebExtensionContext {
     // Action APIs
-    ActionGetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> title, std::optional<String> error);
-    ActionSetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String title) -> (std::optional<String> error);
-    ActionSetIcon(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String iconDictionaryJSON) -> (std::optional<String> error);
-    ActionGetPopup(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> popupPath, std::optional<String> error);
-    ActionSetPopup(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String popupPath) -> (std::optional<String> error);
-    ActionOpenPopup(WebKit::WebPageProxyIdentifier identifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> error);
-    ActionGetBadgeText(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> text, std::optional<String> error);
-    ActionSetBadgeText(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String text) -> (std::optional<String> error);
-    ActionGetEnabled(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<bool> enabled, std::optional<String> error);
-    ActionSetEnabled(std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, bool enabled) -> (std::optional<String> error);
+    ActionGetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
+    ActionSetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String title) -> (Expected<void, WebKit::WebExtensionError> result)
+    ActionSetIcon(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String iconDictionaryJSON) -> (Expected<void, WebKit::WebExtensionError> result)
+    ActionGetPopup(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
+    ActionSetPopup(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String popupPath) -> (Expected<void, WebKit::WebExtensionError> result)
+    ActionOpenPopup(WebKit::WebPageProxyIdentifier identifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
+    ActionGetBadgeText(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
+    ActionSetBadgeText(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String text) -> (Expected<void, WebKit::WebExtensionError> result)
+    ActionGetEnabled(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<bool, WebKit::WebExtensionError> result)
+    ActionSetEnabled(std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, bool enabled) -> (Expected<void, WebKit::WebExtensionError> result)
 
     // Alarms APIs
-    AlarmsCreate(String name, Seconds initialInterval, Seconds repeatInterval);
-    AlarmsGet(String name) -> (std::optional<WebKit::WebExtensionAlarmParameters> alarmInfo);
-    AlarmsClear(String name) -> ();
-    AlarmsGetAll() -> (Vector<WebKit::WebExtensionAlarmParameters> alarms);
-    AlarmsClearAll() -> ();
+    AlarmsCreate(String name, Seconds initialInterval, Seconds repeatInterval)
+    AlarmsGet(String name) -> (std::optional<WebKit::WebExtensionAlarmParameters> alarmInfo)
+    AlarmsClear(String name) -> ()
+    AlarmsGetAll() -> (Vector<WebKit::WebExtensionAlarmParameters> alarms)
+    AlarmsClearAll() -> ()
 
-    // Commands
-    CommandsGetAll() -> (Vector<WebKit::WebExtensionCommandParameters> commands);
+    // Commands APIs
+    CommandsGetAll() -> (Vector<WebKit::WebExtensionCommandParameters> commands)
 
-    // Cookies
-    CookiesGet(std::optional<PAL::SessionID> sessionID, String name, URL url) -> (std::optional<WebKit::WebExtensionCookieParameters> cookie, WebKit::WebExtensionContext::ErrorString error);
-    CookiesGetAll(std::optional<PAL::SessionID> sessionID, URL url, struct WebKit::WebExtensionCookieFilterParameters filterParameters) -> (Vector<WebKit::WebExtensionCookieParameters> cookies, WebKit::WebExtensionContext::ErrorString error);
-    CookiesSet(std::optional<PAL::SessionID> sessionID, struct WebKit::WebExtensionCookieParameters cookie) -> (std::optional<WebKit::WebExtensionCookieParameters> cookie, WebKit::WebExtensionContext::ErrorString error);
-    CookiesRemove(std::optional<PAL::SessionID> sessionID, String name, URL url) -> (std::optional<WebKit::WebExtensionCookieParameters> cookie, WebKit::WebExtensionContext::ErrorString error);
-    CookiesGetAllCookieStores() -> (HashMap<PAL::SessionID, Vector<WebKit::WebExtensionTabIdentifier>> cookieStores, WebKit::WebExtensionContext::ErrorString error);
+    // Cookies APIs
+    CookiesGet(std::optional<PAL::SessionID> sessionID, String name, URL url) -> (Expected<std::optional<WebKit::WebExtensionCookieParameters>, WebKit::WebExtensionError> result)
+    CookiesGetAll(std::optional<PAL::SessionID> sessionID, URL url, struct WebKit::WebExtensionCookieFilterParameters filterParameters) -> (Expected<Vector<WebKit::WebExtensionCookieParameters>, WebKit::WebExtensionError> result)
+    CookiesSet(std::optional<PAL::SessionID> sessionID, struct WebKit::WebExtensionCookieParameters cookie) -> (Expected<std::optional<WebKit::WebExtensionCookieParameters>, WebKit::WebExtensionError> result)
+    CookiesRemove(std::optional<PAL::SessionID> sessionID, String name, URL url) -> (Expected<std::optional<WebKit::WebExtensionCookieParameters>, WebKit::WebExtensionError> result)
+    CookiesGetAllCookieStores() -> (Expected<HashMap<PAL::SessionID, Vector<WebKit::WebExtensionTabIdentifier>>, WebKit::WebExtensionError> result)
 
-    // DeclarativeNetRequest
-    DeclarativeNetRequestGetEnabledRulesets() -> (Vector<String> rulesetIdentifiers);
-    DeclarativeNetRequestUpdateEnabledRulesets(Vector<String> rulesetIdentifiersToEnable, Vector<String> rulesetIdentifiersToDisable) -> (std::optional<String> error);
-    DeclarativeNetRequestDisplayActionCountAsBadgeText(bool result) -> (std::optional<String> error);
-    DeclarativeNetRequestIncrementActionCount(WebKit::WebExtensionTabIdentifier tabIdentifier, double increment) -> (std::optional<String> error);
-    DeclarativeNetRequestGetMatchedRules(std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WallTime> minTimeStamp) -> (std::optional<Vector<WebKit::WebExtensionMatchedRuleParameters>> matchedRules, std::optional<String> error);
-    DeclarativeNetRequestGetDynamicRules() -> (std::optional<String> rulesJSON, std::optional<String> error);
-    DeclarativeNetRequestUpdateDynamicRules(std::optional<String> rulesToAddJSON, std::optional<Vector<double>> ruleIdsToRemove) -> (std::optional<String> error);
-    DeclarativeNetRequestGetSessionRules() -> (std::optional<String> rulesJSON, std::optional<String> error);
-    DeclarativeNetRequestUpdateSessionRules(std::optional<String> rulesToAddJSON, std::optional<Vector<double>> ruleIdsToRemove) -> (std::optional<String> error);
+    // DeclarativeNetRequest APIs
+    DeclarativeNetRequestGetEnabledRulesets() -> (Vector<String> rulesetIdentifiers)
+    DeclarativeNetRequestUpdateEnabledRulesets(Vector<String> rulesetIdentifiersToEnable, Vector<String> rulesetIdentifiersToDisable) -> (Expected<void, WebKit::WebExtensionError> result)
+    DeclarativeNetRequestDisplayActionCountAsBadgeText(bool result) -> (Expected<void, WebKit::WebExtensionError> result)
+    DeclarativeNetRequestIncrementActionCount(WebKit::WebExtensionTabIdentifier tabIdentifier, double increment) -> (Expected<void, WebKit::WebExtensionError> result)
+    DeclarativeNetRequestGetMatchedRules(std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WallTime> minTimeStamp) -> (Expected<Vector<WebKit::WebExtensionMatchedRuleParameters>, WebKit::WebExtensionError> result)
+    DeclarativeNetRequestGetDynamicRules() -> (Expected<String, WebKit::WebExtensionError> result)
+    DeclarativeNetRequestUpdateDynamicRules(String rulesToAddJSON, Vector<double> ruleIdsToRemove) -> (Expected<void, WebKit::WebExtensionError> result)
+    DeclarativeNetRequestGetSessionRules() -> (Expected<String, WebKit::WebExtensionError> result)
+    DeclarativeNetRequestUpdateSessionRules(String rulesToAddJSON, Vector<double> ruleIdsToRemove) -> (Expected<void, WebKit::WebExtensionError> result)
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // DevTools APIs
-    DevToolsPanelsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String title, String iconPath, String pagePath) -> (Expected<Inspector::ExtensionTabID, String> result);
-    DevToolsInspectedWindowEval(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String scriptSource, std::optional<URL> frameURL) -> (Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, String> result);
-    DevToolsInspectedWindowReload(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<bool> ignoreCache);
+    DevToolsPanelsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String title, String iconPath, String pagePath) -> (Expected<Inspector::ExtensionTabID, WebKit::WebExtensionError> result)
+    DevToolsInspectedWindowEval(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String scriptSource, std::optional<URL> frameURL) -> (Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, WebKit::WebExtensionError> result)
+    DevToolsInspectedWindowReload(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<bool> ignoreCache)
 #endif
 
     // Event APIs
-    AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType);
-    RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType, size_t removedCount);
+    AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType)
+    RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType, size_t removedCount)
 
     // Extensions APIs
-    ExtensionIsAllowedIncognitoAccess() -> (bool result);
+    ExtensionIsAllowedIncognitoAccess() -> (bool result)
 
     // Menus APIs
-    MenusCreate(struct WebKit::WebExtensionMenuItemParameters parameters) -> (std::optional<String> error);
-    MenusUpdate(String identifier, struct WebKit::WebExtensionMenuItemParameters parameters) -> (std::optional<String> error);
-    MenusRemove(String identifier) -> (std::optional<String> error);
-    MenusRemoveAll() -> (std::optional<String> error);
+    MenusCreate(struct WebKit::WebExtensionMenuItemParameters parameters) -> (Expected<void, WebKit::WebExtensionError> result)
+    MenusUpdate(String identifier, struct WebKit::WebExtensionMenuItemParameters parameters) -> (Expected<void, WebKit::WebExtensionError> result)
+    MenusRemove(String identifier) -> (Expected<void, WebKit::WebExtensionError> result)
+    MenusRemoveAll() -> (Expected<void, WebKit::WebExtensionError> result)
 
     // Permissions APIs
-    PermissionsGetAll() -> (Vector<String> permissions, Vector<String> origins);
-    PermissionsContains(HashSet<String> permissions, HashSet<String> origins) -> (bool containsPermissions);
-    PermissionsRequest(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
-    PermissionsRemove(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
+    PermissionsGetAll() -> (Vector<String> permissions, Vector<String> origins)
+    PermissionsContains(HashSet<String> permissions, HashSet<String> origins) -> (bool containsPermissions)
+    PermissionsRequest(HashSet<String> permissions, HashSet<String> origins) -> (bool success)
+    PermissionsRemove(HashSet<String> permissions, HashSet<String> origins) -> (bool success)
 
     // Port APIs
-    PortPostMessage(WebKit::WebExtensionContentWorldType targetContentWorldType, std::optional<WebKit::WebPageProxyIdentifier> sendingPageProxyIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON);
-    PortDisconnect(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier);
+    PortPostMessage(WebKit::WebExtensionContentWorldType targetContentWorldType, std::optional<WebKit::WebPageProxyIdentifier> sendingPageProxyIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON)
+    PortDisconnect(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier)
 
     // Runtime APIs
-    RuntimeGetBackgroundPage() -> (std::optional<WebCore::PageIdentifier> pageIdentifier, std::optional<String> error);
-    RuntimeOpenOptionsPage() -> (std::optional<String> error);
-    RuntimeReload();
-    RuntimeSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON, std::optional<String> error);
-    RuntimeConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> error);
-    RuntimeSendNativeMessage(String applicationID, String messageJSON) -> (std::optional<String> replyJSON, std::optional<String> error);
-    RuntimeConnectNative(String applicationID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier) -> (std::optional<String> error);
-    RuntimeWebPageSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON, std::optional<String> error);
-    RuntimeWebPageConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> error);
+    RuntimeGetBackgroundPage() -> (Expected<std::optional<WebCore::PageIdentifier>, WebKit::WebExtensionError> result)
+    RuntimeOpenOptionsPage() -> (Expected<void, WebKit::WebExtensionError> result)
+    RuntimeReload()
+    RuntimeSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<String, WebKit::WebExtensionError> result)
+    RuntimeConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<void, WebKit::WebExtensionError> result)
+    RuntimeSendNativeMessage(String applicationID, String messageJSON) -> (Expected<String, WebKit::WebExtensionError> result)
+    RuntimeConnectNative(String applicationID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
+    RuntimeWebPageSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<String, WebKit::WebExtensionError> result)
+    RuntimeWebPageConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<void, WebKit::WebExtensionError> result)
 
     // Scripting APIs
-    ScriptingExecuteScript(WebKit::WebExtensionScriptInjectionParameters parameters) -> (std::optional<Vector<WebKit::WebExtensionScriptInjectionResultParameters>> results, WebKit::WebExtensionDynamicScripts::Error error);
-    ScriptingInsertCSS(WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionDynamicScripts::Error error);
-    ScriptingRemoveCSS(WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionDynamicScripts::Error error);
-    ScriptingRegisterContentScripts(Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts) -> (WebKit::WebExtensionDynamicScripts::Error error);
-    ScriptingUpdateRegisteredScripts(Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts) -> (WebKit::WebExtensionDynamicScripts::Error error);
-    ScriptingGetRegisteredScripts(Vector<String> scriptIDs) -> (Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts);
-    ScriptingUnregisterContentScripts(Vector<String> scriptIDs) -> (WebKit::WebExtensionDynamicScripts::Error error);
+    ScriptingExecuteScript(WebKit::WebExtensionScriptInjectionParameters parameters) -> (Expected<Vector<WebKit::WebExtensionScriptInjectionResultParameters>, WebKit::WebExtensionError> result)
+    ScriptingInsertCSS(WebKit::WebExtensionScriptInjectionParameters parameters) -> (Expected<void, WebKit::WebExtensionError> result)
+    ScriptingRemoveCSS(WebKit::WebExtensionScriptInjectionParameters parameters) -> (Expected<void, WebKit::WebExtensionError> result)
+    ScriptingRegisterContentScripts(Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts) -> (Expected<void, WebKit::WebExtensionError> result)
+    ScriptingUpdateRegisteredScripts(Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts) -> (Expected<void, WebKit::WebExtensionError> result)
+    ScriptingGetRegisteredScripts(Vector<String> scriptIDs) -> (Expected<Vector<WebKit::WebExtensionRegisteredScriptParameters>, WebKit::WebExtensionError> result)
+    ScriptingUnregisterContentScripts(Vector<String> scriptIDs) -> (Expected<void, WebKit::WebExtensionError> result)
 
     // Storage APIs
-    StorageGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (std::optional<String> dataJSON, WebKit::WebExtensionContext::ErrorString error);
-    StorageGetBytesInUse(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (std::optional<size_t> size, WebKit::WebExtensionContext::ErrorString error);
-    StorageSet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, String dataJSON) -> (WebKit::WebExtensionContext::ErrorString error);
-    StorageRemove(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (WebKit::WebExtensionContext::ErrorString error);
-    StorageClear(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType) -> (WebKit::WebExtensionContext::ErrorString error);
-    StorageSetAccessLevel(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, WebKit::WebExtensionStorageAccessLevel accessLevel) -> (WebKit::WebExtensionContext::ErrorString error);
+    StorageGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (Expected<String, WebKit::WebExtensionError> result)
+    StorageGetBytesInUse(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (Expected<size_t, WebKit::WebExtensionError> result)
+    StorageSet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, String dataJSON) -> (Expected<void, WebKit::WebExtensionError> result)
+    StorageRemove(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (Expected<void, WebKit::WebExtensionError> result)
+    StorageClear(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType) -> (Expected<void, WebKit::WebExtensionError> result)
+    StorageSetAccessLevel(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, WebKit::WebExtensionStorageAccessLevel accessLevel) -> (Expected<void, WebKit::WebExtensionError> result)
 
     // Tabs APIs
-    TabsCreate(std::optional<WebKit::WebPageProxyIdentifier> webPageProxyIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
-    TabsUpdate(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionTabParameters updateParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
-    TabsDuplicate(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
-    TabsGet(WebKit::WebExtensionTabIdentifier tabIdentifier) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
-    TabsGetCurrent(WebKit::WebPageProxyIdentifier webPageProxyIdentifier) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
-    TabsQuery(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabQueryParameters queryParameters) -> (Vector<WebKit::WebExtensionTabParameters> tabs, WebKit::WebExtensionWindow::Error error);
-    TabsReload(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionContext::ReloadFromOrigin reloadFromOrigin) -> (WebKit::WebExtensionWindow::Error error);
-    TabsGoBack(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (WebKit::WebExtensionTab::Error error);
-    TabsGoForward(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (WebKit::WebExtensionTab::Error error);
-    TabsDetectLanguage(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> language, WebKit::WebExtensionTab::Error error);
-    TabsToggleReaderMode(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (WebKit::WebExtensionTab::Error error);
-    TabsCaptureVisibleTab(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, WebKit::WebExtensionTab::ImageFormat imageFormat, uint8_t imageQuality) -> (std::optional<URL> imageDataURL, WebKit::WebExtensionTab::Error error);
-    TabsSendMessage(WebKit::WebExtensionTabIdentifier tabIdentifier, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON, WebKit::WebExtensionTab::Error error);
-    TabsConnect(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (WebKit::WebExtensionTab::Error error);
-    TabsGetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<double> zoomFactor, WebKit::WebExtensionTab::Error error);
-    TabsSetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, double zoomFactor) -> (WebKit::WebExtensionTab::Error error);
-    TabsRemove(Vector<WebKit::WebExtensionTabIdentifier> tabIdentifiers) -> (WebKit::WebExtensionWindow::Error error);
-    TabsExecuteScript(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (std::optional<Vector<WebKit::WebExtensionScriptInjectionResultParameters>> results, WebKit::WebExtensionTab::Error error);
-    TabsInsertCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionTab::Error error);
-    TabsRemoveCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionTab::Error error);
+    TabsCreate(std::optional<WebKit::WebPageProxyIdentifier> webPageProxyIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (Expected<std::optional<WebKit::WebExtensionTabParameters>, WebKit::WebExtensionError> result)
+    TabsUpdate(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionTabParameters updateParameters) -> (Expected<std::optional<WebKit::WebExtensionTabParameters>, WebKit::WebExtensionError> result)
+    TabsDuplicate(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (Expected<std::optional<WebKit::WebExtensionTabParameters>, WebKit::WebExtensionError> result)
+    TabsGet(WebKit::WebExtensionTabIdentifier tabIdentifier) -> (Expected<std::optional<WebKit::WebExtensionTabParameters>, WebKit::WebExtensionError> result)
+    TabsGetCurrent(WebKit::WebPageProxyIdentifier webPageProxyIdentifier) -> (Expected<std::optional<WebKit::WebExtensionTabParameters>, WebKit::WebExtensionError> result)
+    TabsQuery(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabQueryParameters queryParameters) -> (Expected<Vector<WebKit::WebExtensionTabParameters>, WebKit::WebExtensionError> result)
+    TabsReload(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionContext::ReloadFromOrigin reloadFromOrigin) -> (Expected<void, WebKit::WebExtensionError> result)
+    TabsGoBack(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
+    TabsGoForward(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
+    TabsDetectLanguage(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
+    TabsToggleReaderMode(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
+    TabsCaptureVisibleTab(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, WebKit::WebExtensionTab::ImageFormat imageFormat, uint8_t imageQuality) -> (Expected<URL, WebKit::WebExtensionError> result)
+    TabsSendMessage(WebKit::WebExtensionTabIdentifier tabIdentifier, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<String, WebKit::WebExtensionError> result)
+    TabsConnect(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<void, WebKit::WebExtensionError> result)
+    TabsGetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<double, WebKit::WebExtensionError> result)
+    TabsSetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, double zoomFactor) -> (Expected<void, WebKit::WebExtensionError> result)
+    TabsRemove(Vector<WebKit::WebExtensionTabIdentifier> tabIdentifiers) -> (Expected<void, WebKit::WebExtensionError> result)
+    TabsExecuteScript(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (Expected<Vector<WebKit::WebExtensionScriptInjectionResultParameters>, WebKit::WebExtensionError> result)
+    TabsInsertCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (Expected<void, WebKit::WebExtensionError> result)
+    TabsRemoveCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (Expected<void, WebKit::WebExtensionError> result)
 
     // WebNavigation APIs
-    WebNavigationGetAllFrames(WebKit::WebExtensionTabIdentifier tabIdentifier) -> (std::optional<Vector<WebKit::WebExtensionFrameParameters>> allFrameParameters, std::optional<String> error)
-    WebNavigationGetFrame(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionFrameIdentifier frameIdentifier) -> (std::optional<WebKit::WebExtensionFrameParameters> frameParameters, std::optional<String> error)
+    WebNavigationGetAllFrames(WebKit::WebExtensionTabIdentifier tabIdentifier) -> (Expected<Vector<WebKit::WebExtensionFrameParameters>, WebKit::WebExtensionError> result)
+    WebNavigationGetFrame(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionFrameIdentifier frameIdentifier) -> (Expected<std::optional<WebKit::WebExtensionFrameParameters>, WebKit::WebExtensionError> result)
 
     // Windows APIs
-    WindowsCreate(WebKit::WebExtensionWindowParameters creationParameters) -> (std::optional<WebKit::WebExtensionWindowParameters> windowParameters, WebKit::WebExtensionWindow::Error error);
-    WindowsGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, OptionSet<WebKit::WebExtensionWindow::TypeFilter> filter, WebKit::WebExtensionWindow::PopulateTabs populate) -> (std::optional<WebKit::WebExtensionWindowParameters> windowParameters, WebKit::WebExtensionWindow::Error error);
-    WindowsGetLastFocused(OptionSet<WebKit::WebExtensionWindow::TypeFilter> filter, WebKit::WebExtensionWindow::PopulateTabs populate) -> (std::optional<WebKit::WebExtensionWindowParameters> windowParameters, WebKit::WebExtensionWindow::Error error);
-    WindowsGetAll(OptionSet<WebKit::WebExtensionWindow::TypeFilter> filter, WebKit::WebExtensionWindow::PopulateTabs populate) -> (Vector<WebKit::WebExtensionWindowParameters> windows, WebKit::WebExtensionWindow::Error error);
-    WindowsUpdate(WebKit::WebExtensionWindowIdentifier windowIdentifier, WebKit::WebExtensionWindowParameters updateParameters) -> (std::optional<WebKit::WebExtensionWindowParameters> windowParameters, WebKit::WebExtensionWindow::Error error);
-    WindowsRemove(WebKit::WebExtensionWindowIdentifier windowIdentifier) -> (WebKit::WebExtensionWindow::Error error);
+    WindowsCreate(WebKit::WebExtensionWindowParameters creationParameters) -> (Expected<std::optional<WebKit::WebExtensionWindowParameters>, WebKit::WebExtensionError> result)
+    WindowsGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, OptionSet<WebKit::WebExtensionWindow::TypeFilter> filter, WebKit::WebExtensionWindow::PopulateTabs populate) -> (Expected<WebKit::WebExtensionWindowParameters, WebKit::WebExtensionError> result)
+    WindowsGetLastFocused(OptionSet<WebKit::WebExtensionWindow::TypeFilter> filter, WebKit::WebExtensionWindow::PopulateTabs populate) -> (Expected<WebKit::WebExtensionWindowParameters, WebKit::WebExtensionError> result)
+    WindowsGetAll(OptionSet<WebKit::WebExtensionWindow::TypeFilter> filter, WebKit::WebExtensionWindow::PopulateTabs populate) -> (Expected<Vector<WebKit::WebExtensionWindowParameters>, WebKit::WebExtensionError> result)
+    WindowsUpdate(WebKit::WebExtensionWindowIdentifier windowIdentifier, WebKit::WebExtensionWindowParameters updateParameters) -> (Expected<WebKit::WebExtensionWindowParameters, WebKit::WebExtensionError> result)
+    WindowsRemove(WebKit::WebExtensionWindowIdentifier windowIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -253,7 +253,7 @@ void WebExtensionController::sendToAllProcesses(const T& message, const ObjectId
 {
     for (auto& process : allProcesses()) {
         if (process.canSendMessage())
-            process.send(T(message), destinationID.toUInt64());
+            process.send(T(message), destinationID);
     }
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -49,7 +49,6 @@ class WebExtensionTab;
 namespace WebExtensionDynamicScripts {
 
 using InjectionResults = Vector<WebExtensionScriptInjectionResultParameters>;
-using Error = std::optional<String>;
 
 using SourcePair = std::pair<String, std::optional<URL>>;
 using SourcePairs = Vector<std::optional<SourcePair>>;
@@ -58,22 +57,6 @@ using InjectionTime = WebExtension::InjectionTime;
 
 using UserScriptVector = Vector<Ref<API::UserScript>>;
 using UserStyleSheetVector = Vector<Ref<API::UserStyleSheet>>;
-
-class InjectionResultHolder : public RefCounted<InjectionResultHolder> {
-    WTF_MAKE_NONCOPYABLE(InjectionResultHolder);
-    WTF_MAKE_FAST_ALLOCATED;
-
-public:
-    template<typename... Args>
-    static Ref<InjectionResultHolder> create(Args&&... args)
-    {
-        return adoptRef(*new InjectionResultHolder(std::forward<Args>(args)...));
-    }
-
-    InjectionResultHolder() { };
-
-    InjectionResults results;
-};
 
 class WebExtensionRegisteredScript : public RefCounted<WebExtensionRegisteredScript> {
     WTF_MAKE_NONCOPYABLE(WebExtensionRegisteredScript);
@@ -116,7 +99,7 @@ std::optional<SourcePair> sourcePairForResource(String path, RefPtr<WebExtension
 SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParameters&, RefPtr<WebExtension>);
 Vector<RetainPtr<_WKFrameTreeNode>> getFrames(_WKFrameTreeNode *, std::optional<Vector<WebExtensionFrameIdentifier>>);
 
-void executeScript(std::optional<SourcePairs>, WKWebView *, API::ContentWorld&, WebExtensionTab*, const WebExtensionScriptInjectionParameters&, WebExtensionContext&, CompletionHandler<void(InjectionResultHolder&)>&&);
+void executeScript(std::optional<SourcePairs>, WKWebView *, API::ContentWorld&, WebExtensionTab*, const WebExtensionScriptInjectionParameters&, WebExtensionContext&, CompletionHandler<void(InjectionResults&&)>&&);
 void injectStyleSheets(SourcePairs, WKWebView *, API::ContentWorld&, WebCore::UserContentInjectedFrames, WebExtensionContext&);
 void removeStyleSheets(SourcePairs, WKWebView *, WebCore::UserContentInjectedFrames, WebExtensionContext&);
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "CocoaImage.h"
+#include "WebExtensionError.h"
 #include "WebExtensionEventListenerType.h"
 #include "WebExtensionTabIdentifier.h"
 #include "WebPageProxyIdentifier.h"
@@ -98,7 +99,6 @@ public:
     enum class AssumeWindowMatches : bool { No, Yes };
     enum class MainWebViewOnly : bool { No, Yes };
 
-    using Error = std::optional<String>;
     using WebProcessProxySet = HashSet<Ref<WebProcessProxy>>;
 
     WebExtensionTabIdentifier identifier() const { return m_identifier; }
@@ -128,7 +128,7 @@ public:
     size_t index() const;
 
     RefPtr<WebExtensionTab> parentTab() const;
-    void setParentTab(RefPtr<WebExtensionTab>, CompletionHandler<void(Error)>&&);
+    void setParentTab(RefPtr<WebExtensionTab>, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     WKWebView *mainWebView() const;
     NSArray *webViews() const;
@@ -143,18 +143,18 @@ public:
     bool isSelected() const;
     bool isPrivate() const;
 
-    void pin(CompletionHandler<void(Error)>&&);
-    void unpin(CompletionHandler<void(Error)>&&);
+    void pin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void unpin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     bool isPinned() const;
 
-    void toggleReaderMode(CompletionHandler<void(Error)>&&);
+    void toggleReaderMode(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     bool isReaderModeAvailable() const;
     bool isShowingReaderMode() const;
 
-    void mute(CompletionHandler<void(Error)>&&);
-    void unmute(CompletionHandler<void(Error)>&&);
+    void mute(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void unmute(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     bool isAudible() const;
     bool isMuted() const;
@@ -162,31 +162,31 @@ public:
     CGSize size() const;
 
     double zoomFactor() const;
-    void setZoomFactor(double, CompletionHandler<void(Error)>&&);
+    void setZoomFactor(double, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     URL url() const;
     URL pendingURL() const;
 
     bool isLoadingComplete() const;
 
-    void detectWebpageLocale(CompletionHandler<void(NSLocale *, Error)>&&);
-    void captureVisibleWebpage(CompletionHandler<void(CocoaImage *, Error)>&&);
+    void detectWebpageLocale(CompletionHandler<void(Expected<NSLocale *, WebExtensionError>&&)>&&);
+    void captureVisibleWebpage(CompletionHandler<void(Expected<CocoaImage *, WebExtensionError>&&)>&&);
 
-    void loadURL(URL, CompletionHandler<void(Error)>&&);
+    void loadURL(URL, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
-    void reload(CompletionHandler<void(Error)>&&);
-    void reloadFromOrigin(CompletionHandler<void(Error)>&&);
+    void reload(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void reloadFromOrigin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
-    void goBack(CompletionHandler<void(Error)>&&);
-    void goForward(CompletionHandler<void(Error)>&&);
+    void goBack(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void goForward(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
-    void activate(CompletionHandler<void(Error)>&&);
-    void select(CompletionHandler<void(Error)>&&);
-    void deselect(CompletionHandler<void(Error)>&&);
+    void activate(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void select(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void deselect(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
-    void duplicate(const WebExtensionTabParameters&, CompletionHandler<void(RefPtr<WebExtensionTab>, Error)>&&);
+    void duplicate(const WebExtensionTabParameters&, CompletionHandler<void(Expected<RefPtr<WebExtensionTab>, WebExtensionError>&&)>&&);
 
-    void close(CompletionHandler<void(Error)>&&);
+    void close(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     bool shouldGrantTabPermissionsOnUserGesture() const;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "WebExtensionError.h"
 #include "WebExtensionWindowIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
@@ -87,7 +88,6 @@ public:
 
     enum class PopulateTabs : bool { No, Yes };
 
-    using Error = std::optional<String>;
     using TabVector = Vector<Ref<WebExtensionTab>>;
 
     WebExtensionWindowIdentifier identifier() const { return m_identifier; }
@@ -109,7 +109,7 @@ public:
     Type type() const;
 
     State state() const;
-    void setState(State, CompletionHandler<void(Error)>&&);
+    void setState(State, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     bool isOpen() const;
     void didOpen() { ASSERT(!m_isOpen); m_isOpen = true; }
@@ -117,7 +117,7 @@ public:
 
     bool isFocused() const;
     bool isFrontmost() const;
-    void focus(CompletionHandler<void(Error)>&&);
+    void focus(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     bool isPrivate() const;
 
@@ -126,11 +126,11 @@ public:
 
     // Handles the frame in the screen's native coordinate system.
     CGRect frame() const;
-    void setFrame(CGRect, CompletionHandler<void(Error)>&&);
+    void setFrame(CGRect, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     CGRect screenFrame() const;
 
-    void close(CompletionHandler<void(Error)>&&);
+    void close(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
 #ifdef __OBJC__
     _WKWebExtensionWindow *delegate() const { return m_delegate.getAutoreleased(); }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		1C2B4D442A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C2B4D462A8199CD00C528A1 /* WebExtensionAPIAlarms.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */; };
 		1C2B4D4B2A819D0D00C528A1 /* JSWebExtensionAPIAlarms.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C2BBF932B82BC5D001DBDFC /* WebExtensionError.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2BBF922B82BC5D001DBDFC /* WebExtensionError.h */; };
 		1C386F302AF4082F004108F0 /* WebExtensionAPINotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C386F2F2AF4082F004108F0 /* WebExtensionAPINotifications.h */; };
 		1C386F322AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C386F312AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C386F352AF409F9004108F0 /* JSWebExtensionAPINotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C386F332AF409F9004108F0 /* JSWebExtensionAPINotifications.h */; };
@@ -3754,6 +3755,7 @@
 		1C2B4D472A819C4700C528A1 /* WebExtensionAPIAlarms.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIAlarms.idl; sourceTree = "<group>"; };
 		1C2B4D482A819D0C00C528A1 /* JSWebExtensionAPIAlarms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIAlarms.h; sourceTree = "<group>"; };
 		1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIAlarms.mm; sourceTree = "<group>"; };
+		1C2BBF922B82BC5D001DBDFC /* WebExtensionError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionError.h; sourceTree = "<group>"; };
 		1C386F2E2AF407B1004108F0 /* WebExtensionAPINotifications.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPINotifications.idl; sourceTree = "<group>"; };
 		1C386F2F2AF4082F004108F0 /* WebExtensionAPINotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPINotifications.h; sourceTree = "<group>"; };
 		1C386F312AF40849004108F0 /* WebExtensionAPINotificationsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPINotificationsCocoa.mm; sourceTree = "<group>"; };
@@ -13397,6 +13399,7 @@
 				1CF35F492B36089E0079C02C /* WebExtensionCookieParameters.serialization.in */,
 				B6B156582B5E1779004F9894 /* WebExtensionDataType.h */,
 				B624FF1C2ABE54B500F6EDF6 /* WebExtensionDynamicScripts.serialization.in */,
+				1C2BBF922B82BC5D001DBDFC /* WebExtensionError.h */,
 				B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */,
 				8696CE2F297EB3C90081C800 /* WebExtensionEventListenerType.serialization.in */,
 				1C4A14C52ABB710E00A1018C /* WebExtensionFrameIdentifier.h */,
@@ -16659,6 +16662,7 @@
 				B6058CF52B6D98E8006D4C77 /* WebExtensionDataRecord.h in Headers */,
 				B6B1565C2B5E177A004F9894 /* WebExtensionDataType.h in Headers */,
 				B6D031052AC1F241006C8E0B /* WebExtensionDynamicScripts.h in Headers */,
+				1C2BBF932B82BC5D001DBDFC /* WebExtensionError.h in Headers */,
 				B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */,
 				1C4A14C62ABB710E00A1018C /* WebExtensionFrameIdentifier.h in Headers */,
 				33B5A80C2AFD298100A15D40 /* WebExtensionFrameParameters.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -97,16 +97,14 @@ void WebExtensionAPIAction::getTitle(NSDictionary *details, Ref<WebExtensionCall
     if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetTitle(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> title, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetTitle(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        ASSERT(title);
-
-        callback->call((NSString *)title.value());
-    }, extensionContext().identifier().toUInt64());
+        callback->call(result.value());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::setTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -131,14 +129,14 @@ void WebExtensionAPIAction::setTitle(NSDictionary *details, Ref<WebExtensionCall
     if (NSString *string = objectForKey<NSString>(details, titleKey, false))
         title = string;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetTitle(windowIdentifier, tabIdentifier, title), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetTitle(windowIdentifier, tabIdentifier, title), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
         callback->call();
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::getBadgeText(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -150,16 +148,14 @@ void WebExtensionAPIAction::getBadgeText(NSDictionary *details, Ref<WebExtension
     if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetBadgeText(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> badgeText, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetBadgeText(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        ASSERT(badgeText);
-
-        callback->call((NSString *)badgeText.value());
-    }, extensionContext().identifier().toUInt64());
+        callback->call(result.value());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::setBadgeText(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -184,14 +180,14 @@ void WebExtensionAPIAction::setBadgeText(NSDictionary *details, Ref<WebExtension
     if (NSString *string = objectForKey<NSString>(details, textKey, false))
         text = string;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetBadgeText(windowIdentifier, tabIdentifier, text), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetBadgeText(windowIdentifier, tabIdentifier, text), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
         callback->call();
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::getBadgeBackgroundColor(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -230,14 +226,14 @@ void WebExtensionAPIAction::enable(double tabID, Ref<WebExtensionCallbackHandler
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetEnabled(tabIdentifer, true), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetEnabled(tabIdentifer, true), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
         callback->call();
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::disable(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -248,14 +244,14 @@ void WebExtensionAPIAction::disable(double tabID, Ref<WebExtensionCallbackHandle
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetEnabled(tabIdentifer, false), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetEnabled(tabIdentifer, false), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
         callback->call();
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::isEnabled(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -267,16 +263,14 @@ void WebExtensionAPIAction::isEnabled(NSDictionary *details, Ref<WebExtensionCal
     if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetEnabled(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<bool> enabled, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetEnabled(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<bool, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        ASSERT(enabled);
-
-        callback->call(@(enabled.value()));
-    }, extensionContext().identifier().toUInt64());
+        callback->call(@(result.value()));
+    }, extensionContext().identifier());
 }
 
 static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSString *sourceKey, NSString **outExceptionString)
@@ -463,14 +457,14 @@ void WebExtensionAPIAction::setIcon(JSContextRef, NSDictionary *details, Ref<Web
 
     auto *iconDictionaryJSON = encodeJSONString(iconDictionary);
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetIcon(windowIdentifier, tabIdentifier, iconDictionaryJSON), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetIcon(windowIdentifier, tabIdentifier, iconDictionaryJSON), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
         callback->call();
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::getPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -482,16 +476,14 @@ void WebExtensionAPIAction::getPopup(NSDictionary *details, Ref<WebExtensionCall
     if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetPopup(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> popupPath, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetPopup(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        ASSERT(popupPath);
-
-        callback->call((NSString *)popupPath.value());
-    }, extensionContext().identifier().toUInt64());
+        callback->call(result.value());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::setPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -516,14 +508,14 @@ void WebExtensionAPIAction::setPopup(NSDictionary *details, Ref<WebExtensionCall
     if (NSString *string = objectForKey<NSString>(details, popupKey, false))
         popup = string;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetPopup(windowIdentifier, tabIdentifier, popup), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetPopup(windowIdentifier, tabIdentifier, popup), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
         callback->call();
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIAction::openPopup(WebPage& page, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -535,14 +527,14 @@ void WebExtensionAPIAction::openPopup(WebPage& page, NSDictionary *details, Ref<
     if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionOpenPopup(page.webPageProxyIdentifier(), windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionOpenPopup(page.webPageProxyIdentifier(), windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
         callback->call();
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 WebExtensionAPIEvent& WebExtensionAPIAction::onClicked()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
@@ -76,7 +76,7 @@ void WebExtensionAPICommands::getAll(Ref<WebExtensionCallbackHandler>&& callback
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::CommandsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionCommandParameters> commands) {
         callback->call(toAPI(commands));
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 WebExtensionAPIEvent& WebExtensionAPICommands::onCommand()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -74,12 +74,12 @@ void WebExtensionAPIDeclarativeNetRequest::updateEnabledRulesets(NSDictionary *o
     if (!validateDictionary(options, @"options", nil, types, outExceptionString))
         return;
 
-    Vector<String> rulesetsToEnable =  makeVector<String>(objectForKey<NSArray>(options, enableRulesetsKey, true, NSString.class));
+    Vector<String> rulesetsToEnable = makeVector<String>(objectForKey<NSArray>(options, enableRulesetsKey, true, NSString.class));
     Vector<String> rulesetsToDisable = makeVector<String>(objectForKey<NSArray>(options, disableRulesetsKey, true, NSString.class));
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateEnabledRulesets(rulesetsToEnable, rulesetsToDisable), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateEnabledRulesets(rulesetsToEnable, rulesetsToDisable), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
@@ -118,23 +118,19 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
         ++index;
     }
 
-    std::optional<String> optionalRulesToAdd;
+    String rulesToAddJSON;
     if (rulesToAdd)
-        optionalRulesToAdd = encodeJSONString(rulesToAdd, JSONOptions::FragmentsAllowed);
+        rulesToAddJSON = encodeJSONString(rulesToAdd, JSONOptions::FragmentsAllowed);
 
-    std::optional<Vector<double>> optionalRuleIDsToRemove;
+    Vector<double> ruleIDsToRemove;
     if (NSArray *rulesToRemove = objectForKey<NSArray>(options, removeRulesKey, false, NSNumber.class)) {
-        Vector<double> ruleIDsToRemove;
-
         for (NSNumber *ruleIDToRemove in rulesToRemove)
             ruleIDsToRemove.append(ruleIDToRemove.doubleValue);
-
-        optionalRuleIDsToRemove = ruleIDsToRemove;
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateDynamicRules(optionalRulesToAdd, optionalRuleIDsToRemove), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateDynamicRules(WTFMove(rulesToAddJSON), WTFMove(ruleIDsToRemove)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
@@ -144,13 +140,13 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
 
 void WebExtensionAPIDeclarativeNetRequest::getDynamicRules(Ref<WebExtensionCallbackHandler>&& callback)
 {
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetDynamicRules(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetDynamicRules(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        callback->call(parseJSON(replyJSON.value(), JSONOptions::FragmentsAllowed));
+        callback->call(parseJSON(result.value(), JSONOptions::FragmentsAllowed));
     }, extensionContext().identifier());
 }
 
@@ -178,23 +174,19 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
         ++index;
     }
 
-    std::optional<String> optionalRulesToAdd;
+    String rulesToAddJSON;
     if (rulesToAdd)
-        optionalRulesToAdd = encodeJSONString(rulesToAdd, JSONOptions::FragmentsAllowed);
+        rulesToAddJSON = encodeJSONString(rulesToAdd, JSONOptions::FragmentsAllowed);
 
-    std::optional<Vector<double>> optionalRuleIDsToRemove;
+    Vector<double> ruleIDsToRemove;
     if (NSArray *rulesToRemove = objectForKey<NSArray>(options, removeRulesKey, false, NSNumber.class)) {
-        Vector<double> ruleIDsToRemove;
-
         for (NSNumber *ruleIDToRemove in rulesToRemove)
             ruleIDsToRemove.append(ruleIDToRemove.doubleValue);
-
-        optionalRuleIDsToRemove = ruleIDsToRemove;
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateSessionRules(optionalRulesToAdd, optionalRuleIDsToRemove), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestUpdateSessionRules(WTFMove(rulesToAddJSON), WTFMove(ruleIDsToRemove)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
@@ -204,13 +196,13 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
 
 void WebExtensionAPIDeclarativeNetRequest::getSessionRules(Ref<WebExtensionCallbackHandler>&& callback)
 {
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetSessionRules(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetSessionRules(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        callback->call(parseJSON(replyJSON.value(), JSONOptions::FragmentsAllowed));
+        callback->call(parseJSON(result.value(), JSONOptions::FragmentsAllowed));
     }, extensionContext().identifier());
 }
 
@@ -223,7 +215,8 @@ static bool extensionHasPermission(WebExtensionContextProxy& extensionContext, N
 
 static NSDictionary *toWebAPI(const Vector<WebExtensionMatchedRuleParameters>& matchedRules)
 {
-    NSMutableArray *matchedRuleArray = [NSMutableArray array];
+    NSMutableArray *matchedRuleArray = [NSMutableArray arrayWithCapacity:matchedRules.size()];
+
     for (auto& matchedRule : matchedRules) {
         [matchedRuleArray addObject:@{
             @"request": @{ @"url": matchedRule.url.string() },
@@ -270,13 +263,13 @@ void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter,
     if (minTimeStamp)
         optionalTimeStamp = WallTime::fromRawSeconds(Seconds::fromMilliseconds(minTimeStamp.doubleValue).value());
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetMatchedRules(optionalTabIdentifier, optionalTimeStamp), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<Vector<WebExtensionMatchedRuleParameters>> matchedRules, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestGetMatchedRules(optionalTabIdentifier, optionalTimeStamp), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionMatchedRuleParameters>, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        callback->call(toWebAPI(matchedRules.value()));
+        callback->call(toWebAPI(result.value()));
     }, extensionContext().identifier());
 }
 
@@ -324,9 +317,9 @@ void WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions(NSDictionar
             return;
         }
 
-        WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestIncrementActionCount(tabIdentifier.value(), objectForKey<NSNumber>(tabUpdateDictionary, actionCountIncrementKey).doubleValue), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-            if (error) {
-                callback->reportError(error.value());
+        WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestIncrementActionCount(tabIdentifier.value(), objectForKey<NSNumber>(tabUpdateDictionary, actionCountIncrementKey).doubleValue), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+            if (!result) {
+                callback->reportError(result.error());
                 return;
             }
 
@@ -335,9 +328,9 @@ void WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions(NSDictionar
         return;
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestDisplayActionCountAsBadgeText(objectForKey<NSNumber>(options, actionCountDisplayActionCountAsBadgeTextKey).boolValue), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DeclarativeNetRequestDisplayActionCountAsBadgeText(objectForKey<NSNumber>(options, actionCountDisplayActionCountAsBadgeTextKey).boolValue), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
@@ -75,7 +75,7 @@ void WebExtensionContextProxy::dispatchDevToolsExtensionPanelShownEvent(Inspecto
 
         for (auto& listener : extensionPanel->onShown().listeners()) {
             auto globalContext = listener->globalContext();
-            auto *windowObject = toWindowObject(globalContext, *frame);
+            auto *windowObject = toWindowObject(globalContext, *frame) ?: NSNull.null;
             listener->call(windowObject);
         }
     });

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -72,7 +72,7 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPage& page, NSString *expre
         }
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsInspectedWindowEval(page.webPageProxyIdentifier(), expression, frameURL), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, String> result) mutable {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsInspectedWindowEval(page.webPageProxyIdentifier(), expression, frameURL), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, WebExtensionError>&& result) mutable {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
@@ -52,7 +52,7 @@ void WebExtensionAPIDevToolsPanels::createPanel(WebPage& page, NSString *title, 
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/create
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsPanelsCreate(page.webPageProxyIdentifier(), title, iconPath, pagePath), [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Inspector::ExtensionTabID, String> result) mutable {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsPanelsCreate(page.webPageProxyIdentifier(), title, iconPath, pagePath), [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Inspector::ExtensionTabID, WebExtensionError>&& result) mutable {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -109,7 +109,7 @@ JSValue *WebExtensionAPIExtension::getBackgroundPage(JSContextRef context)
 
     auto backgroundPage = extensionContext().backgroundPage();
     if (!backgroundPage)
-        return nil;
+        return toJSValue(context, JSValueMakeNull(context));
 
     return toWindowObject(context, *backgroundPage);
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -305,9 +305,9 @@ id WebExtensionAPIMenus::createMenu(WebPage& page, NSDictionary *properties, Ref
     if (parameters.value().identifier.isEmpty())
         parameters.value().identifier = createVersion4UUIDString();
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusCreate(parameters.value()), [this, protectedThis = Ref { *this }, callback = WTFMove(callback), clickCallback = WTFMove(clickCallback), identifier = parameters.value().identifier](std::optional<String> error) mutable {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusCreate(parameters.value()), [this, protectedThis = Ref { *this }, callback = WTFMove(callback), clickCallback = WTFMove(clickCallback), identifier = parameters.value().identifier](Expected<void, WebExtensionError>&& result) mutable {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
@@ -341,9 +341,9 @@ void WebExtensionAPIMenus::update(WebPage& page, id identifier, NSDictionary *pr
     if (NSNumber *identifierNumber = dynamic_objc_cast<NSNumber>(identifier))
         identifier = identifierNumber.stringValue;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusUpdate(identifier, parameters.value()), [this, protectedThis = Ref { *this }, callback = WTFMove(callback), clickCallback = WTFMove(clickCallback), newIdentifier = parameters.value().identifier, oldIdentifier = String(identifier)](std::optional<String> error) mutable {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusUpdate(identifier, parameters.value()), [this, protectedThis = Ref { *this }, callback = WTFMove(callback), clickCallback = WTFMove(clickCallback), newIdentifier = parameters.value().identifier, oldIdentifier = String(identifier)](Expected<void, WebExtensionError>&& result) mutable {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
@@ -378,9 +378,9 @@ void WebExtensionAPIMenus::remove(id identifier, Ref<WebExtensionCallbackHandler
     if (NSNumber *identifierNumber = dynamic_objc_cast<NSNumber>(identifier))
         identifier = identifierNumber.stringValue;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusRemove(identifier), [this, protectedThis = Ref { *this }, callback = WTFMove(callback), identifier = String(identifier)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusRemove(identifier), [this, protectedThis = Ref { *this }, callback = WTFMove(callback), identifier = String(identifier)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
@@ -397,9 +397,9 @@ void WebExtensionAPIMenus::removeAll(Ref<WebExtensionCallbackHandler>&& callback
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/removeAll
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusRemoveAll(), [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusRemoveAll(), [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -56,7 +56,7 @@ void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callb
             permissionsKey: createNSArray(permissions).get(),
             originsKey: createNSArray(origins).get()
         });
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -75,7 +75,7 @@ void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensio
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsContains(permissions, origins), [protectedThis = Ref { *this }, callback = WTFMove(callback)](bool containsPermissions) {
         callback->call(containsPermissions ? @YES : @NO);
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -112,7 +112,7 @@ void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtension
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsRequest(permissions, origins), [protectedThis = Ref { *this }, callback = WTFMove(callback)](bool success) {
         callback->call(success ? @YES : @NO);
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -141,7 +141,7 @@ void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionC
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsRemove(permissions, origins), [protectedThis = Ref { *this }, callback = WTFMove(callback)](bool success) {
         callback->call(success ? @YES : @NO);
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 bool WebExtensionAPIPermissions::parseDetailsDictionary(NSDictionary *details, HashSet<String>& permissions, HashSet<String>& origins, NSString *callingAPIName, NSString **outExceptionString)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -103,18 +103,19 @@ void WebExtensionAPIStorageArea::get(WebPage& page, id items, Ref<WebExtensionCa
         keysVector = { key };
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(page.webPageProxyIdentifier(), m_type, keysVector), [&, keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> dataJSON, WebKit::WebExtensionContext::ErrorString error) {
-        if (error)
-            callback->reportError(error.value());
-        else {
-            NSDictionary *data = parseJSON(dataJSON.value());
-            NSDictionary<NSString *, id> *deserializedData = mapObjects(data, ^id(NSString *key, NSString *jsonString) {
-                return parseJSON(jsonString, { JSONOptions::FragmentsAllowed });
-            });
-
-            deserializedData = keysWithDefaultValues ? mergeDictionaries(deserializedData, keysWithDefaultValues) : deserializedData;
-            callback->call(deserializedData);
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(page.webPageProxyIdentifier(), m_type, keysVector), [&, keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
+            return;
         }
+
+        NSDictionary *data = parseJSON(result.value());
+        NSDictionary<NSString *, id> *deserializedData = mapObjects(data, ^id(NSString *key, NSString *jsonString) {
+            return parseJSON(jsonString, JSONOptions::FragmentsAllowed);
+        });
+
+        deserializedData = keysWithDefaultValues ? mergeDictionaries(deserializedData, keysWithDefaultValues) : deserializedData;
+        callback->call(deserializedData);
     }, extensionContext().identifier());
 }
 
@@ -134,11 +135,11 @@ void WebExtensionAPIStorageArea::getBytesInUse(WebPage& page, id keys, Ref<WebEx
     else if (NSString *key = dynamic_objc_cast<NSString>(keys))
         keysVector = { key };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetBytesInUse(page.webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<size_t> size, WebKit::WebExtensionContext::ErrorString error) {
-        if (error)
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetBytesInUse(page.webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<size_t, WebExtensionError>&& result) {
+        if (!result)
+            callback->reportError(result.error());
         else
-            callback->call(@(size.value()));
+            callback->call(@(result.value()));
     }, extensionContext().identifier());
 }
 
@@ -178,9 +179,9 @@ void WebExtensionAPIStorageArea::set(WebPage& page, NSDictionary *items, Ref<Web
         return;
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSet(page.webPageProxyIdentifier(), m_type, encodeJSONString(serializedData)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
-        if (error)
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSet(page.webPageProxyIdentifier(), m_type, encodeJSONString(serializedData)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result)
+            callback->reportError(result.error());
         else
             callback->call();
     }, extensionContext().identifier());
@@ -195,9 +196,9 @@ void WebExtensionAPIStorageArea::remove(WebPage& page, id keys, Ref<WebExtension
 
     Vector<String> keysVector = [keys isKindOfClass:NSArray.class] ? makeVector<String>((NSArray *)keys) : Vector<String> { keys };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageRemove(page.webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
-        if (error)
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageRemove(page.webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result)
+            callback->reportError(result.error());
         else
             callback->call();
     }, extensionContext().identifier());
@@ -205,9 +206,9 @@ void WebExtensionAPIStorageArea::remove(WebPage& page, id keys, Ref<WebExtension
 
 void WebExtensionAPIStorageArea::clear(WebPage& page, Ref<WebExtensionCallbackHandler>&& callback)
 {
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageClear(page.webPageProxyIdentifier(), m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
-        if (error)
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageClear(page.webPageProxyIdentifier(), m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result)
+            callback->reportError(result.error());
         else
             callback->call();
     }, extensionContext().identifier());
@@ -234,9 +235,9 @@ void WebExtensionAPIStorageArea::setAccessLevel(WebPage& page, NSDictionary *acc
 
     WebExtensionStorageAccessLevel accessLevel = [accessLevelString isEqualToString:accessLevelTrustedContexts] ? WebExtensionStorageAccessLevel::TrustedContexts : WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSetAccessLevel(page.webPageProxyIdentifier(), m_type, accessLevel), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
-        if (error)
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSetAccessLevel(page.webPageProxyIdentifier(), m_type, accessLevel), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result)
+            callback->reportError(result.error());
         else
             callback->call();
     }, extensionContext().identifier());

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -89,13 +89,13 @@ void WebExtensionAPIWebNavigation::getAllFrames(NSDictionary *details, Ref<WebEx
     if (!isValid(tabIdentifier, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WebNavigationGetAllFrames(tabIdentifier.value()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<Vector<WebExtensionFrameParameters>> results, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WebNavigationGetAllFrames(tabIdentifier.value()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionFrameParameters>, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        callback->call(results ? toWebAPI(results.value()) : nil);
+        callback->call(toWebAPI(result.value()));
     }, extensionContext().identifier());
 }
 
@@ -124,13 +124,13 @@ void WebExtensionAPIWebNavigation::getFrame(NSDictionary *details, Ref<WebExtens
         return;
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WebNavigationGetFrame(tabIdentifier.value(), frameIdentifier.value()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionFrameParameters> frameInfo, std::optional<String> error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WebNavigationGetFrame(tabIdentifier.value(), frameIdentifier.value()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionFrameParameters>, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        callback->call(frameInfo ? toWebAPI(frameInfo.value()) : nil);
+        callback->call(toWebAPI(result.value()));
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -395,19 +395,14 @@ void WebExtensionAPIWindows::createWindow(NSDictionary *data, Ref<WebExtensionCa
     if (!parseWindowCreateOptions(data, parameters, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsCreate(WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsCreate(WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionWindowParameters>, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        if (!windowParameters) {
-            callback->call();
-            return;
-        }
-
-        callback->call(toWebAPI(windowParameters.value()));
-    }, extensionContext().identifier().toUInt64());
+        callback->call(toWebAPI(result.value()));
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIWindows::get(WebPage& page, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -423,19 +418,14 @@ void WebExtensionAPIWindows::get(WebPage& page, double windowID, NSDictionary *i
     if (!parseWindowGetOptions(info, populate, filter, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page.webPageProxyIdentifier(), windowIdentifer.value(), filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page.webPageProxyIdentifier(), windowIdentifer.value(), filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        if (!windowParameters) {
-            callback->call();
-            return;
-        }
-
-        callback->call(toWebAPI(windowParameters.value()));
-    }, extensionContext().identifier().toUInt64());
+        callback->call(toWebAPI(result.value()));
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIWindows::getCurrent(WebPage& page, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -447,19 +437,14 @@ void WebExtensionAPIWindows::getCurrent(WebPage& page, NSDictionary *info, Ref<W
     if (!parseWindowGetOptions(info, populate, filter, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page.webPageProxyIdentifier(), WebExtensionWindowConstants::CurrentIdentifier, filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page.webPageProxyIdentifier(), WebExtensionWindowConstants::CurrentIdentifier, filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        if (!windowParameters) {
-            callback->call();
-            return;
-        }
-
-        callback->call(toWebAPI(windowParameters.value()));
-    }, extensionContext().identifier().toUInt64());
+        callback->call(toWebAPI(result.value()));
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIWindows::getLastFocused(NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -471,19 +456,14 @@ void WebExtensionAPIWindows::getLastFocused(NSDictionary *info, Ref<WebExtension
     if (!parseWindowGetOptions(info, populate, filter, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGetLastFocused(filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGetLastFocused(filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        if (!windowParameters) {
-            callback->call();
-            return;
-        }
-
-        callback->call(toWebAPI(windowParameters.value()));
-    }, extensionContext().identifier().toUInt64());
+        callback->call(toWebAPI(result.value()));
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIWindows::getAll(NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -495,18 +475,14 @@ void WebExtensionAPIWindows::getAll(NSDictionary *info, Ref<WebExtensionCallback
     if (!parseWindowGetOptions(info, populate, filter, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGetAll(filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionWindowParameters> windows, WebExtensionWindow::Error error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGetAll(filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionWindowParameters>, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        NSMutableArray *result = [[NSMutableArray alloc] initWithCapacity:windows.size()];
-        for (auto& windowParameters : windows)
-            [result addObject:toWebAPI(windowParameters)];
-
-        callback->call([result copy]);
-    }, extensionContext().identifier().toUInt64());
+        callback->call(toWebAPI(result.value()));
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIWindows::update(double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -521,19 +497,14 @@ void WebExtensionAPIWindows::update(double windowID, NSDictionary *info, Ref<Web
     if (!parseWindowUpdateOptions(info, parameters, @"properties", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsUpdate(windowIdentifer.value(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsUpdate(windowIdentifer.value(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
-        if (!windowParameters) {
-            callback->call();
-            return;
-        }
-
-        callback->call(toWebAPI(windowParameters.value()));
-    }, extensionContext().identifier().toUInt64());
+        callback->call(toWebAPI(result.value()));
+    }, extensionContext().identifier());
 }
 
 void WebExtensionAPIWindows::remove(double windowID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -544,14 +515,14 @@ void WebExtensionAPIWindows::remove(double windowID, Ref<WebExtensionCallbackHan
     if (!isValid(windowIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsRemove(windowIdentifer.value()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionWindow::Error error) {
-        if (error) {
-            callback->reportError(error.value());
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsRemove(windowIdentifer.value()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error());
             return;
         }
 
         callback->call();
-    }, extensionContext().identifier().toUInt64());
+    }, extensionContext().identifier());
 }
 
 WebExtensionAPIWindowsEvent& WebExtensionAPIWindows::onCreated()
@@ -606,7 +577,7 @@ void WebExtensionContextProxy::dispatchWindowsEvent(WebExtensionEventListenerTyp
         case WebExtensionEventListenerType::WindowsOnCreated:
             // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onCreated
             ASSERT(windowParameters);
-            windowsObject.onCreated().invokeListenersWithArgument(toWebAPI(windowParameters.value()), filter);
+            windowsObject.onCreated().invokeListenersWithArgument(toWebAPI(windowParameters), filter);
             break;
 
         case WebExtensionEventListenerType::WindowsOnFocusChanged:

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -75,7 +75,7 @@ private:
 };
 
 NSArray *toWebAPI(const Vector<WebExtensionScriptInjectionResultParameters>&, bool returnExecutionResultOnly);
-NSArray *toWebAPI(const Vector<WebExtensionRegisteredScriptParameters>&);
+NSDictionary *toWebAPI(const WebExtensionRegisteredScriptParameters&);
 NSString *toWebAPI(WebExtension::InjectionTime);
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -170,9 +170,9 @@ private:
     void dispatchPortDisconnectEvent(WebExtensionPortChannelIdentifier);
 
     // Runtime
-    void internalDispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
+    void internalDispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(String&& replyJSON)>&&);
     void internalDispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
-    void dispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
+    void dispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(String&& replyJSON)>&&);
     void dispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
     void dispatchRuntimeInstalledEvent(WebExtensionContext::InstallReason, String previousVersion);
     void dispatchRuntimeStartupEvent();

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -64,7 +64,7 @@ messages -> WebExtensionContextProxy {
     DispatchPortDisconnectEvent(WebKit::WebExtensionPortChannelIdentifier channelIdentifier)
 
     // Runtime
-    DispatchRuntimeMessageEvent(WebKit::WebExtensionContentWorldType contentWorldType, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON)
+    DispatchRuntimeMessageEvent(WebKit::WebExtensionContentWorldType contentWorldType, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (String replyJSON)
     DispatchRuntimeConnectEvent(WebKit::WebExtensionContentWorldType contentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (size_t firedEventCount)
     DispatchRuntimeInstalledEvent(WebKit::WebExtensionContext::InstallReason installReason, String previousVersion)
     DispatchRuntimeStartupEvent()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
@@ -535,7 +535,7 @@ TEST(WKWebExtensionAPIWindows, CreateIncognitoWithoutPrivateAccess)
         @"};",
 
         @"const window = await browser.windows.create(windowOptions);",
-        @"browser.test.assertEq(window, undefined, 'The window should be created but undefined without access');",
+        @"browser.test.assertEq(window, null, 'The window should be created but null without access');",
 
         @"browser.test.notifyPass();"
     ]);


### PR DESCRIPTION
#### 1e5e2883c8bda6ee86b1717947a226daed9f1437
<pre>
Use Expected for error reporting in Web Extensions completionHandlers.
<a href="https://webkit.org/b/269681">https://webkit.org/b/269681</a>
<a href="https://rdar.apple.com/123199880">rdar://123199880</a>

Reviewed by Brian Weinstein.

Instead of using std::optional&lt;String&gt; for errors, and std::optional for the
real result, wrap them together with Expected to be more efficient.

Also use r-value references for these results, so the result is moved instead
of copied when the completionHandler is called.

Added two helper templates for toWebAPI that that return nil for std::optional
wrapped objects that have a toWebAPI function, and similarly for Vector wrapped
objects to get an NSArray result.

Some other misc drive-by fixes too, like using Ref and RefPtr explicitly, and
not using toUInt64() when sending a message for the destination identifier.

All existing Web Extension API tests pass, except WKWebExtensionAPIWindows,
CreateIncognitoWithoutPrivateAccess needed updated expectations for null.

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/Extensions/WebExtensionConstants.h:
* Source/WebKit/Shared/Extensions/WebExtensionError.h: Added.
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
(WebKit::toWebAPI):
(WebKit::toWebExtensionError):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::getActionWithIdentifiers):
(WebKit::getOrCreateActionWithIdentifiers):
(WebKit::WebExtensionContext::actionGetTitle):
(WebKit::WebExtensionContext::actionSetTitle):
(WebKit::WebExtensionContext::actionSetIcon):
(WebKit::WebExtensionContext::actionGetPopup):
(WebKit::WebExtensionContext::actionSetPopup):
(WebKit::WebExtensionContext::actionOpenPopup):
(WebKit::WebExtensionContext::actionGetBadgeText):
(WebKit::WebExtensionContext::actionSetBadgeText):
(WebKit::WebExtensionContext::actionGetEnabled):
(WebKit::WebExtensionContext::actionSetEnabled):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm:
(WebKit::WebExtensionContext::alarmsGet):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::fetchCookies):
(WebKit::WebExtensionContext::cookiesGet):
(WebKit::WebExtensionContext::cookiesGetAll):
(WebKit::WebExtensionContext::cookiesSet):
(WebKit::WebExtensionContext::cookiesRemove):
(WebKit::WebExtensionContext::cookiesGetAllCookieStores):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestGetEnabledRulesets):
(WebKit::WebExtensionContext::declarativeNetRequestValidateRulesetIdentifiers):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets):
(WebKit::WebExtensionContext::declarativeNetRequestDisplayActionCountAsBadgeText):
(WebKit::WebExtensionContext::declarativeNetRequestIncrementActionCount):
(WebKit::WebExtensionContext::declarativeNetRequestGetMatchedRules):
(WebKit::WebExtensionContext::updateDeclarativeNetRequestRulesInStorage):
(WebKit::WebExtensionContext::declarativeNetRequestGetDynamicRules):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateDynamicRules):
(WebKit::WebExtensionContext::declarativeNetRequestGetSessionRules):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateSessionRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm:
(WebKit::WebExtensionContext::devToolsInspectedWindowEval):
(WebKit::WebExtensionContext::devToolsInspectedWindowReload):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm:
(WebKit::WebExtensionContext::devToolsPanelsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIMenusCocoa.mm:
(WebKit::WebExtensionContext::menusCreate):
(WebKit::WebExtensionContext::menusUpdate):
(WebKit::WebExtensionContext::menusRemove):
(WebKit::WebExtensionContext::menusRemoveAll):
(WebKit::WebExtensionContext::fireMenusClickedEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::permissionsGetAll):
(WebKit::WebExtensionContext::permissionsContains):
(WebKit::WebExtensionContext::permissionsRequest):
(WebKit::WebExtensionContext::permissionsRemove):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeGetBackgroundPage):
(WebKit::WebExtensionContext::runtimeOpenOptionsPage):
(WebKit::WebExtensionContext::runtimeSendMessage):
(WebKit::WebExtensionContext::runtimeConnect):
(WebKit::WebExtensionContext::runtimeSendNativeMessage):
(WebKit::WebExtensionContext::runtimeConnectNative):
(WebKit::WebExtensionContext::runtimeWebPageSendMessage):
(WebKit::WebExtensionContext::runtimeWebPageConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingExecuteScript):
(WebKit::WebExtensionContext::scriptingInsertCSS):
(WebKit::WebExtensionContext::scriptingRemoveCSS):
(WebKit::WebExtensionContext::scriptingRegisterContentScripts):
(WebKit::WebExtensionContext::scriptingUpdateRegisteredScripts):
(WebKit::WebExtensionContext::scriptingGetRegisteredScripts):
(WebKit::WebExtensionContext::scriptingUnregisterContentScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
(WebKit::WebExtensionContext::storageGet):
(WebKit::WebExtensionContext::storageGetBytesInUse):
(WebKit::WebExtensionContext::storageSet):
(WebKit::WebExtensionContext::storageRemove):
(WebKit::WebExtensionContext::storageClear):
(WebKit::WebExtensionContext::storageSetAccessLevel):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate):
(WebKit::WebExtensionContext::tabsUpdate):
(WebKit::WebExtensionContext::tabsDuplicate):
(WebKit::WebExtensionContext::tabsGet):
(WebKit::WebExtensionContext::tabsGetCurrent):
(WebKit::WebExtensionContext::tabsQuery):
(WebKit::WebExtensionContext::tabsReload):
(WebKit::WebExtensionContext::tabsGoBack):
(WebKit::WebExtensionContext::tabsGoForward):
(WebKit::WebExtensionContext::tabsDetectLanguage):
(WebKit::WebExtensionContext::tabsCaptureVisibleTab):
(WebKit::WebExtensionContext::tabsToggleReaderMode):
(WebKit::WebExtensionContext::tabsSendMessage):
(WebKit::WebExtensionContext::tabsConnect):
(WebKit::WebExtensionContext::tabsGetZoom):
(WebKit::WebExtensionContext::tabsSetZoom):
(WebKit::WebExtensionContext::tabsRemove):
(WebKit::WebExtensionContext::tabsExecuteScript):
(WebKit::WebExtensionContext::tabsInsertCSS):
(WebKit::WebExtensionContext::tabsRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm:
(WebKit::frameParametersForFrame):
(WebKit::WebExtensionContext::webNavigationGetFrame):
(WebKit::WebExtensionContext::webNavigationGetAllFrames):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
(WebKit::WebExtensionContext::windowsGet):
(WebKit::WebExtensionContext::windowsGetLastFocused):
(WebKit::WebExtensionContext::windowsGetAll):
(WebKit::WebExtensionContext::windowsUpdate):
(WebKit::WebExtensionContext::windowsRemove):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::openNewTab):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::InjectionResultHolder::create):
(WebKit::WebExtensionDynamicScripts::executeScript):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::setParentTab):
(WebKit::WebExtensionTab::pin):
(WebKit::WebExtensionTab::unpin):
(WebKit::WebExtensionTab::toggleReaderMode):
(WebKit::WebExtensionTab::mute):
(WebKit::WebExtensionTab::unmute):
(WebKit::WebExtensionTab::setZoomFactor):
(WebKit::WebExtensionTab::detectWebpageLocale):
(WebKit::WebExtensionTab::captureVisibleWebpage):
(WebKit::WebExtensionTab::loadURL):
(WebKit::WebExtensionTab::reload):
(WebKit::WebExtensionTab::reloadFromOrigin):
(WebKit::WebExtensionTab::goBack):
(WebKit::WebExtensionTab::goForward):
(WebKit::WebExtensionTab::activate):
(WebKit::WebExtensionTab::select):
(WebKit::WebExtensionTab::deselect):
(WebKit::WebExtensionTab::duplicate):
(WebKit::WebExtensionTab::close):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::setState):
(WebKit::WebExtensionWindow::focus):
(WebKit::WebExtensionWindow::setFrame):
(WebKit::WebExtensionWindow::close):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
(WebKit::WebExtensionDynamicScripts::InjectionResultHolder::create): Deleted.
(WebKit::WebExtensionDynamicScripts::InjectionResultHolder::InjectionResultHolder): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::getTitle):
(WebKit::WebExtensionAPIAction::setTitle):
(WebKit::WebExtensionAPIAction::getBadgeText):
(WebKit::WebExtensionAPIAction::setBadgeText):
(WebKit::WebExtensionAPIAction::enable):
(WebKit::WebExtensionAPIAction::disable):
(WebKit::WebExtensionAPIAction::isEnabled):
(WebKit::WebExtensionAPIAction::setIcon):
(WebKit::WebExtensionAPIAction::getPopup):
(WebKit::WebExtensionAPIAction::setPopup):
(WebKit::WebExtensionAPIAction::openPopup):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIAlarms::get):
(WebKit::WebExtensionAPIAlarms::getAll):
(WebKit::WebExtensionAPIAlarms::clear):
(WebKit::WebExtensionAPIAlarms::clearAll):
(WebKit::WebExtensionContextProxy::dispatchAlarmsEvent):
(WebKit::toAPI): Deleted.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm:
(WebKit::WebExtensionAPICommands::getAll):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(WebKit::WebExtensionAPICookies::get):
(WebKit::WebExtensionAPICookies::getAll):
(WebKit::WebExtensionAPICookies::set):
(WebKit::WebExtensionAPICookies::remove):
(WebKit::WebExtensionAPICookies::getAllCookieStores):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateEnabledRulesets):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateSessionRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getSessionRules):
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getMatchedRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm:
(WebKit::WebExtensionAPIDevToolsPanels::createPanel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::createMenu):
(WebKit::WebExtensionAPIMenus::update):
(WebKit::WebExtensionAPIMenus::remove):
(WebKit::WebExtensionAPIMenus::removeAll):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::getAll):
(WebKit::WebExtensionAPIPermissions::contains):
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getBackgroundPage):
(WebKit::WebExtensionAPIRuntime::openOptionsPage):
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::sendNativeMessage):
(WebKit::WebExtensionAPIRuntime::connectNative):
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionAPIWebPageRuntime::connect):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
(WebKit::WebExtensionContextProxy::dispatchRuntimeMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIScripting::executeScript):
(WebKit::WebExtensionAPIScripting::insertCSS):
(WebKit::WebExtensionAPIScripting::removeCSS):
(WebKit::WebExtensionAPIScripting::registerContentScripts):
(WebKit::WebExtensionAPIScripting::getRegisteredContentScripts):
(WebKit::WebExtensionAPIScripting::updateContentScripts):
(WebKit::WebExtensionAPIScripting::unregisterContentScripts):
(WebKit::WebExtensionAPIScripting::validateScript):
(WebKit::WebExtensionAPIScripting::parseScriptInjectionOptions):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::get):
(WebKit::WebExtensionAPIStorageArea::getBytesInUse):
(WebKit::WebExtensionAPIStorageArea::set):
(WebKit::WebExtensionAPIStorageArea::remove):
(WebKit::WebExtensionAPIStorageArea::clear):
(WebKit::WebExtensionAPIStorageArea::setAccessLevel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::createTab):
(WebKit::WebExtensionAPITabs::query):
(WebKit::WebExtensionAPITabs::get):
(WebKit::WebExtensionAPITabs::getCurrent):
(WebKit::WebExtensionAPITabs::getSelected):
(WebKit::WebExtensionAPITabs::duplicate):
(WebKit::WebExtensionAPITabs::update):
(WebKit::WebExtensionAPITabs::remove):
(WebKit::WebExtensionAPITabs::reload):
(WebKit::WebExtensionAPITabs::goBack):
(WebKit::WebExtensionAPITabs::goForward):
(WebKit::WebExtensionAPITabs::getZoom):
(WebKit::WebExtensionAPITabs::setZoom):
(WebKit::WebExtensionAPITabs::detectLanguage):
(WebKit::WebExtensionAPITabs::toggleReaderMode):
(WebKit::WebExtensionAPITabs::captureVisibleTab):
(WebKit::WebExtensionAPITabs::sendMessage):
(WebKit::WebExtensionAPITabs::connect):
(WebKit::WebExtensionAPITabs::executeScript):
(WebKit::WebExtensionAPITabs::insertCSS):
(WebKit::WebExtensionAPITabs::removeCSS):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionAPIWebNavigation::getAllFrames):
(WebKit::WebExtensionAPIWebNavigation::getFrame):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::createWindow):
(WebKit::WebExtensionAPIWindows::get):
(WebKit::WebExtensionAPIWindows::getCurrent):
(WebKit::WebExtensionAPIWindows::getLastFocused):
(WebKit::WebExtensionAPIWindows::getAll):
(WebKit::WebExtensionAPIWindows::update):
(WebKit::WebExtensionAPIWindows::remove):
(WebKit::WebExtensionContextProxy::dispatchWindowsEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/274986@main">https://commits.webkit.org/274986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/845bdbbc2df29298a20e7e0dcc76ac9fc0c526e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40594 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19607 "Failed to checkout and rebase branch from PR 24717") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43147 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42901 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/22568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/16938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41168 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/22568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/40464 "Failed to checkout and rebase branch from PR 24717") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/22568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44420 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/22568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/16938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5388 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->