### PR TITLE
"start-local-buildbot-server --ews" fails to start: builtins.ModuleNotFoundError: No module named 'ews-build'

### DIFF
--- a/Tools/CISupport/start-local-buildbot-server
+++ b/Tools/CISupport/start-local-buildbot-server
@@ -240,7 +240,7 @@ class BuildbotTestRunner(object):
         return result
 
     def _setup_server_workdir(self):
-        self._server_wordir = os.path.join(self._base_workdir_temp, 'buildbot-server')
+        self._server_wordir = os.path.join(self._base_workdir_temp, os.path.basename(self._configdir))
         assert(not os.path.exists(self._server_wordir))
         self._server_log = os.path.join(self._server_wordir, 'server.log')
         self._server_ready_fd = os.path.join(self._server_wordir, '.server-is-ready')


### PR DESCRIPTION
#### 69379105c3551cd269726ab7773145f208a9bea4
<pre>
&quot;start-local-buildbot-server --ews&quot; fails to start: builtins.ModuleNotFoundError: No module named &apos;ews-build&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=269688">https://bugs.webkit.org/show_bug.cgi?id=269688</a>

Reviewed by Carlos Alberto Lopez Perez.

After 267005@main changed master.cfg to use importlib to load
loadConfig, start-local-buildbot-server failed to start. The basename
of _server_wordir should be same with the basename of _configdir.

* Tools/CISupport/start-local-buildbot-server:
(BuildbotTestRunner._setup_server_workdir): Use the basename of
_configdir instead of the hard-coded directory name &apos;buildbot-server&apos;
for the basename of _server_wordir.

Canonical link: <a href="https://commits.webkit.org/275008@main">https://commits.webkit.org/275008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36eda6485314114e47bb86413d628fc48735af93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33624 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39980 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38298 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17010 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5403 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->