### PR TITLE
Normalize Latin-1 characters in `String#normalize("NFKC")``

### DIFF
--- a/JSTests/es6/String.prototype_methods_String.prototype.normalize.js
+++ b/JSTests/es6/String.prototype_methods_String.prototype.normalize.js
@@ -2,6 +2,7 @@ function test() {
 
 return typeof String.prototype.normalize === "function"
   && "c\u0327\u0301".normalize("NFC") === "\u1e09"
+  && "\u00A8".normalize("NFKC") === "\u0020\u0308"
   && "\u1e09".normalize("NFD") === "c\u0327\u0301";
       
 }


### PR DESCRIPTION
#### c1a059873be72b0942c21d34a6431be396822a85
<pre>
Normalize Latin-1 characters in `String#normalize(&quot;NFKC&quot;)``
<a href="https://bugs.webkit.org/show_bug.cgi?id=269783">https://bugs.webkit.org/show_bug.cgi?id=269783</a>

Reviewed by Alexey Proskuryakov.

The `String.prototype.normalize` implementation has a fast-path in
cases where normalization does not affect the string. It was incorrectly
assumed that NFKC does not affect 8-bit strings. The only normalization
that doesn&apos;t affect them is NFC.

* JSTests/es6/String.prototype_methods_String.prototype.normalize.js:
(test):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::normalize):
(JSC::normalizationAffects8Bit): Deleted.

Canonical link: <a href="https://commits.webkit.org/275062@main">https://commits.webkit.org/275062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b829120eb36ca80ec6121665def073a34d12278

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43289 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36821 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33782 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44561 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34184 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40149 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40357 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38490 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17165 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47367 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17216 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9730 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->