### PR TITLE
Simplify CapabilityRange

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
@@ -32,34 +32,25 @@
 
 namespace WebCore {
 
-static DoubleRange capabilityDoubleRange(const CapabilityRange& value)
+static DoubleRange capabilityDoubleRange(const DoubleCapabilityRange& value)
 {
-    if (value.type() == CapabilityRange::Type::DoubleRange) {
-        DoubleRange range;
-        auto min = value.doubleRange().min;
-        auto max = value.doubleRange().max;
+    auto min = value.min();
+    auto max = value.max();
 
-        ASSERT(min != std::numeric_limits<double>::min() || max != std::numeric_limits<double>::max());
+    ASSERT(min != std::numeric_limits<double>::min() || max != std::numeric_limits<double>::max());
 
-        if (min != std::numeric_limits<double>::min())
-            range.min = min;
-        if (max != std::numeric_limits<double>::max())
-            range.max = max;
+    DoubleRange range;
+    if (min != std::numeric_limits<double>::min())
+        range.min = min;
+    if (max != std::numeric_limits<double>::max())
+        range.max = max;
 
-        return range;
-    }
-
-    ASSERT_NOT_REACHED();
-    return { };
+    return range;
 }
 
-static LongRange capabilityIntRange(const CapabilityRange& value)
+static LongRange capabilityLongRange(const LongCapabilityRange& value)
 {
-    if (value.type() == CapabilityRange::Type::LongRange)
-        return { value.longRange().max, value.longRange().min };
-
-    ASSERT_NOT_REACHED();
-    return { };
+    return { value.max(), value.min() };
 }
 
 static Vector<String> capabilityStringVector(const Vector<VideoFacingMode>& modes)
@@ -90,9 +81,9 @@ MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabil
 {
     MediaTrackCapabilities result;
     if (capabilities.supportsWidth())
-        result.width = capabilityIntRange(capabilities.width());
+        result.width = capabilityLongRange(capabilities.width());
     if (capabilities.supportsHeight())
-        result.height = capabilityIntRange(capabilities.height());
+        result.height = capabilityLongRange(capabilities.height());
     if (capabilities.supportsAspectRatio())
         result.aspectRatio = capabilityDoubleRange(capabilities.aspectRatio());
     if (capabilities.supportsFrameRate())
@@ -102,9 +93,9 @@ MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabil
     if (capabilities.supportsVolume())
         result.volume = capabilityDoubleRange(capabilities.volume());
     if (capabilities.supportsSampleRate())
-        result.sampleRate = capabilityIntRange(capabilities.sampleRate());
+        result.sampleRate = capabilityLongRange(capabilities.sampleRate());
     if (capabilities.supportsSampleSize())
-        result.sampleSize = capabilityIntRange(capabilities.sampleSize());
+        result.sampleSize = capabilityLongRange(capabilities.sampleSize());
     if (capabilities.supportsEchoCancellation())
         result.echoCancellation = capabilityBooleanVector(capabilities.echoCancellation());
     if (capabilities.supportsDeviceId())

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -119,7 +119,7 @@ public:
     template<typename RangeType>
     double fitnessDistance(const RangeType& range) const
     {
-        return fitnessDistance(range.min, range.max);
+        return fitnessDistance(range.min(), range.max());
     }
 
     double fitnessDistance(ValueType rangeMin, ValueType rangeMax) const
@@ -233,7 +233,7 @@ public:
     template<typename RangeType>
     ValueType valueForCapabilityRange(ValueType current, const RangeType& range) const
     {
-        return valueForCapabilityRange(current, range.min, range.max);
+        return valueForCapabilityRange(current, range.min(), range.max());
     }
 
     ValueType valueForCapabilityRange(ValueType current, ValueType capabilityMin, ValueType capabilityMax) const

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -474,7 +474,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         if (std::isinf(constraintDistance)) {
 #if !RELEASE_LOG_DISABLED
             auto range = capabilities.width();
-            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed width constraint, capabilities are [", range.longRange().min, ", ", range.longRange().max, "]");
+            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed width constraint, capabilities are [", range.min(), ", ", range.max(), "]");
 #endif
             return MediaConstraintType::Width;
         }
@@ -482,7 +482,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         distance = std::min(distance, constraintDistance);
         if (widthConstraint->isMandatory()) {
             auto range = capabilities.width();
-            width = widthConstraint->valueForCapabilityRange(size().width(), range.longRange());
+            width = widthConstraint->valueForCapabilityRange(size().width(), range);
         }
     }
 
@@ -492,7 +492,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         if (std::isinf(constraintDistance)) {
 #if !RELEASE_LOG_DISABLED
             auto range = capabilities.height();
-            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed height constraint, capabilities are [%d, %d]", range.longRange().min, range.longRange().max);
+            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed height constraint, capabilities are [%d, %d]", range.min(), range.max());
 #endif
             return MediaConstraintType::Height;
         }
@@ -500,7 +500,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         distance = std::min(distance, constraintDistance);
         if (heightConstraint->isMandatory()) {
             auto range = capabilities.height();
-            height = heightConstraint->valueForCapabilityRange(size().height(), range.longRange());
+            height = heightConstraint->valueForCapabilityRange(size().height(), range);
         }
     }
 
@@ -510,7 +510,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         if (std::isinf(constraintDistance)) {
 #if !RELEASE_LOG_DISABLED
             auto range = capabilities.frameRate();
-            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed frame rate constraint, capabilities are [", range.doubleRange().min, ", ", range.doubleRange().max, "]");
+            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed frame rate constraint, capabilities are [", range.min(), ", ", range.max(), "]");
 #endif
             return MediaConstraintType::FrameRate;
         }
@@ -518,7 +518,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         distance = std::min(distance, constraintDistance);
         if (frameRateConstraint->isMandatory()) {
             auto range = capabilities.frameRate();
-            frameRate = frameRateConstraint->valueForCapabilityRange(this->frameRate(), range.doubleRange());
+            frameRate = frameRateConstraint->valueForCapabilityRange(this->frameRate(), range);
         }
     }
 
@@ -528,7 +528,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         if (std::isinf(constraintDistance)) {
 #if !RELEASE_LOG_DISABLED
             auto range = capabilities.zoom();
-            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed zoom constraint, capabilities are [", range.doubleRange().min, ", ", range.doubleRange().max, "]");
+            ERROR_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource::supportsSizeFrameRateAndZoom failed zoom constraint, capabilities are [", range.min(), ", ", range.max(), "]");
 #endif
             return MediaConstraintType::Zoom;
         }
@@ -536,7 +536,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasInvalidSizeFrameRateA
         distance = std::min(distance, constraintDistance);
         if (zoomConstraint->isMandatory()) {
             auto range = capabilities.zoom();
-            zoom = zoomConstraint->valueForCapabilityRange(this->zoom(), range.doubleRange());
+            zoom = zoomConstraint->valueForCapabilityRange(this->zoom(), range);
         }
     }
 
@@ -566,12 +566,12 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
         if (!capabilities.supportsWidth())
             return 0;
 
-        return constraint.fitnessDistance(capabilities.width().longRange());
+        return constraint.fitnessDistance(capabilities.width());
     case MediaConstraintType::Height:
         if (!capabilities.supportsHeight())
             return 0;
 
-        return constraint.fitnessDistance(capabilities.height().longRange());
+        return constraint.fitnessDistance(capabilities.height());
     case MediaConstraintType::SampleRate:
         if (!capabilities.supportsSampleRate())
             return 0;
@@ -579,7 +579,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
         if (auto discreteRates = discreteSampleRates())
             return constraint.fitnessDistance(*discreteRates);
 
-        return constraint.fitnessDistance(capabilities.sampleRate().longRange());
+        return constraint.fitnessDistance(capabilities.sampleRate());
     case MediaConstraintType::SampleSize:
         if (!capabilities.supportsSampleSize())
             return 0;
@@ -587,7 +587,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
         if (auto discreteSizes = discreteSampleSizes())
             return constraint.fitnessDistance(*discreteSizes);
 
-        return constraint.fitnessDistance(capabilities.sampleSize().longRange());
+        return constraint.fitnessDistance(capabilities.sampleSize());
     case MediaConstraintType::FrameRate:
     case MediaConstraintType::AspectRatio:
     case MediaConstraintType::Volume:
@@ -617,22 +617,22 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
         if (!capabilities.supportsFrameRate())
             return 0;
 
-        return constraint.fitnessDistance(capabilities.frameRate().doubleRange());
+        return constraint.fitnessDistance(capabilities.frameRate());
     case MediaConstraintType::AspectRatio:
         if (!capabilities.supportsAspectRatio())
             return 0;
 
-        return constraint.fitnessDistance(capabilities.aspectRatio().doubleRange());
+        return constraint.fitnessDistance(capabilities.aspectRatio());
     case MediaConstraintType::Volume:
         if (!capabilities.supportsVolume())
             return 0;
 
-        return constraint.fitnessDistance(capabilities.volume().doubleRange());
+        return constraint.fitnessDistance(capabilities.volume());
     case MediaConstraintType::Zoom:
         if (!capabilities.supportsZoom())
             return 0;
 
-        return constraint.fitnessDistance(capabilities.zoom().doubleRange());
+        return constraint.fitnessDistance(capabilities.zoom());
     case MediaConstraintType::Width:
     case MediaConstraintType::Height:
     case MediaConstraintType::SampleRate:
@@ -815,7 +815,7 @@ void RealtimeMediaSource::applyConstraint(MediaConstraintType constraintType, co
             return;
 
         auto range = capabilities.zoom();
-        applyNumericConstraint(downcast<DoubleConstraint>(constraint), zoom(), { }, range.doubleRange().min, range.doubleRange().max, *this, &RealtimeMediaSource::setZoom);
+        applyNumericConstraint(downcast<DoubleConstraint>(constraint), zoom(), { }, range.min(), range.max(), *this, &RealtimeMediaSource::setZoom);
         break;
     }
 
@@ -825,7 +825,7 @@ void RealtimeMediaSource::applyConstraint(MediaConstraintType constraintType, co
             return;
 
         auto range = capabilities.sampleRate();
-        applyNumericConstraint(downcast<IntConstraint>(constraint), sampleRate(), discreteSampleRates(), range.longRange().min, range.longRange().max, *this, &RealtimeMediaSource::setSampleRate);
+        applyNumericConstraint(downcast<IntConstraint>(constraint), sampleRate(), discreteSampleRates(), range.min(), range.max(), *this, &RealtimeMediaSource::setSampleRate);
         break;
     }
 
@@ -835,7 +835,7 @@ void RealtimeMediaSource::applyConstraint(MediaConstraintType constraintType, co
             return;
 
         auto range = capabilities.sampleSize();
-        applyNumericConstraint(downcast<IntConstraint>(constraint), sampleSize(), { }, range.longRange().min, range.longRange().max, *this, &RealtimeMediaSource::setSampleSize);
+        applyNumericConstraint(downcast<IntConstraint>(constraint), sampleSize(), { }, range.min(), range.max(), *this, &RealtimeMediaSource::setSampleSize);
         break;
     }
 
@@ -905,7 +905,7 @@ void RealtimeMediaSource::applyConstraint(MediaConstraintType constraintType, co
             return;
 
         auto range = capabilities.volume();
-        applyNumericConstraint(downcast<DoubleConstraint>(constraint), volume(), { }, range.doubleRange().min, range.doubleRange().max, *this, &RealtimeMediaSource::setVolume);
+        applyNumericConstraint(downcast<DoubleConstraint>(constraint), volume(), { }, range.min(), range.max(), *this, &RealtimeMediaSource::setVolume);
         break;
     }
 
@@ -1163,17 +1163,13 @@ RealtimeMediaSource::VideoFrameSizeConstraints RealtimeMediaSource::extractVideo
     auto& capabilities = this->capabilities();
 
     if (auto constraint = constraints.width()) {
-        if (capabilities.supportsWidth()) {
-            auto range = capabilities.width();
-            result.width = constraint->valueForCapabilityRange(size().width(), range.longRange());
-        }
+        if (capabilities.supportsWidth())
+            result.width = constraint->valueForCapabilityRange(size().width(), capabilities.width());
     }
 
     if (auto constraint = constraints.height()) {
-        if (capabilities.supportsHeight()) {
-            auto range = capabilities.height();
-            result.height = constraint->valueForCapabilityRange(size().height(), range.longRange());
-        }
+        if (capabilities.supportsHeight())
+            result.height = constraint->valueForCapabilityRange(size().height(), capabilities.height());
     }
 
     if (auto constraint = constraints.aspectRatio()) {
@@ -1181,7 +1177,7 @@ RealtimeMediaSource::VideoFrameSizeConstraints RealtimeMediaSource::extractVideo
             auto size = this->size();
             auto range = capabilities.aspectRatio();
             auto currentAspectRatio = size.width() ? size.width() / static_cast<double>(size.height()) : 0;
-            if (auto aspectRatio = constraint->valueForCapabilityRange(currentAspectRatio, range.doubleRange())) {
+            if (auto aspectRatio = constraint->valueForCapabilityRange(currentAspectRatio, range)) {
                 if (!result.width && result.height)
                     result.width = *result.height * aspectRatio;
                 if (result.width && !result.height)
@@ -1193,7 +1189,7 @@ RealtimeMediaSource::VideoFrameSizeConstraints RealtimeMediaSource::extractVideo
     if (auto constraint = constraints.frameRate()) {
         if (capabilities.supportsFrameRate()) {
             auto range = capabilities.frameRate();
-            result.frameRate = constraint->valueForCapabilityRange(this->frameRate(), range.doubleRange());
+            result.frameRate = constraint->valueForCapabilityRange(this->frameRate(), range);
         }
     }
 
@@ -1214,7 +1210,7 @@ void RealtimeMediaSource::applyConstraints(const MediaTrackConstraintSetMap& con
         auto& capabilities = this->capabilities();
         if (capabilities.supportsZoom()) {
             auto range = capabilities.zoom();
-            zoom = constraint->valueForCapabilityRange(this->zoom(), range.doubleRange());
+            zoom = constraint->valueForCapabilityRange(this->zoom(), range);
         }
     }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -37,83 +37,41 @@
 
 namespace WebCore {
 
+template<typename T>
 class CapabilityRange {
-private:
-    friend struct IPC::ArgumentCoder<CapabilityRange, void>;
 public:
-    struct LongRange {
-        LongRange(int max, int min)
-            : max(max)
-            , min(min)
-        {
-            RELEASE_ASSERT(min <= max);
-        }
-        int max;
-        int min;
-    };
-
-    struct DoubleRange {
-        DoubleRange(double max, double min)
-            : max(max)
-            , min(min)
-        {
-            RELEASE_ASSERT(min <= max);
-        }
-        double max;
-        double min;
-    };
-
-    enum class Type : uint8_t {
-        Undefined,
-        DoubleRange,
-        LongRange,
-    };
-    Type type() const
-    {
-        if (m_doubleRange)
-            return Type::DoubleRange;
-        if (m_longRange)
-            return Type::LongRange;
-        return Type::Undefined;
-    }
-
     CapabilityRange() = default;
-
-    CapabilityRange(double value)
-        : m_doubleRange({ value, value })
+    CapabilityRange(T min, T max)
+        : m_min(min)
+        , m_max(max)
     {
+        RELEASE_ASSERT(min <= max);
     }
 
-    CapabilityRange(int value)
-        : m_longRange({ value, value })
-    {
-    }
-
-    CapabilityRange(double min, double max)
-        : m_doubleRange({ max, min })
-    {
-    }
-    
-    CapabilityRange(int min, int max)
-        : m_longRange({ max, min })
-    {
-    }
-
-    const DoubleRange& doubleRange() const
-    {
-        ASSERT(m_doubleRange);
-        return *m_doubleRange;
-    }
-
-    const LongRange& longRange() const
-    {
-        ASSERT(m_longRange);
-        return *m_longRange;
-    }
+    T min() const { return m_min; }
+    T max() const { return m_max; }
 
 private:
-    std::optional<DoubleRange> m_doubleRange;
-    std::optional<LongRange> m_longRange;
+    T m_min { 0 };
+    T m_max { 0 };
+};
+
+class LongCapabilityRange : public CapabilityRange<int> {
+public:
+    LongCapabilityRange() = default;
+    LongCapabilityRange(int min, int max)
+        : CapabilityRange(min, max)
+    {
+    }
+};
+
+class DoubleCapabilityRange : public CapabilityRange<double> {
+public:
+    DoubleCapabilityRange() = default;
+    DoubleCapabilityRange(double min, double max)
+        : CapabilityRange(min, max)
+    {
+    }
 };
 
 class RealtimeMediaSourceCapabilities {
@@ -129,7 +87,7 @@ public:
         ReadWrite = 1,
     };
     
-    RealtimeMediaSourceCapabilities(CapabilityRange width, CapabilityRange height, CapabilityRange aspectRatio, CapabilityRange frameRate, Vector<VideoFacingMode>&& facingMode, CapabilityRange volume, CapabilityRange sampleRate, CapabilityRange sampleSize, EchoCancellation echoCancellation, String&& deviceId, String&& groupId, CapabilityRange focusDistance, Vector<MeteringMode>&& whiteBalanceModes, CapabilityRange zoom, bool torch, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceCapabilities(LongCapabilityRange width, LongCapabilityRange height, DoubleCapabilityRange aspectRatio, DoubleCapabilityRange frameRate, Vector<VideoFacingMode>&& facingMode, DoubleCapabilityRange volume, LongCapabilityRange sampleRate, LongCapabilityRange sampleSize, EchoCancellation echoCancellation, String&& deviceId, String&& groupId, DoubleCapabilityRange focusDistance, Vector<MeteringMode>&& whiteBalanceModes, DoubleCapabilityRange zoom, bool torch, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(WTFMove(width))
         , m_height(WTFMove(height))
         , m_aspectRatio(WTFMove(aspectRatio))
@@ -158,36 +116,36 @@ public:
     }
 
     bool supportsWidth() const { return m_supportedConstraints.supportsWidth(); }
-    const CapabilityRange& width() const { return m_width; }
-    void setWidth(const CapabilityRange& width) { m_width = width; }
+    const LongCapabilityRange& width() const { return m_width; }
+    void setWidth(const LongCapabilityRange& width) { m_width = width; }
 
     bool supportsHeight() const { return m_supportedConstraints.supportsHeight(); }
-    const CapabilityRange& height() const { return m_height; }
-    void setHeight(const CapabilityRange& height) { m_height = height; }
+    const LongCapabilityRange& height() const { return m_height; }
+    void setHeight(const LongCapabilityRange& height) { m_height = height; }
 
     bool supportsFrameRate() const { return m_supportedConstraints.supportsFrameRate(); }
-    const CapabilityRange& frameRate() const { return m_frameRate; }
-    void setFrameRate(const CapabilityRange& frameRate) { m_frameRate = frameRate; }
+    const DoubleCapabilityRange& frameRate() const { return m_frameRate; }
+    void setFrameRate(const DoubleCapabilityRange& frameRate) { m_frameRate = frameRate; }
 
     bool supportsFacingMode() const { return m_supportedConstraints.supportsFacingMode(); }
     const Vector<VideoFacingMode>& facingMode() const { return m_facingMode; }
     void addFacingMode(VideoFacingMode mode) { m_facingMode.append(mode); }
 
     bool supportsAspectRatio() const { return m_supportedConstraints.supportsAspectRatio(); }
-    const CapabilityRange& aspectRatio() const { return m_aspectRatio; }
-    void setAspectRatio(const CapabilityRange& aspectRatio) { m_aspectRatio = aspectRatio; }
+    const DoubleCapabilityRange& aspectRatio() const { return m_aspectRatio; }
+    void setAspectRatio(const DoubleCapabilityRange& aspectRatio) { m_aspectRatio = aspectRatio; }
 
     bool supportsVolume() const { return m_supportedConstraints.supportsVolume(); }
-    const CapabilityRange& volume() const { return m_volume; }
-    void setVolume(const CapabilityRange& volume) { m_volume = volume; }
+    const DoubleCapabilityRange& volume() const { return m_volume; }
+    void setVolume(const DoubleCapabilityRange& volume) { m_volume = volume; }
 
     bool supportsSampleRate() const { return m_supportedConstraints.supportsSampleRate(); }
-    const CapabilityRange& sampleRate() const { return m_sampleRate; }
-    void setSampleRate(const CapabilityRange& sampleRate) { m_sampleRate = sampleRate; }
+    const LongCapabilityRange& sampleRate() const { return m_sampleRate; }
+    void setSampleRate(const LongCapabilityRange& sampleRate) { m_sampleRate = sampleRate; }
 
     bool supportsSampleSize() const { return m_supportedConstraints.supportsSampleSize(); }
-    const CapabilityRange& sampleSize() const { return m_sampleSize; }
-    void setSampleSize(const CapabilityRange& sampleSize) { m_sampleSize = sampleSize; }
+    const LongCapabilityRange& sampleSize() const { return m_sampleSize; }
+    void setSampleSize(const LongCapabilityRange& sampleSize) { m_sampleSize = sampleSize; }
 
     bool supportsEchoCancellation() const { return m_supportedConstraints.supportsEchoCancellation(); }
     EchoCancellation echoCancellation() const { return m_echoCancellation; }
@@ -202,16 +160,16 @@ public:
     void setGroupId(const String& id)  { m_groupId = id; }
 
     bool supportsFocusDistance() const { return m_supportedConstraints.supportsFocusDistance(); }
-    const CapabilityRange& focusDistance() const { return m_focusDistance; }
-    void setFocusDistance(const CapabilityRange& focusDistance) { m_focusDistance = focusDistance; }
+    const DoubleCapabilityRange& focusDistance() const { return m_focusDistance; }
+    void setFocusDistance(const DoubleCapabilityRange& focusDistance) { m_focusDistance = focusDistance; }
 
     bool supportsWhiteBalanceMode() const { return m_supportedConstraints.supportsWhiteBalanceMode(); }
     const Vector<MeteringMode>& whiteBalanceModes() const { return m_whiteBalanceModes; }
     void setWhiteBalanceModes(Vector<MeteringMode>&& modes) { m_whiteBalanceModes = WTFMove(modes); }
 
     bool supportsZoom() const { return m_supportedConstraints.supportsZoom(); }
-    const CapabilityRange& zoom() const { return m_zoom; }
-    void setZoom(const CapabilityRange& zoom) { m_zoom = zoom; }
+    const DoubleCapabilityRange& zoom() const { return m_zoom; }
+    void setZoom(const DoubleCapabilityRange& zoom) { m_zoom = zoom; }
 
     bool supportsTorch() const { return m_supportedConstraints.supportsTorch(); }
     bool torch() const { return m_torch; }
@@ -223,21 +181,21 @@ public:
     RealtimeMediaSourceCapabilities isolatedCopy() const { return { m_width, m_height, m_aspectRatio, m_frameRate, Vector<VideoFacingMode> { m_facingMode }, m_volume, m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_focusDistance, Vector<MeteringMode> { m_whiteBalanceModes }, m_zoom, m_torch, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } }; }
 
 private:
-    CapabilityRange m_width;
-    CapabilityRange m_height;
-    CapabilityRange m_aspectRatio;
-    CapabilityRange m_frameRate;
+    LongCapabilityRange m_width;
+    LongCapabilityRange m_height;
+    DoubleCapabilityRange m_aspectRatio;
+    DoubleCapabilityRange m_frameRate;
     Vector<VideoFacingMode> m_facingMode;
-    CapabilityRange m_volume;
-    CapabilityRange m_sampleRate;
-    CapabilityRange m_sampleSize;
+    DoubleCapabilityRange m_volume;
+    LongCapabilityRange m_sampleRate;
+    LongCapabilityRange m_sampleSize;
     EchoCancellation m_echoCancellation { EchoCancellation::ReadOnly };
     String m_deviceId;
     String m_groupId;
-    CapabilityRange m_focusDistance;
+    DoubleCapabilityRange m_focusDistance;
 
     Vector<MeteringMode> m_whiteBalanceModes;
-    CapabilityRange m_zoom;
+    DoubleCapabilityRange m_zoom;
     bool m_torch { false };
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -125,9 +125,9 @@ const RealtimeMediaSourceCapabilities& DisplayCaptureSourceCocoa::capabilities()
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
 
         auto intrinsicSize = m_capturer->intrinsicSize();
-        capabilities.setWidth(CapabilityRange(1, intrinsicSize.width()));
-        capabilities.setHeight(CapabilityRange(1, intrinsicSize.height()));
-        capabilities.setFrameRate(CapabilityRange(.01, 30.0));
+        capabilities.setWidth({ 1, intrinsicSize.width() });
+        capabilities.setHeight({ 1, intrinsicSize.height() });
+        capabilities.setFrameRate({ .01, 30.0 });
 
         m_capabilities = WTFMove(capabilities);
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -35,9 +35,9 @@
 
 namespace WebCore {
 
-static CapabilityRange defaultVolumeCapability()
+static DoubleCapabilityRange defaultVolumeCapability()
 {
-    return CapabilityRange(0.0, 1.0);
+    return { 0.0, 1.0 };
 }
 const static RealtimeMediaSourceCapabilities::EchoCancellation defaultEchoCancellationCapability = RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite;
 
@@ -160,7 +160,7 @@ const RealtimeMediaSourceCapabilities& GStreamerAudioCaptureSource::capabilities
     capabilities.setDeviceId(hashedId());
     capabilities.setEchoCancellation(defaultEchoCancellationCapability);
     capabilities.setVolume(defaultVolumeCapability());
-    capabilities.setSampleRate(CapabilityRange(minSampleRate, maxSampleRate));
+    capabilities.setSampleRate({ minSampleRate, maxSampleRate });
     m_capabilities = WTFMove(capabilities);
 
     return m_capabilities.value();

--- a/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
@@ -85,9 +85,9 @@ const RealtimeMediaSourceCapabilities& MockDisplayCaptureSourceGStreamer::capabi
 
         // FIXME: what should these be?
         // Currently mimicking the values for SCREEN-1 in MockRealtimeMediaSourceCenter.cpp::defaultDevices()
-        capabilities.setWidth(CapabilityRange(1, 1920));
-        capabilities.setHeight(CapabilityRange(1, 1080));
-        capabilities.setFrameRate(CapabilityRange(.01, 30.0));
+        capabilities.setWidth({ 1, 1920 });
+        capabilities.setHeight({ 1, 1080 });
+        capabilities.setFrameRate({ .01, 30.0 });
 
         m_capabilities = WTFMove(capabilities);
     }

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -685,10 +685,10 @@ auto AVVideoCaptureSource::getPhotoCapabilities() -> Ref<PhotoCapabilitiesNative
     PhotoCapabilities photoCapabilities;
 
     auto height = capabilities.height();
-    photoCapabilities.imageHeight = { height.longRange().max, height.longRange().min, 1 };
+    photoCapabilities.imageHeight = { height.max(), height.min(), 1 };
 
     auto width = capabilities.width();
-    photoCapabilities.imageWidth = { width.longRange().max, width.longRange().min, 1 };
+    photoCapabilities.imageWidth = { width.max(), width.min(), 1 };
 
     m_photoCapabilities = WTFMove(photoCapabilities);
 

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -79,7 +79,7 @@ public:
     virtual bool hasAudioUnit() const = 0;
     void setCaptureDevice(String&&, uint32_t);
 
-    virtual CapabilityRange sampleRateCapacities() const = 0;
+    virtual LongCapabilityRange sampleRateCapacities() const = 0;
     virtual int actualSampleRate() const { return sampleRate(); }
 
     void whenAudioCaptureUnitIsNotRunning(Function<void()>&&);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -272,7 +272,7 @@ const RealtimeMediaSourceCapabilities& CoreAudioCaptureSource::capabilities()
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
         capabilities.setDeviceId(hashedId());
         capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
-        capabilities.setVolume(CapabilityRange(0.0, 1.0));
+        capabilities.setVolume({ 0.0, 1.0 });
         capabilities.setSampleRate(unit().sampleRateCapacities());
         m_capabilities = WTFMove(capabilities);
     }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -88,7 +88,7 @@ public:
     void registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     void unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     bool isRunning() const { return m_ioUnitStarted; }
-    void setSampleRateRange(CapabilityRange range) { m_sampleRateCapabilities = range; }
+    void setSampleRateRange(LongCapabilityRange range) { m_sampleRateCapabilities = range; }
 
 #if PLATFORM(IOS_FAMILY)
     void setIsInBackground(bool);
@@ -110,7 +110,7 @@ public:
 private:
     static size_t preferredIOBufferSize();
 
-    CapabilityRange sampleRateCapacities() const final { return m_sampleRateCapabilities; }
+    LongCapabilityRange sampleRateCapacities() const final { return m_sampleRateCapabilities; }
 
     bool hasAudioUnit() const final { return !!m_ioUnit; }
     void captureDeviceChanged() final;
@@ -172,7 +172,7 @@ private:
     String m_ioUnitName;
 #endif
 
-    CapabilityRange m_sampleRateCapabilities;
+    LongCapabilityRange m_sampleRateCapabilities;
 
     uint64_t m_microphoneProcsCalled { 0 };
     uint64_t m_microphoneProcsCalledLastTime { 0 };

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -168,7 +168,7 @@ CoreAudioSharedUnit& MockAudioSharedUnit::singleton()
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&] () {
         s_shouldIncreaseBufferSize = false;
-        unit->setSampleRateRange(CapabilityRange(44100, 96000));
+        unit->setSampleRateRange({ 44100, 96000 });
         unit->setInternalUnitCreationCallback([](bool enableEchoCancellation) {
             UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<MockAudioSharedInternalUnit>(enableEchoCancellation);
             return result;

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -128,9 +128,9 @@ const RealtimeMediaSourceCapabilities& MockRealtimeAudioSource::capabilities()
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
 
         capabilities.setDeviceId(hashedId());
-        capabilities.setVolume(CapabilityRange(0.0, 1.0));
+        capabilities.setVolume({ 0.0, 1.0 });
         capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
-        capabilities.setSampleRate(CapabilityRange(44100, 96000));
+        capabilities.setSampleRate({ 44100, 96000 });
 
         m_capabilities = WTFMove(capabilities);
     }

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -212,7 +212,7 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
         updateCapabilities(capabilities);
 
         if (facingMode == VideoFacingMode::Environment) {
-            capabilities.setFocusDistance(CapabilityRange(0.2, std::numeric_limits<double>::max()));
+            capabilities.setFocusDistance({ 0.2, std::numeric_limits<double>::max() });
             supportedConstraints.setSupportsFocusDistance(true);
         }
 
@@ -229,13 +229,13 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
 
         capabilities.setSupportedConstraints(supportedConstraints);
     } else if (mockDisplay()) {
-        capabilities.setWidth(CapabilityRange(72, std::get<MockDisplayProperties>(m_device.properties).defaultSize.width()));
-        capabilities.setHeight(CapabilityRange(45, std::get<MockDisplayProperties>(m_device.properties).defaultSize.height()));
-        capabilities.setFrameRate(CapabilityRange(.01, 60.0));
+        capabilities.setWidth({ 72, std::get<MockDisplayProperties>(m_device.properties).defaultSize.width() });
+        capabilities.setHeight({ 45, std::get<MockDisplayProperties>(m_device.properties).defaultSize.height() });
+        capabilities.setFrameRate({ .01, 60.0 });
     } else {
-        capabilities.setWidth(CapabilityRange(72, 2880));
-        capabilities.setHeight(CapabilityRange(45, 1800));
-        capabilities.setFrameRate(CapabilityRange(.01, 60.0));
+        capabilities.setWidth({ 72, 2880 });
+        capabilities.setHeight({ 45, 1800 });
+        capabilities.setFrameRate({ .01, 60.0 });
     }
 
     m_capabilities = WTFMove(capabilities);
@@ -266,10 +266,10 @@ auto MockRealtimeVideoSource::getPhotoCapabilities() -> Ref<PhotoCapabilitiesNat
     PhotoCapabilities photoCapabilities;
 
     auto height = capabilities.height();
-    photoCapabilities.imageHeight = { height.longRange().max, height.longRange().min, 1 };
+    photoCapabilities.imageHeight = { height.max(), height.min(), 1 };
 
     auto width = capabilities.width();
-    photoCapabilities.imageWidth = { width.longRange().max, width.longRange().min, 1 };
+    photoCapabilities.imageWidth = { width.max(), width.min(), 1 };
 
     m_photoCapabilities = WTFMove(photoCapabilities);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5231,37 +5231,33 @@ struct WebCore::CaptureDeviceWithCapabilities {
 
 [Nested] enum class WebCore::RealtimeMediaSourceCapabilities::EchoCancellation : bool
 
-[Nested] struct WebCore::CapabilityRange::DoubleRange {
-    double max;
-    [Validator='min <= max'] double min;
-};
-
-[Nested] struct WebCore::CapabilityRange::LongRange {
-    int max;
-    [Validator='min <= max'] int min;
+header: <WebCore/RealtimeMediaSourceCapabilities.h>
+[CustomHeader] class WebCore::DoubleCapabilityRange {
+    double min();
+    [Validator='min <= max'] double max();
 };
 
 header: <WebCore/RealtimeMediaSourceCapabilities.h>
-[CustomHeader, LegacyPopulateFromEmptyConstructor] class WebCore::CapabilityRange {
-    std::optional<WebCore::CapabilityRange::DoubleRange> m_doubleRange;
-    std::optional<WebCore::CapabilityRange::LongRange> m_longRange;
+[CustomHeader] class WebCore::LongCapabilityRange {
+    int min();
+    [Validator='min <= max'] int max();
 };
 
 class WebCore::RealtimeMediaSourceCapabilities {
-    WebCore::CapabilityRange width();
-    WebCore::CapabilityRange height();
-    WebCore::CapabilityRange aspectRatio();
-    WebCore::CapabilityRange frameRate();
+    WebCore::LongCapabilityRange width();
+    WebCore::LongCapabilityRange height();
+    WebCore::DoubleCapabilityRange aspectRatio();
+    WebCore::DoubleCapabilityRange frameRate();
     Vector<WebCore::VideoFacingMode> facingMode();
-    WebCore::CapabilityRange volume();
-    WebCore::CapabilityRange sampleRate();
-    WebCore::CapabilityRange sampleSize();
+    WebCore::DoubleCapabilityRange volume();
+    WebCore::LongCapabilityRange sampleRate();
+    WebCore::LongCapabilityRange sampleSize();
     WebCore::RealtimeMediaSourceCapabilities::EchoCancellation echoCancellation();
     String deviceId();
     String groupId();
-    WebCore::CapabilityRange focusDistance();
+    WebCore::DoubleCapabilityRange focusDistance();
     Vector<WebCore::MeteringMode> whiteBalanceModes();
-    WebCore::CapabilityRange zoom();
+    WebCore::DoubleCapabilityRange zoom();
     bool torch();
     WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
 };


### PR DESCRIPTION
#### be6d1fe9dbef14685f60118e5eabea2d8837c97c
<pre>
Simplify CapabilityRange
<a href="https://rdar.apple.com/123239032">rdar://123239032</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269711">https://bugs.webkit.org/show_bug.cgi?id=269711</a>

Reviewed by Eric Carlson.

CapabilityRange could handle double and integer values inside the same structure as two optionals.
But CapabilityRange values are typically typed (a width CapabilityRange is in integers).
It is therefore best to use a typed value directly.
We make CapabilityRange a template and have LongCapabilityRange and DoubleCapabilityRange.
We make them classes instead of templated classes so that they work well with generated serializers.

* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp:
(WebCore::capabilityDoubleRange):
(WebCore::capabilityLongRange):
(WebCore::toMediaTrackCapabilities):
(WebCore::capabilityIntRange): Deleted.
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::NumericConstraint::fitnessDistance const):
(WebCore::NumericConstraint::valueForCapabilityRange const):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::hasInvalidSizeFrameRateAndZoomConstraints):
(WebCore::RealtimeMediaSource::fitnessDistance):
(WebCore::RealtimeMediaSource::applyConstraint):
(WebCore::RealtimeMediaSource::extractVideoFrameSizeConstraints):
(WebCore::RealtimeMediaSource::applyConstraints):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::CapabilityRange::CapabilityRange):
(WebCore::CapabilityRange::min const):
(WebCore::CapabilityRange::max const):
(WebCore::LongCapabilityRange::LongCapabilityRange):
(WebCore::DoubleCapabilityRange::DoubleCapabilityRange):
(WebCore::RealtimeMediaSourceCapabilities::RealtimeMediaSourceCapabilities):
(WebCore::RealtimeMediaSourceCapabilities::width const):
(WebCore::RealtimeMediaSourceCapabilities::setWidth):
(WebCore::RealtimeMediaSourceCapabilities::height const):
(WebCore::RealtimeMediaSourceCapabilities::setHeight):
(WebCore::RealtimeMediaSourceCapabilities::frameRate const):
(WebCore::RealtimeMediaSourceCapabilities::setFrameRate):
(WebCore::RealtimeMediaSourceCapabilities::aspectRatio const):
(WebCore::RealtimeMediaSourceCapabilities::setAspectRatio):
(WebCore::RealtimeMediaSourceCapabilities::volume const):
(WebCore::RealtimeMediaSourceCapabilities::setVolume):
(WebCore::RealtimeMediaSourceCapabilities::sampleRate const):
(WebCore::RealtimeMediaSourceCapabilities::setSampleRate):
(WebCore::RealtimeMediaSourceCapabilities::sampleSize const):
(WebCore::RealtimeMediaSourceCapabilities::setSampleSize):
(WebCore::RealtimeMediaSourceCapabilities::focusDistance const):
(WebCore::RealtimeMediaSourceCapabilities::setFocusDistance):
(WebCore::RealtimeMediaSourceCapabilities::zoom const):
(WebCore::RealtimeMediaSourceCapabilities::setZoom):
(WebCore::CapabilityRange::LongRange::LongRange): Deleted.
(WebCore::CapabilityRange::DoubleRange::DoubleRange): Deleted.
(WebCore::CapabilityRange::type const): Deleted.
(WebCore::CapabilityRange::doubleRange const): Deleted.
(WebCore::CapabilityRange::longRange const): Deleted.
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::capabilities):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
(WebCore::defaultVolumeCapability):
(WebCore::GStreamerAudioCaptureSource::capabilities):
* Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp:
(WebCore::MockDisplayCaptureSourceGStreamer::capabilities):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::getPhotoCapabilities):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::capabilities):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedUnit::singleton):
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::capabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):
(WebCore::MockRealtimeVideoSource::getPhotoCapabilities):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/275046@main">https://commits.webkit.org/275046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7ca49c91785c2c65c5c9aa3145698b8e5ba57dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43044 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/22759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17081 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14389 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14479 "layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44567 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40156 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38497 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17171 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9132 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->