### PR TITLE
[Skia] Use Skia API when adding rounded rect to path and strategy is PreferNative

### DIFF
--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -25,6 +25,7 @@ platform/graphics/skia/TransformationMatrixSkia.cpp
 platform/graphics/skia/ComplexTextControllerSkia.cpp
 platform/graphics/skia/DrawGlyphsRecorderSkia.cpp
 platform/graphics/skia/FloatRectSkia.cpp
+platform/graphics/skia/FloatRoundedRectSkia.cpp
 platform/graphics/skia/FontCacheSkia.cpp
 platform/graphics/skia/FontCascadeSkia.cpp
 platform/graphics/skia/FontCustomPlatformDataSkia.cpp

--- a/Source/WebCore/platform/graphics/FloatRoundedRect.h
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.h
@@ -35,6 +35,10 @@
 #include "Region.h"
 #include "RoundedRect.h"
 
+#if USE(SKIA)
+class SkRRect;
+#endif
+
 namespace WebCore {
 
 class FloatRoundedRect {
@@ -149,6 +153,11 @@ public:
     bool intersectionIsRectangular(const FloatRect&) const;
 
     friend bool operator==(const FloatRoundedRect&, const FloatRoundedRect&) = default;
+
+#if USE(SKIA)
+    FloatRoundedRect(const SkRRect&);
+    operator SkRRect() const;
+#endif
 
 private:
     FloatRect m_rect;

--- a/Source/WebCore/platform/graphics/skia/FloatRoundedRectSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FloatRoundedRectSkia.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FloatRoundedRect.h"
+
+#if USE(SKIA)
+#include <skia/core/SkRRect.h>
+
+namespace WebCore {
+
+FloatRoundedRect::FloatRoundedRect(const SkRRect& skRect)
+    : m_rect(skRect.rect())
+{
+    SkVector corner = skRect.radii(SkRRect::kUpperLeft_Corner);
+    m_radii.setTopLeft({ corner.x(), corner.y() });
+    corner = skRect.radii(SkRRect::kUpperRight_Corner);
+    m_radii.setTopRight({ corner.x(), corner.y() });
+    corner = skRect.radii(SkRRect::kLowerRight_Corner);
+    m_radii.setBottomRight({ corner.x(), corner.y() });
+    corner = skRect.radii(SkRRect::kLowerLeft_Corner);
+    m_radii.setBottomLeft({ corner.x(), corner.y() });
+}
+
+FloatRoundedRect::operator SkRRect() const
+{
+    if (!isRounded())
+        return SkRRect::MakeRect(rect());
+
+    SkVector radii[4];
+    radii[SkRRect::kUpperLeft_Corner].set(m_radii.topLeft().width(), m_radii.topLeft().height());
+    radii[SkRRect::kUpperRight_Corner].set(m_radii.topRight().width(), m_radii.topRight().height());
+    radii[SkRRect::kLowerRight_Corner].set(m_radii.bottomRight().width(), m_radii.bottomRight().height());
+    radii[SkRRect::kLowerLeft_Corner].set(m_radii.bottomLeft().width(), m_radii.bottomLeft().height());
+    SkRRect skRect;
+    skRect.setRectRadii(rect(), radii);
+    return skRect;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -642,18 +642,9 @@ void GraphicsContextSkia::clipOut(const FloatRect& rect)
 
 void GraphicsContextSkia::fillRoundedRectImpl(const FloatRoundedRect& rect, const Color& color)
 {
-    auto skRect = SkRRect::MakeEmpty();
-    const auto& radii = rect.radii();
-    SkVector skRadii[4] = {
-        { SkFloatToScalar(radii.topLeft().width()), SkFloatToScalar(radii.topLeft().height()) },
-        { SkFloatToScalar(radii.topRight().width()), SkFloatToScalar(radii.topRight().height()) },
-        { SkFloatToScalar(radii.bottomLeft().width()), SkFloatToScalar(radii.bottomLeft().height()) },
-        { SkFloatToScalar(radii.bottomRight().width()), SkFloatToScalar(radii.bottomRight().height()) } };
-    skRect.setRectRadii(rect.rect(), skRadii);
-
     SkPaint paint = createFillPaint(color);
     paint.setImageFilter(createDropShadowFilterIfNeeded(ShadowStyle::Outset));
-    canvas().drawRRect(skRect, paint);
+    canvas().drawRRect(rect, paint);
 }
 
 void GraphicsContextSkia::fillRectWithRoundedHole(const FloatRect& outerRect, const FloatRoundedRect& innerRRect, const Color& color)
@@ -661,18 +652,9 @@ void GraphicsContextSkia::fillRectWithRoundedHole(const FloatRect& outerRect, co
     if (!color.isValid())
         return;
 
-    auto innerSkRect = SkRRect::MakeEmpty();
-    const auto& radii = innerRRect.radii();
-    SkVector skRadii[4] = {
-        { SkFloatToScalar(radii.topLeft().width()), SkFloatToScalar(radii.topLeft().height()) },
-        { SkFloatToScalar(radii.topRight().width()), SkFloatToScalar(radii.topRight().height()) },
-        { SkFloatToScalar(radii.bottomLeft().width()), SkFloatToScalar(radii.bottomLeft().height()) },
-        { SkFloatToScalar(radii.bottomRight().width()), SkFloatToScalar(radii.bottomRight().height()) } };
-    innerSkRect.setRectRadii(innerRRect.rect(), skRadii);
-
     SkPaint paint = createFillPaint(color);
     paint.setImageFilter(createDropShadowFilterIfNeeded(ShadowStyle::Inset));
-    canvas().drawDRRect(SkRRect::MakeRect(outerRect), innerSkRect, paint);
+    canvas().drawDRRect(SkRRect::MakeRect(outerRect), innerRRect, paint);
 }
 
 void GraphicsContextSkia::drawPattern(NativeImage& nativeImage, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -31,6 +31,7 @@
 #include "NotImplemented.h"
 #include "PathStream.h"
 #include <skia/core/SkPathUtils.h>
+#include <skia/core/SkRRect.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
@@ -167,7 +168,10 @@ void PathSkia::add(PathRect rect)
 
 void PathSkia::add(PathRoundedRect roundedRect)
 {
-    addBeziersForRoundedRect(roundedRect.roundedRect);
+    if (roundedRect.strategy == PathRoundedRect::Strategy::PreferNative)
+        m_platformPath.addRRect(roundedRect.roundedRect);
+    else
+        addBeziersForRoundedRect(roundedRect.roundedRect);
 }
 
 void PathSkia::add(PathCloseSubpath)


### PR DESCRIPTION
#### 7d9a6549eb1269c0d823ac95fe940f17f49a4b53
<pre>
[Skia] Use Skia API when adding rounded rect to path and strategy is PreferNative
<a href="https://bugs.webkit.org/show_bug.cgi?id=269845">https://bugs.webkit.org/show_bug.cgi?id=269845</a>

Reviewed by Adrian Perez de Castro.

Also add conversion operators between FloatRounrdedRect and SkRREct to
remove duplicated code.

* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/FloatRoundedRect.h:
* Source/WebCore/platform/graphics/skia/FloatRoundedRectSkia.cpp: Added.
(WebCore::FloatRoundedRect::FloatRoundedRect):
(WebCore::FloatRoundedRect::operator SkRRect const):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::fillRoundedRectImpl):
(WebCore::GraphicsContextSkia::fillRectWithRoundedHole):
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::add):

Canonical link: <a href="https://commits.webkit.org/275106@main">https://commits.webkit.org/275106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06df9c0a41bc8bc9b5adc7f6b1864ae5a41011db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43451 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36984 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33894 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40304 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38672 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17378 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5434 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->