### PR TITLE
[WGSL] Add support for constant structs

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -109,10 +109,11 @@ static ConstantValue zeroValue(const Type* type)
                 result.elements[i] = value;
             return result;
         },
-        [&](const Types::Struct&) -> ConstantValue {
-            // FIXME: this is valid and needs to be implemented, but we don't
-            // yet have ConstantStruct
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Types::Struct& structType) -> ConstantValue {
+            HashMap<String, ConstantValue> constantFields;
+            for (auto& [key, type] : structType.fields)
+                constantFields.set(key, zeroValue(type));
+            return ConstantStruct { WTFMove(constantFields) };
         },
         [&](const Types::PrimitiveStruct&) -> ConstantValue {
             // Primitive structs can't be zero initialized


### PR DESCRIPTION
#### 3cfd9dd3b52c39e46afe97c1a9460418d3c98b84
<pre>
[WGSL] Add support for constant structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=269710">https://bugs.webkit.org/show_bug.cgi?id=269710</a>
<a href="https://rdar.apple.com/123238708">rdar://123238708</a>

Reviewed by Mike Wyrzykowski.

We already had ConstantStruct, but it was only being used for primitive structs
(like the one returned by frexp), so we just needed to create the constant values
and add the lookup logic to FieldAccessExpression.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::convertValueImpl):

Canonical link: <a href="https://commits.webkit.org/275043@main">https://commits.webkit.org/275043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc2e2f56bb85c1b6bd6aefe3e3e17ca9516d0507

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16927 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33671 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14333 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44409 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36800 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36287 "Found 2 new test failures: http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html, http/tests/navigation/ping-attribute/area-cross-origin-from-https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40026 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38357 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17017 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9128 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->