### PR TITLE
Update WebKit::RegisterTZoneTypes() to be callable from ObjC

### DIFF
--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -21,6 +21,7 @@ set(WebKit_PUBLIC_FRAMEWORK_HEADERS
     Shared/API/c/WKPageLoadTypes.h
     Shared/API/c/WKPageVisibilityTypes.h
     Shared/API/c/WKPluginInformation.h
+    Shared/API/c/WKRegisterTZoneTypes.h
     Shared/API/c/WKSecurityOriginRef.h
     Shared/API/c/WKSerializedScriptValue.h
     Shared/API/c/WKString.h

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -974,6 +974,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module WKRegisterTZoneTypes {
+    header "WKRegisterTZoneTypes.h"
+    export *
+  }
+
   explicit module WKRenderLayer {
     header "WKRenderLayer.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -1674,6 +1674,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module WKRegisterTZoneTypes {
+    header "WKRegisterTZoneTypes.h"
+    export *
+  }
+
   explicit module WKRenderLayer {
     header "WKRenderLayer.h"
     export *

--- a/Source/WebKit/Shared/API/Cocoa/WKMain.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKMain.mm
@@ -27,7 +27,7 @@
 #import "WKMain.h"
 
 #import "PCMDaemonEntryPoint.h"
-#import "RegisterTZoneTypes.h"
+#import "WKRegisterTZoneTypes.h"
 #import "WebPushDaemonMain.h"
 #import "WebPushToolMain.h"
 #import <JavaScriptCore/TZoneInit.h>
@@ -36,7 +36,7 @@
 int WKXPCServiceMain(int argc, const char** argv, const char**, const char** darwinEnvp)
 {
     TZoneInit(darwinEnvp);
-    WebKit::registerTZoneTypes();
+    WKRegisterTZoneTypes();
     TZoneRegisterationDone();
 
     return WebKit::XPCServiceMain(argc, argv);

--- a/Source/WebKit/Shared/API/c/WKRegisterTZoneTypes.cpp
+++ b/Source/WebKit/Shared/API/c/WKRegisterTZoneTypes.cpp
@@ -27,22 +27,18 @@
  */
 
 #include "config.h"
-#include "RegisterTZoneTypes.h"
+#include "WKRegisterTZoneTypes.h"
 
 #include <wtf/TZoneMalloc.h>
-
-namespace WebKit {
 
 #if USE(WK_TZONE_MALLOC)
 extern const bmalloc::api::TZoneAnnotation startOfTZoneTypes __asm("section$start$__DATA_CONST$__tzone_descs");
 extern const bmalloc::api::TZoneAnnotation endOfTZoneTypes __asm("section$end$__DATA_CONST$__tzone_descs");
 
-void registerTZoneTypes()
+void WKRegisterTZoneTypes()
 {
     WTF_TZONE_REGISTER_TYPES(&startOfTZoneTypes, &endOfTZoneTypes);
 }
 #else
-void registerTZoneTypes() { }
+void WKRegisterTZoneTypes() { }
 #endif
-
-} // namespace WebKit

--- a/Source/WebKit/Shared/API/c/WKRegisterTZoneTypes.h
+++ b/Source/WebKit/Shared/API/c/WKRegisterTZoneTypes.h
@@ -28,8 +28,14 @@
 
 #pragma once
 
-namespace WebKit {
+#include <WebKit/WKBase.h>
 
-void registerTZoneTypes();
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-} // namespace WebKit
+WK_EXPORT void WKRegisterTZoneTypes(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -270,7 +270,6 @@ Shared/API/APIDictionary.cpp
 Shared/API/APIError.cpp
 Shared/API/APIObject.cpp
 Shared/API/APIURLRequest.cpp
-Shared/API/RegisterTZoneTypes.cpp
 
 Shared/API/c/WKArray.cpp
 Shared/API/c/WKCertificateInfo.cpp
@@ -286,6 +285,7 @@ Shared/API/c/WKMutableArray.cpp
 Shared/API/c/WKMutableDictionary.cpp
 Shared/API/c/WKNumber.cpp
 Shared/API/c/WKPluginInformation.cpp
+Shared/API/c/WKRegisterTZoneTypes.cpp
 Shared/API/c/WKRenderLayer.cpp
 Shared/API/c/WKRenderObject.cpp
 Shared/API/c/WKSecurityOriginRef.cpp

--- a/Source/WebKit/UIProcess/API/C/WebKit2_C.h
+++ b/Source/WebKit/UIProcess/API/C/WebKit2_C.h
@@ -55,6 +55,7 @@
 #include <WebKit/WKPageConfigurationRef.h>
 #include <WebKit/WKPageGroup.h>
 #include <WebKit/WKPreferencesRef.h>
+#include <WebKit/WKRegisterTZoneTypes.h>
 #include <WebKit/WKString.h>
 #include <WebKit/WKURL.h>
 #include <WebKit/WKURLRequest.h>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1560,7 +1560,7 @@
 		637281A321ADC744009E0DE6 /* WKDownloadProgress.mm in Sources */ = {isa = PBXBuildFile; fileRef = 637281A121ADC744009E0DE6 /* WKDownloadProgress.mm */; };
 		63C32C261E9810D900699BD0 /* _WKGeolocationPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 63C32C241E9810D900699BD0 /* _WKGeolocationPosition.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		63C32C281E98119000699BD0 /* _WKGeolocationPositionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 63C32C271E98119000699BD0 /* _WKGeolocationPositionInternal.h */; };
-		65F85BC32B7DC92700D0AC74 /* RegisterTZoneTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 65FE73BE2B7DC62C00C5CDAF /* RegisterTZoneTypes.h */; };
+		65F85BE32B81D54800D0AC74 /* WKRegisterTZoneTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 65F85BE12B81D54800D0AC74 /* WKRegisterTZoneTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6A5080BF1F0EDAAA00E617C5 /* WKWindowFeaturesPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A5080BE1F0EDAAA00E617C5 /* WKWindowFeaturesPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6BD05865220CE8C2000BED5C /* PrivateClickMeasurementManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD05863220CE8C2000BED5C /* PrivateClickMeasurementManager.h */; };
 		6BE969C11E54D452008B7483 /* corePrediction_model in Resources */ = {isa = PBXBuildFile; fileRef = 6BE969C01E54D452008B7483 /* corePrediction_model */; };
@@ -6282,8 +6282,8 @@
 		63FABE191E970D65003011D5 /* _WKGeolocationCoreLocationProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKGeolocationCoreLocationProvider.h; sourceTree = "<group>"; };
 		6546A82913000164000CEB1C /* InjectedBundlePageResourceLoadClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InjectedBundlePageResourceLoadClient.cpp; sourceTree = "<group>"; };
 		6546A82A13000164000CEB1C /* InjectedBundlePageResourceLoadClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectedBundlePageResourceLoadClient.h; sourceTree = "<group>"; };
-		65FE73BD2B7DC62C00C5CDAF /* RegisterTZoneTypes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegisterTZoneTypes.cpp; sourceTree = "<group>"; };
-		65FE73BE2B7DC62C00C5CDAF /* RegisterTZoneTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegisterTZoneTypes.h; sourceTree = "<group>"; };
+		65F85BE02B81D54800D0AC74 /* WKRegisterTZoneTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKRegisterTZoneTypes.cpp; sourceTree = "<group>"; };
+		65F85BE12B81D54800D0AC74 /* WKRegisterTZoneTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKRegisterTZoneTypes.h; sourceTree = "<group>"; };
 		6A5080BE1F0EDAAA00E617C5 /* WKWindowFeaturesPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWindowFeaturesPrivate.h; sourceTree = "<group>"; };
 		6BD05863220CE8C2000BED5C /* PrivateClickMeasurementManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrivateClickMeasurementManager.h; sourceTree = "<group>"; };
 		6BD05864220CE8C2000BED5C /* PrivateClickMeasurementManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PrivateClickMeasurementManager.cpp; sourceTree = "<group>"; };
@@ -14713,8 +14713,6 @@
 				7AE42B432954E8C200B20510 /* APIURLResponse.serialization.in */,
 				F6113E24126CE1820057D0A7 /* APIUserContentURLPattern.h */,
 				FA9AFA652B224DE400953DC5 /* APIUserContentURLPattern.serialization.in */,
-				65FE73BD2B7DC62C00C5CDAF /* RegisterTZoneTypes.cpp */,
-				65FE73BE2B7DC62C00C5CDAF /* RegisterTZoneTypes.h */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -14764,6 +14762,8 @@
 				A5EFD38B16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h */,
 				7C135AA6173B0BCA00586AE2 /* WKPluginInformation.cpp */,
 				7C135AA7173B0BCA00586AE2 /* WKPluginInformation.h */,
+				65F85BE02B81D54800D0AC74 /* WKRegisterTZoneTypes.cpp */,
+				65F85BE12B81D54800D0AC74 /* WKRegisterTZoneTypes.h */,
 				4990001E24D2429C00049CB4 /* WKRenderLayer.cpp */,
 				4990001F24D2429C00049CB4 /* WKRenderLayer.h */,
 				4990002224D24C1C00049CB4 /* WKRenderObject.cpp */,
@@ -16350,7 +16350,6 @@
 				7BE9326327F5C75A00D5FEFB /* ReceiverMatcher.h in Headers */,
 				950FECF4285027200002DE4E /* RecurringPaymentRequest.h in Headers */,
 				57FD318222B3515E008D0E8B /* RedirectSOAuthorizationSession.h in Headers */,
-				65F85BC32B7DC92700D0AC74 /* RegisterTZoneTypes.h in Headers */,
 				71E29A342B20610C0010F3C9 /* RemoteAcceleratedEffectStack.h in Headers */,
 				9B1229D223FF2BCC008CA751 /* RemoteAudioDestinationIdentifier.h in Headers */,
 				9B1229CD23FF25F2008CA751 /* RemoteAudioDestinationManager.h in Headers */,
@@ -17187,6 +17186,7 @@
 				411B89C927B2B75D00F9EBD3 /* WKQueryPermissionResultCallback.h in Headers */,
 				F4D5F51F206087A10038BBA8 /* WKQuickboardViewControllerDelegate.h in Headers */,
 				F4975CF22624B80A003C626E /* WKQuickLookPreviewController.h in Headers */,
+				65F85BE32B81D54800D0AC74 /* WKRegisterTZoneTypes.h in Headers */,
 				1AD01BCD1905D54900C9C45F /* WKReloadFrameErrorRecoveryAttempter.h in Headers */,
 				1A9E329B1822E1CC00F5D04C /* WKRemoteObject.h in Headers */,
 				1A9E329F1822FEDD00F5D04C /* WKRemoteObjectCoder.h in Headers */,


### PR DESCRIPTION
#### 5abde68d40b78e963ab1bce5b0a57af77019ee5a
<pre>
Update WebKit::RegisterTZoneTypes() to be callable from ObjC
<a href="https://bugs.webkit.org/show_bug.cgi?id=269726">https://bugs.webkit.org/show_bug.cgi?id=269726</a>
<a href="https://rdar.apple.com/123165001">rdar://123165001</a>

Reviewed by NOBODY (OOPS!).

Changed WebKit::RegisterTZoneTypes() to WKRegisterTZoneTypes() and gave it C linkage to make it more compatible with
calling it from ObjC.  As part of this change moved Shared/API/RegisterTZoneTypes.{cpp,h} files to Shared/API/c with
a &quot;WK&quot; prefix.  Marked WKRegisterTZoneTypes.h as a Private header file.  Added WKRegisterTZoneTypes() to swift
modules maps.

* Source/WebKit/Headers.cmake:
* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Shared/API/Cocoa/WKMain.mm:
(WKXPCServiceMain):
* Source/WebKit/Shared/API/c/WKRegisterTZoneTypes.cpp: Renamed from Source/WebKit/Shared/API/RegisterTZoneTypes.cpp.
(WKRegisterTZoneTypes):
* Source/WebKit/Shared/API/c/WKRegisterTZoneTypes.h: Renamed from Source/WebKit/Shared/API/RegisterTZoneTypes.h.
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/C/WebKit2_C.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5abde68d40b78e963ab1bce5b0a57af77019ee5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33689 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16559 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14351 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36821 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40045 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38377 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17039 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->