### PR TITLE
[results.webkit.org] Pass branch to database query in suites view

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/suite_view.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/suite_view.py
@@ -58,7 +58,11 @@ class SuiteView(HasCommitContext):
         AssertRequest.query_kwargs_empty(**kwargs)
 
         with self.upload_controller.upload_context:
-            suites_by_configuration = self.upload_controller.upload_context.find_suites(configurations=configurations, recent=boolean_query(*recent)[0] if recent else True)
+            suites_by_configuration = self.upload_controller.upload_context.find_suites(
+                configurations=configurations,
+                recent=boolean_query(*recent)[0] if recent else True,
+                branch=branch[0] if branch else None,
+            )
             candidate_suites = set()
             for suites_for_config in suites_by_configuration.values():
                 for s in suites_for_config:
@@ -88,7 +92,11 @@ class SuiteView(HasCommitContext):
         AssertRequest.query_kwargs_empty(**kwargs)
 
         with self.upload_controller.upload_context:
-            suites_by_configuration = self.upload_controller.upload_context.find_suites(configurations=configurations, recent=boolean_query(*recent)[0] if recent else True)
+            suites_by_configuration = self.upload_controller.upload_context.find_suites(
+                configurations=configurations,
+                recent=boolean_query(*recent)[0] if recent else True,
+                branch=branch[0] if branch else None,
+            )
             candidate_suites = set()
             for suites_for_config in suites_by_configuration.values():
                 for s in suites_for_config:


### PR DESCRIPTION
#### d0b2303a3a8031c07672abf1f01a4d18c5042cc9
<pre>
[results.webkit.org] Pass branch to database query in suites view
<a href="https://bugs.webkit.org/show_bug.cgi?id=269882">https://bugs.webkit.org/show_bug.cgi?id=269882</a>
<a href="https://rdar.apple.com/123414141">rdar://123414141</a>

Reviewed by Dewei Zhu.

The &quot;suite&quot; view should pass branch arguments into its database query
similar to how the suite API endpoint does.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/suite_view.py:
(SuiteView): Pass branch into database query.

Canonical link: <a href="https://commits.webkit.org/275197@main">https://commits.webkit.org/275197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d6d1e9c65d2f4b5e7e752ec08dad49099f65f95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37098 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33959 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14586 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/40876 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44870 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40380 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38750 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41053 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17491 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5486 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->