### PR TITLE
[Cocoa] Audio distortion during media playback when many AudioContexts are created

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1818,6 +1818,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/PlatformMediaSessionManager.h
     platform/audio/PlatformRawAudioData.h
     platform/audio/PushPullFIFO.h
+    platform/audio/SharedAudioDestination.h
 
     platform/calc/CalcExpressionNode.h
     platform/calc/CalculationValue.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2210,6 +2210,7 @@ platform/audio/ReverbAccumulationBuffer.cpp
 platform/audio/ReverbConvolver.cpp
 platform/audio/ReverbConvolverStage.cpp
 platform/audio/ReverbInputBuffer.cpp
+platform/audio/SharedAudioDestination.cpp
 platform/audio/SincResampler.cpp
 platform/audio/StereoPanner.cpp
 platform/audio/UpSampler.cpp

--- a/Source/WebCore/platform/audio/SharedAudioDestination.cpp
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SharedAudioDestination.h"
+
+#if ENABLE(WEB_AUDIO)
+
+#include "AudioUtilities.h"
+#include <wtf/NeverDestroyed.h>
+#include <wtf/WTFSemaphore.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/WorkQueue.h>
+
+namespace WebCore {
+
+class SharedAudioDestinationAdapter : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SharedAudioDestinationAdapter>, public AudioIOCallback {
+public:
+    using AudioDestinationCreationFunction = SharedAudioDestination::AudioDestinationCreationFunction;
+    static Ref<SharedAudioDestinationAdapter> ensureAdapter(unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction);
+    ~SharedAudioDestinationAdapter();
+
+    void addRenderer(SharedAudioDestination&, CompletionHandler<void(bool)>&&);
+    void removeRenderer(SharedAudioDestination&, CompletionHandler<void(bool)>&&);
+
+    unsigned framesPerBuffer() const
+    {
+        return m_workBus->length();
+    }
+
+private:
+    using AdapterKey = std::tuple<unsigned, float>;
+    using AdapterMap = HashMap<AdapterKey, ThreadSafeWeakPtr<SharedAudioDestinationAdapter>>;
+    static AdapterMap& sharedMap();
+
+    SharedAudioDestinationAdapter(unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&&);
+
+    void render(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition) final;
+    void isPlayingDidChange() final { }
+
+    void configureRenderThread(CompletionHandler<void(bool)>&&);
+
+    Ref<AudioDestination> protectedDestination() { return m_destination; }
+    Ref<AudioBus> protectedWorkBus() { return m_workBus; }
+    Ref<WorkQueue> protectedConfigurationQueue() { return m_configurationQueue; }
+
+    unsigned m_numberOfOutputChannels;
+    float m_sampleRate;
+
+    Ref<AudioDestination> m_destination;
+    Ref<AudioBus> m_workBus;
+    Ref<WorkQueue> m_configurationQueue;
+
+    bool m_started { false };
+
+    Lock m_renderLock;
+    Semaphore m_configurationSemaphore;
+
+    // Only accessed on m_configurationQueue:
+    Vector<RefPtr<SharedAudioDestination>> m_renderers;
+
+    bool m_needsConfiguration WTF_GUARDED_BY_LOCK(m_renderLock) { true };
+    Vector<RefPtr<SharedAudioDestination>> m_newRenderers WTF_GUARDED_BY_LOCK(m_renderLock);
+
+    // Only accessed on the audio thread:
+    Vector<RefPtr<SharedAudioDestination>> m_configuredRenderers;
+};
+
+auto SharedAudioDestinationAdapter::sharedMap() -> AdapterMap&
+{
+    static MainThreadNeverDestroyed<AdapterMap> map;
+    return map;
+}
+
+Ref<SharedAudioDestinationAdapter> SharedAudioDestinationAdapter::ensureAdapter(unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction)
+{
+    std::tuple key { numberOfOutputChannels, sampleRate };
+    auto results = sharedMap().find(key);
+    if (results != sharedMap().end()) {
+        if (RefPtr existingAdapter = results->value.get())
+            return existingAdapter.releaseNonNull();
+    }
+
+    Ref newAdapter = adoptRef(*new SharedAudioDestinationAdapter(numberOfOutputChannels, sampleRate, WTFMove(ensureFunction)));
+    auto weakAdapter = ThreadSafeWeakPtr<SharedAudioDestinationAdapter> { newAdapter.get() };
+    sharedMap().set(key, WTFMove(weakAdapter));
+    return newAdapter;
+}
+
+SharedAudioDestinationAdapter::SharedAudioDestinationAdapter(unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction)
+    : m_numberOfOutputChannels { numberOfOutputChannels }
+    , m_sampleRate { sampleRate }
+    , m_destination { ensureFunction(*this) }
+    , m_workBus { AudioBus::create(numberOfOutputChannels, AudioUtilities::renderQuantumSize).releaseNonNull() }
+    , m_configurationQueue { WorkQueue::create("SharedAudioDestinationAdapter configuration queue") }
+    , m_configurationSemaphore(0)
+{
+}
+
+SharedAudioDestinationAdapter::~SharedAudioDestinationAdapter()
+{
+    auto key = std::make_tuple(m_numberOfOutputChannels, m_sampleRate);
+    sharedMap().remove(key);
+    protectedDestination()->clearCallback();
+}
+
+void SharedAudioDestinationAdapter::addRenderer(SharedAudioDestination& renderer, CompletionHandler<void(bool)>&& completionHandler)
+{
+    protectedConfigurationQueue()->dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, renderer = RefPtr { &renderer }, completionHandler = WTFMove(completionHandler)] () mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            callOnMainThread([completionHandler = WTFMove(completionHandler)] () mutable { completionHandler(false);
+            });
+            return;
+        }
+
+        if (!m_renderers.contains(renderer))
+            m_renderers.append(WTFMove(renderer));
+        configureRenderThread(WTFMove(completionHandler));
+    });
+}
+
+void SharedAudioDestinationAdapter::removeRenderer(SharedAudioDestination& renderer, CompletionHandler<void(bool)>&& completionHandler)
+{
+    protectedConfigurationQueue()->dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, renderer = RefPtr { &renderer }, completionHandler = WTFMove(completionHandler)] () mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            callOnMainThread([completionHandler = WTFMove(completionHandler)] () mutable { completionHandler(false);
+            });
+            return;
+        }
+
+        m_renderers.removeFirst(renderer);
+        configureRenderThread(WTFMove(completionHandler));
+    });
+}
+
+void SharedAudioDestinationAdapter::configureRenderThread(CompletionHandler<void(bool)>&& completionHandler)
+{
+    ASSERT(m_configurationQueue->isCurrent());
+    {
+        Locker locker { m_renderLock };
+        m_newRenderers = m_renderers;
+        m_needsConfiguration = true;
+    }
+
+    bool shouldStart = !m_started && !m_renderers.isEmpty();
+    bool shouldStop = m_started && m_renderers.isEmpty();
+
+    // If the destination has not been started, and the list of
+    // renderers is empty, do not wait for the render thread to
+    // finish configuration, as it will never run.
+    bool shouldSkipRendering = !m_started && m_renderers.isEmpty();
+
+    if (!shouldSkipRendering) {
+        // The AudioDestination must be started for configuration to take place.
+        if (shouldStart) {
+            // Dispatching to the main thread is required for destinations
+            // which are subclasses of AudioDestinationResampler.
+            callOnMainThreadAndWait([this] {
+                protectedDestination()->start(nullptr, [] (bool) { });
+            });
+            m_started = true;
+        }
+
+        m_configurationSemaphore.wait();
+
+        // The AudioDestination must not be stopped before configuration takes place.
+        if (shouldStop) {
+            // Dispatching to the main thread is required for destinations
+            // which are subclasses of AudioDestinationResampler.
+            callOnMainThreadAndWait([this] {
+                protectedDestination()->stop();
+            });
+            m_started = false;
+        }
+    }
+
+    // Move the previously configured list of renderers to the MainThread for destruction:
+    Vector<RefPtr<SharedAudioDestination>> renderersToDispose;
+    {
+        Locker locker { m_renderLock };
+        renderersToDispose = std::exchange(m_newRenderers, { });
+    }
+
+    callOnMainThread([completionHandler = WTFMove(completionHandler), renderersToDispose = WTFMove(renderersToDispose)]() mutable {
+        renderersToDispose.clear();
+        completionHandler(true);
+    });
+}
+
+void SharedAudioDestinationAdapter::render(AudioBus* sourceBus, AudioBus* destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition)
+{
+    if (m_renderLock.tryLock()) {
+        Locker locker { AdoptLock, m_renderLock };
+        if (m_needsConfiguration) {
+            // The SharedAudioDestinationAdapter avoids allocing or deallocing on the
+            // high priority audio thread by merely swapping the contents of the renderer
+            // configuration vectors. After the swap, the contents of m_newRenderers will
+            // be destroyed by configureRenderThread() on the m_configurationWorkQueue.
+            std::swap(m_newRenderers, m_configuredRenderers);
+            m_needsConfiguration = false;
+            m_configurationSemaphore.signal();
+        }
+    }
+
+    bool isFirstRenderer = true;
+    for (RefPtr renderer : m_configuredRenderers) {
+        if (isFirstRenderer) {
+            // The first renderer should render directly to destinationBus.
+            renderer->sharedRender(sourceBus, destinationBus, numberOfFrames, outputPosition);
+            isFirstRenderer = false;
+            continue;
+        }
+        // Subsequent renderers should render to the m_workBus, which will
+        // then be summed to the destinationBus.
+        Ref protectedWorkBus = this->protectedWorkBus();
+        renderer->sharedRender(sourceBus, protectedWorkBus.ptr(), numberOfFrames, outputPosition);
+        destinationBus->sumFrom(protectedWorkBus);
+    }
+}
+Ref<SharedAudioDestination> SharedAudioDestination::create(AudioIOCallback& callback, unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction)
+{
+    return adoptRef(*new SharedAudioDestination(callback, numberOfOutputChannels, sampleRate, WTFMove(ensureFunction)));
+}
+
+SharedAudioDestination::SharedAudioDestination(AudioIOCallback& callback, unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction)
+    : AudioDestination(callback, sampleRate)
+    , m_outputAdapter(SharedAudioDestinationAdapter::ensureAdapter(numberOfOutputChannels, sampleRate, WTFMove(ensureFunction)))
+{
+}
+
+SharedAudioDestination::~SharedAudioDestination()
+{
+    if (isPlaying())
+        stop([] (bool) { });
+}
+
+void SharedAudioDestination::start(Function<void(Function<void()>&&)>&& dispatchToRenderThread, CompletionHandler<void(bool)>&& completionHandler)
+{
+    {
+        Locker locker { m_dispatchToRenderThreadLock };
+        m_dispatchToRenderThread = WTFMove(dispatchToRenderThread);
+    }
+
+    setIsPlaying(true);
+    protectedOutputAdapter()->addRenderer(*this, WTFMove(completionHandler));
+}
+
+void SharedAudioDestination::stop(CompletionHandler<void(bool)>&& completionHandler)
+{
+    setIsPlaying(false);
+    protectedOutputAdapter()->removeRenderer(*this, WTFMove(completionHandler));
+
+    {
+        Locker locker { m_dispatchToRenderThreadLock };
+        m_dispatchToRenderThread = nullptr;
+    }
+}
+
+unsigned SharedAudioDestination::framesPerBuffer() const
+{
+    return m_outputAdapter->framesPerBuffer();
+}
+
+void SharedAudioDestination::setIsPlaying(bool isPlaying)
+{
+    ASSERT(isMainThread());
+
+    if (m_isPlaying == isPlaying)
+        return;
+
+    m_isPlaying = isPlaying;
+
+    {
+        Locker locker { m_callbackLock };
+        if (m_callback)
+            m_callback->isPlayingDidChange();
+    }
+}
+
+void SharedAudioDestination::sharedRender(AudioBus* sourceBus, AudioBus* destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition)
+{
+    if (!m_dispatchToRenderThreadLock.tryLock()) {
+        destinationBus->zero();
+        return;
+    }
+
+    Locker locker { AdoptLock, m_dispatchToRenderThreadLock };
+    if (!m_dispatchToRenderThread)
+        callRenderCallback(sourceBus, destinationBus, numberOfFrames, outputPosition);
+    else {
+        m_dispatchToRenderThread([protectedThis = Ref { *this }, sourceBus = RefPtr { sourceBus }, destinationBus = RefPtr { destinationBus }, numberOfFrames, outputPosition]() mutable {
+            protectedThis->callRenderCallback(sourceBus.get(), destinationBus.get(), numberOfFrames, outputPosition);
+        });
+    }
+}
+
+Ref<SharedAudioDestinationAdapter> SharedAudioDestination::protectedOutputAdapter()
+{
+    return m_outputAdapter;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/SharedAudioDestination.h
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUDIO)
+
+#include "AudioDestination.h"
+
+namespace WebCore {
+
+class SharedAudioDestinationAdapter;
+
+class SharedAudioDestination final : public AudioDestination, public ThreadSafeRefCounted<SharedAudioDestination, WTF::DestructionThread::Main> {
+public:
+    using AudioDestinationCreationFunction = Function<Ref<AudioDestination>(AudioIOCallback&)>;
+    WEBCORE_EXPORT static Ref<SharedAudioDestination> create(AudioIOCallback&, unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&&);
+    WEBCORE_EXPORT virtual ~SharedAudioDestination();
+
+    void ref() const final { return ThreadSafeRefCounted::ref(); }
+    void deref() const final { return ThreadSafeRefCounted::deref(); }
+
+    void sharedRender(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition&);
+
+private:
+    SharedAudioDestination(AudioIOCallback&, unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&&);
+
+    // AudioDestination
+    void start(Function<void(Function<void()>&&)>&& dispatchToRenderThread, CompletionHandler<void(bool)>&&) final;
+    void stop(CompletionHandler<void(bool)>&&) final;
+    bool isPlaying() final { return m_isPlaying; }
+    unsigned framesPerBuffer() const final;
+
+    void setIsPlaying(bool);
+
+    Ref<SharedAudioDestinationAdapter> protectedOutputAdapter();
+
+    Lock m_dispatchToRenderThreadLock;
+    Function<void(Function<void()>&&)> m_dispatchToRenderThread WTF_GUARDED_BY_LOCK(m_dispatchToRenderThreadLock);
+
+    bool m_isPlaying { false };
+    Ref<SharedAudioDestinationAdapter> m_outputAdapter;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
@@ -34,6 +34,7 @@
 #include "Logging.h"
 #include "MultiChannelResampler.h"
 #include "PushPullFIFO.h"
+#include "SharedAudioDestination.h"
 #include <algorithm>
 
 namespace WebCore {
@@ -56,8 +57,9 @@ Ref<AudioDestination> AudioDestination::create(AudioIOCallback& callback, const 
     if (AudioDestinationCocoa::createOverride)
         return AudioDestinationCocoa::createOverride(callback, sampleRate);
 
-    auto destination = adoptRef(*new AudioDestinationCocoa(callback, numberOfOutputChannels, sampleRate));
-    return destination;
+    return SharedAudioDestination::create(callback, numberOfOutputChannels, sampleRate, [numberOfOutputChannels, sampleRate] (AudioIOCallback& callback) {
+        return adoptRef(*new AudioDestinationCocoa(callback, numberOfOutputChannels, sampleRate));
+    });
 }
 
 float AudioDestination::hardwareSampleRate()

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
+#include "MediaPlayerPrivate.h"
 #include "MediaSource.h"
 #include "MediaSourcePrivateClient.h"
 #include "PlatformTimeRanges.h"

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/CDMFactory.h>
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/NowPlayingManager.h>
+#include <WebCore/SharedAudioDestination.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/MediaSessionManagerCocoa.h>
@@ -56,7 +57,9 @@ Ref<WebCore::AudioDestination> WebMediaStrategy::createAudioDestination(WebCore:
 {
 #if ENABLE(GPU_PROCESS)
     if (m_useGPUProcess)
-        return RemoteAudioDestinationProxy::create(callback, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate);
+        return WebCore::SharedAudioDestination::create(callback, numberOfOutputChannels, sampleRate, [inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate] (WebCore::AudioIOCallback& callback) {
+            return RemoteAudioDestinationProxy::create(callback, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate);
+        });
 #endif
     return WebCore::AudioDestination::create(callback, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate);
 }


### PR DESCRIPTION
#### a78127adb38a402b5d0fe6b17367aba32a38eb22
<pre>
[Cocoa] Audio distortion during media playback when many AudioContexts are created
<a href="https://bugs.webkit.org/show_bug.cgi?id=269833">https://bugs.webkit.org/show_bug.cgi?id=269833</a>
<a href="https://rdar.apple.com/122590884">rdar://122590884</a>

Reviewed by Chris Dumez.

In WebKit, each AudioContext created results in an additional thread serving that context&apos;s
AudioDestination. (In WebKitLegacy, each AudioContext will result in an additional
AudioOutputUnit running on a single high-priority audio thread.) When many threads
(or AudioOutputUnits) are created, the overhead alone can cause underruns. And when this
happens on the high-priority audio thread, it affects all audio playback within that
process.

Rather than create new threads or AudioOutputUnits (that are all rendering on the same
thread to the same buffer in the end) for each AudioContext, a shared AudioDestination
can be used for multiple AudioContext&apos;s with the same number of channels and sample rate.
For common scenarios, this means only one high-priority audio thread will be created
and serviced by a single AudioDestination. Specifically for WebKit, it means a single
RemoteAudioDestination/Proxy pair for each WebContent process.

* Source/WebCore/platform/audio/SharedAudioDestination.cpp: Added.
(WebCore::SharedAudioDestinationAdapter::framesPerBuffer const):
(WebCore::SharedAudioDestinationAdapter::sharedMap):
(WebCore::SharedAudioDestinationAdapter::ensureAdapter):
(WebCore::SharedAudioDestinationAdapter::SharedAudioDestinationAdapter):
(WebCore::m_configurationSemaphore):
(WebCore::SharedAudioDestinationAdapter::addRenderer):
(WebCore::SharedAudioDestinationAdapter::removeRenderer):
(WebCore::SharedAudioDestinationAdapter::configureRenderThread):
(WebCore::SharedAudioDestinationAdapter::render):
(WebCore::SharedAudioDestination::create):
(WebCore::SharedAudioDestination::SharedAudioDestination):
(WebCore::SharedAudioDestination::~SharedAudioDestination):
(WebCore::SharedAudioDestination::start):
(WebCore::SharedAudioDestination::stop):
(WebCore::SharedAudioDestination::framesPerBuffer const):
(WebCore::SharedAudioDestination::setIsPlaying):
* Source/WebCore/platform/audio/SharedAudioDestination.h: Added.
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp:
(WebCore::AudioDestination::create):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::createAudioDestination):

Canonical link: <a href="https://commits.webkit.org/275262@main">https://commits.webkit.org/275262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9b5c40c0d747eca45b325022c9ce9a84600d89f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41323 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34174 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14837 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40657 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39061 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17757 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9270 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->