### PR TITLE
[WGSL] Failed concretization generates invalid types

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -149,13 +149,22 @@ const Type* concretize(const Type* type, TypeStore& types)
             return satisfyOrPromote(type, Constraints::ConcreteScalar, types);
         },
         [&](const Vector& vector) -> const Type* {
-            return types.vectorType(vector.size, concretize(vector.element, types));
+            auto* element = concretize(vector.element, types);
+            if (!element)
+                return nullptr;
+            return types.vectorType(vector.size, element);
         },
         [&](const Matrix& matrix) -> const Type* {
-            return types.matrixType(matrix.columns, matrix.rows, concretize(matrix.element, types));
+            auto* element = concretize(matrix.element, types);
+            if (!element)
+                return nullptr;
+            return types.matrixType(matrix.columns, matrix.rows, element);
         },
         [&](const Array& array) -> const Type* {
-            return types.arrayType(concretize(array.element, types), array.size);
+            auto* element = concretize(array.element, types);
+            if (!element)
+                return nullptr;
+            return types.arrayType(element, array.size);
         },
         [&](const Struct&) -> const Type* {
             return type;
@@ -165,11 +174,15 @@ const Type* concretize(const Type* type, TypeStore& types)
             case PrimitiveStruct::FrexpResult::kind: {
                 auto* fract = concretize(primitiveStruct.values[PrimitiveStruct::FrexpResult::fract], types);
                 auto* exp = concretize(primitiveStruct.values[PrimitiveStruct::FrexpResult::exp], types);
+                if (!fract || !exp)
+                    return nullptr;
                 return types.frexpResultType(fract, exp);
             }
             case PrimitiveStruct::ModfResult::kind: {
                 auto* fract = concretize(primitiveStruct.values[PrimitiveStruct::ModfResult::fract], types);
                 auto* whole = concretize(primitiveStruct.values[PrimitiveStruct::ModfResult::whole], types);
+                if (!fract || !whole)
+                    return nullptr;
                 return types.modfResultType(fract, whole);
             }
             case PrimitiveStruct::AtomicCompareExchangeResult::kind: {


### PR DESCRIPTION
#### ce88073de78f1edecd17a089451523034ffba6ac
<pre>
[WGSL] Failed concretization generates invalid types
<a href="https://bugs.webkit.org/show_bug.cgi?id=269720">https://bugs.webkit.org/show_bug.cgi?id=269720</a>
<a href="https://rdar.apple.com/123238768">rdar://123238768</a>

Reviewed by Mike Wyrzykowski.

`concretize` might return a nullptr if the type can&apos;t be concretized, so recursive
calls need to check the result before constructing the return type, otherwise it
can result in e.g. a vector with a nullptr element.

* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::concretize):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):

Canonical link: <a href="https://commits.webkit.org/275040@main">https://commits.webkit.org/275040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95b70a6866e14a7553221dadacdf7e89474f887f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36674 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33674 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14257 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14414 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40028 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38359 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17019 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9130 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->