### PR TITLE
applyConstraints on an ended track should synchronously resolve

### DIFF
--- a/LayoutTests/fast/mediastream/applyConstraints-ended-expected.txt
+++ b/LayoutTests/fast/mediastream/applyConstraints-ended-expected.txt
@@ -1,0 +1,4 @@
+
+PASS applyConstraints on an ended video track
+PASS applyConstraints on an ended audio track
+

--- a/LayoutTests/fast/mediastream/applyConstraints-ended.html
+++ b/LayoutTests/fast/mediastream/applyConstraints-ended.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/gc.js"></script>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <script>
+    promise_test(async (t) => {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        const track = stream.getVideoTracks()[0];
+
+        const badConstraints = { width: { exact: 10000000  } };
+        await track.applyConstraints(badConstraints).then(assert_unreached, e => {
+            assert_equals(e.name, "OverconstrainedError");
+        });
+        track.stop();
+        await track.applyConstraints(badConstraints);
+    }, "applyConstraints on an ended video track");
+
+    promise_test(async (t) => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        const track = stream.getAudioTracks()[0];
+
+        const badConstraints = { sampleRate: { exact: 10000000  } };
+        await track.applyConstraints(badConstraints).then(assert_unreached, e => {
+            assert_equals(e.name, "OverconstrainedError");
+        });
+        track.stop();
+        await track.applyConstraints(badConstraints);
+    }, "applyConstraints on an ended audio track");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -382,7 +382,7 @@ static MediaConstraints createMediaConstraints(const std::optional<MediaTrackCon
 void MediaStreamTrack::applyConstraints(const std::optional<MediaTrackConstraints>& constraints, DOMPromiseDeferred<void>&& promise)
 {
     if (m_ended) {
-        promise.reject(Exception { ExceptionCode::InvalidAccessError, "Track has ended"_s });
+        promise.resolve();
         return;
     }
 


### PR DESCRIPTION
#### ccd45357bd2ad7e46bbf93b899234eeb1c62cca2
<pre>
applyConstraints on an ended track should synchronously resolve
<a href="https://rdar.apple.com/123221377">rdar://123221377</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269695">https://bugs.webkit.org/show_bug.cgi?id=269695</a>

Reviewed by Jean-Yves Avenard.

As per <a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-applyconstraints">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-applyconstraints</a>,
we should resolve and not reject the applyConstraints promise on an ended track.
Update the code according spec and add a dedicated test.

* LayoutTests/fast/mediastream/applyConstraints-ended-expected.txt: Added.
* LayoutTests/fast/mediastream/applyConstraints-ended.html: Added.
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::applyConstraints):

Canonical link: <a href="https://commits.webkit.org/274975@main">https://commits.webkit.org/274975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/734cda01f18d2324056c6cb2b968a373d5fa86e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33634 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14217 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14292 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44365 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39987 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15354 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12584 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-detach-element.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38307 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9085 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->