### PR TITLE
[LibWebRTC] Build fails with clang on Linux

### DIFF
--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp
@@ -29,6 +29,7 @@
 
 #include "LibWebRTCMacros.h"
 #include "LibWebRTCProvider.h"
+#include "LibWebRTCUtils.h"
 #include "RTCCertificate.h"
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
@@ -44,11 +45,6 @@ ALLOW_UNUSED_PARAMETERS_END
 namespace WebCore {
 
 namespace LibWebRTCCertificateGenerator {
-
-static inline String fromStdString(const std::string& value)
-{
-    return String::fromUTF8(value.data(), value.length());
-}
 
 class RTCCertificateGeneratorCallbackWrapper : public ThreadSafeRefCounted<RTCCertificateGeneratorCallbackWrapper, WTF::DestructionThread::Main> {
 public:

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -30,6 +30,7 @@
 
 #include "ContentType.h"
 #include "LibWebRTCAudioModule.h"
+#include "LibWebRTCUtils.h"
 #include "Logging.h"
 #include "MediaCapabilitiesDecodingInfo.h"
 #include "MediaCapabilitiesEncodingInfo.h"
@@ -424,11 +425,6 @@ static inline std::optional<cricket::MediaType> typeFromKind(const String& kind)
     if (kind == "video"_s)
         return cricket::MediaType::MEDIA_TYPE_VIDEO;
     return { };
-}
-
-static inline String fromStdString(const std::string& value)
-{
-    return String::fromUTF8(value.data(), value.length());
 }
 
 static inline std::optional<uint16_t> toChannels(absl::optional<int> numChannels)


### PR DESCRIPTION
#### 4278c2f09831654c985a90e362f522fda88041f9
<pre>
[LibWebRTC] Build fails with clang on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=269707">https://bugs.webkit.org/show_bug.cgi?id=269707</a>

Reviewed by Youenn Fablet.

Remove duplicate fromStdString() implementations.

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp:
(WebCore::LibWebRTCCertificateGenerator::fromStdString): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::fromStdString): Deleted.

Canonical link: <a href="https://commits.webkit.org/274980@main">https://commits.webkit.org/274980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aa7b977307dc06d5a45af9217eefae65d532cbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33653 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14237 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14311 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36776 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40008 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38341 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16995 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9086 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->