### PR TITLE
Remove browser.test.testEvent and browser.test.fireTestEvent().

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -336,19 +336,6 @@ JSValue *WebExtensionAPITest::assertSafeResolve(JSContextRef context, JSValue *f
     return assertResolves(context, result, message);
 }
 
-WebExtensionAPIEvent& WebExtensionAPITest::testEvent()
-{
-    if (!m_event)
-        m_event = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::ActionOnClicked);
-
-    return *m_event;
-}
-
-void WebExtensionAPITest::fireTestEvent()
-{
-    testEvent().invokeListeners();
-}
-
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -66,13 +66,6 @@ public:
     JSValue *assertSafe(JSContextRef, JSValue *function, NSString *message);
 
     JSValue *assertSafeResolve(JSContextRef, JSValue *function, NSString *message);
-
-    WebExtensionAPIEvent& testEvent();
-    void fireTestEvent();
-
-private:
-    RefPtr<WebExtensionAPIWebNavigationEvent> m_webNavigationEvent;
-    RefPtr<WebExtensionAPIEvent> m_event;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -73,7 +73,4 @@
     // Asserts the function does not thow an exception and the result promise is resolved.
     [NeedsScriptContext] any assertSafeResolve(any function, [Optional] DOMString message);
 
-    // FIXME: Temporary Event for bring-up. Remove this.
-    readonly attribute WebExtensionAPIEvent testEvent;
-    void fireTestEvent();
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm
@@ -36,9 +36,9 @@ static auto *eventManifest = @{ @"manifest_version": @3, @"background": @{ @"scr
 TEST(WKWebExtensionAPIEvent, Errors)
 {
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.test.assertThrows(() => browser.test.testEvent.addListener('bad'), /'listener' value is invalid, because a function is expected/i)",
-        @"browser.test.assertThrows(() => browser.test.testEvent.removeListener('bad'), /'listener' value is invalid, because a function is expected/i)",
-        @"browser.test.assertThrows(() => browser.test.testEvent.hasListener('bad'), /'listener' value is invalid, because a function is expected/i)",
+        @"browser.test.assertThrows(() => browser.runtime.onStartup.addListener('bad'), /'listener' value is invalid, because a function is expected/i)",
+        @"browser.test.assertThrows(() => browser.runtime.onStartup.removeListener('bad'), /'listener' value is invalid, because a function is expected/i)",
+        @"browser.test.assertThrows(() => browser.runtime.onStartup.hasListener('bad'), /'listener' value is invalid, because a function is expected/i)",
 
         @"browser.test.notifyPass()"
     ]);
@@ -50,18 +50,18 @@ TEST(WKWebExtensionAPIEvent, TestEventListener)
 {
     auto *backgroundScript = Util::constructScript(@[
         // Setup
-        @"function listener() { browser.test.notifyPass('This listener should have been called.') }",
-        @"browser.test.assertFalse(browser.test.testEvent.hasListener(listener), 'Should not have listener')",
-        @"browser.test.testEvent.addListener(listener)",
+        @"function listener() { }",
+        @"browser.test.assertFalse(browser.runtime.onStartup.hasListener(listener), 'Should not have listener')",
+        @"browser.runtime.onStartup.addListener(listener)",
 
         // Test
-        @"browser.test.assertTrue(browser.test.testEvent.hasListener(listener), 'Should have listener')",
-        @"browser.test.testEvent.removeListener(listener)",
-        @"browser.test.assertFalse(browser.test.testEvent.hasListener(listener), 'Should not have listener')",
-        @"browser.test.testEvent.addListener(listener)",
+        @"browser.test.assertTrue(browser.runtime.onStartup.hasListener(listener), 'Should have listener')",
+        @"browser.runtime.onStartup.removeListener(listener)",
+        @"browser.test.assertFalse(browser.runtime.onStartup.hasListener(listener), 'Should not have listener')",
+        @"browser.runtime.onStartup.addListener(listener)",
 
-        // Finish. The listener firing will indicate that the test passed.
-        @"browser.test.fireTestEvent()"
+        // Finish.
+        @"browser.test.notifyPass()"
     ]);
 
     Util::loadAndRunExtension(eventManifest, @{ @"background.js": backgroundScript });


### PR DESCRIPTION
#### 607817d6a54bd5803b8a719493511a70034a533e
<pre>
Remove browser.test.testEvent and browser.test.fireTestEvent().
<a href="https://webkit.org/b/269659">https://webkit.org/b/269659</a>
<a href="https://rdar.apple.com/123173676">rdar://123173676</a>

Reviewed by Brian Weinstein.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::testEvent): Deleted.
(WebKit::WebExtensionAPITest::fireTestEvent): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm:
(TEST(WKWebExtensionAPIEvent, Errors)): Use browser.runtime.onStartup instead.
(TEST(WKWebExtensionAPIEvent, TestEventListener)): Ditto. Firing events is
tested plenty of times in other tests.

Canonical link: <a href="https://commits.webkit.org/275071@main">https://commits.webkit.org/275071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7002480169d1ea6da765d4323a329eab81613368

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17138 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14432 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44628 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38548 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17228 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5420 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->