### PR TITLE
[Wasm-GC] Handle OOM for allocations consistently

### DIFF
--- a/JSTests/wasm/gc/array_new_data.js
+++ b/JSTests/wasm/gc/array_new_data.js
@@ -150,7 +150,7 @@ function testBadOffset() {
           (i32.const 0)
           (array.get_u 0)))`)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => check(instantiate(`
       (module
         (memory (export "memory") 1)
@@ -163,7 +163,7 @@ function testBadOffset() {
           (i32.const 0)
           (array.get_u 0)))`)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
 }
 
 function testOffsets() {
@@ -211,7 +211,7 @@ function testReadOutOfBounds() {
             (i32.const 0)
             (array.get` + suffix + ` 0)))`)).exports.f(),
                   WebAssembly.RuntimeError,
-                    "Offset + array length would exceed the size of a data segment")
+                    "Out of bounds or failed to allocate in array.new_data")
     };
     // Test {i8, i16, i32, i64}
     for (const type of [8, 16, 32, 64]) {
@@ -243,28 +243,28 @@ function testInt32Overflow() {
     let maxUint32 = 0xffffffff;
     assert.throws(() => instantiate(f(1, maxUint32)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => instantiate(f(2, maxUint32)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => instantiate(f(2, maxUint32 - 1)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => instantiate(f(10, maxUint32)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => instantiate(f(maxUint32, maxUint32)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => instantiate(f(maxUint32 - 4, 5)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => instantiate(f(maxUint32, 1)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => instantiate(f(maxUint32 - 1, 2)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     // Check for overflow when multiplying element size by array size
     f = (offset, len) => instantiate(`
       (module
@@ -280,10 +280,10 @@ function testInt32Overflow() {
     let badArraySize = 0x40000000;
     assert.throws(() => instantiate(f(0, badArraySize)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
     assert.throws(() => instantiate(f(1, badArraySize - 1)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the size of a data segment");
+                  "Out of bounds or failed to allocate in array.new_data");
 }
 
 
@@ -308,7 +308,7 @@ function testZeroLengthArray() {
     // zero-length array from zero-length data segment; non-zero offset; should throw
     m = f("", 3);
     assert.throws(() => instantiate(m).exports.f(),
-                  WebAssembly.RuntimeError, "Offset + array length would exceed the size of a data segment");
+                  WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
     // zero-length array from non-zero-length data segment; non-zero offset
     m = f("xyz", 1);
     assert.eq(instantiate(m).exports.f(), 0);
@@ -318,7 +318,7 @@ function testZeroLengthArray() {
     assert.eq(instantiate(m).exports.f(), 0);
     // zero-length array from non-zero-length data segment; offset > length; should throw
     m = f("xyz", 4);
-    assert.throws(() => instantiate(m).exports.f(), WebAssembly.RuntimeError, "Offset + array length would exceed the size of a data segment");
+    assert.throws(() => instantiate(m).exports.f(), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
 }
 
 function testSingletonArray() {
@@ -332,7 +332,7 @@ function testSingletonArray() {
           (i32.const 1)
           (array.new_data 0 0)
           (array.len)))`);
-    let msg = "Offset + array length would exceed the size of a data segment";
+    let msg = "Out of bounds or failed to allocate in array.new_data";
     // singleton array from 0-length data segment -- should throw
     var m = f("", 0);
     assertFails(m, msg);

--- a/JSTests/wasm/gc/array_new_elem.js
+++ b/JSTests/wasm/gc/array_new_elem.js
@@ -257,32 +257,31 @@ function testInt32Overflow() {
           (array.len)))`).exports.f();
     let maxUint32 = 0xffffffff;
     assert.throws(() => instantiate(f(0, maxUint32)),
-                  WebAssembly.RuntimeError, "Offset + array length would exceed the length of an element segment");
+                  WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_elem");
     assert.throws(() => instantiate(f(1, maxUint32)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the length of an element segment");
+                  "Out of bounds or failed to allocate in array.new_elem");
     assert.throws(() => instantiate(f(2, maxUint32)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the length of an element segment");
+                  "Out of bounds or failed to allocate in array.new_elem");
     assert.throws(() => instantiate(f(2, maxUint32 - 1)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the length of an element segment");
+                  "Out of bounds or failed to allocate in array.new_elem");
     assert.throws(() => instantiate(f(10, maxUint32)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the length of an element segment");
+                  "Out of bounds or failed to allocate in array.new_elem");
     assert.throws(() => instantiate(f(maxUint32, maxUint32)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the length of an element segment");
+                  "Out of bounds or failed to allocate in array.new_elem");
     assert.throws(() => instantiate(f(maxUint32 - 4, 5)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the length of an element segment");
+                  "Out of bounds or failed to allocate in array.new_elem");
     assert.throws(() => instantiate(f(maxUint32, 1)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the length of an element segment");
+                  "Out of bounds or failed to allocate in array.new_elem");
     assert.throws(() => instantiate(f(maxUint32 - 1, 2)),
                   WebAssembly.RuntimeError,
-                  "Offset + array length would exceed the length of an element segment");
-
+                  "Out of bounds or failed to allocate in array.new_elem");
 }
 
 // Creating a zero-length array should work, as long as the element segment offset is valid
@@ -306,7 +305,7 @@ function testZeroLengthArray() {
     // zero-length array from zero-length element segment; non-zero offset; should throw
     m = f("", 3);
     assert.throws(() => instantiate(m).exports.f(),
-                  WebAssembly.RuntimeError, "Offset + array length would exceed the length of an element segment");
+                  WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_elem");
     // zero-length array from non-zero-length data segment; non-zero offset
     m = f("(ref.func $f) (ref.func $f)", 1);
     assert.eq(instantiate(m).exports.f(), 0);
@@ -316,7 +315,7 @@ function testZeroLengthArray() {
     assert.eq(instantiate(m).exports.f(), 0);
     // zero-length array from non-zero-length element segment; offset > length; should throw
     m = f("(ref.func $f) (ref.func $f) (ref.func $f)", 4);
-    assert.throws(() => instantiate(m).exports.f(), WebAssembly.RuntimeError, "Offset + array length would exceed the length of an element segment");
+    assert.throws(() => instantiate(m).exports.f(), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_elem");
 }
 
 function testArrayNewCanonElemSubtype() {
@@ -629,8 +628,8 @@ function testAllElementSegmentKinds() {
     assert.throws(
       () => { m.exports.test(0) },
       WebAssembly.RuntimeError,
-      "Offset + array length would exceed the length of an element segment (evaluating 'm.exports.test(0)')"
-    )
+      "Out of bounds or failed to allocate in array.new_elem"
+    );
 
     m = instantiate(`
     (module

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -2992,6 +2992,8 @@ auto B3IRGenerator::addArrayNew(uint32_t typeIndex, ExpressionType size, Express
 
     result = pushArrayNew(typeIndex, initValue, size);
 
+    emitArrayNullCheck(get(result), ExceptionType::BadArrayNew);
+
     return { };
 }
 
@@ -3002,12 +3004,8 @@ Variable* B3IRGenerator::pushArrayNewFromSegment(arraySegmentOperation operation
         m_currentBlock->appendNew<Const32Value>(m_proc, origin(), segmentIndex),
         get(arraySize), get(offset));
 
-    // Check for null return value (indicating that this access is out of bounds for the segment)
-    CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
-        m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), resultValue, m_currentBlock->appendNew<Const64Value>(m_proc, origin(), JSValue::encode(jsNull()))));
-    check->setGenerator([=, this] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-        this->emitExceptionCheck(jit, exceptionType);
-    });
+    // Indicates out of bounds for the segment or allocation failure.
+    emitArrayNullCheck(resultValue, exceptionType);
 
     return push(resultValue);
 }
@@ -3020,19 +3018,21 @@ auto B3IRGenerator::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, 
     result = push(callWasmOperation(m_currentBlock, toB3Type(resultType), operationWasmArrayNewEmpty,
         instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex), get(size)));
 
+    emitArrayNullCheck(get(result), ExceptionType::BadArrayNew);
+
     return { };
 }
 
 auto B3IRGenerator::addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result) -> PartialResult
 {
-    result = pushArrayNewFromSegment(operationWasmArrayNewData, typeIndex, dataIndex, arraySize, offset, ExceptionType::OutOfBoundsDataSegmentAccess);
+    result = pushArrayNewFromSegment(operationWasmArrayNewData, typeIndex, dataIndex, arraySize, offset, ExceptionType::BadArrayNewInitData);
 
     return { };
 }
 
 auto B3IRGenerator::addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result) -> PartialResult
 {
-    result = pushArrayNewFromSegment(operationWasmArrayNewElem, typeIndex, elemSegmentIndex, arraySize, offset, ExceptionType::OutOfBoundsElementSegmentAccess);
+    result = pushArrayNewFromSegment(operationWasmArrayNewElem, typeIndex, elemSegmentIndex, arraySize, offset, ExceptionType::BadArrayNewInitElem);
     return { };
 }
 
@@ -3050,9 +3050,7 @@ auto B3IRGenerator::addArrayNewFixed(uint32_t typeIndex, Vector<ExpressionType>&
         instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex),
         m_currentBlock->appendNew<Const32Value>(m_proc, origin(), args.size()));
 
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=264454
-    // Ensure array is non-null
-    emitArrayNullCheck(arrayValue, ExceptionType::NullArraySet);
+    emitArrayNullCheck(arrayValue, ExceptionType::BadArrayNew);
 
     for (uint32_t i = 0; i < args.size(); ++i) {
         // Emit the array set code -- note that this omits the bounds check, since
@@ -3326,6 +3324,14 @@ auto B3IRGenerator::addStructNew(uint32_t typeIndex, Vector<ExpressionType>& arg
         instanceValue(),
         m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex));
 
+    {
+        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
+            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), structValue, m_currentBlock->appendNew<Const64Value>(m_proc, origin(), JSValue::encode(jsNull()))));
+        check->setGenerator([=, this] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+            this->emitExceptionCheck(jit, ExceptionType::BadStructNew);
+        });
+    }
+
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     for (uint32_t i = 0; i < args.size(); ++i)
         emitStructSet(structValue, i, structType, get(args[i]));
@@ -3344,6 +3350,14 @@ auto B3IRGenerator::addStructNewDefault(uint32_t typeIndex, ExpressionType& resu
     Value* structValue = callWasmOperation(m_currentBlock, toB3Type(type), operationWasmStructNewEmpty,
         instanceValue(),
         m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex));
+
+    {
+        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
+            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), structValue, m_currentBlock->appendNew<Const64Value>(m_proc, origin(), JSValue::encode(jsNull()))));
+        check->setGenerator([=, this] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+            this->emitExceptionCheck(jit, ExceptionType::BadStructNew);
+        });
+    }
 
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     for (StructFieldCount i = 0; i < structType.fieldCount(); ++i) {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1417,14 +1417,14 @@ void BBQJIT::pushArrayNewFromSegment(arraySegmentOperation operation, uint32_t t
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
 {
-    pushArrayNewFromSegment(operationWasmArrayNewData, typeIndex, dataIndex, arraySize, offset, ExceptionType::OutOfBoundsDataSegmentAccess, result);
+    pushArrayNewFromSegment(operationWasmArrayNewData, typeIndex, dataIndex, arraySize, offset, ExceptionType::BadArrayNewInitData, result);
     LOG_INSTRUCTION("ArrayNewData", typeIndex, dataIndex, arraySize, offset, RESULT(result));
     return { };
 }
 
 PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
 {
-    pushArrayNewFromSegment(operationWasmArrayNewElem, typeIndex, elemSegmentIndex, arraySize, offset, ExceptionType::OutOfBoundsElementSegmentAccess, result);
+    pushArrayNewFromSegment(operationWasmArrayNewElem, typeIndex, elemSegmentIndex, arraySize, offset, ExceptionType::BadArrayNewInitElem, result);
     LOG_INSTRUCTION("ArrayNewElem", typeIndex, elemSegmentIndex, arraySize, offset, RESULT(result));
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -1955,10 +1955,9 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNewDefault(uint32_t typeIndex,
     result = topValue(TypeKind::I64);
     emitCCall(operationWasmStructNewEmpty, arguments, result);
 
-    // FIXME: What about OOM?
-
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     Location structLocation = allocate(result);
+    emitThrowOnNullReference(ExceptionType::BadStructNew, structLocation);
     m_jit.loadPtr(MacroAssembler::Address(structLocation.asGPRlo(), JSWebAssemblyStruct::offsetOfPayload()), wasmScratchGPR);
     for (StructFieldCount i = 0; i < structType.fieldCount(); ++i) {
         if (Wasm::isRefType(structType.field(i).type))
@@ -1986,6 +1985,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNew(uint32_t typeIndex, Vector
 
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     Location structLocation = allocate(allocationResult);
+    emitThrowOnNullReference(ExceptionType::BadStructNew, structLocation);
     m_jit.loadPtr(MacroAssembler::Address(structLocation.asGPRlo(), JSWebAssemblyStruct::offsetOfPayload()), wasmScratchGPR);
     bool hasRefTypeField = false;
     for (uint32_t i = 0; i < args.size(); ++i) {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2132,10 +2132,9 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNewDefault(uint32_t typeIndex,
     result = topValue(TypeKind::I64);
     emitCCall(operationWasmStructNewEmpty, arguments, result);
 
-    // FIXME: What about OOM?
-
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     Location structLocation = allocate(result);
+    emitThrowOnNullReference(ExceptionType::BadStructNew, structLocation);
     m_jit.loadPtr(MacroAssembler::Address(structLocation.asGPR(), JSWebAssemblyStruct::offsetOfPayload()), wasmScratchGPR);
     for (StructFieldCount i = 0; i < structType.fieldCount(); ++i) {
         if (Wasm::isRefType(structType.field(i).type))
@@ -2166,6 +2165,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructNew(uint32_t typeIndex, Vector
 
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     Location structLocation = allocate(allocationResult);
+    emitThrowOnNullReference(ExceptionType::BadStructNew, structLocation);
     m_jit.loadPtr(MacroAssembler::Address(structLocation.asGPR(), JSWebAssemblyStruct::offsetOfPayload()), wasmScratchGPR);
     bool hasRefTypeField = false;
     for (uint32_t i = 0; i < args.size(); ++i) {

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -54,7 +54,10 @@ namespace Wasm {
     macro(OutOfBoundsArrayCopy, "Out of bounds array.copy"_s) \
     macro(OutOfBoundsArrayInitElem, "Out of bounds array.init_elem"_s) \
     macro(OutOfBoundsArrayInitData, "Out of bounds array.init_data"_s) \
+    macro(BadStructNew, "Failed to allocate new struct"_s) \
     macro(BadArrayNew, "Failed to allocate new array"_s) \
+    macro(BadArrayNewInitElem, "Out of bounds or failed to allocate in array.new_elem"_s) \
+    macro(BadArrayNewInitData, "Out of bounds or failed to allocate in array.new_data"_s) \
     macro(NullArrayGet, "array.get to a null reference"_s) \
     macro(NullArraySet, "array.set to a null reference"_s) \
     macro(NullArrayLen, "array.len to a null reference"_s) \
@@ -116,7 +119,10 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::OutOfBoundsArrayCopy:
     case ExceptionType::OutOfBoundsArrayInitElem:
     case ExceptionType::OutOfBoundsArrayInitData:
+    case ExceptionType::BadStructNew:
     case ExceptionType::BadArrayNew:
+    case ExceptionType::BadArrayNewInitElem:
+    case ExceptionType::BadArrayNewInitData:
     case ExceptionType::NullArrayGet:
     case ExceptionType::NullArraySet:
     case ExceptionType::NullArrayLen:

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -54,12 +54,14 @@ public:
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     template <typename ElementType>
-    static JSWebAssemblyArray* create(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<ElementType>&& payload, RefPtr<const Wasm::RTT> rtt)
+    static JSWebAssemblyArray* tryCreate(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<ElementType>&& payload, RefPtr<const Wasm::RTT> rtt)
     {
-        JSWebAssemblyArray* array = new (NotNull, allocateCell<JSWebAssemblyArray>(vm)) JSWebAssemblyArray(vm, structure, elementType, size, WTFMove(payload), rtt);
+        void* buffer = tryAllocateCell<JSWebAssemblyArray>(vm);
+        if (UNLIKELY(!buffer))
+            return nullptr;
+        JSWebAssemblyArray* array = new (NotNull, buffer) JSWebAssemblyArray(vm, structure, elementType, size, WTFMove(payload), rtt);
         array->finishCreation(vm);
         return array;
-
     }
 
     DECLARE_VISIT_CHILDREN;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -50,13 +50,16 @@ JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, Structure* structure, Ref<const
 {
 }
 
-JSWebAssemblyStruct* JSWebAssemblyStruct::create(JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, uint32_t typeIndex, RefPtr<const Wasm::RTT> rtt)
+JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, uint32_t typeIndex, RefPtr<const Wasm::RTT> rtt)
 {
     VM& vm = globalObject->vm();
 
     Ref<const Wasm::TypeDefinition> type = instance->instance().module().moduleInformation().typeSignatures[typeIndex]->expand();
 
-    auto* structValue = new (NotNull, allocateCell<JSWebAssemblyStruct>(vm)) JSWebAssemblyStruct(vm, structure, Ref { type }, rtt);
+    void* buffer = tryAllocateCell<JSWebAssemblyStruct>(vm);
+    if (UNLIKELY(!buffer))
+        return nullptr;
+    auto* structValue = new (NotNull, buffer) JSWebAssemblyStruct(vm, structure, Ref { type }, rtt);
     structValue->finishCreation(vm);
     return structValue;
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -53,7 +53,7 @@ public:
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    static JSWebAssemblyStruct* create(JSGlobalObject*, Structure*, JSWebAssemblyInstance*, uint32_t, RefPtr<const Wasm::RTT>);
+    static JSWebAssemblyStruct* tryCreate(JSGlobalObject*, Structure*, JSWebAssemblyInstance*, uint32_t, RefPtr<const Wasm::RTT>);
 
     DECLARE_VISIT_CHILDREN;
 


### PR DESCRIPTION
#### 6b7295ed661f0827a0e1a58c7abb7bc361dd5754
<pre>
[Wasm-GC] Handle OOM for allocations consistently
<a href="https://bugs.webkit.org/show_bug.cgi?id=264454">https://bugs.webkit.org/show_bug.cgi?id=264454</a>

Reviewed by Justin Michaud.

Check for OOM and raise an exception consistently for all Wasm GC allocation
points. Refactors some function names to match.

* JSTests/wasm/gc/array_new_data.js:
(testBadOffset):
(testReadOutOfBounds):
(testInt32Overflow):
* JSTests/wasm/gc/array_new_elem.js:
(testInt32Overflow):
(testAllElementSegmentKinds):
Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addArrayNew):
(JSC::Wasm::B3IRGenerator::pushArrayNewFromSegment):
(JSC::Wasm::B3IRGenerator::addArrayNewDefault):
(JSC::Wasm::B3IRGenerator::addArrayNewData):
(JSC::Wasm::B3IRGenerator::addArrayNewElem):
(JSC::Wasm::B3IRGenerator::addArrayNewFixed):
(JSC::Wasm::B3IRGenerator::addStructNew):
(JSC::Wasm::B3IRGenerator::addStructNewDefault):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewData):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewElem):
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::ConstExprValue::ConstExprValue):
(JSC::Wasm::ConstExprGenerator::ConstExprValue::isInvalid):
(JSC::Wasm::ConstExprGenerator::createNewArray):
(JSC::Wasm::ConstExprGenerator::addArrayNew):
(JSC::Wasm::ConstExprGenerator::addArrayNewDefault):
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
(JSC::Wasm::ConstExprGenerator::createNewStruct):
(JSC::Wasm::ConstExprGenerator::addStructNewDefault):
(JSC::Wasm::ConstExprGenerator::addStructNew):
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::fillArray):
(JSC::Wasm::arrayNew):
(JSC::Wasm::copyElementsInReverse):
(JSC::Wasm::arrayNewFixed):
(JSC::Wasm::createArrayValue):
(JSC::Wasm::structNew):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::tryCreate):
(JSC::JSWebAssemblyStruct::create): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:

Canonical link: <a href="https://commits.webkit.org/275059@main">https://commits.webkit.org/275059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/300346af6393215ff057d1401830620aee552605

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36769 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33741 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14332 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44509 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34132 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40101 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40305 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38442 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17113 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47315 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9141 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17164 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9720 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->