### PR TITLE
[CSS Container Queries][Style queries] Allow !important

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt
@@ -5,7 +5,7 @@ PASS style(not ((--foo: calc(10px + 2em)) and ((--foo: url(x)))))
 PASS style((--foo: bar) or (--bar: 10px))
 PASS style(--my-prop:)
 PASS style(--my-prop: )
-FAIL style(--foo: bar !important) assert_equals: expected "true" but got ""
+PASS style(--foo: bar !important)
 PASS style(--foo)
 PASS style(--foo: bar;)
 PASS style(style(--foo: bar))

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
@@ -47,7 +47,7 @@ PASS outer style(--outer-space-after: true)
 PASS outer style(--outer-space-after:true)
 PASS outer style(--outer-space-after:true )
 PASS outer style(--outer-space-after: true )
-FAIL Query custom property with !important declaration assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Query custom property with !important declaration
 PASS Query custom property using var()
 PASS Query custom property including unknown var() reference
 PASS Query custom property including unknown var() reference with non-matching fallback

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -109,6 +109,8 @@ public:
     static void parseDeclarationListForInspector(const String&, const CSSParserContext&, CSSParserObserver&);
     static void parseStyleSheetForInspector(const String&, const CSSParserContext&, StyleSheetContents&, CSSParserObserver&);
 
+    static bool consumeTrailingImportantAndWhitespace(CSSParserTokenRange&);
+
     CSSTokenizer* tokenizer() const { return m_tokenizer.get(); }
 
 private:

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -105,14 +105,19 @@ void CSSParserTokenRange::consumeComponentValue()
     } while (nestingLevel && m_first < m_last);
 }
 
-CSSParserTokenRange CSSParserTokenRange::consumeAllExcludingTrailingWhitespace()
+void CSSParserTokenRange::trimTrailingWhitespace()
 {
-    auto* last = m_last;
-    for (; last > m_first; --last) {
-        if ((last - 1)->type() != WhitespaceToken)
-            break;
+    for (; m_last > m_first; --m_last) {
+        if ((m_last - 1)->type() != WhitespaceToken)
+            return;
     }
-    return { std::exchange(m_first, last), last };
+}
+
+const CSSParserToken& CSSParserTokenRange::consumeLast()
+{
+    if (atEnd())
+        eofToken();
+    return *--m_last;
 }
 
 String CSSParserTokenRange::serialize() const

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -91,8 +91,10 @@ public:
             ++m_first;
     }
 
+    void trimTrailingWhitespace();
+    const CSSParserToken& consumeLast();
+
     CSSParserTokenRange consumeAll() { return { std::exchange(m_first, m_last), m_last }; }
-    CSSParserTokenRange consumeAllExcludingTrailingWhitespace();
 
     String serialize() const;
 

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -27,6 +27,7 @@
 
 #include "CSSAspectRatioValue.h"
 #include "CSSCustomPropertyValue.h"
+#include "CSSParserImpl.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSValue.h"
@@ -58,11 +59,16 @@ std::optional<Feature> FeatureParser::consumeFeature(CSSParserTokenRange& range,
 
 static RefPtr<CSSValue> consumeCustomPropertyValue(AtomString propertyName, CSSParserTokenRange& range)
 {
-    auto propertyValueRange = range.consumeAllExcludingTrailingWhitespace();
-    range.consumeWhitespace();
-    if (propertyValueRange.atEnd())
+    auto valueRange = range;
+    range.consumeAll();
+
+    // Syntax is that of a valid declaration so !important is allowed. It just gets ignored.
+    CSSParserImpl::consumeTrailingImportantAndWhitespace(valueRange);
+
+    if (valueRange.atEnd())
         return CSSCustomPropertyValue::createEmpty(propertyName);
-    return CSSVariableParser::parseDeclarationValue(propertyName, propertyValueRange, strictCSSParserContext());
+
+    return CSSVariableParser::parseDeclarationValue(propertyName, valueRange, strictCSSParserContext());
 }
 
 std::optional<Feature> FeatureParser::consumeBooleanOrPlainFeature(CSSParserTokenRange& range, const MediaQueryParserContext& context)


### PR DESCRIPTION
#### 7839f9caaeec6540011d7470842f0966773b92a1
<pre>
[CSS Container Queries][Style queries] Allow !important
<a href="https://bugs.webkit.org/show_bug.cgi?id=269844">https://bugs.webkit.org/show_bug.cgi?id=269844</a>
<a href="https://rdar.apple.com/123374708">rdar://123374708</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeTrailingImportantAndWhitespace):

Factor into a function and clean up.

(WebCore::CSSParserImpl::consumeDeclaration):
(WebCore::removeTrailingWhitespace): Deleted.
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
(WebCore::CSSParserTokenRange::trimTrailingWhitespace):
(WebCore::CSSParserTokenRange::consumeLast):
(WebCore::CSSParserTokenRange::consumeAllExcludingTrailingWhitespace): Deleted.

Some helper improvements.

* Source/WebCore/css/parser/CSSParserTokenRange.h:
(WebCore::CSSParserTokenRange::consumeAll):
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::consumeCustomPropertyValue):

Consume away any !important and proceed to ignore it.

Canonical link: <a href="https://commits.webkit.org/275104@main">https://commits.webkit.org/275104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6442b4af3c1ab92b800ffadb3c9d16e57878dc7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17242 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14519 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44751 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40303 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38673 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17332 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9182 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->