### PR TITLE
REGRESSION(273637@main?): [ Sonoma+ wk2 Release arm64] 7 http/wpt/webcodecs (layout-tests) are constant text failures

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1974,15 +1974,6 @@ webkit.org/b/268200 [ Sonoma+ Release ] inspector/console/console-screenshot.htm
 
 webkit.org/b/268332 [ Monterey+ x86_64 ] imported/w3c/web-platform-tests/webrtc/simulcast/getStats.https.html [ Failure ]
 
-# webkit.org/b/268347 REGRESSION(273637@main?): [ Sonoma+ wk2 Release arm64] 7 http/wpt/webcodecs (layout-tests) are constant text failures
-[ Sonoma+ Release arm64 ] http/tests/webcodecs/h264-reordering.html [ Failure ]
-[ Sonoma+ Release arm64 ] http/wpt/webrtc/audiovideo-script-transform.html [ Failure ]
-[ Sonoma+ Release arm64 ] http/wpt/webcodecs/webcodecs-gc.html [ Failure ]
-[ Sonoma+ Release arm64 ] http/wpt/webcodecs/videoFrame-negative-timestamp.html [ Failure ]
-[ Sonoma+ Release arm64 ] http/wpt/webcodecs/hevc-decoder-annexb.https.any.worker.html [ Failure ]
-[ Sonoma+ Release arm64 ] http/wpt/webcodecs/hevc-decoder-annexb.https.any.html [ Failure ]
-[ Sonoma+ Release arm64 ] http/tests/webcodecs/hevc-reordering.html [ Failure ]
-
 webkit.org/b/268406 transitions/flex-transitions.html [ Pass Failure ]
 
 # webkit.org/b/268414 [ macOS ] 2 tests in imported/w3c/web-platform-tests/webrtc are flaky failure


### PR DESCRIPTION
#### 680b214f093a338118a9b7ddd2a480adb192b6aa
<pre>
REGRESSION(273637@main?): [ Sonoma+ wk2 Release arm64] 7 http/wpt/webcodecs (layout-tests) are constant text failures
<a href="https://rdar.apple.com/121889869">rdar://121889869</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268347">https://bugs.webkit.org/show_bug.cgi?id=268347</a>

Unreviewed.

* LayoutTests/platform/mac-wk2/TestExpectations:
Remove expectations as tests are no longer failing.

Canonical link: <a href="https://commits.webkit.org/275109@main">https://commits.webkit.org/275109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/134e2ad53dec0fbd052a9545421851ccb624dca5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36965 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33877 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44722 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37088 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40278 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38648 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17308 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9183 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->