### PR TITLE
[Skia] Implement inset shadows

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -51,7 +51,9 @@ void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font,
     }
     auto blob = builder.make();
     auto* canvas = graphicsContext.platformContext();
-    canvas->drawTextBlob(blob, SkFloatToScalar(position.x()), SkFloatToScalar(position.y()), static_cast<GraphicsContextSkia*>(&graphicsContext)->createFillPaint());
+    SkPaint paint = static_cast<GraphicsContextSkia*>(&graphicsContext)->createFillPaint();
+    paint.setImageFilter(static_cast<GraphicsContextSkia*>(&graphicsContext)->createDropShadowFilterIfNeeded(GraphicsContextSkia::ShadowStyle::Outset));
+    canvas->drawTextBlob(blob, SkFloatToScalar(position.x()), SkFloatToScalar(position.y()), paint);
 }
 
 bool FontCascade::canReturnFallbackFontsForComplexText()

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -99,6 +99,9 @@ public:
 
     RenderingMode renderingMode() const final;
 
+    enum class ShadowStyle : uint8_t { Outset, Inset };
+    sk_sp<SkImageFilter> createDropShadowFilterIfNeeded(ShadowStyle) const;
+
     SkPaint createFillPaint(std::optional<Color> fillColor = std::nullopt) const;
     SkPaint createStrokeStylePaint() const;
     SkPaint createStrokePaint(std::optional<Color> strokeColor = std::nullopt) const;


### PR DESCRIPTION
#### bcffee080ac979d3b38875f008acdd39798ac7a4
<pre>
[Skia] Implement inset shadows
<a href="https://bugs.webkit.org/show_bug.cgi?id=269714">https://bugs.webkit.org/show_bug.cgi?id=269714</a>

Reviewed by Carlos Garcia Campos.

Move the drop shadow filter creation into a helper method, and refactor
all callers of GraphicsContextSkia::createFillPaint() to manually create
and apply a drop shadow. The helper method returns nullptr if there is
no shadow, or if the shadow is effectively hidden, following Cairo&apos;s
optimization.

Add a selector enum for inset and outset shadows, used by the helper
method aforementioned, and handle the case for both inset and outset
shadows. The outset shadow case is just what was there before.

The inset shadow case is a combination of two image filters. One creates
a black shadow with the drop shadow parameters, and uses it as a mask to
apply a color blend. The color blend is what uses the actual drop shadow
color, and blends it with the SrcIn mode, which effectively inverts the
drop shadow based on the pixel opacity.

The only place in code that interprets GraphicsContext.dropShadow() as
an inset shadow is inside GraphicsContext::fillRectWithRoundedHole(),
which is implemented in this commit using SkCanvas::drawDRRect().

* Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawNativeImageInternal):
(WebCore::GraphicsContextSkia::fillPath):
(WebCore::GraphicsContextSkia::createDropShadowFilter const):
(WebCore::GraphicsContextSkia::createFillPaint const):
(WebCore::GraphicsContextSkia::fillRect):
(WebCore::GraphicsContextSkia::fillRoundedRectImpl):
(WebCore::GraphicsContextSkia::fillRectWithRoundedHole):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:

Canonical link: <a href="https://commits.webkit.org/275093@main">https://commits.webkit.org/275093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdc6b0febcab80f13661f9ed293e5793ab10c08b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17231 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41461 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/16846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44737 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38659 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17321 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5430 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->