### PR TITLE
Sync `video-append-source.html` from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/media/video-append-source-expected.txt
+++ b/LayoutTests/media/video-append-source-expected.txt
@@ -1,7 +1,4 @@
 
-EXPECTED (video.currentSrc == '') OK
-EXPECTED (video.currentSrc == '') OK
-EVENT(canplaythrough)
-EXPECTED (stripExtension(relativeURL(video.currentSrc)) == 'content/test') OK
-END OF TEST
+
+PASS Verify that a media element's currentSrc is correctly set to source element's src
 

--- a/LayoutTests/media/video-append-source.html
+++ b/LayoutTests/media/video-append-source.html
@@ -1,19 +1,22 @@
-<video controls></video>
-<script src=media-file.js></script>
-<script src=video-test.js></script>
-
+<!DOCTYPE html>
+<title>Verify that a media element's currentSrc is correctly set to source element's src</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<video></video>
 <script>
-    testExpected("video.currentSrc", "");
-    var mediaFile = findMediaFile("video", "content/test");
+async_test(function(t) {
+    var video = document.querySelector("video");
+    assert_equals(video.currentSrc, "");
+    var mediaFile = "content/test.mp4";
     var source = document.createElement("source");
-    source.setAttribute("src", mediaFile);
+    source.src = mediaFile;
     video.appendChild(source);
 
-    testExpected("video.currentSrc", "");
+    assert_equals(video.currentSrc, "");
 
-    waitForEvent("canplaythrough", function () {
-        testExpected("stripExtension(relativeURL(video.currentSrc))", stripExtension(mediaFile));
-        endTest();
+    video.oncanplaythrough = t.step_func_done(function () {
+        var currentSrc = video.currentSrc;
+        assert_equals(currentSrc.substr(currentSrc.lastIndexOf('/media/')+7), mediaFile);
     });
-
+});
 </script>


### PR DESCRIPTION
#### 2644f4c513410c8699b617df4a854984a44e6ab9
<pre>
Sync `video-append-source.html` from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=116263">https://bugs.webkit.org/show_bug.cgi?id=116263</a>

Reviewed by Eric Carlson.

This patch is to sync `video-append-source.html` from
Blink / Chromium upstream as per below latest commit:

Only change is to use `mp4` rather than `ogv`.

Partial Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/f0b4140302ed4571ec1c063fcb0a87b7cca67514">https://source.chromium.org/chromium/chromium/src/+/f0b4140302ed4571ec1c063fcb0a87b7cca67514</a>

* LayoutTests/media/video-append-source.html: Updated
* LayoutTests/media/video-append-source-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/275041@main">https://commits.webkit.org/275041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24c0217a4d6ce0aaf71e7396d2ddc8c2b65c1462

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43240 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36775 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33745 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36944 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36368 "Found 1 new test failure: http/tests/navigation/ping-attribute/area-cross-origin-from-https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40107 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38448 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35333 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->