### PR TITLE
[Skia] Remove m_elementsStream from PathSkia

### DIFF
--- a/Source/WebCore/platform/graphics/skia/PathSkia.h
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.h
@@ -73,8 +73,8 @@ public:
     FloatRect strokeBoundingRect(const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
 
 private:
-    PathSkia();
-    explicit PathSkia(SkPath&&, RefPtr<PathStream>&&);
+    PathSkia() = default;
+    explicit PathSkia(const SkPath&);
 
     void applySegments(const PathSegmentApplier&) const final;
 
@@ -86,7 +86,6 @@ private:
     FloatRect boundingRect() const final;
 
     SkPath m_platformPath;
-    RefPtr<PathStream> m_elementsStream;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7874af8ac73eddcceeea51497d9df2e2b7297d50
<pre>
[Skia] Remove m_elementsStream from PathSkia
<a href="https://bugs.webkit.org/show_bug.cgi?id=269698">https://bugs.webkit.org/show_bug.cgi?id=269698</a>

Reviewed by Adrian Perez de Castro.

We copied it from cairo, but it&apos;s not needed with Skia.

* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::PathSkia):
(WebCore::PathSkia::copy const):
(WebCore::PathSkia::add):
(WebCore::PathSkia::addPath):
(WebCore::PathSkia::applyElements const):
(WebCore::PathSkia::fastBoundingRect const):
(WebCore::PathSkia::boundingRect const):
* Source/WebCore/platform/graphics/skia/PathSkia.h:

Canonical link: <a href="https://commits.webkit.org/274969@main">https://commits.webkit.org/274969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e110ab25ab38d1685bae39320396b20e1457123

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16890 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33640 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14224 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36765 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39994 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38320 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17032 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5379 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->