### PR TITLE
::view-transition-group dynamic styles doesn't compute the transform.

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -736,7 +736,7 @@ static LayoutRect sizingBox(RenderObject& renderer)
     return box->style().boxSizing() == BoxSizing::BorderBox ? box->borderBoxRect() : box->computedCSSContentBoxRect();
 }
 
-static Ref<CSSFunctionValue> matrixTransformValue(const TransformationMatrix& transform, const RenderStyle& style)
+Ref<CSSFunctionValue> ComputedStyleExtractor::matrixTransformValue(const TransformationMatrix& transform, const RenderStyle& style)
 {
     auto zoom = style.effectiveZoom();
     if (transform.isAffine()) {
@@ -849,7 +849,7 @@ RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation& 
     case TransformOperation::Type::Matrix3D: {
         TransformationMatrix transform;
         operation.apply(transform, { });
-        return matrixTransformValue(transform, style);
+        return ComputedStyleExtractor::matrixTransformValue(transform, style);
     }
     case TransformOperation::Type::Identity:
     case TransformOperation::Type::None:
@@ -868,7 +868,7 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
     if (renderer) {
         TransformationMatrix transform;
         style.applyTransform(transform, TransformOperationData(renderer->transformReferenceBoxRect(style), renderer), { });
-        return CSSTransformListValue::create(matrixTransformValue(transform, style));
+        return CSSTransformListValue::create(ComputedStyleExtractor::matrixTransformValue(transform, style));
     }
 
     // https://w3c.github.io/csswg-drafts/css-transforms-1/#serialization-of-the-computed-value

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -40,6 +40,7 @@ class RenderStyle;
 class ShadowData;
 class StyleColor;
 class StylePropertyShorthand;
+class TransformationMatrix;
 class TransformOperation;
 
 struct PropertyValue;
@@ -81,6 +82,7 @@ public:
     static Ref<CSSValue> valueForFilter(const RenderStyle&, const FilterOperations&, AdjustPixelValuesForComputedStyle = AdjustPixelValuesForComputedStyle::Yes);
 
     static Ref<CSSPrimitiveValue> currentColorOrValidColor(const RenderStyle&, const StyleColor&);
+    static Ref<CSSFunctionValue> matrixTransformValue(const TransformationMatrix&, const RenderStyle&);
 
     static bool updateStyleIfNeededForProperty(Element&, CSSPropertyID);
 

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ViewTransition.h"
 
+#include "CSSTransformListValue.h"
 #include "CheckVisibilityOptions.h"
 #include "ComputedStyleExtractor.h"
 #include "Document.h"
@@ -409,7 +410,6 @@ void ViewTransition::clearViewTransition()
 
 Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(Element& element)
 {
-    // FIXME: Transform - ComputedStyleExtractor.cpp::matrixTransformValue
     ComputedStyleExtractor styleExtractor(&element);
 
     CSSPropertyID transitionProperties[] = {
@@ -425,7 +425,28 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(Element& e
         CSSPropertyHeight,
     };
 
-    return styleExtractor.copyProperties(transitionProperties);
+    Ref<MutableStyleProperties> props = styleExtractor.copyProperties(transitionProperties);
+
+    TransformationMatrix transform;
+    auto* renderer = element.renderer();
+    RenderElement* container = nullptr;
+    while (renderer && !renderer->isRenderView()) {
+        container = renderer->container();
+        if (!container)
+            break;
+        LayoutSize containerOffset = renderer->offsetFromContainer(*container, LayoutPoint());
+        TransformationMatrix localTransform;
+        renderer->getTransformFromContainer(nullptr, containerOffset, localTransform);
+        transform.multiply(localTransform);
+        renderer = container;
+    }
+
+    if (element.renderer()) {
+        Ref<CSSValue> transformListValue = CSSTransformListValue::create(ComputedStyleExtractor::matrixTransformValue(transform, element.renderer()->style()));
+        props->setProperty(CSSPropertyTransform, WTFMove(transformListValue));
+    }
+
+    return props;
 }
 
 // https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles


### PR DESCRIPTION
#### 142e5436fbfb59ae112dda82b4580a33fa6bec73
<pre>
::view-transition-group dynamic styles doesn&apos;t compute the transform.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269692">https://bugs.webkit.org/show_bug.cgi?id=269692</a>
&lt;<a href="https://rdar.apple.com/123213197">rdar://123213197</a>&gt;

Reviewed by Tim Nguyen.

The dynamically computed style for :root::view-transition-group(transitionName)
should include &apos;a transform that would map capturedElement’s new element&apos;s
border box from the snapshot containing block origin to its current visual
position.&apos;

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::matrixTransformValue):
(WebCore::transformOperationAsCSSValue):
(WebCore::computedTransform):
(WebCore::matrixTransformValue): Deleted.
* Source/WebCore/css/ComputedStyleExtractor.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::copyElementBaseProperties):

Canonical link: <a href="https://commits.webkit.org/275080@main">https://commits.webkit.org/275080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7208b83a827538b892a0df29aaecf87115d406

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33824 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14433 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36143 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40198 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38545 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17227 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9159 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->