### PR TITLE
[WK2] WebKit abandons compiled sandbox profiles

### DIFF
--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -294,15 +294,9 @@ static String sandboxDirectory(WebCore::AuxiliaryProcessType processType, const 
     return directory.toString();
 }
 
-static String sandboxFilePath(const String& directoryPath, const CString& header)
+static String sandboxFilePath(const String& directoryPath)
 {
-    // Make the filename semi-unique based on the contents of the header.
-
-    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(header.data(), header.length());
-    auto hash = crypto->computeHash();
-
-    return makeString(directoryPath, "/CompiledSandbox+", base64URLEncoded(hash.data(), hash.size()));
+    return makeString(directoryPath, "/CompiledSandbox");
 }
 
 static bool ensureSandboxCacheDirectory(const SandboxInfo& info)
@@ -590,7 +584,7 @@ static bool applySandbox(const AuxiliaryProcessInitializationParameters& paramet
     }
 
     String directoryPath { sandboxDirectory(parameters.processType, dataVaultParentDirectory) };
-    String filePath = sandboxFilePath(directoryPath, *header);
+    String filePath = sandboxFilePath(directoryPath);
     SandboxInfo info {
         dataVaultParentDirectory,
         directoryPath,


### PR DESCRIPTION
#### 2dfb4e9da6fd0294f2899c73592c9d4647fe0d9f
<pre>
[WK2] WebKit abandons compiled sandbox profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=212177">https://bugs.webkit.org/show_bug.cgi?id=212177</a>
<a href="https://rdar.apple.com/54613619">rdar://54613619</a>

Reviewed by Per Arne Vollan.

WebKit generates new compiled sandbox profiles whenever sandbox profiles are updated or
whenever webkit directories change (which is super common for WebKitTestRunner). Previous
compiled sandbox profiles do not get deleted and therefore may accumulate.

To address the issue, stop including the sandbox profile hash in the compiled sandbox&apos;s
filename. We end up using:
- com.apple.WebKit.Networking.Sandbox/CompiledSandbox
instead of
- com.apple.WebKit.Networking.Sandbox/CompiledSandbox+D2hn1Pn_lLcl-wJoTYvS45lVG6tqDaa3Lhp_AZPFesI

This means that every time the sandbox profile gets updated, we&apos;ll just overwrite the
previous version on disk. Therefore, compiled sandbox files will no longer accumulate.

The one inconvenient I can think of is when running two different versions of Safari
locally. Both instances will overwrite each other compiled sandbox files, which could
impact process launch time when alternating between the 2 instances. However, this is
not a super common use case and the impact is only a minor performance one, no
correctness issue.

* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::sandboxFilePath):
(WebKit::applySandbox):

Canonical link: <a href="https://commits.webkit.org/275108@main">https://commits.webkit.org/275108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cce171d4106e7c74542ef21a096ee388574210cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36943 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33862 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14481 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14582 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44693 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40255 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38615 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17286 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17337 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5436 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->