### PR TITLE
[WebGPU] Buffer index is not validated prior to metal compilation

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.h
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.h
@@ -31,8 +31,10 @@
 namespace WGSL {
 
 class CallGraph;
+class ShaderModule;
+
 struct PipelineLayout;
 
-std::optional<Error> rewriteGlobalVariables(CallGraph&, const HashMap<String, std::optional<PipelineLayout>>&);
+std::optional<Error> rewriteGlobalVariables(CallGraph&, const HashMap<String, std::optional<PipelineLayout>>&, const ShaderModule&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -104,7 +104,7 @@ inline std::variant<PrepareResult, Error> prepareImpl(ShaderModule& shaderModule
         RUN_PASS(rewritePointers, callGraph);
         RUN_PASS(insertBoundsChecks, shaderModule);
         RUN_PASS(rewriteEntryPoints, callGraph);
-        CHECK_PASS(rewriteGlobalVariables, callGraph, pipelineLayouts);
+        CHECK_PASS(rewriteGlobalVariables, callGraph, pipelineLayouts, shaderModule);
 
         dumpASTAtEndIfNeeded(shaderModule);
 


### PR DESCRIPTION
#### 3fc81749e677cd4cd339c89b7cf3145c2972ea59
<pre>
[WebGPU] Buffer index is not validated prior to metal compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=269821">https://bugs.webkit.org/show_bug.cgi?id=269821</a>
&lt;radar://123322561&gt;

Reviewed by Dan Glastonbury.

WGSL allows any buffer to be used, but we need to fail
pipeline creation if the buffer index in the WGSL is too
large.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::RewriteGlobalVariables):
(WGSL::RewriteGlobalVariables::run):
(WGSL::buffersForStage):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::rewriteGlobalVariables):
* Source/WebGPU/WGSL/GlobalVariableRewriter.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):

Canonical link: <a href="https://commits.webkit.org/275112@main">https://commits.webkit.org/275112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdb81de4ae2810550c922ed2a67636f34f6dc5d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36923 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33847 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14561 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44670 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36495 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40233 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38597 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17266 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9188 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->