### PR TITLE
Improve SVG Markers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7451,8 +7451,6 @@ webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-att
 imported/w3c/web-platform-tests/svg/painting/reftests/fallback-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-implicit-subpaths.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-003.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-011.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-012.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-013.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-units-strokewidth-non-scaling-stroke.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/markers-orient-002.svg [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/svg/SVGMarkerData.h
+++ b/Source/WebCore/rendering/svg/SVGMarkerData.h
@@ -49,7 +49,6 @@ class SVGMarkerData {
 public:
     SVGMarkerData(Vector<MarkerPosition>& positions, bool reverseStart)
         : m_positions(positions)
-        , m_elementIndex(0)
         , m_reverseStart(reverseStart)
     {
     }
@@ -57,16 +56,25 @@ public:
     static void updateFromPathElement(SVGMarkerData& markerData, const PathElement& element)
     {
         // First update the outslope for the previous element.
-        markerData.updateOutslope(element.points[0]);
+        if (element.type != PathElement::Type::MoveToPoint)
+            markerData.updateOutslope(element.points[0]);
 
         // Record the marker for the previous element.
         if (markerData.m_elementIndex > 0) {
             SVGMarkerType markerType = markerData.m_elementIndex == 1 ? StartMarker : MidMarker;
-            markerData.m_positions.append(MarkerPosition(markerType, markerData.m_origin, markerData.currentAngle(markerType)));
+            SVGMarkerType markerTypeForOrientation;
+            if (markerData.m_previousWasMoveTo)
+                markerTypeForOrientation = StartMarker;
+            else if (element.type == PathElement::Type::MoveToPoint)
+                markerTypeForOrientation = EndMarker;
+            else
+                markerTypeForOrientation = markerType;
+            markerData.m_positions.append(MarkerPosition(markerType, markerData.m_origin, markerData.currentAngle(markerTypeForOrientation)));
         }
 
         // Update our marker data for this element.
         markerData.updateMarkerDataForPathElement(element);
+        markerData.m_previousWasMoveTo = element.type == PathElement::Type::MoveToPoint;
         ++markerData.m_elementIndex;
     }
 
@@ -109,6 +117,12 @@ private:
         m_outslopePoints[1] = point;
     }
 
+    void updateInslope(const FloatPoint& point)
+    {
+        m_inslopePoints[0] = m_origin;
+        m_inslopePoints[1] = point;
+    }
+
     void updateMarkerDataForPathElement(const PathElement& element)
     {
         auto& points = element.points;
@@ -137,19 +151,14 @@ private:
         }
     }
 
-    void updateInslope(const FloatPoint& point)
-    {
-        m_inslopePoints[0] = m_origin;
-        m_inslopePoints[1] = point;
-    }
-
     Vector<MarkerPosition>& m_positions;
-    unsigned m_elementIndex;
+    unsigned m_elementIndex { 0 };
     FloatPoint m_origin;
     FloatPoint m_subpathStart;
     FloatPoint m_inslopePoints[2];
     FloatPoint m_outslopePoints[2];
     bool m_reverseStart;
+    bool m_previousWasMoveTo { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 25a983afbde5c58bd75b054a5fdd511e28216d8e
<pre>
Improve SVG Markers
<a href="https://bugs.webkit.org/show_bug.cgi?id=269789">https://bugs.webkit.org/show_bug.cgi?id=269789</a>

Reviewed by Nikolas Zimmermann.

Fix the following problems:
- if the previous segment was a move to, we need to calculate the previous (mid-marker) segment orientation as a start marker
- if we are now moving to a new subpath, the previous (mid-marker) segment orientation should be calculated as an end marker
- don&apos;t calculate the out slope if we are moving to a new suboath

Fixes:
web-platform-tests/svg/painting/reftests/marker-path-011.svg
web-platform-tests/svg/painting/reftests/marker-path-012.svg

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/svg/SVGMarkerData.h:
(WebCore::SVGMarkerData::SVGMarkerData):
(WebCore::SVGMarkerData::updateFromPathElement):

Canonical link: <a href="https://commits.webkit.org/275167@main">https://commits.webkit.org/275167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0b4b42adaa0881053a9f13d76dfab57296f6cea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43632 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37163 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17415 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35371 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44945 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37257 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36683 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13021 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17505 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9217 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->