### PR TITLE
Fix layout tests in simulator after https://commits.webkit.org/274822@main

### DIFF
--- a/Source/WebKit/Configurations/BaseExtension.xcconfig
+++ b/Source/WebKit/Configurations/BaseExtension.xcconfig
@@ -57,9 +57,6 @@ EXCLUDED_SOURCE_FILE_NAMES_YES[sdk=xr*] = *;
 
 CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 
-// For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
-CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtension.entitlements;
-
 WK_PROCESSED_XCENT_FILE=$(TEMP_FILE_DIR)/$(FULL_PRODUCT_NAME).entitlements
 WK_LIBRARY_VALIDATION_CODE_SIGN_FLAGS = --entitlements $(WK_PROCESSED_XCENT_FILE);
 

--- a/Source/WebKit/Configurations/GPUExtension.xcconfig
+++ b/Source/WebKit/Configurations/GPUExtension.xcconfig
@@ -28,3 +28,6 @@ INFOPLIST_KEY_CFBundleDisplayName = GPUExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.GPU;
 EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = GPUExtension;
+
+// For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
+CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/GPUProcessExtension.entitlements;

--- a/Source/WebKit/Configurations/NetworkingExtension.xcconfig
+++ b/Source/WebKit/Configurations/NetworkingExtension.xcconfig
@@ -28,3 +28,6 @@ INFOPLIST_KEY_CFBundleDisplayName = NetworkingExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.Networking;
 EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = NetworkingExtension;
+
+// For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
+CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.entitlements;

--- a/Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig
@@ -28,3 +28,6 @@ INFOPLIST_KEY_CFBundleDisplayName = WebContentCaptivePortalExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContent.CaptivePortal;
 EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = WebContentCaptivePortalExtension;
+
+// For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
+CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements;

--- a/Source/WebKit/Configurations/WebContentExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentExtension.xcconfig
@@ -28,3 +28,6 @@ INFOPLIST_KEY_CFBundleDisplayName = WebContentExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContent;
 EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = WebContentExtension;
+
+// For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
+CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements;

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.private.webkit.use-xpc-endpoint</key>
 	<true/>
+	<key>com.apple.developer.web-browser-engine.rendering</key>
+	<true/>
 	<key>com.apple.private.extensionkit.host-requirement-exemption</key>
 	<true/>
 </dict>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.runningboard.assertions.webkit</key>
+	<true/>
+	<key>com.apple.private.webkit.use-xpc-endpoint</key>
+	<true/>
+	<key>com.apple.developer.web-browser-engine.networking</key>
+	<true/>
+	<key>com.apple.private.extensionkit.host-requirement-exemption</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.runningboard.assertions.webkit</key>
+	<true/>
+	<key>com.apple.private.webkit.use-xpc-endpoint</key>
+	<true/>
+	<key>com.apple.developer.web-browser-engine.webcontent</key>
+	<true/>
+	<key>com.apple.private.extensionkit.host-requirement-exemption</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7914,6 +7914,9 @@
 		E36D701D27B718EF006531B7 /* WebAttachmentElementClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebAttachmentElementClient.cpp; sourceTree = "<group>"; };
 		E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SandboxStateVariables.h; sourceTree = "<group>"; };
 		E36FF00227F36FBD004BE21A /* preferences.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = preferences.sb; sourceTree = "<group>"; };
+		E37A2F1A2B8523300087F394 /* NetworkingProcessExtension.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = NetworkingProcessExtension.entitlements; sourceTree = "<group>"; };
+		E37A2F1B2B8523B10087F394 /* WebContentProcessExtension.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = WebContentProcessExtension.entitlements; sourceTree = "<group>"; };
+		E37A2F1C2B8523B10087F394 /* GPUProcessExtension.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = GPUProcessExtension.entitlements; sourceTree = "<group>"; };
 		E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebMockContentFilterManager.cpp; path = Network/WebMockContentFilterManager.cpp; sourceTree = "<group>"; };
 		E3816B3C27E24639005EAFC0 /* WebMockContentFilterManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebMockContentFilterManager.h; path = Network/WebMockContentFilterManager.h; sourceTree = "<group>"; };
 		E3866AE42397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebDeviceOrientationUpdateProviderProxy.mm; path = ios/WebDeviceOrientationUpdateProviderProxy.mm; sourceTree = "<group>"; };
@@ -12636,11 +12639,14 @@
 				5C139DB829DB847E00D5117B /* AuxiliaryProcessExtensionBridge.mm */,
 				5C139DB529DB847D00D5117B /* com.apple.WebKit.appexpt */,
 				5C139DB629DB847E00D5117B /* GPUExtension-Info.plist */,
+				E37A2F1C2B8523B10087F394 /* GPUProcessExtension.entitlements */,
 				E3B9B5D62AB65822008568FE /* GPUProcessExtension.swift */,
 				5C139DB729DB847E00D5117B /* NetworkingExtension-Info.plist */,
+				E37A2F1A2B8523300087F394 /* NetworkingProcessExtension.entitlements */,
 				E3B9B5D42AB65795008568FE /* NetworkingProcessExtension.swift */,
 				5C139DB029DB847C00D5117B /* WebContentExtension-CaptivePortal-Info.plist */,
 				5C139DB129DB847D00D5117B /* WebContentExtension-Info.plist */,
+				E37A2F1B2B8523B10087F394 /* WebContentProcessExtension.entitlements */,
 				5C139DB929DB847E00D5117B /* WebContentProcessExtension.swift */,
 			);
 			path = AuxiliaryProcessExtensions;


### PR DESCRIPTION
#### 638c7e3dc4085c70eb9e26984f8dd84d101f949c
<pre>
Fix layout tests in simulator after <a href="https://commits.webkit.org/274822@main">https://commits.webkit.org/274822@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269800">https://bugs.webkit.org/show_bug.cgi?id=269800</a>
<a href="https://rdar.apple.com/123322718">rdar://123322718</a>

Reviewed by Brent Fulgham.

Entitlement changes related to process grants are required for simulator after &lt;<a href="https://commits.webkit.org/274822@main">https://commits.webkit.org/274822@main</a>&gt;.

* Source/WebKit/Configurations/BaseExtension.xcconfig:
* Source/WebKit/Configurations/GPUExtension.xcconfig:
* Source/WebKit/Configurations/NetworkingExtension.xcconfig:
* Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig:
* Source/WebKit/Configurations/WebContentExtension.xcconfig:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.entitlements: Copied from Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtension.entitlements.
* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.entitlements: Copied from Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtension.entitlements.
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements: Renamed from Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtension.entitlements.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/275072@main">https://commits.webkit.org/275072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36bfb12dc92984e5289fba91b87cf4e2adeef786

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43335 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36867 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17121 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35146 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44609 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40193 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15592 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12793 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38538 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17211 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9151 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17262 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->