### PR TITLE
[Curl] Support local host aliases for WPT testing

### DIFF
--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt
@@ -1,0 +1,44 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: TypeError: Module name, 'bare/to-bare' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare/bare
+
+
+PASS bare/bare: <script src type=module>
+PASS bare/bare: <script src type=text/javascript>
+PASS bare/bare: static import
+PASS bare/bare: dynamic import (from module)
+PASS bare/bare: dynamic import (from text/javascript)
+PASS bare/cross-origin-bare: <script src type=module>
+PASS bare/cross-origin-bare: <script src type=text/javascript>
+PASS bare/cross-origin-bare: static import
+PASS bare/cross-origin-bare: dynamic import (from module)
+PASS bare/cross-origin-bare: dynamic import (from text/javascript)
+PASS bare/to-data: <script src type=module>
+PASS bare/to-data: <script src type=text/javascript>
+PASS bare/to-data: static import
+PASS bare/to-data: dynamic import (from module)
+PASS bare/to-data: dynamic import (from text/javascript)
+PASS bare/to-bare: <script src type=module>
+PASS bare/to-bare: <script src type=text/javascript>
+PASS bare/to-bare: static import
+PASS bare/to-bare: dynamic import (from module)
+PASS bare/to-bare: dynamic import (from text/javascript)
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
+
+PASS The URL after mapping violates CSP (but not the URL before mapping)
+PASS The URL before mapping violates CSP (but not the URL after mapping)
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Refused to load https://www1.web-platform.test:9443/import-maps/resources/log.js?pipe=sub&name=B because it does not appear in the script-src directive of the Content Security Policy.
+
+PASS The URL after mapping violates CSP (but not the URL before mapping)
+PASS The URL before mapping violates CSP (but not the URL after mapping)
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt
@@ -1,0 +1,44 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: TypeError: Module name, 'data:text/javascript,log.push('data:to-bare')' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+
+
+PASS data:text/javascript,log.push('data:foo'): <script src type=module>
+PASS data:text/javascript,log.push('data:foo'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:foo'): static import
+PASS data:text/javascript,log.push('data:foo'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:foo'): dynamic import (from text/javascript)
+PASS data:text/javascript,log.push('data:cross-origin-foo'): <script src type=module>
+PASS data:text/javascript,log.push('data:cross-origin-foo'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:cross-origin-foo'): static import
+PASS data:text/javascript,log.push('data:cross-origin-foo'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:cross-origin-foo'): dynamic import (from text/javascript)
+PASS data:text/javascript,log.push('data:to-data'): <script src type=module>
+PASS data:text/javascript,log.push('data:to-data'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:to-data'): static import
+PASS data:text/javascript,log.push('data:to-data'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:to-data'): dynamic import (from text/javascript)
+PASS data:text/javascript,log.push('data:to-bare'): <script src type=module>
+PASS data:text/javascript,log.push('data:to-bare'): <script src type=text/javascript>
+PASS data:text/javascript,log.push('data:to-bare'): static import
+PASS data:text/javascript,log.push('data:to-bare'): dynamic import (from module)
+PASS data:text/javascript,log.push('data:to-bare'): dynamic import (from text/javascript)
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt
@@ -1,0 +1,44 @@
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: TypeError: Module name, 'http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare' does not resolve to a valid URL.
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+CONSOLE MESSAGE: value in specifier map cannot be parsed as URL bare
+
+
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=module>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: <script src type=text/javascript>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: static import
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: dynamic import (from module)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=foo: dynamic import (from text/javascript)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: <script src type=module>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: <script src type=text/javascript>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: static import
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: dynamic import (from module)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=cross-origin-foo: dynamic import (from text/javascript)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: <script src type=module>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: <script src type=text/javascript>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: static import
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: dynamic import (from module)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-data: dynamic import (from text/javascript)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: <script src type=module>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: <script src type=text/javascript>
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: static import
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: dynamic import (from module)
+PASS http://web-platform.test:8800/import-maps/resources/log.js?pipe=sub&name=to-bare: dynamic import (from text/javascript)
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt
@@ -1,0 +1,8 @@
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+
+PASS Imported inline CSS with no quote is not blocked on pending CSS
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative-expected.txt
@@ -1,0 +1,8 @@
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+
+PASS Imported inline CSS with no semicolon is not blocked on pending CSS
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative-expected.txt
@@ -1,0 +1,8 @@
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+
+PASS Imported inline CSS with no space is not blocked on pending CSS
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_origin-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_origin-expected.txt
@@ -1,0 +1,9 @@
+Description
+
+This test validates that for a cross origin resource, the timing allow check algorithm will pass when the Timing-Allow-Origin header value list contains a case-sensitive match for the value of the origin of the current document.
+
+
+PASS window.performance is defined
+PASS window.performance.getEntriesByType is defined
+PASS redirectStart, redirectEnd, domainLookupStart, domainLookupEnd, connectStart, connectEnd, secureConnectionStart, requestStart, and responseStart -- should NOT be all returned as 0 when the Timing-Allow-Origin header value list contains a case-sensitive match for the value of the origin of the current document and TAO algorithm passes
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/trusted-types/default-policy-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/trusted-types/default-policy-expected.txt
@@ -1,0 +1,23 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Count SecurityPolicyViolation events. Test timed out
+FAIL script.src no default policy assert_throws_js: function "_ => element[c[1]] = "nodefault"" did not throw
+FAIL div.innerHTML no default policy assert_throws_js: function "_ => element[c[1]] = "nodefault"" did not throw
+FAIL script.text no default policy assert_throws_js: function "_ => element[c[1]] = "nodefault"" did not throw
+FAIL script.src default assert_equals: expected "sanitized: abc" but got "http://web-platform.test:8800/trusted-types/abc"
+FAIL script.src null assert_throws_js: function "_ => element[c[1]] = "null"" did not throw
+FAIL script.src throw assert_throws_js: function "_ => element[c[1]] = "throw"" did not throw
+FAIL script.src undefined assert_throws_js: function "_ => element[c[1]] = "undefined"" did not throw
+FAIL script.src typeerror assert_throws_js: function "_ => element[c[1]] = "typeerror"" did not throw
+FAIL div.innerHTML default assert_equals: expected "sanitized: abc" but got "abc"
+FAIL div.innerHTML null assert_throws_js: function "_ => element[c[1]] = "null"" did not throw
+FAIL div.innerHTML throw assert_throws_js: function "_ => element[c[1]] = "throw"" did not throw
+FAIL div.innerHTML undefined assert_throws_js: function "_ => element[c[1]] = "undefined"" did not throw
+FAIL div.innerHTML typeerror assert_throws_js: function "_ => element[c[1]] = "typeerror"" did not throw
+FAIL script.text default assert_equals: expected "sanitized: abc" but got "abc"
+FAIL script.text null assert_throws_js: function "_ => element[c[1]] = "null"" did not throw
+FAIL script.text throw assert_throws_js: function "_ => element[c[1]] = "throw"" did not throw
+FAIL script.text undefined assert_throws_js: function "_ => element[c[1]] = "undefined"" did not throw
+FAIL script.text typeerror assert_throws_js: function "_ => element[c[1]] = "typeerror"" did not throw
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/trusted-types/default-policy-report-only-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/trusted-types/default-policy-report-only-expected.txt
@@ -1,0 +1,24 @@
+CONSOLE MESSAGE: The Content Security Policy 'require-trusted-types-for 'script';' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Count SecurityPolicyViolation events. Test timed out
+PASS script.src no default policy
+PASS div.innerHTML no default policy
+PASS script.text no default policy
+FAIL script.src default assert_equals: expected "sanitized: abc" but got "http://web-platform.test:8800/trusted-types/abc"
+PASS script.src null
+FAIL script.src throw assert_throws_js: function "_ => element[c[1]] = "throw"" did not throw
+PASS script.src undefined
+FAIL script.src typeerror assert_throws_js: function "_ => element[c[1]] = "typeerror"" did not throw
+FAIL div.innerHTML default assert_equals: expected "sanitized: abc" but got "abc"
+PASS div.innerHTML null
+FAIL div.innerHTML throw assert_throws_js: function "_ => element[c[1]] = "throw"" did not throw
+PASS div.innerHTML undefined
+FAIL div.innerHTML typeerror assert_throws_js: function "_ => element[c[1]] = "typeerror"" did not throw
+FAIL script.text default assert_equals: expected "sanitized: abc" but got "abc"
+PASS script.text null
+FAIL script.text throw assert_throws_js: function "_ => element[c[1]] = "throw"" did not throw
+PASS script.text undefined
+FAIL script.text typeerror assert_throws_js: function "_ => element[c[1]] = "typeerror"" did not throw
+

--- a/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/webtransport/constructor.https.any-expected.txt
+++ b/LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/webtransport/constructor.https.any-expected.txt
@@ -1,0 +1,18 @@
+
+PASS WebTransport constructor should reject URL 'null'
+PASS WebTransport constructor should reject URL ''
+PASS WebTransport constructor should reject URL 'no-scheme'
+PASS WebTransport constructor should reject URL 'http://example.com/'
+PASS WebTransport constructor should reject URL 'quic-transport://example.com/'
+PASS WebTransport constructor should reject URL 'https:///'
+PASS WebTransport constructor should reject URL 'https://example.com/#failing'
+PASS WebTransport constructor should reject URL 'https://web-platform.test:999999/'
+PASS WebTransport constructor should allow options {"allowPooling":true}
+PASS WebTransport constructor should allow options {"requireUnreliable":true}
+PASS WebTransport constructor should allow options {"allowPooling":true,"requireUnreliable":true}
+PASS WebTransport constructor should allow options {"congestionControl":"default"}
+PASS WebTransport constructor should allow options {"congestionControl":"throughput"}
+PASS WebTransport constructor should allow options {"congestionControl":"low-latency"}
+PASS WebTransport constructor should allow options {"allowPooling":true,"requireUnreliable":true,"congestionControl":"low-latency"}
+FAIL Connection to port 0 should fail assert_unreached: Should have rejected: ready should be rejected Reached unreachable code
+

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -235,6 +235,11 @@ public:
         StrictNameCheck = 2
     };
 
+    enum class LocalhostAlias : bool {
+        Disable,
+        Enable
+    };
+
     CurlHandle();
     virtual ~CurlHandle();
 
@@ -248,7 +253,7 @@ public:
 
     void enableShareHandle();
 
-    void setUrl(const URL&);
+    void setURL(const URL&, LocalhostAlias);
     void enableSSL();
 
     void appendRequestHeaders(const HTTPHeaderMap&);
@@ -334,6 +339,7 @@ private:
     char m_errorBuffer[CURL_ERROR_SIZE] { };
 
     URL m_url;
+    CurlSList m_localhostAlias;
     CurlSList m_requestHeaders;
 
     std::unique_ptr<CurlSSLVerifier> m_sslVerifier;

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -188,7 +188,7 @@ CURL* CurlRequest::setupTransfer()
 
     m_curlHandle = makeUnique<CurlHandle>();
 
-    m_curlHandle->setUrl(m_request.url());
+    m_curlHandle->setURL(m_request.url(), m_localhostAlias);
 
     m_curlHandle->appendRequestHeaders(httpHeaderFields);
 

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -63,6 +63,7 @@ public:
     WEBCORE_EXPORT void setUserPass(const String&, const String&);
     bool isServerTrustEvaluationDisabled() { return m_shouldDisableServerTrustEvaluation; }
     void disableServerTrustEvaluation() { m_shouldDisableServerTrustEvaluation = true; }
+    void enableLocalhostAlias() { m_localhostAlias = CurlHandle::LocalhostAlias::Enable; }
 
     WEBCORE_EXPORT void resume();
     WEBCORE_EXPORT void cancel();
@@ -136,6 +137,7 @@ private:
     String m_password;
     unsigned long m_authType { CURLAUTH_ANY };
     bool m_shouldDisableServerTrustEvaluation { false };
+    CurlHandle::LocalhostAlias m_localhostAlias { CurlHandle::LocalhostAlias::Disable };
 
     std::unique_ptr<CurlHandle> m_curlHandle;
     CurlFormDataStream m_formDataStream;

--- a/Source/WebCore/platform/network/curl/CurlStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlStream.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-CurlStream::CurlStream(CurlStreamScheduler& scheduler, CurlStreamID streamID, URL&& url, ServerTrustEvaluation serverTrustEvaluation)
+CurlStream::CurlStream(CurlStreamScheduler& scheduler, CurlStreamID streamID, URL&& url, ServerTrustEvaluation serverTrustEvaluation, LocalhostAlias localhostAlias)
     : m_scheduler(scheduler)
     , m_streamID(streamID)
 {
@@ -43,7 +43,7 @@ CurlStream::CurlStream(CurlStreamScheduler& scheduler, CurlStreamID streamID, UR
     m_curlHandle = makeUnique<CurlHandle>();
 
     url.setProtocol(url.protocolIs("wss"_s) ? "https"_s : "http"_s);
-    m_curlHandle->setUrl(WTFMove(url));
+    m_curlHandle->setURL(WTFMove(url), localhostAlias);
 
     if (serverTrustEvaluation == ServerTrustEvaluation::Disable)
         m_curlHandle->disableServerTrustEvaluation();

--- a/Source/WebCore/platform/network/curl/CurlStream.h
+++ b/Source/WebCore/platform/network/curl/CurlStream.h
@@ -43,6 +43,8 @@ class CurlStream {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(CurlStream);
 public:
+    using LocalhostAlias = CurlHandle::LocalhostAlias;
+
     enum class ServerTrustEvaluation : bool { Disable, Enable };
 
     class Client {
@@ -53,12 +55,12 @@ public:
         virtual void didFail(CurlStreamID, CURLcode, CertificateInfo&&) = 0;
     };
 
-    static std::unique_ptr<CurlStream> create(CurlStreamScheduler& scheduler, CurlStreamID streamID, URL&& url, ServerTrustEvaluation serverTrustEvaluation)
+    static std::unique_ptr<CurlStream> create(CurlStreamScheduler& scheduler, CurlStreamID streamID, URL&& url, ServerTrustEvaluation serverTrustEvaluation, LocalhostAlias localhostAlias)
     {
-        return makeUnique<CurlStream>(scheduler, streamID, WTFMove(url), serverTrustEvaluation);
+        return makeUnique<CurlStream>(scheduler, streamID, WTFMove(url), serverTrustEvaluation, localhostAlias);
     }
 
-    CurlStream(CurlStreamScheduler&, CurlStreamID, URL&&, ServerTrustEvaluation);
+    CurlStream(CurlStreamScheduler&, CurlStreamID, URL&&, ServerTrustEvaluation, LocalhostAlias);
     virtual ~CurlStream();
 
     void send(UniqueArray<uint8_t>&&, size_t);

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp
@@ -40,7 +40,7 @@ CurlStreamScheduler::~CurlStreamScheduler()
     ASSERT(isMainThread());
 }
 
-CurlStreamID CurlStreamScheduler::createStream(const URL& url, CurlStream::Client& client, CurlStream::ServerTrustEvaluation serverTrustEvaluation)
+CurlStreamID CurlStreamScheduler::createStream(const URL& url, CurlStream::Client& client, CurlStream::ServerTrustEvaluation serverTrustEvaluation, CurlStream::LocalhostAlias localhostAlias)
 {
     ASSERT(isMainThread());
 
@@ -51,8 +51,8 @@ CurlStreamID CurlStreamScheduler::createStream(const URL& url, CurlStream::Clien
     auto streamID = m_currentStreamID;
     m_clientList.add(streamID, &client);
 
-    callOnWorkerThread([this, streamID, url = url.isolatedCopy(), serverTrustEvaluation]() mutable {
-        m_streamList.add(streamID, CurlStream::create(*this, streamID, WTFMove(url), serverTrustEvaluation));
+    callOnWorkerThread([this, streamID, url = url.isolatedCopy(), serverTrustEvaluation, localhostAlias]() mutable {
+        m_streamList.add(streamID, CurlStream::create(*this, streamID, WTFMove(url), serverTrustEvaluation, localhostAlias));
     });
 
     return streamID;

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
@@ -38,7 +38,7 @@ public:
     CurlStreamScheduler();
     virtual ~CurlStreamScheduler();
 
-    WEBCORE_EXPORT CurlStreamID createStream(const URL&, CurlStream::Client&, CurlStream::ServerTrustEvaluation = CurlStream::ServerTrustEvaluation::Enable);
+    WEBCORE_EXPORT CurlStreamID createStream(const URL&, CurlStream::Client&, CurlStream::ServerTrustEvaluation, CurlStream::LocalhostAlias);
     WEBCORE_EXPORT void destroyStream(CurlStreamID);
     WEBCORE_EXPORT void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
 

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -138,7 +138,12 @@ Ref<CurlRequest> NetworkDataTaskCurl::createCurlRequest(ResourceRequest&& reques
     // Creates a CurlRequest in suspended state.
     // Then, NetworkDataTaskCurl::resume() will be called and communication resumes.
     const auto captureMetrics = shouldCaptureExtraNetworkLoadMetrics() ? CurlRequest::CaptureNetworkLoadMetrics::Extended : CurlRequest::CaptureNetworkLoadMetrics::Basic;
-    return CurlRequest::create(request, *this, captureMetrics);
+    auto curlRequest = CurlRequest::create(request, *this, captureMetrics);
+
+    if (m_session->networkProcess().localhostAliasesForTesting().contains<StringViewHashTranslator>(curlRequest->resourceRequest().url().host()))
+        curlRequest->enableLocalhostAlias();
+
+    return curlRequest;
 }
 
 void NetworkDataTaskCurl::curlDidSendData(CurlRequest&, unsigned long long totalBytesSent, unsigned long long totalBytesExpectedToSend)

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -480,6 +480,7 @@ class WinPort(ApplePort):
 
 class WinCairoPort(WinPort):
     port_name = "wincairo"
+    supports_localhost_aliases = True
 
     DEFAULT_ARCHITECTURE = 'x86_64'
 


### PR DESCRIPTION
#### 97ccc52dcedaa11df94a28245f6d1bd4c9c16810
<pre>
[Curl] Support local host aliases for WPT testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=269822">https://bugs.webkit.org/show_bug.cgi?id=269822</a>

Reviewed by Fujii Hironori.

GTK port can run WPT tests against the web-platform.test domains after bug 243428.
The curl port also supports local host aliases added in this bug for WPT testing.

* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target-dynamic.sub-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/csp/applied-to-target.sub-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_origin-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/trusted-types/default-policy-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/trusted-types/default-policy-report-only-expected.txt: Added.
* LayoutTests/platform/wincairo/imported/w3c/web-platform-tests/webtransport/constructor.https.any-expected.txt: Added.
* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::setURL):
* Source/WebCore/platform/network/curl/CurlContext.h:
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::setupTransfer):
* Source/WebCore/platform/network/curl/CurlRequest.h:
(WebCore::CurlRequest::enableLocalhostAlias):
* Source/WebCore/platform/network/curl/CurlStream.cpp:
(WebCore::CurlStream::CurlStream):
* Source/WebCore/platform/network/curl/CurlStream.h:
(WebCore::CurlStream::create):
* Source/WebCore/platform/network/curl/CurlStreamScheduler.cpp:
(WebCore::CurlStreamScheduler::createStream):
* Source/WebCore/platform/network/curl/CurlStreamScheduler.h:
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::createCurlRequest):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::tryServerTrustEvaluation):
* Tools/Scripts/webkitpy/port/win.py:
(WinCairoPort):

Canonical link: <a href="https://commits.webkit.org/275129@main">https://commits.webkit.org/275129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1b608ddf1dc3d7456c0602775dbb14c14d5c5db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36963 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33876 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14497 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/40742 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44719 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40275 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38640 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17357 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5449 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->