### PR TITLE
AudioConverterNew triggers FastMalloc allocations

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm
@@ -125,6 +125,7 @@ OSStatus AudioSampleDataConverter::convert(const AudioBufferList& inputBuffer, A
 
 OSStatus AudioSampleDataConverter::Converter::initialize(const AudioStreamBasicDescription& inputDescription, const AudioStreamBasicDescription& outputDescription)
 {
+    DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
     if (m_audioConverter) {
         PAL::AudioConverterDispose(m_audioConverter);
         m_audioConverter = nullptr;


### PR DESCRIPTION
#### a7f4b07d854b6715e93b40cd5f6fd55e9286f8ba
<pre>
AudioConverterNew triggers FastMalloc allocations
<a href="https://rdar.apple.com/123032034">rdar://123032034</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269794">https://bugs.webkit.org/show_bug.cgi?id=269794</a>

Reviewed by Eric Carlson.

Allocations in registerLogHook may be triggered when creating a converter.
We disable the warning by using DisableMallocRestrictionsForCurrentThreadScope.

* Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm:
(WebCore::AudioSampleDataConverter::Converter::initialize):

Canonical link: <a href="https://commits.webkit.org/275060@main">https://commits.webkit.org/275060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f6f3efc0728c6bc66a35f389f50fd2641e999b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43311 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17097 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40166 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38516 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17187 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9142 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->