### PR TITLE
Add nullptr check for ProcessLauncher client

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -177,8 +177,7 @@ void ProcessLauncher::launchProcess()
 #if USE(EXTENSIONKIT)
     auto handler = [](ThreadSafeWeakPtr<ProcessLauncher> weakProcessLauncher, ExtensionProcess&& process, ASCIILiteral name, NSError *error)
     {
-        RefPtr launcher = weakProcessLauncher.get();
-        if (!launcher) {
+        if (!weakProcessLauncher.get()) {
             process.invalidate();
             return;
         }
@@ -213,7 +212,8 @@ void ProcessLauncher::launchProcess()
 
         callOnMainRunLoop([weakProcessLauncher, name, process = WTFMove(process), launchGrant = WTFMove(launchGrant)] () mutable {
             RefPtr launcher = weakProcessLauncher.get();
-            if (!launcher) {
+            // If m_client is null, the Process launcher has been invalidated, and we should not proceed with the launch.
+            if (!launcher || !launcher->m_client) {
                 process.invalidate();
                 return;
             }


### PR DESCRIPTION
#### 9ff5a32ea773d660f731a47c326ac36896ac7ced
<pre>
Add nullptr check for ProcessLauncher client
<a href="https://bugs.webkit.org/show_bug.cgi?id=269759">https://bugs.webkit.org/show_bug.cgi?id=269759</a>
<a href="https://rdar.apple.com/122995875">rdar://122995875</a>

Reviewed by Brent Fulgham.

This patch fixes a null pointer dereference crash that was introduced in &lt;<a href="https://commits.webkit.org/274390@main">https://commits.webkit.org/274390@main</a>&gt;.
The commit 274390@main introduced a race condition by holding a reference to the Process launcher in the completion
handler for starting WebKit extension processes. This reference was held througout the duration of the completion
handler. This meant that on rare occasions, the Process launcher could be deleted at the end of the completion
handler, instead of in the AuxiliaryProcessProxy destructor, where it normally is invalidated and deleted. The
lambda to finish the launch scheduled from the completion handler on the main thread could then end up having a
Process launcher that was invalidated but not deallocated. When the Process launcher is invalidated, the m_client
member is set to nullptr. This member is later dereferenced in ProcessLauncher::finishLaunchingProcess, and caused
a null pointer crash in this case. This patch is fixing the crash by reverting the change in 274390@main that
introduced the crash as well as adding a null pointer check for m_client, to guard against this race being
reintroduced in the future.

* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):

Canonical link: <a href="https://commits.webkit.org/275047@main">https://commits.webkit.org/275047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d80c97645737d3504f3045dc93d2426457f21e5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36792 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33756 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14426 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44532 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36901 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40121 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38462 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17187 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5415 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->