### PR TITLE
RealtimeMediaSource error logging is wrong for zoom and frame rate constraints

### DIFF
--- a/LayoutTests/fast/mediastream/applyConstraints-bad-constraints-expected.txt
+++ b/LayoutTests/fast/mediastream/applyConstraints-bad-constraints-expected.txt
@@ -1,0 +1,8 @@
+
+PASS applyConstraints with a frameRate constraint that is too high
+PASS applyConstraints with a frameRate constraint that is too low
+PASS applyConstraints with a zoom constraint that is too high
+PASS applyConstraints with a zoom constraint that is too low
+PASS applyConstraints with a sampleRate constraint that is too high
+PASS applyConstraints with a sampleRate constraint that is too low
+

--- a/LayoutTests/fast/mediastream/applyConstraints-bad-constraints.html
+++ b/LayoutTests/fast/mediastream/applyConstraints-bad-constraints.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <script>
+async function doTest(test, isVideo, badConstraints)
+{
+    const stream = await navigator.mediaDevices.getUserMedia({ video: isVideo, audio: !isVideo });
+    const track = stream.getTracks()[0];
+
+    await track.applyConstraints(badConstraints).then(() => {
+    }, e => {
+        assert_equals(e.name, "OverconstrainedError");
+    });
+}
+
+promise_test(async (t) => {
+    return doTest(t, true, { frameRate: { exact: 10000000 } });
+}, "applyConstraints with a frameRate constraint that is too high");
+
+promise_test(async (t) => {
+    return doTest(t, true, { frameRate: { exact: -1 } });
+}, "applyConstraints with a frameRate constraint that is too low");
+
+promise_test(async (t) => {
+    return doTest(t, true, { zoom: { exact: 10000000 } });
+}, "applyConstraints with a zoom constraint that is too high");
+
+promise_test(async (t) => {
+    return doTest(t, true, { zoom: { exact: -1 } });
+}, "applyConstraints with a zoom constraint that is too low");
+
+promise_test(async (t) => {
+    return doTest(t, false, { sampleRate: { exact: 10000000 } });
+}, "applyConstraints with a sampleRate constraint that is too high");
+
+promise_test(async (t) => {
+    return doTest(t, false, { sampleRate: { exact: -1 } });
+}, "applyConstraints with a sampleRate constraint that is too low");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -510,7 +510,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         if (std::isinf(constraintDistance)) {
 #if !RELEASE_LOG_DISABLED
             auto range = capabilities.frameRate();
-            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed frame rate constraint, capabilities are [%d, %d]", range.longRange().min, range.longRange().max);
+            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed frame rate constraint, capabilities are [", range.doubleRange().min, ", ", range.doubleRange().max, "]");
 #endif
             return MediaConstraintType::FrameRate;
         }
@@ -528,7 +528,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         if (std::isinf(constraintDistance)) {
 #if !RELEASE_LOG_DISABLED
             auto range = capabilities.zoom();
-            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed zoom constraint, capabilities are [%d, %d]", range.longRange().min, range.longRange().max);
+            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed zoom constraint, capabilities are [", range.doubleRange().min, ", ", range.doubleRange().max, "]");
 #endif
             return MediaConstraintType::Zoom;
         }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -101,13 +101,13 @@ public:
 
     const DoubleRange& doubleRange() const
     {
-        RELEASE_ASSERT(m_doubleRange);
+        ASSERT(m_doubleRange);
         return *m_doubleRange;
     }
 
     const LongRange& longRange() const
     {
-        RELEASE_ASSERT(m_longRange);
+        ASSERT(m_longRange);
         return *m_longRange;
     }
 


### PR DESCRIPTION
#### 5f7adde53ff63535d548a3c038b2a84b89afde3a
<pre>
RealtimeMediaSource error logging is wrong for zoom and frame rate constraints
<a href="https://rdar.apple.com/121949844">rdar://121949844</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269700">https://bugs.webkit.org/show_bug.cgi?id=269700</a>

Reviewed by Eric Carlson.

Debug ASSERTs were changed into RELEASE_ASSERT in <a href="https://github.com/WebKit/WebKit/commit/f685afa11acafdf44fd60af91b837cb1f3bf85f9.">https://github.com/WebKit/WebKit/commit/f685afa11acafdf44fd60af91b837cb1f3bf85f9.</a>
But these asserts are hit since our loggings are mistakenly calling longRange() for double constraints.
Update our logging code to use double constraints and add corresponding tests.
We downgrade the two RELEASE_ASSERT to ASSERT like it was the case before <a href="https://github.com/WebKit/WebKit/commit/f685afa11acafdf44fd60af91b837cb1f3bf85f9.">https://github.com/WebKit/WebKit/commit/f685afa11acafdf44fd60af91b837cb1f3bf85f9.</a>
A future patch should further refactor this code to remove these ASSERTS.

* LayoutTests/fast/mediastream/applyConstraints-bad-constraints-expected.txt: Added.
* LayoutTests/fast/mediastream/applyConstraints-bad-constraints.html: Added.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::hasInvalidSizeFrameRateAndZoomConstraints):

Canonical link: <a href="https://commits.webkit.org/275036@main">https://commits.webkit.org/275036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c398de57d2408396a20406d908cd2a4c61f72ec2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17067 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44553 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40141 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38482 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35370 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9122 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->