### PR TITLE
Regression(274445@main) Hang on twitch.tv when playing certain videos

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -126,7 +126,7 @@ template<typename, typename> class PODInterval;
 class RemotePlayback;
 #endif
 
-using CueInterval = PODInterval<MediaTime, WeakPtr<TextTrackCue, WeakPtrImplWithEventTargetData>>;
+using CueInterval = PODInterval<MediaTime, TextTrackCue*>;
 using CueList = Vector<CueInterval>;
 
 using MediaProvider = std::optional < std::variant <

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -87,7 +87,7 @@ RenderPtr<RenderElement> MediaControlTextTrackContainerElement::createElementRen
 
 static bool compareCueIntervalForDisplay(const CueInterval& one, const CueInterval& two)
 {
-    return one.data()->isPositionedAbove(two.data().get());
+    return one.data()->isPositionedAbove(two.data());
 };
 
 void MediaControlTextTrackContainerElement::updateDisplay()
@@ -156,7 +156,7 @@ void MediaControlTextTrackContainerElement::updateDisplay()
         removeChildren();
 
     activeCues.removeAllMatching([] (CueInterval& cueInterval) {
-        RefPtr cue = cueInterval.data().get();
+        RefPtr cue = cueInterval.data();
         return !cue->track()
             || !cue->track()->isRendered()
             || cue->track()->mode() == TextTrack::Mode::Disabled
@@ -256,7 +256,7 @@ void MediaControlTextTrackContainerElement::updateActiveCuesFontSize()
     m_fontSize = lroundf(100 * fontScale);
 
     for (auto& activeCue : m_mediaElement->currentlyActiveCues()) {
-        RefPtr cue = activeCue.data().get();
+        RefPtr cue = activeCue.data();
         if (cue->isRenderable())
             cue->setFontSize(m_fontSize, m_fontSizeIsImportant);
     }

--- a/Source/WebCore/platform/PODInterval.h
+++ b/Source/WebCore/platform/PODInterval.h
@@ -143,18 +143,7 @@ public:
             return true;
         if (other.Base::low() < Base::low())
             return false;
-        if (Base::high() < other.Base::high())
-            return true;
-        if (other.Base::high() < Base::high())
-            return false;
-        return Base::data().get() < other.Base::data().get();
-    }
-
-    bool operator==(const PODInterval& other) const
-    {
-        return Base::low() == other.Base::low()
-            && Base::high() == other.Base::high()
-            && Base::data() == other.Base::data();
+        return Base::high() < other.Base::high();
     }
 
 private:


### PR DESCRIPTION
#### 84643ce2ac865f3d6021c479ec98f0c92addaf8e
<pre>
Regression(274445@main) Hang on twitch.tv when playing certain videos
<a href="https://bugs.webkit.org/show_bug.cgi?id=269810">https://bugs.webkit.org/show_bug.cgi?id=269810</a>
<a href="https://rdar.apple.com/123324508">rdar://123324508</a>

Unreviewed partial revert of 274445@main and full revert of the follow-up
fix in 274670@main as it appears to be causing hangs under
HTMLMediaElement::updateActiveTextTrackCues().

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::compareCueInterval):
(WebCore::HTMLMediaElement::updateActiveTextTrackCues):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::compareCueIntervalForDisplay):
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::updateActiveCuesFontSize):
* Source/WebCore/platform/PODInterval.h:

Canonical link: <a href="https://commits.webkit.org/275075@main">https://commits.webkit.org/275075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3926d43ef175d8f49261d17192aadc38cf934572

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43359 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17145 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14440 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36466 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12813 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17286 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5424 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->