### PR TITLE
[WebGPU] GPUDevice::destroy deference deallocated GPUBuffer instances

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -40,13 +40,14 @@
 #include <wtf/RangeSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class GPUDevice;
 
-class GPUBuffer : public RefCounted<GPUBuffer> {
+class GPUBuffer : public RefCounted<GPUBuffer>, public CanMakeWeakPtr<GPUBuffer> {
 public:
     static Ref<GPUBuffer> create(Ref<WebGPU::Buffer>&& backing, size_t bufferSize, GPUBufferUsageFlags usage, bool mappedAtCreation, GPUDevice& device)
     {

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -114,18 +114,18 @@ Ref<GPUQueue> GPUDevice::queue() const
 
 void GPUDevice::addBufferToUnmap(GPUBuffer& buffer)
 {
-    m_buffersToUnmap.add(&buffer);
+    m_buffersToUnmap.add(buffer);
 }
 
 void GPUDevice::removeBufferToUnmap(GPUBuffer& buffer)
 {
-    m_buffersToUnmap.remove(&buffer);
+    m_buffersToUnmap.remove(buffer);
 }
 
 void GPUDevice::destroy(ScriptExecutionContext& scriptExecutionContext)
 {
     for (auto& buffer : m_buffersToUnmap)
-        buffer->destroy(scriptExecutionContext);
+        buffer.destroy(scriptExecutionContext);
 
     m_buffersToUnmap.clear();
 

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -41,6 +41,7 @@
 #include <wtf/IsoMalloc.h>
 #include <wtf/Ref.h>
 #include <wtf/WeakHashMap.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -156,7 +157,7 @@ private:
     Ref<WebGPU::Device> m_backing;
     Ref<GPUQueue> m_queue;
     Ref<GPUPipelineLayout> m_autoPipelineLayout;
-    HashSet<GPUBuffer*> m_buffersToUnmap;
+    WeakHashSet<GPUBuffer> m_buffersToUnmap;
     GPUExternalTexture* externalTextureForDescriptor(const GPUExternalTextureDescriptor&);
 
     WeakHashMap<HTMLVideoElement, WeakPtr<GPUExternalTexture>> m_videoElementToExternalTextureMap;


### PR DESCRIPTION
#### 453410211ed24fa7155e7f34fedfcaf0bb958911
<pre>
[WebGPU] GPUDevice::destroy deference deallocated GPUBuffer instances
<a href="https://bugs.webkit.org/show_bug.cgi?id=269741">https://bugs.webkit.org/show_bug.cgi?id=269741</a>
&lt;radar://123051116&gt;

Reviewed by Dan Glastonbury.

Use WeakHashSet instead of HashSet since some GPUBuffers
may be destroyed / deallocated before the device is destroyed.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::addBufferToUnmap):
(WebCore::GPUDevice::removeBufferToUnmap):
(WebCore::GPUDevice::destroy):
* Source/WebCore/Modules/WebGPU/GPUDevice.h:

Canonical link: <a href="https://commits.webkit.org/275027@main">https://commits.webkit.org/275027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e537d4549853dc474c71e5254456118b4d67305

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33719 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14309 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44464 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34089 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40069 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38404 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17070 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35285 "Build is in progress. Recent messages:") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9114 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->