### PR TITLE
REGRESSION(274164@main): Do not consult against Document's WeakHashSet for every Canvas ops

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1865,8 +1865,8 @@ public:
     const String& fragmentDirective() const { return m_fragmentDirective; }
 
     void prepareCanvasesForDisplayOrFlushIfNeeded();
-    void addCanvasNeedingPreparationForDisplayOrFlush(CanvasBase&);
-    void removeCanvasNeedingPreparationForDisplayOrFlush(CanvasBase&);
+    void addCanvasNeedingPreparationForDisplayOrFlush(CanvasRenderingContext&);
+    void removeCanvasNeedingPreparationForDisplayOrFlush(CanvasRenderingContext&);
 
     bool contains(const Node& node) const { return this == &node.treeScope() && node.isConnected(); }
     bool contains(const Node* node) const { return node && contains(*node); }

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -364,15 +364,25 @@ void CanvasBase::recordLastFillText(const String& text)
 
 void CanvasBase::addCanvasNeedingPreparationForDisplayOrFlush()
 {
+    auto* context = renderingContext();
+    if (!context)
+        return;
+    if (context->isInPreparationForDisplayOrFlush())
+        return;
     if (auto* document = dynamicDowncast<Document>(scriptExecutionContext()))
-        document->addCanvasNeedingPreparationForDisplayOrFlush(*this);
+        document->addCanvasNeedingPreparationForDisplayOrFlush(*context);
     // FIXME: WorkerGlobalContext does not have prepare phase yet.
 }
 
 void CanvasBase::removeCanvasNeedingPreparationForDisplayOrFlush()
 {
+    auto* context = renderingContext();
+    if (!context)
+        return;
+    if (!context->isInPreparationForDisplayOrFlush())
+        return;
     if (auto* document = dynamicDowncast<Document>(scriptExecutionContext()))
-        document->removeCanvasNeedingPreparationForDisplayOrFlush(*this);
+        document->removeCanvasNeedingPreparationForDisplayOrFlush(*context);
     // FIXME: WorkerGlobalContext does not have prepare phase yet.
 }
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -956,8 +956,11 @@ void HTMLCanvasElement::eventListenersDidChange()
 
 void HTMLCanvasElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
-    oldDocument.removeCanvasNeedingPreparationForDisplayOrFlush(*this);
-    newDocument.addCanvasNeedingPreparationForDisplayOrFlush(*this);
+    auto* context = renderingContext();
+    if (context) {
+        oldDocument.removeCanvasNeedingPreparationForDisplayOrFlush(*context);
+        newDocument.addCanvasNeedingPreparationForDisplayOrFlush(*context);
+    }
     HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -112,6 +112,9 @@ public:
     virtual DestinationColorSpace colorSpace() const;
     virtual OptionSet<ImageBufferOptions> adjustImageBufferOptionsForTesting(OptionSet<ImageBufferOptions> bufferOptions) { return bufferOptions; }
 
+    void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }
+    bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
+
 protected:
     explicit CanvasRenderingContext(CanvasBase&);
     bool taintsOrigin(const CanvasPattern*);
@@ -131,6 +134,7 @@ protected:
     void checkOrigin(const URL&);
     void checkOrigin(const CSSStyleImageValue&);
 
+    bool m_isInPreparationForDisplayOrFlush { false };
     bool m_hasActiveInspectorCanvasCallTracer { false };
 
 private:


### PR DESCRIPTION
#### 3e7f2c1bc01db4255c2de428d4b5d04ab054df86
<pre>
REGRESSION(274164@main): Do not consult against Document&apos;s WeakHashSet for every Canvas ops
<a href="https://bugs.webkit.org/show_bug.cgi?id=269867">https://bugs.webkit.org/show_bug.cgi?id=269867</a>
<a href="https://rdar.apple.com/123400342">rdar://123400342</a>

Reviewed by Ryosuke Niwa.

274164@main introduced addCanvasNeedingPreparationForDisplayOrFlush and removeCanvasNeedingPreparationForDisplayOrFlush, which consult against Document&apos;s WeakHashSet
for every Canvas operation. Because each Canvas operation is very tiny, Canvas operations are called super frequently, and any kind of performance regression on each
call can be exhibited as visible performance regression. WeakHashSet querying is costly, and Document is super large so frequent cache miss happens.
Instead, we store a bool flag to CanvasRenderingContext, which says whether it is registered in Document&apos;s WeakHashSet. And avoid this costly operation once it gets registered.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::prepareCanvasesForDisplayOrFlushIfNeeded):
(WebCore::Document::addCanvasNeedingPreparationForDisplayOrFlush):
(WebCore::Document::removeCanvasNeedingPreparationForDisplayOrFlush):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::addCanvasNeedingPreparationForDisplayOrFlush):
(WebCore::CanvasBase::removeCanvasNeedingPreparationForDisplayOrFlush):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::didMoveToNewDocument):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::setIsToPrepare):
(WebCore::CanvasRenderingContext::isInPreparationForDisplayOrFlush const):

Canonical link: <a href="https://commits.webkit.org/275137@main">https://commits.webkit.org/275137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e79ae52257a2daf26374452a55388522a32fc9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17304 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37158 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36605 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12948 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17445 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5459 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->