### PR TITLE
Adopt dynamicDowncast<> in platform/calc/Calc*

### DIFF
--- a/Source/WebCore/platform/calc/CalcExpressionBlendLength.cpp
+++ b/Source/WebCore/platform/calc/CalcExpressionBlendLength.cpp
@@ -40,10 +40,14 @@ CalcExpressionBlendLength::CalcExpressionBlendLength(Length from, Length to, dou
 {
     // Flatten nesting of CalcExpressionBlendLength as a speculative fix for rdar://problem/30533005.
     // CalcExpressionBlendLength is only used as a result of animation and they don't nest in normal cases.
-    if (m_from.isCalculated() && m_from.calculationValue().expression().type() == CalcExpressionNodeType::BlendLength)
-        m_from = downcast<CalcExpressionBlendLength>(m_from.calculationValue().expression()).from();
-    if (m_to.isCalculated() && m_to.calculationValue().expression().type() == CalcExpressionNodeType::BlendLength)
-        m_to = downcast<CalcExpressionBlendLength>(m_to.calculationValue().expression()).to();
+    if (m_from.isCalculated()) {
+        if (auto* blendLength = dynamicDowncast<CalcExpressionBlendLength>(m_from.calculationValue().expression()))
+            m_from = blendLength->from();
+    }
+    if (m_to.isCalculated()) {
+        if (auto* blendLength =  dynamicDowncast<CalcExpressionBlendLength>(m_to.calculationValue().expression()))
+            m_to = blendLength->to();
+    }
 }
 
 float CalcExpressionBlendLength::evaluate(float maxValue) const
@@ -53,7 +57,8 @@ float CalcExpressionBlendLength::evaluate(float maxValue) const
 
 bool CalcExpressionBlendLength::operator==(const CalcExpressionNode& other) const
 {
-    return is<CalcExpressionBlendLength>(other) && *this == downcast<CalcExpressionBlendLength>(other);
+    auto* otherBlendLength = dynamicDowncast<CalcExpressionBlendLength>(other);
+    return otherBlendLength && *this == *otherBlendLength;
 }
 
 void CalcExpressionBlendLength::dump(TextStream& ts) const

--- a/Source/WebCore/platform/calc/CalcExpressionInversion.cpp
+++ b/Source/WebCore/platform/calc/CalcExpressionInversion.cpp
@@ -42,7 +42,8 @@ void CalcExpressionInversion::dump(TextStream& ts) const
 
 bool CalcExpressionInversion::operator==(const CalcExpressionNode& other) const
 {
-    return is<CalcExpressionInversion>(other) && *this == downcast<CalcExpressionInversion>(other);
+    auto otherExpressionInversion = dynamicDowncast<CalcExpressionInversion>(other);
+    return otherExpressionInversion && *this == *otherExpressionInversion;
 }
 
 bool operator==(const CalcExpressionInversion& a, const CalcExpressionInversion& b)

--- a/Source/WebCore/platform/calc/CalcExpressionLength.cpp
+++ b/Source/WebCore/platform/calc/CalcExpressionLength.cpp
@@ -38,7 +38,8 @@ float CalcExpressionLength::evaluate(float maxValue) const
 
 bool CalcExpressionLength::operator==(const CalcExpressionNode& other) const
 {
-    return is<CalcExpressionLength>(other) && *this == downcast<CalcExpressionLength>(other);
+    auto* otherExpressionLength = dynamicDowncast<CalcExpressionLength>(other);
+    return otherExpressionLength && *this == *otherExpressionLength;
 }
 
 void CalcExpressionLength::dump(TextStream& ts) const

--- a/Source/WebCore/platform/calc/CalcExpressionNegation.cpp
+++ b/Source/WebCore/platform/calc/CalcExpressionNegation.cpp
@@ -37,7 +37,8 @@ float CalcExpressionNegation::evaluate(float maxValue) const
 
 bool CalcExpressionNegation::operator==(const CalcExpressionNode& other) const
 {
-    return is<CalcExpressionNegation>(other) && *this == downcast<CalcExpressionNegation>(other);
+    auto* otherExpressionNegation = dynamicDowncast<CalcExpressionNegation>(other);
+    return otherExpressionNegation && *this == *otherExpressionNegation;
 }
 
 void CalcExpressionNegation::dump(TextStream& ts) const

--- a/Source/WebCore/platform/calc/CalcExpressionNumber.cpp
+++ b/Source/WebCore/platform/calc/CalcExpressionNumber.cpp
@@ -42,7 +42,8 @@ void CalcExpressionNumber::dump(TextStream& ts) const
 
 bool CalcExpressionNumber::operator==(const CalcExpressionNode& other) const
 {
-    return is<CalcExpressionNumber>(other) && *this == downcast<CalcExpressionNumber>(other);
+    auto* otherExpressionNumber = dynamicDowncast<CalcExpressionNumber>(other);
+    return otherExpressionNumber && *this == *otherExpressionNumber;
 }
 
 }

--- a/Source/WebCore/platform/calc/CalcExpressionOperation.cpp
+++ b/Source/WebCore/platform/calc/CalcExpressionOperation.cpp
@@ -38,7 +38,8 @@ float CalcExpressionOperation::evaluate(float maxValue) const
 
 bool CalcExpressionOperation::operator==(const CalcExpressionNode& other) const
 {
-    return is<CalcExpressionOperation>(other) && *this == downcast<CalcExpressionOperation>(other);
+    auto* otherExpressionOperation = dynamicDowncast<CalcExpressionOperation>(other);
+    return otherExpressionOperation && *this == *otherExpressionOperation;
 }
 
 bool operator==(const CalcExpressionOperation& a, const CalcExpressionOperation& b)


### PR DESCRIPTION
#### 6db9bb57df3bfff6c2a29bf793aaef9768d86b71
<pre>
Adopt dynamicDowncast&lt;&gt; in platform/calc/Calc*
<a href="https://bugs.webkit.org/show_bug.cgi?id=269857">https://bugs.webkit.org/show_bug.cgi?id=269857</a>

Reviewed by Chris Dumez.

* Source/WebCore/platform/calc/CalcExpressionBlendLength.cpp:
(WebCore::CalcExpressionBlendLength::CalcExpressionBlendLength):
(WebCore::CalcExpressionBlendLength::operator== const):
* Source/WebCore/platform/calc/CalcExpressionInversion.cpp:
(WebCore::CalcExpressionInversion::operator== const):
* Source/WebCore/platform/calc/CalcExpressionLength.cpp:
(WebCore::CalcExpressionLength::operator== const):
* Source/WebCore/platform/calc/CalcExpressionNegation.cpp:
(WebCore::CalcExpressionNegation::operator== const):
* Source/WebCore/platform/calc/CalcExpressionNumber.cpp:
(WebCore::CalcExpressionNumber::operator== const):
* Source/WebCore/platform/calc/CalcExpressionOperation.cpp:
(WebCore::CalcExpressionOperation::operator== const):

Canonical link: <a href="https://commits.webkit.org/275141@main">https://commits.webkit.org/275141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d352eaf76f87ad4fab4bb4b7e12804a878600bf0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33923 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40350 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38719 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17371 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9198 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17422 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->