### PR TITLE
EmberJS Web Extension fails to detect Ember application.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
@@ -36,6 +36,9 @@ enum class WebExtensionContentWorldType : uint8_t {
     ContentScript,
     Native,
     WebPage,
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    Inspector,
+#endif
 };
 
 inline String toDebugString(WebExtensionContentWorldType contentWorldType)
@@ -49,6 +52,10 @@ inline String toDebugString(WebExtensionContentWorldType contentWorldType)
         return "native"_s;
     case WebExtensionContentWorldType::WebPage:
         return "web page"_s;
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    case WebExtensionContentWorldType::Inspector:
+        return "inspector"_s;
+#endif
     }
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in
@@ -29,6 +29,9 @@ enum class WebKit::WebExtensionContentWorldType : uint8_t {
     ContentScript,
     Native,
     WebPage,
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    Inspector,
+#endif
 }
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -50,6 +50,7 @@ struct WebExtensionContextParameters {
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
 #if ENABLE(INSPECTOR_EXTENSIONS)
+    Vector<WebExtensionContext::PageIdentifierTuple> inspectorPageIdentifiers;
     Vector<WebExtensionContext::PageIdentifierTuple> inspectorBackgroundPageIdentifiers;
 #endif
     Vector<WebExtensionContext::PageIdentifierTuple> popupPageIdentifiers;

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -36,6 +36,7 @@ struct WebKit::WebExtensionContextParameters {
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
 #if ENABLE(INSPECTOR_EXTENSIONS)
+    Vector<WebKit::WebExtensionContext::PageIdentifierTuple> inspectorPageIdentifiers;
     Vector<WebKit::WebExtensionContext::PageIdentifierTuple> inspectorBackgroundPageIdentifiers;
 #endif
     Vector<WebKit::WebExtensionContext::PageIdentifierTuple> popupPageIdentifiers;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
@@ -60,6 +60,9 @@ void WebExtensionContext::portPostMessage(WebExtensionContentWorldType targetCon
 
     switch (targetContentWorldType) {
     case WebExtensionContentWorldType::Main:
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    case WebExtensionContentWorldType::Inspector:
+#endif
         wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
             sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortMessageEvent(sendingPageProxyIdentifier, channelIdentifier, messageJSON));
         });
@@ -193,6 +196,9 @@ void WebExtensionContext::firePortDisconnectEventIfNeeded(WebExtensionContentWor
 
     switch (targetContentWorldType) {
     case WebExtensionContentWorldType::Main:
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    case WebExtensionContentWorldType::Inspector:
+#endif
         wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
             sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortDisconnectEvent(channelIdentifier));
         });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2507,6 +2507,22 @@ Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorB
 
     return result;
 }
+
+Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::inspectorPageIdentifiers() const
+{
+    Vector<PageIdentifierTuple> result;
+
+    for (auto [inspector, tab] : loadedInspectors()) {
+        RefPtr window = tab ? tab->window() : nullptr;
+
+        auto tabIdentifier = tab ? std::optional(tab->identifier()) : std::nullopt;
+        auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
+
+        result.append({ inspector->inspectorPage()->webPageID(), tabIdentifier, windowIdentifier });
+    }
+
+    return result;
+}
 #endif // ENABLE(INSPECTOR_EXTENSIONS)
 
 Vector<WebExtensionContext::PageIdentifierTuple> WebExtensionContext::popupPageIdentifiers() const
@@ -2886,7 +2902,7 @@ void WebExtensionContext::performTasksAfterBackgroundContentLoads()
     }).get());
 }
 
-void WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet types, CompletionHandler<void()>&& completionHandler)
+void WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet&& types, CompletionHandler<void()>&& completionHandler)
 {
     if (extension().backgroundContentIsPersistent()) {
         completionHandler();
@@ -3214,6 +3230,7 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
 
         Ref process = webView._page->process();
         ASSERT(inspectorWebView._page->process() == process);
+        process->send(Messages::WebExtensionContextProxy::AddInspectorPageIdentifier(inspectorWebView._page->webPageID(), tab->identifier(), windowIdentifier), identifier());
         process->send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(webView._page->webPageID(), tab->identifier(), windowIdentifier), identifier());
         process->send(Messages::WebExtensionContextProxy::DispatchDevToolsPanelsThemeChangedEvent(appearance), identifier());
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -161,6 +161,7 @@ public:
     using EventListenerTypeCountedSet = HashCountedSet<WebExtensionEventListenerType>;
     using EventListenerTypePageMap = HashMap<WebExtensionEventListenerTypeWorldPair, WeakPageCountedSet>;
     using EventListenerTypeSet = HashSet<WebExtensionEventListenerType>;
+    using ContentWorldTypeSet = HashSet<WebExtensionContentWorldType>;
     using VoidCompletionHandlerVector = Vector<CompletionHandler<void()>>;
 
     using WindowIdentifierMap = HashMap<WebExtensionWindowIdentifier, Ref<WebExtensionWindow>>;
@@ -446,6 +447,7 @@ public:
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier() const;
 #if ENABLE(INSPECTOR_EXTENSIONS)
     Vector<PageIdentifierTuple> inspectorBackgroundPageIdentifiers() const;
+    Vector<PageIdentifierTuple> inspectorPageIdentifiers() const;
 #endif
     Vector<PageIdentifierTuple> popupPageIdentifiers() const;
     Vector<PageIdentifierTuple> tabPageIdentifiers() const;
@@ -463,10 +465,19 @@ public:
     void cookiesDidChange(API::HTTPCookieStore&);
 
     void wakeUpBackgroundContentIfNecessary(CompletionHandler<void()>&&);
-    void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet, CompletionHandler<void()>&&);
+    void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet&&, CompletionHandler<void()>&&);
 
-    HashSet<Ref<WebProcessProxy>> processes(WebExtensionEventListenerType, WebExtensionContentWorldType) const;
-    HashSet<Ref<WebProcessProxy>> processes(EventListenerTypeSet, WebExtensionContentWorldType) const;
+    HashSet<Ref<WebProcessProxy>> processes(WebExtensionEventListenerType type, WebExtensionContentWorldType contentWorldType) const
+    {
+        return processes(EventListenerTypeSet { type }, contentWorldType);
+    }
+
+    HashSet<Ref<WebProcessProxy>> processes(EventListenerTypeSet&& typeSet, WebExtensionContentWorldType contentWorldType) const
+    {
+        return processes(WTFMove(typeSet), ContentWorldTypeSet { contentWorldType });
+    }
+
+    HashSet<Ref<WebProcessProxy>> processes(EventListenerTypeSet&&, ContentWorldTypeSet&&) const;
 
     const UserContentControllerProxySet& userContentControllers() const;
 
@@ -479,7 +490,7 @@ public:
     void sendToProcessesForEvent(WebExtensionEventListenerType, const T& message) const;
 
     template<typename T>
-    void sendToProcessesForEvents(EventListenerTypeSet, const T& message) const;
+    void sendToProcessesForEvents(EventListenerTypeSet&&, const T& message) const;
 
     template<typename T>
     void sendToContentScriptProcessesForEvent(WebExtensionEventListenerType, const T& message) const;
@@ -886,9 +897,9 @@ void WebExtensionContext::sendToProcessesForEvent(WebExtensionEventListenerType 
 }
 
 template<typename T>
-void WebExtensionContext::sendToProcessesForEvents(EventListenerTypeSet typeSet, const T& message) const
+void WebExtensionContext::sendToProcessesForEvents(EventListenerTypeSet&& typeSet, const T& message) const
 {
-    sendToProcesses(processes(typeSet, WebExtensionContentWorldType::Main), message);
+    sendToProcesses(processes(WTFMove(typeSet), WebExtensionContentWorldType::Main), message);
 }
 
 template<typename T>

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -623,6 +623,9 @@ void WebExtensionContextProxy::dispatchRuntimeMessageEvent(WebExtensionContentWo
 {
     switch (contentWorldType) {
     case WebExtensionContentWorldType::Main:
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    case WebExtensionContentWorldType::Inspector:
+#endif
         ASSERT(!frameIdentifier);
         internalDispatchRuntimeMessageEvent(contentWorldType, messageJSON, std::nullopt, senderParameters, WTFMove(completionHandler));
         return;
@@ -677,6 +680,9 @@ void WebExtensionContextProxy::dispatchRuntimeConnectEvent(WebExtensionContentWo
 {
     switch (contentWorldType) {
     case WebExtensionContentWorldType::Main:
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    case WebExtensionContentWorldType::Inspector:
+#endif
         ASSERT(!frameIdentifier);
         internalDispatchRuntimeConnectEvent(contentWorldType, channelIdentifier, name, std::nullopt, senderParameters, WTFMove(completionHandler));
         return;

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -137,6 +137,9 @@ WebCore::DOMWrapperWorld& WebExtensionContextProxy::toDOMWrapperWorld(WebExtensi
     switch (contentWorldType) {
     case WebExtensionContentWorldType::Main:
     case WebExtensionContentWorldType::WebPage:
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    case WebExtensionContentWorldType::Inspector:
+#endif
         return mainWorld();
     case WebExtensionContentWorldType::ContentScript:
         return contentScriptWorld();

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -77,9 +77,9 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
     auto contentWorldType = isMainWorld ? WebExtensionContentWorldType::Main : WebExtensionContentWorldType::ContentScript;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    if (extension->isInspectorBackgroundPage(page)) {
-        // Inspector background pages have a limited set of APIs (like content scripts).
-        contentWorldType = WebExtensionContentWorldType::ContentScript;
+    if (page.isInspectorPage() || extension->isInspectorBackgroundPage(page)) {
+        // Inspector pages have a limited set of APIs (like content scripts).
+        contentWorldType = WebExtensionContentWorldType::Inspector;
     }
 #endif
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -59,6 +59,9 @@ std::optional<WebExtensionTabIdentifier> WebExtensionContextProxy::tabIdentifier
         return std::get<std::optional<WebExtensionTabIdentifier>>(m_tabPageMap.get(page));
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
+    if (m_inspectorPageMap.contains(page))
+        return std::get<std::optional<WebExtensionTabIdentifier>>(m_inspectorPageMap.get(page));
+
     if (m_inspectorBackgroundPageMap.contains(page))
         return std::get<std::optional<WebExtensionTabIdentifier>>(m_inspectorBackgroundPageMap.get(page));
 #endif
@@ -82,6 +85,17 @@ void WebExtensionContextProxy::setBackgroundPage(WebPage& page)
 }
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
+void WebExtensionContextProxy::addInspectorPage(WebPage& page, std::optional<WebExtensionTabIdentifier> tabIdentifier, std::optional<WebExtensionWindowIdentifier> windowIdentifier)
+{
+    m_inspectorPageMap.set(page, TabWindowIdentifierPair { tabIdentifier, windowIdentifier });
+}
+
+void WebExtensionContextProxy::addInspectorPageIdentifier(WebCore::PageIdentifier pageIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, std::optional<WebExtensionWindowIdentifier> windowIdentifier)
+{
+    if (RefPtr page = WebProcess::singleton().webPage(pageIdentifier))
+        addInspectorPage(*page, tabIdentifier, windowIdentifier);
+}
+
 void WebExtensionContextProxy::addInspectorBackgroundPageIdentifier(WebCore::PageIdentifier pageIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, std::optional<WebExtensionWindowIdentifier> windowIdentifier)
 {
     if (RefPtr page = WebProcess::singleton().webPage(pageIdentifier))

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -103,6 +103,8 @@ public:
     void setBackgroundPage(WebPage&);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
+    void addInspectorPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
+
     void addInspectorBackgroundPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
     bool isInspectorBackgroundPage(WebPage&) const;
 #endif
@@ -147,6 +149,7 @@ private:
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // DevTools
+    void addInspectorPageIdentifier(WebCore::PageIdentifier, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
     void addInspectorBackgroundPageIdentifier(WebCore::PageIdentifier, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
     void dispatchDevToolsExtensionPanelShownEvent(Inspector::ExtensionTabID, WebCore::FrameIdentifier);
     void dispatchDevToolsExtensionPanelHiddenEvent(Inspector::ExtensionTabID);
@@ -220,6 +223,7 @@ private:
     WeakFrameSet m_extensionContentFrames;
     WeakPtr<WebPage> m_backgroundPage;
 #if ENABLE(INSPECTOR_EXTENSIONS)
+    WeakPageTabWindowMap m_inspectorPageMap;
     WeakPageTabWindowMap m_inspectorBackgroundPageMap;
 #endif
     WeakPageTabWindowMap m_popupPageMap;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -41,6 +41,7 @@ messages -> WebExtensionContextProxy {
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // DevTools
+    AddInspectorPageIdentifier(WebCore::PageIdentifier pageID, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier)
     AddInspectorBackgroundPageIdentifier(WebCore::PageIdentifier pageID, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier)
     DispatchDevToolsExtensionPanelShownEvent(Inspector::ExtensionTabID identifier, WebCore::FrameIdentifier frameIdentifier)
     DispatchDevToolsExtensionPanelHiddenEvent(Inspector::ExtensionTabID identifier)


### PR DESCRIPTION
#### 7c0a7f074ef28ce5047f221780989c47e18e763c
<pre>
EmberJS Web Extension fails to detect Ember application.
<a href="https://webkit.org/b/269816">https://webkit.org/b/269816</a>
<a href="https://rdar.apple.com/problem/123338506">rdar://problem/123338506</a>

Reviewed by Brian Weinstein.

DevTools extensions need to use a custom content world type, that is similar to
Main but distinct since it has less APIs. Previously we were just using the
ContentScript world type to limit the APIs. This prevented message passing
from being delivered properly to the Inspector pages.

We also need the pass the Inspector page, tab, and window identifiers to the
web process so browser.devtools.inspectedWindow.tabId returns the correct value.

* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h:
(WebKit::toDebugString):
* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::portPostMessage):
(WebKit::WebExtensionContext::firePortDisconnectEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeSendMessage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::inspectorPageIdentifiers const):
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
(WebKit::WebExtensionContext::pageListensForEvent const):
(WebKit::WebExtensionContext::processes const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::sendToProcessesForEvents const):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchRuntimeMessageEvent):
(WebKit::WebExtensionContextProxy::dispatchRuntimeConnectEvent):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::toDOMWrapperWorld):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::tabIdentifier const):
(WebKit::WebExtensionContextProxy::addInspectorPage):
(WebKit::WebExtensionContextProxy::addInspectorPageIdentifier):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm:
(TEST(WKWebExtensionAPIDevTools, MessagePassingToBackground)): Added.
(TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToBackground)): Added.
(TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToDevToolsBackground)): Added.
(TEST(WKWebExtensionAPIDevTools, PortMessagePassingToBackground)): Added.
(TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToBackground)): Added.
(TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)): Added.

Canonical link: <a href="https://commits.webkit.org/275135@main">https://commits.webkit.org/275135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/593374d88102f146921ac637d85fb948660d3b8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19989 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/43354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43535 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43283 "Failed to checkout and rebase branch from PR 24899") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17320 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41550 "Failed to checkout and rebase branch from PR 24899") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/16918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/43354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/43354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44836 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/43354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/43354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5457 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->