### PR TITLE
121459787-log-remote-drawing

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -113,6 +113,9 @@
 		65072B162B6D7FAA0065065C /* TZoneMallocInitialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 65072B152B6D7FAA0065065C /* TZoneMallocInitialization.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		70A993FE1AD7151300FA615B /* SymbolRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70A993FC1AD7151300FA615B /* SymbolRegistry.cpp */; };
 		70ECA60D1B02426800449739 /* AtomStringImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70ECA60A1B02426800449739 /* AtomStringImpl.cpp */; };
+		741A66E92B81F68E004ED035 /* TrackingRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 741A66E62B81F68E004ED035 /* TrackingRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		741A66EA2B81F68E004ED035 /* TrackableRefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = 741A66E72B81F68E004ED035 /* TrackableRefCounted.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		741A66EB2B81F68E004ED035 /* TrackingRefPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 741A66E82B81F68E004ED035 /* TrackingRefPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7A05093F1FB9DCC500B33FB8 /* JSONValues.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A05093E1FB9DCC500B33FB8 /* JSONValues.cpp */; };
 		7A6EBA3420746C34004F9C44 /* MachSendRight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A6EBA3320746C34004F9C44 /* MachSendRight.cpp */; };
 		7AAF9CA42AC4C39100E73DD3 /* PlatformEnableGlib.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AAF9CA32AC4C39100E73DD3 /* PlatformEnableGlib.h */; };
@@ -1238,6 +1241,9 @@
 		70ECA60A1B02426800449739 /* AtomStringImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AtomStringImpl.cpp; sourceTree = "<group>"; };
 		70ECA60B1B02426800449739 /* SymbolImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SymbolImpl.h; sourceTree = "<group>"; };
 		70ECA60C1B02426800449739 /* UniquedStringImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UniquedStringImpl.h; sourceTree = "<group>"; };
+		741A66E62B81F68E004ED035 /* TrackingRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TrackingRef.h; sourceTree = "<group>"; };
+		741A66E72B81F68E004ED035 /* TrackableRefCounted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TrackableRefCounted.h; sourceTree = "<group>"; };
+		741A66E82B81F68E004ED035 /* TrackingRefPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TrackingRefPtr.h; sourceTree = "<group>"; };
 		79038E05224B05A7004C0738 /* SpanningTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanningTree.h; sourceTree = "<group>"; };
 		7936D6A91C99F8AE000D1AED /* SmallSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmallSet.h; sourceTree = "<group>"; };
 		793BFADD9CED44B8B9FBCA16 /* StdUnorderedMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StdUnorderedMap.h; sourceTree = "<group>"; };
@@ -2423,6 +2429,9 @@
 				0F7075F31FBF537A00489AF0 /* TimingScope.h */,
 				553071C91C40427200384898 /* TinyLRUCache.h */,
 				0FED67B51B22D4D80066CE15 /* TinyPtrSet.h */,
+				741A66E72B81F68E004ED035 /* TrackableRefCounted.h */,
+				741A66E62B81F68E004ED035 /* TrackingRef.h */,
+				741A66E82B81F68E004ED035 /* TrackingRefPtr.h */,
 				E3538D4D276220880075DA50 /* TrailingArray.h */,
 				521CC6B324A277C2004377D6 /* TranslatedProcess.cpp */,
 				2D1F2F462498F73300C63A83 /* TranslatedProcess.h */,
@@ -3459,6 +3468,9 @@
 				DD3DC95A27A4BF8E007E5B61 /* TinyLRUCache.h in Headers */,
 				DD3DC98F27A4BF8E007E5B61 /* TinyPtrSet.h in Headers */,
 				DDF3073827C086CD006A526F /* TollFreeBridging.h in Headers */,
+				741A66EA2B81F68E004ED035 /* TrackableRefCounted.h in Headers */,
+				741A66E92B81F68E004ED035 /* TrackingRef.h in Headers */,
+				741A66EB2B81F68E004ED035 /* TrackingRefPtr.h in Headers */,
 				DD3DC8A827A4BF8E007E5B61 /* TrailingArray.h in Headers */,
 				DD3DC97127A4BF8E007E5B61 /* TranslatedProcess.h in Headers */,
 				DD3DC87627A4BF8E007E5B61 /* TriState.h in Headers */,

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -284,9 +284,6 @@ void WTFReportBacktraceWithPrefix(const char* prefix)
     WTFReportBacktraceWithPrefixAndPrintStream(out, prefix);
 }
 
-static constexpr int kDefaultFramesToShow = 31;
-static constexpr int kDefaultFramesToSkip = 2;
-
 void WTFReportBacktraceWithStackDepth(int framesToShow)
 {
     WTFReportBacktraceWithPrefixAndStackDepth("", framesToShow);
@@ -306,14 +303,16 @@ void WTFReportBacktraceWithPrefixAndStackDepth(const char* prefix, int framesToS
         out.print("%sno stacktrace available", prefix);
 }
 
-void WTFReportBacktraceWithPrefixAndPrintStream(PrintStream& out, const char* prefix)
+void WTFReportBacktraceWithPrefixAndPrintStream(PrintStream& out, const char* prefix, int toShow, int toSkip)
 {
     void* samples[kDefaultFramesToShow + kDefaultFramesToSkip];
-    int frames = kDefaultFramesToShow + kDefaultFramesToSkip;
+    if (toShow + toSkip > kDefaultFramesToShow + kDefaultFramesToSkip)
+        toShow = kDefaultFramesToShow + kDefaultFramesToSkip - toSkip;
+    int frames = toShow + toSkip;
 
     WTFGetBacktrace(samples, &frames);
-    if (frames > kDefaultFramesToSkip)
-        WTFPrintBacktraceWithPrefixAndPrintStream(out, samples + kDefaultFramesToSkip, frames - kDefaultFramesToSkip, prefix);
+    if (frames > toSkip)
+        WTFPrintBacktraceWithPrefixAndPrintStream(out, samples + toSkip, frames - toSkip, prefix);
     else
         out.print("%sno stacktrace available", prefix);
 }

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -238,7 +238,9 @@ WTF_EXPORT_PRIVATE void WTFReportBacktraceWithStackDepth(int);
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndStackDepth(const char*, int);
 WTF_EXPORT_PRIVATE void WTFReportBacktrace(void);
 #ifdef __cplusplus
-WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, const char*);
+static constexpr int kDefaultFramesToShow = 31;
+static constexpr int kDefaultFramesToSkip = 2;
+WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, const char*, int toShow = kDefaultFramesToShow, int toSkip = kDefaultFramesToSkip);
 WTF_EXPORT_PRIVATE void WTFPrintBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, void** stack, int size, const char* prefix);
 #endif
 WTF_EXPORT_PRIVATE void WTFPrintBacktrace(void** stack, int size);

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -312,6 +312,9 @@ set(WTF_PUBLIC_HEADERS
     TimingScope.h
     TinyLRUCache.h
     TinyPtrSet.h
+    TrackableRefCounted.h
+    TrackingRef.h
+    TrackingRefPtr.h
     TrailingArray.h
     TranslatedProcess.h
     TriState.h

--- a/Source/WTF/wtf/LogChannels.cpp
+++ b/Source/WTF/wtf/LogChannels.cpp
@@ -68,7 +68,11 @@ void LogChannels::initializeLogChannelsIfNecessary(std::optional<String> logChan
 
     m_logChannelsNeedInitialization = false;
 
+#if 1
+    String enabledChannelsString = "EventLoop,Loading,Network,Process,ProcessSwapping,ViewState"_s;
+#else
     String enabledChannelsString = logChannelString ? logChannelString.value() : logLevelString();
+#endif
     WTFInitializeLogChannelStatesFromString(m_logChannels.data(), m_logChannels.size(), enabledChannelsString.utf8().data());
 }
 

--- a/Source/WTF/wtf/ObjectIdentifier.cpp
+++ b/Source/WTF/wtf/ObjectIdentifier.cpp
@@ -34,13 +34,13 @@ namespace WTF {
 uint64_t ObjectIdentifierMainThreadAccessTraits::generateIdentifierInternal()
 {
     ASSERT(isMainThread()); // You should use AtomicObjectIdentifier if you're hitting this assertion.
-    static uint64_t current = 0;
+    static uint64_t current = uint64_t(getpid()) * 1000u;
     return ++current;
 }
 
 uint64_t ObjectIdentifierThreadSafeAccessTraits::generateIdentifierInternal()
 {
-    static std::atomic<uint64_t> current;
+    static std::atomic<uint64_t> current { uint64_t(getpid()) * 10000u };
     return ++current;
 }
 

--- a/Source/WTF/wtf/TrackableRefCounted.h
+++ b/Source/WTF/wtf/TrackableRefCounted.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Assertions.h>
+#include <wtf/TrackingRef.h>
+#include <wtf/text/TextStream.h>
+
+namespace WTF {
+
+template <typename T>
+class TrackableRefCounted {
+public:
+    void recordRefOperation(T& refCountedObject, TrackingReferenceOperation operation, HolderContainer holderContainer, String holderName)
+    {
+        m_records.append({ refCountedObject, operation, holderContainer, WTFMove(holderName), notFound });
+    }
+
+    void dumpRefOperationRecords(String listPrefix = ""_s, String rowPrefix = ""_s)
+    {
+        const size_t len = m_records.size();
+        if (!len) {
+            ALWAYS_LOG_WITH_STREAM(stream << listPrefix << (listPrefix.isEmpty() ? "" : " - ") << "no operations");
+            return;
+        }
+
+        for (size_t indexToStartMatch = 0; indexToStartMatch < len - 1; ++indexToStartMatch) {
+            auto& recordToMatch = m_records[indexToStartMatch];
+            if (recordToMatch.matchingIndex != notFound)
+                continue;
+            if (recordToMatch.operation != TrackingReferenceOperation::ref)
+                continue;
+            for (size_t indexToLookForMatching = indexToStartMatch + 1; indexToLookForMatching < len; ++indexToLookForMatching) {
+                auto& recordPossiblyMatching = m_records[indexToLookForMatching];
+                if (recordPossiblyMatching.operation == TrackingReferenceOperation::deref && recordPossiblyMatching.holderContainer == recordToMatch.holderContainer && recordPossiblyMatching.matchingIndex == notFound && recordPossiblyMatching.holderName == recordToMatch.holderName) {
+                    recordToMatch.matchingIndex = indexToLookForMatching;
+                    recordPossiblyMatching.matchingIndex = indexToStartMatch;
+                    break;
+                }
+            }
+        }
+
+        constexpr auto toString = [](TrackingReferenceOperation op) {
+            switch (op) {
+            case TrackingReferenceOperation::ref: return "ref"_s;
+            case TrackingReferenceOperation::deref: return "deref"_s;
+            default: return "?"_s;
+            }
+        };
+
+        size_t alives = 0;
+        for (const auto& record : m_records)
+            if (record.matchingIndex == notFound)
+                ++alives;
+
+        ALWAYS_LOG_WITH_STREAM(stream << listPrefix << (listPrefix.isEmpty() ? "" : " - ") << len << " operation" << ((len > 1) ? "s: (" : ": (") << alives << " alive)");
+        for (size_t i = 0; i < m_records.size(); ++i) {
+            const auto& record = m_records[i];
+            ALWAYS_LOG_WITH_STREAM(stream << rowPrefix << (listPrefix.isEmpty() ? "#" : " #") << (i + 1) << ": " << &record.refCountedObject << "." << toString(record.operation) << " by " << record.holderName << " @" << reinterpret_cast<const void*>(record.holderContainer.m_value); if (record.matchingIndex == notFound) stream << " alive"; else stream << " matching with #" << (record.matchingIndex + 1));
+        }
+    }
+
+private:
+    struct Record {
+        T& refCountedObject;
+        TrackingReferenceOperation operation;
+        HolderContainer holderContainer;
+        String holderName;
+        size_t matchingIndex;
+    };
+    Vector<Record> m_records;
+};
+
+} // namespace WTF

--- a/Source/WTF/wtf/TrackingRef.h
+++ b/Source/WTF/wtf/TrackingRef.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Ref.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+template <typename T>
+struct DefaultTrackingTester { static constexpr bool shouldTrack(T&) { return true; } };
+
+template <typename PointeeType, typename DowncastTypeToTrack>
+struct DowncastTrackingTester { static constexpr bool shouldTrack(PointeeType& ob) { return is<DowncastTypeToTrack>(ob); } };
+
+enum class TrackingReferenceOperation { ref, deref };
+
+struct HolderContainer {
+    HolderContainer(uintptr_t value) : m_value(value) {}
+    HolderContainer(const void* value) : m_value(reinterpret_cast<uintptr_t>(value)) {}
+    constexpr bool operator==(const HolderContainer& other) const { return other.m_value == m_value; }
+    uintptr_t m_value;
+};
+
+template<typename T, typename TrackingTester>
+class TrackingReferenceHolder {
+protected:
+    TrackingReferenceHolder(HolderContainer holderContainer, String holderName) : m_holderContainer(holderContainer), m_holderName(WTFMove(holderName)) {}
+
+    static constexpr bool shouldTrack(T& ob) { return TrackingTester::shouldTrack(ob); }
+
+    void record(T& ob, TrackingReferenceOperation op) { if (shouldTrack(ob)) { ob.recordRefOperation(ob, op, m_holderContainer, m_holderName); } }
+
+private:
+    HolderContainer m_holderContainer;
+    String m_holderName;
+};
+
+template<typename T, typename TrackingTester = DefaultTrackingTester<T>>
+class TrackingRef : public TrackingReferenceHolder<T, TrackingTester> {
+    using Base = TrackingReferenceHolder<T, TrackingTester>;
+public:
+    // Constructors must contain information about this holder.
+    TrackingRef(HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_ref(nullptr) {}
+    TrackingRef(std::nullptr_t, HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_ref(nullptr) {}
+    TrackingRef(T& ob, HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_ref(ob) { haveRefd(); }
+
+    TrackingRef(const TrackingRef&) = delete;
+    TrackingRef& operator=(const TrackingRef&) = delete;
+
+    TrackingRef(const Ref<T>& ob, HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_ref(ob) { haveRefd(); }
+    TrackingRef(Ref<T>&& ob, HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_ref(WTFMove(ob)) { haveRefd(); }
+
+    ~TrackingRef() { willDeref(); }
+
+    TrackingRef& operator=(const Ref<T>& r)
+    {
+        if (LIKELY(r.ptr() != m_ref.ptr())) {
+            willDeref();
+            m_ref = r;
+            haveRefd();
+        } else
+            m_ref = r; // m_ref.refCount() won't actually change.
+        return *this;
+    }
+    TrackingRef& operator=(Ref<T>&& r)
+    {
+        if (LIKELY(r.ptr() != m_ref.ptr())) {
+            willDeref();
+            m_ref = WTFMove(r);
+            haveRefd();
+        } else
+            m_ref = WTFMove(r); // m_ref.refCount() won't actually change.
+        return *this;
+    }
+
+    void swap(Ref<T>& r) { willDeref(); m_ref.swap(r); haveRefd(); }
+    friend void swap(Ref<T>& r, TrackingRef& self) { self.willDeref(); self.m_ref.swap(r); self.haveRefd(); }
+
+    TrackingRef& operator=(T* ptr) { willDeref(); m_ref = ptr; haveRefd(); return *this; }
+    TrackingRef& operator=(std::nullptr_t) { willDeref(); m_ref = nullptr; return *this; }
+
+    Ref<T> extractRef() { willDeref(); return WTFMove(m_ref); }
+
+    Ref<T> releaseNonNull() { ASSERT(m_ref); willDeref(); Ref<T> tmp(adoptRef(*m_ref)); m_ref = nullptr; return tmp; }
+
+    T* leakRef() { willDeref(); return m_ref.leakRef(); }
+
+    // Pass-through operations, which shouldn't affect the refCount.
+    const Ref<T>& getRef() const { return m_ref; }
+    T* ptr() const { return m_ref.ptr(); }
+    T& get() const { return m_ref.get(); }
+    ALWAYS_INLINE T* operator->() const { return m_ref.ptr(); }
+
+private:
+    static constexpr bool shouldTrack(T& ob) { return TrackingTester::shouldTrack(ob); }
+
+    void record(TrackingReferenceOperation op) { Base::record(m_ref.get(), op); }
+    void haveRefd() { record(TrackingReferenceOperation::ref); }
+    void willDeref() { record(TrackingReferenceOperation::deref); }
+
+    Ref<T> m_ref;
+};
+
+} // namespace WTF

--- a/Source/WTF/wtf/TrackingRefPtr.h
+++ b/Source/WTF/wtf/TrackingRefPtr.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/TrackingRef.h>
+
+namespace WTF {
+
+template<typename T, typename TrackingTester = DefaultTrackingTester<T>>
+class TrackingRefPtr : public TrackingReferenceHolder<T, TrackingTester> {
+    using Base = TrackingReferenceHolder<T, TrackingTester>;
+public:
+    // Constructors must contain information about this holder.
+    TrackingRefPtr(HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_refPtr(nullptr) {}
+    TrackingRefPtr(std::nullptr_t, HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_refPtr(nullptr) {}
+    TrackingRefPtr(T* ob, HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_refPtr(ob) { haveRefd(); }
+
+    TrackingRefPtr(const TrackingRefPtr&) = delete;
+    TrackingRefPtr& operator=(const TrackingRefPtr&) = delete;
+
+    TrackingRefPtr(const RefPtr<T>& ob, HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_refPtr(ob) { haveRefd(); }
+    TrackingRefPtr(RefPtr<T>&& ob, HolderContainer holderContainer, String holderName) : Base(holderContainer, WTFMove(holderName)), m_refPtr(WTFMove(ob)) { haveRefd(); }
+
+    ~TrackingRefPtr() { willDeref(); }
+
+    TrackingRefPtr& operator=(const RefPtr<T>& r)
+    {
+        if (LIKELY(r.get() != m_refPtr.get())) {
+            willDeref();
+            m_refPtr = r;
+            haveRefd();
+        } else
+            m_refPtr = r; // m_refPtr.refCount() won't actually change.
+        return *this;
+    }
+    TrackingRefPtr& operator=(RefPtr<T>&& r)
+    {
+        if (LIKELY(r.get() != m_refPtr.get())) {
+            willDeref();
+            m_refPtr = WTFMove(r);
+            haveRefd();
+        } else
+            m_refPtr = WTFMove(r); // m_refPtr.refCount() won't actually change.
+        return *this;
+    }
+
+    void swap(RefPtr<T>& r) { willDeref(); m_refPtr.swap(r); haveRefd(); }
+    friend void swap(RefPtr<T>& r, TrackingRefPtr& self) { self.willDeref(); self.m_refPtr.swap(r); self.haveRefd(); }
+
+    TrackingRefPtr& operator=(T* ptr) { willDeref(); m_refPtr = ptr; haveRefd(); return *this; }
+    TrackingRefPtr& operator=(std::nullptr_t) { willDeref(); m_refPtr = nullptr; return *this; }
+
+    RefPtr<T> extractRefPtr() { willDeref(); return WTFMove(m_refPtr); }
+
+    Ref<T> releaseNonNull() { ASSERT(m_refPtr); willDeref(); Ref<T> tmp(adoptRef(*m_refPtr)); m_refPtr = nullptr; return tmp; }
+
+    T* leakRef() { willDeref(); return m_refPtr.leakRef(); }
+
+    // Pass-through operations, which shouldn't affect the refCount.
+    const RefPtr<T>& getRefPtr() const { return m_refPtr; }
+    explicit operator bool() const { return bool(m_refPtr); }
+    T* get() const { return m_refPtr.get(); }
+    T& operator*() const { ASSERT(m_refPtr); return *m_refPtr.get(); }
+    ALWAYS_INLINE T* operator->() const { return m_refPtr.get(); }
+
+private:
+    static constexpr bool shouldTrack(T& ob) { return TrackingTester::shouldTrack(ob); }
+
+    void record(TrackingReferenceOperation op) { if (m_refPtr) { Base::record(*m_refPtr, op); } }
+    void haveRefd() { record(TrackingReferenceOperation::ref); }
+    void willDeref() { record(TrackingReferenceOperation::deref); }
+
+    RefPtr<T> m_refPtr;
+};
+
+} // namespace WTF

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -57,6 +57,7 @@
 #include <JavaScriptCore/JSFunction.h>
 #include <JavaScriptCore/Lookup.h>
 #include <JavaScriptCore/Structure.h>
+#include <wtf/TrackingRefPtr.h>
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
 #include "JSWebKitNamespace.h"
@@ -460,6 +461,7 @@ public:
     explicit DialogHandler(JSGlobalObject& lexicalGlobalObject, CallFrame& callFrame)
         : m_globalObject(lexicalGlobalObject)
         , m_callFrame(callFrame)
+        , m_frame(this, "DialogHandler::m_frame"_s)
     {
     }
 
@@ -469,7 +471,7 @@ public:
 private:
     JSGlobalObject& m_globalObject;
     CallFrame& m_callFrame;
-    RefPtr<LocalFrame> m_frame;
+    WTF::TrackingRefPtr<LocalFrame> m_frame;
 };
 
 inline void DialogHandler::dialogCreated(LocalDOMWindow& dialog)

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -43,6 +43,7 @@
 #include "VisibleSelection.h"
 #include "WritingDirection.h"
 #include <memory>
+#include <wtf/TrackingRefPtr.h>
 #include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
@@ -317,7 +318,7 @@ public:
         const EditorInternalCommand* m_command { nullptr };
         EditorCommandSource m_source;
         RefPtr<Document> m_document;
-        RefPtr<LocalFrame> m_frame;
+        WTF::TrackingRefPtr<LocalFrame> m_frame;
     };
     WEBCORE_EXPORT Command command(const String& commandName); // Command source is EditorCommandSource::MenuOrKeyBinding.
     Command command(const String& commandName, EditorCommandSource);

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1899,6 +1899,7 @@ bool Editor::commandIsSupportedFromMenuOrKeyBinding(const String& commandName)
 }
 
 Editor::Command::Command()
+    : m_frame(this, "Editor::Command::m_frame"_s)
 {
 }
 
@@ -1906,7 +1907,7 @@ Editor::Command::Command(const EditorInternalCommand* command, EditorCommandSour
     : m_command(command)
     , m_source(source)
     , m_document(command ? &document : nullptr)
-    , m_frame(command ? document.frame() : nullptr)
+    , m_frame(command ? document.frame() : nullptr, this, "Editor::Command::m_frame"_s)
 {
     ASSERT(command || !m_document);
 }
@@ -1920,7 +1921,7 @@ bool Editor::Command::execute(const String& parameter, Event* triggeringEvent) c
     }
 
     m_document->updateLayoutIgnorePendingStylesheets();
-    if (m_document->frame() != m_frame)
+    if (m_document->frame() != m_frame.get())
         return false;
 
     return m_command->execute(*m_frame, triggeringEvent, m_source, parameter);

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -70,6 +70,7 @@
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
 #import <wtf/FileSystem.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/TrackingRef.h>
 #import <wtf/URLParser.h>
 
 #if PLATFORM(MAC)
@@ -172,7 +173,7 @@ static FragmentAndResources createFragment(LocalFrame& frame, NSAttributedString
 class DeferredLoadingScope {
 public:
     DeferredLoadingScope(LocalFrame& frame)
-        : m_frame(frame)
+        : m_frame(frame, this, "DeferredLoadingScope::m_frame"_s)
         , m_cachedResourceLoader(frame.document()->cachedResourceLoader())
     {
         if (!frame.page()->defersLoading()) {
@@ -195,7 +196,7 @@ public:
     }
 
 private:
-    Ref<LocalFrame> m_frame;
+    WTF::TrackingRef<LocalFrame> m_frame;
     Ref<CachedResourceLoader> m_cachedResourceLoader;
     bool m_didEnabledDeferredLoading { false };
     bool m_didDisableImage { false };

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -178,6 +178,7 @@ void HTMLFrameElementBase::didAttachRenderers()
 
 void HTMLFrameElementBase::setLocation(const String& str)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "HTMLFrameElementBase[" << this << " frameID=" << (contentFrame() ? contentFrame()->frameID() : FrameIdentifier()) << " frameURL=" << frameURL() << "]::setLocation(" << str << ")");
     if (document().settings().needsAcrobatFrameReloadingQuirk() && m_frameURL == str)
         return;
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -794,6 +794,7 @@ void FrameLoader::receivedFirstData()
 
     LinkLoader::loadLinksFromHeader(documentLoader->response().httpHeaderField(HTTPHeaderName::Link), document->url(), document, LinkLoader::MediaAttributeCheck::MediaAttributeEmpty);
 
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** FrameLoader[" << this << " pageID=" << pageID() << " frameId=" << frameID() << "]::receivedFirstData() -> scheduleRefreshIfNeeded()");
     scheduleRefreshIfNeeded(document, documentLoader->response().httpHeaderField(HTTPHeaderName::Refresh), IsMetaRefresh::No);
 }
 
@@ -2957,6 +2958,7 @@ void FrameLoader::closeAndRemoveChild(LocalFrame& child)
 {
     child.tree().detachFromParent();
 
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** FrameLoader[" << this << " pageID=" << pageID() << " frameId=" << frameID() << "]::closeAndRemoveChild -> setView(0)");
     child.setView(nullptr);
     child.willDetachPage();
     child.detachFromPage();
@@ -3242,9 +3244,10 @@ void FrameLoader::scheduleRefreshIfNeeded(Document& document, const String& cont
     String urlString;
     if (parseMetaHTTPEquivRefresh(content, delay, urlString)) {
         auto completedURL = urlString.isEmpty() ? document.url() : document.completeURL(urlString);
-        if (!completedURL.protocolIsJavaScript())
+        if (!completedURL.protocolIsJavaScript()) {
+            ALWAYS_LOG_WITH_STREAM(stream << "**GS** FrameLoader[" << this << " pageID=" << pageID() << " frameId=" << frameID() << "]::scheduleRefreshIfNeeded(url=" << completedURL.string() << ") -> scheduleRedirect()");
             protectedFrame()->checkedNavigationScheduler()->scheduleRedirect(document, delay, completedURL, isMetaRefresh);
-        else {
+        } else {
             String message = "Refused to refresh " + document.url().stringCenterEllipsizedToLength() + " to a javascript: URL";
             document.addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
         }

--- a/Source/WebCore/loader/NavigationDisabler.h
+++ b/Source/WebCore/loader/NavigationDisabler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "LocalFrame.h"
+#include <wtf/TrackingRefPtr.h>
 
 namespace WebCore {
 
@@ -33,7 +34,7 @@ class NavigationDisabler {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     NavigationDisabler(LocalFrame* frame)
-        : m_frame(frame)
+        : m_frame(frame, this, "NavigationDisabler::m_frame"_s)
     {
         if (frame) {
             if (auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
@@ -63,7 +64,7 @@ public:
     }
 
 private:
-    RefPtr<LocalFrame> m_frame;
+    WTF::TrackingRefPtr<LocalFrame> m_frame;
 
     static unsigned s_globalNavigationDisableCount;
 };

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -141,8 +141,11 @@ protected:
         Ref protectedFrame { frame };
 
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
-        if (!localFrame)
+        if (!localFrame) {
+            ALWAYS_LOG_WITH_STREAM(stream << "ScheduledURLNavigation[url=" << m_url.url().string() << "]::didStartTimer(non-local frame=[" << &frame << "pageID=" << frame.pageID() << " frameID=" << frame.frameID() << "])");
             return;
+        }
+        ALWAYS_LOG_WITH_STREAM(stream << "ScheduledURLNavigation[url=" << m_url.url().string() << "]::didStartTimer(localFrame=[" << localFrame.get() << "pageID=" << localFrame->pageID() << " frameID=" << localFrame->frameID() << " view=" << localFrame->view() << (localFrame->isRootFrame() ? " root" : "") << "])");
         localFrame->checkedLoader()->clientRedirected(URL(m_url), delay(), WallTime::now() + timer.nextFireInterval(), lockBackForwardList());
     }
 
@@ -472,6 +475,7 @@ inline bool NavigationScheduler::shouldScheduleNavigation(const URL& url) const
 
 void NavigationScheduler::scheduleRedirect(Document& initiatingDocument, double delay, const URL& url, IsMetaRefresh isMetaRefresh)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "NavigationScheduler::scheduleRedirect(url=" << url.string() << ")");
     if (!shouldScheduleNavigation(url))
         return;
     if (delay < 0 || delay > INT_MAX / 1000)

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -32,7 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/RefPtr.h>
+#include <wtf/TrackingRefPtr.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakRef.h>
 
@@ -76,7 +76,7 @@ private:
 
     SingleThreadWeakRef<Page> m_page;
     UniqueRef<ProgressTrackerClient> m_client;
-    RefPtr<LocalFrame> m_originatingProgressFrame;
+    WTF::TrackingRefPtr<LocalFrame> m_originatingProgressFrame;
     HashMap<ResourceLoaderIdentifier, std::unique_ptr<ProgressItem>> m_progressItems;
     Timer m_progressHeartbeatTimer;
 

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -84,15 +84,17 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ResourceLoader);
 
 ResourceLoader::ResourceLoader(LocalFrame& frame, ResourceLoaderOptions options)
-    : m_frame { &frame }
+    : m_frame { &frame, this, "ResourceLoader::m_frame"_s }
     , m_documentLoader { frame.loader().activeDocumentLoader() }
     , m_defersLoading { options.defersLoadingPolicy == DefersLoadingPolicy::AllowDefersLoading && frame.page()->defersLoading() }
     , m_options { options }
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** ResourceLoader[" << this << " pageID=" << (m_frame ? m_frame->pageID() : PageIdentifier()) << " frameID=" << (m_frame ? m_frame->frameID() : FrameIdentifier()) << "]::constructor");
 }
 
 ResourceLoader::~ResourceLoader()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** ResourceLoader[" << this << " pageID=" << (m_frame ? m_frame->pageID() : PageIdentifier()) << " frameID=" << (m_frame ? m_frame->frameID() : FrameIdentifier()) << "]::~ResourceLoader()");
     ASSERT(m_reachedTerminalState);
 }
 
@@ -117,6 +119,7 @@ void ResourceLoader::releaseResources()
     // has been deallocated and also to avoid reentering this method.
     Ref protectedThis { *this };
 
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** ResourceLoader[" << this << " pageID=" << (m_frame ? m_frame->pageID() : PageIdentifier()) << " frameID=" << (m_frame ? m_frame->frameID() : FrameIdentifier()) << "]::releaseResources -> m_frame=0 was " << m_frame.get());
     m_frame = nullptr;
     m_documentLoader = nullptr;
     
@@ -935,7 +938,7 @@ bool ResourceLoader::isPDFJSResourceLoad() const
 
 RefPtr<LocalFrame> ResourceLoader::protectedFrame() const
 {
-    return m_frame;
+    return m_frame.getRefPtr();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -38,6 +38,7 @@
 #include "ResourceResponse.h"
 #include "SharedBuffer.h"
 #include <wtf/Forward.h>
+#include <wtf/TrackingRefPtr.h>
 #include <wtf/WeakPtr.h>
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -186,7 +187,7 @@ protected:
     virtual void willSendRequestInternal(ResourceRequest&&, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&&);
 
     RefPtr<ResourceHandle> m_handle;
-    RefPtr<LocalFrame> m_frame;
+    WTF::TrackingRefPtr<LocalFrame> m_frame;
     RefPtr<DocumentLoader> m_documentLoader;
     ResourceResponse m_response;
     ResourceLoadTiming m_loadTiming;

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -310,7 +310,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
 
         if (!portAllowed(newRequest.url())) {
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load (redirect) canceled because it attempted to use a blocked port");
-            if (RefPtr frame = m_frame)
+            if (RefPtr frame = m_frame.getRefPtr())
                 FrameLoader::reportBlockedLoadFailed(*frame, newRequest.url());
             cancel(frameLoader()->blockedError(newRequest));
             return completionHandler(WTFMove(newRequest));

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -39,6 +39,7 @@ namespace WebCore {
 DOMWindowExtension::DOMWindowExtension(LocalDOMWindow* window, DOMWrapperWorld& world)
     : m_window(window)
     , m_world(world)
+    , m_disconnectedFrame(this, "DOMWindowExtension::m_disconnectedFrame"_s)
     , m_wasDetached(false)
 {
     ASSERT(this->frame());
@@ -77,7 +78,7 @@ void DOMWindowExtension::suspendForBackForwardCache()
 void DOMWindowExtension::resumeFromBackForwardCache()
 {
     ASSERT(frame());
-    ASSERT(m_disconnectedFrame == frame());
+    ASSERT(m_disconnectedFrame.get() == frame());
     ASSERT(frame()->document()->domWindow() == m_window);
 
     m_disconnectedFrame = nullptr;
@@ -93,7 +94,7 @@ void DOMWindowExtension::willDestroyGlobalObjectInCachedFrame()
     // while there is still work to do.
     Ref protectedThis { *this };
 
-    if (RefPtr disconnectedFrame = m_disconnectedFrame)
+    if (RefPtr disconnectedFrame = m_disconnectedFrame.getRefPtr())
         disconnectedFrame->checkedLoader()->client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
     m_disconnectedFrame = nullptr;
 

--- a/Source/WebCore/page/DOMWindowExtension.h
+++ b/Source/WebCore/page/DOMWindowExtension.h
@@ -28,7 +28,7 @@
 #include "LocalDOMWindow.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
+#include <wtf/TrackingRefPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -60,7 +60,7 @@ private:
 
     WeakPtr<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_window;
     Ref<DOMWrapperWorld> m_world;
-    RefPtr<LocalFrame> m_disconnectedFrame;
+    WTF::TrackingRefPtr<LocalFrame> m_disconnectedFrame;
     bool m_wasDetached;
 };
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -382,6 +382,7 @@ EventHandler::EventHandler(LocalFrame& frame)
     , m_textRecognitionHoverTimer(*this, &EventHandler::textRecognitionHoverTimerFired, 250_ms)
 #endif
     , m_autoscrollController(makeUnique<AutoscrollController>())
+    , m_lastMouseMoveEventSubframe(this, "EventHandler::m_lastMouseMoveEventSubframe"_s)
 #if !ENABLE(IOS_TOUCH_EVENTS)
     , m_fakeMouseMoveEventTimer(*this, &EventHandler::fakeMouseMoveEventTimerFired)
 #endif
@@ -2181,7 +2182,7 @@ HandleUserInputEventResult EventHandler::handleMouseMoveEvent(const PlatformMous
     RefPtr localSubframe = dynamicDowncast<LocalFrame>(subframe.get());
  
     // We want mouseouts to happen first, from the inside out.  First send a move event to the last subframe so that it will fire mouseouts.
-    if (RefPtr lastMouseMoveEventSubframe = m_lastMouseMoveEventSubframe; lastMouseMoveEventSubframe && lastMouseMoveEventSubframe->tree().isDescendantOf(frame.ptr()) && lastMouseMoveEventSubframe != localSubframe)
+    if (RefPtr lastMouseMoveEventSubframe = m_lastMouseMoveEventSubframe.getRefPtr(); lastMouseMoveEventSubframe && lastMouseMoveEventSubframe->tree().isDescendantOf(frame.ptr()) && lastMouseMoveEventSubframe != localSubframe)
         passMouseMoveEventToSubframe(mouseEvent, *lastMouseMoveEventSubframe);
 
     if (localSubframe) {

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -43,7 +43,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
-#include <wtf/RefPtr.h>
+#include <wtf/TrackingRefPtr.h>
 #include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
@@ -648,7 +648,7 @@ private:
     RefPtr<Element> m_capturingMouseEventsElement;
     RefPtr<Element> m_elementUnderMouse;
     RefPtr<Element> m_lastElementUnderMouse;
-    RefPtr<LocalFrame> m_lastMouseMoveEventSubframe;
+    WTF::TrackingRefPtr<LocalFrame> m_lastMouseMoveEventSubframe;
     SingleThreadWeakPtr<Scrollbar> m_lastScrollbarUnderMouse;
     Cursor m_currentMouseCursor;
 

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -39,6 +39,8 @@ namespace WebCore {
 FrameTree::FrameTree(Frame& thisFrame, Frame* parentFrame)
     : m_thisFrame(thisFrame)
     , m_parent(parentFrame)
+    , m_nextSibling(this, "FrameTree::m_nextSibling"_s)
+    , m_firstChild(this, "FrameTree::m_firstChild"_s)
 {
 }
 
@@ -91,11 +93,11 @@ void FrameTree::appendChild(Frame& child)
 void FrameTree::removeChild(Frame& child)
 {
     WeakPtr<Frame>& newLocationForPrevious = m_lastChild == &child ? m_lastChild : child.tree().m_nextSibling->tree().m_previousSibling;
-    RefPtr<Frame>& newLocationForNext = m_firstChild == &child ? m_firstChild : child.tree().m_previousSibling->tree().m_nextSibling;
+    auto& newLocationForNext = m_firstChild.get() == &child ? m_firstChild : child.tree().m_previousSibling->tree().m_nextSibling;
 
     child.tree().m_parent = nullptr;
     newLocationForPrevious = std::exchange(child.tree().m_previousSibling, nullptr);
-    newLocationForNext = WTFMove(child.tree().m_nextSibling);
+    newLocationForNext = child.tree().m_nextSibling.extractRefPtr();
 
     m_scopedChildCount = invalidCount;
 }

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/TrackingRefPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 
@@ -110,9 +111,9 @@ private:
     AtomString m_specifiedName; // The actual frame name (may be empty).
     AtomString m_uniqueName;
 
-    RefPtr<Frame> m_nextSibling;
+    WTF::TrackingRefPtr<Frame, WTF::DowncastTrackingTester<Frame, LocalFrame>> m_nextSibling;
     WeakPtr<Frame> m_previousSibling;
-    RefPtr<Frame> m_firstChild;
+    WTF::TrackingRefPtr<Frame, WTF::DowncastTrackingTester<Frame, LocalFrame>> m_firstChild;
     WeakPtr<Frame> m_lastChild;
     mutable unsigned m_scopedChildCount { invalidCount };
     mutable uint64_t m_frameIDGenerator { 0 };

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -116,6 +116,8 @@ using NodeQualifier = Function<Node* (const HitTestResult&, Node* terminationNod
 
 class LocalFrame final : public Frame {
 public:
+    bool m_crashOnDestruction = false;
+
     WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, UniqueRef<LocalFrameLoaderClient>&&, FrameIdentifier, Frame* opener);
     WEBCORE_EXPORT static Ref<LocalFrame> createSubframe(Page&, UniqueRef<LocalFrameLoaderClient>&&, FrameIdentifier, HTMLFrameOwnerElement&);
     WEBCORE_EXPORT static Ref<LocalFrame> createSubframeHostedInAnotherProcess(Page&, UniqueRef<LocalFrameLoaderClient>&&, FrameIdentifier, Frame& parent);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -191,7 +191,7 @@ Pagination::Mode paginationModeForRenderStyle(const RenderStyle& style)
 }
 
 LocalFrameView::LocalFrameView(LocalFrame& frame)
-    : m_frame(frame)
+    : m_frame(frame, this, "LocalFrameView::m_frame"_s)
     , m_layoutContext(*this)
     , m_updateEmbeddedObjectsTimer(*this, &LocalFrameView::updateEmbeddedObjectsTimerFired)
     , m_updateWidgetPositionsTimer(*this, &LocalFrameView::updateWidgetPositionsTimerFired)
@@ -223,6 +223,7 @@ LocalFrameView::LocalFrameView(LocalFrame& frame)
 
 Ref<LocalFrameView> LocalFrameView::create(LocalFrame& frame)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** LocalFrameView::create(LocalFrame[" << &frame << " pageID=" << frame.pageID() << " frameID=" << frame.frameID() << "])");
     Ref<LocalFrameView> view = adoptRef(*new LocalFrameView(frame));
     if (frame.page() && frame.page()->isVisible())
         view->show();
@@ -231,6 +232,7 @@ Ref<LocalFrameView> LocalFrameView::create(LocalFrame& frame)
 
 Ref<LocalFrameView> LocalFrameView::create(LocalFrame& frame, const IntSize& initialSize)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** LocalFrameView::create(LocalFrame[" << &frame << " pageID=" << frame.pageID() << " frameID=" << frame.frameID() << "], " << initialSize << ")");
     Ref<LocalFrameView> view = adoptRef(*new LocalFrameView(frame));
     view->Widget::setFrameRect(IntRect(view->location(), initialSize));
     if (frame.page() && frame.page()->isVisible())
@@ -240,6 +242,7 @@ Ref<LocalFrameView> LocalFrameView::create(LocalFrame& frame, const IntSize& ini
 
 LocalFrameView::~LocalFrameView()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** LocalFrameView[" << this << " pageID=" << m_frame->pageID() << " frame[" << m_frame.ptr() << "]ID=" << m_frame->frameID() << "]::~LocalFrameView()");
     removeFromAXObjectCache();
     resetScrollbars();
 
@@ -345,6 +348,7 @@ void LocalFrameView::init()
 
 void LocalFrameView::prepareForDetach()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** LocalFrameView[" << this << "]::prepareForDetach()");
     detachCustomScrollbars();
     // When the view is no longer associated with a frame, it needs to be removed from the ax object cache
     // right now, otherwise it won't be able to reach the topDocument()'s axObject cache later.
@@ -5738,12 +5742,12 @@ ScrollBehaviorForFixedElements LocalFrameView::scrollBehaviorForFixedElements() 
 
 LocalFrame& LocalFrameView::frame() const
 {
-    return m_frame;
+    return m_frame.get();
 }
 
 Ref<LocalFrame> LocalFrameView::protectedFrame() const
 {
-    return m_frame;
+    return m_frame.getRef();
 }
 
 RenderView* LocalFrameView::renderView() const
@@ -5758,13 +5762,13 @@ CheckedPtr<RenderView> LocalFrameView::checkedRenderView() const
 
 int LocalFrameView::mapFromLayoutToCSSUnits(LayoutUnit value) const
 {
-    Ref frame = m_frame;
+    Ref frame = m_frame.getRef();
     return value / (frame->pageZoomFactor() * frame->frameScaleFactor());
 }
 
 LayoutUnit LocalFrameView::mapFromCSSToLayoutUnits(int value) const
 {
-    Ref frame = m_frame;
+    Ref frame = m_frame.getRef();
     return LayoutUnit(value * frame->pageZoomFactor() * frame->frameScaleFactor());
 }
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -43,6 +43,7 @@
 #include <wtf/IsoMalloc.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/OptionSet.h>
+#include <wtf/TrackingRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
@@ -910,7 +911,7 @@ private:
 
     float deviceScaleFactor() const final;
 
-    const Ref<LocalFrame> m_frame;
+    const WTF::TrackingRef<LocalFrame> m_frame;
     LocalFrameViewLayoutContext m_layoutContext;
 
     HashSet<SingleThreadWeakRef<Widget>> m_widgetsInRenderTree;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -57,6 +57,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/TrackingRef.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
@@ -1178,7 +1179,7 @@ private:
     UniqueRef<BackForwardController> m_backForwardController;
     HashSet<WeakRef<LocalFrame>> m_rootFrames;
     UniqueRef<EditorClient> m_editorClient;
-    Ref<Frame> m_mainFrame;
+    WTF::TrackingRef<Frame, WTF::DowncastTrackingTester<Frame, LocalFrame>> m_mainFrame;
     URL m_mainFrameURL;
 
     RefPtr<PluginData> m_pluginData;
@@ -1503,5 +1504,6 @@ inline RefPtr<Page> Document::protectedPage() const
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, RenderingUpdateStep);
+WTF::TextStream& operator<<(WTF::TextStream&, FinalizeRenderingUpdateFlags);
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -27,7 +27,7 @@
 
 #include "Frame.h"
 #include "LayerHostingContextIdentifier.h"
-#include <wtf/RefPtr.h>
+#include <wtf/TrackingRefPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/UniqueRef.h>
 
@@ -88,7 +88,7 @@ private:
     FrameLoaderClient& loaderClient() final;
 
     Ref<RemoteDOMWindow> m_window;
-    RefPtr<Frame> m_opener;
+    WTF::TrackingRefPtr<Frame, WTF::DowncastTrackingTester<Frame, LocalFrame>> m_opener;
     RefPtr<RemoteFrameView> m_view;
     UniqueRef<RemoteFrameClient> m_client;
     Markable<LayerHostingContextIdentifier> m_layerHostingContextIdentifier;

--- a/Source/WebCore/platform/ProcessIdentifier.cpp
+++ b/Source/WebCore/platform/ProcessIdentifier.cpp
@@ -36,6 +36,7 @@ static std::optional<ProcessIdentifier> globalIdentifier;
 void setIdentifier(ProcessIdentifier processIdentifier)
 {
     ASSERT(isUIThread());
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** Process::setIdentifier(" << processIdentifier << ") was " << globalIdentifier);
     globalIdentifier = processIdentifier;
 }
 
@@ -44,7 +45,7 @@ ProcessIdentifier identifier()
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         if (!globalIdentifier)
-            globalIdentifier = ProcessIdentifier::generate();
+            globalIdentifier = ProcessIdentifier(uint64_t(getpid()));
     });
 
     return *globalIdentifier;

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -96,6 +96,7 @@ constexpr Seconds minimumLifetimeBeforeIdleExit { 5_s };
 GPUProcess::GPUProcess()
     : m_idleExitTimer(*this, &GPUProcess::tryExitIfUnused)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** GPUProcess[" << this << "]::constructor -> base class AuxiliaryProcess::initialize");
     RELEASE_LOG(Process, "%p - GPUProcess::GPUProcess:", this);
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -176,6 +176,7 @@ NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parame
             webProcessConnection->setOnLineState(isOnLine);
     });
 
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** NetworkProcess[" << this << "]::constructor -> base class AuxiliaryProcess::initialize");
     initialize(WTFMove(parameters));
 }
 

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -84,6 +84,7 @@ void AuxiliaryProcess::initialize(const AuxiliaryProcessInitializationParameters
     setAuxiliaryProcessType(parameters.processType);
 
     RELEASE_ASSERT_WITH_MESSAGE(parameters.processIdentifier, "Unable to initialize child process without a WebCore process identifier");
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** AuxiliaryProcess[" << this << "]::initialize(uiProcessName=" << parameters.uiProcessName << ", clientIdentifier=" << parameters.clientIdentifier << ", clientBundleIdentifier=" << parameters.clientBundleIdentifier << ", extraInitializationData=" << parameters.extraInitializationData << ") -> Process::setIdentifier(" << *parameters.processIdentifier << ")");
     Process::setIdentifier(*parameters.processIdentifier);
 
     platformInitialize(parameters);

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -164,7 +164,9 @@ void AuxiliaryProcessProxy::connect()
     m_processStart = MonotonicTime::now();
     ProcessLauncher::LaunchOptions launchOptions;
     getLaunchOptions(launchOptions);
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** AuxiliaryProcessProxy[" << this << " core/ProcID=" << coreProcessIdentifier() << "/" << processID() << "]::connect() -> ProcessLauncher::create()...");
     m_processLauncher = ProcessLauncher::create(this, WTFMove(launchOptions));
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** AuxiliaryProcessProxy[" << this << " core/ProcID=" << coreProcessIdentifier() << "/" << processID() << "]::connect() -> ProcessLauncher::create() done");
 }
 
 void AuxiliaryProcessProxy::terminate()

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -161,6 +161,7 @@ GPUProcessProxy::GPUProcessProxy()
     , m_useMockCaptureDevices(MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled())
 #endif
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** GPUProcessProxy[" << this << " core/ProcID=" << coreProcessIdentifier() << "/" << processID() << "]::constructor");
     connect();
 
     GPUProcessCreationParameters parameters;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -239,6 +239,7 @@ NetworkProcessProxy::NetworkProcessProxy()
     , m_backgroundActivityToPreventSuspension(m_throttler.backgroundActivity("Prevent suspension"_s))
 #endif
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** NetworkProcessProxy[" << this << " core/ProcID=" << coreProcessIdentifier() << "/" << processID() << "]::constructor");
     RELEASE_LOG(Process, "%p - NetworkProcessProxy::NetworkProcessProxy", this);
 
     connect();

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -42,6 +42,7 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, WebProcessPro
     , m_webPageID(frame.page()->identifier())
     , m_layerHostingContextIdentifier(WebCore::LayerHostingContextIdentifier::generate())
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** ProvisionalFrameProxy[" << this << " frameID=" << m_frame->frameID() << " remotePageProxyID=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " layerHostingContextId=" << m_layerHostingContextIdentifier << " core/ProcID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::constructor");
     ASSERT(!m_remotePageProxy || m_remotePageProxy->process().coreProcessIdentifier() == process.coreProcessIdentifier());
     m_process->markProcessAsRecentlyUsed();
 }
@@ -50,6 +51,7 @@ ProvisionalFrameProxy::~ProvisionalFrameProxy() = default;
 
 RefPtr<RemotePageProxy> ProvisionalFrameProxy::takeRemotePageProxy()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** ProvisionalFrameProxy[" << this << " frameID=" << m_frame->frameID() << " remotePageProxyID=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " layerHostingContextId=" << m_layerHostingContextIdentifier << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::takeRemotePageProxy()");
     return std::exchange(m_remotePageProxy, nullptr);
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -57,6 +57,7 @@ RemoteLayerTreeNode::RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier layerI
 {
     initializeLayer();
     [m_layer setDelegate:[WebActionDisablingCALayerDelegate shared]];
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemoteLayerTreeNode[" << this << "]::constructor(layerID=" << layerID << ", layerHostingContextId=" << hostIdentifier << ")");
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -51,13 +51,16 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
     , m_page(page)
     , m_domain(domain)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemotePageProxy[" << this << " webPageProxyID=" << (m_page ? m_page->identifier() : WebPageProxyIdentifier()) << " webPageID=" << m_webPageID << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << " ]::constructor(domain=" << domain.string() << ")");
     if (registrationToTransfer)
         m_messageReceiverRegistration.transferMessageReceivingFrom(*registrationToTransfer, *this);
     else
         m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this);
 
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemotePageProxy[" << this << " webPageProxyID=" << (m_page ? m_page->identifier() : WebPageProxyIdentifier()) << " webPageID=" << m_webPageID << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << " ]::constructor(domain=" << domain.string() << ") -> m_process[" << m_process.ptr() << "]->addRemotePageProxy()");
     m_process->addRemotePageProxy(*this);
 
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemotePageProxy[" << this << " webPageProxyID=" << (m_page ? m_page->identifier() : WebPageProxyIdentifier()) << " webPageID=" << m_webPageID << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << " ]::constructor(domain=" << domain.string() << ") -> page[" << &page << "]->addRemotePageProxy()");
     page.addRemotePageProxy(domain, *this);
 }
 
@@ -100,11 +103,13 @@ void RemotePageProxy::processDidTerminate(WebCore::ProcessIdentifier processIden
 
 void RemotePageProxy::addFrame(WebFrameProxy& frame)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemotePageProxy[" << this << " webPageProxyID=" << (m_page ? m_page->identifier() : WebPageProxyIdentifier()) << " webPageID=" << m_webPageID << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << " ]::addFrame(webFrameProxyID=" << frame.frameID() << ")");
     m_frames.add(frame);
 }
 
 void RemotePageProxy::removeFrame(WebFrameProxy& frame)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemotePageProxy[" << this << " webPageProxyID=" << (m_page ? m_page->identifier() : WebPageProxyIdentifier()) << " webPageID=" << m_webPageID << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << " ]::removeFrame(webFrameProxyID=" << frame.frameID() << ")");
     m_frames.remove(frame);
 }
 
@@ -167,10 +172,12 @@ void RemotePageProxy::decidePolicyForResponse(FrameInfoData&& frameInfo, uint64_
 
 void RemotePageProxy::didCommitLoadForFrame(WebCore::FrameIdentifier frameID, FrameInfoData&& frameInfo, WebCore::ResourceRequest&& request, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType frameLoadType, const WebCore::CertificateInfo& certificateInfo, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent hasInsecureContent, WebCore::MouseEventPolicy mouseEventPolicy, const UserData& userData)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemotePageProxy[" << this << " webPageProxyID=" << (m_page ? m_page->identifier() : WebPageProxyIdentifier()) << " webPageID=" << m_webPageID << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << " ]::didCommitLoadForFrame(frameID=" << frameID << ") -> m_process->didCommitProvisionalLoad()");
     m_process->didCommitProvisionalLoad();
     RefPtr frame = WebFrameProxy::webFrame(frameID);
     if (!frame)
         return;
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemotePageProxy[" << this << " webPageProxyID=" << (m_page ? m_page->identifier() : WebPageProxyIdentifier()) << " webPageID=" << m_webPageID << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << " ]::didCommitLoadForFrame(frameID=" << frameID << ") -> frame[" << frame.get() << " frameID=" << frame->frameID() << "]->commitProvisionalFrame()");
     frame->commitProvisionalFrame(frameID, WTFMove(frameInfo), WTFMove(request), navigationID, mimeType, frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, containsPluginDocument, hasInsecureContent, mouseEventPolicy, userData); // Will delete |this|.
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -90,6 +90,7 @@ WebFrameProxy::WebFrameProxy(WebPageProxy& page, WebProcessProxy& process, Frame
     , m_process(process)
     , m_frameID(frameID)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " frameID=" << m_frameID << " pageID=" << page.webPageID() << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::constructor");
     ASSERT(!allFrames().contains(frameID));
     allFrames().set(frameID, *this);
     WebProcessPool::statistics().wkFrameCount++;
@@ -239,22 +240,26 @@ bool WebFrameProxy::isDisplayingPDFDocument() const
 
 void WebFrameProxy::didStartProvisionalLoad(const URL& url)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didStartProvisionalLoad " << url);
     m_frameLoadState.didStartProvisionalLoad(url);
 }
 
 void WebFrameProxy::didExplicitOpen(URL&& url, String&& mimeType)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didExplicitOpen " << url);
     m_MIMEType = WTFMove(mimeType);
     m_frameLoadState.didExplicitOpen(WTFMove(url));
 }
 
 void WebFrameProxy::didReceiveServerRedirectForProvisionalLoad(const URL& url)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didReceiveServerRedirectForProvisionalLoad " << url);
     m_frameLoadState.didReceiveServerRedirectForProvisionalLoad(url);
 }
 
 void WebFrameProxy::didFailProvisionalLoad()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didFailProvisionalLoad ");
     m_frameLoadState.didFailProvisionalLoad();
 
     if (m_navigateCallback)
@@ -263,6 +268,7 @@ void WebFrameProxy::didFailProvisionalLoad()
 
 void WebFrameProxy::didCommitLoad(const String& contentType, const WebCore::CertificateInfo& certificateInfo, bool containsPluginDocument)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didCommitLoad ");
     m_frameLoadState.didCommitLoad();
 
     m_title = String();
@@ -273,6 +279,7 @@ void WebFrameProxy::didCommitLoad(const String& contentType, const WebCore::Cert
 
 void WebFrameProxy::didFinishLoad()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didFinishLoad ");
     m_frameLoadState.didFinishLoad();
 
     if (m_navigateCallback)
@@ -281,6 +288,7 @@ void WebFrameProxy::didFinishLoad()
 
 void WebFrameProxy::didFailLoad()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didFailLoad ");
     m_frameLoadState.didFailLoad();
 
     if (m_navigateCallback)
@@ -289,11 +297,13 @@ void WebFrameProxy::didFailLoad()
 
 void WebFrameProxy::didSameDocumentNavigation(const URL& url)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didSameDocumentNavigation " << url);
     m_frameLoadState.didSameDocumentNotification(url);
 }
 
 void WebFrameProxy::didChangeTitle(const String& title)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::didChangeTitle " << title);
     m_title = title;
 }
 
@@ -435,8 +445,10 @@ void WebFrameProxy::prepareForProvisionalNavigationInProcess(WebProcessProxy& pr
         LocalFrameCreationParameters localFrameCreationParameters {
             m_provisionalFrame->layerHostingContextIdentifier()
         };
+        ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::prepareForProvisionalNavigationInProcess(core/procID=" << process.coreProcessIdentifier() << "/" << process.processID() << ", navigation=" << navigation.currentRequest().url() << ") - same procID -> send TransitionFrameToLocal");
         process.send(Messages::WebPage::TransitionFrameToLocal(localFrameCreationParameters, frameID()), page()->webPageIDInProcessForDomain(navigationDomain));
-    }
+    } else
+        ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::prepareForProvisionalNavigationInProcess(core/procID=" << process.coreProcessIdentifier() << "/" << process.processID() << ", navigation=" << navigation.currentRequest().url() << ") - different procID -> NO TransitionFrameToLocal");
 
     if (completionHandler)
         completionHandler();
@@ -446,6 +458,7 @@ void WebFrameProxy::commitProvisionalFrame(FrameIdentifier frameID, FrameInfoDat
 {
     ASSERT(m_page);
     if (m_provisionalFrame) {
+        ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::commitProvisionalFrame(frameID=" << frameID << ") - m_provisionalFrame=" << m_provisionalFrame.get() << " -> send WebPage::DidCommitLoadInAnotherProcess to core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << ", then switch to core/procID=" << m_provisionalFrame->process().coreProcessIdentifier() << "/" << m_provisionalFrame->process().processID());
         m_process->send(Messages::WebPage::DidCommitLoadInAnotherProcess(frameID, m_provisionalFrame->layerHostingContextIdentifier()), m_page->webPageID());
         m_process = m_provisionalFrame->process();
         if (m_remotePageProxy)
@@ -455,6 +468,7 @@ void WebFrameProxy::commitProvisionalFrame(FrameIdentifier frameID, FrameInfoDat
             m_remotePageProxy->addFrame(*this);
         m_provisionalFrame = nullptr;
     }
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebFrameProxy[" << this << " id=" << m_frameID << " pageId=" << (m_page ? m_page->webPageID() : WebCore::PageIdentifier()) << "/rem=" << (m_remotePageProxy ? m_remotePageProxy->pageID() : WebCore::PageIdentifier()) << " core/procID=" << m_process->coreProcessIdentifier() << "/" << m_process->processID() << "]::commitProvisionalFrame(frameID=" << frameID << ") -> m_page[" << m_page.get() << "]->didCommitLoadForFrame(" << frameID << ")");
     m_page->didCommitLoadForFrame(frameID, WTFMove(frameInfo), WTFMove(request), navigationID, mimeType, frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, containsPluginDocument, hasInsecureContent, mouseEventPolicy, userData);
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -310,6 +310,7 @@ WebProcessProxy::WebProcessProxy(WebProcessPool& processPool, WebsiteDataStore* 
     , m_routingArbitrator(makeUniqueRef<AudioSessionRoutingArbitratorProxy>(*this))
 #endif
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebProcessProxy[" << this << " core/ProcID=" << coreProcessIdentifier() << "/" << processID() << "]::constructor");
     RELEASE_ASSERT(isMainThreadOrCheckDisabled());
     WEBPROCESSPROXY_RELEASE_LOG(Process, "constructor:");
 
@@ -741,6 +742,7 @@ void WebProcessProxy::setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMo
 
 Ref<WebPageProxy> WebProcessProxy::createWebPage(PageClient& pageClient, Ref<API::PageConfiguration>&& pageConfiguration)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebProcessProxy[" << this << "]::createWebPage() -> WebPageProxy::create()");
     Ref webPage = WebPageProxy::create(pageClient, *this, WTFMove(pageConfiguration));
 
     addExistingWebPage(webPage.get(), BeginsUsingDataStore::Yes);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -629,6 +629,7 @@ void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureC
 #endif
 
     // Notify the UIProcess.
+    ALWAYS_LOG_WITH_STREAM(stream << "WebLocalFrameLoaderClient[" << this << "]::dispatchDidCommitLoad() -> webPage[" << webPage.get() << " pageId=" << webPage->identifier() << "]->send WebPageProxy::DidCommitLoadForFrame(frameID=" << m_frame->frameID() << ")");
     webPage->send(Messages::WebPageProxy::DidCommitLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader->request(), documentLoader->navigationID(), documentLoader->response().mimeType(), m_frameHasCustomContentProvider, m_frame->coreLocalFrame()->loader().loadType(), certificateInfo, usedLegacyTLS, wasPrivateRelayed, m_frame->coreLocalFrame()->document()->isPluginDocument(), *hasInsecureContent, documentLoader->mouseEventPolicy(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
     webPage->didCommitLoad(m_frame.ptr());
 }
@@ -1620,6 +1621,7 @@ RefPtr<LocalFrame> WebLocalFrameLoaderClient::createFrame(const AtomString& name
 {
     RefPtr webPage = m_frame->page();
     ASSERT(webPage);
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebLocalFrameLoaderClient[" << this << "]::createFrame(name=" << name << ") -> WebFrame::createSubframe(pageID=" << webPage->identifier() << ", parentFrameID=" << m_frame->frameID() << ")");
     auto subframe = WebFrame::createSubframe(*webPage, m_frame, name, ownerElement);
     auto* coreSubframe = subframe->coreLocalFrame();
     if (!coreSubframe)
@@ -2028,6 +2030,7 @@ void WebLocalFrameLoaderClient::didAccessWindowProxyPropertyViaOpener(WebCore::S
     if (!page)
         return;
 
+    ALWAYS_LOG_WITH_STREAM(stream << "WebLocalFrameLoaderClient[" << this << "]::didAccessWindowProxyPropertyViaOpenerForFrame() -> page[" << page.get() << " pageID=" << page->identifier() << "].send WebPageProxy::DidAccessWindowProxyPropertyViaOpenerForFrame(" << m_frame->frameID() << ")");
     page->send(Messages::WebPageProxy::DidAccessWindowProxyPropertyViaOpenerForFrame(m_frame->frameID(), WTFMove(parentOrigin), property));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -281,6 +281,7 @@ void DrawingArea::setShouldScaleViewToFitDocument(bool shouldScaleView)
         return;
 
     m_shouldScaleViewToFitDocument = shouldScaleView;
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** DrawingArea[" << this << "]::setShouldScaleViewToFitDocument() -> triggerRenderingUpdate()");
     triggerRenderingUpdate();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -68,6 +68,7 @@ RemoteScrollingCoordinator::~RemoteScrollingCoordinator()
 
 void RemoteScrollingCoordinator::scheduleTreeStateCommit()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** RemoteScrollingCoordinator[" << this << "]::scheduleTreeStateCommit() -> WebPage[" << m_webPage.get() << "]->DrawingArea[" << m_webPage->drawingArea() << "]->triggerRenderingUpdate()");
     m_webPage->drawingArea()->triggerRenderingUpdate();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -241,7 +241,7 @@ public:
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);
 
-    void setLayerHostingContextIdentifier(WebCore::LayerHostingContextIdentifier identifier) { m_layerHostingContextIdentifier = identifier; }
+    void setLayerHostingContextIdentifier(WebCore::LayerHostingContextIdentifier identifier);
 
     inline WebCore::DocumentLoader* policySourceDocumentLoader() const;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -353,6 +353,7 @@ void TiledCoreAnimationDrawingArea::updateRendering(UpdateRenderingType flushTyp
     @autoreleasepool {
         scaleViewToFitDocumentIfNeeded();
 
+        ALWAYS_LOG_WITH_STREAM(stream << "**GS** TiledCoreAnimationDrawingArea[" << this << "]::updateRendering() -> webPage[" << webPage.ptr() << "]->updateRendering()");
         webPage->updateRendering();
         webPage->flushPendingThemeColorChange();
         webPage->flushPendingPageExtendedBackgroundColorChange();

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -311,6 +311,7 @@ WebProcess::WebProcess()
     , m_webSQLiteDatabaseTracker([this](bool isHoldingLockedFiles) { parentProcessConnection()->send(Messages::WebProcessProxy::SetIsHoldingLockedFiles(isHoldingLockedFiles), 0); })
 #endif
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**GS** WebProcess[" << this << "]::constructor");
     // Initialize our platform strategies.
     WebPlatformStrategies::initialize();
 


### PR DESCRIPTION
#### 9110af729c73212c967a609beb06fb5e409c36a1
<pre>
121459787-log-remote-drawing
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/LogChannels.cpp:
(WTF::LogChannels::initializeLogChannelsIfNecessary):
* Source/WTF/wtf/ObjectIdentifier.cpp:
(WTF::ObjectIdentifierMainThreadAccessTraits::generateIdentifierInternal):
(WTF::ObjectIdentifierThreadSafeAccessTraits::generateIdentifierInternal):
* Source/WTF/wtf/TrackableRefCounted.h: Added.
(WTF::TrackableRefCounted::recordRefOperation):
(WTF::TrackableRefCounted::dumpRefOperationRecords):
* Source/WTF/wtf/TrackingRef.h: Added.
(WTF::DefaultTrackingTester::shouldTrack):
(WTF::DowncastTrackingTester::shouldTrack):
(WTF::HolderContainer::HolderContainer):
(WTF::HolderContainer::operator== const):
(WTF::TrackingReferenceHolder::TrackingReferenceHolder):
(WTF::TrackingReferenceHolder::shouldTrack):
(WTF::TrackingReferenceHolder::record):
(WTF::TrackingRef::TrackingRef):
(WTF::TrackingRef::~TrackingRef):
(WTF::TrackingRef::operator=):
(WTF::TrackingRef::swap):
(WTF::TrackingRef::extractRef):
(WTF::TrackingRef::releaseNonNull):
(WTF::TrackingRef::leakRef):
(WTF::TrackingRef::getRef const):
(WTF::TrackingRef::ptr const):
(WTF::TrackingRef::get const):
(WTF::TrackingRef::operator-&gt; const):
(WTF::TrackingRef::shouldTrack):
(WTF::TrackingRef::record):
(WTF::TrackingRef::haveRefd):
(WTF::TrackingRef::willDeref):
* Source/WTF/wtf/TrackingRefPtr.h: Added.
(WTF::TrackingRefPtr::TrackingRefPtr):
(WTF::TrackingRefPtr::~TrackingRefPtr):
(WTF::TrackingRefPtr::operator=):
(WTF::TrackingRefPtr::swap):
(WTF::TrackingRefPtr::extractRefPtr):
(WTF::TrackingRefPtr::releaseNonNull):
(WTF::TrackingRefPtr::leakRef):
(WTF::TrackingRefPtr::getRefPtr const):
(WTF::TrackingRefPtr::operator bool const):
(WTF::TrackingRefPtr::get const):
(WTF::TrackingRefPtr::operator* const):
(WTF::TrackingRefPtr::operator-&gt; const):
(WTF::TrackingRefPtr::shouldTrack):
(WTF::TrackingRefPtr::record):
(WTF::TrackingRefPtr::haveRefd):
(WTF::TrackingRefPtr::willDeref):
* Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp:
(WebCore::DialogHandler::DialogHandler):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::destroyRenderTree):
(WebCore::Document::willBeRemovedFromFrame):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::Editor::Command::Command):
(WebCore::Editor::Command::execute const):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::DeferredLoadingScope::DeferredLoadingScope):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::setLocation):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::receivedFirstData):
(WebCore::FrameLoader::closeAndRemoveChild):
(WebCore::FrameLoader::scheduleRefreshIfNeeded):
* Source/WebCore/loader/NavigationDisabler.h:
(WebCore::NavigationDisabler::NavigationDisabler):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleRedirect):
* Source/WebCore/loader/ProgressTracker.cpp:
(WebCore::ProgressTracker::ProgressTracker):
(WebCore::ProgressTracker::progressStarted):
(WebCore::ProgressTracker::progressCompleted):
(WebCore::ProgressTracker::finalProgressComplete):
(WebCore::ProgressTracker::incrementProgress):
(WebCore::ProgressTracker::progressHeartbeatTimerFired):
* Source/WebCore/loader/ProgressTracker.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::ResourceLoader):
(WebCore::ResourceLoader::~ResourceLoader):
(WebCore::ResourceLoader::releaseResources):
(WebCore::ResourceLoader::protectedFrame const):
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
* Source/WebCore/page/DOMWindowExtension.cpp:
(WebCore::DOMWindowExtension::DOMWindowExtension):
(WebCore::DOMWindowExtension::resumeFromBackForwardCache):
(WebCore::DOMWindowExtension::willDestroyGlobalObjectInCachedFrame):
* Source/WebCore/page/DOMWindowExtension.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::EventHandler):
(WebCore::EventHandler::handleMouseMoveEvent):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::addStack const):
(WebCore::OpString):
(WebCore::OpDiff):
(WebCore::Frame::logStacks const):
(WebCore::Frame::ref const):
(WebCore::Frame::refAllowingPartiallyDestroyed const):
(WebCore::Frame::deref const):
(WebCore::Frame::derefAllowingPartiallyDestroyed const):
* Source/WebCore/page/Frame.h:
(operator&lt;&lt;):
(WebCore::Frame::FrameHandleAndName::operator==):
(WebCore::Frame::operator&lt;&lt;):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::FrameTree):
(WebCore::FrameTree::removeChild):
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
(WebCore::LocalFrame::createMainFrame):
(WebCore::LocalFrame::createSubframe):
(WebCore::LocalFrame::createSubframeHostedInAnotherProcess):
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::setView):
(WebCore::LocalFrame::setDocument):
(WebCore::LocalFrame::createView):
(WebCore::LocalFrame::disconnectView):
(WebCore::LocalFrame::selfOnlyRef):
(WebCore::LocalFrame::selfOnlyDeref):
(WebCore::LocalFrame::didAccessWindowProxyPropertyViaOpener):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::LocalFrameView):
(WebCore::LocalFrameView::create):
(WebCore::LocalFrameView::~LocalFrameView):
(WebCore::LocalFrameView::prepareForDetach):
(WebCore::LocalFrameView::frame const):
(WebCore::LocalFrameView::protectedFrame const):
(WebCore::LocalFrameView::mapFromLayoutToCSSUnits const):
(WebCore::LocalFrameView::mapFromCSSToLayoutUnits const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::createMainFrame):
(WebCore::Page::Page):
(WebCore::Page::~Page):
(WebCore::Page::goToItem):
(WebCore::Page::protectedMainFrame const):
(WebCore::Page::scheduleRenderingUpdate):
(WebCore::Page::computeUnfulfilledRenderingSteps):
(WebCore::Page::updateRendering):
(WebCore::Page::doAfterUpdateRendering):
(WebCore::operator&lt;&lt;):
(WebCore::Page::finalizeRenderingUpdate):
(WebCore::Page::finalizeRenderingUpdateForRootFrame):
(WebCore::Page::renderingUpdateCompleted):
(WebCore::Page::addRootFrame):
(WebCore::Page::removeRootFrame):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::createMainFrame):
(WebCore::RemoteFrame::createSubframe):
(WebCore::RemoteFrame::createSubframeWithContentsInAnotherProcess):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/platform/ProcessIdentifier.cpp:
(WebCore::Process::setIdentifier):
(WebCore::Process::identifier):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::GPUProcess):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::initialize):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::connect):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::NetworkProcessProxy):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
(WebKit::ProvisionalFrameProxy::takeRemotePageProxy):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::didCreateMainFrame):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::RemoteLayerTreeHost):
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::clearLayers):
(WebKit::RemoteLayerTreeHost::detachRootLayer):
(WebKit::RemoteLayerTreeHost::remotePageProcessCrashed):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::RemoteLayerTreeNode):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):
(WebKit::RemotePageProxy::addFrame):
(WebKit::RemotePageProxy::removeFrame):
(WebKit::RemotePageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::didStartProvisionalLoad):
(WebKit::WebFrameProxy::didExplicitOpen):
(WebKit::WebFrameProxy::didReceiveServerRedirectForProvisionalLoad):
(WebKit::WebFrameProxy::didFailProvisionalLoad):
(WebKit::WebFrameProxy::didCommitLoad):
(WebKit::WebFrameProxy::didFinishLoad):
(WebKit::WebFrameProxy::didFailLoad):
(WebKit::WebFrameProxy::didSameDocumentNavigation):
(WebKit::WebFrameProxy::didChangeTitle):
(WebKit::WebFrameProxy::prepareForProvisionalNavigationInProcess):
(WebKit::WebFrameProxy::commitProvisionalFrame):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_browsingContextGroup):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::PolicyActionString):
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::printFrames):
(WebKit::WebPageProxy::didFinishDocumentLoadForFrame):
(WebKit::WebPageProxy::createRemoteSubframesInOtherProcesses):
(WebKit::WebPageProxy::didAccessWindowProxyPropertyViaOpenerForFrame):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::processForNavigation):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::m_routingArbitrator):
(WebKit::WebProcessProxy::createWebPage):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidCommitLoad):
(WebKit::WebLocalFrameLoaderClient::createFrame):
(WebKit::WebLocalFrameLoaderClient::didAccessWindowProxyPropertyViaOpener):
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::setShouldScaleViewToFitDocument):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea):
(WebKit::RemoteLayerTreeDrawingArea::addRootFrame):
(WebKit::RemoteLayerTreeDrawingArea::removeRootFrame):
(WebKit::RemoteLayerTreeDrawingArea::setRootCompositingLayer):
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen):
(WebKit::RemoteLayerTreeDrawingArea::setExposedContentRect):
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer):
(WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
(WebKit::RemoteLayerTreeDrawingArea::activityStateDidChange):
(WebKit::RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::scheduleTreeStateCommit):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::initWithCoreMainFrame):
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::createRemoteSubframe):
(WebKit::WebFrame::WebFrame):
(WebKit::WebFrame::setLayerHostingContextIdentifier):
(WebKit::WebFrame::didCommitLoadInAnotherProcess):
(WebKit::WebFrame::transitionToLocal):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
(WebKit::WebFrame::setLayerHostingContextIdentifier): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::WebPage):
(WebKit::m_mainFrame):
(WebKit::WebPage::constructFrameTree):
(WebKit::WebPage::createRemoteSubframe):
(WebKit::WebPage::didCommitLoadInAnotherProcess):
(WebKit::WebPage::enterAcceleratedCompositingMode):
(WebKit::WebPage::exitAcceleratedCompositingMode):
(WebKit::WebPage::transitionFrameToLocal):
(WebKit::WebPage::updateFrameSize):
(WebKit::WebPage::updateRendering):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebProcess.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9110af729c73212c967a609beb06fb5e409c36a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40510 "39 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/19522 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/42888 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43062 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36599 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/42817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/22482 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/16852 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/43062 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/41084 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/22482 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/42888 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43062 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/22482 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/42888 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44336 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/33963 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/22482 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/42888 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/44336 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/40136 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15325 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/16852 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/44336 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16944 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/42888 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/47146 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/47146 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16588 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->