### PR TITLE
REGRESSION (270621@main?): [ Sonoma+ iOS17 wk2 Release  ] webrtc/audio-samplerate-change.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2395,8 +2395,6 @@ webkit.org/b/269116 imported/w3c/web-platform-tests/css/css-flexbox/negative-ove
 
 webkit.org/b/269321 webgl/1.0.3/conformance/uniforms/out-of-bounds-uniform-array-access.html [ Timeout ]
 
-webkit.org/b/269327 [ Release ] webrtc/audio-samplerate-change.html [ Pass Failure ]
-
 webkit.org/b/269378 [ Debug ] fast/forms/switch/click-disabled.html [ Skip ]
 
 webkit.org/b/269483 [ Debug ] http/wpt/webcodecs/h264-encoder-default-config.https.any.worker.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2001,8 +2001,6 @@ webkit.org/b/269639 http/tests/site-isolation/window-properties.html [ Skip ]
 [ Monterey+ x86_64 ] imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.html [ Failure ]
 [ Monterey+ x86_64 ] imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.worker.html [ Failure ]
 
-webkit.org/b/269327 [ Sonoma+ Release ] webrtc/audio-samplerate-change.html [ Pass Failure ]
-
 webkit.org/b/268398 [ Sonoma+ ] compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back.html [ Pass Failure ]
 
 webkit.org/b/269581 http/tests/site-isolation/mouse-events/context-menu-event-twice.html [ Skip ]

--- a/LayoutTests/webrtc/audio-samplerate-change.html
+++ b/LayoutTests/webrtc/audio-samplerate-change.html
@@ -16,7 +16,7 @@ promise_test(async (test) => {
         testRunner.setUserMediaPermission(true);
 
     const localStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    setInterval(() => {
+    const interval = setInterval(() => {
         usesLowSampleRate = !usesLowSampleRate;
         const rate = usesLowSampleRate ? 44100 : 48000;
         localStream.getAudioTracks()[0].applyConstraints({sampleRate: rate});
@@ -34,6 +34,7 @@ promise_test(async (test) => {
 
     await new Promise(resolve => setTimeout(resolve, 1000));
     localStream.getAudioTracks()[0].stop();
+    clearInterval(interval);
 }, "Audio connection with track changing sample rate");
     </script>
 </body>


### PR DESCRIPTION
#### bab48fb51b70c146323f32d616e5624d82721f11
<pre>
REGRESSION (270621@main?): [ Sonoma+ iOS17 wk2 Release  ] webrtc/audio-samplerate-change.html is a flaky failure
<a href="https://rdar.apple.com/122917306">rdar://122917306</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269327">https://bugs.webkit.org/show_bug.cgi?id=269327</a>

Reviewed by Jean-Yves Avenard.

In 270621@main, we changed applyConstraints behavior.
This made webrtc/audio-samplerate-change.html flaky as it is calling applyConstraints repeatedly with a timer
and stopping the track with another timer.
We are now clearing the timer that calls applyConstraints to remove the flakiness.

* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webrtc/audio-samplerate-change.html:

Canonical link: <a href="https://commits.webkit.org/274977@main">https://commits.webkit.org/274977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1a5f6b49fa0c9948476c05fedc16623f0e1c8c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36629 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16883 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33635 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39988 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38319 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35199 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9084 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->