### PR TITLE
[WPE][GTK] Deprecate insecure-content-detected signals

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -2235,19 +2235,16 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
      * @web_view: the #WebKitWebView on which the signal is emitted
      * @event: the #WebKitInsecureContentEvent
      *
-     * This signal is emitted when insecure content has been detected
-     * in a page loaded through a secure connection. This typically
-     * means that a external resource from an unstrusted source has
-     * been run or displayed, resulting in a mix of HTTPS and
-     * non-HTTPS content.
+     * Prior to 2.46, this signal was emitted when insecure content was
+     * loaded in a secure content. Since 2.46, this signal is generally
+     * no longer emitted.
      *
-     * You can check the @event parameter to know exactly which kind
-     * of event has been detected (see #WebKitInsecureContentEvent).
+     * Deprecated: 2.46
      */
     signals[INSECURE_CONTENT_DETECTED] =
         g_signal_new("insecure-content-detected",
             G_TYPE_FROM_CLASS(webViewClass),
-            G_SIGNAL_RUN_LAST,
+            static_cast<GSignalFlags>(G_SIGNAL_RUN_LAST | G_SIGNAL_DEPRECATED),
             G_STRUCT_OFFSET(WebKitWebViewClass, insecure_content_detected),
             0, 0,
             g_cclosure_marshal_VOID__ENUM,

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -175,8 +175,11 @@ typedef enum {
  * detected by trying to display any kind of resource (e.g. an image)
  * from an untrusted source.
  *
- * Enum values used to denote the different events which can trigger
- * the detection of insecure content.
+ * Enum values previously used to denote the different events which can trigger
+ * the detection of insecure content. Since 2.46, WebKit generally no longer
+ * loads insecure content in secure contexts.
+ *
+ * Deprecated: 2.46
  */
 typedef enum {
     WEBKIT_INSECURE_CONTENT_RUN,


### PR DESCRIPTION
#### 9cf4048416d8bdd0ff193189422bf20427bccb6a
<pre>
[WPE][GTK] Deprecate insecure-content-detected signals
<a href="https://bugs.webkit.org/show_bug.cgi?id=219396">https://bugs.webkit.org/show_bug.cgi?id=219396</a>

Reviewed by Carlos Garcia Campos.

I&apos;m being a bit careful with the language here because although in
practice these signals will never be emitted anymore, technically it is
still possible if the user toggles the right runtime setting using the
WebKitFeature API. But in practice, this is not something anybody is
ever likely to do, so we should indicate that these signals are
obsolete.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:

Canonical link: <a href="https://commits.webkit.org/275056@main">https://commits.webkit.org/275056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c680b00c1e9efb87abe8bd60fdfa42aefe8c9808

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43192 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36728 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33714 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14380 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44467 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40071 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38406 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17073 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9139 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17124 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->