### PR TITLE
Emit logical right-shift for unsigned div in BBQ JIT

### DIFF
--- a/JSTests/wasm/stress/unsigned-integer-division.js
+++ b/JSTests/wasm/stress/unsigned-integer-division.js
@@ -1,0 +1,48 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// If we compute using a signed division, then the results of the long computation inside the `if`s below
+// will be a large negative number rather than a large positive one, and the functions will return 1.
+let wat = `
+(module
+    (type (func (param f64) (result i32)))
+    (func (export "test64") (type 0) (local i64) (local i32)
+        (local.set 1 (i64.const -9999))
+        (if (i64.le_s (i64.clz (i64.add (local.get 1) (i64.const 1))) (i64.sub (i64.div_u (local.get 1) (i64.const 2)) (i64.const 2)))
+            (then (local.set 2 (i32.const 0)))
+            (else (local.set 2 (i32.const 1)))
+        )
+        (local.get 2)
+    )
+
+    (type (func (param f32) (result i32)))
+    (func (export "test32") (type 1) (local i32) (local i32)
+        (local.set 1 (i32.const -9999))
+        (if (i32.le_s (i32.clz (i32.add (local.get 1) (i32.const 1))) (i32.sub (i32.div_u (local.get 1) (i32.const 2)) (i32.const 2)))
+            (then (local.set 2 (i32.const 0)))
+            (else (local.set 2 (i32.const 1)))
+        )
+        (local.get 2)
+    )
+)
+`;
+
+async function test() {
+  const instance = await instantiate(wat, {}, {});
+  const {test64, test32} = instance.exports;
+  for (let i = 0; i < 100; i++) {
+    assert.eq(test64(10.0), 0);
+    assert.eq(test32(10.0), 0);
+
+    assert.eq(test64(-10.0), 0);
+    assert.eq(test32(-10.0), 0);
+
+    assert.eq(test64(1028.0), 0);
+    assert.eq(test32(1028.0), 0);
+
+    assert.eq(test64(1234.0), 0);
+    assert.eq(test32(1234.0), 0);
+  }
+}
+
+assert.asyncTest(test());


### PR DESCRIPTION
#### 3ee7e4fc30fd0bbaef2065502b5d7998960d9fbf
<pre>
Emit logical right-shift for unsigned div in BBQ JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=269729">https://bugs.webkit.org/show_bug.cgi?id=269729</a>
<a href="https://rdar.apple.com/120840889">rdar://120840889</a>

Reviewed by Justin Michaud.

Previously, the function BBQ::emitModOrDiv would unconditionally emit
an arithmetic right-shift in cases where the lhs was a power of two.
This produces the correct result when the sign bit is 0 (i.e. the lhs,
interpreted as a signed 64-bit integer, is positive) but an incorrect
one when the sign bit is 1: specifically, it would compute a signed
division instead.
By checking the sign of the division taking place and emitting a logical
shift when the operation is unsigned, we get the correct result.

* JSTests/wasm/stress/i64divu-sign-maintanance.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitModOrDiv):

Canonical link: <a href="https://commits.webkit.org/275011@main">https://commits.webkit.org/275011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fda21c80ca4933d7d6fd192384fad43c67f3839

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36705 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33695 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14282 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44443 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34069 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40053 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40242 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38386 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17050 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47252 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9101 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17101 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9711 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->