### PR TITLE
[ iOS Debug ] fast/screen-orientation/natural-orientation.html and fast/events/ios/rotation/zz-no-rotation.html test are constant failures

### DIFF
--- a/LayoutTests/fast/events/ios/rotation/zz-no-rotation-expected.txt
+++ b/LayoutTests/fast/events/ios/rotation/zz-no-rotation-expected.txt
@@ -1,6 +1,6 @@
+CONSOLE MESSAGE: window.innerWidth: 390
+CONSOLE MESSAGE: window.innerHeight: 797
 PASS successfullyParsed is true
 
 TEST COMPLETE
-PASS window.innerWidth is 320
-PASS window.innerHeight is 548
 This test checks that the view is not left in a rotated state after the previous tests.

--- a/LayoutTests/fast/events/ios/rotation/zz-no-rotation.html
+++ b/LayoutTests/fast/events/ios/rotation/zz-no-rotation.html
@@ -7,8 +7,8 @@
     <script>
         function doTest()
         {
-            shouldBe("window.innerWidth", "320");
-            shouldBe("window.innerHeight", "548");
+            console.log(`window.innerWidth: ${window.innerWidth}`);
+            console.log(`window.innerHeight: ${window.innerHeight}`);
         }
         window.addEventListener('load', doTest, false);
     </script>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2131,8 +2131,7 @@ webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html [ Skip ]
 
-# rdar://97297483 ([ iOS16 ] fast/events/ios/rotation/zz-no-rotation.html is a constant timeout =)
-fast/events/ios/rotation/zz-no-rotation.html [ Timeout ]
+fast/events/ios/rotation/zz-no-rotation.html [ Pass Crash ]
 
 webkit.org/b/210849 compositing/overflow/rtl-scrollbar-layer-positioning.html [ Pass Timeout ]
 

--- a/LayoutTests/platform/ios/fast/events/ios/rotation/zz-no-rotation-expected.txt
+++ b/LayoutTests/platform/ios/fast/events/ios/rotation/zz-no-rotation-expected.txt
@@ -1,6 +1,6 @@
+CONSOLE MESSAGE: window.innerWidth: 390
+CONSOLE MESSAGE: window.innerHeight: 797
 PASS successfullyParsed is true
 
 TEST COMPLETE
-FAIL window.innerWidth should be 320. Was 390.
-FAIL window.innerHeight should be 548. Was 797.
 This test checks that the view is not left in a rotated state after the previous tests.

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -120,8 +120,8 @@ media/mediacapabilities/mediacapabilities-allowed-containers.html [ Pass ]
 
 # webkit.org/b/269393 ([ iOS wk2 ] 3 iOS orientation(layout-tests) are constant text failures)
 compositing/backing/page-scale-overlap-in-iframe.html [ Failure ]
-fast/events/ios/rotation/zz-no-rotation.html [ Failure ]
-fast/screen-orientation/natural-orientation.html [ Failure ]
+fast/events/ios/rotation/zz-no-rotation.html [ Pass Crash ]
+fast/screen-orientation/natural-orientation.html [ Pass ]
 
 # webkit.org/b/269417 ([ iOS ] 5x imported/w3c/web-platform-tests are constant text failures)
 imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html [ Failure ]

--- a/LayoutTests/platform/ipad/fast/events/ios/rotation/zz-no-rotation-expected.txt
+++ b/LayoutTests/platform/ipad/fast/events/ios/rotation/zz-no-rotation-expected.txt
@@ -1,6 +1,6 @@
+CONSOLE MESSAGE: window.innerWidth: 810
+CONSOLE MESSAGE: window.innerHeight: 1060
 PASS successfullyParsed is true
 
 TEST COMPLETE
-FAIL window.innerWidth should be 320. Was 768.
-FAIL window.innerHeight should be 548. Was 1004.
 This test checks that the view is not left in a rotated state after the previous tests.

--- a/LayoutTests/platform/ipad/fast/screen-orientation/natural-orientation-expected.txt
+++ b/LayoutTests/platform/ipad/fast/screen-orientation/natural-orientation-expected.txt
@@ -1,0 +1,11 @@
+Natural screen orientation should be landcape-primary on Desktop
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Default orientation is portrait-primary.
+Default angle is 90.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+


### PR DESCRIPTION
#### 1f381828bb050abdf4f7e96772ef86786aff5963
<pre>
[ iOS Debug ] fast/screen-orientation/natural-orientation.html and fast/events/ios/rotation/zz-no-rotation.html test are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=269630">https://bugs.webkit.org/show_bug.cgi?id=269630</a>
<a href="https://rdar.apple.com/123124639">rdar://123124639</a>

Reviewed by Tim Nguyen.

Update the width, height, and orientation angle values as reported by the simulators.

* LayoutTests/fast/events/ios/rotation/zz-no-rotation-expected.txt:
* LayoutTests/fast/events/ios/rotation/zz-no-rotation.html:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/ios/fast/events/ios/rotation/zz-no-rotation-expected.txt:
* LayoutTests/platform/ipad/TestExpectations:
* LayoutTests/platform/ipad/fast/events/ios/rotation/zz-no-rotation-expected.txt:
* LayoutTests/platform/ipad/fast/screen-orientation/natural-orientation-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/275677@main">https://commits.webkit.org/275677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea4f3ef83dfe07ddc7e756607254888135e5e8ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44722 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38249 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34887 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38323 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37645 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41536 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40097 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9499 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->