### PR TITLE
Sync `auto-play-in-sandbox-with-allow-scripts.html` from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/media/auto-play-in-sandbox-with-allow-scripts-expected.txt
+++ b/LayoutTests/media/auto-play-in-sandbox-with-allow-scripts-expected.txt
@@ -1,13 +1,4 @@
 
 
---------
-Frame: '<!--frame1-->'
---------
-
-Test that play event fires when "src" set with an autoplay attribute in a sandbox with allows-scripts.
-
-EXPECTED (video.paused == 'true') OK
-EVENT(play)
-PLAY fired OK
-END OF TEST
+PASS Test that play event fires when "src" set with an autoplay attribute in a sandbox with allows-scripts.
 

--- a/LayoutTests/media/auto-play-in-sandbox-with-allow-scripts.html
+++ b/LayoutTests/media/auto-play-in-sandbox-with-allow-scripts.html
@@ -1,10 +1,20 @@
-<script>
-if (window.testRunner) {
-    testRunner.dumpAsText();
-    testRunner.dumpChildFramesAsText();
-}
-</script>
+<!DOCTYPE html>
+<title>Test that play event fires when "src" set with an autoplay attribute in a sandbox with allows-scripts.</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
 <iframe
-    style="width: 400px; height: 600px"
     sandbox="allow-scripts allow-same-origin"
-    src="resources/auto-play-in-sandbox-with-allow-scripts-iframe.html"></iframe>
+    src="resources/auto-play-in-sandbox-with-allow-scripts-iframe.html">
+</iframe>
+<script>
+async_test(function(t) {
+    var iframe = document.querySelector("iframe");
+
+    iframe.onload = t.step_func(function() {
+        var video = iframe.contentDocument.querySelector("video");
+        assert_true(video.paused);
+        video.onplay = t.step_func_done();
+        video.src = "content/test.mp4";
+    });
+});
+</script>

--- a/LayoutTests/media/resources/auto-play-in-sandbox-with-allow-scripts-iframe.html
+++ b/LayoutTests/media/resources/auto-play-in-sandbox-with-allow-scripts-iframe.html
@@ -1,15 +1,3 @@
+<!DOCTYPE html>
 <base href="..">
-<video autoplay controls></video>
-<p>Test that play event fires when "src" set with an autoplay attribute in a sandbox with allows-scripts.</p>
-<script src=media-file.js></script>
-<script src=video-test.js></script>
-<script>
-    testExpected("video.paused", true);
-
-    waitForEvent('play', function () {
-        logResult(true, "PLAY fired");
-        endTest();
-    } );
-
-    video.src = findMediaFile("video", "content/test");
-</script>
+<video autoplay></video>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1100,8 +1100,6 @@ webkit.org/b/138697 fast/events/overflow-scroll-fake-mouse-move.html [ Pass Fail
 
 webkit.org/b/82747 fast/events/scroll-div-with-prevent-default-in-subframe.html [ Failure ]
 
-webkit.org/b/112533 media/auto-play-in-sandbox-with-allow-scripts.html [ Pass Timeout ]
-
 webkit.org/b/139778 fullscreen/exit-full-screen-iframe.html [ Skip ]
 
 webkit.org/b/139778 fullscreen/enter-fullscreen-main-frame-window-open-iframe.html [ Skip ]


### PR DESCRIPTION
#### 281bb85fd5a55bf1d0245993a879bde442d9f6d9
<pre>
Sync `auto-play-in-sandbox-with-allow-scripts.html` from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=112533">https://bugs.webkit.org/show_bug.cgi?id=112533</a>

Reviewed by Eric Carlson.

This patch is to sync `auto-play-in-sandbox-with-allow-scripts.html` from
Blink / Chromium upstream as per below commit:

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/66f2fa7fc9c02fe7929245a915433602c956a959">https://source.chromium.org/chromium/chromium/src/+/66f2fa7fc9c02fe7929245a915433602c956a959</a>

&gt; Test &amp; Test Expectations Updated:
* LayoutTests/media/auto-play-in-sandbox-with-allow-scripts.html:
* LayoutTests/media/resources/auto-play-in-sandbox-with-allow-scripts-iframe.html:
* LayoutTests/media/auto-play-in-sandbox-with-allow-scripts-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/275009@main">https://commits.webkit.org/275009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbd03bb2d855a40435f466bdb344b1d70cfd7deb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36653 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33655 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14239 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40009 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38338 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9100 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17049 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->