### PR TITLE
Fix Web Inspector: Remember the message type selection in the Console tab

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -453,7 +453,8 @@ WI.contentLoaded = function()
     WI._consoleWarningsTabBarButton.imageType = WI.ButtonNavigationItem.ImageType.IMG;
     WI._consoleWarningsTabBarButton.hidden = true;
     WI._consoleWarningsTabBarButton.addEventListener(WI.ButtonNavigationItem.Event.Clicked, function(event) {
-        WI.showConsoleTab(WI.LogContentView.Scopes.Warnings, {
+        WI.showConsoleTab({
+            requestedScope: WI.LogContentView.Scopes.Warnings,
             initiatorHint: WI.TabBrowser.TabNavigationInitiator.Dashboard,
         });
     }, WI);
@@ -462,7 +463,8 @@ WI.contentLoaded = function()
     WI._consoleErrorsTabBarButton.imageType = WI.ButtonNavigationItem.ImageType.IMG;
     WI._consoleErrorsTabBarButton.hidden = true;
     WI._consoleErrorsTabBarButton.addEventListener(WI.ButtonNavigationItem.Event.Clicked, function(event) {
-        WI.showConsoleTab(WI.LogContentView.Scopes.Errors, {
+        WI.showConsoleTab({
+            requestedScope: WI.LogContentView.Scopes.Errors,
             initiatorHint: WI.TabBrowser.TabNavigationInitiator.Dashboard,
         });
     }, WI);
@@ -1199,13 +1201,12 @@ WI.hideSplitConsole = function()
     WI.consoleDrawer.collapsed = true;
 };
 
-WI.showConsoleTab = function(requestedScope, options = {})
+WI.showConsoleTab = function(options = {})
 {
-    requestedScope = requestedScope || WI.LogContentView.Scopes.All;
-
     WI.hideSplitConsole();
 
-    WI.consoleContentView.scopeBar.item(requestedScope).selected = true;
+    if (options.requestedScope)
+        WI.consoleContentView.scopeBar.item(options.requestedScope).selected = true;
 
     const cookie = null;
     WI.showRepresentedObject(WI._consoleRepresentedObject, cookie, options);

--- a/Source/WebInspectorUI/UserInterface/Protocol/InspectorFrontendAPI.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/InspectorFrontendAPI.js
@@ -94,8 +94,7 @@ InspectorFrontendAPI = {
 
     showConsole: function()
     {
-        const requestedScope = null;
-        WI.showConsoleTab(requestedScope, {
+        WI.showConsoleTab({
             initiatorHint: WI.TabBrowser.TabNavigationInitiator.FrontendAPI,
         });
 

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
@@ -876,8 +876,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
 
     _showConsoleTab()
     {
-        const requestedScope = null;
-        WI.showConsoleTab(requestedScope, {
+        WI.showConsoleTab({
             initiatorHint: WI.TabBrowser.TabNavigationInitiator.ButtonClick,
         });
     }


### PR DESCRIPTION
#### 08a1f3998383fe5de26c9910bff87e89cb1739f3
<pre>
Fix Web Inspector: Remember the message type selection in the Console tab
<a href="https://rdar.apple.com/122924275">rdar://122924275</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268882">https://bugs.webkit.org/show_bug.cgi?id=268882</a>

Reviewed by Devin Rousso.

When showing the the inspector&apos;s console using `WI.showConsole()`, the
caller can optionally pass in a `requestedScope` to control which levels
(AKA message types) to be filtered automatically when the Console tab
shows up. However, when `requestedScope` is falsy or left empty, it
always applies `WI.LogContentView.Scopes.All` instead, which
overrides the levels selected by default, which are read from local
settings when the scope bar is created at the inspector&apos;s startup.

This commit removes the forced application of `Scopes.All`, so when
`requestedScope` is left empty, the Console tab is shown with levels
unchanged, which is the expected behavior when launching the Console tab
through Develop -&gt; Show JavaScript Console (or Option-Command-C).

This fix has one known side-effect: when an inspector tab does not
support split console view, pressing Esc will switch to the actual
Console tab instead. (The Settings tab is one example of such tab.)
This commit will make that also &quot;remember&quot; the previously selected
levels instead of deselecting back to just `Scopes.All`, which is
arguably the correct behavior anyway.

This commit also cleans up on how `requestedScope` gets passed in;
passing in as part of the `options` parameter allows callers of
`showConsole()` to self-document the usage `requestedScope`.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
  - Fix the bug.
  - Adapt to the clean up for the `options` parameter.
* Source/WebInspectorUI/UserInterface/Protocol/InspectorFrontendAPI.js:
(InspectorFrontendAPI.showConsole):
  - Adapt to the clean up for the `options` parameter.
* Source/WebInspectorUI/UserInterface/Views/LogContentView.js:
(WI.LogContentView.prototype._showConsoleTab):
  - Adapt to the clean up for the `options` parameter.

Canonical link: <a href="https://commits.webkit.org/275143@main">https://commits.webkit.org/275143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a4a0ec520016237521577c7cab7cfb76ec287ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43547 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37080 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17332 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16921 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14575 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44850 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37175 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38737 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17422 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9199 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->