### PR TITLE
[WPE] WPE Platform: add API to maximize/unmaximize a WPEView

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -640,6 +640,44 @@ gboolean wpe_view_unfullscreen(WPEView* view)
 }
 
 /**
+ * wpe_view_maximize:
+ * @view: a #WPEView
+ *
+ * Request that the @view is maximized. If the view is already maximized this function
+ * does nothing.
+ *
+ * To track the state see #WPEView::state-changed
+ *
+ * Returns: %TRUE if maximize is supported, otherwise %FALSE
+ */
+gboolean wpe_view_maximize(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
+
+    auto* viewClass = WPE_VIEW_GET_CLASS(view);
+    return viewClass->set_maximized ? viewClass->set_maximized(view, TRUE) : FALSE;
+}
+
+/**
+ * wpe_view_unmaximize:
+ * @view: a #WPEView
+ *
+ * Request that the @view is unmaximized. If the view is not maximized this function
+ * does nothing.
+ *
+ * To track the state see #WPEView::state-changed
+ *
+ * Returns: %TRUE if maximize is supported, otherwise %FALSE
+ */
+gboolean wpe_view_unmaximize(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
+
+    auto* viewClass = WPE_VIEW_GET_CLASS(view);
+    return viewClass->set_maximized ? viewClass->set_maximized(view, FALSE) : FALSE;
+}
+
+/**
  * wpe_view_render_buffer:
  * @view: a #WPEView
  * @buffer: a #WPEBuffer to render

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -53,6 +53,8 @@ struct _WPEViewClass
     WPEMonitor *(* get_monitor)                   (WPEView    *view);
     gboolean    (* set_fullscreen)                (WPEView    *view,
                                                    gboolean    fullscreen);
+    gboolean    (* set_maximized)                 (WPEView    *view,
+                                                   gboolean    maximized);
     GList      *(* get_preferred_dma_buf_formats) (WPEView    *view);
     void        (* set_cursor_from_name)          (WPEView    *view,
                                                    const char *name);
@@ -69,12 +71,16 @@ struct _WPEViewClass
 
 /**
  * WPEViewState:
+ * @WPE_VIEW_STATE_NONE: the view is in normal state
+ * @WPE_VIEW_STATE_FULLSCREEN: the view is fullscreen
+ * @WPE_VIEW_STATE_MAXIMIZED: the view is maximized
  *
  * The current state of the view.
  */
 typedef enum {
     WPE_VIEW_STATE_NONE = 0,
     WPE_VIEW_STATE_FULLSCREEN = (1 << 0),
+    WPE_VIEW_STATE_MAXIMIZED = (1 << 1)
 } WPEViewState;
 
 #define WPE_VIEW_ERROR (wpe_view_error_quark())
@@ -120,6 +126,8 @@ WPE_API void         wpe_view_set_state                     (WPEView     *view,
 WPE_API WPEMonitor  *wpe_view_get_monitor                   (WPEView     *view);
 WPE_API gboolean     wpe_view_fullscreen                    (WPEView     *view);
 WPE_API gboolean     wpe_view_unfullscreen                  (WPEView     *view);
+WPE_API gboolean     wpe_view_maximize                      (WPEView     *view);
+WPE_API gboolean     wpe_view_unmaximize                    (WPEView     *view);
 WPE_API gboolean     wpe_view_render_buffer                 (WPEView     *view,
                                                              WPEBuffer   *buffer,
                                                              GError     **error);

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -141,6 +141,14 @@ static gboolean wpeViewEventCallback(WPEView* view, WPEEvent* event, WebKitWebVi
             webkit_web_view_go_forward(webView);
             return TRUE;
         }
+
+        if (keyval == WPE_KEY_Up) {
+            if (wpe_view_get_state(view) & WPE_VIEW_STATE_MAXIMIZED)
+                wpe_view_unmaximize(view);
+            else
+                wpe_view_maximize(view);
+            return TRUE;
+        }
     }
 
     if (keyval == WPE_KEY_F11) {


### PR DESCRIPTION
#### e9496d0854d091f2a23e372089fa7b98c8c514bd
<pre>
[WPE] WPE Platform: add API to maximize/unmaximize a WPEView
<a href="https://bugs.webkit.org/show_bug.cgi?id=269842">https://bugs.webkit.org/show_bug.cgi?id=269842</a>

Reviewed by Adrian Perez de Castro.

* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_maximize):
(wpe_view_unmaximize):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandSaveSize):
(wpeViewWaylandSetFullscreen):
(wpeViewWaylandSetMaximized):
(wpe_view_wayland_class_init):
* Tools/MiniBrowser/wpe/main.cpp:

Canonical link: <a href="https://commits.webkit.org/275175@main">https://commits.webkit.org/275175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/250c4819c8c8975a0f3e5afbde6bbb0b810b6afe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33886 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40294 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38662 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17373 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5470 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->