### PR TITLE
[JSC] Implement Promise.try

### DIFF
--- a/JSTests/stress/promise-try.js
+++ b/JSTests/stress/promise-try.js
@@ -1,0 +1,52 @@
+//@ requireOptions("--usePromiseTryMethod=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function notReached() {
+    throw new Error('should not reach here');
+}
+
+async function delay() {
+    return new Promise((resolve, reject) => {
+        setTimeout(resolve);
+    });
+}
+
+shouldBe(Promise.try.length, 1);
+
+async function test() {
+    {
+        let result = [];
+        Promise.try(() => { result.push(1); });
+        result.push(2);
+        await delay();
+        shouldBe(`${result}`, '1,2');
+    }
+
+    shouldBe(await Promise.try(() => Promise.resolve(3)), 3);
+
+    try {
+        await Promise.try(() => { throw 4; });
+        notReached();
+    } catch (e) {
+        shouldBe(e, 4);
+    }
+
+    try {
+        await Promise.try(() => Promise.reject(5));
+        notReached();
+    } catch (e) {
+        shouldBe(e, 5);
+    }
+
+    shouldBe(await Promise.try((x, y, z) => x + y + z, 1, 2, 3), 6);
+}
+
+test().catch((error) => {
+    print(`FAIL: ${error}\n${error.stack}`);
+    $vm.abort();
+});
+drainMicrotasks();

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -368,6 +368,28 @@ function resolve(value)
     return @promiseResolve(this, value);
 }
 
+function try(callback /*, ...args */)
+{
+    "use strict";
+
+    if (!@isObject(this))
+        @throwTypeError("|this| is not an object");
+
+    var args = [];
+    for (var i = 1; i < arguments.length; i++)
+        @putByValDirect(args, i - 1, arguments[i]);
+
+    var promiseCapability = @newPromiseCapability(this);
+    try {
+        var value = callback.@apply(@undefined, args);
+        promiseCapability.resolve.@call(@undefined, value);
+    } catch (error) {
+        promiseCapability.reject.@call(@undefined, error);
+    }
+
+    return promiseCapability.promise;
+}
+
 function withResolvers()
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -88,6 +88,8 @@ void JSPromiseConstructor::finishCreation(VM& vm, JSPromisePrototype* promisePro
 
     if (Options::usePromiseWithResolversMethod())
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().withResolversPublicName(), promiseConstructorWithResolversCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    if (Options::usePromiseTryMethod())
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->tryKeyword, promiseConstructorTryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 void JSPromiseConstructor::addOwnInternalSlots(VM& vm, JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -589,6 +589,7 @@ bool canUseHandlerIC();
     v(Bool, useImportAttributes, true, Normal, "Enable import attributes.") \
     v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat.") \
     v(Bool, usePromiseWithResolversMethod, true, Normal, "Expose the Promise.withResolvers() method.") \
+    v(Bool, usePromiseTryMethod, false, Normal, "Expose the Promise.try() method.") \
     v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature.") \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object.") \


### PR DESCRIPTION
#### 6d51d579af47028306a003653150ade5d395f942
<pre>
[JSC] Implement Promise.try
<a href="https://bugs.webkit.org/show_bug.cgi?id=269775">https://bugs.webkit.org/show_bug.cgi?id=269775</a>

Reviewed by Justin Michaud.

This patch implements <a href="https://github.com/tc39/proposal-promise-try">https://github.com/tc39/proposal-promise-try</a> behind a runtime option;
the proposal is currently at Stage 2 but the spec is very simple and not expected to change.

Effectively, Promise.try(f) is a more convenient way to write `new Promise((resolve) =&gt; { resolve(f()); })` --
we don&apos;t care whether f is sync or async, but if is synchronous, we want it to be executed immediately.

This implementation includes <a href="https://github.com/tc39/proposal-promise-try/pull/16">https://github.com/tc39/proposal-promise-try/pull/16</a>, which the champion expects to merge;
it simply extends the API to Promise.try(f, ...args) such that arguments can be forwarded to the callback.

* JSTests/stress/promise-try.js: Added.
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(try): Added.
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSPromiseConstructor::finishCreation):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/275081@main">https://commits.webkit.org/275081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adb9e753d38cb783eae667d7e9db262d5a9acfff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43266 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36800 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44540 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34163 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40127 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38470 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17144 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47346 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9158 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17195 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9725 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->