### PR TITLE
REGRESSION(273406@main): Twitter/X inline video playback spins endlessly in Safari

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -362,6 +362,7 @@ private:
 
     bool supportsAcceleratedRendering() const final;
     void acceleratedRenderingStateChanged() final;
+    void checkAcceleratedRenderingState();
 
     void setShouldMaintainAspectRatio(bool) final;
 
@@ -507,6 +508,7 @@ private:
     std::atomic<bool> m_seeking { false };
     bool m_isCurrentPlaybackTargetWireless { false };
     bool m_waitingForKey { false };
+    bool m_renderingCanBeAccelerated { false };
     std::optional<bool> m_shouldMaintainAspectRatio;
     std::optional<bool> m_pageIsVisible;
     RefPtr<RemoteVideoFrameProxy> m_videoFrameForCurrentTime;


### PR DESCRIPTION
#### 63fb0340db2161a5d56b1d51dad26cee6011d334
<pre>
REGRESSION(273406@main): Twitter/X inline video playback spins endlessly in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=269684">https://bugs.webkit.org/show_bug.cgi?id=269684</a>
<a href="https://rdar.apple.com/123190795">rdar://123190795</a>

Reviewed by NOBODY (OOPS!).

In 273406@main, an incorrect assumption was made: that the state of MediaPlayer::supportsAcceleratedRendering
was the only factor that would influence the value of MediaPlayer::renderingCanBeAccelerated().
Previously, when the MediaPlayer&apos;s readyState changed, the AcceleratedRenderingStateChanged notification
to the GPUProcess would have been sent which would have triggered the decoding to start.
This notification was removed following 273406@main.

This change is a partial revert, to re-add the logic so that we check once again that the value of
renderingCanBeAccelerated() has changed and notify the GPUP if that is the case.

The original bug is still corrected, which would have been re-introduced with a full revert.

Manually tested, confirmed that the incorrect behaviour has been corrected and that the video
playback starts.
I haven&apos;t found a way to reproduce the bug with a test at this stage.

* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::readyStateChanged):
(WebKit::MediaPlayerPrivateRemote::acceleratedRenderingStateChanged):
(WebKit::MediaPlayerPrivateRemote::checkAcceleratedRenderingState):
(WebKit::MediaPlayerPrivateRemote::updateConfiguration):
(WebKit::MediaPlayerPrivateRemote::setVideoFullscreenLayer):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63fb0340db2161a5d56b1d51dad26cee6011d334

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36616 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33627 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14285 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44353 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39979 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38296 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16961 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->