### PR TITLE
[UnifiedPDF] Crash when scrolling after a swipe back from an external link follow

### DIFF
--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -65,6 +65,7 @@ public:
 
     virtual bool usesAsyncScrolling() const { return false; }
     virtual ScrollingNodeID scrollingNodeID() const { return { }; }
+    virtual void willAttachScrollingNode() { }
     virtual void didAttachScrollingNode() { }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -127,6 +127,14 @@ ScrollingNodeID RenderEmbeddedObject::scrollingNodeID() const
     return pluginViewBase->scrollingNodeID();
 }
 
+void RenderEmbeddedObject::willAttachScrollingNode()
+{
+    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    if (!pluginViewBase)
+        return;
+    pluginViewBase->willAttachScrollingNode();
+}
+
 void RenderEmbeddedObject::didAttachScrollingNode()
 {
     auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -63,6 +63,7 @@ public:
 
     bool usesAsyncScrolling() const;
     ScrollingNodeID scrollingNodeID() const;
+    void willAttachScrollingNode();
     void didAttachScrollingNode();
 
 private:

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -192,6 +192,7 @@ public:
     WebCore::Scrollbar* verticalScrollbar() const override { return m_verticalScrollbar.get(); }
     void setScrollOffset(const WebCore::ScrollOffset&) final;
 
+    virtual void willAttachScrollingNode() { }
     virtual void didAttachScrollingNode() { }
     virtual void didChangeSettings() { }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -163,6 +163,7 @@ private:
 
     void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) override;
     void updateScrollbars() override;
+    void willAttachScrollingNode() final;
     void didAttachScrollingNode() final;
 
     bool geometryDidChange(const WebCore::IntSize&, const WebCore::AffineTransform&) override;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -725,6 +725,14 @@ ScrollingNodeID PluginView::scrollingNodeID() const
     return protectedPlugin()->scrollingNodeID();
 }
 
+void PluginView::willAttachScrollingNode()
+{
+    if (!m_isInitialized)
+        return;
+
+    return protectedPlugin()->willAttachScrollingNode();
+}
+
 void PluginView::didAttachScrollingNode()
 {
     if (!m_isInitialized)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -164,6 +164,7 @@ private:
 
     bool usesAsyncScrolling() const final;
     WebCore::ScrollingNodeID scrollingNodeID() const final;
+    void willAttachScrollingNode() final;
     void didAttachScrollingNode() final;
 
     // WebCore::Widget


### PR DESCRIPTION
#### a55bd5c3df1c8395a4ca3a81c88b176ec8b3b664
<pre>
[UnifiedPDF] Crash when scrolling after a swipe back from an external link follow
<a href="https://bugs.webkit.org/show_bug.cgi?id=269244">https://bugs.webkit.org/show_bug.cgi?id=269244</a>
<a href="https://rdar.apple.com/122835175">rdar://122835175</a>

Reviewed by Tim Horton.

Having calls to `UnifiedPDFPlugin::scrollingNodeID()` lazily create the scrolling tree node is problematic,
since this can happen early (under `UnifiedPDFPlugin::updateOverflowControlsLayers()`), which causes
the ScrollingCoordinator to create an unparented node, which is later replaced by a different node
with the same ID, causing us to lose the layer registrations.

Fix by adding an explicit `willAttachScrollingNode()` which is called by `RenderLayerCompositor::attachWidgetContentLayers()`,
and have it create the node, and done the necessary layer and geometry updates on the node.

* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::willAttachScrollingNode):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::willAttachScrollingNode):
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::attachWidgetContentLayers):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::willAttachScrollingNode):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::willAttachScrollingNode):
(WebKit::UnifiedPDFPlugin::scrollingNodeID const):
(WebKit::UnifiedPDFPlugin::createScrollingNodeIfNecessary):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::willAttachScrollingNode):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/275123@main">https://commits.webkit.org/275123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5143fbf7bb28c1bde20f70abda4e556db5560872

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33854 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40257 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12849 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38618 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17274 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9192 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->