### PR TITLE
Remove testingMode from WebExtensionContext.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -46,7 +46,6 @@ struct WebExtensionContextParameters {
     Ref<API::Data> manifestJSON;
 
     double manifestVersion { 0 };
-    bool testingMode { false };
     bool isSessionStorageAllowedInContentScripts { false };
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -32,7 +32,6 @@ struct WebKit::WebExtensionContextParameters {
     Ref<API::Data> manifestJSON;
 
     double manifestVersion;
-    bool testingMode;
     bool isSessionStorageAllowedInContentScripts;
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -792,16 +792,6 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
     _webExtensionContext->didChangeTabProperties(toImpl(changedTab, *_webExtensionContext), toImpl(properties));
 }
 
-- (BOOL)_inTestingMode
-{
-    return _webExtensionContext->inTestingMode();
-}
-
-- (void)_setTestingMode:(BOOL)testingMode
-{
-    _webExtensionContext->setTestingMode(testingMode);
-}
-
 - (WKWebView *)_backgroundWebView
 {
     return _webExtensionContext->backgroundWebView();
@@ -1155,15 +1145,6 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (void)didChangeTabProperties:(_WKWebExtensionTabChangedProperties)properties forTab:(id<_WKWebExtensionTab>)changedTab
-{
-}
-
-- (BOOL)_inTestingMode
-{
-    return NO;
-}
-
-- (void)_setTestingMode:(BOOL)testingMode
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h
@@ -29,12 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKWebExtensionContext ()
 
-/*!
- @abstract Enables extra `browser.test` APIs and unsupported API stubs for testing.
- @discussion Defaults to `YES` in debug builds.
- */
-@property (nonatomic, getter=_inTestingMode, setter=_setTestingMode:) BOOL _testingMode;
-
 /*! @abstract The extension background view used for the extension, or `nil` if the extension does not have background content or it is currently unloaded. */
 @property (nonatomic, nullable, readonly) WKWebView *_backgroundWebView;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2480,15 +2480,6 @@ void WebExtensionContext::clearUserGesture(WebExtensionTab& tab)
     tab.setTemporaryPermissionMatchPattern(nullptr);
 }
 
-void WebExtensionContext::setTestingMode(bool testingMode)
-{
-    ASSERT(!isLoaded());
-    if (isLoaded())
-        return;
-
-    m_testingMode = testingMode;
-}
-
 std::optional<WebCore::PageIdentifier> WebExtensionContext::backgroundPageIdentifier() const
 {
     if (!m_backgroundWebView || extension().backgroundContentIsServiceWorker())

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -30,6 +30,7 @@
 
 #include "WebExtensionContextParameters.h"
 #include "WebExtensionContextProxyMessages.h"
+#include "WebExtensionController.h"
 #include "WebPageProxy.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
@@ -65,7 +66,6 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
         extension().serializeLocalization(),
         extension().serializeManifest(),
         extension().manifestVersion(),
-        inTestingMode(),
         isSessionStorageAllowedInContentScripts(),
         backgroundPageIdentifier(),
 #if ENABLE(INSPECTOR_EXTENSIONS)
@@ -74,6 +74,11 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
         popupPageIdentifiers(),
         tabPageIdentifiers()
     };
+}
+
+bool WebExtensionContext::inTestingMode() const
+{
+    return m_extensionController && m_extensionController->inTestingMode();
 }
 
 const WebExtensionContext::UserContentControllerProxySet& WebExtensionContext::userContentControllers() const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -422,8 +422,7 @@ public:
     bool hasActiveUserGesture(WebExtensionTab&) const;
     void clearUserGesture(WebExtensionTab&);
 
-    bool inTestingMode() const { return m_testingMode; }
-    void setTestingMode(bool);
+    bool inTestingMode() const;
 
     URL backgroundContentURL();
     WKWebView *backgroundWebView() const { return m_backgroundWebView.get(); }
@@ -810,11 +809,6 @@ private:
 
     bool m_requestedOptionalAccessToAllHosts { false };
     bool m_hasAccessInPrivateBrowsing { false };
-#ifdef NDEBUG
-    bool m_testingMode { false };
-#else
-    bool m_testingMode { true };
-#endif
 
     VoidCompletionHandlerVector m_actionsToPerformAfterBackgroundContentLoads;
     EventListenerTypeCountedSet m_backgroundContentEventListeners;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -28,11 +28,13 @@
 #endif
 
 #import "config.h"
-#import "CocoaHelpers.h"
 #import "WebExtensionAPINamespace.h"
-#import <WebKit/_WKWebExtensionPermission.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WebExtensionControllerProxy.h"
+#import <WebKit/_WKWebExtensionPermission.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -30,6 +30,8 @@
 #import "config.h"
 #import "WebExtensionAPIPermissions.h"
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+
 #import "CocoaHelpers.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
@@ -39,8 +41,6 @@
 #import "WebExtensionUtilities.h"
 #import "WebProcess.h"
 #import <wtf/cocoa/VectorCocoa.h>
-
-#if ENABLE(WK_WEB_EXTENSIONS)
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -80,7 +80,6 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
         context.m_localization = parseLocalization(parameters.localizationJSON.get(), parameters.baseURL);
         context.m_manifest = parseJSON(parameters.manifestJSON.get());
         context.m_manifestVersion = parameters.manifestVersion;
-        context.m_testingMode = parameters.testingMode;
         context.m_isSessionStorageAllowedInContentScripts = parameters.isSessionStorageAllowedInContentScripts;
 
         if (parameters.backgroundPageIdentifier) {

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -66,6 +66,11 @@ std::optional<WebExtensionTabIdentifier> WebExtensionContextProxy::tabIdentifier
     return std::nullopt;
 }
 
+bool WebExtensionContextProxy::inTestingMode() const
+{
+    return m_extensionControllerProxy && m_extensionControllerProxy->inTestingMode();
+}
+
 RefPtr<WebPage> WebExtensionContextProxy::backgroundPage() const
 {
     return m_backgroundPage.get();

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -85,7 +85,7 @@ public:
 
     bool isSessionStorageAllowedInContentScripts() { return m_isSessionStorageAllowedInContentScripts; }
 
-    bool inTestingMode() { return m_testingMode; }
+    bool inTestingMode() const;
 
     WebCore::DOMWrapperWorld& toDOMWrapperWorld(WebExtensionContentWorldType);
 
@@ -215,7 +215,6 @@ private:
     RetainPtr<_WKWebExtensionLocalization> m_localization;
     RetainPtr<NSDictionary> m_manifest;
     double m_manifestVersion { 0 };
-    bool m_testingMode { false };
     bool m_isSessionStorageAllowedInContentScripts { false };
     RefPtr<WebCore::DOMWrapperWorld> m_contentScriptWorld;
     WeakFrameSet m_extensionContentFrames;

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -63,7 +63,6 @@
     _controller = [[_WKWebExtensionController alloc] initWithConfiguration:configuration ?: _WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
     _controller._testingMode = YES;
-    _context._testingMode = YES;
 
     // This should always be self. If you need the delegate, use the controllerDelegate property.
     // Delegate method calls will be forwarded to the controllerDelegate.


### PR DESCRIPTION
#### 948644e21eefcb6fdb3703d087b67c5d39e8a0c3
<pre>
Remove testingMode from WebExtensionContext.
<a href="https://webkit.org/b/269735">https://webkit.org/b/269735</a>
<a href="https://rdar.apple.com/problem/123254659">rdar://problem/123254659</a>

Reviewed by Brian Weinstein.

testingMode was added to WebExtensionController, so it is no longer needed on WebExtensionContext.
Removing it prevents the context and controller from mismathcing.

* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext _inTestingMode]): Deleted.
(-[_WKWebExtensionContext _setTestingMode:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::setTestingMode): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
(WebKit::WebExtensionContext::inTestingMode const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::inTestingMode const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::inTestingMode const):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]):

Canonical link: <a href="https://commits.webkit.org/275006@main">https://commits.webkit.org/275006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3589e5788668f900088c02a789472827c1604c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16964 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14284 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36316 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40055 "Found 1 new test failure: fast/repaint/animation-after-layer-scroll.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38388 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17054 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17105 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5400 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->