### PR TITLE
Add nullptr check for ProcessLauncher client

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -177,8 +177,7 @@ void ProcessLauncher::launchProcess()
 #if USE(EXTENSIONKIT)
     auto handler = [](ThreadSafeWeakPtr<ProcessLauncher> weakProcessLauncher, ExtensionProcess&& process, ASCIILiteral name, NSError *error)
     {
-        RefPtr launcher = weakProcessLauncher.get();
-        if (!launcher) {
+        if (!weakProcessLauncher.get()) {
             process.invalidate();
             return;
         }
@@ -213,7 +212,8 @@ void ProcessLauncher::launchProcess()
 
         callOnMainRunLoop([weakProcessLauncher, name, process = WTFMove(process), launchGrant = WTFMove(launchGrant)] () mutable {
             RefPtr launcher = weakProcessLauncher.get();
-            if (!launcher) {
+            // If m_client is null, the Process launcher has been invalidated, and we should not proceed with the launch.
+            if (!launcher || !launcher->m_client) {
                 process.invalidate();
                 return;
             }


### PR DESCRIPTION
#### ffc2b5a384618d30690a68f73165d17be5e8a13d
<pre>
Add nullptr check for ProcessLauncher client
<a href="https://bugs.webkit.org/show_bug.cgi?id=269759">https://bugs.webkit.org/show_bug.cgi?id=269759</a>
<a href="https://rdar.apple.com/122995875">rdar://122995875</a>

Reviewed by NOBODY (OOPS!).

This patch fixes a null pointer dereference crash that was introduced in &lt;<a href="https://commits.webkit.org/274390@main">https://commits.webkit.org/274390@main</a>&gt;.
The commit 274390@main introduced a race condition by holding a reference to the Process launcher in the completion
handler for starting WebKit extension processes. This reference was held througout the duration of the completion
handler. This meant that on rare occasions, the Process launcher could be deleted at the end of the completion
handler, instead of in the AuxiliaryProcessProxy destructor, where it normally is invalidated and deleted. The
lambda to finish the launch scheduled from the completion handler on the main thread could then end up having a
Process launcher that was invalidated but not deallocated. When the Process launcher is invalidated, the m_client
member is set to nullptr. This member is later dereferenced in ProcessLauncher::finishLaunchingProcess, and caused
a null pointer crash in this case. This patch is fixing the crash by reverting the change in 274390@main that
introduced the crash as well as adding a null pointer check for m_client, in order to guard against this race being
reintroduced in the future.

* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffc2b5a384618d30690a68f73165d17be5e8a13d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40766 "Failed to checkout and rebase branch from PR 24822") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19779 "Failed to checkout and rebase branch from PR 24822") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43144 "Failed to checkout and rebase branch from PR 24822") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43324 "Failed to checkout and rebase branch from PR 24822") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36856 "Failed to checkout and rebase branch from PR 24822") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22767 "Failed to checkout and rebase branch from PR 24822") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17110 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/43324 "Failed to checkout and rebase branch from PR 24822") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41340 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/22767 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/43144 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/43324 "Failed to checkout and rebase branch from PR 24822") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/22767 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/43144 "Failed to checkout and rebase branch from PR 24822") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44596 "Failed to checkout and rebase branch from PR 24822") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/22767 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/43144 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/44596 "Failed to checkout and rebase branch from PR 24822") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15581 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/17110 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/44596 "Failed to checkout and rebase branch from PR 24822") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17200 "Failed to checkout and rebase branch from PR 24822") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/43144 "Failed to checkout and rebase branch from PR 24822") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17251 "Failed to checkout and rebase branch from PR 24822") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16844 "Failed to checkout and rebase branch from PR 24822") | | | 
<!--EWS-Status-Bubble-End-->