### PR TITLE
[iOS] Extending selection with arrow keys before an inline prediction causes a MESSAGE_CHECK

### DIFF
--- a/LayoutTests/editing/selection/ios/select-backwards-with-inline-predictions-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-backwards-with-inline-predictions-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that selecting backwards after typing with inline predictions does not cause a crash. This test requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/select-backwards-with-inline-predictions.html
+++ b/LayoutTests/editing/selection/ios/select-backwards-with-inline-predictions.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true allowsInlinePredictions=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body {
+    margin: 0;
+    font-family: system-ui;
+    line-height: 150%;
+}
+
+input {
+    border: 1px solid tomato;
+    box-sizing: border-box;
+    outline: none;
+    font-size: 18px;
+    width: 300px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that selecting backwards after typing with inline predictions does not cause a crash. This test requires WebKitTestRunner.");
+
+    input = document.querySelector("input");
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    for (let character of [..."i want to c"]) {
+        await UIHelper.callFunctionAndWaitForEvent(async () => {
+            await UIHelper.typeCharacter(character);
+            await UIHelper.ensurePresentationUpdate();
+        }, document.body, "keyup");
+    }
+
+    await UIHelper.setInlinePrediction("elebrate");
+    await UIHelper.ensurePresentationUpdate();
+
+    await UIHelper.keyDown("leftArrow", ["shiftKey"]);
+    await UIHelper.ensurePresentationUpdate();
+
+    input.blur();
+    await UIHelper.waitForKeyboardToHide();
+
+    testPassed("Did not crash");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <input />
+</body>
+</html>


### PR DESCRIPTION
#### 33ccda6e9a0510fd5d89c720c09f48dcb183af74
<pre>
[iOS] Extending selection with arrow keys before an inline prediction causes a MESSAGE_CHECK
<a href="https://bugs.webkit.org/show_bug.cgi?id=269750">https://bugs.webkit.org/show_bug.cgi?id=269750</a>
<a href="https://rdar.apple.com/123018695">rdar://123018695</a>

Reviewed by Ryosuke Niwa.

When computing `selectedRangeInMarkedText`, we use `distanceBetweenPositions` to compute the
location of the range, based on the number of characters from the start of the composition range to
the start of the selection. When an inline prediction is active, however, it&apos;s possible to extend
the selection backwards, before the start of the marked text representing the inline prediction. In
this case, `distanceBetweenPositions` returns -1; this value is then interpreted as the `uint64_t`
numeric max limit and sent over IPC in `DocumentEditingContext::Range`, where it fails to decode due
to overflowing the max value which (subsequently) causes the web process to terminate.

To avoid this, we clamp the `selectedRangeInMarkedText` to the marked text range, such that the
endpoints of this range are both clamped to `[0, markedTextLength]`.

* LayoutTests/editing/selection/ios/select-backwards-with-inline-predictions-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-backwards-with-inline-predictions.html: Added.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):

Canonical link: <a href="https://commits.webkit.org/275017@main">https://commits.webkit.org/275017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18210e0284602785844b821df2e342a6b99a57d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36750 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17004 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40088 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38427 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35304 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9105 "Found 1 new test failure: http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17145 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5406 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->