### PR TITLE
Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm:40:25: error: instance method '-isValid' not found

### DIFF
--- a/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm
@@ -35,7 +35,7 @@
 
 namespace WebKit {
 
-static void platformInvalidate(BEProcessCapabilityGrant *platformGrant)
+static void platformInvalidate(id<BEProcessCapabilityGrant> platformGrant)
 {
     if (![platformGrant isValid])
         return;


### PR DESCRIPTION
#### 8b4edddf2455f4c5a5632bc7aea781e845b113c0
<pre>
Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm:40:25: error: instance method &apos;-isValid&apos; not found
<a href="https://bugs.webkit.org/show_bug.cgi?id=269839">https://bugs.webkit.org/show_bug.cgi?id=269839</a>
<a href="https://rdar.apple.com/123369227">rdar://123369227</a>

Unreviewed compilation failure fix

Change platformInvalidate prototype definition.

* Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm:
(WebKit::platformInvalidate):

Canonical link: <a href="https://commits.webkit.org/275092@main">https://commits.webkit.org/275092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e342e819e6f40cf5d1e01a6173cb8be2c5ca59d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36970 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17223 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16839 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14503 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44728 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37093 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38652 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17313 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17364 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5429 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->