### PR TITLE
[Clang] Unused parameter warnings in WebsiteDataStoreClient.h

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -117,7 +117,7 @@ public:
     {
     }
 
-    virtual void didExceedMemoryFootprintThreshold(size_t footprint, const String& domain, unsigned pageCount, Seconds processLifetime, bool inForeground)
+    virtual void didExceedMemoryFootprintThreshold(size_t, const String&, unsigned, Seconds, bool)
     {
     }
 };


### PR DESCRIPTION
#### 5240fc400e2fbee5e8c86c76e21706760ce15bd2
<pre>
[Clang] Unused parameter warnings in WebsiteDataStoreClient.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=269841">https://bugs.webkit.org/show_bug.cgi?id=269841</a>

Reviewed by Michael Catanzaro.

Make the didExceedMemoryFootprintThreshold() unused parameters anonymous.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::didExceedMemoryFootprintThreshold):

Canonical link: <a href="https://commits.webkit.org/275118@main">https://commits.webkit.org/275118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c89ac0095b13b16f68f344a166f08e64fdca378f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36997 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33902 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14629 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44759 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37114 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40309 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15721 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12906 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38678 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17340 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9184 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17391 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5440 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->