### PR TITLE
Wasm Callee should remain set even after tier-up

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1216,9 +1216,6 @@ media/modern-media-controls/media-documents/background-color-and-centering.html 
 
 webkit.org/b/178083 media/media-source/media-source-paint-to-canvas.html [ Failure ]
 
-webkit.org/b/175102 workers/wasm-hashset-many.html [ Skip ]
-webkit.org/b/175102 workers/wasm-hashset-many-2.html [ Skip ]
-
 webkit.org/b/175193 fast/images/async-image-body-background-image.html [ Pass Timeout ]
 
 webkit.org/b/173010 [ Debug ] js/slow-stress/Int32Array-alloc-huge.html [ Pass Timeout ]
@@ -2575,4 +2572,3 @@ imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-023.svg [ Fail
 imported/w3c/web-platform-tests/svg/painting/reftests/percentage-attribute.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/percentage.svg [ ImageOnlyFailure ]
 
-webkit.org/b/269598 [ Debug ] workers/wasm-hashset.html [ Skip ]

--- a/Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp
@@ -88,7 +88,6 @@ void CallsiteCollection::updateCallsitesToCallUs(const AbstractLocker& calleeGro
     WTF::storeStoreFence(); // This probably isn't necessary but it's good to be paranoid.
 
     calleeGroup.m_wasmIndirectCallEntryPoints[functionIndex] = entrypoint;
-    calleeGroup.m_wasmIndirectCallWasmCallees[functionIndex] = nullptr;
 
     for (auto& callsite : m_callsites[functionIndex]) {
         dataLogLnIf(WasmCallsiteCollectionInternal::verbose, "Repatching call at: ", RawPointer(callsite.m_callLocation.dataLocation()), " to ", RawPointer(entrypoint.taggedPtr()));


### PR DESCRIPTION
#### a9c33a2b496aeadd33e500d7e474710f4abfbf8a
<pre>
Wasm Callee should remain set even after tier-up
<a href="https://bugs.webkit.org/show_bug.cgi?id=268990">https://bugs.webkit.org/show_bug.cgi?id=268990</a>
<a href="https://rdar.apple.com/123015079">rdar://123015079</a>

Reviewed by Alexey Shvayka.

We may still need to call into the LLInt after tier-up, so we shouldn&apos;t clear
callee.

* Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp:
(JSC::Wasm::CallsiteCollection::updateCallsitesToCallUs):

Canonical link: <a href="https://commits.webkit.org/275095@main">https://commits.webkit.org/275095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ef5aaed59fc46ce36af934a949ba3177d94f767

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36900 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33835 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44656 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34263 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40221 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40436 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38574 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17244 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47446 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9174 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17295 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9748 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->