### PR TITLE
[WebGPU] TextureView should hold a Ref<Texture> instead of a Texture&

### DIFF
--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -95,7 +95,7 @@ private:
     const std::optional<WGPUExtent3D> m_renderExtent;
 
     const Ref<Device> m_device;
-    Texture& m_parentTexture;
+    Ref<Texture> m_parentTexture;
     mutable WeakPtr<CommandEncoder> m_commandEncoder;
 };
 

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -56,47 +56,47 @@ void TextureView::setLabel(String&& label)
 
 id<MTLTexture> TextureView::parentTexture() const
 {
-    return m_parentTexture.texture();
+    return m_parentTexture->texture();
 }
 
 bool TextureView::previouslyCleared() const
 {
-    return m_parentTexture.previouslyCleared(m_texture.parentRelativeLevel, m_texture.parentRelativeSlice);
+    return m_parentTexture->previouslyCleared(m_texture.parentRelativeLevel, m_texture.parentRelativeSlice);
 }
 
 void TextureView::setPreviouslyCleared()
 {
-    m_parentTexture.setPreviouslyCleared(m_texture.parentRelativeLevel, m_texture.parentRelativeSlice);
+    m_parentTexture->setPreviouslyCleared(m_texture.parentRelativeLevel, m_texture.parentRelativeSlice);
 }
 
 uint32_t TextureView::width() const
 {
-    return m_parentTexture.physicalMiplevelSpecificTextureExtent(baseMipLevel()).width;
+    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).width;
 }
 
 uint32_t TextureView::height() const
 {
-    return m_parentTexture.physicalMiplevelSpecificTextureExtent(baseMipLevel()).height;
+    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).height;
 }
 
 uint32_t TextureView::depthOrArrayLayers() const
 {
-    return m_parentTexture.physicalMiplevelSpecificTextureExtent(baseMipLevel()).depthOrArrayLayers;
+    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).depthOrArrayLayers;
 }
 
 WGPUTextureUsageFlags TextureView::usage() const
 {
-    return m_parentTexture.usage();
+    return m_parentTexture->usage();
 }
 
 uint32_t TextureView::sampleCount() const
 {
-    return m_parentTexture.sampleCount();
+    return m_parentTexture->sampleCount();
 }
 
 WGPUTextureFormat TextureView::parentFormat() const
 {
-    return m_parentTexture.format();
+    return m_parentTexture->format();
 }
 
 WGPUTextureFormat TextureView::format() const
@@ -106,7 +106,7 @@ WGPUTextureFormat TextureView::format() const
 
 uint32_t TextureView::parentMipLevelCount() const
 {
-    return m_parentTexture.mipLevelCount();
+    return m_parentTexture->mipLevelCount();
 }
 
 uint32_t TextureView::mipLevelCount() const
@@ -141,7 +141,7 @@ WGPUTextureViewDimension TextureView::dimension() const
 
 bool TextureView::isDestroyed() const
 {
-    return m_parentTexture.isDestroyed();
+    return m_parentTexture->isDestroyed();
 }
 
 bool TextureView::isValid() const


### PR DESCRIPTION
#### 9a7ee2735d19c8372febcde381fcfdeb8bf796c0
<pre>
[WebGPU] TextureView should hold a Ref&lt;Texture&gt; instead of a Texture&amp;
<a href="https://bugs.webkit.org/show_bug.cgi?id=269745">https://bugs.webkit.org/show_bug.cgi?id=269745</a>
&lt;radar://123224537&gt;

Reviewed by Dan Glastonbury.

We don&apos;t want the underlying Texture object to have its
lifetime end while any derived TextureView instances are still
alive.

Hold a strong reference to the Texture instead of a raw C++ reference.

* Source/WebGPU/WebGPU/TextureView.h:
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::parentTexture const):
(WebGPU::TextureView::previouslyCleared const):
(WebGPU::TextureView::setPreviouslyCleared):
(WebGPU::TextureView::width const):
(WebGPU::TextureView::height const):
(WebGPU::TextureView::depthOrArrayLayers const):
(WebGPU::TextureView::usage const):
(WebGPU::TextureView::sampleCount const):
(WebGPU::TextureView::parentFormat const):
(WebGPU::TextureView::parentMipLevelCount const):
(WebGPU::TextureView::isDestroyed const):

Canonical link: <a href="https://commits.webkit.org/275028@main">https://commits.webkit.org/275028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25a3bd2a2dd782ff5817867835f8bb331b8d33a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43021 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36732 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16987 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33717 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14306 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14383 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40076 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38413 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17077 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9115 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->