### PR TITLE
Web Inspector: WI.ScopeBar.Event.SelectionChanged is fired four times whenever selecting an item (242705)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -299,7 +299,7 @@ WI.contentLoaded = function()
     WI.detailsSidebar.addEventListener(WI.Sidebar.Event.CollapsedStateDidChange, WI._sidebarSizeDidChange, WI);
     WI.detailsSidebar.addEventListener(WI.MultiSidebar.Event.MultipleSidebarsVisibleChanged, WI._sidebarSizeDidChange, WI);
     WI.detailsSidebar.canMoveToBottom = true;
-    
+
     WI.searchKeyboardShortcut = new WI.KeyboardShortcut(WI.KeyboardShortcut.Modifier.CommandOrControl | WI.KeyboardShortcut.Modifier.Shift, "F", WI._focusSearchField);
     WI._findKeyboardShortcut = new WI.KeyboardShortcut(WI.KeyboardShortcut.Modifier.CommandOrControl, "F", WI._find);
     WI.saveKeyboardShortcut = new WI.KeyboardShortcut(WI.KeyboardShortcut.Modifier.CommandOrControl, "S", WI._save);
@@ -569,7 +569,7 @@ WI.contentLoaded = function()
     WI.tabBar.addEventListener(WI.TabBar.Event.TabBarItemAdded, WI._rememberOpenTabs, WI);
     WI.tabBar.addEventListener(WI.TabBar.Event.TabBarItemRemoved, WI._rememberOpenTabs, WI);
     WI.tabBar.addEventListener(WI.TabBar.Event.TabBarItemsReordered, WI._rememberOpenTabs, WI);
-    
+
     WI._updateLayoutMode();
     WI.settings.enableNarrowLayoutMode.addEventListener(WI.Setting.Event.Changed, WI._updateLayoutMode, WI);
 
@@ -1201,11 +1201,10 @@ WI.hideSplitConsole = function()
 
 WI.showConsoleTab = function(requestedScope, options = {})
 {
-    requestedScope = requestedScope || WI.LogContentView.Scopes.All;
-
     WI.hideSplitConsole();
 
-    WI.consoleContentView.scopeBar.item(requestedScope).selected = true;
+    if (requestedScope)
+        WI.consoleContentView.scopeBar.item(requestedScope).selected = true;
 
     const cookie = null;
     WI.showRepresentedObject(WI._consoleRepresentedObject, cookie, options);
@@ -1852,16 +1851,16 @@ WI._windowResized = function(event)
 WI._updateLayoutMode = function()
 {
     let computedMode = WI.LayoutMode.Default;
-    
+
     if (WI.settings.enableNarrowLayoutMode.value && window.innerWidth < WI.NarrowLayoutMaximumWidth)
         computedMode = WI.LayoutMode.Narrow;
-    
+
     if (WI.layoutMode !== computedMode) {
         WI.layoutMode = computedMode;
         document.body.classList.toggle("narrow", WI.layoutMode === WI.LayoutMode.Narrow);
         WI.detailsSidebar.updateLayout(WI.View.LayoutReason.Resize);
     }
-    
+
     WI._tabBrowserSizeDidChange();
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.js
@@ -123,11 +123,10 @@ WI.ScopeBar = class ScopeBar extends WI.NavigationItem
                     this._element.appendChild(item.element);
                 else
                     nonExclusiveItems.push(item);
-
-                item.addEventListener(WI.ScopeBarItem.Event.SelectionChanged, this._itemSelectionDidChange, this);
             }
 
             this._multipleItem = new WI.MultipleScopeBarItem(nonExclusiveItems);
+            this._multipleItem.addEventListener(WI.ScopeBarItem.Event.SelectionChanged, this._multipleItemSelectionDidChange, this);
             this._element.appendChild(this._multipleItem.element);
         } else {
             for (var item of this._items) {
@@ -146,8 +145,18 @@ WI.ScopeBar = class ScopeBar extends WI.NavigationItem
         }
     }
 
+    _multipleItemSelectionDidChange(event)
+    {
+        this.dispatchEventToListeners(WI.ScopeBar.Event.SelectionChanged);
+    }
+
     _itemSelectionDidChange(event)
     {
+        if (this._ignoreItemSelectedEvent)
+            return;
+
+        this._ignoreItemSelectedEvent = true;
+
         var sender = event.target;
         var item;
 
@@ -159,7 +168,7 @@ WI.ScopeBar = class ScopeBar extends WI.NavigationItem
                     item.selected = false;
             }
         } else {
-            let replacesCurrentSelection = this._shouldGroupNonExclusiveItems || !event.data.extendSelection;
+            let replacesCurrentSelection = !event.data.extendSelection;
             for (var i = 0; i < this._items.length; ++i) {
                 item = this._items[i];
                 if (item.exclusive && item !== sender && sender.selected)
@@ -177,6 +186,8 @@ WI.ScopeBar = class ScopeBar extends WI.NavigationItem
         }
 
         this.dispatchEventToListeners(WI.ScopeBar.Event.SelectionChanged);
+
+        this._ignoreItemSelectedEvent = false;
     }
 
     _handleKeyDown(event)


### PR DESCRIPTION
#### 780b165a9d70a39891eb2fcee3a232b4218daef4
<pre>
Web Inspector: WI.ScopeBar.Event.SelectionChanged is fired four times whenever selecting an item (242705)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242705">https://bugs.webkit.org/show_bug.cgi?id=242705</a>
<a href="https://rdar.apple.com/96963052">rdar://96963052</a>

Reviewed by NOBODY (OOPS!).

The bug report refers to an issue that happens with the components
ScopeBar and MultipleScopeBarItem, which is used across multiple
places in the inspector&apos;s frontend. This commit fixes the issue for both
components, such that the event `ScopeBar.Event.SelectionChanged` is
always only fired once, no matter whether MultipleScopeBarItem is
involved (like in the Sources tab) or not (like in the Console tab).

However, the solution to solving the bug for either component is
independent and different:
  - The class MultipleScopeBarItem already does well to suppress
    multiple echos of the SelectionChanged event with the help of
    `_ignoreItemSelectedEvent` (see <a href="https://github.com/WebKit/WebKit/blob/6d51d579af47028306a003653150ade5d395f942/Source/WebInspectorUI/UserInterface/Views/MultipleScopeBarItem.js#L211-L212)">https://github.com/WebKit/WebKit/blob/6d51d579af47028306a003653150ade5d395f942/Source/WebInspectorUI/UserInterface/Views/MultipleScopeBarItem.js#L211-L212)</a>
    However, in the original code, ScopeBar did not make use of this
    benefit and still listens to SelectionChanged from the individual
    items. When MultipleScopeBarItem is used, this commit makes ScopeBar
    listen to MultipleScopeBarItem instead, where it already only fires
    once per change, so we only need to forward the event.
  - When MultipleScopeBarItem is not used, ScopeBar in the original code
    did not do anything to protect against echos (i.e. events caused by
    the ScopeBar itself as a result of deselecting its ScopeBarItems).
    This commit mimics the fix from MultipleScopeBarItem and introduces
    the same boolean flag to bypass echos caused by the ScopeBar itself.

* Source/WebInspectorUI/UserInterface/Views/ScopeBar.js:
(WI.ScopeBar.prototype._populate):
  - When MultipleScopeBarItem is used, listen to SelectionChanged events
    from it instead of the individual ScopeBarItems.
(WI.ScopeBar.prototype._multipleItemSelectionDidChange):
  - MultipleScopeBarItem already correctly fires one event per change,
    so all we need is forward that.
(WI.ScopeBar.prototype._itemSelectionDidChange):
  - This handler is only used when MultipleScopeBarItem is not used.
    Guard against echos by ignoring events caused by
    `item.selected = ...` statements within the handler itself.
</pre>
----------------------------------------------------------------------
#### ac3f308f5a705c9c91891260f10fcb6469730eb0
<pre>
Fix Console not remembering selected levels
<a href="https://bugs.webkit.org/show_bug.cgi?id=268882">https://bugs.webkit.org/show_bug.cgi?id=268882</a>
<a href="https://rdar.apple.com/122924275">rdar://122924275</a>

Reviewed by NOBODY (OOPS!).

When showing the the inspector&apos;s console using `WI.showConsole()`, the
caller can optionally pass in a `requestedScope` to control which levels
(AKA message types) to be filtered automatically when the Console tab
shows up. However, when `requestedScope` is falsy or left empty, it
always applies `WI.LogContentView.Scopes.All` instead, which
overrides the levels selected by default, which are read from local
settings when the scope bar is created at the inspector&apos;s startup.

This commit removes the forced application of `Scopes.All`, so when
`requestedScope` is left empty, the Console tab is shown with levels
unchanged, which is the expected behavior when launching the Console tab
through Develop -&gt; Show JavaScript Console (or Option-Command-C).

This fix has one known side-effect: when an inspector tab does not
support split console view, pressing Esc will switch to the actual
Console tab instead. (The Settings tab is one example of such tab.)
This commit will make that also &quot;remember&quot; the previously selected
levels instead of deselecting back to just `Scopes.All`, which is
arguably the correct behavior anyway.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/780b165a9d70a39891eb2fcee3a232b4218daef4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43220 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17186 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/43400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16796 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44681 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37050 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12850 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->