### PR TITLE
baseline-shift initial value should be `0px` rather than `baseline`

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
@@ -12,7 +12,7 @@ background-image: none;
 background-origin: padding-box;
 background-repeat: repeat;
 background-size: auto;
-baseline-shift: baseline;
+baseline-shift: 0px;
 border-bottom-color: rgb(0, 0, 0);
 border-bottom-left-radius: 0px;
 border-bottom-right-radius: 0px;

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -11,7 +11,7 @@ background-image: none
 background-origin: padding-box
 background-repeat: repeat
 background-size: auto
-baseline-shift: baseline
+baseline-shift: 0px
 border-bottom-color: rgb(0, 0, 0)
 border-bottom-left-radius: 0px
 border-bottom-right-radius: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/inheritance-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Property alignment-baseline has initial value baseline
 PASS Property alignment-baseline does not inherit
-FAIL Property baseline-shift has initial value 0px assert_equals: expected "0px" but got "baseline"
+PASS Property baseline-shift has initial value 0px
 PASS Property baseline-shift does not inherit
 PASS Property dominant-baseline has initial value auto
 FAIL Property dominant-baseline inherits assert_equals: expected "central" but got "auto"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt
@@ -4,7 +4,7 @@ PASS Testing 'stroke-width' on '#box2'.
 PASS Testing 'stroke-width' on '#box3'.
 PASS Testing 'clip' on '#test4'.
 PASS Testing 'alignment-baseline'.
-PASS Testing 'baseline-shift'.
+FAIL Testing 'baseline-shift'. assert_equals: Default value. expected "baseline" but got "0px"
 PASS Testing 'clip-rule'.
 PASS Testing 'color'.
 FAIL Testing 'color-interpolation-filters'. assert_equals: Default value. expected "" but got "linearrgb"

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -10,7 +10,7 @@ rect: style.getPropertyValue(background-image) : none
 rect: style.getPropertyValue(background-origin) : padding-box
 rect: style.getPropertyValue(background-repeat) : repeat
 rect: style.getPropertyValue(background-size) : auto
-rect: style.getPropertyValue(baseline-shift) : baseline
+rect: style.getPropertyValue(baseline-shift) : 0px
 rect: style.getPropertyValue(border-bottom-color) : rgb(0, 0, 0)
 rect: style.getPropertyValue(border-bottom-left-radius) : 0px
 rect: style.getPropertyValue(border-bottom-right-radius) : 0px
@@ -252,7 +252,7 @@ g: style.getPropertyValue(background-image) : none
 g: style.getPropertyValue(background-origin) : padding-box
 g: style.getPropertyValue(background-repeat) : repeat
 g: style.getPropertyValue(background-size) : auto
-g: style.getPropertyValue(baseline-shift) : baseline
+g: style.getPropertyValue(baseline-shift) : 0px
 g: style.getPropertyValue(border-bottom-color) : rgb(0, 0, 0)
 g: style.getPropertyValue(border-bottom-left-radius) : 0px
 g: style.getPropertyValue(border-bottom-right-radius) : 0px

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -10,7 +10,7 @@ rect: style.getPropertyValue(background-image) : none
 rect: style.getPropertyValue(background-origin) : padding-box
 rect: style.getPropertyValue(background-repeat) : repeat
 rect: style.getPropertyValue(background-size) : auto
-rect: style.getPropertyValue(baseline-shift) : baseline
+rect: style.getPropertyValue(baseline-shift) : 0px
 rect: style.getPropertyValue(border-bottom-color) : rgb(0, 0, 0)
 rect: style.getPropertyValue(border-bottom-left-radius) : 0px
 rect: style.getPropertyValue(border-bottom-right-radius) : 0px
@@ -250,7 +250,7 @@ g: style.getPropertyValue(background-image) : none
 g: style.getPropertyValue(background-origin) : padding-box
 g: style.getPropertyValue(background-repeat) : repeat
 g: style.getPropertyValue(background-size) : auto
-g: style.getPropertyValue(baseline-shift) : baseline
+g: style.getPropertyValue(baseline-shift) : 0px
 g: style.getPropertyValue(border-bottom-color) : rgb(0, 0, 0)
 g: style.getPropertyValue(border-bottom-left-radius) : 0px
 g: style.getPropertyValue(border-bottom-right-radius) : 0px

--- a/LayoutTests/svg/css/scientific-numbers-expected.txt
+++ b/LayoutTests/svg/css/scientific-numbers-expected.txt
@@ -96,19 +96,19 @@ PASS getComputedStyle(text).baselineShift is "50px"
 
 Test behavior on overflow
 PASS getComputedStyle(text).baselineShift is "baseline"
+PASS getComputedStyle(text).baselineShift is "0px"
 PASS getComputedStyle(text).baselineShift is "baseline"
-PASS getComputedStyle(text).baselineShift is "baseline"
-PASS getComputedStyle(text).baselineShift is "baseline"
+PASS getComputedStyle(text).baselineShift is "0px"
 
 Invalid values
 PASS getComputedStyle(text).baselineShift is "baseline"
+PASS getComputedStyle(text).baselineShift is "0px"
 PASS getComputedStyle(text).baselineShift is "baseline"
+PASS getComputedStyle(text).baselineShift is "0px"
 PASS getComputedStyle(text).baselineShift is "baseline"
+PASS getComputedStyle(text).baselineShift is "0px"
 PASS getComputedStyle(text).baselineShift is "baseline"
-PASS getComputedStyle(text).baselineShift is "baseline"
-PASS getComputedStyle(text).baselineShift is "baseline"
-PASS getComputedStyle(text).baselineShift is "baseline"
-PASS getComputedStyle(text).baselineShift is "baseline"
+PASS getComputedStyle(text).baselineShift is "0px"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/svg/css/scientific-numbers.html
+++ b/LayoutTests/svg/css/scientific-numbers.html
@@ -101,18 +101,19 @@ test("5e1      ", "50px");
 
 debug("");
 debug("Test behavior on overflow");
-test("2E+500", "baseline");
-test("-2E+500", "baseline");
+test("2E+500", "0px");
+test("-2E+500", "0px");
 
 debug("");
 debug("Invalid values");
-test("50e0.0", "baseline");
-test("50 e0", "baseline");
-test("50e 0", "baseline");
-test("50.e0", "baseline");
+test("50e0.0", "0px");
+test("50 e0", "0px");
+test("50e 0", "0px");
+test("50.e0", "0px");
 
 var successfullyParsed = true;
 
-completeTest();</script>
+completeTest();
+</script>
 </body>
 </html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2432,7 +2432,7 @@
         },
         "baseline-shift": {
             "animation-type": "by computed value",
-            "initial": "baseline",
+            "initial": "0px",
             "values": [
                 "baseline",
                 "sub",

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
                   2004, 2005 Rob Buis <buis@kde.org>
-    Copyright (C) 2005-2017 Apple Inc. All rights reserved.
+    Copyright (C) 2005-2024 Apple Inc. All rights reserved.
     Copyright (C) Research In Motion Limited 2010. All rights reserved.
     Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
 
@@ -52,7 +52,7 @@ public:
     // Initial values for all the properties
     static AlignmentBaseline initialAlignmentBaseline() { return AlignmentBaseline::Baseline; }
     static DominantBaseline initialDominantBaseline() { return DominantBaseline::Auto; }
-    static BaselineShift initialBaselineShift() { return BaselineShift::Baseline; }
+    static BaselineShift initialBaselineShift() { return BaselineShift::Length; }
     static VectorEffect initialVectorEffect() { return VectorEffect::None; }
     static BufferedRendering initialBufferedRendering() { return BufferedRendering::Auto; }
     static WindRule initialClipRule() { return WindRule::NonZero; }
@@ -82,7 +82,7 @@ public:
     static String initialMarkerMidResource() { return String(); }
     static String initialMarkerEndResource() { return String(); }
     static MaskType initialMaskType() { return MaskType::Luminance; }
-    static SVGLengthValue initialBaselineShiftValue() { return SVGLengthValue(0, SVGLengthType::Number); }
+    static SVGLengthValue initialBaselineShiftValue() { return SVGLengthValue(0, SVGLengthType::Pixels); }
     static SVGLengthValue initialKerning() { return SVGLengthValue(0, SVGLengthType::Number); }
 
     // SVG CSS Property setters

--- a/Source/WebCore/style/values/svg/StyleSVGBaselineShift.h
+++ b/Source/WebCore/style/values/svg/StyleSVGBaselineShift.h
@@ -53,6 +53,11 @@ struct SVGBaselineShift {
     {
     }
 
+    SVGBaselineShift(CSS::ValueLiteral<CSS::LengthUnit::Px> literal)
+        : m_value { LengthPercentage { literal } }
+    {
+    }
+
     bool isBaseline() const { return WTF::holdsAlternative<CSS::Keyword::Baseline>(m_value); }
     bool isSub() const { return WTF::holdsAlternative<CSS::Keyword::Sub>(m_value); }
     bool isSuper() const { return WTF::holdsAlternative<CSS::Keyword::Super>(m_value); }


### PR DESCRIPTION
#### 6191387a5dda9101bb3e5a67429ec31583420a6b
<pre>
baseline-shift initial value should be `0px` rather than `baseline`

<a href="https://bugs.webkit.org/show_bug.cgi?id=269878">https://bugs.webkit.org/show_bug.cgi?id=269878</a>
<a href="https://rdar.apple.com/problem/123792212">rdar://problem/123792212</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium and Web Specification [1]:

[1] <a href="https://drafts.csswg.org/css-inline-3/#property-index">https://drafts.csswg.org/css-inline-3/#property-index</a>

As per web specification, the initial value for &apos;baseline-shift&apos; is &apos;0&apos; of `&lt;length-percentage&gt;`.

* Source/WebCore/css/CSSProperties.json:
Set the initial value of `baseline-shift` to `0px`.
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/inheritance-expected.txt: Rebaselined
* LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt: Rebaselined
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt: Ditto (failure matching with other browsers)
* LayoutTests/svg/css/getComputedStyle-basic-expected.txt:
* LayoutTests/svg/css/scientific-numbers.html: Updated
* LayoutTests/svg/css/scientific-numbers-expected.txt: Rebaselined
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6191387a5dda9101bb3e5a67429ec31583420a6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127952 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d1c5f11-c722-4218-92df-52e245f76e78) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132725 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93550 "1 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8e8d871-5900-46cf-8137-072535055d06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113226 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/626df86f-f524-4bae-abf8-28c7c8f08404) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32851 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28298 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182199 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34988 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37023 "Found 1 new test failure: http/tests/site-isolation/https-load.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141166 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140990 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44509 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29526 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108920 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36262 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116390 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43019 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7626 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42411 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42665 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42554 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->