### PR TITLE
FocusController::focusedOrMainFrame should return a LocalFrame*

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -516,7 +516,10 @@ AccessibilityObject* AXObjectCache::focusedObjectForPage(const Page* page)
         return nullptr;
 
     // get the focused node in the page
-    RefPtr document = page->focusController().focusedOrMainFrame().document();
+    RefPtr focusedOrMainFrame = page->focusController().focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return nullptr;
+    RefPtr document = focusedOrMainFrame->document();
     if (!document)
         return nullptr;
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3619,7 +3619,7 @@ void Element::focus(const FocusOptions& options)
         // Focus and change event handlers can cause us to lose our last ref.
         // If a focus event handler changes the focus to a different node it
         // does not make sense to continue and update appearence.
-        if (!CheckedRef(page->focusController())->setFocusedElement(newTarget.get(), frame, optionsWithVisibility))
+        if (!page->checkedFocusController()->setFocusedElement(newTarget.get(), frame, optionsWithVisibility))
             return;
     }
 
@@ -3685,7 +3685,7 @@ void Element::blur()
 {
     if (treeScope().focusedElementInScope() == this) {
         if (RefPtr frame = document().frame())
-            CheckedRef(frame->page()->focusController())->setFocusedElement(nullptr, *frame);
+            frame->page()->checkedFocusController()->setFocusedElement(nullptr, *frame);
         else
             protectedDocument()->setFocusedElement(nullptr);
     }

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2079,7 +2079,7 @@ void FrameSelection::selectFrameElementInParentIfFullySelected()
     // Focus on the parent frame, and then select from before this element to after.
     VisibleSelection newSelection(beforeOwnerElement, afterOwnerElement);
     if (parent->selection().shouldChangeSelection(newSelection) && page) {
-        CheckedRef(page->focusController())->setFocusedFrame(parent.get());
+        page->checkedFocusController()->setFocusedFrame(parent.get());
         // Previous focus can trigger DOM events, ensure the selection did not become orphan.
         if (newSelection.isOrphan())
             parent->selection().clear();
@@ -2385,7 +2385,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
                 FocusOptions focusOptions;
                 if (options & SetSelectionOption::ForBindings)
                     focusOptions.trigger = FocusTrigger::Bindings;
-                CheckedRef(m_document->page()->focusController())->setFocusedElement(target.get(), *m_document->frame(), focusOptions);
+                m_document->page()->checkedFocusController()->setFocusedElement(target.get(), *m_document->frame(), focusOptions);
                 return;
             }
             target = target->parentOrShadowHostElement();
@@ -2394,7 +2394,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
     }
 
     if (caretBrowsing)
-        CheckedRef(m_document->page()->focusController())->setFocusedElement(nullptr, *m_document->frame());
+        m_document->page()->checkedFocusController()->setFocusedElement(nullptr, *m_document->frame());
 }
 
 void DragCaretController::paintDragCaret(LocalFrame* frame, GraphicsContext& p, const LayoutPoint& paintOffset) const

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -37,12 +37,19 @@
 #include "VisibleUnits.h"
 #include <stdio.h>
 #include <wtf/Assertions.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextStream.h>
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
+
+const VisibleSelection& VisibleSelection::emptySelection()
+{
+    static NeverDestroyed<VisibleSelection> selection;
+    return selection.get();
+}
 
 VisibleSelection::VisibleSelection()
     : m_anchorIsFirst(true)

--- a/Source/WebCore/editing/VisibleSelection.h
+++ b/Source/WebCore/editing/VisibleSelection.h
@@ -35,6 +35,7 @@ enum class SelectionDirection : uint8_t { Forward, Backward, Right, Left };
 class VisibleSelection {
 public:
     WEBCORE_EXPORT VisibleSelection();
+    static const VisibleSelection& emptySelection();
 
     static constexpr auto defaultAffinity = VisiblePosition::defaultAffinity;
 

--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -313,7 +313,11 @@ std::optional<SimpleRange> DictionaryLookup::rangeAtHitTestResult(const HitTestR
     if (position.isNull())
         position = firstPositionInOrBeforeNode(node);
 
-    auto selection = CheckedRef(frame->page()->focusController())->focusedOrMainFrame().selection().selection();
+    RefPtr focusedOrMainFrame = frame->page()->checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return std::nullopt;
+
+    auto selection = focusedOrMainFrame->selection().selection();
     NSRange selectionRange;
     NSUInteger hitIndex;
     std::optional<SimpleRange> fullCharacterRange;

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -134,7 +134,11 @@ void CachedPage::restore(Page& page)
 
     // Restore the focus appearance for the focused element.
     // FIXME: Right now we don't support pages w/ frames in the b/f cache.  This may need to be tweaked when we add support for that.
-    RefPtr focusedDocument = CheckedRef(page.focusController())->focusedOrMainFrame().document();
+    RefPtr focusedOrMainFrame = page.checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return;
+
+    RefPtr focusedDocument = focusedOrMainFrame->document();
     if (RefPtr element = focusedDocument->focusedElement()) {
 #if PLATFORM(IOS_FAMILY)
         // We don't want focused nodes changing scroll position when restoring from the cache

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -479,7 +479,7 @@ void BaseDateAndTimeInputType::handleFocusEvent(Node* oldFocusedNode, FocusDirec
         // so that this element no longer has focus. In this case, one of the children should
         // not be focused as the element is losing focus entirely.
         if (auto* page = element()->document().page())
-            CheckedRef(page->focusController())->advanceFocus(direction, 0);
+            page->checkedFocusController()->advanceFocus(direction, 0);
 
     } else {
         // If the element received focus in any other direction, transfer focus to the first focusable child.

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -442,7 +442,11 @@ void InspectorFrontendHost::killText(const String& text, bool shouldPrependToKil
     if (!m_frontendPage)
         return;
 
-    Editor& editor = m_frontendPage->focusController().focusedOrMainFrame().editor();
+    RefPtr focusedOrMainFrame = m_frontendPage->checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return;
+
+    Editor& editor = focusedOrMainFrame->editor();
     editor.setStartNewKillRingSequence(shouldStartNewSequence);
     Editor::KillRingInsertionMode insertionMode = shouldPrependToKillRing ? Editor::KillRingInsertionMode::PrependText : Editor::KillRingInsertionMode::AppendText;
     editor.addTextToKillRing(text, insertionMode);

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -238,7 +238,11 @@ bool DragController::performDragOperation(DragData&& dragData)
     removeAllDroppedImagePlaceholders();
 
     SetForScope isPerformingDrop(m_isPerformingDrop, true);
-    IgnoreSelectionChangeForScope ignoreSelectionChanges { m_page->focusController().focusedOrMainFrame() };
+    RefPtr focusedOrMainFrame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return false;
+
+    IgnoreSelectionChangeForScope ignoreSelectionChanges { *focusedOrMainFrame };
 
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2395,9 +2395,9 @@ bool EventHandler::handlePasteGlobalSelection(const PlatformMouseEvent& platform
 
     if (!m_frame->page())
         return false;
-    LocalFrame& focusFrame = CheckedRef(m_frame->page()->focusController())->focusedOrMainFrame();
+    RefPtr focusFrame = m_frame->page()->checkedFocusController()->focusedOrMainFrame();
     // Do not paste here if the focus was moved somewhere else.
-    if (m_frame.ptr() == &focusFrame && m_frame->editor().client()->supportsGlobalSelection())
+    if (m_frame.ptr() == focusFrame.get() && m_frame->editor().client()->supportsGlobalSelection())
         return protectedFrame()->editor().command("PasteGlobalSelection"_s).execute();
 
     return false;
@@ -2958,7 +2958,7 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
 
     // If focus shift is blocked, we eat the event.
     RefPtr page = frame->page();
-    if (page && !CheckedRef(page->focusController())->setFocusedElement(element.get(), protectedFrame(), { { }, { }, { }, FocusTrigger::Click, { } }))
+    if (page && !page->checkedFocusController()->setFocusedElement(element.get(), protectedFrame(), { { }, { }, { }, FocusTrigger::Click, { } }))
         return false;
 
     if (element && m_mouseDownDelegatedFocus)
@@ -3837,7 +3837,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     if (initialKeyEvent.type() == PlatformEvent::Type::RawKeyDown) {
         element->dispatchEvent(keydown);
         // If frame changed as a result of keydown dispatch, then return true to avoid sending a subsequent keypress message to the new frame.
-        bool changedFocusedFrame = frame->page() && frame.ptr() != &frame->page()->focusController().focusedOrMainFrame();
+        bool changedFocusedFrame = frame->page() && frame.ptr() != frame->page()->focusController().focusedOrMainFrame();
         return keydown->defaultHandled() || keydown->defaultPrevented() || changedFocusedFrame;
     }
 
@@ -3871,7 +3871,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     }
 
     // If frame changed as a result of keydown dispatch, then return early to avoid sending a subsequent keypress message to the new frame.
-    bool changedFocusedFrame = frame->page() && frame.ptr() != &frame->page()->focusController().focusedOrMainFrame();
+    bool changedFocusedFrame = frame->page() && frame.ptr() != frame->page()->focusController().focusedOrMainFrame();
     bool keydownResult = keydown->defaultHandled() || keydown->defaultPrevented() || changedFocusedFrame;
     if (keydownResult && !backwardCompatibilityMode)
         return keydownResult;
@@ -4761,7 +4761,7 @@ void EventHandler::defaultArrowEventHandler(FocusDirection focusDirection, Keybo
     if (m_frame->document()->inDesignMode())
         return;
 
-    if (CheckedRef(page->focusController())->advanceFocus(focusDirection, &event))
+    if (page->checkedFocusController()->advanceFocus(focusDirection, &event))
         event.setDefaultHandled();
 }
 
@@ -4786,7 +4786,7 @@ void EventHandler::defaultTabEventHandler(KeyboardEvent& event)
     if (!page->tabKeyCyclesThroughElements())
         return;
 
-    if (CheckedRef(page->focusController())->advanceFocus(event.shiftKey() ? FocusDirection::Backward : FocusDirection::Forward, &event))
+    if (page->checkedFocusController()->advanceFocus(event.shiftKey() ? FocusDirection::Backward : FocusDirection::Forward, &event))
         event.setDefaultHandled();
 }
 
@@ -5198,7 +5198,7 @@ bool EventHandler::passMouseDownEventToWidget(Widget*)
 void EventHandler::focusDocumentView()
 {
     if (RefPtr page = m_frame->page())
-        CheckedRef(page->focusController())->setFocusedFrame(protectedFrame().ptr());
+        page->checkedFocusController()->setFocusedFrame(protectedFrame().ptr());
 }
 #endif // !PLATFORM(COCOA)
 

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -58,7 +58,7 @@ public:
     WEBCORE_EXPORT void setFocusedFrame(Frame*, BroadcastFocusedFrame = BroadcastFocusedFrame::Yes);
     Frame* focusedFrame() const { return m_focusedFrame.get(); }
     LocalFrame* focusedLocalFrame() const { return dynamicDowncast<LocalFrame>(m_focusedFrame.get()); }
-    WEBCORE_EXPORT LocalFrame& focusedOrMainFrame() const;
+    WEBCORE_EXPORT LocalFrame* focusedOrMainFrame() const;
 
     WEBCORE_EXPORT bool setInitialFocus(FocusDirection, KeyboardEvent*);
     bool advanceFocus(FocusDirection, KeyboardEvent*, bool initialFocus = false);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1078,7 +1078,7 @@ void LocalDOMWindow::focus(bool allowFocus)
         return;
 
     // Clear the current frame's focused node if a new frame is about to be focused.
-    RefPtr focusedFrame = CheckedRef(page->focusController())->focusedLocalFrame();
+    RefPtr focusedFrame = page->checkedFocusController()->focusedLocalFrame();
     if (focusedFrame && focusedFrame != frame)
         focusedFrame->protectedDocument()->setFocusedElement(nullptr);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1150,7 +1150,10 @@ uint32_t Page::replaceRangesWithText(const Vector<SimpleRange>& rangesToReplace,
 
 uint32_t Page::replaceSelectionWithText(const String& replacementText)
 {
-    Ref frame = checkedFocusController()->focusedOrMainFrame();
+    RefPtr frame = checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return 0;
+
     auto selection = frame->selection().selection();
     if (!selection.isContentEditable())
         return 0;
@@ -1234,7 +1237,8 @@ Vector<Ref<Element>> Page::editableElementsInRect(const FloatRect& searchRectInR
     // tries to avoid creating line boxes, which are things it hit tests, for them to reduce memory. If the
     // focused element is inside the search rect it's the most likely target for future editing operations,
     // even if it's empty. So, we special case it here.
-    if (RefPtr focusedElement = checkedFocusController()->focusedOrMainFrame().document()->focusedElement()) {
+    RefPtr focusedOrMainFrame = checkedFocusController()->focusedOrMainFrame();
+    if (RefPtr focusedElement = focusedOrMainFrame ? focusedOrMainFrame->document()->focusedElement() : nullptr) {
         if (searchRectInRootViewCoordinates.inclusivelyIntersects(focusedElement->boundingBoxInRootViewCoordinates())) {
             if (auto* editableElement = rootEditableElement(*focusedElement))
                 rootEditableElements.add(*editableElement);
@@ -1267,7 +1271,10 @@ void Page::setInteractionRegionsEnabled(bool enable)
 
 const VisibleSelection& Page::selection() const
 {
-    return checkedFocusController()->focusedOrMainFrame().selection().selection();
+    RefPtr focusedOrMainFrame = checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return VisibleSelection::emptySelection();
+    return focusedOrMainFrame->selection().selection();
 }
 
 void Page::setDefersLoading(bool defers)
@@ -4241,16 +4248,23 @@ bool Page::shouldDisableCorsForRequestTo(const URL& url) const
 
 const URL Page::fragmentDirectiveURLForSelectedText()
 {
-    if (auto range = CheckedRef(focusController())->focusedOrMainFrame().selection().selection().range()) {
+    RefPtr focusedOrMainFrame = checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return { };
+
+    if (auto range = focusedOrMainFrame->selection().selection().range()) {
         FragmentDirectiveGenerator fragmentDirectiveGenerator(range.value());
         return fragmentDirectiveGenerator.urlWithFragment();
     }
-    return URL();
+    return { };
 }
 
 void Page::revealCurrentSelection()
 {
-    checkedFocusController()->focusedOrMainFrame().checkedSelection()->revealSelection(SelectionRevealMode::Reveal, ScrollAlignment::alignCenterIfNeeded);
+    RefPtr focusedOrMainFrame = checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return;
+    focusedOrMainFrame->checkedSelection()->revealSelection(SelectionRevealMode::Reveal, ScrollAlignment::alignCenterIfNeeded);
 }
 
 void Page::injectUserStyleSheet(UserStyleSheet& userStyleSheet)

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -199,7 +199,7 @@ void EventHandler::focusDocumentView()
     }
 
     RELEASE_ASSERT(page == m_frame->page());
-    CheckedRef(page->focusController())->setFocusedFrame(protectedFrame().ptr());
+    page->checkedFocusController()->setFocusedFrame(protectedFrame().ptr());
 }
 
 bool EventHandler::passWidgetMouseDownEventToWidget(const MouseEventWithHitTestResults& event)

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -189,7 +189,7 @@ void EventHandler::focusDocumentView()
     }
 
     RELEASE_ASSERT(page == m_frame->page());
-    CheckedRef(page->focusController())->setFocusedFrame(protectedFrame().ptr());
+    page->checkedFocusController()->setFocusedFrame(protectedFrame().ptr());
 }
 
 bool EventHandler::passWidgetMouseDownEventToWidget(const MouseEventWithHitTestResults& event)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -293,7 +293,7 @@ void WKBundleFrameFocus(WKBundleFrameRef frameRef)
     if (!coreFrame)
         return;
 
-    CheckedRef(coreFrame->page()->focusController())->setFocusedFrame(coreFrame.get());
+    coreFrame->page()->checkedFocusController()->setFocusedFrame(coreFrame.get());
 }
 
 void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef message, WKStringRef group)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -281,24 +281,27 @@ void* WKAccessibilityRootObject(WKBundlePageRef pageRef)
 void* WKAccessibilityFocusedObject(WKBundlePageRef pageRef)
 {
     if (!pageRef)
-        return 0;
+        return nullptr;
 
     WebCore::Page* page = WebKit::toImpl(pageRef)->corePage();
     if (!page)
-        return 0;
+        return nullptr;
 
-    RefPtr focusedDocument = CheckedRef(page->focusController())->focusedOrMainFrame().document();
+    RefPtr focusedOrMainFrame = page->checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return nullptr;
+    RefPtr focusedDocument = focusedOrMainFrame->document();
     if (!focusedDocument)
-        return 0;
+        return nullptr;
 
     WebCore::AXObjectCache::enableAccessibility();
 
     auto* axObjectCache = focusedDocument->axObjectCache();
     if (!axObjectCache)
-        return 0;
+        return nullptr;
 
     auto* focus = axObjectCache->focusedObjectForPage(page);
-    return focus ? focus->wrapper() : 0;
+    return focus ? focus->wrapper() : nullptr;
 }
 
 void* WKAccessibilityFocusedUIElement()

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -67,14 +67,16 @@ void WebEditorClient::setInsertionPasteboard(const String&)
 
 static void changeWordCase(WebPage* page, NSString *(*changeCase)(NSString *))
 {
-    Ref frame = CheckedRef(page->corePage()->focusController())->focusedOrMainFrame();
+    RefPtr frame = page->corePage()->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
     if (!frame->editor().canEdit())
         return;
 
     frame->editor().command("selectWord"_s).execute();
 
     NSString *selectedString = frame->displayStringModifiedByEncoding(frame->editor().selectedText());
-    page->replaceSelectionWithText(frame.ptr(), changeCase(selectedString));
+    page->replaceSelectionWithText(frame.get(), changeCase(selectedString));
 }
 
 void WebEditorClient::uppercaseWord()

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -73,7 +73,10 @@ static OptionSet<DocumentMarker::Type> relevantMarkerTypes()
 
 std::optional<TextCheckingControllerProxy::RangeAndOffset> TextCheckingControllerProxy::rangeAndOffsetRelativeToSelection(int64_t offset, uint64_t length)
 {
-    auto& frameSelection = CheckedRef(m_page.corePage()->focusController())->focusedOrMainFrame().selection();
+    RefPtr focusedOrMainFrame = m_page.corePage()->checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return std::nullopt;
+    auto& frameSelection = focusedOrMainFrame->selection();
     auto selection = frameSelection.selection();
 
     RefPtr root = frameSelection.rootEditableElementOrDocumentElement();
@@ -96,7 +99,7 @@ std::optional<TextCheckingControllerProxy::RangeAndOffset> TextCheckingControlle
 
 void TextCheckingControllerProxy::replaceRelativeToSelection(const WebCore::AttributedString& annotatedString, int64_t selectionOffset, uint64_t length, uint64_t relativeReplacementLocation, uint64_t relativeReplacementLength)
 {
-    Ref frame = CheckedRef(m_page.corePage()->focusController())->focusedOrMainFrame();
+    Ref frame = m_page.corePage()->checkedFocusController()->focusedOrMainFrame();
     auto& frameSelection = frame->selection();
     if (!frameSelection.selection().isContentEditable())
         return;
@@ -158,7 +161,10 @@ void TextCheckingControllerProxy::removeAnnotationRelativeToSelection(const Stri
 
     auto removeCoreSpellingMarkers = annotation == "NSSpellingState"_s;
     auto types = removeCoreSpellingMarkers ? relevantMarkerTypes() : WebCore::DocumentMarker::Type::PlatformTextChecking;
-    RefPtr document = CheckedRef(m_page.corePage()->focusController())->focusedOrMainFrame().document();
+    RefPtr focusedOrMainFrame = m_page.corePage()->checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return;
+    RefPtr document = focusedOrMainFrame->document();
     document->markers().filterMarkers(rangeAndOffset->range, [&] (const DocumentMarker& marker) {
         if (!std::holds_alternative<WebCore::DocumentMarker::PlatformTextCheckingData>(marker.data()))
             return FilterMarkerResult::Keep;

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp
@@ -127,7 +127,9 @@ void UnifiedTextReplacementController::willBeginTextReplacementSession(const WTF
     ASSERT(!m_contextRanges.contains(uuid));
     m_contextRanges.set(uuid, liveRange);
 
-    Ref frame = CheckedRef(corePage->focusController())->focusedOrMainFrame();
+    RefPtr frame = corePage->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler({ });
 
     auto selectedTextRange = frame->selection().selection().firstRange();
 
@@ -157,7 +159,9 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveReplaceme
         return;
     }
 
-    Ref frame = CheckedRef(corePage->focusController())->focusedOrMainFrame();
+    RefPtr frame = corePage->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
 
     ASSERT(m_contextRanges.contains(uuid));
 
@@ -178,7 +182,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveReplaceme
         auto originalRangeWithOffset = CharacterRange { locationWithOffset, replacementData.originalRange.length };
         auto resolvedRange = resolveCharacterRange(*sessionRange, originalRangeWithOffset);
 
-        replaceTextInRange(frame.get(), resolvedRange, replacementData.replacement);
+        replaceTextInRange(*frame, resolvedRange, replacementData.replacement);
 
         auto newRangeWithOffset = CharacterRange { locationWithOffset, replacementData.replacement.length() };
         auto newResolvedRange = resolveCharacterRange(*sessionRange, newRangeWithOffset);
@@ -205,7 +209,10 @@ void UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForRe
         return;
     }
 
-    Ref frame = CheckedRef(corePage->focusController())->focusedOrMainFrame();
+    RefPtr frame = corePage->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     RefPtr document = frame->document();
     if (!document) {
         ASSERT_NOT_REACHED();
@@ -243,7 +250,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForRe
         }
     }();
 
-    replaceTextInRange(frame.get(), rangeToReplace, newText);
+    replaceTextInRange(*frame, rangeToReplace, newText);
 
     auto newData = DocumentMarker::UnifiedTextReplacementData { oldData.originalText, oldData.uuid, newState };
     document->markers().addMarker(node, DocumentMarker { DocumentMarker::Type::UnifiedTextReplacement, offsetRange, WTFMove(newData) });
@@ -264,7 +271,9 @@ void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::U
         return;
     }
 
-    Ref frame = CheckedRef(corePage->focusController())->focusedOrMainFrame();
+    RefPtr frame = corePage->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
     RefPtr document = frame->document();
     if (!document) {
         ASSERT_NOT_REACHED();
@@ -281,7 +290,7 @@ void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::U
                 return false;
 
             auto rangeToReplace = makeSimpleRange(node, marker);
-            replaceTextInRange(frame.get(), rangeToReplace, data.originalText);
+            replaceTextInRange(*frame, rangeToReplace, data.originalText);
 
             return false;
         });
@@ -309,7 +318,9 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithR
         return;
     }
 
-    Ref frame = CheckedRef(corePage->focusController())->focusedOrMainFrame();
+    RefPtr frame = corePage->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
     RefPtr document = frame->document();
     if (!document) {
         ASSERT_NOT_REACHED();
@@ -355,7 +366,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithR
 
     auto newResolvedRange = resolveCharacterRange(*sessionRange, newRange);
 
-    replaceTextInRange(frame.get(), newResolvedRange, newText);
+    replaceTextInRange(*frame, newResolvedRange, newText);
 
     auto updatedLiveRange = createLiveRange(*sessionRange);
     m_contextRanges.set(uuid, updatedLiveRange);
@@ -378,7 +389,10 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveEditActio
         return;
     }
 
-    Ref frame = CheckedRef(corePage->focusController())->focusedOrMainFrame();
+    RefPtr frame = corePage->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     RefPtr document = frame->document();
     if (!document) {
         ASSERT_NOT_REACHED();
@@ -411,7 +425,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveEditActio
 
         m_originalDocumentNodes.set(uuid, contents.returnValue()); // Deep clone.
 
-        replaceContentsInRange(frame, *sessionRange, *originalFragment);
+        replaceContentsInRange(*frame, *sessionRange, *originalFragment);
 
         auto updatedLiveRange = createLiveRange(*sessionRange);
         m_contextRanges.set(uuid, updatedLiveRange);

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -327,10 +327,11 @@ RefPtr<WebCore::TextIndicator> WebFoundTextRangeController::createTextIndicatorF
         options.add({ WebCore::TextIndicatorOption::PaintAllContent, WebCore::TextIndicatorOption::PaintBackgrounds });
 
 #if PLATFORM(IOS_FAMILY)
-    Ref frame = CheckedRef(m_webPage->corePage()->focusController())->focusedOrMainFrame();
-    frame->selection().setUpdateAppearanceEnabled(true);
-    frame->selection().updateAppearance();
-    frame->selection().setUpdateAppearanceEnabled(false);
+    if (RefPtr frame = m_webPage->corePage()->checkedFocusController()->focusedOrMainFrame()) {
+        frame->selection().setUpdateAppearanceEnabled(true);
+        frame->selection().updateAppearance();
+        frame->selection().setUpdateAppearanceEnabled(false);
+    }
 #endif
 
     return WebCore::TextIndicator::createWithRange(range, options, transition, WebCore::FloatSize(indicatorMargin, indicatorMargin));

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -167,7 +167,9 @@ void FindController::didFindString()
     // updateAppearance, so the selection won't have been pushed to the render tree.
     // Therefore, we need to force an update no matter what.
 
-    Ref frame = CheckedRef(m_webPage->corePage()->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_webPage->corePage()->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
     frame->selection().setUpdateAppearanceEnabled(true);
     frame->selection().updateAppearance();
     frame->selection().setUpdateAppearanceEnabled(false);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -250,7 +250,10 @@ void WebPage::platformInitializeAccessibility()
 
 void WebPage::platformReinitialize()
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     accessibilityTransferRemoteToken(accessibilityRemoteTokenData(), frame->frameID());
 }
 
@@ -423,7 +426,10 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 void WebPage::platformWillPerformEditingCommand()
 {
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     if (RefPtr document = frame->document()) {
         if (auto* holdingTank = document->domTimerHoldingTankIfExists())
             holdingTank->removeAll();
@@ -629,7 +635,10 @@ bool WebPage::performNonEditingBehaviorForSelector(const String&, WebCore::Keybo
 
 void WebPage::getSelectionContext(CompletionHandler<void(const String&, const String&, const String&)>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     if (!frame->selection().isRange())
         return completionHandler({ }, { }, { });
     const int selectionExtendedContextLength = 350;
@@ -728,7 +737,10 @@ IntRect WebPage::rectForElementAtInteractionLocation() const
 
 void WebPage::updateSelectionAppearance()
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     auto& editor = frame->editor();
     if (editor.ignoreSelectionChanges())
         return;
@@ -739,7 +751,7 @@ void WebPage::updateSelectionAppearance()
     if (!editor.hasComposition() && frame->selection().selection().isNone())
         return;
 
-    didChangeSelection(frame.get());
+    didChangeSelection(*frame);
 }
 
 static void dispatchSyntheticMouseMove(LocalFrame& mainFrame, const WebCore::FloatPoint& location, OptionSet<WebEventModifier> modifiers, WebCore::PointerID pointerId = WebCore::mousePointerID)
@@ -753,7 +765,9 @@ static void dispatchSyntheticMouseMove(LocalFrame& mainFrame, const WebCore::Flo
 void WebPage::generateSyntheticEditingCommand(SyntheticEditingCommandType command)
 {
     PlatformKeyboardEvent keyEvent;
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
     
     OptionSet<PlatformEvent::Modifier> modifiers;
     modifiers.add(PlatformEvent::Modifier::MetaKey);
@@ -909,7 +923,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     if (!localMainFrame)
         return;
 
-    RefPtr oldFocusedFrame = CheckedRef(m_page->focusController())->focusedLocalFrame();
+    RefPtr oldFocusedFrame = m_page->checkedFocusController()->focusedLocalFrame();
     RefPtr<Element> oldFocusedElement = oldFocusedFrame ? oldFocusedFrame->document()->focusedElement() : nullptr;
 
     SetForScope userIsInteractingChange { m_userIsInteracting, true };
@@ -932,7 +946,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     if (m_isClosed)
         return;
 
-    RefPtr newFocusedFrame = CheckedRef(m_page->focusController())->focusedLocalFrame();
+    RefPtr newFocusedFrame = m_page->checkedFocusController()->focusedLocalFrame();
     RefPtr<Element> newFocusedElement = newFocusedFrame ? newFocusedFrame->document()->focusedElement() : nullptr;
 
     if (nodeRespondingToClick.document().settings().contentChangeObserverEnabled()) {
@@ -1077,7 +1091,10 @@ void WebPage::didConcludeEditDrag()
 
     m_pendingImageElementsForDropSnapshot.clear();
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     if (auto selectionRange = frame->selection().selection().toNormalizedRange()) {
         m_pendingImageElementsForDropSnapshot = visibleImageElementsInRangeWithNonLoadedImages(*selectionRange);
         frame->selection().setSelectedRange(makeSimpleRange(selectionRange->end), Affinity::Downstream, FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes);
@@ -1262,7 +1279,10 @@ void WebPage::commitPotentialTapFailed()
 
 void WebPage::clearSelectionAfterTapIfNeeded()
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     if (frame->selection().selection().isContentEditable())
         return;
 
@@ -1466,8 +1486,11 @@ void WebPage::selectWithGesture(const IntPoint& point, GestureType gestureType, 
     if (static_cast<GestureRecognizerState>(gestureState) == GestureRecognizerState::Began)
         setFocusedFrameBeforeSelectingTextAtLocation(point);
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-    VisiblePosition position = visiblePositionInFocusedNodeForPoint(frame, point, isInteractingWithFocusedElement);
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
+    VisiblePosition position = visiblePositionInFocusedNodeForPoint(*frame, point, isInteractingWithFocusedElement);
 
     if (position.isNull()) {
         completionHandler(point, gestureType, gestureState, { });
@@ -1802,12 +1825,16 @@ IntRect WebPage::rootViewInteractionBounds(const Node& node)
 void WebPage::clearSelection()
 {
     m_startingGestureRange = std::nullopt;
-    CheckedRef(m_page->focusController())->focusedOrMainFrame().selection().clear();
+    RefPtr focusedOrMainFrame = m_page->checkedFocusController()->focusedOrMainFrame();
+    focusedOrMainFrame->selection().clear();
 }
 
 void WebPage::dispatchSyntheticMouseEventsForSelectionGesture(SelectionTouch touch, const IntPoint& point)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     if (!frame->selection().selection().isContentEditable())
         return;
 
@@ -1842,7 +1869,10 @@ void WebPage::dispatchSyntheticMouseEventsForSelectionGesture(SelectionTouch tou
 
 void WebPage::updateSelectionWithTouches(const IntPoint& point, SelectionTouch selectionTouch, bool baseIsStart, CompletionHandler<void(const WebCore::IntPoint&, SelectionTouch, OptionSet<SelectionFlags>)>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     IntPoint pointInDocument = RefPtr(frame->view())->rootViewToContents(point);
     VisiblePosition position = frame->visiblePositionForPoint(pointInDocument);
     if (position.isNull())
@@ -1864,16 +1894,16 @@ void WebPage::updateSelectionWithTouches(const IntPoint& point, SelectionTouch s
         if (frame->selection().selection().isContentEditable())
             range = makeSimpleRange(closestWordBoundaryForPosition(position));
         else
-            std::tie(range, selectionFlipped) = rangeForPointInRootViewCoordinates(frame, point, baseIsStart, selectionFlippingEnabled());
+            std::tie(range, selectionFlipped) = rangeForPointInRootViewCoordinates(*frame, point, baseIsStart, selectionFlippingEnabled());
         break;
 
     case SelectionTouch::EndedMovingForward:
     case SelectionTouch::EndedMovingBackward:
-        range = rangeAtWordBoundaryForPosition(frame.ptr(), position, baseIsStart);
+        range = rangeAtWordBoundaryForPosition(frame.get(), position, baseIsStart);
         break;
 
     case SelectionTouch::Moved:
-        std::tie(range, selectionFlipped) = rangeForPointInRootViewCoordinates(frame, point, baseIsStart, selectionFlippingEnabled());
+        std::tie(range, selectionFlipped) = rangeForPointInRootViewCoordinates(*frame, point, baseIsStart, selectionFlippingEnabled());
         break;
     }
 
@@ -1888,7 +1918,10 @@ void WebPage::updateSelectionWithTouches(const IntPoint& point, SelectionTouch s
 
 void WebPage::selectWithTwoTouches(const WebCore::IntPoint& from, const WebCore::IntPoint& to, GestureType gestureType, GestureRecognizerState gestureState, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     RefPtr view = frame->view();
     auto fromPosition = frame->visiblePositionForPoint(view->rootViewToContents(from));
     auto toPosition = frame->visiblePositionForPoint(view->rootViewToContents(to));
@@ -1906,7 +1939,10 @@ void WebPage::extendSelectionForReplacement(CompletionHandler<void()>&& completi
 {
     auto callCompletionHandlerOnExit = makeScopeExit(WTFMove(completion));
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     RefPtr document = frame->document();
     if (!document)
         return;
@@ -1947,7 +1983,10 @@ void WebPage::extendSelection(WebCore::TextGranularity granularity, CompletionHa
 {
     auto callCompletionHandlerOnExit = makeScopeExit(WTFMove(completionHandler));
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     // For the moment we handle only TextGranularity::WordGranularity.
     if (granularity != TextGranularity::WordGranularity || !frame->selection().isCaret())
         return;
@@ -1962,7 +2001,10 @@ void WebPage::extendSelection(WebCore::TextGranularity granularity, CompletionHa
 
 void WebPage::setSelectedRangeDispatchingSyntheticMouseEventsIfNeeded(const SimpleRange& range, Affinity affinity)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     IntPoint endLocationForSyntheticMouseEvents;
     bool shouldDispatchMouseEvents = shouldDispatchSyntheticMouseEventsWhenModifyingSelection();
     if (shouldDispatchMouseEvents) {
@@ -1984,7 +2026,10 @@ void WebPage::platformDidSelectAll()
     if (!shouldDispatchSyntheticMouseEventsWhenModifyingSelection())
         return;
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     RefPtr view = frame->view();
     auto startCaretRect = view->contentsToRootView(VisiblePosition(frame->selection().selection().start()).absoluteCaretBounds());
     auto endCaretRect = view->contentsToRootView(VisiblePosition(frame->selection().selection().end()).absoluteCaretBounds());
@@ -1995,7 +2040,10 @@ void WebPage::platformDidSelectAll()
 
 void WebPage::selectWordBackward()
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     if (!frame->selection().isCaret())
         return;
 
@@ -2009,7 +2057,9 @@ void WebPage::selectWordBackward()
 
 void WebPage::moveSelectionByOffset(int32_t offset, CompletionHandler<void()>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
     
     VisiblePosition startPosition = frame->selection().selection().end();
     if (startPosition.isNull())
@@ -2037,7 +2087,9 @@ void WebPage::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWin
         return;
     }
     
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
     auto& selection = frame->selection().selection();
     if (!selection.isRange())
         return;
@@ -2059,7 +2111,10 @@ void WebPage::cancelAutoscroll()
 
 void WebPage::requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<FloatRect>&)>&& reply)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return reply({ });
+
     RefPtr frameView = frame->view();
     if (!frameView) {
         reply({ });
@@ -2170,7 +2225,9 @@ void WebPage::requestEvasionRectsAboveSelection(CompletionHandler<void(const Vec
 
 void WebPage::getRectsForGranularityWithSelectionOffset(WebCore::TextGranularity granularity, int32_t offset, CompletionHandler<void(const Vector<WebCore::SelectionGeometry>&)>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler({ });
 
     auto selection = m_storedSelectionForAccessibility.isNone() ? frame->selection().selection() : m_storedSelectionForAccessibility;
     auto position = visiblePositionForPositionWithOffset(selection.visibleStart(), offset);
@@ -2192,8 +2249,8 @@ void WebPage::storeSelectionForAccessibility(bool shouldStore)
     if (!shouldStore)
         m_storedSelectionForAccessibility = VisibleSelection();
     else {
-        auto& frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-        m_storedSelectionForAccessibility = frame.selection().selection();
+        if (RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame())
+            m_storedSelectionForAccessibility = frame->selection().selection();
     }
 }
 
@@ -2211,7 +2268,9 @@ static std::optional<SimpleRange> rangeNearPositionMatchesText(const VisiblePosi
 
 void WebPage::getRectsAtSelectionOffsetWithText(int32_t offset, const String& text, CompletionHandler<void(const Vector<WebCore::SelectionGeometry>&)>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler({ });
     auto& selection = m_storedSelectionForAccessibility.isNone() ? frame->selection().selection() : m_storedSelectionForAccessibility;
     auto startPosition = visiblePositionForPositionWithOffset(selection.visibleStart(), offset);
     auto range = makeSimpleRange(startPosition, visiblePositionForPositionWithOffset(startPosition, text.length()));
@@ -2247,8 +2306,11 @@ void WebPage::selectPositionAtPoint(const WebCore::IntPoint& point, bool isInter
 
     setFocusedFrameBeforeSelectingTextAtLocation(point);
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-    VisiblePosition position = visiblePositionInFocusedNodeForPoint(frame, point, isInteractingWithFocusedElement);
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler();
+
+    VisiblePosition position = visiblePositionInFocusedNodeForPoint(*frame, point, isInteractingWithFocusedElement);
     
     if (position.isNotNull())
         frame->selection().setSelectedRange(makeSimpleRange(position), position.affinity(), WebCore::FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes);
@@ -2257,8 +2319,11 @@ void WebPage::selectPositionAtPoint(const WebCore::IntPoint& point, bool isInter
 
 void WebPage::selectPositionAtBoundaryWithDirection(const WebCore::IntPoint& point, WebCore::TextGranularity granularity, WebCore::SelectionDirection direction, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-    VisiblePosition position = visiblePositionInFocusedNodeForPoint(frame, point, isInteractingWithFocusedElement);
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler();
+
+    VisiblePosition position = visiblePositionInFocusedNodeForPoint(*frame, point, isInteractingWithFocusedElement);
 
     if (position.isNotNull()) {
         position = positionOfNextBoundaryOfGranularity(position, granularity, direction);
@@ -2270,7 +2335,9 @@ void WebPage::selectPositionAtBoundaryWithDirection(const WebCore::IntPoint& poi
 
 void WebPage::moveSelectionAtBoundaryWithDirection(WebCore::TextGranularity granularity, WebCore::SelectionDirection direction, CompletionHandler<void()>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler();
 
     if (!frame->selection().selection().isNone()) {
         bool isForward = (direction == SelectionDirection::Forward || direction == SelectionDirection::Right);
@@ -2333,7 +2400,7 @@ void WebPage::setFocusedFrameBeforeSelectingTextAtLocation(const IntPoint& point
     auto* hitNode = result.innerNode();
     if (hitNode && hitNode->renderer()) {
         RefPtr frame = result.innerNodeFrame();
-        CheckedRef(m_page->focusController())->setFocusedFrame(frame.get());
+        m_page->checkedFocusController()->setFocusedFrame(frame.get());
     }
 }
 
@@ -2341,8 +2408,11 @@ void WebPage::setSelectionRange(const WebCore::IntPoint& point, WebCore::TextGra
 {
     setFocusedFrameBeforeSelectingTextAtLocation(point);
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-    auto range = rangeForGranularityAtPoint(frame, point, granularity, isInteractingWithFocusedElement);
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
+    auto range = rangeForGranularityAtPoint(*frame, point, granularity, isInteractingWithFocusedElement);
     if (range)
         frame->selection().setSelectedRange(*range, Affinity::Upstream, WebCore::FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes);
     m_initialSelection = range;
@@ -2380,9 +2450,12 @@ void WebPage::beginSelectionInDirection(WebCore::SelectionDirection direction, C
 
 void WebPage::updateSelectionWithExtentPointAndBoundary(const WebCore::IntPoint& point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void(bool)>&& callback)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-    auto position = visiblePositionInFocusedNodeForPoint(frame, point, isInteractingWithFocusedElement);
-    auto newRange = rangeForGranularityAtPoint(frame, point, granularity, isInteractingWithFocusedElement);
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return callback(false);
+
+    auto position = visiblePositionInFocusedNodeForPoint(*frame, point, isInteractingWithFocusedElement);
+    auto newRange = rangeForGranularityAtPoint(*frame, point, granularity, isInteractingWithFocusedElement);
     
     if (position.isNull() || !m_initialSelection || !newRange)
         return callback(false);
@@ -2405,8 +2478,11 @@ void WebPage::updateSelectionWithExtentPointAndBoundary(const WebCore::IntPoint&
 
 void WebPage::updateSelectionWithExtentPoint(const WebCore::IntPoint& point, bool isInteractingWithFocusedElement, RespectSelectionAnchor respectSelectionAnchor, CompletionHandler<void(bool)>&& callback)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-    auto position = visiblePositionInFocusedNodeForPoint(frame, point, isInteractingWithFocusedElement);
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return callback(false);
+
+    auto position = visiblePositionInFocusedNodeForPoint(*frame, point, isInteractingWithFocusedElement);
 
     if (position.isNull())
         return callback(false);
@@ -2453,7 +2529,10 @@ void WebPage::updateSelectionWithExtentPoint(const WebCore::IntPoint& point, boo
 #if ENABLE(REVEAL)
 RevealItem WebPage::revealItemForCurrentSelection()
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return { };
+
     auto selection = frame->selection().selection();
     if (!selection.isNone()) {
         std::optional<SimpleRange> fullCharacterRange;
@@ -2519,19 +2598,25 @@ void WebPage::prepareSelectionForContextMenuWithLocationInView(IntPoint point, C
 
 void WebPage::replaceSelectedText(const String& oldText, const String& newText)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     auto wordRange = frame->selection().isCaret() ? wordRangeFromPosition(frame->selection().selection().start()) : frame->selection().selection().toNormalizedRange();
     if (plainTextForContext(wordRange) != oldText)
         return;
 
-    IgnoreSelectionChangeForScope ignoreSelectionChanges { frame };
+    IgnoreSelectionChangeForScope ignoreSelectionChanges { *frame };
     frame->selection().setSelectedRange(wordRange, Affinity::Upstream, WebCore::FrameSelection::ShouldCloseTyping::Yes);
     frame->editor().insertText(newText, 0);
 }
 
 void WebPage::replaceDictatedText(const String& oldText, const String& newText)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     if (frame->selection().isNone())
         return;
     
@@ -2550,18 +2635,21 @@ void WebPage::replaceDictatedText(const String& oldText, const String& newText)
         return;
 
     // We don't want to notify the client that the selection has changed until we are done inserting the new text.
-    IgnoreSelectionChangeForScope ignoreSelectionChanges { frame };
+    IgnoreSelectionChangeForScope ignoreSelectionChanges { *frame };
     frame->selection().setSelectedRange(range, Affinity::Upstream, WebCore::FrameSelection::ShouldCloseTyping::Yes);
     frame->editor().insertText(newText, 0);
 }
 
 void WebPage::willInsertFinalDictationResult()
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     if (frame->selection().isNone())
         return;
 
-    m_ignoreSelectionChangeScopeForDictation = makeUnique<IgnoreSelectionChangeForScope>(frame);
+    m_ignoreSelectionChangeScopeForDictation = makeUnique<IgnoreSelectionChangeForScope>(*frame);
 }
 
 void WebPage::didInsertFinalDictationResult()
@@ -2572,7 +2660,10 @@ void WebPage::didInsertFinalDictationResult()
 
 void WebPage::requestAutocorrectionData(const String& textForAutocorrection, CompletionHandler<void(WebAutocorrectionData)>&& reply)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return reply({ });
+
     if (!frame->selection().isCaret()) {
         reply({ });
         return;
@@ -2643,7 +2734,10 @@ void WebPage::syncApplyAutocorrection(const String& correction, const String& or
 
 bool WebPage::applyAutocorrectionInternal(const String& correction, const String& originalText, bool isCandidate)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return false;
+
     if (!frame->selection().isCaretOrRange())
         return false;
 
@@ -2708,7 +2802,7 @@ bool WebPage::applyAutocorrectionInternal(const String& correction, const String
     if (correction.length()) {
         frame->editor().insertText(correction, 0, originalText.isEmpty() ? TextEventInputKeyboard : TextEventInputAutocompletion);
         if (isCandidate)
-            adjustCandidateAutocorrectionInFrame(correction, frame.get());
+            adjustCandidateAutocorrectionInFrame(correction, *frame);
     } else if (originalText.length())
         frame->editor().deleteWithDirection(SelectionDirection::Backward, TextGranularity::CharacterGranularity, false, true);
     return true;
@@ -2719,7 +2813,10 @@ WebAutocorrectionContext WebPage::autocorrectionContext()
     if (!m_focusedElement)
         return { };
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return { };
+
     if (!frame->selection().selection().hasEditableStyle())
         return { };
 
@@ -2857,15 +2954,15 @@ static inline bool isObscuredElement(Element& element)
     
 static void focusedElementPositionInformation(WebPage& page, Element& focusedElement, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)
 {
-    Ref frame = CheckedRef(page.corePage()->focusController())->focusedOrMainFrame();
-    if (!frame->editor().hasComposition())
+    RefPtr frame = page.corePage()->checkedFocusController()->focusedOrMainFrame();
+    if (!frame || !frame->editor().hasComposition())
         return;
 
     const uint32_t kHitAreaWidth = 66;
     const uint32_t kHitAreaHeight = 66;
     Ref view = *frame->view();
     IntPoint adjustedPoint(view->rootViewToContents(request.point));
-    IntPoint constrainedPoint = constrainPoint(adjustedPoint, frame, focusedElement);
+    IntPoint constrainedPoint = constrainPoint(adjustedPoint, *frame, focusedElement);
     VisiblePosition position = frame->visiblePositionForPoint(constrainedPoint);
 
     auto compositionRange = frame->editor().compositionRange();
@@ -3528,7 +3625,10 @@ void WebPage::focusNextFocusedElement(bool isForward, CompletionHandler<void()>&
 
 std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
 {
-    RefPtr<Document> document = CheckedRef(m_page->focusController())->focusedOrMainFrame().document();
+    RefPtr focusedOrMainFrame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return std::nullopt;
+    RefPtr<Document> document = focusedOrMainFrame->document();
     if (!document || !document->view())
         return std::nullopt;
 
@@ -3543,7 +3643,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
 
     FocusedElementInformation information;
 
-    information.frameID = CheckedRef(m_page->focusController())->focusedOrMainFrame().frameID();
+    information.frameID = focusedOrMainFrame->frameID();
 
     information.lastInteractionLocation = m_lastInteractionLocation;
     if (auto elementContext = contextForElement(*focusedElement))
@@ -4723,7 +4823,7 @@ void WebPage::hardwareKeyboardAvailabilityChanged(bool keyboardIsAttached)
 {
     m_keyboardIsAttached = keyboardIsAttached;
 
-    if (RefPtr focusedFrame = CheckedRef(m_page->focusController())->focusedLocalFrame())
+    if (RefPtr focusedFrame = m_page->checkedFocusController()->focusedLocalFrame())
         focusedFrame->eventHandler().capsLockStateMayHaveChanged();
 }
 
@@ -4744,7 +4844,10 @@ bool WebPage::platformPrefersTextLegibilityBasedZoomScaling() const
 void WebPage::insertTextPlaceholder(const IntSize& size, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&& completionHandler)
 {
     // Inserting the placeholder may run JavaScript, which can do anything, including frame destruction.
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler({ });
+
     auto placeholder = frame->editor().insertTextPlaceholder(size);
     completionHandler(placeholder ? contextForElement(*placeholder) : std::nullopt);
 }
@@ -4760,7 +4863,10 @@ void WebPage::removeTextPlaceholder(const ElementContext& placeholder, Completio
 
 void WebPage::updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&& completionHandler)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler();
+
     RefPtr root = frame->selection().rootEditableElementOrDocumentElement();
     auto selectionRange = frame->selection().selection().toNormalizedRange();
     if (!root || !selectionRange) {
@@ -4842,7 +4948,10 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
         return;
     }
 
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return completionHandler({ });
+
     RefPtr { frame->document() }->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     VisibleSelection selection = frame->selection().selection();
@@ -4873,8 +4982,8 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
         }
     } else if (isSpatialRequest) {
         // FIXME: We might need to be a bit more careful that we get something useful (test the other corners?).
-        rangeOfInterest.start = visiblePositionForPointInRootViewCoordinates(frame.get(), request.rect.minXMinYCorner());
-        rangeOfInterest.end = visiblePositionForPointInRootViewCoordinates(frame.get(), request.rect.maxXMaxYCorner());
+        rangeOfInterest.start = visiblePositionForPointInRootViewCoordinates(*frame, request.rect.minXMinYCorner());
+        rangeOfInterest.end = visiblePositionForPointInRootViewCoordinates(*frame, request.rect.maxXMaxYCorner());
         if (request.options.contains(DocumentEditingContextRequest::Options::SpatialAndCurrentSelection)) {
             if (RefPtr rootEditableElement = selection.rootEditableElement()) {
                 VisiblePosition startOfEditableRoot { firstPositionInOrBeforeNode(rootEditableElement.get()) };
@@ -5115,7 +5224,7 @@ void WebPage::focusTextInputContextAndPlaceCaret(const ElementContext& elementCo
     // because we only want to do so if the caret can be placed.
     UserGestureIndicator gestureIndicator { IsProcessingUserGesture::Yes, &target->document() };
     SetForScope userIsInteractingChange { m_userIsInteracting, true };
-    CheckedRef(m_page->focusController())->setFocusedElement(target.get(), targetFrame);
+    m_page->checkedFocusController()->setFocusedElement(target.get(), targetFrame);
 
     // Setting the focused element could tear down the element's renderer. Check that we still have one.
     if (m_focusedElement != target || !target->renderer()) {
@@ -5178,7 +5287,10 @@ void WebPage::requestPasswordForQuickLookDocumentInMainFrame(const String& fileN
 
 void WebPage::animationDidFinishForElement(const WebCore::Element& animatedElement)
 {
-    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
     auto& selection = frame->selection().selection();
     if (selection.isNoneOrOrphaned())
         return;

--- a/Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm
@@ -214,8 +214,8 @@ RetainPtr<NSImage> WebSharingServicePickerClient::imageForCurrentSharingServiceP
         }];
     }
     else if ([item isKindOfClass:[NSAttributedString class]]) {
-        auto& frame = _pickerClient->pageForSharingServicePicker(*self)->focusController().focusedOrMainFrame();
-        frame.editor().replaceSelectionWithAttributedString(item);
+        if (RefPtr frame = _pickerClient->pageForSharingServicePicker(*self)->focusController().focusedOrMainFrame())
+            frame->editor().replaceSelectionWithAttributedString(item);
     } else
         LOG_ERROR("sharingService:didShareItems: - Unknown item type returned\n");
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -2021,8 +2021,10 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         WebCore::TextIndicatorOption::IncludeSnapshotWithSelectionHighlight,
         WebCore::TextIndicatorOption::RespectTextColor
     };
-    auto& frame = page->focusController().focusedOrMainFrame();
-    if (auto range = frame.selection().selection().toNormalizedRange()) {
+    RefPtr frame = page->focusController().focusedOrMainFrame();
+    if (!frame)
+        return;
+    if (auto range = frame->selection().selection().toNormalizedRange()) {
         if (auto textIndicator = WebCore::TextIndicator::createWithRange(*range, defaultEditDragTextIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, WebCore::FloatSize()))
             _private->dataOperationTextIndicator = adoptNS([[WebUITextIndicatorData alloc] initWithImage:nil textIndicatorData:textIndicator->data() scale:page->deviceScaleFactor()]);
     }
@@ -4031,8 +4033,13 @@ IGNORE_WARNINGS_END
 
 - (void)_executeCoreCommandByName:(NSString *)name value:(NSString *)value
 {
-    if (RefPtr page = _private->page)
-        page->focusController().focusedOrMainFrame().editor().command(name).execute(value);
+    RefPtr page = _private->page;
+    if (!page)
+        return;
+    RefPtr focusedOrMainFrame = page->focusController().focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return;
+    focusedOrMainFrame->editor().command(name).execute(value);
 }
 
 - (void)_clearMainFrameName


### PR DESCRIPTION
#### b99b4d6f85701aeb323b540fb5eaef0d891a564a
<pre>
FocusController::focusedOrMainFrame should return a LocalFrame*
<a href="https://bugs.webkit.org/show_bug.cgi?id=269761">https://bugs.webkit.org/show_bug.cgi?id=269761</a>
<a href="https://rdar.apple.com/116201648">rdar://116201648</a>

Reviewed by Chris Dumez.

With site isolation, the main frame is not always a LocalFrame.
Instead of returning a random root frame, correctly return null.
This requires null checks for all callers.
This should fix <a href="https://rdar.apple.com/121960445">rdar://121960445</a> too.

In order to make it so that the layout test security/clip-invalid-rect.html
does not crash because of an invalid IPC message WebPageProxy::EditorStateChanged,
I made it so that WebPage::editorState always returns an EditorState with a valid
identifier.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::focusedObjectForPage):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::focus):
(WebCore::Element::blur):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::selectFrameElementInParentIfFullySelected):
(WebCore::FrameSelection::setFocusedElementIfNeeded):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::emptySelection):
* Source/WebCore/editing/VisibleSelection.h:
* Source/WebCore/editing/cocoa/DictionaryLookup.mm:
(WebCore::DictionaryLookup::rangeAtHitTestResult):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::handleFocusEvent):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::killText):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::performDragOperation):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handlePasteGlobalSelection):
(WebCore::EventHandler::dispatchMouseEvent):
(WebCore::EventHandler::internalKeyEvent):
(WebCore::EventHandler::defaultArrowEventHandler):
(WebCore::EventHandler::defaultTabEventHandler):
(WebCore::EventHandler::focusDocumentView):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::focusedOrMainFrame const):
(WebCore::FocusController::setFocusedInternal):
(WebCore::FocusController::setInitialFocus):
(WebCore::FocusController::relinquishFocusToChrome):
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::FocusController::setActiveInternal):
(WebCore::FocusController::advanceFocusDirectionallyInContainer):
(WebCore::FocusController::advanceFocusDirectionally):
(WebCore::FocusController::focusRepaintTimerFired):
* Source/WebCore/page/FocusController.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::focus):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::replaceSelectionWithText):
(WebCore::Page::editableElementsInRect const):
(WebCore::Page::selection const):
(WebCore::Page::fragmentDirectiveURLForSelectedText):
(WebCore::Page::revealCurrentSelection):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::focusDocumentView):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::focusDocumentView):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::remainingTimeUntilHighlightShouldBeShown const):
(WebCore::ServicesOverlayController::telephoneNumberRangesForFocusedFrame):
(WebCore::ServicesOverlayController::handleClick):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameFocus):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKAccessibilityFocusedObject):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::changeWordCase):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::TextCheckingControllerProxy::rangeAndOffsetRelativeToSelection):
(WebKit::TextCheckingControllerProxy::replaceRelativeToSelection):
(WebKit::TextCheckingControllerProxy::removeAnnotationRelativeToSelection):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::performDictionaryLookupAtLocation):
(WebKit::WebPage::performDictionaryLookupOfCurrentSelection):
(WebKit::WebPage::insertDictatedTextAsync):
(WebKit::WebPage::addDictationAlternative):
(WebKit::WebPage::dictationAlternativesAtSelection):
(WebKit::WebPage::clearDictationAlternatives):
(WebKit::WebPage::replaceImageForRemoveBackground):
(WebKit::WebPage::readSelectionFromPasteboard):
(WebKit::WebPage::insertMultiRepresentationHEIC):
(WebKit::WebPage::autocorrectionContextRange):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp:
(WebKit::UnifiedTextReplacementController::willBeginTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveEditAction):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::createTextIndicatorForRange):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):
(WebKit::WebPage::changeFontAttributes):
(WebKit::WebPage::changeFont):
(WebKit::WebPage::updateEditorStateAfterLayoutIfEditabilityChanged):
(WebKit::WebPage::executeEditingCommand):
(WebKit::WebPage::setEditable):
(WebKit::WebPage::increaseListLevel):
(WebKit::WebPage::decreaseListLevel):
(WebKit::WebPage::changeListType):
(WebKit::WebPage::setBaseWritingDirection):
(WebKit::WebPage::isEditingCommandEnabled):
(WebKit::WebPage::contextMenuForKeyEvent):
(WebKit::WebPage::handleKeyEventByRelinquishingFocusToChrome):
(WebKit::WebPage::validateCommand):
(WebKit::WebPage::requestFontAttributesAtSelectionStart):
(WebKit::WebPage::scroll):
(WebKit::WebPage::logicalScroll):
(WebKit::WebPage::centerSelectionInVisibleArea):
(WebKit::WebPage::insertNewlineInQuotedContent):
(WebKit::WebPage::viewWillStartLiveResize):
(WebKit::WebPage::viewWillEndLiveResize):
(WebKit::WebPage::setInitialFocus):
(WebKit::WebPage::copyLinkToHighlight):
(WebKit::WebPage::getSelectionOrContentsAsString):
(WebKit::WebPage::advanceToNextMisspelling):
(WebKit::WebPage::hasRichlyEditableSelection const):
(WebKit::WebPage::changeSpellingToWord):
(WebKit::WebPage::uppercaseWord):
(WebKit::WebPage::lowercaseWord):
(WebKit::WebPage::capitalizeWord):
(WebKit::WebPage::clearSelection):
(WebKit::WebPage::restoreSelectionInFocusedEditableElement):
(WebKit::WebPage::setCaretAnimatorType):
(WebKit::WebPage::setCaretBlinkingSuspended):
(WebKit::WebPage::handleAlternativeTextUIResult):
(WebKit::WebPage::setCompositionForTesting):
(WebKit::WebPage::hasCompositionForTesting):
(WebKit::WebPage::confirmCompositionForTesting):
(WebKit::WebPage::setTextAsync):
(WebKit::WebPage::insertTextAsync):
(WebKit::WebPage::hasMarkedText):
(WebKit::WebPage::getMarkedRangeAsync):
(WebKit::WebPage::getSelectedRangeAsync):
(WebKit::WebPage::characterIndexForPointAsync):
(WebKit::WebPage::firstRectForCharacterRangeAsync):
(WebKit::WebPage::setCompositionAsync):
(WebKit::WebPage::confirmCompositionAsync):
(WebKit::targetFrameForEditing):
(WebKit::WebPage::didChangeSelectionOrOverflowScrollPosition):
(WebKit::WebPage::didEndUserTriggeredSelectionChanges):
(WebKit::WebPage::sendEditorStateUpdate):
(WebKit::WebPage::flushPendingEditorStateUpdate):
(WebKit::WebPage::insertAttachment):
(WebKit::WebPage::createAppHighlightInSelectedRange):
(WebKit::WebPage::restoreAppHighlightsAndScrollToIndex):
* Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm:
(WebKit::FindController::didFindString):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::platformReinitialize):
(WebKit::WebPage::platformWillPerformEditingCommand):
(WebKit::WebPage::getSelectionContext):
(WebKit::WebPage::updateSelectionAppearance):
(WebKit::WebPage::generateSyntheticEditingCommand):
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::didConcludeEditDrag):
(WebKit::WebPage::clearSelectionAfterTapIfNeeded):
(WebKit::WebPage::selectWithGesture):
(WebKit::WebPage::clearSelection):
(WebKit::WebPage::dispatchSyntheticMouseEventsForSelectionGesture):
(WebKit::WebPage::updateSelectionWithTouches):
(WebKit::WebPage::selectWithTwoTouches):
(WebKit::WebPage::extendSelectionForReplacement):
(WebKit::WebPage::extendSelection):
(WebKit::WebPage::setSelectedRangeDispatchingSyntheticMouseEventsIfNeeded):
(WebKit::WebPage::platformDidSelectAll):
(WebKit::WebPage::selectWordBackward):
(WebKit::WebPage::moveSelectionByOffset):
(WebKit::WebPage::startAutoscrollAtPosition):
(WebKit::WebPage::requestEvasionRectsAboveSelection):
(WebKit::WebPage::getRectsForGranularityWithSelectionOffset):
(WebKit::WebPage::storeSelectionForAccessibility):
(WebKit::WebPage::getRectsAtSelectionOffsetWithText):
(WebKit::WebPage::selectPositionAtPoint):
(WebKit::WebPage::selectPositionAtBoundaryWithDirection):
(WebKit::WebPage::moveSelectionAtBoundaryWithDirection):
(WebKit::WebPage::setFocusedFrameBeforeSelectingTextAtLocation):
(WebKit::WebPage::setSelectionRange):
(WebKit::WebPage::updateSelectionWithExtentPointAndBoundary):
(WebKit::WebPage::updateSelectionWithExtentPoint):
(WebKit::WebPage::revealItemForCurrentSelection):
(WebKit::WebPage::replaceSelectedText):
(WebKit::WebPage::replaceDictatedText):
(WebKit::WebPage::willInsertFinalDictationResult):
(WebKit::WebPage::requestAutocorrectionData):
(WebKit::WebPage::applyAutocorrectionInternal):
(WebKit::WebPage::autocorrectionContext):
(WebKit::focusedElementPositionInformation):
(WebKit::WebPage::focusedElementInformation):
(WebKit::WebPage::hardwareKeyboardAvailabilityChanged):
(WebKit::WebPage::insertTextPlaceholder):
(WebKit::WebPage::updateSelectionWithDelta):
(WebKit::WebPage::requestDocumentEditingContext):
(WebKit::WebPage::focusTextInputContextAndPlaceCaret):
(WebKit::WebPage::animationDidFinishForElement):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::platformReinitialize):
(WebKit::WebPage::executeKeypressCommandsInternal):
(WebKit::WebPage::attributedSubstringForCharacterRangeAsync):
(WebKit::WebPage::getStringSelectionForPasteboard):
(WebKit::WebPage::getDataSelectionForPasteboard):
(WebKit::WebPage::shouldDelayWindowOrderingEvent):
(WebKit::WebPage::requestAcceptsFirstMouse):
(WebKit::WebPage::performImmediateActionHitTestAtLocation):
* Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm:
(-[WebSharingServicePickerController sharingService:didShareItems:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _didConcludeEditDrag]):
(-[WebView _executeCoreCommandByName:value:]):

Canonical link: <a href="https://commits.webkit.org/275171@main">https://commits.webkit.org/275171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e86cdd5f1f3e9d718a33bfdb6f5effc9b084d76a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33990 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14622 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40418 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38795 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17484 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9223 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->