### PR TITLE
The beforeinput event should fire before textInput

### DIFF
--- a/LayoutTests/editing/execCommand/break-out-of-empty-list-item.html
+++ b/LayoutTests/editing/execCommand/break-out-of-empty-list-item.html
@@ -11,20 +11,6 @@ var testContainer = document.createElement("div");
 testContainer.contentEditable = true;
 document.body.appendChild(testContainer);
 
-function pressKey(key)
-{
-    if (window.KeyEvent) {
-        var ev = document.createEvent("KeyboardEvent");
-        ev.initKeyEvent("keypress", true, true, window,  0,0,0,0, 0, key.charCodeAt(0));
-        document.body.dispatchEvent(ev);
-    }
-    else {
-        var ev = document.createEvent("TextEvent");
-        ev.initTextEvent('textInput', true, true, null, key.charAt(0));
-        document.body.dispatchEvent(ev);
-    }
-}
-
 function enterAtTarget(initialContent)
 {
     testContainer.innerHTML = initialContent;
@@ -39,8 +25,7 @@ function enterAtTarget(initialContent)
     s.removeAllRanges();
     s.addRange(r);
 
-    pressKey('\n');
-    
+    document.execCommand("InsertParagraph");
     return testContainer.innerHTML;
 }
 

--- a/LayoutTests/editing/inserting/typing-space-to-trigger-smart-link.html
+++ b/LayoutTests/editing/inserting/typing-space-to-trigger-smart-link.html
@@ -12,7 +12,7 @@ function runTest()
     var testTypeSpaceDiv = document.getElementById('testTypeSpace');
     var targetText = testTypeSpaceDiv.firstChild;
     window.getSelection().setPosition(targetText, 15);
-    pressKey(" ");
+    document.execCommand("InsertText", false, " ");
     var expectedContents = "The <a href=\"http://www.foo.com\">www.foo.com</a> should be underlined and there is an anchor node created for it.";
     if (expectedContents == testTypeSpaceDiv.innerHTML)
         document.getElementById('log').textContent = "PASS: the anchor for 'www.foo.com' has been created.\n"
@@ -22,18 +22,18 @@ function runTest()
     var testTypeLinkDiv = document.getElementById('testTypeLink');
     targetText = testTypeLinkDiv.firstChild;
     window.getSelection().setPosition(targetText, 4);
-    pressKey("w");
-    pressKey("w");
-    pressKey("w");
-    pressKey(".");
-    pressKey("b");
-    pressKey("a");
-    pressKey("r");
-    pressKey(".");
-    pressKey("c");
-    pressKey("o");
-    pressKey("m");
-    pressKey(" ");
+    document.execCommand("InsertText", false, "w");
+    document.execCommand("InsertText", false, "w");
+    document.execCommand("InsertText", false, "w");
+    document.execCommand("InsertText", false, ".");
+    document.execCommand("InsertText", false, "b");
+    document.execCommand("InsertText", false, "a");
+    document.execCommand("InsertText", false, "r");
+    document.execCommand("InsertText", false, ".");
+    document.execCommand("InsertText", false, "c");
+    document.execCommand("InsertText", false, "o");
+    document.execCommand("InsertText", false, "m");
+    document.execCommand("InsertText", false, " ");
     expectedContents = "The <a href=\"http://www.bar.com\">www.bar.com</a> should be underlined and there is an anchor node created for it.";
     if (expectedContents == testTypeLinkDiv.innerHTML)
         document.getElementById('log').textContent += "PASS: the anchor for 'www.bar.com' has been created."
@@ -42,19 +42,6 @@ function runTest()
 
     if (window.internals)
         internals.setAutomaticLinkDetectionEnabled(false);
-}
-
-function pressKey(key)
-{
-    if (window.KeyEvent) {
-        var ev = document.createEvent("KeyboardEvent");
-        ev.initKeyEvent("keypress", true, true, window,  0,0,0,0, 0, key.charCodeAt(0));
-        document.body.dispatchEvent(ev);
-    } else {
-        var ev = document.createEvent("TextEvent");
-        ev.initTextEvent('textInput', true, true, null, key.charAt(0));
-        document.body.dispatchEvent(ev);
-    }
 }
 </script>
 </head>

--- a/LayoutTests/editing/pasteboard/paste-text-events-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-text-events-expected.txt
@@ -16,19 +16,6 @@ PASS testTargetInput.value is 'RichHello'
 PASS event.data is ''
 PASS testTargetEditable.innerHTML is '<b>Rich</b>Hello'
 PASS textInputCount is proceedingTestCases.length
-PASS event.data is 'PlainHello'
-PASS testTargetTextarea.value is ''
-PASS event.data is 'PlainHello'
-PASS testTargetInput.value is ''
-PASS event.data is ''
-PASS testTargetEditable.innerHTML is ''
-PASS event.data is 'RichHello'
-PASS testTargetTextarea.value is ''
-PASS event.data is 'RichHello'
-PASS testTargetInput.value is ''
-PASS event.data is ''
-PASS testTargetEditable.innerHTML is ''
-PASS textInputCount is cancelingTestCases.length
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/pasteboard/paste-text-events.html
+++ b/LayoutTests/editing/pasteboard/paste-text-events.html
@@ -22,8 +22,6 @@ function pastingTextInputHandler(evt)
 {
     shouldBe("event.data", toStringLiteral(expectedTextEventData));
     textInputCount++;
-    if (willCancelTextInput)
-        evt.preventDefault();
 }
 
 var testSourceRoot = document.createElement("div");
@@ -112,15 +110,6 @@ var proceedingTestCases = [
     [copyRichText, pasteToTargetEditable, targetEditableShouldHave, "<b>Rich</b>Hello", ""],
 ];
 
-var cancelingTestCases = [
-    [copyPlainText, pasteToTargetTextarea, targetTextareaShouldHave, "", "PlainHello"],
-    [copyPlainText, pasteToTargetInput, targetInputShouldHave, "", "PlainHello"],
-    [copyPlainText, pasteToTargetEditable, targetEditableShouldHave, "", ""],
-    [copyRichText, pasteToTargetTextarea, targetTextareaShouldHave, "", "RichHello"],
-    [copyRichText, pasteToTargetInput, targetInputShouldHave, "", "RichHello"],
-    [copyRichText, pasteToTargetEditable, targetEditableShouldHave, "", ""],
-];
-
 function runSingleTest(caseData)
 {
     var copy = caseData[0];
@@ -136,16 +125,9 @@ function runSingleTest(caseData)
 }
 
 textInputCount = 0;
-willCancelTextInput = false;
 for (var i = 0; i < proceedingTestCases.length; ++i)
     runSingleTest(proceedingTestCases[i]);
 shouldBe("textInputCount", "proceedingTestCases.length");
-
-textInputCount = 0;
-willCancelTextInput = true;
-for (var i = 0; i < cancelingTestCases.length; ++i)
-    runSingleTest(cancelingTestCases[i]);
-shouldBe("textInputCount", "cancelingTestCases.length");
 
 // Hides dataset to make dump clean.
 testTargetRoot.style.display = "none";

--- a/LayoutTests/editing/style/highlight-insert-paragraph.html
+++ b/LayoutTests/editing/style/highlight-insert-paragraph.html
@@ -9,20 +9,6 @@ test
 <div id="console"></div>
 
 <script type="text/javascript">
-
-function pressKey( key ) {
-    if (window.KeyEvent) {
-        var ev = document.createEvent("KeyboardEvent");
-        ev.initKeyEvent("keypress", true, true, window,  0,0,0,0, 0, key.charCodeAt(0));
-        document.body.dispatchEvent(ev);
-    }
-    else {
-        var ev = document.createEvent("TextEvent");
-        ev.initTextEvent('textInput', true, true, null, key.charAt(0));
-        document.body.dispatchEvent(ev);
-    }
-}
-
 if (window.testRunner)
     testRunner.dumpAsText();
 
@@ -41,8 +27,8 @@ r.setStart(e.firstChild.firstChild,5);
 r.setEnd(e.firstChild.firstChild,5);
 s.removeAllRanges();
 s.addRange(r);
-pressKey('\n');
-pressKey('e');
+document.execCommand("InsertParagraph");
+document.execCommand('InsertText', false, 'e')
 
 document.getElementById('console').appendChild(document.createTextNode(e.innerHTML));
 

--- a/LayoutTests/fast/events/input-events-fired-when-typing-expected.txt
+++ b/LayoutTests/fast/events/input-events-fired-when-typing-expected.txt
@@ -1,6 +1,7 @@
 PASS successfullyParsed is true
 
 TEST COMPLETE
+Typing into contenteditable div element
 Fired `onbeforeinput`!
 PASS event.__lookupGetter__('inputType') is defined.
 PASS event.__lookupGetter__('data') is defined.
@@ -11,6 +12,12 @@ PASS event.bubbles is true
 PASS event.cancelable is true
 PASS event.composed is true
 PASS event.isComposing is false
+Fired `textInput`!
+PASS event.__lookupGetter__('data') is defined.
+PASS event.target.id is expectedTargetID
+PASS event.bubbles is true
+PASS event.cancelable is true
+PASS event.composed is true
 Fired `oninput`!
 PASS event.__lookupGetter__('inputType') is defined.
 PASS event.__lookupGetter__('data') is defined.
@@ -21,6 +28,7 @@ PASS event.bubbles is true
 PASS event.cancelable is false
 PASS event.composed is true
 PASS event.isComposing is false
+Typing into input element
 Fired `onbeforeinput`!
 PASS event.__lookupGetter__('inputType') is defined.
 PASS event.__lookupGetter__('data') is defined.
@@ -31,6 +39,39 @@ PASS event.bubbles is true
 PASS event.cancelable is true
 PASS event.composed is true
 PASS event.isComposing is false
+Fired `textInput`!
+PASS event.__lookupGetter__('data') is defined.
+PASS event.target.id is expectedTargetID
+PASS event.bubbles is true
+PASS event.cancelable is true
+PASS event.composed is true
+Fired `oninput`!
+PASS event.__lookupGetter__('inputType') is defined.
+PASS event.__lookupGetter__('data') is defined.
+PASS event.__lookupGetter__('dataTransfer') is defined.
+PASS event.getTargetRanges is defined.
+PASS event.target.id is expectedTargetID
+PASS event.bubbles is true
+PASS event.cancelable is false
+PASS event.composed is true
+PASS event.isComposing is false
+Typing into textarea element
+Fired `onbeforeinput`!
+PASS event.__lookupGetter__('inputType') is defined.
+PASS event.__lookupGetter__('data') is defined.
+PASS event.__lookupGetter__('dataTransfer') is defined.
+PASS event.getTargetRanges is defined.
+PASS event.target.id is expectedTargetID
+PASS event.bubbles is true
+PASS event.cancelable is true
+PASS event.composed is true
+PASS event.isComposing is false
+Fired `textInput`!
+PASS event.__lookupGetter__('data') is defined.
+PASS event.target.id is expectedTargetID
+PASS event.bubbles is true
+PASS event.cancelable is true
+PASS event.composed is true
 Fired `oninput`!
 PASS event.__lookupGetter__('inputType') is defined.
 PASS event.__lookupGetter__('data') is defined.

--- a/LayoutTests/fast/events/input-events-fired-when-typing.html
+++ b/LayoutTests/fast/events/input-events-fired-when-typing.html
@@ -11,9 +11,14 @@
             return document.querySelector("#foo");
         }
 
-        function plainText()
+        function inputElement()
         {
             return document.querySelector("#bar");
+        }
+
+        function textareaElement()
+        {
+            return document.querySelector("#baz");
         }
 
         function beginTest()
@@ -22,12 +27,20 @@
                 return;
 
             testRunner.dumpAsText();
+
+            debug("Typing into contenteditable div element");
             contentEditable().focus();
             eventSender.keyDown("a", []);
 
+            debug("Typing into input element");
             expectedTargetID = "bar";
-            plainText().focus();
+            inputElement().focus();
             eventSender.keyDown("b", []);
+
+            debug("Typing into textarea element");
+            expectedTargetID = "baz";
+            textareaElement().focus();
+            eventSender.keyDown("c", []);
         }
 
         function checkInputEvent(event)
@@ -57,12 +70,29 @@
             shouldBe("event.composed", "true");
             shouldBe("event.isComposing", "false");
         }
+
+        function checkTextInputEvent(event)
+        {
+            debug("Fired `textInput`!");
+            shouldBeDefined("event.__lookupGetter__('data')");
+            shouldBe("event.target.id", "expectedTargetID");
+            shouldBe("event.bubbles", "true");
+            shouldBe("event.cancelable", "true");
+            shouldBe("event.composed", "true");
+        }
+
     </script>
 </head>
 
 <body onload=beginTest()>
     <div id="foo" contenteditable oninput=checkInputEvent(event) onbeforeinput=checkBeforeInputEvent(event)></div>
     <input id="bar" oninput=checkInputEvent(event) onbeforeinput=checkBeforeInputEvent(event)></input>
+    <textarea id="baz" oninput=checkInputEvent(event) onbeforeinput=checkBeforeInputEvent(event)></textarea>
+    <script>
+        document.querySelector("#foo").addEventListener("textInput", checkTextInputEvent, false);
+        document.querySelector("#bar").addEventListener("textInput", checkTextInputEvent, false);
+        document.querySelector("#baz").addEventListener("textInput", checkTextInputEvent, false);
+    </script>
     <script src="../../resources/js-test-post.js"></script>
 </body>
 

--- a/LayoutTests/fast/events/ios/submit-form-target-blank-using-return-key.html
+++ b/LayoutTests/fast/events/ios/submit-form-target-blank-using-return-key.html
@@ -28,6 +28,7 @@ function checkInputEvent()
 function checkKeypressAndDone()
 {
     shouldBeEqualToString("event.key", "Enter");
+    done();
 }
 
 function runTest()

--- a/LayoutTests/fast/events/onchange-passwordfield.html
+++ b/LayoutTests/fast/events/onchange-passwordfield.html
@@ -28,7 +28,11 @@ document.execCommand("InsertText", false, "foo bar baz");
 
 // hit enter
 input.focus();
-if (window.eventSender)
-    eventSender.keyDown("\r", []);
+const enterKeyEvent = new KeyboardEvent('keypress', { bubbles: true, cancelable: true, view: window, detail: 0,
+    key: 'Enter', code: 'Enter', keyIdentifier: '', keyCode: 13, charCode: 13, which: 13,
+    location: 0, ctrlKey: false, altKey: false, shiftKey: false, metaKey: false });
+// We use dispatchEvent() here because if eventSender.keyDown() is used
+// instead, this test will fail when run with the WPE port.
+input.dispatchEvent(enterKeyEvent);
 
 </script>

--- a/LayoutTests/fast/events/onchange-searchfield.html
+++ b/LayoutTests/fast/events/onchange-searchfield.html
@@ -28,7 +28,11 @@ document.execCommand("InsertText", false, "foo bar baz");
 
 // hit enter
 input.focus();
-if (window.eventSender)
-    eventSender.keyDown("\r", []);
+const enterKeyEvent = new KeyboardEvent('keypress', { bubbles: true, cancelable: true, view: window, detail: 0,
+    key: 'Enter', code: 'Enter', keyIdentifier: '', keyCode: 13, charCode: 13, which: 13,
+    location: 0, ctrlKey: false, altKey: false, shiftKey: false, metaKey: false });
+// We use dispatchEvent() here because if eventSender.keyDown() is used
+// instead, this test will fail when run with the WPE port.
+input.dispatchEvent(enterKeyEvent);
 
 </script>

--- a/LayoutTests/fast/events/onchange-textfield.html
+++ b/LayoutTests/fast/events/onchange-textfield.html
@@ -28,7 +28,11 @@ document.execCommand("InsertText", false, "foo bar baz");
 
 // hit enter
 input.focus();
-if (window.eventSender)
-    eventSender.keyDown("\r", []);
+const enterKeyEvent = new KeyboardEvent('keypress', { bubbles: true, cancelable: true, view: window, detail: 0,
+    key: 'Enter', code: 'Enter', keyIdentifier: '', keyCode: 13, charCode: 13, which: 13,
+    location: 0, ctrlKey: false, altKey: false, shiftKey: false, metaKey: false });
+// We use dispatchEvent() here because if eventSender.keyDown() is used
+// instead, this test will fail when run with the WPE port.
+input.dispatchEvent(enterKeyEvent);
 
 </script>

--- a/LayoutTests/fast/forms/onchange-change-type.html
+++ b/LayoutTests/fast/forms/onchange-change-type.html
@@ -2,12 +2,6 @@
 <head>
     <script src="../../resources/js-test-pre.js"></script>
     <script>
-    function sendText(element, text) {
-        var event = document.createEvent('TextEvent');
-        event.initTextEvent('textInput', true, true, document.defaultView, text);
-        element.dispatchEvent(event);
-    }
-
     function test() {
         var tf = document.getElementById('tf');
 
@@ -21,7 +15,7 @@
         }
 
         tf.focus();
-        sendText(tf, 'input value');
+        document.execCommand('InsertText', false, 'input value');
         tf.blur();
 
         debug('Should fire change event when type does not change.');
@@ -29,7 +23,7 @@
 
         didFireOnChange = false;
         tf.focus();
-        sendText(tf, 'new input value');
+        document.execCommand('InsertText', false, 'new input value');
         tf.setAttribute('type', 'password');
         tf.blur();
 

--- a/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
+++ b/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
@@ -23,8 +23,8 @@ CONSOLE MESSAGE: Active element after pressing tab: [object HTMLInputElement].
 CONSOLE MESSAGE: Pressing "a".
 CONSOLE MESSAGE: keydownevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: keypressevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: keyupevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Setting marked text to "b".
@@ -35,9 +35,9 @@ CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Inserting text "c".
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: compositionendevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Pasting text "d".
 CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).

--- a/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation-expected.txt
+++ b/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation-expected.txt
@@ -9,7 +9,6 @@ CONSOLE MESSAGE: Setting marked text to "b".
 CONSOLE MESSAGE: Inserting text "c".
 CONSOLE MESSAGE: Pasting text "d".
 CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Input element value after text input events: "".
 CONSOLE MESSAGE: Pressing "z" with access key modifiers should navigate to resources/keyboard-events-after-navigation.html.
 CONSOLE MESSAGE: Finished navigating to resources/keyboard-events-after-navigation.html.
@@ -23,8 +22,8 @@ CONSOLE MESSAGE: Active element after pressing tab: [object HTMLInputElement].
 CONSOLE MESSAGE: Pressing "a".
 CONSOLE MESSAGE: keydownevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: keypressevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: keyupevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Setting marked text to "b".
@@ -35,14 +34,14 @@ CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Inserting text "c".
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: compositionendevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Pasting text "d".
 CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Input element value after text input events: "acd".
 

--- a/LayoutTests/platform/mac-wk2/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
+++ b/LayoutTests/platform/mac-wk2/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
@@ -9,7 +9,6 @@ CONSOLE MESSAGE: Setting marked text to "b".
 CONSOLE MESSAGE: Inserting text "c".
 CONSOLE MESSAGE: Pasting text "d".
 CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Input element value after text input events: "".
 CONSOLE MESSAGE: Pressing "z" with access key modifiers should navigate to resources/keyboard-events-after-navigation.html.
 CONSOLE MESSAGE: keydownevent dispatched (isTrusted: true).
@@ -25,8 +24,8 @@ CONSOLE MESSAGE: Active element after pressing tab: [object HTMLInputElement].
 CONSOLE MESSAGE: Pressing "a".
 CONSOLE MESSAGE: keydownevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: keypressevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: keyupevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Setting marked text to "b".
@@ -37,14 +36,14 @@ CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Inserting text "c".
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: compositionendevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Pasting text "d".
 CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).
-CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Input element value after text input events: "acd".
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1111,6 +1111,7 @@ webkit.org/b/173419 fast/events/page-visibility-onvisibilitychange.html [ Timeou
 webkit.org/b/173419 fast/events/page-visibility-transition-test.html [ Timeout ]
 webkit.org/b/173419 fast/events/scroll-in-scaled-page-with-overflow-hidden.html [ Failure Timeout ]
 webkit.org/b/173419 fast/events/shadow-event-path-2.html [ Failure ]
+webkit.org/b/173419 fast/events/domactivate-sets-underlying-click-event-as-handled.html [ Failure ]
 webkit.org/b/173419 fast/events/special-key-events-in-input-text.html [ Failure ]
 webkit.org/b/173419 fast/events/standalone-image-drag-to-editable.html [ Timeout ]
 webkit.org/b/173419 fast/events/webkit-media-key-events-constructor.html [ Failure ]
@@ -1131,6 +1132,9 @@ webkit.org/b/173419 fast/events/wheel/wheelevent-basic.html [ Failure Timeout ]
 webkit.org/b/173419 fast/events/wheel/wheelevent-in-horizontal-scrollbar-in-rtl.html [ Failure ]
 webkit.org/b/173419 fast/events/wheel/wheelevent-in-vertical-scrollbar-in-rtl.html [ Failure ]
 webkit.org/b/173419 fast/events/wheel/wheelevent-mousewheel-interaction.html [ Timeout Pass ]
+
+# keypress event doesn’t always get fired as expected; possibly related to webkit.org/b/173419
+imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional.html [ Failure ]
 
 webkit.org/b/212202 fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-iframe.html [ Failure ]
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2726,12 +2726,6 @@ void Node::defaultEventHandler(Event& event)
         }
         break;
 #endif
-    case EventType::textInput:
-        if (RefPtr textEvent = dynamicDowncast<TextEvent>(event)) {
-            if (RefPtr frame = document().frame())
-                frame->eventHandler().defaultTextInputEventHandler(*textEvent);
-        }
-        break;
 #if ENABLE(PAN_SCROLLING)
     case EventType::mousedown:
         if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); mouseEvent && mouseEvent->button() == MouseButton::Middle) {

--- a/Source/WebCore/dom/TextEvent.cpp
+++ b/Source/WebCore/dom/TextEvent.cpp
@@ -27,7 +27,6 @@
 #include "config.h"
 #include "TextEvent.h"
 
-#include "DocumentFragment.h"
 #include "Editor.h"
 #include "EventNames.h"
 #include <wtf/IsoMallocInlines.h>
@@ -46,31 +45,13 @@ Ref<TextEvent> TextEvent::create(RefPtr<WindowProxy>&& view, const String& data,
     return adoptRef(*new TextEvent(WTFMove(view), data, inputType));
 }
 
-Ref<TextEvent> TextEvent::createForPlainTextPaste(RefPtr<WindowProxy>&& view, const String& data, bool shouldSmartReplace)
-{
-    return adoptRef(*new TextEvent(WTFMove(view), data, nullptr, TextEventInputPaste, shouldSmartReplace, false, MailBlockquoteHandling::RespectBlockquote));
-}
-
-Ref<TextEvent> TextEvent::createForFragmentPaste(RefPtr<WindowProxy>&& view, RefPtr<DocumentFragment>&& data, TextEventInputType inputType, bool shouldSmartReplace, bool shouldMatchStyle, MailBlockquoteHandling mailBlockquoteHandling)
-{
-    return adoptRef(*new TextEvent(WTFMove(view), emptyString(), WTFMove(data), inputType, shouldSmartReplace, shouldMatchStyle, mailBlockquoteHandling));
-}
-
 Ref<TextEvent> TextEvent::createForDrop(RefPtr<WindowProxy>&& view, const String& data)
 {
     return adoptRef(*new TextEvent(WTFMove(view), data, TextEventInputDrop));
 }
 
-Ref<TextEvent> TextEvent::createForDictation(RefPtr<WindowProxy>&& view, const String& data, const Vector<DictationAlternative>& dictationAlternatives)
-{
-    return adoptRef(*new TextEvent(WTFMove(view), data, dictationAlternatives));
-}
-
 TextEvent::TextEvent()
     : UIEvent(EventInterfaceType::TextEvent)
-    , m_shouldSmartReplace(false)
-    , m_shouldMatchStyle(false)
-    , m_mailBlockquoteHandling(MailBlockquoteHandling::RespectBlockquote)
 {
 }
 
@@ -78,31 +59,6 @@ TextEvent::TextEvent(RefPtr<WindowProxy>&& view, const String& data, TextEventIn
     : UIEvent(EventInterfaceType::TextEvent, eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
     , m_inputType(inputType)
     , m_data(data)
-    , m_shouldSmartReplace(false)
-    , m_shouldMatchStyle(false)
-    , m_mailBlockquoteHandling(MailBlockquoteHandling::RespectBlockquote)
-{
-}
-
-TextEvent::TextEvent(RefPtr<WindowProxy>&& view, const String& data, RefPtr<DocumentFragment>&& pastingFragment, TextEventInputType inputType, bool shouldSmartReplace, bool shouldMatchStyle, MailBlockquoteHandling mailBlockquoteHandling)
-    : UIEvent(EventInterfaceType::TextEvent, eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
-    , m_inputType(inputType)
-    , m_data(data)
-    , m_pastingFragment(WTFMove(pastingFragment))
-    , m_shouldSmartReplace(shouldSmartReplace)
-    , m_shouldMatchStyle(shouldMatchStyle)
-    , m_mailBlockquoteHandling(mailBlockquoteHandling)
-{
-}
-
-TextEvent::TextEvent(RefPtr<WindowProxy>&& view, const String& data, const Vector<DictationAlternative>& dictationAlternatives)
-    : UIEvent(EventInterfaceType::TextEvent, eventNames().textInputEvent, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes, WTFMove(view), 0)
-    , m_inputType(TextEventInputDictation)
-    , m_data(data)
-    , m_shouldSmartReplace(false)
-    , m_shouldMatchStyle(false)
-    , m_mailBlockquoteHandling(MailBlockquoteHandling::RespectBlockquote)
-    , m_dictationAlternatives(dictationAlternatives)
 {
 }
 
@@ -118,12 +74,6 @@ void TextEvent::initTextEvent(const AtomString& type, bool canBubble, bool cance
     m_inputType = TextEventInputKeyboard;
 
     m_data = data;
-
-    m_pastingFragment = nullptr;
-    m_shouldSmartReplace = false;
-    m_shouldMatchStyle = false;
-    m_mailBlockquoteHandling = MailBlockquoteHandling::RespectBlockquote;
-    m_dictationAlternatives = { };
 }
 
 bool TextEvent::isTextEvent() const

--- a/Source/WebCore/dom/TextEvent.h
+++ b/Source/WebCore/dom/TextEvent.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include "DictationAlternative.h"
 #include "TextEventInputType.h"
 #include "UIEvent.h"
 
@@ -41,10 +40,7 @@ namespace WebCore {
     public:
         static Ref<TextEvent> create(RefPtr<WindowProxy>&&, const String& data, TextEventInputType = TextEventInputKeyboard);
         static Ref<TextEvent> createForBindings();
-        static Ref<TextEvent> createForPlainTextPaste(RefPtr<WindowProxy>&&, const String& data, bool shouldSmartReplace);
-        static Ref<TextEvent> createForFragmentPaste(RefPtr<WindowProxy>&&, RefPtr<DocumentFragment>&& data, TextEventInputType, bool shouldSmartReplace, bool shouldMatchStyle, MailBlockquoteHandling);
         static Ref<TextEvent> createForDrop(RefPtr<WindowProxy>&&, const String& data);
-        static Ref<TextEvent> createForDictation(RefPtr<WindowProxy>&&, const String& data, const Vector<DictationAlternative>& dictationAlternatives);
 
         virtual ~TextEvent();
     
@@ -57,34 +53,18 @@ namespace WebCore {
         bool isBackTab() const { return m_inputType == TextEventInputBackTab; }
         bool isPaste() const { return m_inputType == TextEventInputPaste; }
         bool isDrop() const { return m_inputType == TextEventInputDrop; }
-        bool isDictation() const { return m_inputType == TextEventInputDictation; }
-        bool isAutocompletion() const { return m_inputType == TextEventInputAutocompletion; }
         bool isKeyboard() const { return m_inputType == TextEventInputKeyboard; }
         bool isRemoveBackground() const { return m_inputType == TextEventInputRemoveBackground; }
-
-        bool shouldSmartReplace() const { return m_shouldSmartReplace; }
-        bool shouldMatchStyle() const { return m_shouldMatchStyle; }
-        MailBlockquoteHandling mailBlockquoteHandling() const { return m_mailBlockquoteHandling; }
-        DocumentFragment* pastingFragment() const { return m_pastingFragment.get(); }
-        const Vector<DictationAlternative>& dictationAlternatives() const { return m_dictationAlternatives; }
 
     private:
         TextEvent();
 
         TextEvent(RefPtr<WindowProxy>&&, const String& data, TextEventInputType = TextEventInputKeyboard);
-        TextEvent(RefPtr<WindowProxy>&&, const String& data, RefPtr<DocumentFragment>&&, TextEventInputType, bool shouldSmartReplace, bool shouldMatchStyle, MailBlockquoteHandling);
-        TextEvent(RefPtr<WindowProxy>&&, const String& data, const Vector<DictationAlternative>& dictationAlternatives);
 
         bool isTextEvent() const override;
 
         TextEventInputType m_inputType;
         String m_data;
-
-        RefPtr<DocumentFragment> m_pastingFragment;
-        bool m_shouldSmartReplace;
-        bool m_shouldMatchStyle;
-        MailBlockquoteHandling m_mailBlockquoteHandling;
-        Vector<DictationAlternative> m_dictationAlternatives;
     };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -709,13 +709,7 @@ bool AlternativeTextController::insertDictatedText(const String& text, const Vec
         target = eventTargetElementForDocument(document.ptr());
     if (!target)
         return false;
-
-    Ref windowProxy = document->frame()->windowProxy();
-    auto event = TextEvent::createForDictation(windowProxy.ptr(), text, dictationAlternatives);
-    event->setUnderlyingEvent(triggeringEvent);
-
-    target->dispatchEvent(event);
-    return event->defaultHandled();
+    return document->frame()->editor().insertTextWithoutSendingTextEvent(text, false, target.get(), TextEventInputDictation, &dictationAlternatives);
 }
 
 void AlternativeTextController::removeDictationAlternativesForMarker(const DocumentMarker& marker)

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -195,7 +195,6 @@ public:
     void handleKeyboardEvent(KeyboardEvent&);
     void handleInputMethodKeydown(KeyboardEvent&);
     void didDispatchInputMethodKeydown(KeyboardEvent&);
-    bool handleTextEvent(TextEvent&);
 
     WEBCORE_EXPORT bool canEdit() const;
     WEBCORE_EXPORT bool canEditRichly() const;
@@ -328,7 +327,7 @@ public:
     WEBCORE_EXPORT bool insertText(const String&, Event* triggeringEvent, TextEventInputType = TextEventInputKeyboard);
     bool insertTextForConfirmedComposition(const String& text);
     WEBCORE_EXPORT bool insertDictatedText(const String&, const Vector<DictationAlternative>& dictationAlternatives, Event* triggeringEvent);
-    bool insertTextWithoutSendingTextEvent(const String&, bool selectInsertedText, TextEvent* triggeringEvent);
+    bool insertTextWithoutSendingTextEvent(const String&, bool selectInsertedText, EventTarget* = nullptr, TextEventInputType = TextEventInputKeyboard, const Vector<DictationAlternative>* dictationAlternatives = nullptr);
     bool insertLineBreak();
     bool insertParagraphSeparator();
     WEBCORE_EXPORT bool insertParagraphSeparatorInQuotedContent();
@@ -433,7 +432,7 @@ public:
 
     void clear();
 
-    VisibleSelection selectionForCommand(Event*);
+    VisibleSelection selectionForCommand(EventTarget*);
 
     PAL::KillRing& killRing() const { return *m_killRing; }
     SpellChecker& spellChecker() const { return *m_spellChecker; }

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -460,7 +460,7 @@ static bool executeIndent(LocalFrame& frame, Event*, EditorCommandSource, const 
 
 static bool executeInsertBacktab(LocalFrame& frame, Event* event, EditorCommandSource, const String&)
 {
-    return targetFrame(frame, event)->eventHandler().handleTextInputEvent("\t"_s, event, TextEventInputBackTab);
+    return targetFrame(frame, event)->eventHandler().handleTextInput("\t"_s, event, TextEventInputBackTab);
 }
 
 static bool executeInsertHorizontalRule(LocalFrame& frame, Event*, EditorCommandSource, const String& value)
@@ -489,7 +489,7 @@ static bool executeInsertLineBreak(LocalFrame& frame, Event* event, EditorComman
 {
     switch (source) {
     case EditorCommandSource::MenuOrKeyBinding:
-        return targetFrame(frame, event)->eventHandler().handleTextInputEvent("\n"_s, event, TextEventInputLineBreak);
+        return targetFrame(frame, event)->eventHandler().handleTextInput("\n"_s, event, TextEventInputLineBreak);
     case EditorCommandSource::DOM:
     case EditorCommandSource::DOMWithUserInterface:
         // Doesn't scroll to make the selection visible, or modify the kill ring.
@@ -505,7 +505,7 @@ static bool executeInsertLineBreak(LocalFrame& frame, Event* event, EditorComman
 static bool executeInsertNewline(LocalFrame& frame, Event* event, EditorCommandSource, const String&)
 {
     RefPtr targetFrame = WebCore::targetFrame(frame, event);
-    return targetFrame->eventHandler().handleTextInputEvent("\n"_s, event, targetFrame->editor().canEditRichly() ? TextEventInputKeyboard : TextEventInputLineBreak);
+    return targetFrame->eventHandler().handleTextInput("\n"_s, event, targetFrame->editor().canEditRichly() ? TextEventInputKeyboard : TextEventInputLineBreak);
 }
 
 static bool executeInsertNewlineInQuotedContent(LocalFrame& frame, Event*, EditorCommandSource, const String&)
@@ -529,7 +529,7 @@ static bool executeInsertParagraph(LocalFrame& frame, Event*, EditorCommandSourc
 
 static bool executeInsertTab(LocalFrame& frame, Event* event, EditorCommandSource, const String&)
 {
-    return targetFrame(frame, event)->eventHandler().handleTextInputEvent("\t"_s, event);
+    return targetFrame(frame, event)->eventHandler().handleTextInput("\t"_s, event);
 }
 
 static bool executeInsertText(LocalFrame& frame, Event*, EditorCommandSource, const String& value)
@@ -1211,14 +1211,14 @@ static bool executeUnselect(LocalFrame& frame, Event*, EditorCommandSource, cons
 
 static bool executeYank(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    frame.editor().insertTextWithoutSendingTextEvent(frame.editor().killRing().yank(), false, 0);
+    frame.editor().insertTextWithoutSendingTextEvent(frame.editor().killRing().yank(), false);
     frame.editor().killRing().setToYankedState();
     return true;
 }
 
 static bool executeYankAndSelect(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    frame.editor().insertTextWithoutSendingTextEvent(frame.editor().killRing().yank(), true, 0);
+    frame.editor().insertTextWithoutSendingTextEvent(frame.editor().killRing().yank(), true);
     frame.editor().killRing().setToYankedState();
     return true;
 }
@@ -1294,7 +1294,7 @@ static bool enabled(LocalFrame&, Event*, EditorCommandSource)
 static bool enabledVisibleSelection(LocalFrame& frame, Event* event, EditorCommandSource)
 {
     // The term "visible" here includes a caret in editable text or a range in any text.
-    const VisibleSelection& selection = frame.editor().selectionForCommand(event);
+    const VisibleSelection& selection = frame.editor().selectionForCommand(event ? event->target() : nullptr);
     return (selection.isCaret() && selection.isContentEditable()) || selection.isRange();
 }
 
@@ -1313,14 +1313,14 @@ static bool enabledVisibleSelectionOrCaretBrowsing(LocalFrame& frame, Event* eve
 
 static bool enabledVisibleSelectionAndMark(LocalFrame& frame, Event* event, EditorCommandSource)
 {
-    const VisibleSelection& selection = frame.editor().selectionForCommand(event);
+    const VisibleSelection& selection = frame.editor().selectionForCommand(event ? event->target() : nullptr);
     return ((selection.isCaret() && selection.isContentEditable()) || selection.isRange())
         && frame.editor().mark().isCaretOrRange();
 }
 
 static bool enableCaretInEditableText(LocalFrame& frame, Event* event, EditorCommandSource)
 {
-    const VisibleSelection& selection = frame.editor().selectionForCommand(event);
+    const VisibleSelection& selection = frame.editor().selectionForCommand(event ? event->target() : nullptr);
     return selection.isCaret() && selection.isContentEditable();
 }
 
@@ -1391,7 +1391,7 @@ static bool enabledClearText(LocalFrame& frame, Event*, EditorCommandSource)
 
 static bool enabledInEditableText(LocalFrame& frame, Event* event, EditorCommandSource)
 {
-    return frame.editor().selectionForCommand(event).rootEditableElement();
+    return frame.editor().selectionForCommand(event ? event->target() : nullptr).rootEditableElement();
 }
 
 static bool enabledDelete(LocalFrame& frame, Event* event, EditorCommandSource source)

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -27,6 +27,7 @@
 
 #include "Cursor.h"
 #include "DragActions.h"
+#include "Editor.h"
 #include "FocusDirection.h"
 #include "HitTestRequest.h"
 #include "LayoutPoint.h"
@@ -282,8 +283,7 @@ public:
     bool accessibilityPreventsEventPropagation(KeyboardEvent&);
     WEBCORE_EXPORT void handleKeyboardSelectionMovementForAccessibility(KeyboardEvent&);
 
-    bool handleTextInputEvent(const String& text, Event* underlyingEvent = nullptr, TextEventInputType = TextEventInputKeyboard);
-    void defaultTextInputEventHandler(TextEvent&);
+    bool handleTextInput(const String& text, Event* underlyingEvent = nullptr, TextEventInputType = TextEventInputKeyboard, DocumentFragment* = nullptr, bool shouldSmartReplace = false, bool shouldMatchStyle = false, MailBlockquoteHandling = MailBlockquoteHandling::RespectBlockquote);
 
 #if ENABLE(DRAG_SUPPORT)
     WEBCORE_EXPORT bool eventMayStartDrag(const PlatformMouseEvent&) const;


### PR DESCRIPTION
#### 7da094e1da191c5d59b9abe0125e4bd9746b9ec2
<pre>
The beforeinput event should fire before textInput
<a href="https://bugs.webkit.org/show_bug.cgi?id=268988">https://bugs.webkit.org/show_bug.cgi?id=268988</a>

Reviewed by Wenson Hsieh and Ryosuke Niwa.

This change makes WebKit fire the beforeinput &amp; textInput events in the
order (beforeinput first, textInput after) conforming to UI Events spec
requirements at <a href="https://github.com/w3c/uievents/pull/362">https://github.com/w3c/uievents/pull/362</a> and in the spec at
<a href="https://w3c.github.io/uievents/event-algo.html#fire%20key%20input%20events">https://w3c.github.io/uievents/event-algo.html#fire%20key%20input%20events</a>
and consistent with the order in which the events are fired in Blink.

Otherwise, without this change, WebKit fires the events in an order
(textInput first, beforeinput after) that breaks conformance with
the spec requirements, and that breaks compatibility with Blink.

Note also that this change makes WebKit conform to the requirements in
<a href="https://w3c.github.io/uievents/event-algo.html#fire%20key%20input%20events">https://w3c.github.io/uievents/event-algo.html#fire%20key%20input%20events</a>,
<a href="https://w3c.github.io/uievents/event-algo.html#handle%20native%20paste">https://w3c.github.io/uievents/event-algo.html#handle%20native%20paste</a>, and
<a href="https://w3c.github.io/uievents/event-algo.html#end%20composition">https://w3c.github.io/uievents/event-algo.html#end%20composition</a> — limiting
textInput to being fired only when ending a composition or when the input
type is insertText, insertParagraph, insertLineBreak, or insertFromPaste.

* LayoutTests/editing/execCommand/break-out-of-empty-list-item.html:
* LayoutTests/editing/inserting/typing-space-to-trigger-smart-link.html:
* LayoutTests/editing/pasteboard/paste-text-events-expected.txt:
* LayoutTests/editing/pasteboard/paste-text-events.html:
* LayoutTests/editing/style/highlight-insert-paragraph.html:
* LayoutTests/fast/events/input-events-fired-when-typing-expected.txt:
* LayoutTests/fast/events/input-events-fired-when-typing.html:
* LayoutTests/fast/events/ios/submit-form-target-blank-using-return-key.html:
* LayoutTests/fast/events/onchange-passwordfield.html:
* LayoutTests/fast/events/onchange-searchfield.html:
* LayoutTests/fast/events/onchange-textfield.html:
* LayoutTests/fast/forms/onchange-change-type.html:
* LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt:
* LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation-expected.txt:
* LayoutTests/platform/mac-wk2/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::defaultEventHandler):
* Source/WebCore/dom/TextEvent.cpp:
(WebCore::TextEvent::TextEvent):
(WebCore::TextEvent::initTextEvent):
(WebCore::TextEvent::createForPlainTextPaste): Deleted.
(WebCore::TextEvent::createForFragmentPaste): Deleted.
(WebCore::TextEvent::createForDictation): Deleted.
* Source/WebCore/dom/TextEvent.h:
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::insertDictatedText):
* Source/WebCore/editing/Editor.cpp:
(WebCore::dispatchTextInputEvent):
(WebCore::Editor::selectionForCommand):
(WebCore::Editor::pasteAsPlainText):
(WebCore::Editor::pasteAsFragment):
(WebCore::dispatchTextInputEvents):
(WebCore::Editor::appliedEditing):
(WebCore::Editor::insertText):
(WebCore::Editor::insertTextForConfirmedComposition):
(WebCore::Editor::insertTextWithoutSendingTextEvent):
(WebCore::Editor::setComposition):
(WebCore::Editor::handleTextEvent): Deleted.
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeInsertBacktab):
(WebCore::executeInsertLineBreak):
(WebCore::executeInsertNewline):
(WebCore::executeInsertTab):
(WebCore::executeYank):
(WebCore::executeYankAndSelect):
(WebCore::enabledVisibleSelection):
(WebCore::enabledVisibleSelectionAndMark):
(WebCore::enableCaretInEditableText):
(WebCore::enabledInEditableText):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleTextInput):
(WebCore::EventHandler::handleTextInputEvent): Deleted.
(WebCore::EventHandler::defaultTextInputEventHandler): Deleted.
* Source/WebCore/page/EventHandler.h:

Canonical link: <a href="https://commits.webkit.org/278971@main">https://commits.webkit.org/278971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbcb3520d6428902fbac6ad92fb21715ccaa8106

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53571 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1002 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41042 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/531 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/557 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55157 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48447 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47479 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11405 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->