### PR TITLE
[view-transitions] Implement "update pseudo-element styles" algorithm.

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2695,6 +2695,7 @@ rendering/RenderTreeMutationDisallowedScope.cpp
 rendering/RenderVTTCue.cpp
 rendering/RenderVideo.cpp
 rendering/RenderView.cpp
+rendering/RenderViewTransitionCapture.cpp
 rendering/RenderWidget.cpp
 rendering/StyledMarkedText.cpp
 rendering/TableLayout.cpp

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -27,9 +27,15 @@
 #include "ViewTransition.h"
 
 #include "CheckVisibilityOptions.h"
+#include "ComputedStyleExtractor.h"
 #include "Document.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
+#include "PseudoElementRequest.h"
+#include "RenderBox.h"
+#include "StyleResolver.h"
+#include "StyleScope.h"
+#include "Styleable.h"
 #include "TypedElementDescendantIteratorInlines.h"
 
 namespace WebCore {
@@ -271,6 +277,12 @@ ExceptionOr<void> ViewTransition::captureOldState()
     for (auto& element : captureElements) {
         // FIXME: Fill in the rest of CapturedElement.
         CapturedElement capture;
+
+        CheckedPtr renderBox = dynamicDowncast<RenderBox>(element->renderer());
+        if (renderBox)
+            capture.oldSize = renderBox->size();
+        capture.oldProperties = copyElementBaseProperties(element.get());
+
         auto transitionName = element->computedStyle()->viewTransitionName();
         m_namedElements.add(transitionName->name, capture);
     }
@@ -329,7 +341,7 @@ void ViewTransition::activateViewTransition()
     // FIXME: Set captured element flag to true.
 
     setupTransitionPseudoElements();
-    // FIXME: Update pseudo-element styles for transition.
+    updatePseudoElementStyles();
 
     m_phase = ViewTransitionPhase::Animating;
     m_ready.second->resolve();
@@ -349,7 +361,7 @@ void ViewTransition::handleTransitionFrame()
     }
 
     // FIXME: If transition’s initial snapshot containing block size is not equal to the snapshot containing block size, then skip the view transition for transition, and return.
-    // FIXME: Update pseudo-element styles for transition.
+    updatePseudoElementStyles();
 }
 
 // https://drafts.csswg.org/css-view-transitions/#clear-view-transition-algorithm
@@ -364,9 +376,55 @@ void ViewTransition::clearViewTransition()
 
     protectedDocument()->setHasViewTransitionPseudoElementTree(false);
     protectedDocument()->setActiveViewTransition(nullptr);
+    protectedDocument()->styleScope().clearViewTransitionStyles();
 
     if (RefPtr documentElement = protectedDocument()->documentElement())
         documentElement->invalidateStyleInternal();
+}
+
+Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(Element& element)
+{
+    // FIXME: Transform - ComputedStyleExtractor.cpp::matrixTransformValue
+    ComputedStyleExtractor styleExtractor(&element);
+
+    CSSPropertyID transitionProperties[] = {
+        CSSPropertyWritingMode,
+        CSSPropertyDirection,
+        CSSPropertyTextOrientation,
+        CSSPropertyMixBlendMode,
+        CSSPropertyBackdropFilter,
+#if ENABLE(DARK_MODE_CSS)
+        CSSPropertyColorScheme,
+#endif
+        CSSPropertyWidth,
+        CSSPropertyHeight,
+    };
+
+    return styleExtractor.copyProperties(transitionProperties);
+}
+
+// https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles
+void ViewTransition::updatePseudoElementStyles()
+{
+    auto& resolver = protectedDocument()->styleScope().resolver();
+
+    for (auto& iter : m_namedElements.map()) {
+        RefPtr<MutableStyleProperties> properties;
+        if (iter.value->newElement)
+            properties = copyElementBaseProperties(*iter.value->newElement);
+        else
+            properties = iter.value->oldProperties;
+
+        if (properties) {
+            if (!iter.value->groupStyleProperties) {
+                iter.value->groupStyleProperties = properties;
+                resolver.setViewTransitionGroupStyles(iter.key, *properties);
+            } else
+                iter.value->groupStyleProperties->mergeAndOverrideOnConflict(*properties);
+        }
+    }
+
+    protectedDocument()->styleScope().didChangeStyleSheetContents();
 }
 
 }

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -29,6 +29,7 @@
 #include "Element.h"
 #include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
+#include "MutableStyleProperties.h"
 #include "ViewTransitionUpdateCallback.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
@@ -52,18 +53,16 @@ struct CapturedElement {
 public:
     // FIXME: Add the following:
     // old image (2d bitmap)
-    // old width / height
+    LayoutSize oldSize;
+    RefPtr<MutableStyleProperties> oldProperties;
     // old transform
-    // old writing mode
-    // old direction
-    // old text-orientation
-    // old mix-blend-mode
     WeakPtr<Element, WeakPtrImplWithEventTargetData> newElement;
+
+    RefPtr<MutableStyleProperties> groupStyleProperties;
 
     // FIXME: Also handle these:
     // group keyframes
     // group animation name rule
-    // group styles rule
     // image pair isolation rule
     // image animation name rule
 };
@@ -92,12 +91,29 @@ public:
         return m_keys;
     }
 
+    auto& map() const
+    {
+        return m_map;
+    }
+
+    auto& map()
+    {
+        return m_map;
+    }
+
     bool isEmpty() const
     {
         return m_keys.isEmpty();
     }
 
     CapturedElement* find(const AtomString& key)
+    {
+        if (auto it = m_map.find(key); it != m_map.end())
+            return &it->value;
+        return nullptr;
+    }
+
+    const CapturedElement* find(const AtomString& key) const
     {
         if (auto it = m_map.find(key); it != m_map.end())
             return &it->value;
@@ -137,6 +153,10 @@ public:
 
 private:
     ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&);
+
+    Ref<MutableStyleProperties> copyElementBaseProperties(Element&);
+
+    void updatePseudoElementStyles();
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -169,6 +169,7 @@ public:
         VTTCue,
         Video,
         View,
+        ViewTransitionCapture,
 #if ENABLE(MATHML)
         MathMLBlock,
         MathMLFenced,
@@ -254,6 +255,7 @@ public:
         IsImage = 1 << 0,
         IsMedia = 1 << 1,
         IsWidget = 1 << 2,
+        IsViewTransitionCapture = 1 << 3,
     };
 
     enum class SVGModelObjectFlag : uint8_t {
@@ -474,6 +476,7 @@ public:
     bool isRenderSearchField() const { return type() == Type::SearchField; }
     bool isRenderTextControlInnerBlock() const { return type() == Type::TextControlInnerBlock; }
     bool isRenderVideo() const { return type() == Type::Video; }
+    bool isRenderViewTransitionCapture() const { return isRenderReplaced() && m_typeSpecificFlags.replacedFlags().contains(ReplacedFlag::IsViewTransitionCapture); }
     bool isRenderWidget() const { return isRenderReplaced() && m_typeSpecificFlags.replacedFlags().contains(ReplacedFlag::IsWidget); }
     bool isRenderHTMLCanvas() const { return type() == Type::HTMLCanvas; }
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RenderViewTransitionCapture.h"
+
+#include "RenderBoxModelObjectInlines.h"
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(RenderViewTransitionCapture);
+
+RenderViewTransitionCapture::RenderViewTransitionCapture(Type type, Document& document, RenderStyle&& style)
+    : RenderReplaced(type, document, WTFMove(style), { }, ReplacedFlag::IsViewTransitionCapture)
+{ }
+
+void RenderViewTransitionCapture::setImage(const LayoutSize& size)
+{
+    setIntrinsicSize(size);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderReplaced.h"
+
+namespace WebCore {
+
+class RenderViewTransitionCapture : public RenderReplaced {
+    WTF_MAKE_ISO_ALLOCATED(RenderViewTransitionCapture);
+public:
+    RenderViewTransitionCapture(Type, Document&, RenderStyle&&);
+
+    // FIXME: This should be setting the actual image, as well as the instrinsic
+    // size
+    void setImage(const LayoutSize&);
+
+private:
+    ASCIILiteral renderName() const override { return style().pseudoElementType() == PseudoId::ViewTransitionNew ? "RenderViewTransitionNew"_s : "RenderViewTransitionOld"_s; }
+
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderViewTransitionCapture, isRenderViewTransitionCapture())

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -99,6 +99,7 @@ ElementRuleCollector::ElementRuleCollector(const Element& element, const ScopeRu
     , m_authorStyle(ruleSets.authorStyle())
     , m_userStyle(ruleSets.userStyle())
     , m_userAgentMediaQueryStyle(ruleSets.userAgentMediaQueryStyle())
+    , m_dynamicViewTransitionsStyle(ruleSets.dynamicViewTransitionsStyle())
     , m_selectorMatchingState(selectorMatchingState)
     , m_result(makeUnique<MatchResult>(element.isLink()))
 {
@@ -429,6 +430,9 @@ void ElementRuleCollector::matchUARules()
 
     if (m_userAgentMediaQueryStyle)
         matchUARules(*m_userAgentMediaQueryStyle);
+
+    if (m_dynamicViewTransitionsStyle)
+        matchUARules(*m_dynamicViewTransitionsStyle);
 }
 
 void ElementRuleCollector::matchUARules(const RuleSet& rules)

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -122,6 +122,7 @@ private:
     Ref<const RuleSet> m_authorStyle;
     RefPtr<const RuleSet> m_userStyle;
     RefPtr<const RuleSet> m_userAgentMediaQueryStyle;
+    RefPtr<const RuleSet> m_dynamicViewTransitionsStyle;
     SelectorMatchingState* m_selectorMatchingState;
 
     bool m_shouldIncludeEmptyRules { false };

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -118,6 +118,8 @@ public:
     std::unique_ptr<RenderStyle> styleForKeyframe(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, BlendingKeyframe&);
     bool isAnimationNameValid(const String&);
 
+    void setViewTransitionGroupStyles(const AtomString&, Ref<MutableStyleProperties>);
+
     // These methods will give back the set of rules that matched for a given element (or a pseudo-element).
     enum CSSRuleFilter {
         UAAndUserCSSRules   = 1 << 1,

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -48,6 +48,7 @@
 #include "ProcessingInstruction.h"
 #include "RenderBoxInlines.h"
 #include "RenderView.h"
+#include "RuleSet.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGStyleElement.h"
 #include "Settings.h"
@@ -114,6 +115,11 @@ void Scope::createDocumentResolver()
 
     m_resolver = Resolver::create(m_document, Resolver::ScopeType::Document);
 
+    if (!m_dynamicViewTransitionsStyle)
+        m_dynamicViewTransitionsStyle = RuleSet::create();
+
+    m_resolver->ruleSets().setDynamicViewTransitionsStyle(m_dynamicViewTransitionsStyle.get());
+
     m_document->fontSelector().buildStarted();
 
     m_resolver->ruleSets().initializeUserStyle();
@@ -174,6 +180,12 @@ void Scope::clearResolver()
     m_resolver = nullptr;
     customPropertyRegistry().clearRegisteredFromStylesheets();
     counterStyleRegistry().clearAuthorCounterStyles();
+}
+
+void Scope::clearViewTransitionStyles()
+{
+    clearResolver();
+    m_dynamicViewTransitionsStyle = nullptr;
 }
 
 void Scope::releaseMemory()

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -65,6 +65,7 @@ namespace Style {
 
 class CustomPropertyRegistry;
 class Resolver;
+class RuleSet;
 
 class Scope : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
@@ -128,6 +129,8 @@ public:
     Resolver* resolverIfExists() { return m_resolver.get(); }
     void clearResolver();
     void releaseMemory();
+
+    void clearViewTransitionStyles();
 
     const Document& document() const { return m_document; }
     Document& document() { return m_document; }
@@ -210,6 +213,8 @@ private:
 
     Vector<RefPtr<StyleSheet>> m_styleSheetsForStyleSheetList;
     Vector<RefPtr<CSSStyleSheet>> m_activeStyleSheets;
+
+    mutable RefPtr<RuleSet> m_dynamicViewTransitionsStyle;
 
     Timer m_pendingUpdateTimer;
 

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -83,6 +83,11 @@ void ScopeRuleSets::updateUserAgentMediaQueryStyleIfNeeded() const
     builder.addRulesFromSheet(*UserAgentStyle::mediaQueryStyleSheet);
 }
 
+RuleSet* ScopeRuleSets::dynamicViewTransitionsStyle() const
+{
+    return m_dynamicViewTransitionsStyle.get();
+}
+
 RuleSet* ScopeRuleSets::userStyle() const
 {
     if (m_usesSharedUserStyle)

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -60,6 +60,7 @@ public:
 
     bool isAuthorStyleDefined() const { return m_isAuthorStyleDefined; }
     RuleSet* userAgentMediaQueryStyle() const;
+    RuleSet* dynamicViewTransitionsStyle() const;
     RuleSet& authorStyle() const { return *m_authorStyle; }
     RuleSet* userStyle() const;
     RuleSet* styleForCascadeLevel(CascadeLevel);
@@ -93,6 +94,11 @@ public:
 
     RuleFeatureSet& mutableFeatures();
 
+    void setDynamicViewTransitionsStyle(RuleSet* ruleSet)
+    {
+        m_dynamicViewTransitionsStyle = ruleSet;
+    }
+
     bool& isInvalidatingStyleWithRuleSets() { return m_isInvalidatingStyleWithRuleSets; }
 
     bool hasMatchingUserOrAuthorStyle(const Function<bool(RuleSet&)>&);
@@ -104,6 +110,7 @@ private:
 
     RefPtr<RuleSet> m_authorStyle;
     mutable RefPtr<RuleSet> m_userAgentMediaQueryStyle;
+    mutable RefPtr<RuleSet> m_dynamicViewTransitionsStyle;
     RefPtr<RuleSet> m_userStyle;
 
     Resolver& m_styleResolver;


### PR DESCRIPTION
#### 066b75f5a58bba233bfb505248d89ba1fbbc0e1f
<pre>
[view-transitions] Implement &quot;update pseudo-element styles&quot; algorithm.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265224">https://bugs.webkit.org/show_bug.cgi?id=265224</a>
<a href="https://rdar.apple.com/118703293">rdar://118703293</a>&gt;

Reviewed by Tim Nguyen.

Implements the basic outline of capturing the computed style from both
the old and new elements, and using these to generate a style rule
for the selector &apos;:root::view-transition-group(transitionName)&apos;.

Adds a mostly empty RenderViewTransitionOld class that we will use
for the replaced snapshot content, but just acts as a placeholder
for the intrinsic size right now.

With these changes, the size of the transitioned element now gets
applied correctly to the :view-transition-new/old renderers, and
styles targetting them (like background color) correctly get
applied and rendered.

The next step is to implement the &apos;capture the image&apos; algorithm
for new and old (likely splitting RenderViewTransformNew as a separate
class), so that we also include the replaced content.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::copyElementBaseProperties):
(WebCore::ViewTransition::updatePseudoElementStyles):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::OrderedNamedElementsMap::map const):
(WebCore::OrderedNamedElementsMap::find const):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderViewTransitionOld const):
* Source/WebCore/rendering/RenderViewTransitionOld.cpp: Added.
(WebCore::RenderViewTransitionOld::RenderViewTransitionOld):
(WebCore::RenderViewTransitionOld::setImage):
* Source/WebCore/rendering/RenderViewTransitionOld.h: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::RenderTreeUpdater::ViewTransition::buildPseudoElementGroup):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ElementRuleCollector):
(WebCore::Style::ElementRuleCollector::matchUARules):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::applyMatchedProperties):
(WebCore::Style::Resolver::setViewTransitionGroupStyles):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createDocumentResolver):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::dynamicViewTransitionsStyle const):
* Source/WebCore/style/StyleScopeRuleSets.h:
(WebCore::Style::ScopeRuleSets::setDynamicViewTransitionsStyle):

Canonical link: <a href="https://commits.webkit.org/275005@main">https://commits.webkit.org/275005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd64e86f28e134dca5ed00751260e4ec19979bcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43199 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16990 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16595 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44475 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17080 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9099 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17131 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->