### PR TITLE
[Skia] Implement PathSkia::strokeContains

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -602,6 +602,7 @@ add_library(Skia STATIC
     src/image/SkRescaleAndReadPixels.cpp
     src/image/SkSurface.cpp
     src/image/SkSurface_Base.cpp
+    src/image/SkSurface_Null.cpp
     src/image/SkSurface_Raster.cpp
 
     src/effects/Sk1DPathEffect.cpp

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -29,6 +29,7 @@
 
 #include "GraphicsContext.h"
 #include <skia/core/SkCanvas.h>
+#include <skia/effects/SkDashPathEffect.h>
 
 IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
 #include <skia/core/SkSurface.h>
@@ -99,6 +100,7 @@ public:
     RenderingMode renderingMode() const final;
 
     SkPaint createFillPaint(std::optional<Color> fillColor = std::nullopt) const;
+    SkPaint createStrokeStylePaint() const;
     SkPaint createStrokePaint(std::optional<Color> strokeColor = std::nullopt) const;
 
 private:
@@ -112,12 +114,8 @@ private:
             SkScalar miter { SkFloatToScalar(4) };
             SkPaint::Cap cap { SkPaint::kButt_Cap };
             SkPaint::Join join { SkPaint::kMiter_Join };
+            sk_sp<SkPathEffect> dash;
         } m_stroke;
-
-        struct {
-            DashArray array;
-            float offset { 0.0f };
-        } m_dash;
     };
 
     sk_sp<SkSurface> m_surface;


### PR DESCRIPTION
#### f7d847c5baf3deec5e1fb251cdb93a960cad58f7
<pre>
[Skia] Implement PathSkia::strokeContains
<a href="https://bugs.webkit.org/show_bug.cgi?id=269701">https://bugs.webkit.org/show_bug.cgi?id=269701</a>

Reviewed by Adrian Perez de Castro.

This patch adds GraphicsContextSkia::createStrokeStylePaint() that
creates the SkPaint for stroke with only the stroke style state, because
it&apos;s needed by PathSkia::strokeContains(). It also simplifies the dash
line handling by creating the SkDashPathEffect when the line dash is
set instead of when it&apos;s applied.

* Source/ThirdParty/skia/CMakeLists.txt:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::createStrokeStylePaint const):
(WebCore::GraphicsContextSkia::createStrokePaint const):
(WebCore::GraphicsContextSkia::setLineDash):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::strokeContains const):

Canonical link: <a href="https://commits.webkit.org/274973@main">https://commits.webkit.org/274973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/344015be0a99a68540c98426fce2605dab4476ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16896 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14230 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44379 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36256 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15368 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12597 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17038 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5382 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->