### PR TITLE
Teach package-root to include seatbelt profiles

### DIFF
--- a/Tools/Scripts/package-root
+++ b/Tools/Scripts/package-root
@@ -77,11 +77,13 @@ setConfiguration();
 my @privateFrameworks = qw(WebCore WebGPU WebKitLegacy);
 my @publicFrameworks = qw(JavaScriptCore WebKit);
 my @extensions = qw(GPUExtension NetworkingExtension WebContentCaptivePortalExtension WebContentExtension);
+my @sandboxProfiles = qw(com.apple.WebKit.GPU com.apple.WebKit.GPUProcess com.apple.WebKit.NetworkProcess com.apple.WebKit.Networking com.apple.WebKit.WebContent com.apple.WebProcess);
 my $packagedRootBasePath = usesCryptexPath() ? "/System/Cryptexes/OS/" : "/";
 $packagedRootBasePath = "$packagedRootBasePath" . "System/iOSSupport/" if isMacCatalystWebKit();
 my $privateInstallPath = "$packagedRootBasePath" . "System/Library/PrivateFrameworks";
 my $publicInstallPath = "$packagedRootBasePath" . "System/Library/Frameworks";
 my $extensionsInstallPath = "/System/Library/ExtensionKit/Extensions";
+my $sandboxProfilesInstallPath = "/usr/local/share/sandbox";
 
 my $configuration = configuration();
 my $platform = xcodeSDKPlatformName();
@@ -90,6 +92,7 @@ my $stagingRoot = tempdir(CLEANUP => 1);
 my $stagingPrivatePath = "$stagingRoot$privateInstallPath";
 my $stagingPublicPath = "$stagingRoot$publicInstallPath";
 my $stagingExtensionsPath = "$stagingRoot$extensionsInstallPath";
+my $stagingSandboxProfilesPath = "$stagingRoot$sandboxProfilesInstallPath";
 my $archiveName = "webkit-$configuration-$platform";
 my $archivePath = "$productDir/$archiveName.tar.gz";
 my ($fh, $tempArchiveName) = tempfile( "/tmp/$archiveName-XXXXXXX");
@@ -97,6 +100,7 @@ my ($fh, $tempArchiveName) = tempfile( "/tmp/$archiveName-XXXXXXX");
 system 'mkdir', '-p', $stagingPrivatePath;
 system 'mkdir', '-p', $stagingPublicPath;
 system 'mkdir', '-p', $stagingExtensionsPath;
+system 'mkdir', '-p', $stagingSandboxProfilesPath;
 
 foreach my $framework (@privateFrameworks) {
     print "Copying Private $framework from $productDir ...\n";
@@ -114,6 +118,12 @@ foreach my $extension (@extensions) {
     print "Copying extension $extension from $productDir ...\n";
     system 'cp', '-LpR', $productDir . "/$extension.appex", "$stagingExtensionsPath/";
     die "Check to see that you have built $extension for $configuration-$platform" if $?;
+}
+
+foreach my $sandboxProfile (@sandboxProfiles) {
+    print "Copying sandbox profile $sandboxProfile from $productDir ...\n";
+    system 'cp', '-LpR', $productDir . "/DerivedSources/WebKit/$sandboxProfile.sb", "$stagingSandboxProfilesPath/";
+    die "Check to see that you have built $sandboxProfile for $configuration-$platform" if $?;
 }
 
 system 'ditto', "$productDir/usr", "$stagingRoot" . "$packagedRootBasePath" . "usr";


### PR DESCRIPTION
#### c5c620a368ea59157bb0cfbc8ac5d4acaff7493b
<pre>
Teach package-root to include seatbelt profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=269724">https://bugs.webkit.org/show_bug.cgi?id=269724</a>
<a href="https://rdar.apple.com/123245847">rdar://123245847</a>

Reviewed by NOBODY (OOPS!).

Teach package-root to package seatbelt profiles in DerivedSources/WebKit in the root under /usr/local/share/sandbox.

* Tools/Scripts/package-root:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5c620a368ea59157bb0cfbc8ac5d4acaff7493b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33677 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44426 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40041 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38372 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->