### PR TITLE
WebContent process stays in the isUnderMemoryPressure state forever after it breaches the PROC_LIMIT_CRITICAL threshold

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -323,19 +323,25 @@ void MemoryPressureHandler::releaseMemory(Critical critical, Synchronous synchro
     platformReleaseMemory(critical);
 }
 
-void MemoryPressureHandler::setMemoryPressureStatus(MemoryPressureStatus memoryPressureStatus)
+void MemoryPressureHandler::setMemoryPressureStatus(SystemMemoryPressureStatus status)
 {
-    if (m_memoryPressureStatus == memoryPressureStatus)
+    if (m_memoryPressureStatus == status)
         return;
 
-    m_memoryPressureStatus = memoryPressureStatus;
+    m_memoryPressureStatus = status;
     memoryPressureStatusChanged();
 }
 
 void MemoryPressureHandler::memoryPressureStatusChanged()
 {
     if (m_memoryPressureStatusChangedCallback)
-        m_memoryPressureStatusChangedCallback(m_memoryPressureStatus);
+        m_memoryPressureStatusChangedCallback();
+}
+
+void MemoryPressureHandler::didExceedProcessMemoryLimit(ProcessMemoryLimit limit)
+{
+    if (m_didExceedProcessMemoryLimitCallback)
+        m_didExceedProcessMemoryLimitCallback(limit);
 }
 
 void MemoryPressureHandler::ReliefLogger::logMemoryUsageChange()

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -43,16 +43,15 @@
 
 namespace WTF {
 
-enum class MemoryPressureStatus : uint8_t {
+enum class SystemMemoryPressureStatus : uint8_t {
     Normal,
+    Warning,
+    Critical,
+};
 
-    // The entire system is at a warning or critical pressure level.
-    SystemWarning,
-    SystemCritical,
-
-    // This specific process crossed a warning or critical memory usage limit.
-    ProcessLimitWarning,
-    ProcessLimitCritical
+enum class ProcessMemoryLimit : uint8_t {
+    Warning,
+    Critical,
 };
 
 enum class MemoryUsagePolicy : uint8_t {
@@ -99,7 +98,8 @@ public:
 #endif
 
     void setMemoryKillCallback(WTF::Function<void()>&& function) { m_memoryKillCallback = WTFMove(function); }
-    void setMemoryPressureStatusChangedCallback(WTF::Function<void(MemoryPressureStatus)>&& function) { m_memoryPressureStatusChangedCallback = WTFMove(function); }
+    void setMemoryPressureStatusChangedCallback(WTF::Function<void()>&& function) { m_memoryPressureStatusChangedCallback = WTFMove(function); }
+    void setDidExceedProcessMemoryLimitCallback(WTF::Function<void(ProcessMemoryLimit)>&& function) { m_didExceedProcessMemoryLimitCallback = WTFMove(function); }
 
     void setLowMemoryHandler(LowMemoryHandler&& handler)
     {
@@ -108,9 +108,7 @@ public:
 
     bool isUnderMemoryWarning() const
     {
-        auto memoryPressureStatus = m_memoryPressureStatus.load();
-        return memoryPressureStatus == MemoryPressureStatus::SystemWarning
-            || memoryPressureStatus == MemoryPressureStatus::ProcessLimitWarning
+        return m_memoryPressureStatus == SystemMemoryPressureStatus::Warning
 #if PLATFORM(MAC)
             || m_memoryUsagePolicy == MemoryUsagePolicy::Conservative
 #endif
@@ -119,17 +117,16 @@ public:
 
     bool isUnderMemoryPressure() const
     {
-        auto memoryPressureStatus = m_memoryPressureStatus.load();
-        return memoryPressureStatus == MemoryPressureStatus::SystemCritical
-            || memoryPressureStatus == MemoryPressureStatus::ProcessLimitCritical
+        return m_memoryPressureStatus == SystemMemoryPressureStatus::Critical
 #if PLATFORM(MAC)
             || m_memoryUsagePolicy >= MemoryUsagePolicy::Strict
 #endif
             || m_isSimulatingMemoryPressure;
     }
+
     bool isSimulatingMemoryWarning() const { return m_isSimulatingMemoryWarning; }
     bool isSimulatingMemoryPressure() const { return m_isSimulatingMemoryPressure; }
-    void setMemoryPressureStatus(MemoryPressureStatus);
+    void setMemoryPressureStatus(SystemMemoryPressureStatus);
 
     WTF_EXPORT_PRIVATE MemoryUsagePolicy currentMemoryUsagePolicy();
 
@@ -228,6 +225,7 @@ private:
     MemoryPressureHandler();
     ~MemoryPressureHandler() = delete;
 
+    void didExceedProcessMemoryLimit(ProcessMemoryLimit);
     void respondToMemoryPressure(Critical, Synchronous = Synchronous::No);
     void platformReleaseMemory(Critical);
     void platformInitialize();
@@ -238,7 +236,7 @@ private:
 
     unsigned m_pageCount { 0 };
 
-    std::atomic<MemoryPressureStatus> m_memoryPressureStatus { MemoryPressureStatus::Normal };
+    std::atomic<SystemMemoryPressureStatus> m_memoryPressureStatus { SystemMemoryPressureStatus::Normal };
     bool m_installed { false };
     bool m_isSimulatingMemoryWarning { false };
     bool m_isSimulatingMemoryPressure { false };
@@ -250,7 +248,8 @@ private:
 
     std::unique_ptr<RunLoop::Timer>m_measurementTimer;
     WTF::Function<void()> m_memoryKillCallback;
-    WTF::Function<void(MemoryPressureStatus)> m_memoryPressureStatusChangedCallback;
+    WTF::Function<void()> m_memoryPressureStatusChangedCallback;
+    WTF::Function<void(ProcessMemoryLimit)> m_didExceedProcessMemoryLimitCallback;
     LowMemoryHandler m_lowMemoryHandler;
     Vector<size_t> m_memoryFootprintNotificationThresholds;
     WTF::Function<void(size_t)> m_memoryFootprintNotificationHandler;

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -91,28 +91,28 @@ void MemoryPressureHandler::install()
             switch (status) {
             // VM pressure events.
             case DISPATCH_MEMORYPRESSURE_NORMAL:
-                setMemoryPressureStatus(MemoryPressureStatus::Normal);
+                setMemoryPressureStatus(SystemMemoryPressureStatus::Normal);
                 break;
             case DISPATCH_MEMORYPRESSURE_WARN:
-                setMemoryPressureStatus(MemoryPressureStatus::SystemWarning);
+                setMemoryPressureStatus(SystemMemoryPressureStatus::Warning);
                 respondToMemoryPressure(Critical::No);
                 break;
             case DISPATCH_MEMORYPRESSURE_CRITICAL:
-                setMemoryPressureStatus(MemoryPressureStatus::SystemCritical);
+                setMemoryPressureStatus(SystemMemoryPressureStatus::Critical);
                 respondToMemoryPressure(Critical::Yes);
                 break;
             // Process memory limit events.
             case DISPATCH_MEMORYPRESSURE_PROC_LIMIT_WARN:
-                setMemoryPressureStatus(MemoryPressureStatus::ProcessLimitWarning);
+                didExceedProcessMemoryLimit(ProcessMemoryLimit::Warning);
                 respondToMemoryPressure(Critical::No);
                 break;
             case DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL:
-                setMemoryPressureStatus(MemoryPressureStatus::ProcessLimitCritical);
+                didExceedProcessMemoryLimit(ProcessMemoryLimit::Critical);
                 respondToMemoryPressure(Critical::Yes);
                 break;
             }
             if (m_shouldLogMemoryMemoryPressureEvents)
-                RELEASE_LOG(MemoryPressure, "Received memory pressure event %lu vm pressure %d", status, isUnderMemoryPressure());
+                RELEASE_LOG(MemoryPressure, "Received memory pressure event: %lu, system vm pressure critical: %d", status, isUnderMemoryPressure());
         });
         dispatch_resume(memoryPressureEventSource().get());
     });

--- a/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
+++ b/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
@@ -69,7 +69,7 @@ void MemoryPressureHandler::triggerMemoryPressureEvent(bool isCritical)
     if (ReliefLogger::loggingEnabled())
         LOG(MemoryPressure, "Got memory pressure notification (%s)", isCritical ? "critical" : "non-critical");
 
-    setMemoryPressureStatus(MemoryPressureStatus::SystemCritical);
+    setMemoryPressureStatus(SystemMemoryPressureStatus::Critical);
 
     ensureOnMainThread([this, isCritical] {
         respondToMemoryPressure(isCritical ? Critical::Yes : Critical::No);
@@ -78,7 +78,7 @@ void MemoryPressureHandler::triggerMemoryPressureEvent(bool isCritical)
     if (ReliefLogger::loggingEnabled() && isUnderMemoryPressure())
         LOG(MemoryPressure, "System is no longer under memory pressure.");
 
-    setMemoryPressureStatus(MemoryPressureStatus::Normal);
+    setMemoryPressureStatus(SystemMemoryPressureStatus::Normal);
 }
 
 void MemoryPressureHandler::install()

--- a/Source/WTF/wtf/win/MemoryPressureHandlerWin.cpp
+++ b/Source/WTF/wtf/win/MemoryPressureHandlerWin.cpp
@@ -38,12 +38,12 @@ void MemoryPressureHandler::platformInitialize()
 
 void MemoryPressureHandler::windowsMeasurementTimerFired()
 {
-    setMemoryPressureStatus(MemoryPressureStatus::Normal);
+    setMemoryPressureStatus(SystemMemoryPressureStatus::Normal);
 
     BOOL memoryLow;
 
     if (QueryMemoryResourceNotification(m_lowMemoryHandle.get(), &memoryLow) && memoryLow) {
-        setMemoryPressureStatus(MemoryPressureStatus::SystemCritical);
+        setMemoryPressureStatus(SystemMemoryPressureStatus::Critical);
         releaseMemory(Critical::Yes);
         return;
     }
@@ -60,7 +60,7 @@ void MemoryPressureHandler::windowsMeasurementTimerFired()
     const int maxMemoryUsageBytes = 0.9 * 1024 * 1024 * 1024;
 
     if (counters.PrivateUsage > maxMemoryUsageBytes) {
-        setMemoryPressureStatus(MemoryPressureStatus::ProcessLimitCritical);
+        didExceedProcessMemoryLimit(ProcessMemoryLimit::Critical);
         releaseMemory(Critical::Yes);
     }
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -481,14 +481,15 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
             parentProcessConnection()->send(Messages::WebProcessProxy::DidExceedMemoryFootprintThreshold(footprint), 0);
         });
 #endif
-        memoryPressureHandler.setMemoryPressureStatusChangedCallback([this](WTF::MemoryPressureStatus memoryPressureStatus) {
+        memoryPressureHandler.setMemoryPressureStatusChangedCallback([this]() {
             if (parentProcessConnection())
                 parentProcessConnection()->send(Messages::WebProcessProxy::MemoryPressureStatusChanged(MemoryPressureHandler::singleton().isUnderMemoryPressure()), 0);
-
-            if (memoryPressureStatus == WTF::MemoryPressureStatus::ProcessLimitWarning && !m_loggedProcessLimitWarningMemoryStatistics) {
+        });
+        memoryPressureHandler.setDidExceedProcessMemoryLimitCallback([this](WTF::ProcessMemoryLimit limit) {
+            if (limit == WTF::ProcessMemoryLimit::Warning && !m_loggedProcessLimitWarningMemoryStatistics) {
                 m_loggedProcessLimitWarningMemoryStatistics = true;
                 scheduleLogMemoryStatistics(LogMemoryStatisticsReason::WarningMemoryPressureNotification);
-            } else if (memoryPressureStatus == WTF::MemoryPressureStatus::ProcessLimitCritical && !m_loggedProcessLimitCriticalMemoryStatistics) {
+            } else if (limit == WTF::ProcessMemoryLimit::Critical && !m_loggedProcessLimitCriticalMemoryStatistics) {
                 m_loggedProcessLimitCriticalMemoryStatistics = true;
                 scheduleLogMemoryStatistics(LogMemoryStatisticsReason::CriticalMemoryPressureNotification);
             }


### PR DESCRIPTION
#### a45b3b20b1061b5faa7d063b15cfe93e24e7ee79
<pre>
WebContent process stays in the isUnderMemoryPressure state forever after it breaches the PROC_LIMIT_CRITICAL threshold
<a href="https://bugs.webkit.org/show_bug.cgi?id=269859">https://bugs.webkit.org/show_bug.cgi?id=269859</a>
<a href="https://rdar.apple.com/118126701">rdar://118126701</a>

Reviewed by Antti Koivisto.

After 244148@main, a WebContent process that exceeds the PROC_LIMIT_CRITICAL threshold ends up in
the isUnderMemoryPressure state forever. This is because we were mutating the memory pressure state
instance variable when handling the process limit notification. Since the OS only notifies you when
you exceed the proc limit, but not when you go back under the proc limit, that state variable ended
up staying in the critical state forever. (This bug has occurred before, see r234646.)

To fix this, stop mutating the memory pressure state when the process limit notification fires, and
add a separate callback for handling process limit notifications.

* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::setMemoryPressureStatus):
(WTF::MemoryPressureHandler::memoryPressureStatusChanged):
(WTF::MemoryPressureHandler::didExceedProcessMemoryLimit):
* Source/WTF/wtf/MemoryPressureHandler.h:
(WTF::MemoryPressureHandler::setMemoryPressureStatusChangedCallback):
(WTF::MemoryPressureHandler::setDidExceedProcessMemoryLimitCallback):
(WTF::MemoryPressureHandler::isUnderMemoryWarning const):
(WTF::MemoryPressureHandler::isUnderMemoryPressure const):
* Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm:
(WTF::MemoryPressureHandler::install):
* Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp:
(WTF::MemoryPressureHandler::triggerMemoryPressureEvent):
* Source/WTF/wtf/win/MemoryPressureHandlerWin.cpp:
(WTF::MemoryPressureHandler::windowsMeasurementTimerFired):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/275198@main">https://commits.webkit.org/275198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1fb266ec1562a9de268db1092f3c79d396f43ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43599 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37131 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33982 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44909 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34492 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37262 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40405 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15854 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12999 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38782 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17473 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47676 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9234 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17524 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9773 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->