### PR TITLE
[view-transitions] Support style inheritance in the pseudo-element tree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: group expected "rgb(255, 0, 0)" but got "rgba(0, 0, 0, 0)"
-
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: group expected "rgb(255, 0, 0)" but got "rgba(0, 0, 0, 0)"
 
 PASS style inheritance of pseudo elements
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4141,8 +4141,7 @@ const RenderStyle& Element::resolvePseudoElementStyle(const Style::PseudoElement
         style->inheritFrom(*parentStyle);
         // FIXME: RenderStyle should switch to use PseudoElementIdentifier.
         style->setPseudoElementType(pseudoElementIdentifier.pseudoId);
-        if (!pseudoElementIdentifier.nameArgument.isNull())
-            style->setPseudoElementNameArgument(pseudoElementIdentifier.nameArgument);
+        style->setPseudoElementNameArgument(pseudoElementIdentifier.nameArgument);
     }
 
     auto* computedStyle = style.get();

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -471,7 +471,8 @@ inline void RenderStyle::setPseudoElementNameArgument(const AtomString& identifi
         || pseudoElementType() == PseudoId::ViewTransitionImagePair
         || pseudoElementType() == PseudoId::ViewTransitionNew
         || pseudoElementType() == PseudoId::ViewTransitionOld
-        || pseudoElementType() == PseudoId::Highlight);
+        || pseudoElementType() == PseudoId::Highlight
+        || identifier.isNull());
     SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, identifier);
 }
 


### PR DESCRIPTION
#### ce47267f2d5ecaa5aefd2346a8cfa59b7aaeb08a
<pre>
[view-transitions] Support style inheritance in the pseudo-element tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=269808">https://bugs.webkit.org/show_bug.cgi?id=269808</a>
<a href="https://rdar.apple.com/123331760">rdar://123331760</a>

Reviewed by Anne van Kesteren.

The style inheritance must follow the pseudo-element tree structure. This allows the different `inherit` declarations in the `viewTransitions.css` UA stylesheet to work.

This is also ergonomic for developers since they can just set the animation-duration once and have it cascade down the pseudo-element tree.

Also fix the cache to actually store the named view transition style when resolving, otherwise `TreeResolver::makeResolutionContextForPseudoElement` can&apos;t fetch it.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt: Rebaselined test.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolvePseudoElementStyle):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setPseudoElementNameArgument):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):

Canonical link: <a href="https://commits.webkit.org/275121@main">https://commits.webkit.org/275121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91edc7e9eb6ec957a53ddb302490a8a8b62e629a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33900 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14523 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14627 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40312 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38681 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17386 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5442 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->