### PR TITLE
[@starting-style] Starting style should inherit from parent after-change style

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt
@@ -3,5 +3,5 @@ PASS Overridden @starting-style - order of appearance
 PASS @starting-style with higher specificity
 PASS Starting style does not inherit from parent starting style
 PASS Starting style inheriting from parent's after-change style
-FAIL Starting style inheriting from parent's after-change style while parent transitioning assert_equals: Transition started from parent's after-change style color expected "rgb(0, 192, 0)" but got "rgb(0, 160, 0)"
+PASS Starting style inheriting from parent's after-change style while parent transitioning
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -111,7 +111,10 @@ private:
     };
 
     Scope& scope() { return m_scopeStack.last(); }
+    const Scope& scope() const { return m_scopeStack.last(); }
+
     Parent& parent() { return m_parentStack.last(); }
+    const Parent& parent() const { return m_parentStack.last(); }
 
     void pushScope(ShadowRoot&);
     void pushEnclosingScope();


### PR DESCRIPTION
#### 4560c7e615dbcf3a0d3aa9193297ef30c29edcbd
<pre>
[@starting-style] Starting style should inherit from parent after-change style
<a href="https://bugs.webkit.org/show_bug.cgi?id=269781">https://bugs.webkit.org/show_bug.cgi?id=269781</a>
<a href="https://rdar.apple.com/123302667">rdar://123302667</a>

Reviewed by Antoine Quint.

&quot;Starting style inherits from the parent’s after-change style just like after-change style does.&quot;

<a href="https://drafts.csswg.org/css-transitions-2/#defining-before-change-style">https://drafts.csswg.org/css-transitions-2/#defining-before-change-style</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveStartingStyle const):

Use lastStyleChangeEventStyle as the parent after-change style if there is one.

* Source/WebCore/style/StyleTreeResolver.h:
(WebCore::Style::TreeResolver::scope const):
(WebCore::Style::TreeResolver::parent const):

Canonical link: <a href="https://commits.webkit.org/275061@main">https://commits.webkit.org/275061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67d84b95782118a5fc222524c485901037566d9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43076 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/22796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17113 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14415 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14505 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36438 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38522 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17203 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9140 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->