### PR TITLE
new exception handler adoption

### DIFF
--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -137,7 +137,15 @@ void initialize()
 
         if (Wasm::isSupported() || !Options::usePollingTraps()) {
             // JSLock::lock() can call registerThreadForMachExceptionHandling() which crashes if this has not been called first.
-            initializeSignalHandling();
+            int mask = 0;
+#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+            JSC::Wasm::MachExceptionSigningKey keygen;
+            uint32_t signingKey = keygen.randomSigningKey;
+            mask |= toMachMask(Signal::AccessFault);
+#else
+            uint32_t signingKey = 0;
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+            initializeSignalHandling(signingKey, mask);
 
             if (!Options::usePollingTraps())
                 VMTraps::initializeSignals();

--- a/Source/JavaScriptCore/runtime/MachineContext.h
+++ b/Source/JavaScriptCore/runtime/MachineContext.h
@@ -44,6 +44,7 @@ template<typename T = void*> T framePointer(const PlatformRegisters&);
 inline CodePtr<PlatformRegistersLRPtrTag> linkRegister(const PlatformRegisters&);
 inline std::optional<CodePtr<PlatformRegistersPCPtrTag>> instructionPointer(const PlatformRegisters&);
 inline void setInstructionPointer(PlatformRegisters&, CodePtr<CFunctionPtrTag>);
+inline void setInstructionPointer(PlatformRegisters&, void *);
 
 template<size_t N> void*& argumentPointer(PlatformRegisters&);
 template<size_t N> void* argumentPointer(const PlatformRegisters&);
@@ -457,10 +458,25 @@ inline void setInstructionPointer(PlatformRegisters& regs, CodePtr<CFunctionPtrT
 {
 #if USE(PLATFORM_REGISTERS_WITH_PROFILE)
     WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, value.taggedPtr());
+#elif USE(DARWIN_REGISTER_MACROS) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+    __darwin_arm_thread_state64_set_presigned_pc_fptr(regs, value.taggedPtr());
 #elif USE(DARWIN_REGISTER_MACROS)
     __darwin_arm_thread_state64_set_pc_fptr(regs, value.taggedPtr());
 #else
     instructionPointerImpl(regs) = value.taggedPtr();
+#endif
+}
+
+inline void setInstructionPointer(PlatformRegisters& regs, void* value)
+{
+#if USE(PLATFORM_REGISTERS_WITH_PROFILE)
+    WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, value);
+#elif USE(DARWIN_REGISTER_MACROS) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+    __darwin_arm_thread_state64_set_presigned_pc_fptr(regs, value);
+#elif USE(DARWIN_REGISTER_MACROS)
+    __darwin_arm_thread_state64_set_pc_fptr(regs, value);
+#else
+    instructionPointerImpl(regs) = value;
 #endif
 }
 #endif // OS(WINDOWS) || HAVE(MACHINE_CONTEXT)

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -201,6 +201,7 @@ public:
         , m_vm(vm)
     {
         activateSignalHandlersFor(Signal::AccessFault);
+        finalizeSignalHandlers();
     }
 
     static void initializeSignals()

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -38,11 +38,29 @@
 #include "WasmExceptionType.h"
 #include "WasmMemory.h"
 #include "WasmThunks.h"
+#include <wtf/CodePtr.h>
+#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/threads/Signals.h>
 
 namespace JSC { namespace Wasm {
+
+using WTF::CodePtr;
+
+void* presignedTrampoline = { };
+
+#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+MachExceptionSigningKey::MachExceptionSigningKey()
+{
+    // Sign the trampoline pointer using a random diversifier and stash it away before webcontent has started so that
+    // even a PAC signing gadget cannot fake this random diversifier
+    randomSigningKey = WTF::cryptographicallyRandomNumber<uint32_t>() & __DARWIN_ARM_THREAD_STATE64_USER_DIVERSIFIER_MASK;
+    uint64_t diversifier = ptrauth_blend_discriminator((void *)(unsigned long)randomSigningKey, ptrauth_string_discriminator("pc"));
+    presignedTrampoline = JSC::LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance).untaggedPtr();
+    presignedTrampoline = ptrauth_sign_unauthenticated(presignedTrampoline, ptrauth_key_function_pointer, diversifier);
+}
+#endif // CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
 
 namespace {
 namespace WasmFaultSignalHandlerInternal {
@@ -96,7 +114,11 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
             };
 
             if (didFaultInWasm(faultingInstruction)) {
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+                MachineContext::setInstructionPointer(context, presignedTrampoline);
+#else
                 MachineContext::setInstructionPointer(context, LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance));
+#endif
                 return SignalAction::Handled;
             }
         }
@@ -115,6 +137,7 @@ void activateSignalingMemory()
             return;
 
         activateSignalHandlersFor(Signal::AccessFault);
+        WTF::finalizeSignalHandlers();
     });
 }
 

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -28,7 +28,6 @@
 namespace JSC {
 
 namespace Wasm {
-
 #if ENABLE(WEBASSEMBLY)
 void activateSignalingMemory();
 void prepareSignalingMemory();
@@ -36,5 +35,13 @@ void prepareSignalingMemory();
 inline void activateSignalingMemory() { }
 inline void prepareSignalingMemory() { }
 #endif // ENABLE(WEBASSEMBLY)
+
+#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+class MachExceptionSigningKey {
+public:
+    uint32_t randomSigningKey = { };
+    MachExceptionSigningKey();
+};
+#endif // CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
 
 } } // namespace JSC::Wasm

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -4058,6 +4058,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7014689C4700E78B76 /* DebugRelease.xcconfig */;
 			buildSettings = {
+				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN_STATE";
 			};
 			name = Debug;
 		};
@@ -4065,6 +4066,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7014689C4700E78B76 /* DebugRelease.xcconfig */;
 			buildSettings = {
+				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN_STATE";
 			};
 			name = Release;
 		};
@@ -4086,6 +4088,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B6E14689C4700E78B76 /* Base.xcconfig */;
 			buildSettings = {
+				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN_STATE";
 			};
 			name = Production;
 		};

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -84,7 +84,7 @@ elseif (APPLE)
             ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
         MAIN_DEPENDENCY mac/MachExceptions.defs
         WORKING_DIRECTORY ${WTF_DERIVED_SOURCES_DIR}
-        COMMAND mig -sheader MachExceptionsServer.h MachExceptions.defs
+        COMMAND mig -DMACH_EXC_SERVER_TASKIDTOKEN_STATE -sheader MachExceptionsServer.h MachExceptions.defs
         VERBATIM)
     list(APPEND WTF_SOURCES
         cocoa/MemoryFootprintCocoa.cpp

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -117,7 +117,7 @@ add_custom_command(
         ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
     MAIN_DEPENDENCY mac/MachExceptions.defs
     WORKING_DIRECTORY ${WTF_DERIVED_SOURCES_DIR}
-    COMMAND mig -sheader MachExceptionsServer.h MachExceptions.defs
+    COMMAND mig -DMACH_EXC_SERVER_TASKIDTOKEN_STATE -sheader MachExceptionsServer.h MachExceptions.defs
     VERBATIM)
 list(APPEND WTF_SOURCES
     ${WTF_DERIVED_SOURCES_DIR}/mach_excServer.c

--- a/Source/WTF/wtf/PlatformRegisters.cpp
+++ b/Source/WTF/wtf/PlatformRegisters.cpp
@@ -53,6 +53,14 @@ void* threadStateLRInternal(PlatformRegisters& regs)
 
 void* threadStatePCInternal(PlatformRegisters& regs)
 {
+#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+    // If userspace has modified the PC and set it to the presignedTrampoline,
+    // we want to avoid authing the value as it is using a custom ptrauth signing scheme.
+    _STRUCT_ARM_THREAD_STATE64* ts = &(regs);
+    if (!(ts->__opaque_flags & __DARWIN_ARM_THREAD_STATE64_FLAGS_KERNEL_SIGNED_PC))
+        return nullptr;
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+
     void* candidatePC = arm_thread_state64_get_pc_fptr(regs);
 
 #if USE(UNTAGGED_THREAD_STATE_PTR)

--- a/Source/WTF/wtf/PlatformRegisters.h
+++ b/Source/WTF/wtf/PlatformRegisters.h
@@ -30,6 +30,7 @@
 #include <wtf/StdLibExtras.h>
 
 #if OS(DARWIN)
+#include <mach/exception_types.h>
 #include <mach/thread_act.h>
 #include <signal.h>
 #elif OS(WINDOWS)
@@ -130,8 +131,13 @@ using WTF::threadStatePCInternal;
 #define WTF_READ_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs) \
     threadStatePCInternal(const_cast<PlatformRegisters&>(regs))
 
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+#define WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, newPointer) \
+    arm_thread_state64_set_pc_presigned_fptr(regs, newPointer)
+#else // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
 #define WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, newPointer) \
     arm_thread_state64_set_pc_fptr(regs, newPointer)
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
 
 #define WTF_READ_MACHINE_CONTEXT_SP_WITH_PROFILE(machineContext) \
     WTF_READ_PLATFORM_REGISTERS_SP_WITH_PROFILE(machineContext->__ss)

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -41,27 +41,29 @@ extern "C" {
 #if HAVE(MACH_EXCEPTIONS)
 #include <dispatch/dispatch.h>
 #include <mach/mach.h>
+#include <mach/port.h>
+#include <mach/task.h>
 #include <mach/thread_act.h>
+#include <mach/thread_status.h>
 #endif
 
 #if OS(DARWIN)
 #include <mach/vm_param.h>
 #endif
 
+#include <unistd.h>
 #include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PlatformRegisters.h>
+#include <wtf/Scope.h>
 #include <wtf/ThreadGroup.h>
 #include <wtf/Threading.h>
+#include <wtf/TranslatedProcess.h>
 #include <wtf/WTFConfig.h>
 
 namespace WTF {
-
-#if HAVE(MACH_EXCEPTIONS)
-static exception_mask_t toMachMask(Signal);
-#endif
 
 void SignalHandlers::add(Signal signal, SignalHandler&& handler)
 {
@@ -110,8 +112,9 @@ inline void SignalHandlers::forEachHandler(Signal signal, const Func& func) cons
 // http://www.cs.cmu.edu/afs/cs/project/mach/public/doc/unpublished/mig.ps
 
 static constexpr size_t maxMessageSize = 1 * KB;
+uint32_t randomSigningKey = 0;
 
-void initMachExceptionHandlerThread(bool enable)
+void initMachExceptionHandlerThread(bool enable, uint32_t signingKey, exception_mask_t mask)
 {
     static std::once_flag once;
     std::call_once(once, [=] {
@@ -124,18 +127,37 @@ void initMachExceptionHandlerThread(bool enable)
         Config::AssertNotFrozenScope assertScope;
         SignalHandlers& handlers = g_wtfConfig.signalHandlers;
 
-        uint16_t flags = 0;
+        uint16_t flags = MPO_INSERT_SEND_RIGHT;
+
+// This provisional flag can be removed once macos sonoma is no longer supported
 #ifdef MPO_PROVISIONAL_ID_PROT_OPTOUT
         flags |= MPO_PROVISIONAL_ID_PROT_OPTOUT;
+#endif
+
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+        flags |= MPO_EXCEPTION_PORT;
 #endif
         mach_port_options_t opts = {
             .flags = flags
         };
 
+
         kern_return_t kr = mach_port_construct(mach_task_self(), &opts, 0, &handlers.exceptionPort);
         RELEASE_ASSERT(kr == KERN_SUCCESS);
-        kr = mach_port_insert_right(mach_task_self(), handlers.exceptionPort, handlers.exceptionPort, MACH_MSG_TYPE_MAKE_SEND);
+
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+        uint64_t exceptionsAllowed = mask;
+        uint64_t behaviorsAllowed = EXCEPTION_STATE_IDENTITY_PROTECTED | MACH_EXCEPTION_CODES;
+        uint64_t flavorsAllowed = MACHINE_THREAD_STATE;
+
+        kr = task_register_hardened_exception_handler(current_task(),
+            signingKey, exceptionsAllowed,
+            behaviorsAllowed, flavorsAllowed, handlers.exceptionPort);
         RELEASE_ASSERT(kr == KERN_SUCCESS);
+#else
+        UNUSED_PARAM(signingKey);
+        UNUSED_PARAM(mask);
+#endif
 
         dispatch_source_t source = dispatch_source_create(
             DISPATCH_SOURCE_TYPE_MACH_RECV, handlers.exceptionPort, 0, DISPATCH_TARGET_QUEUE_DEFAULT);
@@ -165,18 +187,6 @@ static Signal fromMachException(exception_type_t type)
     default: break;
     }
     return Signal::Unknown;
-}
-
-static exception_mask_t toMachMask(Signal signal)
-{
-    switch (signal) {
-    case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
-    case Signal::IllegalInstruction: return EXC_MASK_BAD_INSTRUCTION;
-    case Signal::FloatingPoint: return EXC_MASK_ARITHMETIC;
-    case Signal::Breakpoint: return EXC_MASK_BREAKPOINT;
-    default: break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 #if CPU(ARM64E) && OS(DARWIN)
@@ -222,6 +232,53 @@ kern_return_t catch_mach_exception_raise_state_identity(mach_port_t, mach_port_t
     return KERN_FAILURE;
 }
 
+static kern_return_t runSignalHandlers(Signal &signal, PlatformRegisters& registers, bool &didHandle, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
+{
+    SigInfo info;
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    if (signal == Signal::AccessFault) {
+        ASSERT_UNUSED(dataCount, dataCount == 2);
+        info.faultingAddress = reinterpret_cast<void*>(exceptionData[1]);
+#if CPU(ADDRESS64)
+        // If the faulting address is out of the range of any valid memory, we would
+        // not have any reason to handle it. Just let the default handler take care of it.
+        static constexpr unsigned validAddressBits = OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
+        static constexpr uintptr_t invalidAddressMask = ~((1ull << validAddressBits) - 1);
+        if (bitwise_cast<uintptr_t>(info.faultingAddress) & invalidAddressMask)
+            return KERN_FAILURE;
+#endif
+    }
+
+    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
+        SignalAction handlerResult = handler(signal, info, registers);
+        didHandle |= handlerResult == SignalAction::Handled;
+    });
+    return KERN_SUCCESS;
+}
+
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+
+kern_return_t catch_mach_exception_raise_state_identity_protected(
+    mach_port_t exceptionPort,
+    uint64_t threadID,
+    mach_port_t taskIDToken,
+    exception_type_t exceptionType,
+    mach_exception_data_t exceptionData,
+    mach_msg_type_number_t dataCount,
+    int* stateFlavor,
+    const thread_state_t inState,
+    mach_msg_type_number_t inStateCount,
+    thread_state_t outState,
+    mach_msg_type_number_t* outStateCount)
+{
+    UNUSED_PARAM(threadID);
+    UNUSED_PARAM(taskIDToken);
+    return catch_mach_exception_raise_state(exceptionPort, exceptionType, exceptionData,
+        dataCount, stateFlavor, inState, inStateCount, outState, outStateCount);
+}
+
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+
 kern_return_t catch_mach_exception_raise_state(
     mach_port_t port,
     exception_type_t exceptionType,
@@ -263,25 +320,10 @@ kern_return_t catch_mach_exception_raise_state(
     PlatformRegisters& registers = reinterpret_cast<arm_unified_thread_state*>(outState)->ts_32;
 #endif
 
-    SigInfo info;
-    if (signal == Signal::AccessFault) {
-        ASSERT_UNUSED(dataCount, dataCount == 2);
-        info.faultingAddress = reinterpret_cast<void*>(exceptionData[1]);
-#if CPU(ADDRESS64)
-        // If the faulting address is out of the range of any valid memory, we would
-        // not have any reason to handle it. Just let the default handler take care of it.
-        static constexpr unsigned validAddressBits = OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
-        static constexpr uintptr_t invalidAddressMask = ~((1ull << validAddressBits) - 1);
-        if (bitwise_cast<uintptr_t>(info.faultingAddress) & invalidAddressMask)
-            return KERN_FAILURE;
-#endif
-    }
-
     bool didHandle = false;
-    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
-        SignalAction handlerResult = handler(signal, info, registers);
-        didHandle |= handlerResult == SignalAction::Handled;
-    });
+    kern_return_t kr = runSignalHandlers(signal, registers, didHandle, dataCount, exceptionData);
+    if (kr != KERN_SUCCESS)
+        return kr;
 
     if (didHandle) {
 #if CPU(ARM64E) && OS(DARWIN)
@@ -307,7 +349,27 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
 {
     UNUSED_PARAM(threadGroupLocker);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions & activeExceptions, handlers.exceptionPort, EXCEPTION_STATE | MACH_EXCEPTION_CODES, MACHINE_THREAD_STATE);
+
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+    exception_behavior_t newBehavior = MACH_EXCEPTION_CODES;
+    if (WTF::isX86BinaryRunningOnARM()) {
+        // If we are a translated process in rosetta, use the old exception style
+        newBehavior |= EXCEPTION_STATE;
+    } else {
+        // Otherwise use the new style
+        newBehavior |= EXCEPTION_STATE_IDENTITY_PROTECTED;
+        kern_return_t result = thread_adopt_exception_handler(thread.machThread(), handlers.exceptionPort, handlers.addedExceptions &activeExceptions, newBehavior, MACHINE_THREAD_STATE);
+        if (result != KERN_SUCCESS) {
+            dataLogLn("thread adopt exception handler failed due to ", mach_error_string(result));
+            CRASH();
+        }
+        return;
+    }
+#else // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+    exception_behavior_t newBehavior = EXCEPTION_STATE | MACH_EXCEPTION_CODES;
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+
+    kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions &activeExceptions, handlers.exceptionPort, newBehavior, MACHINE_THREAD_STATE);
     if (result != KERN_SUCCESS) {
         dataLogLn("thread set port failed due to ", mach_error_string(result));
         CRASH();
@@ -418,10 +480,20 @@ void activateSignalHandlersFor(Signal signal)
     ASSERT(signal < Signal::Unknown);
     ASSERT(!handlers.useMach || signal != Signal::Usr);
 
+    if (handlers.useMach)
+        activeExceptions |= toMachMask(signal);
+#endif
+}
+
+
+void finalizeSignalHandlers()
+{
+#if HAVE(MACH_EXCEPTIONS)
+    const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
+
     Locker locker { activeThreads().getLock() };
     if (handlers.useMach) {
-        activeExceptions |= toMachMask(signal);
-
         for (auto& thread : activeThreads().threads(locker))
             setExceptionPorts(locker, thread.get());
     }

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -124,18 +124,36 @@ struct SignalHandlers {
 // and once commited they can't be turned off.
 WTF_EXPORT_PRIVATE void addSignalHandler(Signal, SignalHandler&&);
 WTF_EXPORT_PRIVATE void activateSignalHandlersFor(Signal);
+WTF_EXPORT_PRIVATE void finalizeSignalHandlers();
 
+#if OS(UNIX) && HAVE(MACH_EXCEPTIONS)
+inline exception_mask_t toMachMask(Signal signal)
+{
+    switch (signal) {
+    case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
+    case Signal::IllegalInstruction: return EXC_MASK_BAD_INSTRUCTION;
+    case Signal::FloatingPoint: return EXC_MASK_ARITHMETIC;
+    case Signal::Breakpoint: return EXC_MASK_BREAKPOINT;
+    default: break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+#endif // OS(UNIX) && HAVE(MACH_EXCEPTIONS)
 
 #if HAVE(MACH_EXCEPTIONS)
 class Thread;
 void registerThreadForMachExceptionHandling(Thread&);
-WTF_EXPORT_PRIVATE void initMachExceptionHandlerThread(bool);
-inline void initializeSignalHandling() { initMachExceptionHandlerThread(true); }
-inline void disableSignalHandling() { initMachExceptionHandlerThread(false); }
+WTF_EXPORT_PRIVATE void initMachExceptionHandlerThread(bool, uint32_t, exception_mask_t);
+inline void initializeSignalHandling(uint32_t signingKey, exception_mask_t mask) { initMachExceptionHandlerThread(true, signingKey, mask); }
+inline void disableSignalHandling() { initMachExceptionHandlerThread(false, 0, 0); }
 
 void handleSignalsWithMach();
 #else
-inline void initializeSignalHandling() { }
+inline void initializeSignalHandling(uint32_t signingKey, int mask)
+{
+    UNUSED_PARAM(signingKey);
+    UNUSED_PARAM(mask);
+}
 inline void disableSignalHandling() { }
 #endif // HAVE(MACH_EXCEPTIONS)
 
@@ -152,5 +170,6 @@ using WTF::SignalAction;
 using WTF::SignalHandler;
 using WTF::addSignalHandler;
 using WTF::activateSignalHandlersFor;
+using WTF::finalizeSignalHandlers;
 using WTF::initializeSignalHandling;
 using WTF::disableSignalHandling;

--- a/Source/WTF/wtf/win/SignalsWin.cpp
+++ b/Source/WTF/wtf/win/SignalsWin.cpp
@@ -149,6 +149,11 @@ void SignalHandlers::initialize()
     // noop
 }
 
+void finalizeSignalHandlers()
+{
+    // noop
+}
+
 } // namespace WTF
 
 #endif // OS(WINDOWS)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1466,13 +1466,22 @@
 #endif
 #endif
 
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+        (with-filter (require-not (webcontent-process-launched))
+            (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler)))
+#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+        (with-filter (require-not (lockdown-mode))
+            (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler)))
+#else
 #if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
         (with-filter (require-not (webcontent-process-launched))
             (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
 #else
         (with-filter (require-not (lockdown-mode))
             (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
-#endif
+#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+#endif ;; defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
 
         (with-filter (lockdown-mode)
             (deny mach-message-send (with telemetry) (with message "Lockdown mode")

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1817,8 +1817,13 @@
 
 (define (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry) (kernel-mig-routine
     thread_info
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+    task_register_hardened_exception_handler
+    thread_adopt_exception_handler
+#else
 #if !ENABLE(BLOCK_SET_EXCEPTION_PORTS)
     thread_set_exception_ports
+#endif
 #endif
 ))
 
@@ -1839,7 +1844,11 @@
 #endif
 #if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
             (with-filter (require-not (webcontent-process-launched))
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+                (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler)))
+#else
                 (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+#endif
 #endif
 
             (allow mach-message-send (kernel-mig-routines-in-use))


### PR DESCRIPTION
#### 079bd31e378144ae39bc940d07cfb8da5814f527
<pre>
new exception handler adoption
<a href="https://bugs.webkit.org/show_bug.cgi?id=269728">https://bugs.webkit.org/show_bug.cgi?id=269728</a>
<a href="https://rdar.apple.com/119256062">rdar://119256062</a>

Reviewed by Keith Miller.

This adopts the new hardened mach exception mechanism which was
introduced in darwin recently. See the radar for more details.

* Source/JavaScriptCore/llint/LLIntData.cpp:
* Source/JavaScriptCore/llint/LLIntData.h:
* Source/JavaScriptCore/runtime/MachineContext.h:
(JSC::MachineContext::setInstructionPointer):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::trapHandler):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/PlatformHave.h:
* Source/WTF/wtf/PlatformJSCOnly.cmake:
* Source/WTF/wtf/PlatformMac.cmake:
* Source/WTF/wtf/PlatformRegisters.h:
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::initMachExceptionHandlerThread):
(WTF::setExceptionPorts):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/276090@main">https://commits.webkit.org/276090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e18c7886f692d65fc714b002102f2e6b64bb7113

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43664 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36100 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44238 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19726 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38668 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1721 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37123 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-agressive-inline (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47858 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43298 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42869 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20121 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41545 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9724 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20302 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50297 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19748 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10134 "Passed tests") | 
<!--EWS-Status-Bubble-End-->