### PR TITLE
[JSC] Rename MegamorphicCache's load related fields

### DIFF
--- a/Source/JavaScriptCore/runtime/MegamorphicCache.cpp
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.cpp
@@ -37,11 +37,11 @@ void MegamorphicCache::age(CollectionScope collectionScope)
 {
     ++m_epoch;
     if (collectionScope == CollectionScope::Full || m_epoch == invalidEpoch) {
-        for (auto& entry : m_primaryEntries) {
+        for (auto& entry : m_loadCachePrimaryEntries) {
             entry.m_uid = nullptr;
             entry.m_epoch = invalidEpoch;
         }
-        for (auto& entry : m_secondaryEntries) {
+        for (auto& entry : m_loadCacheSecondaryEntries) {
             entry.m_uid = nullptr;
             entry.m_epoch = invalidEpoch;
         }
@@ -68,9 +68,9 @@ void MegamorphicCache::age(CollectionScope collectionScope)
 
 void MegamorphicCache::clearEntries()
 {
-    for (auto& entry : m_primaryEntries)
+    for (auto& entry : m_loadCachePrimaryEntries)
         entry.m_epoch = invalidEpoch;
-    for (auto& entry : m_secondaryEntries)
+    for (auto& entry : m_loadCacheSecondaryEntries)
         entry.m_epoch = invalidEpoch;
     for (auto& entry : m_storeCachePrimaryEntries)
         entry.m_epoch = invalidEpoch;


### PR DESCRIPTION
#### bbcc016589702ba11cacd4fe32c235c3ebe72559
<pre>
[JSC] Rename MegamorphicCache&apos;s load related fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=269811">https://bugs.webkit.org/show_bug.cgi?id=269811</a>
<a href="https://rdar.apple.com/123333247">rdar://123333247</a>

Reviewed by Keith Miller and Michael Saboff.

Let&apos;s rename Load related MegamorphicCache fields to explicitly say &quot;Load&quot;.
Previously, it didn&apos;t since MegamorphicCache implementation started with Load only.
And eventually it gets expanded.

* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::loadMegamorphicProperty):
* Source/JavaScriptCore/runtime/MegamorphicCache.cpp:
(JSC::MegamorphicCache::age):
(JSC::MegamorphicCache::clearEntries):
* Source/JavaScriptCore/runtime/MegamorphicCache.h:
(JSC::MegamorphicCache::LoadEntry::offsetOfUid):
(JSC::MegamorphicCache::LoadEntry::offsetOfStructureID):
(JSC::MegamorphicCache::LoadEntry::offsetOfEpoch):
(JSC::MegamorphicCache::LoadEntry::offsetOfOffset):
(JSC::MegamorphicCache::LoadEntry::offsetOfHolder):
(JSC::MegamorphicCache::offsetOfLoadCachePrimaryEntries):
(JSC::MegamorphicCache::offsetOfLoadCacheSecondaryEntries):
(JSC::MegamorphicCache::initAsMiss):
(JSC::MegamorphicCache::initAsHit):
(JSC::MegamorphicCache::Entry::offsetOfUid): Deleted.
(JSC::MegamorphicCache::Entry::offsetOfStructureID): Deleted.
(JSC::MegamorphicCache::Entry::offsetOfEpoch): Deleted.
(JSC::MegamorphicCache::Entry::offsetOfOffset): Deleted.
(JSC::MegamorphicCache::Entry::offsetOfHolder): Deleted.
(JSC::MegamorphicCache::Entry::initAsMiss): Deleted.
(JSC::MegamorphicCache::Entry::initAsHit): Deleted.
(JSC::MegamorphicCache::offsetOfPrimaryEntries): Deleted.
(JSC::MegamorphicCache::offsetOfSecondaryEntries): Deleted.

Canonical link: <a href="https://commits.webkit.org/275073@main">https://commits.webkit.org/275073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1e68a5ff0006d67e691f1a7b499bdc50579bfd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36890 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17144 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16755 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14530 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44635 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/34253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37010 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40426 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12814 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17234 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47436 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9744 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5421 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->