### PR TITLE
NEW TEST (274589@main): [ macOS ] TestWebKitAPI.WKWebExtensionAPIDevTools.CreatePanel is a consistent timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
@@ -85,8 +85,7 @@ TEST(WKWebExtensionAPIDevTools, Basics)
     [manager loadAndRun];
 }
 
-// FIXME: Re-enable this test once webkit.org/b/269402 is resolved.
-TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
+TEST(WKWebExtensionAPIDevTools, CreatePanel)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -102,8 +101,6 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
         @"  browser.test.assertEq(typeof panelWindow, 'object', 'panelWindow should be an object')",
 
         @"  cachedPanelWindow = panelWindow",
-
-        @"  browser.test.yield('Panel Shown')",
         @"})",
 
         @"panel?.onHidden.addListener(() => {",
@@ -119,7 +116,9 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
     auto *panelScript = Util::constructScript(@[
         @"window.notifyHidden = () => {",
         @"  browser.test.yield('Panel Hidden')",
-        @"}"
+        @"}",
+
+        @"browser.test.yield('Panel Loaded')",
     ]);
 
     auto *iconSVG = @"<svg width='16' height='16' xmlns='http://www.w3.org/2000/svg'><circle cx='8' cy='8' r='8' fill='red' /></svg>";
@@ -150,7 +149,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
 
     [manager run];
 
-    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Panel Shown");
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Panel Loaded");
 
     [manager.get().defaultTab.mainWebView._inspector showResources];
 


### PR DESCRIPTION
#### 601dbe0a8712cfebad40ef68b02088cf271d4f65
<pre>
NEW TEST (274589@main): [ macOS ] TestWebKitAPI.WKWebExtensionAPIDevTools.CreatePanel is a consistent timeout
<a href="https://webkit.org/b/269402">https://webkit.org/b/269402</a>
<a href="https://rdar.apple.com/problem/122967271">rdar://problem/122967271</a>

Reviewed by Brian Weinstein.

Fix a race condition between showing the panel, and the panel frame loading.
The frame was not loading fast enough on the bots, and locally it would load
slow about 20% of the time.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm:
(TEST(WKWebExtensionAPIDevTools, CreatePanel)): Move test.yield() to the panel
script, so it happens after the window.notifyHidden function is set.

Canonical link: <a href="https://commits.webkit.org/274984@main">https://commits.webkit.org/274984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e77a2f0150c23bd82d8883f7474bf8b14e14ce10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33613 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14195 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14269 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39966 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38278 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16995 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5386 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->