### PR TITLE
WASM return should be able to return to JIT or LLInt

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -704,6 +704,12 @@ end
 #         end
 #     )
 #
+# LLIntSlowPaths.h
+# extern "C" __attribute__((__used__)) __attribute__((visibility("hidden"))) void cProbeCallbackFunction(uint64_t);
+# LLIntSlowPaths.cpp:
+# extern "C" void cProbeCallbackFunction(uint64_t arg0) {}
+#
+
 if X86_64 or ARM64 or ARM64E or ARMv7
     macro probe(action)
         # save all the registers that the LLInt may use.

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -761,12 +761,7 @@ end
 macro doReturn()
     restoreCalleeSavesUsedByWasm()
     restoreCallerPCAndCFR()
-    if ARM64E
-        leap _g_config, ws0
-        jmp JSCConfigGateMapOffset + (constexpr Gate::returnFromLLInt) * PtrSize[ws0], NativeToJITGatePtrTag
-    else
-        ret
-    end
+    ret
 end
 
 # Entry point
@@ -777,6 +772,17 @@ op(wasm_function_prologue, macro ()
     end
 
     wasmPrologue()
+
+    if ARM64E
+        call _wasm_function_prologue_return_thru_returnFromLLInt
+        pop lr, cfr
+        leap _g_config, ws0
+        jmp JSCConfigGateMapOffset + (constexpr Gate::returnFromLLInt) * PtrSize[ws0], NativeToJITGatePtrTag
+        break
+_wasm_function_prologue_return_thru_returnFromLLInt:
+        push cfr, lr
+    end
+
     wasmNextInstruction()
 end)
 


### PR DESCRIPTION
#### d5a7e905b8fe42368d7f15523c4e472ef5f625a6
<pre>
WASM return should be able to return to JIT or LLInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=269712">https://bugs.webkit.org/show_bug.cgi?id=269712</a>
<a href="https://rdar.apple.com/123239124">rdar://123239124</a>

Reviewed by NOBODY (OOPS!).

Today, wasm_function_prologue is always reached from JIT. Soon we want
that to change. In preparation, we change ret to work in both cases without
breaking operation validation.

* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5a7e905b8fe42368d7f15523c4e472ef5f625a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43123 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36660 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33665 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44397 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34024 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40017 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40197 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38347 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17005 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47207 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17056 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9706 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16649 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->