### PR TITLE
[visionOS] Enable Linear Media Player at build time and runtime

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3979,7 +3979,7 @@ LegacyOverflowScrollingTouchEnabled:
 
 LinearMediaPlayerEnabled:
   type: bool
-  status: unstable
+  status: internal
   category: media
   humanReadableName: "Linear Media Player"
   humanReadableDescription: "Enable LinearMediaPlayer for fullscreen video"
@@ -3988,7 +3988,7 @@ LinearMediaPlayerEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: true
     WebCore:
       default: false
 

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -990,10 +990,9 @@
 #define ENABLE_EXTENSION_CAPABILITIES 1
 #endif
 
-// FIXME: Re-enable once rdar://122200702 is resolved.
 #if !defined(ENABLE_LINEAR_MEDIA_PLAYER) \
     && USE(LINEARMEDIAKIT)
-#define ENABLE_LINEAR_MEDIA_PLAYER 0
+#define ENABLE_LINEAR_MEDIA_PLAYER 1
 #endif
 
 #if !defined(ENABLE_WRITING_SUGGESTIONS) \

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -28,10 +28,11 @@
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 
+#import "WKSLinearMediaPlayer.h"
+#import "WKSLinearMediaTypes.h"
 #import <WebCore/MediaSelectionOption.h>
 #import <WebCore/PlaybackSessionModel.h>
 #import <WebCore/TimeRanges.h>
-#import <WebKitSwift/WebKitSwift.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/WeakPtr.h>
 

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -29,9 +29,10 @@
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 
 #import "PlaybackSessionInterfaceLMK.h"
+#import "WKSLinearMediaPlayer.h"
+#import "WKSLinearMediaTypes.h"
 #import <UIKit/UIKit.h>
 #import <WebCore/WebAVPlayerLayerView.h>
-#import <WebKitSwift/WebKitSwift.h>
 #import <pal/spi/vision/LinearMediaKitSPI.h>
 
 namespace WebKit {

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -104,7 +104,7 @@
            (global-name "com.apple.coremedia.capturesource")       ; Also for video capture (<rdar://problem/15794291>).
            (global-name "com.apple.coremedia.cpe.xpc") ; Needed for HDR playback.
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-           (global-name "com.apple.coremedia.videotarget.xpc") ; Needed for FigVideoTarget
+           (global-name "com.apple.coremedia.mediaplaybackd.videotarget.xpc") ; Needed for FigVideoTarget
 #endif
            (global-name "com.apple.coremedia.remotequeue"))
     (allow mach-lookup

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1925,6 +1925,8 @@
 		A182D5B51BE6BD250087A7CC /* AccessibilityIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = A182D5B31BE6BD250087A7CC /* AccessibilityIOS.h */; };
 		A183494224EF467800BDC9A8 /* SharedBufferReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CC5DB9121488E16006CB8A8 /* SharedBufferReference.h */; };
 		A188D2E52B6B0F4E00E65A08 /* WKVisibilityPropagationView.h in Headers */ = {isa = PBXBuildFile; fileRef = A188D2E22B6B0F4E00E65A08 /* WKVisibilityPropagationView.h */; };
+		A192C25B2B844600004B8B20 /* WKSLinearMediaPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = A14F9B742B68CA6B00AD9C56 /* WKSLinearMediaPlayer.h */; };
+		A192C25C2B844A31004B8B20 /* WKSLinearMediaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A14F9B612B686DD200AD9C56 /* WKSLinearMediaTypes.h */; };
 		A19DD3C01D07D16800AC823B /* _WKWebViewPrintFormatterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A19DD3BF1D07D16800AC823B /* _WKWebViewPrintFormatterInternal.h */; };
 		A1A4FE5A18DCE9FA00B5EA8A /* _WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE5718DCE9FA00B5EA8A /* _WKDownload.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1A4FE5C18DCE9FA00B5EA8A /* _WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE5918DCE9FA00B5EA8A /* _WKDownloadInternal.h */; };
@@ -17219,6 +17221,8 @@
 				BCDDB32B124EC2AB0048D13C /* WKSharedAPICast.h in Headers */,
 				1DB01943211CF002009FB3E8 /* WKShareSheet.h in Headers */,
 				513E462D1AD837560016234A /* WKSharingServicePickerDelegate.h in Headers */,
+				A192C25B2B844600004B8B20 /* WKSLinearMediaPlayer.h in Headers */,
+				A192C25C2B844A31004B8B20 /* WKSLinearMediaTypes.h in Headers */,
 				93F549B41E3174B7000E7239 /* WKSnapshotConfiguration.h in Headers */,
 				DF7A231C291B088D00B98DF3 /* WKSnapshotConfigurationPrivate.h in Headers */,
 				57FD318722B35170008D0E8B /* WKSOAuthorizationDelegate.h in Headers */,

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -28,12 +28,25 @@
 #if defined(TARGET_OS_VISION) && TARGET_OS_VISION
 
 #import <UIKit/UIKit.h>
-#import <WebKitSwift/WKSLinearMediaTypes.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class LMPlayableViewController;
 @class WKSLinearMediaPlayer;
+@class WKSLinearMediaTimeRange;
+@class WKSLinearMediaTrack;
+
+typedef NS_ENUM(NSInteger, WKSLinearMediaContentMode);
+typedef NS_ENUM(NSInteger, WKSLinearMediaContentType);
+typedef NS_ENUM(NSInteger, WKSLinearMediaPresentationMode);
+typedef NS_ENUM(NSInteger, WKSLinearMediaViewingMode);
+
+typedef NS_OPTIONS(NSInteger, WKSLinearMediaFullscreenBehaviors) {
+    WKSLinearMediaFullscreenBehaviorsSceneResize = 1 << 0,
+    WKSLinearMediaFullscreenBehaviorsSceneSizeRestrictions = 1 << 1,
+    WKSLinearMediaFullscreenBehaviorsSceneChromeOptions = 1 << 2,
+    WKSLinearMediaFullscreenBehaviorsHostContentInline = 1 << 3,
+};
 
 API_AVAILABLE(visionos(1.0))
 @protocol WKSLinearMediaPlayerDelegate <NSObject>

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h
@@ -60,13 +60,6 @@ typedef NS_ENUM(NSInteger, WKSLinearMediaViewingMode) {
     WKSLinearMediaViewingModeSpatial
 };
 
-typedef NS_OPTIONS(NSInteger, WKSLinearMediaFullscreenBehaviors) {
-    WKSLinearMediaFullscreenBehaviorsSceneResize = 1 << 0,
-    WKSLinearMediaFullscreenBehaviorsSceneSizeRestrictions = 1 << 1,
-    WKSLinearMediaFullscreenBehaviorsSceneChromeOptions = 1 << 2,
-    WKSLinearMediaFullscreenBehaviorsHostContentInline = 1 << 3,
-};
-
 API_AVAILABLE(visionos(1.0))
 @interface WKSLinearMediaTimeRange : NSObject
 + (instancetype)new NS_UNAVAILABLE;


### PR DESCRIPTION
#### 4abab8a63ae6ed247f3c65f75a88ac47528a9ce7
<pre>
[visionOS] Enable Linear Media Player at build time and runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=269767">https://bugs.webkit.org/show_bug.cgi?id=269767</a>
<a href="https://rdar.apple.com/123284989">rdar://123284989</a>

Reviewed by Wenson Hsieh.

Set ENABLE_LINEAR_MEDIA_PLAYER to 1 and enabled the LinearMediaPlayerEnabled runtime setting by
default.

While here, fixed an issue where the wrong mach port was specified in the GPU process seatbelt
profile for using FigVideoTarget rendering and adjusted the imports of WebKitSwift headers to avoid
creating a circular dependency in the Xcode build system.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h:
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h:

Canonical link: <a href="https://commits.webkit.org/275053@main">https://commits.webkit.org/275053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/879799fce94a33f94c3ff5e437ae1001d68f3867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43248 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36782 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33751 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44522 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34145 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36899 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36377 "Found 2 new test failures: http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html, http/tests/navigation/ping-attribute/area-cross-origin-from-https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40114 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40318 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38455 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17126 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47328 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9133 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17177 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9724 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->