### PR TITLE
[WGSL] Fix small parser bugs

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -607,6 +607,7 @@ Result<AST::ConstAssert::Ref> Parser<Lexer>::parseConstAssert()
     START_PARSE();
     CONSUME_TYPE(KeywordConstAssert);
     PARSE(test, Expression);
+    CONSUME_TYPE(Semicolon);
     RETURN_ARENA_NODE(ConstAssert, WTFMove(test));
 }
 
@@ -634,6 +635,8 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
     if (ident.ident == "group"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(group, Expression);
+        if (current().type  == TokenType::Comma)
+            consume();
         CONSUME_TYPE(ParenRight);
         RETURN_ARENA_NODE(GroupAttribute, WTFMove(group));
     }
@@ -641,6 +644,8 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
     if (ident.ident == "binding"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(binding, Expression);
+        if (current().type  == TokenType::Comma)
+            consume();
         CONSUME_TYPE(ParenRight);
         RETURN_ARENA_NODE(BindingAttribute, WTFMove(binding));
     }
@@ -648,6 +653,8 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
     if (ident.ident == "location"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(location, Expression);
+        if (current().type  == TokenType::Comma)
+            consume();
         CONSUME_TYPE(ParenRight);
         RETURN_ARENA_NODE(LocationAttribute, WTFMove(location));
     }
@@ -675,6 +682,8 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
             break;
         }
 
+        if (current().type  == TokenType::Comma)
+            consume();
         CONSUME_TYPE(ParenRight);
         RETURN_ARENA_NODE(BuiltinAttribute, *builtin);
     }
@@ -709,6 +718,8 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
     if (ident.ident == "align"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(alignment, Expression);
+        if (current().type  == TokenType::Comma)
+            consume();
         CONSUME_TYPE(ParenRight);
         RETURN_ARENA_NODE(AlignAttribute, WTFMove(alignment));
     }
@@ -737,6 +748,8 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
     if (ident.ident == "size"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(size, Expression);
+        if (current().type  == TokenType::Comma)
+            consume();
         CONSUME_TYPE(ParenRight);
         RETURN_ARENA_NODE(SizeAttribute, WTFMove(size));
     }
@@ -744,6 +757,8 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
     if (ident.ident == "id"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(size, Expression);
+        if (current().type  == TokenType::Comma)
+            consume();
         CONSUME_TYPE(ParenRight);
         RETURN_ARENA_NODE(IdAttribute, WTFMove(size));
     }


### PR DESCRIPTION
#### badede9886d3f208291d4ee550ceefd482cfc7ca
<pre>
[WGSL] Fix small parser bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=269790">https://bugs.webkit.org/show_bug.cgi?id=269790</a>
<a href="https://rdar.apple.com/123311105">rdar://123311105</a>

Reviewed by Mike Wyrzykowski.

We were missing a check for a semicolon after const_assert and trailing commas
in attributes, which caused a few CTS test failures.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseConstAssert):
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/275099@main">https://commits.webkit.org/275099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8854b0c92ca2d7d538a07d2495c512c5bf0fc156

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43304 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36836 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33792 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14486 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44576 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40160 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38501 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17180 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9180 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->