### PR TITLE
Adopt more dynamicDowncast<> in FrameIOS

### DIFF
--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -392,17 +392,17 @@ Node* LocalFrame::deepestNodeAtLocation(const FloatPoint& viewportLocation)
 
 static bool nodeIsMouseFocusable(Node& node)
 {
-    if (!is<Element>(node))
+    auto* element = dynamicDowncast<Element>(node);
+    if (!element)
         return false;
 
-    auto& element = downcast<Element>(node);
-    if (element.isMouseFocusable())
+    if (element->isMouseFocusable())
         return true;
 
-    if (RefPtr shadowRoot = element.shadowRoot()) {
+    if (RefPtr shadowRoot = element->shadowRoot()) {
         if (shadowRoot->delegatesFocus()) {
-            for (auto& node : composedTreeDescendants(element)) {
-                if (is<Element>(node) && downcast<Element>(node).isMouseFocusable())
+            for (auto& node : composedTreeDescendants(*element)) {
+                if (auto* element = dynamicDowncast<Element>(node); element && element->isMouseFocusable())
                     return true;
             }
         }
@@ -588,12 +588,11 @@ int LocalFrame::preferredHeight() const
     if (!body)
         return 0;
 
-    RenderObject* renderer = body->renderer();
-    if (!is<RenderBlock>(renderer))
+    auto* block = dynamicDowncast<RenderBlock>(body->renderer());
+    if (!block)
         return 0;
 
-    RenderBlock& block = downcast<RenderBlock>(*renderer);
-    return block.height() + block.marginTop() + block.marginBottom();
+    return block->height() + block->marginTop() + block->marginBottom();
 }
 
 void LocalFrame::updateLayout() const


### PR DESCRIPTION
#### acf728ee70545f5bbe84d807755c25cfbbfa90b0
<pre>
Adopt more dynamicDowncast&lt;&gt; in FrameIOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=269828">https://bugs.webkit.org/show_bug.cgi?id=269828</a>

Reviewed by Chris Dumez.

* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::nodeIsMouseFocusable):
(WebCore::LocalFrame::preferredHeight const):

Canonical link: <a href="https://commits.webkit.org/275096@main">https://commits.webkit.org/275096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a73a33558ebe6255d5577fa99bfac34019ff3fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43413 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36946 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33863 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14482 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40256 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38623 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17289 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9176 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->