### PR TITLE
[WGSL] Validate function parameter and return types

### DIFF
--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -843,6 +843,22 @@ bool Type::containsOverrideArray() const
     return false;
 }
 
+bool Type::isTexture() const
+{
+    auto* primitive = std::get_if<Types::Primitive>(this);
+    if (primitive)
+        return primitive->kind == Types::Primitive::TextureExternal;
+    return std::holds_alternative<Types::Texture>(*this) || std::holds_alternative<Types::TextureStorage>(*this) || std::holds_alternative<Types::TextureDepth>(*this);
+}
+
+bool Type::isSampler() const
+{
+    auto* primitive = std::get_if<Types::Primitive>(this);
+    if (!primitive)
+        return false;
+    return primitive->kind == Types::Primitive::Sampler || primitive->kind == Types::Primitive::SamplerComparison;
+}
+
 bool isPrimitive(const Type* type, Primitive::Kind kind)
 {
     auto* primitive = std::get_if<Primitive>(type);

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -288,6 +288,8 @@ struct Type : public std::variant<
     bool hasCreationFixedFootprint() const;
     bool containsRuntimeArray() const;
     bool containsOverrideArray() const;
+    bool isSampler() const;
+    bool isTexture() const;
 };
 
 using ConversionRank = Markable<unsigned, IntegralMarkableTraits<unsigned, std::numeric_limits<unsigned>::max()>>;


### PR DESCRIPTION
#### f8d79cb3381c3e2e52f3f2fa7aa0c8f3e54e63a9
<pre>
[WGSL] Validate function parameter and return types
<a href="https://bugs.webkit.org/show_bug.cgi?id=269727">https://bugs.webkit.org/show_bug.cgi?id=269727</a>
<a href="https://rdar.apple.com/123238787">rdar://123238787</a>

Reviewed by Mike Wyrzykowski.

Validate function parameters and return types according to the spec[1].

[1]: <a href="https://www.w3.org/TR/WGSL/#function-restriction">https://www.w3.org/TR/WGSL/#function-restriction</a>

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):

Canonical link: <a href="https://commits.webkit.org/275103@main">https://commits.webkit.org/275103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75669faa532ac14ef94aedf47aef40abd34c2ea3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36823 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33783 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14384 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14475 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36950 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36410 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc-extensions/transfer-datachannel-service-worker.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40150 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38491 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17167 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9177 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16811 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->