### PR TITLE
Regression: Mac Buddy crashes after sign in

### DIFF
--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -77,7 +77,7 @@ struct Condition {
 enum class EvaluationResult : uint8_t { False, True, Unknown };
 
 struct FeatureEvaluationContext {
-    CheckedRef<const Document> document;
+    WeakRef<const Document, WeakPtrImplWithEventTargetData> document;
     CSSToLengthConversionData conversionData { };
     CheckedPtr<const RenderElement> renderer { };
 };

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -402,8 +402,7 @@ private:
 };
 
 class Document
-    : public CanMakeCheckedPtr
-    , public ContainerNode
+    : public ContainerNode
     , public TreeScope
     , public ScriptExecutionContext
     , public FontSelectorClient
@@ -422,16 +421,6 @@ public:
     static Ref<Document> create(Document&);
 
     virtual ~Document();
-
-    // Resolve ambiguity for CanMakeCheckedPtr.
-    using CanMakeCheckedPtr::incrementPtrCount;
-    using CanMakeCheckedPtr::decrementPtrCount;
-#if CHECKED_POINTER_DEBUG
-    using CanMakeCheckedPtr::registerCheckedPtr;
-    using CanMakeCheckedPtr::copyCheckedPtr;
-    using CanMakeCheckedPtr::moveCheckedPtr;
-    using CanMakeCheckedPtr::unregisterCheckedPtr;
-#endif // CHECKED_POINTER_DEBUG
 
     // Nodes belonging to this document increase referencingNodeCount -
     // these are enough to keep the document from being destroyed, but
@@ -459,7 +448,7 @@ public:
 
     void removedLastRef();
 
-    using DocumentsMap = HashMap<ScriptExecutionContextIdentifier, CheckedRef<Document>>;
+    using DocumentsMap = HashMap<ScriptExecutionContextIdentifier, WeakRef<Document, WeakPtrImplWithEventTargetData>>;
     WEBCORE_EXPORT static DocumentsMap::ValuesIteratorRange allDocuments();
     WEBCORE_EXPORT static DocumentsMap& allDocumentsMap();
 

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -65,7 +65,7 @@ private:
 
     Ref<Node> m_relatedNode;
     RefPtr<Node> m_retargetedRelatedNode;
-    Vector<CheckedPtr<TreeScope>, 8> m_ancestorTreeScopes;
+    Vector<RefPtr<TreeScope>, 8> m_ancestorTreeScopes;
     unsigned m_lowestCommonAncestorIndex { 0 };
     bool m_hasDifferentTreeRoot { false };
 };
@@ -154,7 +154,7 @@ void EventPath::setRelatedTarget(Node& origin, Node& relatedNode)
 
     bool originIsRelatedTarget = &origin == &relatedNode;
     Ref rootNodeInOriginTreeScope = origin.treeScope().rootNode();
-    CheckedPtr<TreeScope> previousTreeScope;
+    RefPtr<TreeScope> previousTreeScope;
     size_t originalEventPathSize = m_path.size();
     for (unsigned contextIndex = 0; contextIndex < originalEventPathSize; contextIndex++) {
         auto& context = m_path[contextIndex];
@@ -164,7 +164,7 @@ void EventPath::setRelatedTarget(Node& origin, Node& relatedNode)
         }
 
         Ref currentTarget = *context.node();
-        CheckedRef currentTreeScope = currentTarget->treeScope();
+        Ref currentTreeScope = currentTarget->treeScope();
         if (UNLIKELY(previousTreeScope && currentTreeScope.ptr() != previousTreeScope))
             retargeter.moveToNewTreeScope(previousTreeScope.get(), currentTreeScope);
 
@@ -205,10 +205,10 @@ void EventPath::retargetTouch(EventContext::TouchListType type, const Touch& tou
         return;
 
     RelatedNodeRetargeter retargeter(eventTarget.releaseNonNull(), Ref { *m_path[0].node() });
-    CheckedPtr<TreeScope> previousTreeScope;
+    RefPtr<TreeScope> previousTreeScope;
     for (auto& context : m_path) {
         Ref currentTarget = *context.node();
-        CheckedRef currentTreeScope = currentTarget->treeScope();
+        Ref currentTreeScope = currentTarget->treeScope();
         if (UNLIKELY(previousTreeScope && currentTreeScope.ptr() != previousTreeScope))
             retargeter.moveToNewTreeScope(previousTreeScope.get(), currentTreeScope);
 
@@ -306,7 +306,7 @@ RelatedNodeRetargeter::RelatedNodeRetargeter(Ref<Node>&& relatedNode, Node& targ
     , m_retargetedRelatedNode(m_relatedNode.copyRef())
 {
     auto& targetTreeScope = target.treeScope();
-    CheckedPtr currentTreeScope = &m_relatedNode->treeScope();
+    RefPtr currentTreeScope = &m_relatedNode->treeScope();
     if (LIKELY(currentTreeScope == &targetTreeScope && target.isConnected() && m_relatedNode->isConnected()))
         return;
 
@@ -325,15 +325,15 @@ RelatedNodeRetargeter::RelatedNodeRetargeter(Ref<Node>&& relatedNode, Node& targ
     collectTreeScopes();
 
     // FIXME: We should collect this while constructing the event path.
-    Vector<CheckedRef<TreeScope>, 8> targetTreeScopeAncestors;
+    Vector<Ref<TreeScope>, 8> targetTreeScopeAncestors;
     for (TreeScope* currentTreeScope = &targetTreeScope; currentTreeScope; currentTreeScope = currentTreeScope->parentTreeScope())
         targetTreeScopeAncestors.append(*currentTreeScope);
     ASSERT_WITH_SECURITY_IMPLICATION(!targetTreeScopeAncestors.isEmpty());
 
     unsigned i = m_ancestorTreeScopes.size();
     unsigned j = targetTreeScopeAncestors.size();
-    ASSERT_WITH_SECURITY_IMPLICATION(m_ancestorTreeScopes.last() == targetTreeScopeAncestors.last());
-    while (m_ancestorTreeScopes[i - 1] == targetTreeScopeAncestors[j - 1]) {
+    ASSERT_WITH_SECURITY_IMPLICATION(m_ancestorTreeScopes.last() == targetTreeScopeAncestors.last().ptr());
+    while (m_ancestorTreeScopes[i - 1] == targetTreeScopeAncestors[j - 1].ptr()) {
         i--;
         j--;
         if (!i || !j)

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -777,7 +777,7 @@ private:
     mutable OptionSet<StateFlag> m_stateFlags;
 
     ContainerNode* m_parentNode { nullptr };
-    CheckedPtr<TreeScope> m_treeScope;
+    TreeScope* m_treeScope { nullptr };
     Node* m_previous { nullptr };
     Node* m_next { nullptr };
     CompactPointerTuple<RenderObject*, uint16_t> m_rendererWithStyleFlags;

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ShadowRoot);
 
-struct SameSizeAsShadowRoot : public DocumentFragment, public CanMakeCheckedPtr, public TreeScope {
+struct SameSizeAsShadowRoot : public DocumentFragment, public TreeScope {
     uint8_t flagsAndModes[3];
     WeakPtr<Element, WeakPtrImplWithEventTargetData> host;
     void* styleSheetList;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -46,7 +46,7 @@ namespace Style {
 class Scope;
 }
 
-class ShadowRoot final : public CanMakeCheckedPtr, public DocumentFragment, public TreeScope {
+class ShadowRoot final : public DocumentFragment, public TreeScope {
     WTF_MAKE_ISO_ALLOCATED(ShadowRoot);
 public:
 
@@ -67,15 +67,8 @@ public:
 
     virtual ~ShadowRoot();
 
-    // Resolve ambiguity for CanMakeCheckedPtr.
-    using CanMakeCheckedPtr::incrementPtrCount;
-    using CanMakeCheckedPtr::decrementPtrCount;
-#if CHECKED_POINTER_DEBUG
-    using CanMakeCheckedPtr::registerCheckedPtr;
-    using CanMakeCheckedPtr::copyCheckedPtr;
-    using CanMakeCheckedPtr::moveCheckedPtr;
-    using CanMakeCheckedPtr::unregisterCheckedPtr;
-#endif // CHECKED_POINTER_DEBUG
+    using DocumentFragment::ref;
+    using DocumentFragment::deref;
 
     using TreeScope::getElementById;
     using TreeScope::rootNode;

--- a/Source/WebCore/dom/ShouldNotFireMutationEventsScope.h
+++ b/Source/WebCore/dom/ShouldNotFireMutationEventsScope.h
@@ -42,7 +42,7 @@ public:
     }
 
 private:
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -87,20 +87,20 @@ TreeScope::TreeScope(Document& document)
 
 TreeScope::~TreeScope() = default;
 
-void TreeScope::incrementPtrCount() const
+void TreeScope::ref() const
 {
     if (auto* document = dynamicDowncast<Document>(m_rootNode))
-        document->incrementPtrCount();
+        document->ref();
     else
-        checkedDowncast<ShadowRoot>(m_rootNode).incrementPtrCount();
+        checkedDowncast<ShadowRoot>(m_rootNode).ref();
 }
 
-void TreeScope::decrementPtrCount() const
+void TreeScope::deref() const
 {
     if (auto* document = dynamicDowncast<Document>(m_rootNode))
-        document->decrementPtrCount();
+        document->deref();
     else
-        checkedDowncast<ShadowRoot>(m_rootNode).decrementPtrCount();
+        checkedDowncast<ShadowRoot>(m_rootNode).deref();
 }
 
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -67,15 +67,8 @@ public:
     TreeScope* parentTreeScope() const { return m_parentTreeScope; }
     void setParentTreeScope(TreeScope&);
 
-    // For CheckedPtr / CheckedRef use.
-    void incrementPtrCount() const;
-    void decrementPtrCount() const;
-#if CHECKED_POINTER_DEBUG
-    void registerCheckedPtr(const void*) const;
-    void copyCheckedPtr(const void* source, const void* destination) const;
-    void moveCheckedPtr(const void* source, const void* destination) const;
-    void unregisterCheckedPtr(const void*) const;
-#endif // CHECKED_POINTER_DEBUG
+    void ref() const;
+    void deref() const;
 
     Element* focusedElementInScope();
     Element* pointerLockElement() const;

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -230,7 +230,7 @@ public:
     HTMLFastPathResult parseResult() const { return m_parseResult; }
 
 private:
-    CheckedRef<Document> m_document;
+    Document& m_document; // FIXME: Use a smart pointer.
     WeakRef<ContainerNode, WeakPtrImplWithEventTargetData> m_destinationParent;
 
     StringParsingBuffer<CharacterType> m_parsingBuffer;
@@ -689,9 +689,9 @@ private:
 
             if (!text.isNull()) {
                 if (!parent.isConnected())
-                    parent.parserAppendChildIntoIsolatedTree(Text::create(m_document.get(), WTFMove(text)));
+                    parent.parserAppendChildIntoIsolatedTree(Text::create(m_document, WTFMove(text)));
                 else
-                    parent.parserAppendChild(Text::create(m_document.get(), WTFMove(text)));
+                    parent.parserAppendChild(Text::create(m_document, WTFMove(text)));
             }
 
             if (m_parsingBuffer.atEnd())
@@ -833,9 +833,9 @@ private:
     template<typename Tag> Ref<typename Tag::HTMLElementClass> parseElementAfterTagName(ContainerNode& parent)
     {
         if constexpr (Tag::isVoid)
-            return parseVoidElement(Tag::create(m_document.get()), parent);
+            return parseVoidElement(Tag::create(m_document), parent);
         else
-            return parseContainerElement<Tag>(Tag::create(m_document.get()), parent);
+            return parseContainerElement<Tag>(Tag::create(m_document), parent);
     }
 
     template<typename Tag> Ref<typename Tag::HTMLElementClass> parseContainerElement(Ref<typename Tag::HTMLElementClass>&& element, ContainerNode& parent)

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -207,7 +207,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
 
     Ref element = downcast<SVGElement>(*renderer.element());
 
-    CheckedRef treeScope = element->treeScopeForSVGReferences();
+    Ref treeScope = element->treeScopeForSVGReferences();
     Ref document = treeScope->documentScope();
 
     const AtomString& tagName = element->localName();

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -120,13 +120,13 @@ void Scope::createDocumentResolver()
 
     m_resolver->ruleSets().setDynamicViewTransitionsStyle(m_dynamicViewTransitionsStyle.get());
 
-    m_document->fontSelector().buildStarted();
+    m_document.fontSelector().buildStarted();
 
     m_resolver->ruleSets().initializeUserStyle();
     m_resolver->addCurrentSVGFontFaceRules();
     m_resolver->appendAuthorStyleSheets(m_activeStyleSheets);
 
-    m_document->fontSelector().buildCompleted();
+    m_document.fontSelector().buildCompleted();
 }
 
 void Scope::createOrFindSharedShadowTreeResolver()
@@ -191,7 +191,7 @@ void Scope::clearViewTransitionStyles()
 void Scope::releaseMemory()
 {
     if (!m_shadowRoot) {
-        for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots())
+        for (auto& descendantShadowRoot : m_document.inDocumentShadowRoots())
             const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().releaseMemory();
     }
 
@@ -311,7 +311,7 @@ void Scope::didRemovePendingStylesheet()
     didChangeActiveStyleSheetCandidates();
 
     if (!m_shadowRoot)
-        m_document->didRemoveAllPendingStylesheet();
+        m_document.didRemoveAllPendingStylesheet();
 }
 
 bool Scope::hasPendingSheet(const Element& element) const
@@ -338,7 +338,7 @@ void Scope::addStyleSheetCandidateNode(Node& node, bool createdByParser)
     // since styles outside of the body and head continue to be shunted into the head
     // (and thus can shift to end up before dynamically added DOM content that is also
     // outside the body).
-    if ((createdByParser && m_document->bodyOrFrameset()) || m_styleSheetCandidateNodes.isEmptyIgnoringNullReferences()) {
+    if ((createdByParser && m_document.bodyOrFrameset()) || m_styleSheetCandidateNodes.isEmptyIgnoringNullReferences()) {
         m_styleSheetCandidateNodes.add(node);
         return;
     }
@@ -388,7 +388,7 @@ Vector<Ref<ProcessingInstruction>> Scope::collectXSLTransforms()
 
 auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
 {
-    if (!m_document->settings().authorAndUserStylesEnabled())
+    if (!m_document.settings().authorAndUserStylesEnabled())
         return { };
 
     LOG_WITH_STREAM(StyleSheets, stream << "Scope " << this << " collectActiveStyleSheets()");
@@ -543,15 +543,15 @@ void Scope::updateActiveStyleSheets(UpdateType updateType)
 {
     ASSERT(!m_pendingUpdate);
 
-    if (!m_document->hasLivingRenderTree())
+    if (!m_document.hasLivingRenderTree())
         return;
 
-    if (m_document->inStyleRecalc() || m_document->inRenderTreeUpdate()) {
+    if (m_document.inStyleRecalc() || m_document.inRenderTreeUpdate()) {
         // Protect against deleting style resolver in the middle of a style resolution.
         // Crash stacks indicate we can get here when a resource load fails synchronously (for example due to content blocking).
         // FIXME: These kind of cases should be eliminated and this path replaced by an assert.
         m_pendingUpdate = UpdateType::ContentsOrInterpretation;
-        m_document->scheduleFullStyleRebuild();
+        m_document.scheduleFullStyleRebuild();
         return;
     }
 
@@ -560,13 +560,13 @@ void Scope::updateActiveStyleSheets(UpdateType updateType)
     Vector<RefPtr<CSSStyleSheet>> activeCSSStyleSheets;
 
     if (!isForUserAgentShadowTree()) {
-        activeCSSStyleSheets.appendVector(m_document->extensionStyleSheets().injectedAuthorStyleSheets());
-        activeCSSStyleSheets.appendVector(m_document->extensionStyleSheets().authorStyleSheetsForTesting());
+        activeCSSStyleSheets.appendVector(m_document.extensionStyleSheets().injectedAuthorStyleSheets());
+        activeCSSStyleSheets.appendVector(m_document.extensionStyleSheets().authorStyleSheetsForTesting());
     }
 
     filterEnabledNonemptyCSSStyleSheets(activeCSSStyleSheets, collection.activeStyleSheets);
 
-    LOG_WITH_STREAM(StyleSheets, stream << "Scope::updateActiveStyleSheets for document " << m_document.get() << " sheets " << activeCSSStyleSheets);
+    LOG_WITH_STREAM(StyleSheets, stream << "Scope::updateActiveStyleSheets for document " << m_document << " sheets " << activeCSSStyleSheets);
 
     auto styleSheetChange = StyleSheetChange { ResolverUpdateType::Reconstruct };
     if (updateType == UpdateType::ActiveSet)
@@ -597,7 +597,7 @@ void Scope::invalidateStyleAfterStyleSheetChange(const StyleSheetChange& styleSh
         return;
 
     // If we are already parsing the body and so may have significant amount of elements, put some effort into trying to avoid style recalcs.
-    bool invalidateAll = !m_document->bodyOrFrameset() || m_document->hasNodesWithMissingStyle();
+    bool invalidateAll = !m_document.bodyOrFrameset() || m_document.hasNodesWithMissingStyle();
 
     if (styleSheetChange.resolverUpdateType == ResolverUpdateType::Reconstruct || invalidateAll) {
         Invalidator::invalidateAllStyle(*this);
@@ -641,7 +641,7 @@ const Vector<RefPtr<CSSStyleSheet>> Scope::activeStyleSheetsForInspector()
 {
     Vector<RefPtr<CSSStyleSheet>> result;
 
-    if (CheckedPtr extensionStyleSheets = m_document->extensionStyleSheetsIfExists()) {
+    if (CheckedPtr extensionStyleSheets = m_document.extensionStyleSheetsIfExists()) {
         if (auto* pageUserSheet = extensionStyleSheets->pageUserSheet())
             result.append(pageUserSheet);
         result.appendVector(extensionStyleSheets->documentUserStyleSheets());
@@ -691,7 +691,7 @@ void Scope::flushPendingDescendantUpdates()
 {
     ASSERT(m_hasDescendantWithPendingUpdate);
     ASSERT(!m_shadowRoot);
-    for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots())
+    for (auto& descendantShadowRoot : m_document.inDocumentShadowRoots())
         const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().flushPendingUpdate();
     m_hasDescendantWithPendingUpdate = false;
 }
@@ -720,7 +720,7 @@ void Scope::scheduleUpdate(UpdateType update)
         // FIXME: Animation code may trigger resource load in middle of style recalc and that can add a rule to a content extension stylesheet.
         //        Fix and remove isResolvingTreeStyle() test below, see https://bugs.webkit.org/show_bug.cgi?id=194335
         // FIXME: The m_isUpdatingStyleResolver test is here because extension stylesheets can get us here from Resolver::appendAuthorStyleSheets.
-        if (!m_isUpdatingStyleResolver && !m_document->isResolvingTreeStyle())
+        if (!m_isUpdatingStyleResolver && !m_document.isResolvingTreeStyle())
             clearResolver();
     }
 
@@ -780,7 +780,7 @@ auto Scope::collectResolverScopes() -> ResolverScopes
 
     resolverScopes.add(*resolverIfExists(), Vector<WeakPtr<Scope>> { this });
 
-    for (auto& shadowRoot : m_document->inDocumentShadowRoots()) {
+    for (auto& shadowRoot : m_document.inDocumentShadowRoots()) {
         auto& scope = const_cast<ShadowRoot&>(shadowRoot).styleScope();
         auto* resolver = scope.resolverIfExists();
         if (!resolver)
@@ -835,26 +835,26 @@ void Scope::didChangeStyleSheetEnvironment()
     if (!m_shadowRoot) {
         m_sharedShadowTreeResolvers.clear();
 
-        for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots()) {
+        for (auto& descendantShadowRoot : m_document.inDocumentShadowRoots()) {
             // Stylesheets is author shadow roots are potentially affected.
             if (descendantShadowRoot.mode() != ShadowRootMode::UserAgent)
                 const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().scheduleUpdate(UpdateType::ContentsOrInterpretation);
         }
-        m_document->invalidateCachedCSSParserContext();
+        m_document.invalidateCachedCSSParserContext();
     }
     scheduleUpdate(UpdateType::ContentsOrInterpretation);
 }
 
 void Scope::didChangeViewportSize()
 {
-    Ref<ContainerNode> rootNode = m_document.get();
+    Ref<ContainerNode> rootNode = m_document;
     if (m_shadowRoot)
         rootNode = *m_shadowRoot;
     else {
-        if (!m_document->hasStyleWithViewportUnits())
+        if (!m_document.hasStyleWithViewportUnits())
             return;
 
-        for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots()) {
+        for (auto& descendantShadowRoot : m_document.inDocumentShadowRoots()) {
             if (descendantShadowRoot.mode() == ShadowRootMode::UserAgent)
                 continue;
             const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().didChangeViewportSize();
@@ -868,7 +868,7 @@ void Scope::didChangeViewportSize()
 
     if (customPropertyRegistry().invalidatePropertiesWithViewportUnits(m_document)) {
         if (!m_shadowRoot) {
-            if (auto element = m_document->documentElement())
+            if (auto element = m_document.documentElement())
                 element->invalidateStyleForSubtree();
         }
         return;
@@ -885,7 +885,7 @@ void Scope::didChangeViewportSize()
 void Scope::invalidateMatchedDeclarationsCache()
 {
     if (!m_shadowRoot) {
-        for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots())
+        for (auto& descendantShadowRoot : m_document.inDocumentShadowRoots())
             const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().invalidateMatchedDeclarationsCache();
     }
 
@@ -895,8 +895,8 @@ void Scope::invalidateMatchedDeclarationsCache()
 
 void Scope::pendingUpdateTimerFired()
 {
-    auto protectedShadowRoot = RefPtr { m_shadowRoot };
-    auto protectedDocument = Ref { m_document.get() };
+    RefPtr protectedShadowRoot { m_shadowRoot };
+    Ref protectedDocument { m_document };
     flushPendingUpdate();
 }
 
@@ -909,7 +909,7 @@ const Vector<RefPtr<StyleSheet>>& Scope::styleSheetsForStyleSheetList()
 
 Scope& Scope::documentScope()
 {
-    return m_document->styleScope();
+    return m_document.styleScope();
 }
 
 bool Scope::isForUserAgentShadowTree() const
@@ -921,7 +921,7 @@ bool Scope::updateQueryContainerState(QueryContainerUpdateContext& context)
 {
     ASSERT(!m_shadowRoot);
 
-    if (!m_document->renderView())
+    if (!m_document.renderView())
         return false;
 
     auto previousStates = WTFMove(m_queryContainerStates);
@@ -929,7 +929,7 @@ bool Scope::updateQueryContainerState(QueryContainerUpdateContext& context)
 
     Vector<Element*> containersToInvalidate;
 
-    for (auto& containerRenderer : m_document->renderView()->containerQueryBoxes()) {
+    for (auto& containerRenderer : m_document.renderView()->containerQueryBoxes()) {
         auto* containerElement = containerRenderer.element();
         if (!containerElement)
             continue;

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -206,7 +206,7 @@ private:
     using MediaQueryViewportState = std::tuple<IntSize, float, bool>;
     static MediaQueryViewportState mediaQueryViewportStateForDocument(const Document&);
 
-    CheckedRef<Document> m_document;
+    Document& m_document; // FIXME: Use a smart pointer.
     ShadowRoot* m_shadowRoot { nullptr };
 
     RefPtr<Resolver> m_resolver;

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1065,7 +1065,7 @@ void SVGElement::buildPendingResourcesIfNeeded()
     if (!needsPendingResourceHandling() || !isConnected() || isInShadowTree())
         return;
 
-    CheckedRef treeScope = treeScopeForSVGReferences();
+    Ref treeScope = treeScopeForSVGReferences();
     auto resourceId = getIdAttribute();
     if (!treeScope->isIdOfPendingSVGResource(resourceId))
         return;

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -151,7 +151,7 @@ void SVGTextPathElement::buildPendingResource()
     auto target = SVGURIReference::targetElementFromIRIString(href(), treeScopeForSVGReferences());
     if (!target.element) {
         // Do not register as pending if we are already pending this resource.
-        CheckedRef treeScope = treeScopeForSVGReferences();
+        Ref treeScope = treeScopeForSVGReferences();
         if (treeScope->isPendingSVGResource(*this, target.identifier))
             return;
 


### PR DESCRIPTION
#### 8195fa48866243eab439676fdb43c25e0b65e5f6
<pre>
Regression: Mac Buddy crashes after sign in
<a href="https://bugs.webkit.org/show_bug.cgi?id=269824">https://bugs.webkit.org/show_bug.cgi?id=269824</a>
<a href="https://rdar.apple.com/123037271">rdar://123037271</a>

Reviewed by Ryosuke Niwa and Brent Fulgham.

The crash seems to be caused by a CheckedPtr / CheckedRef pointing to
a Document upon destruction. We&apos;ve stopped using CheckedPtr / CheckedRef
for Nodes already but it was still in use for Document.

To address the issue, revert the CheckedPtr / CheckedRef adoption for
Document in order to get back in a good state. In a follow-up, we should
work on adopting more smart pointers (ideally WeakPtr / WeakRef).

* Source/WebCore/css/query/GenericMediaQueryTypes.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::setRelatedTarget):
(WebCore::RelatedNodeRetargeter::RelatedNodeRetargeter):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/ShadowRoot.cpp:
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/ShouldNotFireMutationEventsScope.h:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::ref const):
(WebCore::TreeScope::deref const):
(WebCore::TreeScope::incrementPtrCount const): Deleted.
(WebCore::TreeScope::decrementPtrCount const): Deleted.
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseChildren):
(WebCore::HTMLFastPathParser::parseElementAfterTagName):
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createDocumentResolver):
(WebCore::Style::Scope::releaseMemory):
(WebCore::Style::Scope::didRemovePendingStylesheet):
(WebCore::Style::Scope::addStyleSheetCandidateNode):
(WebCore::Style::Scope::collectActiveStyleSheets):
(WebCore::Style::Scope::updateActiveStyleSheets):
(WebCore::Style::Scope::invalidateStyleAfterStyleSheetChange):
(WebCore::Style::Scope::activeStyleSheetsForInspector):
(WebCore::Style::Scope::flushPendingDescendantUpdates):
(WebCore::Style::Scope::scheduleUpdate):
(WebCore::Style::Scope::collectResolverScopes):
(WebCore::Style::Scope::didChangeStyleSheetEnvironment):
(WebCore::Style::Scope::didChangeViewportSize):
(WebCore::Style::Scope::invalidateMatchedDeclarationsCache):
(WebCore::Style::Scope::pendingUpdateTimerFired):
(WebCore::Style::Scope::documentScope):
(WebCore::Style::Scope::updateQueryContainerState):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::buildPendingResourcesIfNeeded):
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::buildPendingResource):

Canonical link: <a href="https://commits.webkit.org/275125@main">https://commits.webkit.org/275125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef189adda2177f67988e1b9d44eeb36f85226406

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40847 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33857 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14474 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38605 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17281 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17332 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5444 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->