### PR TITLE
[LibWebRTC][CMake] Data channel support broken

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -526,6 +526,10 @@ set(webrtc_SOURCES
     Source/third_party/boringssl/src/tool/transport_common.cc
     Source/third_party/boringssl/src/util/fipstools/acvp/modulewrapper/main.cc
     Source/third_party/boringssl/src/util/fipstools/acvp/modulewrapper/modulewrapper.cc
+    Source/third_party/crc32c/src/src/crc32c_arm64.cc
+    Source/third_party/crc32c/src/src/crc32c.cc
+    Source/third_party/crc32c/src/src/crc32c_portable.cc
+    Source/third_party/crc32c/src/src/crc32c_sse42.cc
     Source/third_party/libyuv/source/compare.cc
     Source/third_party/libyuv/source/compare_common.cc
     Source/third_party/libyuv/source/compare_gcc.cc
@@ -1471,6 +1475,79 @@ set(webrtc_SOURCES
     Source/webrtc/modules/video_coding/video_coding_impl.cc
     Source/webrtc/modules/video_coding/video_receiver2.cc
     Source/webrtc/modules/video_coding/video_receiver.cc
+    Source/webrtc/net/dcsctp/common/handover_testing.cc
+    Source/webrtc/net/dcsctp/fuzzers/dcsctp_fuzzers.cc
+    Source/webrtc/net/dcsctp/packet/chunk/abort_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/cookie_ack_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/cookie_echo_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/data_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/error_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/forward_tsn_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/heartbeat_ack_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/heartbeat_request_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/idata_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/iforward_tsn_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/init_ack_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/init_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/reconfig_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/sack_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/shutdown_ack_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/shutdown_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk/shutdown_complete_chunk.cc
+    Source/webrtc/net/dcsctp/packet/chunk_validators.cc
+    Source/webrtc/net/dcsctp/packet/crc32c.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/cookie_received_while_shutting_down_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/error_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/invalid_mandatory_parameter_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/invalid_stream_identifier_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/missing_mandatory_parameter_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/no_user_data_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/out_of_resource_error_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/protocol_violation_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/restart_of_an_association_with_new_address_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/stale_cookie_error_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/unrecognized_chunk_type_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/unrecognized_parameter_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/unresolvable_address_cause.cc
+    Source/webrtc/net/dcsctp/packet/error_cause/user_initiated_abort_cause.cc
+    Source/webrtc/net/dcsctp/packet/parameter/add_incoming_streams_request_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/add_outgoing_streams_request_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/forward_tsn_supported_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/heartbeat_info_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/incoming_ssn_reset_request_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/outgoing_ssn_reset_request_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/reconfiguration_response_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/ssn_tsn_reset_request_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/state_cookie_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/supported_extensions_parameter.cc
+    Source/webrtc/net/dcsctp/packet/parameter/zero_checksum_acceptable_chunk_parameter.cc
+    Source/webrtc/net/dcsctp/packet/sctp_packet.cc
+    Source/webrtc/net/dcsctp/packet/tlv_trait.cc
+    Source/webrtc/net/dcsctp/public/dcsctp_handover_state.cc
+    Source/webrtc/net/dcsctp/public/dcsctp_socket_factory.cc
+    Source/webrtc/net/dcsctp/public/text_pcap_packet_observer.cc
+    Source/webrtc/net/dcsctp/rx/data_tracker.cc
+    Source/webrtc/net/dcsctp/rx/interleaved_reassembly_streams.cc
+    Source/webrtc/net/dcsctp/rx/reassembly_queue.cc
+    Source/webrtc/net/dcsctp/rx/traditional_reassembly_streams.cc
+    Source/webrtc/net/dcsctp/socket/callback_deferrer.cc
+    Source/webrtc/net/dcsctp/socket/dcsctp_socket.cc
+    Source/webrtc/net/dcsctp/socket/heartbeat_handler.cc
+    Source/webrtc/net/dcsctp/socket/packet_sender.cc
+    Source/webrtc/net/dcsctp/socket/state_cookie.cc
+    Source/webrtc/net/dcsctp/socket/stream_reset_handler.cc
+    Source/webrtc/net/dcsctp/socket/transmission_control_block.cc
+    Source/webrtc/net/dcsctp/testing/data_generator.cc
+    Source/webrtc/net/dcsctp/timer/task_queue_timeout.cc
+    Source/webrtc/net/dcsctp/timer/timer.cc
+    Source/webrtc/net/dcsctp/tx/outstanding_data.cc
+    Source/webrtc/net/dcsctp/tx/retransmission_error_counter.cc
+    Source/webrtc/net/dcsctp/tx/retransmission_queue.cc
+    Source/webrtc/net/dcsctp/tx/retransmission_timeout.cc
+    Source/webrtc/net/dcsctp/tx/rr_send_queue.cc
+    Source/webrtc/net/dcsctp/tx/stream_scheduler.cc
     Source/webrtc/p2p/base/async_stun_tcp_socket.cc
     Source/webrtc/p2p/base/basic_async_resolver_factory.cc
     Source/webrtc/p2p/base/basic_ice_controller.cc
@@ -2106,6 +2183,7 @@ target_compile_definitions(webrtc PRIVATE
   WEBRTC_CODEC_ISAC
   WEBRTC_CODEC_OPUS
   WEBRTC_CODEC_RED
+  WEBRTC_HAVE_DCSCTP
   WEBRTC_HAVE_SCTP
   WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE
   WEBRTC_INTELLIGIBILITY_ENHANCER=0
@@ -2158,6 +2236,8 @@ set(webrtc_INCLUDE_DIRECTORIES PRIVATE
     Source/third_party/abseil-cpp
     Source/third_party/abseil-cpp/absl/types
     Source/third_party/boringssl/src/include
+    Source/third_party/crc32c/config
+    Source/third_party/crc32c/src/include
     Source/third_party/libsrtp/config
     Source/third_party/libsrtp/crypto/include
     Source/third_party/libsrtp/include


### PR DESCRIPTION
#### 541bbd134c5e9e103d318a62f43d19cf394956e4
<pre>
[LibWebRTC][CMake] Data channel support broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=269779">https://bugs.webkit.org/show_bug.cgi?id=269779</a>

Reviewed by Youenn Fablet.

Enable dcsctp data channels support.

* Source/ThirdParty/libwebrtc/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/275089@main">https://commits.webkit.org/275089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f313e13e9e58d1e4137b4c2faaf5036f70d82d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36959 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17212 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16824 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35229 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14593 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40270 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12875 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38634 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17302 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9170 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->