### PR TITLE
[SVG2] Remove non-standard `hasExtension`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt
@@ -43,7 +43,7 @@ PASS SVGElement.prototype.xmlbase must be removed
 PASS SVGElement.prototype.xmllang must be removed
 PASS SVGElement.prototype.xmlspace must be removed
 PASS SVGGraphicsElement.prototype.getTransformToElement must be removed
-FAIL SVGGraphicsElement.prototype.hasExtension must be removed assert_false: expected false got true
+PASS SVGGraphicsElement.prototype.hasExtension must be removed
 FAIL SVGGraphicsElement.prototype.requiredFeatures must be removed assert_false: expected false got true
 FAIL SVGSVGElement.prototype.currentView must be removed assert_false: expected false got true
 PASS SVGSVGElement.prototype.pixelUnitToMillimeterX must be removed

--- a/LayoutTests/svg/dom/SVGTests-expected.txt
+++ b/LayoutTests/svg/dom/SVGTests-expected.txt
@@ -8,14 +8,6 @@ Check the requiredFeatures, requiredExtensions and systemLanguage attributes
 PASS foreignObject.requiredFeatures instanceof SVGStringList is true
 PASS foreignObject.requiredExtensions instanceof SVGStringList is true
 PASS foreignObject.systemLanguage instanceof SVGStringList is true
-
-Check the hasExtension function
-PASS foreignObject.hasExtension('http://www.w3.org/1998/Math/MathML') is true
-PASS foreignObject.hasExtension('http://www.w3.org/1999/xhtml') is true
-PASS foreignObject.hasExtension('') is false
-PASS foreignObject.hasExtension('unknownExtension') is false
-PASS foreignObject.hasExtension('HTTP://WWW.W3.ORG/1999/XHTML') is false
-PASS foreignObject.hasExtension('http://www.w3.org/1998/Math/MathML http://www.w3.org/1999/xhtml') is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/svg/dom/SVGTests.html
+++ b/LayoutTests/svg/dom/SVGTests.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -17,18 +17,7 @@ debug("Check the requiredFeatures, requiredExtensions and systemLanguage attribu
 shouldBeTrue("foreignObject.requiredFeatures instanceof SVGStringList");
 shouldBeTrue("foreignObject.requiredExtensions instanceof SVGStringList");
 shouldBeTrue("foreignObject.systemLanguage instanceof SVGStringList");
-
-debug("");
-debug("Check the hasExtension function");
-shouldBeTrue("foreignObject.hasExtension('http://www.w3.org/1998/Math/MathML')");
-shouldBeTrue("foreignObject.hasExtension('http://www.w3.org/1999/xhtml')");
-shouldBeFalse("foreignObject.hasExtension('')");
-shouldBeFalse("foreignObject.hasExtension('unknownExtension')");
-shouldBeFalse("foreignObject.hasExtension('HTTP://WWW.W3.ORG/1999/XHTML')");
-shouldBeFalse("foreignObject.hasExtension('http://www.w3.org/1998/Math/MathML http://www.w3.org/1999/xhtml')");
-
 successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/svg/SVGTests.idl
+++ b/Source/WebCore/svg/SVGTests.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
  */
 
 // https://svgwg.org/svg2-draft/types.html#InterfaceSVGTests
+
 interface mixin SVGTests {
     [SameObject] readonly attribute SVGStringList requiredExtensions;
     [SameObject] readonly attribute SVGStringList systemLanguage;
@@ -33,5 +34,4 @@ interface mixin SVGTests {
     // As of SVG2, the following are no longer part of this interface.
 
     [SameObject] readonly attribute SVGStringList requiredFeatures;
-    boolean hasExtension(DOMString extension);
 };


### PR DESCRIPTION
#### b13ce5f6d88f54fa5eec58e53633d39514391d09
<pre>
[SVG2] Remove non-standard `hasExtension`

<a href="https://bugs.webkit.org/show_bug.cgi?id=269827">https://bugs.webkit.org/show_bug.cgi?id=269827</a>

Reviewed by Darin Adler.

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

They were removed SVG2 Web Specification [1] and also dropped from
Blink in 2015 [2].

[1] <a href="https://github.com/w3c/svgwg/commit/14d377471e0746c937ea2aa61d73da45bca48d32">https://github.com/w3c/svgwg/commit/14d377471e0746c937ea2aa61d73da45bca48d32</a>

[2] <a href="https://chromium.googlesource.com/chromium/src.git/+/22a2b9b39db47a78307c1d1353d0f55e265823ce">https://chromium.googlesource.com/chromium/src.git/+/22a2b9b39db47a78307c1d1353d0f55e265823ce</a>

* Source/WebCore/svg/SVGTests.idl:
* LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt: Rebaselined
* LayoutTests/svg/dom/SVGTests.html: Ditto
* LayoutTests/svg/dom/SVGTests-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/281817@main">https://commits.webkit.org/281817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bd6a619d460714a62959b640c6c6d36eb79221e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49367 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8075 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30197 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10136 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10531 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66737 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56929 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13630 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4158 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36235 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->