### PR TITLE
[WebXR] Refactor WebXROpaqueFramebuffer attachment logic

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -45,39 +45,33 @@ namespace WebCore {
 
 using GL = GraphicsContextGL;
 
-#if PLATFORM(COCOA)
-static GCEGLImage createAndBindCompositorTexture(GL& gl, GCGLenum target, GCGLOwnedTexture& texture, GL::EGLImageSource source)
+static void ensure(GL& gl, GCGLOwnedFramebuffer& framebuffer)
 {
-    auto object = gl.createTexture();
-    if (!object)
-        return { };
-    texture.adopt(gl, object);
-    gl.bindTexture(target, texture);
-    gl.texParameteri(target, GL::TEXTURE_MAG_FILTER, GL::LINEAR);
-    gl.texParameteri(target, GL::TEXTURE_MIN_FILTER, GL::LINEAR);
-    gl.texParameteri(target, GL::TEXTURE_WRAP_S, GL::CLAMP_TO_EDGE);
-    gl.texParameteri(target, GL::TEXTURE_WRAP_T, GL::CLAMP_TO_EDGE);
-
-    auto image = gl.createAndBindEGLImage(target, source, 0);
-    if (!image)
-        texture.release(gl);
-
-    return image;
+    if (!framebuffer) {
+        auto object = gl.createFramebuffer();
+        if (!object)
+            return;
+        framebuffer.adopt(gl, object);
+    }
 }
 
-static GCEGLImage createAndBindCompositorBuffer(GL& gl, GCGLOwnedRenderbuffer& buffer, GL::EGLImageSource source)
+#if PLATFORM(COCOA)
+
+static void ensure(GL& gl, GCGLOwnedRenderbuffer& buffer)
 {
-    auto object = gl.createRenderbuffer();
-    if (!object)
-        return { };
-    buffer.adopt(gl, object);
-    gl.bindRenderbuffer(GL::RENDERBUFFER, buffer);
+    if (!buffer) {
+        auto object = gl.createRenderbuffer();
+        if (!object)
+            return;
+        buffer.adopt(gl, object);
+    }
+}
 
-    auto image = gl.createAndBindEGLImage(GL::RENDERBUFFER, source, 0);
-    if (!image)
-        buffer.release(gl);
-
-    return image;
+static void createAndBindCompositorBuffer(GL& gl, WebXRExternalRenderbuffer& buffer, GL::EGLImageSource source, GCGLint layer)
+{
+    ensure(gl, buffer.rbo);
+    gl.bindRenderbuffer(GL::RENDERBUFFER, buffer.rbo);
+    buffer.image.adopt(gl, gl.createAndBindEGLImage(GL::RENDERBUFFER, source, layer));
 }
 
 static GL::EGLImageSource makeEGLImageSource(const std::tuple<WTF::MachSendRight, bool>& imageSource)
@@ -99,7 +93,7 @@ std::unique_ptr<WebXROpaqueFramebuffer> WebXROpaqueFramebuffer::create(PlatformX
 
 WebXROpaqueFramebuffer::WebXROpaqueFramebuffer(PlatformXR::LayerHandle handle, Ref<WebGLFramebuffer>&& framebuffer, WebGLRenderingContextBase& context, Attributes&& attributes, IntSize framebufferSize)
     : m_handle(handle)
-    , m_framebuffer(WTFMove(framebuffer))
+    , m_drawFramebuffer(WTFMove(framebuffer))
     , m_context(context)
     , m_attributes(WTFMove(attributes))
     , m_framebufferSize(framebufferSize)
@@ -110,20 +104,23 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
 {
     if (RefPtr gl = m_context.graphicsContextGL()) {
 #if PLATFORM(COCOA)
-        m_colorTexture.release(*gl);
+        for (auto& layer : m_displayAttachments)
+            layer.release(*gl);
 #endif
-        m_depthStencilBuffer.release(*gl);
-        m_multisampleColorBuffer.release(*gl);
+        m_drawAttachments.release(*gl);
+        m_resolveAttachments.release(*gl);
         m_resolvedFBO.release(*gl);
-        m_context.deleteFramebuffer(m_framebuffer.ptr());
+        m_context.deleteFramebuffer(m_drawFramebuffer.ptr());
     } else {
         // The GraphicsContextGL is gone, so disarm the GCGLOwned objects so
         // their destructors don't assert.
 #if PLATFORM(COCOA)
-        m_colorTexture.release(*gl);
+        for (auto& layer : m_displayAttachments)
+            layer.leakObject();
 #endif
-        m_depthStencilBuffer.leakObject();
-        m_multisampleColorBuffer.leakObject();
+        m_drawAttachments.leakObject();
+        m_resolveAttachments.leakObject();
+        m_displayFBO.leakObject();
         m_resolvedFBO.leakObject();
     }
 }
@@ -140,7 +137,7 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& 
     ScopedWebGLRestoreTexture restoreTexture { m_context, textureTarget };
     ScopedWebGLRestoreRenderbuffer restoreRenderBuffer { m_context };
 
-    gl->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER, m_framebuffer->object());
+    gl->bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
     // https://immersive-web.github.io/webxr/#opaque-framebuffer
     // The buffers attached to an opaque framebuffer MUST be cleared to the values in the provided table when first created,
     // or prior to the processing of each XR animation frame.
@@ -148,39 +145,26 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& 
     // the textures/renderbuffers.
 
 #if PLATFORM(COCOA)
-    auto colorTextureSource = makeEGLImageSource(data.colorTexture);
-    m_colorImage = createAndBindCompositorTexture(*gl, textureTarget, m_colorTexture, colorTextureSource);
-    if (!m_colorImage)
-        return;
+    int layerCount = (data.displayLayout == PlatformXR::Layout::Layered) ? 2 : 1;
+    for (int layer = 0; layer < layerCount; ++layer) {
+        auto colorTextureSource = makeEGLImageSource(data.colorTexture);
+        createAndBindCompositorBuffer(*gl, m_displayAttachments[layer].colorBuffer, colorTextureSource, layer);
+        ASSERT(m_displayAttachments[layer].colorBuffer.image);
+        if (!m_displayAttachments[layer].colorBuffer.image)
+            return;
 
-    auto depthStencilBufferSource = makeEGLImageSource(data.depthStencilBuffer);
-    m_depthStencilImage = createAndBindCompositorBuffer(*gl, m_depthStencilBuffer, depthStencilBufferSource);
+        auto depthStencilBufferSource = makeEGLImageSource(data.depthStencilBuffer);
+        createAndBindCompositorBuffer(*gl, m_displayAttachments[layer].depthStencilBuffer, depthStencilBufferSource, layer);
+    }
 
     // The drawing target can change size at any point during the session. If this happens, we need
     // to recreate the framebuffer.
-    if (m_framebufferSize != data.framebufferSize) {
-        m_framebufferSize = data.framebufferSize;
-        if (!setupFramebuffer())
-            return;
-    }
-
-    // Set up the framebuffer to use the texture that points to the IOSurface. If we're not multisampling,
-    // the target framebuffer is m_framebuffer->object() (bound above). If we are multisampling, the target
-    // is the resolved framebuffer we created in setupFramebuffer.
-    if (m_multisampleColorBuffer)
-        gl->bindFramebuffer(GL::FRAMEBUFFER, m_resolvedFBO);
-    gl->framebufferTexture2D(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, textureTarget, m_colorTexture, 0);
-    if (m_depthStencilBuffer)
-        gl->framebufferRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, m_depthStencilBuffer);
-
-    // At this point the framebuffer should be "complete".
-    ASSERT(gl->checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+    if (!setupFramebuffer(*gl, data))
+        return;
 
     m_completionSyncEvent = std::tuple(data.completionSyncEvent);
 #else
     m_colorTexture = data.opaqueTexture;
-    if (!m_multisampleColorBuffer)
-        gl->framebufferTexture2D(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_2D, m_colorTexture, 0);
 #endif
 
     // WebXR must always clear for the rAF of the session. Currently we assume content does not do redundant initial clear,
@@ -196,7 +180,7 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& 
         clearMask |= GL::DEPTH_BUFFER_BIT;
     if (m_attributes.stencil)
         clearMask |= GL::STENCIL_BUFFER_BIT;
-    gl->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER, m_framebuffer->object());
+    gl->bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
     gl->clear(clearMask);
 }
 
@@ -206,16 +190,15 @@ void WebXROpaqueFramebuffer::endFrame()
     if (!gl)
         return;
 
-    if (m_multisampleColorBuffer) {
-        ScopedWebGLRestoreFramebuffer restoreFramebuffer { m_context };
+    ScopedWebGLRestoreFramebuffer restoreFramebuffer { m_context };
 
-        GCGLbitfield buffers = GL::COLOR_BUFFER_BIT;
-        if (m_depthStencilBuffer)
-            buffers |= GL::DEPTH_BUFFER_BIT | GL::STENCIL_BUFFER_BIT;
-
-        gl->bindFramebuffer(GL::READ_FRAMEBUFFER, m_framebuffer->object());
-        gl->bindFramebuffer(GL::DRAW_FRAMEBUFFER, m_resolvedFBO);
-        gl->blitFramebufferANGLE(0, 0, width(), height(), 0, 0, width(), height(), buffers, GL::NEAREST);
+    switch (m_displayLayout) {
+    case PlatformXR::Layout::Shared:
+        blitShared(*gl);
+        break;
+    case PlatformXR::Layout::Layered:
+        blitSharedToLayered(*gl);
+        break;
     }
 
 #if PLATFORM(COCOA)
@@ -228,13 +211,10 @@ void WebXROpaqueFramebuffer::endFrame()
     } else
         gl->finish();
 
-    if (m_colorImage) {
-        gl->destroyEGLImage(m_colorImage);
-        m_colorImage = nullptr;
-    }
-    if (m_depthStencilImage) {
-        gl->destroyEGLImage(m_depthStencilImage);
-        m_depthStencilImage = nullptr;
+    int layerCount = (m_displayLayout == PlatformXR::Layout::Layered) ? 2 : 1;
+    for (int layer = 0; layer < layerCount; ++layer) {
+        m_displayAttachments[layer].colorBuffer.destroyImage(*gl);
+        m_displayAttachments[layer].depthStencilBuffer.destroyImage(*gl);
     }
 #else
     // FIXME: We have to call finish rather than flush because we only want to disconnect
@@ -245,73 +225,178 @@ void WebXROpaqueFramebuffer::endFrame()
 #endif
 }
 
-bool WebXROpaqueFramebuffer::setupFramebuffer()
+void WebXROpaqueFramebuffer::resolveMSAAFramebuffer(GraphicsContextGL& gl)
 {
-    RefPtr gl = m_context.graphicsContextGL();
-    if (!gl)
-        return false;
+    IntSize size = drawFramebufferSize();
+    PlatformGLObject readFBO = m_drawFramebuffer->object();
+    PlatformGLObject drawFBO = m_resolvedFBO ? m_resolvedFBO : m_displayFBO;
 
-    // Set up color, depth and stencil formats
-    const bool hasDepthOrStencil = m_attributes.stencil || m_attributes.depth;
+    GCGLbitfield buffers = GL::COLOR_BUFFER_BIT;
+    if (m_drawAttachments.depthStencilBuffer) {
+        // FIXME: Is it necessary to resolve stencil?
+        buffers |= GL::DEPTH_BUFFER_BIT | GL::STENCIL_BUFFER_BIT;
+    }
+
+    gl.bindFramebuffer(GL::READ_FRAMEBUFFER, readFBO);
+    ASSERT(gl.checkFramebufferStatus(GL::READ_FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+    gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, drawFBO);
+    ASSERT(gl.checkFramebufferStatus(GL::DRAW_FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+    gl.blitFramebuffer(0, 0, size.width(), size.height(), 0, 0, size.width(), size.height(), buffers, GL::NEAREST);
+}
+
+void WebXROpaqueFramebuffer::blitShared(GraphicsContextGL& gl)
+{
+    ASSERT(!m_resolvedFBO, "blitShared should not require intermediate resolve buffers");
+
+    ensure(gl, m_displayFBO);
+    gl.bindFramebuffer(GL::FRAMEBUFFER, m_displayFBO);
+#if PLATFORM(COCOA)
+    gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, m_displayAttachments[0].colorBuffer.rbo);
+#else
+    gl.framebufferTexture2D(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_2D, m_colorTexture, 0);
+#endif
+    ASSERT(gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+    resolveMSAAFramebuffer(gl);
+}
+
+void WebXROpaqueFramebuffer::blitSharedToLayered(GraphicsContextGL& gl)
+{
+#if PLATFORM(COCOA)
+    ensure(gl, m_displayFBO);
+
+    PlatformGLObject readFBO = m_resolvedFBO ? m_resolvedFBO : m_drawFramebuffer->object();
+    ASSERT(readFBO, "readFBO shouldn't be the default framebuffer");
+    PlatformGLObject drawFBO = m_displayFBO;
+    ASSERT(drawFBO, "drawFBO shouldn't be the default framebuffer");
+
+    IntSize size = displayFramebufferSize();
+
+    bool needsMSAAresolve = m_attributes.antialias;
+    if (m_attributes.antialias)
+
+    for (int layer = 0; layer < 2; ++layer) {
+        if (needsMSAAresolve) {
+            needsMSAAresolve = false;
+            resolveMSAAFramebuffer(gl);
+        }
+
+        gl.bindFramebuffer(GL::READ_FRAMEBUFFER, readFBO);
+        gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, drawFBO);
+
+        GCGLbitfield buffers = GL::COLOR_BUFFER_BIT;
+        gl.framebufferRenderbuffer(GL::DRAW_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, m_displayAttachments[layer].colorBuffer.rbo);
+
+        if (m_displayAttachments[layer].depthStencilBuffer.image) {
+            buffers |= GL::DEPTH_BUFFER_BIT;
+            gl.framebufferRenderbuffer(GL::DRAW_FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, m_displayAttachments[layer].depthStencilBuffer.rbo);
+        }
+        ASSERT(gl.checkFramebufferStatus(GL::DRAW_FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+
+        gl.blitFramebuffer(layer * size.width(), 0, (layer + 1) * size.width(), size.height(), 0, 0, size.width(), size.height(), buffers, GL::NEAREST);
+    }
+#else
+    UNUSED_PARAM(gl);
+    ASSERT_NOT_REACHED();
+#endif
+}
+
+IntSize WebXROpaqueFramebuffer::displayFramebufferSize() const
+{
+    return m_framebufferSize;
+}
+
+IntSize WebXROpaqueFramebuffer::drawFramebufferSize() const
+{
+    switch (m_displayLayout) {
+    case PlatformXR::Layout::Layered:
+        return { 2*m_framebufferSize.width(), m_framebufferSize.height() };
+    default:
+        return m_framebufferSize;
+    }
+}
+
+bool WebXROpaqueFramebuffer::setupFramebuffer(GraphicsContextGL& gl, const PlatformXR::FrameData::LayerData& data)
+{
+    if (m_framebufferSize == data.framebufferSize && m_displayLayout == data.displayLayout)
+        return true;
+
+    m_framebufferSize = data.framebufferSize;
+    m_displayLayout = data.displayLayout;
+
+    const bool layeredLayout = m_displayLayout == PlatformXR::Layout::Layered;
+    const bool needsIntermediateResolve = m_attributes.antialias && layeredLayout;
 
     // Set up recommended samples for WebXR.
     auto sampleCount = m_attributes.antialias ? std::min(4, m_context.maxSamples()) : 0;
 
-    if (m_attributes.antialias) {
-        auto fbo = gl->createFramebuffer();
-        if (!fbo)
+    IntSize size = drawFramebufferSize();
+
+    // Intermediate resolve target
+    if (needsIntermediateResolve) {
+        allocateAttachments(gl, m_resolveAttachments, 0, size);
+
+        ensure(gl, m_resolvedFBO);
+        gl.bindFramebuffer(GL::FRAMEBUFFER, m_resolvedFBO);
+        bindAttachments(gl, m_resolveAttachments);
+        ASSERT(gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+        if (gl.checkFramebufferStatus(GL::FRAMEBUFFER) != GL::FRAMEBUFFER_COMPLETE)
             return false;
-        m_resolvedFBO.adopt(*gl, fbo);
+    } else
+        m_resolvedFBO.release(gl);
 
-        auto colorBuffer = allocateColorStorage(*gl, sampleCount, m_framebufferSize);
-        bindColorBuffer(*gl, colorBuffer);
-        m_multisampleColorBuffer.adopt(*gl, colorBuffer);
+    // Drawing target
+    {
+        // FIXME: We always allocate a new drawing target
+        allocateAttachments(gl, m_drawAttachments, sampleCount, size);
 
-        if (hasDepthOrStencil) {
-            auto depthStencilBuffer = allocateDepthStencilStorage(*gl, sampleCount, m_framebufferSize);
-            bindDepthStencilBuffer(*gl, depthStencilBuffer);
-            m_multisampleDepthStencilBuffer.adopt(*gl, depthStencilBuffer);
-        }
-    } else if (hasDepthOrStencil && !m_depthStencilBuffer) {
-        auto depthStencilBuffer = allocateDepthStencilStorage(*gl, sampleCount, m_framebufferSize);
-        bindDepthStencilBuffer(*gl, depthStencilBuffer);
-
-        m_depthStencilBuffer.adopt(*gl, depthStencilBuffer);
+        gl.bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
+        bindAttachments(gl, m_drawAttachments);
+        ASSERT(gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
     }
 
-    return gl->checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE;
+    return gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE;
 }
 
-PlatformGLObject WebXROpaqueFramebuffer::allocateRenderbufferStorage(GraphicsContextGL& gl, GCGLsizei samples, GCGLenum internalFormat, IntSize size)
+void WebXROpaqueFramebuffer::allocateRenderbufferStorage(GraphicsContextGL& gl, GCGLOwnedRenderbuffer& buffer, GCGLsizei samples, GCGLenum internalFormat, IntSize size)
 {
     PlatformGLObject renderbuffer = gl.createRenderbuffer();
     ASSERT(renderbuffer);
     gl.bindRenderbuffer(GL::RENDERBUFFER, renderbuffer);
     gl.renderbufferStorageMultisampleANGLE(GL::RENDERBUFFER, samples, internalFormat, size.width(), size.height());
-
-    return renderbuffer;
+    buffer.adopt(gl, renderbuffer);
 }
 
-PlatformGLObject WebXROpaqueFramebuffer::allocateColorStorage(GraphicsContextGL& gl, GCGLsizei samples, IntSize size)
+void WebXROpaqueFramebuffer::allocateAttachments(GraphicsContextGL& gl, WebXRAttachments& attachments, GCGLsizei samples, IntSize size)
 {
-    return allocateRenderbufferStorage(gl, samples, GL::RGBA8, size);
+    const bool hasDepthOrStencil = m_attributes.stencil || m_attributes.depth;
+    allocateRenderbufferStorage(gl, attachments.colorBuffer, samples, GL::RGBA8, size);
+    if (hasDepthOrStencil)
+        allocateRenderbufferStorage(gl, attachments.depthStencilBuffer, samples, GL::DEPTH24_STENCIL8, size);
 }
 
-PlatformGLObject WebXROpaqueFramebuffer::allocateDepthStencilStorage(GraphicsContextGL& gl, GCGLsizei samples, IntSize size)
+void WebXROpaqueFramebuffer::bindAttachments(GraphicsContextGL& gl, WebXRAttachments& attachments)
 {
-    return allocateRenderbufferStorage(gl, samples, GL::DEPTH24_STENCIL8, size);
-}
-
-void WebXROpaqueFramebuffer::bindColorBuffer(GraphicsContextGL& gl, PlatformGLObject colorBuffer)
-{
-    gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, colorBuffer);
-}
-
-void WebXROpaqueFramebuffer::bindDepthStencilBuffer(GraphicsContextGL& gl, PlatformGLObject depthStencilBuffer)
-{
+    gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, attachments.colorBuffer);
     // NOTE: In WebGL2, GL::DEPTH_STENCIL_ATTACHMENT is an alias to set GL::DEPTH_ATTACHMENT and GL::STENCIL_ATTACHMENT, which is all we require.
-    ASSERT(m_attributes.stencil || m_attributes.depth);
-    gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, depthStencilBuffer);
+    ASSERT((m_attributes.stencil || m_attributes.depth) && attachments.depthStencilBuffer);
+    gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, attachments.depthStencilBuffer);
+}
+
+void WebXRExternalRenderbuffer::destroyImage(GraphicsContextGL& gl)
+{
+    image.release(gl);
+}
+
+void WebXRExternalRenderbuffer::release(GraphicsContextGL& gl)
+{
+    rbo.release(gl);
+    image.release(gl);
+}
+
+void WebXRExternalRenderbuffer::leakObject()
+{
+    rbo.leakObject();
+    image.leakObject();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -195,7 +195,7 @@ const WebGLFramebuffer* WebXRWebGLLayer::framebuffer() const
 unsigned WebXRWebGLLayer::framebufferWidth() const
 {
     if (m_framebuffer)
-        return m_framebuffer->width();
+        return m_framebuffer->drawFramebufferSize().width();
     return WTF::switchOn(m_context,
         [&](const RefPtr<WebGLRenderingContextBase>& baseContext) {
             return baseContext->drawingBufferWidth();
@@ -205,7 +205,7 @@ unsigned WebXRWebGLLayer::framebufferWidth() const
 unsigned WebXRWebGLLayer::framebufferHeight() const
 {
     if (m_framebuffer)
-        return m_framebuffer->height();
+        return m_framebuffer->drawFramebufferSize().height();
     return WTF::switchOn(m_context,
         [&](const RefPtr<WebGLRenderingContextBase>& baseContext) {
             return baseContext->drawingBufferHeight();

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1695,7 +1695,7 @@ private:
 
 WEBCORE_EXPORT RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes&, SerialFunctionDispatcher* = nullptr);
 
-template<void(GraphicsContextGL::*destroyFunc)(PlatformGLObject)>
+template<typename Object, void(GraphicsContextGL::*destroyFunc)(Object)>
 class GCGLOwned {
     WTF_MAKE_NONCOPYABLE(GCGLOwned);
 
@@ -1712,25 +1712,26 @@ public:
         ASSERT(!m_object); // Clients should call release() explicitly.
     }
 
-    operator PlatformGLObject() const { return m_object; }
+    operator Object() const { return m_object; }
 
-    PlatformGLObject leakObject() { return std::exchange(m_object, 0); }
+    Object leakObject() { return std::exchange(m_object, { }); }
 
-    void adopt(GraphicsContextGL& gl, PlatformGLObject object)
+    void adopt(GraphicsContextGL& gl, Object object)
     {
         if (m_object)
             (gl.*destroyFunc)(m_object);
         m_object = object;
     }
 
-    void release(GraphicsContextGL& gl) { adopt(gl, 0); }
+    void release(GraphicsContextGL& gl) { adopt(gl, { }); }
 private:
-    PlatformGLObject m_object { 0 };
+    Object m_object { };
 };
 
-using GCGLOwnedFramebuffer = GCGLOwned<&GraphicsContextGL::deleteFramebuffer>;
-using GCGLOwnedRenderbuffer = GCGLOwned<&GraphicsContextGL::deleteRenderbuffer>;
-using GCGLOwnedTexture = GCGLOwned<&GraphicsContextGL::deleteTexture>;
+using GCGLOwnedFramebuffer = GCGLOwned<PlatformGLObject, &GraphicsContextGL::deleteFramebuffer>;
+using GCGLOwnedRenderbuffer = GCGLOwned<PlatformGLObject, &GraphicsContextGL::deleteRenderbuffer>;
+using GCGLOwnedTexture = GCGLOwned<PlatformGLObject, &GraphicsContextGL::deleteTexture>;
+using GCEGLOwnedImage = GCGLOwned<GCEGLImage, &GraphicsContextGL::destroyEGLImage>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -45,6 +45,11 @@ class SecurityOriginData;
 
 namespace PlatformXR {
 
+enum class Layout : uint8_t {
+    Shared,
+    Layered,
+};
+
 enum class SessionMode : uint8_t {
     Inline,
     ImmersiveVr,
@@ -245,8 +250,9 @@ struct FrameData {
     };
 
     struct LayerData {
-#if PLATFORM(COCOA)
+        Layout displayLayout;
         WebCore::IntSize framebufferSize;
+#if PLATFORM(COCOA)
         std::tuple<MachSendRight, bool> colorTexture = { MachSendRight(), false };
         std::tuple<MachSendRight, bool> depthStencilBuffer = { MachSendRight(), false };
         std::tuple<MachSendRight, uint64_t> completionSyncEvent;

--- a/Source/WebCore/platform/xr/openxr/OpenXRLayer.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRLayer.cpp
@@ -63,7 +63,11 @@ std::optional<FrameData::LayerData> OpenXRLayerProjection::startFrame()
     if (!texture)
         return std::nullopt;
 
-    return FrameData::LayerData { *texture };
+    return FrameData::LayerData {
+        .displayLayout = PlatformXR::Layout::Shared,
+        .framebufferSize = m_swapchain->size(),
+        .opaqueTexture = *texture
+    };
 }
 
 XrCompositionLayerBaseHeader* OpenXRLayerProjection::endFrame(const Device::Layer& layer, XrSpace space, const Vector<XrView>& frameViews)

--- a/Source/WebCore/platform/xr/openxr/OpenXRSwapchain.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRSwapchain.h
@@ -22,6 +22,7 @@
 #if ENABLE(WEBXR) && USE(OPENXR)
 
 #include "GraphicsTypesGL.h"
+#include "IntSize.h"
 #include "OpenXRUtils.h"
 
 #include <wtf/Noncopyable.h>
@@ -41,6 +42,7 @@ public:
     XrSwapchain swapchain() const { return m_swapchain; }
     int32_t width() const { return m_createInfo.width; }
     int32_t height() const { return m_createInfo.height; }
+    WebCore::IntSize size() const { return WebCore::IntSize(width(), height()); }
 
 private:
     OpenXRSwapchain(XrInstance, XrSwapchain, const XrSwapchainCreateInfo&, Vector<XrSwapchainImageOpenGLKHR>&&);

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -156,9 +156,17 @@ void SimulatedXRDevice::frameTimerFired()
     for (auto& layer : m_layers) {
 #if PLATFORM(COCOA)
         auto surface = IOSurface::create(nullptr, recommendedResolution(PlatformXR::SessionMode::ImmersiveVr), DestinationColorSpace::SRGB());
-        data.layers.add(layer.key, PlatformXR::FrameData::LayerData { .colorTexture = std::make_tuple(surface->createSendRight(), false) });
+        data.layers.add(layer.key, PlatformXR::FrameData::LayerData {
+            .displayLayout = PlatformXR::Layout::Shared,
+            .framebufferSize = recommendedResolution(PlatformXR::SessionMode::ImmersiveVr),
+            .colorTexture = std::make_tuple(surface->createSendRight(), false)
+        });
 #else
-        data.layers.add(layer.key, PlatformXR::FrameData::LayerData { .opaqueTexture = layer.value });
+        data.layers.add(layer.key, PlatformXR::FrameData::LayerData {
+            .displayLayout = PlatformXR::Layout::Shared,
+            .framebufferSize = recommendedResolution(PlatformXR::SessionMode::ImmersiveVr),
+            .opaqueTexture = layer.value
+        });
 #endif
     }
 

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -22,6 +22,11 @@
 
 #if ENABLE(WEBXR)
 
+enum class PlatformXR::Layout : uint8_t {
+    Shared,
+    Layered,
+};
+
 enum class PlatformXR::SessionFeature : uint8_t {
     ReferenceSpaceTypeViewer,
     ReferenceSpaceTypeLocal,
@@ -96,8 +101,9 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
 };
 
 [Nested, RValue] struct PlatformXR::FrameData::LayerData {
-#if PLATFORM(COCOA)
+    PlatformXR::Layout displayLayout;
     WebCore::IntSize framebufferSize;
+#if PLATFORM(COCOA)
     std::tuple<MachSendRight, bool> colorTexture;
     std::tuple<MachSendRight, bool> depthStencilBuffer;
     std::tuple<MachSendRight, uint64_t> completionSyncEvent;

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -292,6 +292,7 @@ void ARKitCoordinator::renderLoop(Box<RenderState> active)
 
             // FIXME: rdar://77858090 (Need to transmit color space information)
             frameData.layers.set(defaultLayerHandle(), PlatformXR::FrameData::LayerData {
+                .displayLayout = PlatformXR::Layout::Shared,
                 .framebufferSize = IntSize(colorTexture.width, colorTexture.height),
                 .colorTexture = WTFMove(colorTextureSendRight),
                 .completionSyncEvent = { MachSendRight(completionPort), renderingFrameIndex }


### PR DESCRIPTION
#### f9111bf146917e08bfa6e5e211563061c310cf21
<pre>
[WebXR] Refactor WebXROpaqueFramebuffer attachment logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=269683">https://bugs.webkit.org/show_bug.cgi?id=269683</a>
<a href="https://rdar.apple.com/123201364">rdar://123201364</a>

Reviewed by NOBODY (OOPS!).

Refactor WebXROpaqueFramebuffer handling of framebuffer attachments to support
Shared or Layered layout.

There are a few combinations of context attributes that WebXROpaqueFramebuffer
handles:

if `antialias`:
   Create internal MSAA color buffer
   if `depth/stencil`
      Create internal MSAA depth/stencil buffer
if `!antialias`:
   Draw to externally provided color texture
   if `depth/stencil`
       if `!externally provided depth/stencil`
           Create internal depth/stencil buffer

Prior to this change, the code handled these combinations in `StartFrame(...)` &amp;
`SetupFramebuffer(...)` with a loose collection of state.

This change simplifies the old assumption, dropping support for external
Textures, standardizing on Renderbuffers, and introduces helpers for keeping
related state together via `WebXRExternalRenderbuffer` and
`WebXRAttachmentSet`.

WebXRExternalRenderbuffer represents an externally provided Renderbuffer through
the OpenGL renderbuffer object and EGLImage pointer.

WebXRAttachmentSet represents a group of related color, depth and stencil
buffers. These can be &quot;internal&quot; or &quot;external&quot; via `WebXRAttachments` &amp;
`WebXRExternalAttachments`.

Object naming has been changed to consistently use `draw` for the target of
WebGL rendering commands and `display` for the target presented to the user via
a WebXR compositor system. To simplify the handling of attachments, the output
of WebGL commands are always &quot;blitted&quot; from the draw target to display target,
removing the optimal path in the previous code. This path will not be taken on
any compositors supported on Cocoa and will be redressed in a future patch.

Due to limitations of `glBlitFramebuffer`, blitting to `Layered` layout from an
MSAA enabled attachment set requires the use of an intermediate, resolved path
represented by the `resolve` prefixed `m_resolvedAttachments` &amp; `m_resolveFBO`.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::ensure):
(WebCore::createAndBindCompositorBuffer):
(WebCore::WebXROpaqueFramebuffer::WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
(WebCore::WebXROpaqueFramebuffer::resolveMSAAFramebuffer):
(WebCore::WebXROpaqueFramebuffer::blitShared):
(WebCore::WebXROpaqueFramebuffer::blitSharedToLayered):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
(WebCore::WebXROpaqueFramebuffer::allocateRenderbufferStorage):
(WebCore::WebXROpaqueFramebuffer::allocateAttachments):
(WebCore::WebXROpaqueFramebuffer::bindAttachments):
(WebCore::WebXRExternalRenderbuffer::destroyImage):
(WebCore::WebXRExternalRenderbuffer::release):
(WebCore::WebXRExternalRenderbuffer::leakObject):
(WebCore::createAndBindCompositorTexture): Deleted.
(WebCore::WebXROpaqueFramebuffer::allocateColorStorage): Deleted.
(WebCore::WebXROpaqueFramebuffer::allocateDepthStencilStorage): Deleted.
(WebCore::WebXROpaqueFramebuffer::bindColorBuffer): Deleted.
(WebCore::WebXROpaqueFramebuffer::bindDepthStencilBuffer): Deleted.
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
(WebCore::WebXRAttachmentSet::release):
(WebCore::WebXRAttachmentSet::leakObject):
(WebCore::WebXROpaqueFramebuffer::framebuffer const):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
(WebCore::destroyFunc):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::renderLoop):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9111bf146917e08bfa6e5e211563061c310cf21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33639 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14223 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14296 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35923 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39993 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12591 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38318 "Found 270 new API test failures: /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/cookies-changed, /WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestFrame:/webkit/WebKitFrame/javascript-values, /WebKitGTK/TestDownloads:/webkit/Downloads/remote-file-error, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16980 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->