### PR TITLE
More assorted dynamicDowncast<> adoption in WebKit & WebCore

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -78,8 +78,8 @@ public :
             auto needsLayout = [&] {
                 if (renderer.needsLayout())
                     return true;
-                if (is<RenderBlockFlow>(renderer) && downcast<RenderBlockFlow>(renderer).modernLineLayout())
-                    return downcast<RenderBlockFlow>(renderer).modernLineLayout()->hasDetachedContent();
+                if (auto* renderBlockFlow = dynamicDowncast<RenderBlockFlow>(renderer); renderBlockFlow && renderBlockFlow->modernLineLayout())
+                    return renderBlockFlow->modernLineLayout()->hasDetachedContent();
                 return false;
             };
 

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -146,6 +146,10 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ServiceWorkerGlobalScope)
-    static bool isType(const WebCore::ScriptExecutionContext& context) { return is<WebCore::WorkerGlobalScope>(context) && downcast<WebCore::WorkerGlobalScope>(context).type() == WebCore::WorkerGlobalScope::Type::ServiceWorker; }
+    static bool isType(const WebCore::ScriptExecutionContext& context)
+    {
+        auto* global = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
+        return global && global->type() == WebCore::WorkerGlobalScope::Type::ServiceWorker;
+    }
     static bool isType(const WebCore::WorkerGlobalScope& context) { return context.type() == WebCore::WorkerGlobalScope::Type::ServiceWorker; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -118,10 +118,10 @@ void WebDragClient::didConcludeEditDrag()
 
 static WebCore::CachedImage* cachedImage(Element& element)
 {
-    auto* renderer = element.renderer();
-    if (!is<WebCore::RenderImage>(renderer))
+    auto* renderImage = dynamicDowncast<WebCore::RenderImage>(element.renderer());
+    if (!renderImage)
         return nullptr;
-    WebCore::CachedImage* image = downcast<WebCore::RenderImage>(*renderer).cachedImage();
+    auto* image = renderImage->cachedImage();
     if (!image || image->errorOccurred()) 
         return nullptr;
     return image;

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -78,10 +78,10 @@ void WebTextTrackRepresentationCocoa::setContentScale(float scale)
     if (!m_page)
         return;
     Ref fullscreenManager = m_page->videoPresentationManager();
-    if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
+    RefPtr videoElement = dynamicDowncast<WebCore::HTMLVideoElement>(m_mediaElement.get());
+    if (!videoElement)
         return;
-    Ref videoElement = downcast<WebCore::HTMLVideoElement>(*m_mediaElement);
-    fullscreenManager->setTextTrackRepresentationContentScaleForVideoElement(videoElement, scale);
+    fullscreenManager->setTextTrackRepresentationContentScaleForVideoElement(*videoElement, scale);
 }
 
 void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
@@ -90,10 +90,10 @@ void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
     if (!m_page)
         return;
     Ref fullscreenManager = m_page->videoPresentationManager();
-    if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
+    RefPtr videoElement = dynamicDowncast<WebCore::HTMLVideoElement>(m_mediaElement.get());
+    if (!videoElement)
         return;
-    Ref videoElement = downcast<WebCore::HTMLVideoElement>(*m_mediaElement);
-    fullscreenManager->setTextTrackRepresentationIsHiddenForVideoElement(videoElement, hidden);
+    fullscreenManager->setTextTrackRepresentationIsHiddenForVideoElement(*videoElement, hidden);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### ed5a44f381a891a581bce59f807188e5c30cab31
<pre>
More assorted dynamicDowncast&lt;&gt; adoption in WebKit &amp; WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=269826">https://bugs.webkit.org/show_bug.cgi?id=269826</a>

Reviewed by Chris Dumez.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::RenderTreeNeedsLayoutChecker::~RenderTreeNeedsLayoutChecker):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
(isType):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::cachedImage):
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm:
(WebKit::WebTextTrackRepresentationCocoa::setContentScale):
(WebKit::WebTextTrackRepresentationCocoa::setHidden const):

Canonical link: <a href="https://commits.webkit.org/275094@main">https://commits.webkit.org/275094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a78ea4c9f9d795d5e24a741c79fae7a19b3a80d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33853 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14586 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36197 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44684 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40242 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38600 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17279 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9175 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->