### PR TITLE
[JSC] Set correct ConstructorKind when reparsing functions

### DIFF
--- a/Source/JavaScriptCore/API/JSScriptRef.cpp
+++ b/Source/JavaScriptCore/API/JSScriptRef.cpp
@@ -72,10 +72,9 @@ private:
 
 static bool parseScript(VM& vm, const SourceCode& source, ParserError& error)
 {
-    return !!JSC::parse<JSC::ProgramNode>(
-        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
-        JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, FunctionMode::None, SuperBinding::NotNeeded,
-        error);
+    return !!parseRootNode<ProgramNode>(
+        vm, source, ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
+        JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, error);
 }
 
 extern "C" {

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -219,10 +219,10 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
         JSTextPosition positionBeforeLastNewlineFromParser;
         ParserError error;
         JSParserBuiltinMode builtinMode = isBuiltinDefaultClassConstructor ? JSParserBuiltinMode::NotBuiltin : JSParserBuiltinMode::Builtin;
-        std::unique_ptr<ProgramNode> program = parse<ProgramNode>(
-            vm, source, Identifier(), implementationVisibility, builtinMode,
-            JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, FunctionMode::None, SuperBinding::NotNeeded, error,
-            &positionBeforeLastNewlineFromParser, constructorKind);
+        std::unique_ptr<ProgramNode> program = parseRootNode<ProgramNode>(
+            vm, source, implementationVisibility, builtinMode,
+            JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, error,
+            constructorKind, &positionBeforeLastNewlineFromParser);
 
         if (program) {
             StatementNode* exprStatement = program->singleStatement();

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -57,7 +57,7 @@ static UnlinkedFunctionCodeBlock* generateUnlinkedFunctionCodeBlock(
     ASSERT(isFunctionParseMode(executable->parseMode()));
     auto* classElementDefinitions = executable->classElementDefinitions();
     std::unique_ptr<FunctionNode> function = parse<FunctionNode>(
-        vm, source, executable->name(), executable->implementationVisibility(), builtinMode, strictMode, scriptMode, executable->parseMode(), executable->functionMode(), executable->superBinding(), error, nullptr, ConstructorKind::None, DerivedContextType::None, EvalContextType::None, nullptr, nullptr, classElementDefinitions);
+        vm, source, executable->name(), executable->implementationVisibility(), builtinMode, strictMode, scriptMode, executable->parseMode(), executable->functionMode(), executable->superBinding(), error, executable->constructorKind(), executable->derivedContextType(), EvalContextType::None, nullptr, classElementDefinitions);
 
     if (!function) {
         ASSERT(error.isValid());

--- a/Source/JavaScriptCore/debugger/DebuggerParseData.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerParseData.cpp
@@ -176,10 +176,9 @@ bool gatherDebuggerParseData(VM& vm, const SourceCode& source, DebuggerParseData
     JSParserScriptMode scriptMode = DebuggerParseInfo<T>::scriptMode;
 
     ParserError error;
-    std::unique_ptr<RootNode> rootNode = parse<RootNode>(vm, source, Identifier(), ImplementationVisibility::Public,
-        JSParserBuiltinMode::NotBuiltin, strictMode, scriptMode, parseMode, FunctionMode::None, SuperBinding::NotNeeded,
-        error, nullptr, ConstructorKind::None, DerivedContextType::None, EvalContextType::None,
-        &debuggerParseData);
+    std::unique_ptr<RootNode> rootNode = parseRootNode<RootNode>(vm, source, ImplementationVisibility::Public,
+        JSParserBuiltinMode::NotBuiltin, strictMode, scriptMode, parseMode,
+        error, ConstructorKind::None, nullptr, &debuggerParseData);
     if (!rootNode)
         return false;
 

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -80,7 +80,7 @@ UnlinkedCodeBlockType* generateUnlinkedCodeBlockImpl(VM& vm, const SourceCode& s
     bool isInsideOrdinaryFunction = executable && executable->isInsideOrdinaryFunction();
 
     std::unique_ptr<RootNode> rootNode = parse<RootNode>(
-        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin, strictMode, scriptMode, CacheTypes<UnlinkedCodeBlockType>::parseMode, FunctionMode::None, SuperBinding::NotNeeded, error, nullptr, ConstructorKind::None, derivedContextType, evalContextType, nullptr, privateNameEnvironment, nullptr, isInsideOrdinaryFunction);
+        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin, strictMode, scriptMode, CacheTypes<UnlinkedCodeBlockType>::parseMode, FunctionMode::None, SuperBinding::NotNeeded, error, ConstructorKind::None, derivedContextType, evalContextType, privateNameEnvironment, nullptr, isInsideOrdinaryFunction);
 
     if (!rootNode)
         return nullptr;

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -43,9 +43,9 @@ namespace JSC {
 
 static inline bool checkSyntaxInternal(VM& vm, const SourceCode& source, ParserError& error)
 {
-    return !!parse<ProgramNode>(
-        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
-        JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, FunctionMode::None, SuperBinding::NotNeeded, error);
+    return !!parseRootNode<ProgramNode>(
+        vm, source, ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
+        JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, error);
 }
 
 bool checkSyntax(JSGlobalObject* globalObject, const SourceCode& source, JSValue* returnedException)
@@ -75,9 +75,9 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
-    std::unique_ptr<ModuleProgramNode> moduleProgramNode = parse<ModuleProgramNode>(
-        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
-        JSParserStrictMode::Strict, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, FunctionMode::None, SuperBinding::NotNeeded, error);
+    std::unique_ptr<ModuleProgramNode> moduleProgramNode = parseRootNode<ModuleProgramNode>(
+        vm, source, ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
+        JSParserStrictMode::Strict, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, error);
     if (!moduleProgramNode)
         return false;
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -361,9 +361,9 @@ JSC_DEFINE_HOST_FUNCTION(moduleLoaderParseModule, (JSGlobalObject* globalObject,
     }
 
     ParserError error;
-    std::unique_ptr<ModuleProgramNode> moduleProgramNode = parse<ModuleProgramNode>(
-        vm, sourceCode, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
-        JSParserStrictMode::Strict, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, FunctionMode::None, SuperBinding::NotNeeded, error);
+    std::unique_ptr<ModuleProgramNode> moduleProgramNode = parseRootNode<ModuleProgramNode>(
+        vm, sourceCode, ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
+        JSParserStrictMode::Strict, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, error);
     if (error.isValid())
         RELEASE_AND_RETURN(scope, JSValue::encode(rejectWithError(error.toErrorObject(globalObject, sourceCode))));
     ASSERT(moduleProgramNode);


### PR DESCRIPTION
#### d8aca95c28f69862452c6d9c8a92e169a337c3e5
<pre>
[JSC] Set correct ConstructorKind when reparsing functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=269869">https://bugs.webkit.org/show_bug.cgi?id=269869</a>
&lt;<a href="https://rdar.apple.com/problem/123401267">rdar://problem/123401267</a>&gt;

Reviewed by Justin Michaud.

Before this change, when reparsing a function, ConstructorKind was always set to None,
which prevents a parser-level workaround to fix <a href="https://webkit.org/b/268411.">https://webkit.org/b/268411.</a>
Also, ConstructorKind was abused to allow super() in eval(): please see Parser constructor.

However, passing down ConstructorKind to parser isn&apos;t trivial as it would conflict with
`defaultConstructorKindForTopLevelFunction` that is needed only for bytecode validation.

To avoid using one parameter for two purposes, this patch extracts parseRootNode(), which has
parameters special for debugger / bytecode validation while lacking ones needed only for functions.
overrideConstructorKindForTopLevelFunctionExpressions() is introduced for the same purpose.

Also, this change:
  * passes correct DerivedContextType for eval() and reimplements SyntaxError check for super(),
    all to avoid setting ConstructorKind for non-functions;
  * hoists ConstructorKind override for bytecode validation up to parseFunctionExpression() to
    limit the surface of this bytecode validation only hack;
  * removes unused ParsingContext::Eval.

No new tests, no behavior change.

* Source/JavaScriptCore/API/JSScriptRef.cpp:
(parseScript):
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::generateUnlinkedFunctionCodeBlock):
* Source/JavaScriptCore/debugger/DebuggerParseData.cpp:
(JSC::gatherDebuggerParseData):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::Parser):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
(JSC::Parser&lt;LexerType&gt;::parseFunctionExpression):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::setDerivedContextType):
(JSC::Scope::derivedContextType const):
(JSC::Parser::overrideConstructorKindForTopLevelFunctionExpressions):
(JSC::parse):
(JSC::parseRootNode):
* Source/JavaScriptCore/runtime/CodeCache.cpp:
(JSC::generateUnlinkedCodeBlockImpl):
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::checkSyntaxInternal):
(JSC::checkModuleSyntax):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/275189@main">https://commits.webkit.org/275189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c882b2b8a2df496402e8186ffef107880dc82ac1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37053 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33934 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44842 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34414 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40361 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40587 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38730 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17395 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47598 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17446 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9768 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5479 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->