### PR TITLE
[JSC] Handle 1-rope case for 3-strings JSRopeString resolution in a fast manner

### DIFF
--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -187,16 +187,61 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
 
     // 3 fibers.
     if (fiber2) {
-        if (fiber0->isRope() || fiber1->isRope() || fiber2->isRope())
-            MUST_TAIL_CALL return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, length, stackLimit);
+        unsigned ropeCount = !!fiber0->isRope() + !!fiber1->isRope() + !!fiber2->isRope();
+        if (!ropeCount) {
+            StringView view0 = fiber0->valueInternal().impl();
+            view0.getCharacters(buffer);
+            StringView view1 = fiber1->valueInternal().impl();
+            view1.getCharacters(buffer + view0.length());
+            StringView view2 = fiber2->valueInternal().impl();
+            view2.getCharacters(buffer + view0.length() + view1.length());
+            return;
+        }
 
-        StringView view0 = fiber0->valueInternal().impl();
-        view0.getCharacters(buffer);
-        StringView view1 = fiber1->valueInternal().impl();
-        view1.getCharacters(buffer + view0.length());
-        StringView view2 = fiber2->valueInternal().impl();
-        view2.getCharacters(buffer + view0.length() + view1.length());
-        return;
+        if (ropeCount == 1) {
+            unsigned targetOffset = 0;
+            unsigned offset = 0;
+            const JSRopeString* rope = nullptr;
+            if (!fiber0->isRope()) {
+                StringView view0 = fiber0->valueInternal().impl();
+                view0.getCharacters(buffer + offset);
+                offset += view0.length();
+            } else {
+                targetOffset = offset;
+                rope = static_cast<const JSRopeString*>(fiber0);
+                offset += rope->length();
+            }
+
+            if (!fiber1->isRope()) {
+                StringView view1 = fiber1->valueInternal().impl();
+                view1.getCharacters(buffer + offset);
+                offset += view1.length();
+            } else {
+                targetOffset = offset;
+                rope = static_cast<const JSRopeString*>(fiber1);
+                offset += rope->length();
+            }
+
+            if (!fiber2->isRope()) {
+                StringView view2 = fiber2->valueInternal().impl();
+                view2.getCharacters(buffer + offset);
+            } else {
+                targetOffset = offset;
+                rope = static_cast<const JSRopeString*>(fiber2);
+            }
+
+            if (rope->isSubstring()) {
+                StringView view = *rope->substringBase()->valueInternal().impl();
+                unsigned offset = rope->substringOffset();
+                unsigned length = rope->length();
+                view.substring(offset, length).getCharacters(buffer + targetOffset);
+                return;
+            }
+
+            MUST_TAIL_CALL return resolveToBuffer(rope->fiber0(), rope->fiber1(), rope->fiber2(), buffer + targetOffset, rope->length(), stackLimit);
+        }
+
+        MUST_TAIL_CALL return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, length, stackLimit);
     }
 
     // 2 fibers.


### PR DESCRIPTION
#### 5dbd24c0c45a5b213d39156f7870fa0cdb4588ec
<pre>
[JSC] Handle 1-rope case for 3-strings JSRopeString resolution in a fast manner
<a href="https://bugs.webkit.org/show_bug.cgi?id=269691">https://bugs.webkit.org/show_bug.cgi?id=269691</a>
<a href="https://rdar.apple.com/123211907">rdar://123211907</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::resolveToBuffer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dbd24c0c45a5b213d39156f7870fa0cdb4588ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36618 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33628 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14211 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44355 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33982 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39985 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40155 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38304 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16963 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47165 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17014 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9700 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->