### PR TITLE
Model Process CA layer hosting

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -228,7 +228,7 @@ void HTMLModelElement::notifyFinished(CachedResource& resource, const NetworkLoa
         m_resource->removeClient(*this);
         m_resource = nullptr;
 
-        if (auto* renderer = this->renderer())
+        if (CheckedPtr renderer = this->renderer())
             renderer->updateFromElement();
     };
 
@@ -308,6 +308,13 @@ PlatformLayer* HTMLModelElement::platformLayer() const
     return nullptr;
 }
 
+std::optional<LayerHostingContextIdentifier> HTMLModelElement::layerHostingContextIdentifier() const
+{
+    if (m_modelPlayer)
+        return m_modelPlayer->layerHostingContextIdentifier();
+    return std::nullopt;
+}
+
 void HTMLModelElement::sizeMayHaveChanged()
 {
     if (m_modelPlayer)
@@ -316,11 +323,20 @@ void HTMLModelElement::sizeMayHaveChanged()
         createModelPlayer();
 }
 
+void HTMLModelElement::didUpdateLayerHostingContextIdentifier(ModelPlayer& modelPlayer, LayerHostingContextIdentifier identifier)
+{
+    ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
+    ASSERT_UNUSED(identifier, identifier.toUInt64() > 0);
+
+    if (CheckedPtr renderer = this->renderer())
+        renderer->updateFromElement();
+}
+
 void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer)
 {
     ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
 
-    if (auto* renderer = this->renderer())
+    if (CheckedPtr renderer = this->renderer())
         renderer->updateFromElement();
 
     m_readyPromise->resolve(*this);

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -34,6 +34,7 @@
 #include "HTMLElement.h"
 #include "HTMLModelElementCamera.h"
 #include "IDLTypes.h"
+#include "LayerHostingContextIdentifier.h"
 #include "ModelPlayerClient.h"
 #include "PlatformLayer.h"
 #include "PlatformLayerIdentifier.h"
@@ -74,6 +75,8 @@ public:
 
     bool usesPlatformLayer() const;
     PlatformLayer* platformLayer() const;
+
+    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() const;
 
     void enterFullscreen();
 
@@ -149,6 +152,7 @@ private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
 
     // ModelPlayerClient overrides.
+    void didUpdateLayerHostingContextIdentifier(ModelPlayer&, LayerHostingContextIdentifier) final;
     void didFinishLoading(ModelPlayer&) final;
     void didFailLoading(ModelPlayer&, const ResourceError&) final;
     PlatformLayerIdentifier platformLayerID() final;

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "HTMLModelElementCamera.h"
+#include "LayerHostingContextIdentifier.h"
 #include "LayoutPoint.h"
 #include "LayoutSize.h"
 #include "PlatformLayer.h"
@@ -46,6 +47,7 @@ public:
     virtual void load(Model&, LayoutSize) = 0;
     virtual void sizeDidChange(LayoutSize) = 0;
     virtual PlatformLayer* layer() = 0;
+    virtual std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() = 0;
     virtual void enterFullscreen() = 0;
     virtual bool supportsMouseInteraction();
     virtual bool supportsDragging();

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -38,6 +38,7 @@ class WEBCORE_EXPORT ModelPlayerClient : public CanMakeWeakPtr<ModelPlayerClient
 public:
     virtual ~ModelPlayerClient();
 
+    virtual void didUpdateLayerHostingContextIdentifier(ModelPlayer&, LayerHostingContextIdentifier) = 0;
     virtual void didFinishLoading(ModelPlayer&) = 0;
     virtual void didFailLoading(ModelPlayer&, const ResourceError&) = 0;
     virtual PlatformLayerIdentifier platformLayerID() = 0;

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -54,6 +54,11 @@ PlatformLayer* DummyModelPlayer::layer()
     return nullptr;
 }
 
+std::optional<LayerHostingContextIdentifier> DummyModelPlayer::layerHostingContextIdentifier()
+{
+    return std::nullopt;
+}
+
 void DummyModelPlayer::sizeDidChange(LayoutSize)
 {
 }

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -44,6 +44,7 @@ private:
     void load(Model&, LayoutSize) override;
     void sizeDidChange(LayoutSize) override;
     PlatformLayer* layer() override;
+    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() override;
     void enterFullscreen() override;
     void handleMouseDown(const LayoutPoint&, MonotonicTime) override;
     void handleMouseMove(const LayoutPoint&, MonotonicTime) override;

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.h
@@ -58,6 +58,7 @@ private:
     void load(Model&, LayoutSize) override;
     void sizeDidChange(LayoutSize) override;
     CALayer *layer() override;
+    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() override;
     void enterFullscreen() override;
     void handleMouseDown(const LayoutPoint&, MonotonicTime) override;
     void handleMouseMove(const LayoutPoint&, MonotonicTime) override;

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelPlayer.mm
@@ -82,6 +82,11 @@ PlatformLayer* SceneKitModelPlayer::layer()
     return m_layer.get();
 }
 
+std::optional<LayerHostingContextIdentifier> SceneKitModelPlayer::layerHostingContextIdentifier()
+{
+    return std::nullopt;
+}
+
 void SceneKitModelPlayer::enterFullscreen()
 {
 }

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -539,6 +539,7 @@ public:
         BackgroundColor,
         Plugin,
         Model,
+        HostedModel,
         Host,
     };
 
@@ -546,6 +547,7 @@ public:
     virtual void setContentsToSolidColor(const Color&) { }
     virtual void setContentsToPlatformLayer(PlatformLayer*, ContentsLayerPurpose) { }
     virtual void setContentsToPlatformLayerHost(LayerHostingContextIdentifier) { }
+    virtual void setContentsToRemotePlatformContext(LayerHostingContextIdentifier, ContentsLayerPurpose) { }
     virtual void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) { }
     virtual void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose);
     WEBCORE_EXPORT virtual RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate* existing);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -340,6 +340,12 @@ Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(PlatformLayer* platf
     return PlatformCALayerCocoa::create(platformLayer, owner);
 }
 
+Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(LayerHostingContextIdentifier, PlatformCALayerClient* owner)
+{
+    ASSERT_NOT_REACHED_WITH_MESSAGE("GraphicsLayerCARemote::createPlatformCALayer should always be called instead of this, but this symbol is needed to compile WebKitLegacy.");
+    return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, owner);
+}
+
 #if ENABLE(MODEL_ELEMENT)
 Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(Ref<WebCore::Model>, PlatformCALayerClient* owner)
 {
@@ -1318,6 +1324,18 @@ void GraphicsLayerCA::setContentsToPlatformLayerHost(LayerHostingContextIdentifi
 
     m_contentsLayer = createPlatformCALayerHost(identifier, this);
     m_contentsLayerPurpose = GraphicsLayer::ContentsLayerPurpose::Host;
+    m_contentsDisplayDelegate = nullptr;
+    noteSublayersChanged();
+    noteLayerPropertyChanged(ContentsPlatformLayerChanged);
+}
+
+void GraphicsLayerCA::setContentsToRemotePlatformContext(LayerHostingContextIdentifier identifier, ContentsLayerPurpose purpose)
+{
+    if (m_contentsLayer && m_contentsLayer->hostingContextIdentifier() == identifier)
+        return;
+
+    m_contentsLayer = createPlatformCALayer(identifier, this);
+    m_contentsLayerPurpose = purpose;
     m_contentsDisplayDelegate = nullptr;
     noteSublayersChanged();
     noteLayerPropertyChanged(ContentsPlatformLayerChanged);
@@ -4232,6 +4250,8 @@ const char* GraphicsLayerCA::purposeNameForInnerLayer(PlatformCALayer& layer) co
             return "contents layer (plugin)";
         case ContentsLayerPurpose::Model:
             return "contents layer (model)";
+        case ContentsLayerPurpose::HostedModel:
+            return "contents layer (hosted model)";
         case ContentsLayerPurpose::Host:
             return "contents layer (host)";
         }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -152,6 +152,7 @@ public:
 #endif
     WEBCORE_EXPORT void setContentsToPlatformLayer(PlatformLayer*, ContentsLayerPurpose) override;
     WEBCORE_EXPORT void setContentsToPlatformLayerHost(LayerHostingContextIdentifier) override;
+    WEBCORE_EXPORT void setContentsToRemotePlatformContext(LayerHostingContextIdentifier, ContentsLayerPurpose) override;
     WEBCORE_EXPORT void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) override;
     WEBCORE_EXPORT void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose) override;
     WEBCORE_EXPORT PlatformLayerIdentifier setContentsToAsyncDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>, ContentsLayerPurpose);
@@ -272,6 +273,7 @@ private:
 
     virtual Ref<PlatformCALayer> createPlatformCALayer(PlatformCALayer::LayerType, PlatformCALayerClient* owner);
     virtual Ref<PlatformCALayer> createPlatformCALayer(PlatformLayer*, PlatformCALayerClient* owner);
+    virtual Ref<PlatformCALayer> createPlatformCALayer(LayerHostingContextIdentifier, PlatformCALayerClient*);
 #if ENABLE(MODEL_ELEMENT)
     virtual Ref<PlatformCALayer> createPlatformCALayer(Ref<WebCore::Model>, PlatformCALayerClient* owner);
 #endif

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1198,6 +1198,10 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         // but this is a runtime decision.
         if (element->usesPlatformLayer())
             m_graphicsLayer->setContentsToPlatformLayer(element->platformLayer(), GraphicsLayer::ContentsLayerPurpose::Model);
+#if ENABLE(MODEL_PROCESS)
+        else if (auto contextID = element->layerHostingContextIdentifier(); contextID && element->document().settings().modelProcessEnabled())
+            m_graphicsLayer->setContentsToRemotePlatformContext(contextID.value(), GraphicsLayer::ContentsLayerPurpose::HostedModel);
+#endif
         else if (auto model = element->model())
             m_graphicsLayer->setContentsToModel(WTFMove(model), element->isInteractive() ? GraphicsLayer::ModelInteraction::Enabled : GraphicsLayer::ModelInteraction::Disabled);
 
@@ -1205,7 +1209,7 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
 
         layerConfigChanged = true;
     }
-#endif
+#endif // ENABLE(MODEL_ELEMENT)
     // FIXME: Why do we do this twice?
     if (CheckedPtr widget = dynamicDowncast<RenderWidget>(renderer()); widget && compositor.attachWidgetContentLayers(*widget)) {
         m_owningLayer.setNeedsCompositingGeometryUpdate();

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -196,7 +196,6 @@ set(WebKit_MESSAGES_IN_FILES
     ModelProcess/ModelConnectionToWebProcess
     ModelProcess/ModelProcess
     ModelProcess/ModelProcessModelPlayerManagerProxy
-    ModelProcess/ModelProcessModelPlayerProxy
 
     NetworkProcess/Cookies/WebCookieManager
 

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -120,6 +120,7 @@ $(PROJECT_DIR)/ModelProcess/ModelProcess.messages.in
 $(PROJECT_DIR)/ModelProcess/ModelProcessCreationParameters.serialization.in
 $(PROJECT_DIR)/ModelProcess/ModelProcessModelPlayerManagerProxy.messages.in
 $(PROJECT_DIR)/ModelProcess/ModelProcessModelPlayerProxy.messages.in
+$(PROJECT_DIR)/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
 $(PROJECT_DIR)/Modules/OSX_Private.modulemap
 $(PROJECT_DIR)/Modules/iOS_Private.modulemap
 $(PROJECT_DIR)/NetworkProcess/Classifier/ITPThirdPartyData.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -328,7 +328,7 @@ MESSAGE_RECEIVERS = \
 	ModelProcess/ModelConnectionToWebProcess \
 	ModelProcess/ModelProcess \
 	ModelProcess/ModelProcessModelPlayerManagerProxy \
-	ModelProcess/ModelProcessModelPlayerProxy \
+	ModelProcess/cocoa/ModelProcessModelPlayerProxy \
 	webpushd/PushClientConnection \
 #
 

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -26,9 +26,9 @@
 #include "config.h"
 #include "ModelProcessModelPlayerManagerProxy.h"
 
-#include "ModelProcessModelPlayerProxy.h"
-
 #if ENABLE(MODEL_PROCESS)
+
+#include "ModelProcessModelPlayerProxy.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -28,16 +28,17 @@
 #if ENABLE(MODEL_PROCESS)
 
 #include "Connection.h"
+#include "LayerHostingContext.h"
 #include "MessageReceiver.h"
+
+#include <QuartzCore/CALayer.h>
+#include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/ModelPlayer.h>
 #include <WebCore/ModelPlayerIdentifier.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-}
 
 namespace WebKit {
 
@@ -54,20 +55,27 @@ public:
     WebCore::ModelPlayerIdentifier identifier() const { return m_id; }
     void invalidate();
 
+    std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return WebCore::LayerHostingContextIdentifier(m_layerHostingContext->contextID()); }
+
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    template<typename T> void send(T&& message);
 
     // Messages
-    void loadModel();
+    void createLayer();
+    void loadModel(Ref<WebCore::Model>&&, WebCore::LayoutSize);
+    void sizeDidChange(WebCore::LayoutSize);
 
 private:
     ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&);
 
     WebCore::ModelPlayerIdentifier m_id;
     Ref<IPC::Connection> m_webProcessConnection;
-
     WeakPtr<ModelProcessModelPlayerManagerProxy> m_manager;
+
+    std::unique_ptr<LayerHostingContext> m_layerHostingContext;
+    RetainPtr<CALayer> m_layer;
 };
 
 } // namespace WebKit
 
-#endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+#endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -24,7 +24,11 @@
 #if ENABLE(MODEL_PROCESS)
 
 messages -> ModelProcessModelPlayerProxy {
-    void loadModel()
+    CreateLayer()
+    
+    # ModelPlayer
+    LoadModel(Ref<WebCore::Model> url, WebCore::LayoutSize layoutSize)
+    SizeDidChange(WebCore::LayoutSize layoutSize)
 }
 
 #endif

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in
@@ -22,3 +22,6 @@
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in"
+
+(allow mach-lookup
+    (global-name "com.apple.CARenderServer"))

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -444,7 +444,13 @@ fi
 
 function ios_family_process_model_entitlements()
 {
-    ios_family_process_webcontent_shared_entitlements
+    plistbuddy Add :com.apple.QuartzCore.secure-mode bool YES
+    plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
+    plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
+    plistbuddy Add :com.apple.private.memorystatus bool YES
+    plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
+    plistbuddy Add :com.apple.private.pac.exception bool YES
+    plistbuddy Add :com.apple.private.sandbox.profile string com.apple.WebKit.Model
 }
 
 function ios_family_process_adattributiond_entitlements()

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -94,7 +94,6 @@ GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
 ModelProcess/ModelProcess.cpp
 ModelProcess/ModelConnectionToWebProcess.cpp
 ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
-ModelProcess/ModelProcessModelPlayerProxy.cpp
 
 NetworkProcess/BackgroundFetchLoad.cpp
 NetworkProcess/DatabaseUtilities.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -80,6 +80,7 @@ GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
 ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
 ModelProcess/cocoa/ModelProcessCocoa.mm
 ModelProcess/ios/ModelProcessIOS.mm
+ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
 
 Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
 Platform/classifier/ResourceLoadStatisticsClassifier.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5806,6 +5806,7 @@
 		53CFBBC62224D1B000266546 /* TextCheckerCompletion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextCheckerCompletion.cpp; sourceTree = "<group>"; };
 		53CFBBC72224D1B000266546 /* TextCheckerCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextCheckerCompletion.h; sourceTree = "<group>"; };
 		53F3CAA5206C443E0086490E /* NetworkActivityTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkActivityTracker.cpp; sourceTree = "<group>"; };
+		540D14C72B840E9A007FD5DE /* ModelProcessModelPlayerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ModelProcessModelPlayerProxy.mm; sourceTree = "<group>"; };
 		541A3D0A2B5F2BA3009CE0D6 /* ModelProcessConnectionParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ModelProcessConnectionParameters.serialization.in; sourceTree = "<group>"; };
 		541A3D0B2B5F3948009CE0D6 /* GPUProcessConnectionInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = GPUProcessConnectionInfo.serialization.in; sourceTree = "<group>"; };
 		541A3D0C2B5F3968009CE0D6 /* ModelProcessConnectionInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ModelProcessConnectionInfo.serialization.in; sourceTree = "<group>"; };
@@ -5817,7 +5818,6 @@
 		54BBB6052B7EBE3E00BF1A8A /* ModelProcessModelPlayerManagerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ModelProcessModelPlayerManagerProxy.messages.in; sourceTree = "<group>"; };
 		54BBB6062B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelProcessModelPlayerProxy.h; sourceTree = "<group>"; };
 		54BBB6072B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ModelProcessModelPlayerProxy.messages.in; sourceTree = "<group>"; };
-		54BBB6082B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ModelProcessModelPlayerProxy.cpp; sourceTree = "<group>"; };
 		54BBB6092B80177C00BF1A8A /* ModelProcessModelPlayer.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ModelProcessModelPlayer.messages.in; sourceTree = "<group>"; };
 		5506409D2407160900AAE045 /* RemoteRenderingBackendProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteRenderingBackendProxy.cpp; sourceTree = "<group>"; };
 		5506409E2407160900AAE045 /* RemoteRenderingBackendProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteRenderingBackendProxy.h; sourceTree = "<group>"; };
@@ -10439,9 +10439,6 @@
 				54BBB6042B7EBE3D00BF1A8A /* ModelProcessModelPlayerManagerProxy.cpp */,
 				54BBB6032B7EBE3D00BF1A8A /* ModelProcessModelPlayerManagerProxy.h */,
 				54BBB6052B7EBE3E00BF1A8A /* ModelProcessModelPlayerManagerProxy.messages.in */,
-				54BBB6082B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.cpp */,
-				54BBB6062B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.h */,
-				54BBB6072B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.messages.in */,
 			);
 			path = ModelProcess;
 			sourceTree = "<group>";
@@ -10458,6 +10455,9 @@
 			isa = PBXGroup;
 			children = (
 				2D56C1B028A367760081BD25 /* ModelProcessCocoa.mm */,
+				54BBB6062B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.h */,
+				54BBB6072B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.messages.in */,
+				540D14C72B840E9A007FD5DE /* ModelProcessModelPlayerProxy.mm */,
 			);
 			path = cocoa;
 			sourceTree = "<group>";

--- a/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.h
@@ -53,6 +53,7 @@ private:
     void load(WebCore::Model&, WebCore::LayoutSize) override;
     void sizeDidChange(WebCore::LayoutSize) override;
     PlatformLayer* layer() override;
+    std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() override;
     void enterFullscreen() override;
     void getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&) override;
     void setCamera(WebCore::HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) override;

--- a/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/ARKitInlinePreviewModelPlayer.mm
@@ -56,6 +56,11 @@ PlatformLayer* ARKitInlinePreviewModelPlayer::layer()
     return nullptr;
 }
 
+std::optional<WebCore::LayerHostingContextIdentifier> ARKitInlinePreviewModelPlayer::layerHostingContextIdentifier()
+{
+    return std::nullopt;
+}
+
 void ARKitInlinePreviewModelPlayer::enterFullscreen()
 {
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -46,6 +46,8 @@ public:
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
+    std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() { return m_layerHostingContextIdentifier; };
+
     // Messages
     void didLoad();
 
@@ -55,6 +57,11 @@ private:
     WebCore::ModelPlayerIdentifier identifier() { return m_id; }
     WebPage* page() { return m_page.get(); }
     WebCore::ModelPlayerClient* client() { return m_client.get(); }
+
+    template<typename T> void send(T&& message);
+
+    // Messages
+    void didCreateLayer(WebCore::LayerHostingContextIdentifier);
 
     // WebCore::ModelPlayer overrides.
     void load(WebCore::Model&, WebCore::LayoutSize) final;
@@ -81,6 +88,8 @@ private:
     WebCore::ModelPlayerIdentifier m_id;
     WeakPtr<WebPage> m_page;
     WeakPtr<WebCore::ModelPlayerClient> m_client;
+
+    std::optional<WebCore::LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
 };
 
 }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(MODEL_PROCESS)
 
 messages -> ModelProcessModelPlayer {
-    DidLoad()
+    DidCreateLayer(WebCore::LayerHostingContextIdentifier identifier)
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
@@ -61,9 +61,11 @@ ModelProcessConnection& ModelProcessModelPlayerManager::modelProcessConnection()
 Ref<ModelProcessModelPlayer> ModelProcessModelPlayerManager::createModelProcessModelPlayer(WebPage& page, WebCore::ModelPlayerClient& client)
 {
     auto identifier = WebCore::ModelPlayerIdentifier::generate();
+    modelProcessConnection().connection().send(Messages::ModelProcessModelPlayerManagerProxy::CreateModelPlayer(identifier), 0);
+
     auto player = ModelProcessModelPlayer::create(identifier, page, client);
     m_players.add(identifier, player);
-    modelProcessConnection().connection().send(Messages::ModelProcessModelPlayerManagerProxy::CreateModelPlayer(identifier), 0);
+
     return player;
 }
 
@@ -78,7 +80,6 @@ void ModelProcessModelPlayerManager::didReceivePlayerMessage(IPC::Connection& co
     if (const auto& player = m_players.get(WebCore::ModelPlayerIdentifier(decoder.destinationID())))
         player->didReceiveMessage(connection, decoder);
 }
-
 
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
@@ -49,6 +49,7 @@ private:
 
     Ref<WebCore::PlatformCALayer> createPlatformCALayer(WebCore::PlatformCALayer::LayerType, WebCore::PlatformCALayerClient* owner) override;
     Ref<WebCore::PlatformCALayer> createPlatformCALayer(PlatformLayer*, WebCore::PlatformCALayerClient* owner) override;
+    Ref<WebCore::PlatformCALayer> createPlatformCALayer(WebCore::LayerHostingContextIdentifier, WebCore::PlatformCALayerClient* owner) override;
 #if ENABLE(MODEL_ELEMENT)
     Ref<WebCore::PlatformCALayer> createPlatformCALayer(Ref<WebCore::Model>, WebCore::PlatformCALayerClient* owner) override;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -76,6 +76,11 @@ Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(PlatformLayer*
     return PlatformCALayerRemote::create(platformLayer, owner, *m_context);
 }
 
+Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier, PlatformCALayerClient* owner)
+{
+    return PlatformCALayerRemote::create(layerHostingContextIdentifier.toUInt64(), owner, *m_context);
+}
+
 #if ENABLE(MODEL_ELEMENT)
 Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(Ref<WebCore::Model> model, PlatformCALayerClient* owner)
 {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -45,6 +45,8 @@ namespace WebKit {
 
 class RemoteLayerTreeContext;
 
+using LayerHostingContextID = uint32_t;
+
 struct PlatformCALayerRemoteDelegatedContents {
     ImageBufferBackendHandle surface;
     RefPtr<WebCore::PlatformCALayerDelegatedContentsFence> finishedFence;
@@ -55,6 +57,7 @@ class PlatformCALayerRemote : public WebCore::PlatformCALayer, public CanMakeWea
 public:
     static Ref<PlatformCALayerRemote> create(WebCore::PlatformCALayer::LayerType, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
     static Ref<PlatformCALayerRemote> create(PlatformLayer *, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
+    static Ref<PlatformCALayerRemote> create(LayerHostingContextID, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 #if ENABLE(MODEL_ELEMENT)
     static Ref<PlatformCALayerRemote> create(Ref<WebCore::Model>, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -71,6 +71,11 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(PlatformLayer *platform
     return PlatformCALayerRemoteCustom::create(platformLayer, owner, context);
 }
 
+Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(LayerHostingContextID contextID, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+{
+    return PlatformCALayerRemoteCustom::create(contextID, owner, context);
+}
+
 #if ENABLE(MODEL_ELEMENT)
 Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(Ref<WebCore::Model> model, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
 {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
@@ -36,6 +36,7 @@ class PlatformCALayerRemoteCustom final : public PlatformCALayerRemote {
     friend class PlatformCALayerRemote;
 public:
     static Ref<PlatformCALayerRemote> create(PlatformLayer *, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
+    static Ref<PlatformCALayerRemote> create(LayerHostingContextID, PlatformCALayerClient*, RemoteLayerTreeContext&);
 #if HAVE(AVKIT)
     static Ref<PlatformCALayerRemote> create(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 #endif
@@ -53,6 +54,7 @@ public:
 
 private:
     PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, PlatformLayer *, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
+    PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, LayerHostingContextID, PlatformCALayerClient* owner, RemoteLayerTreeContext&);
     PlatformCALayerRemoteCustom(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 
     Ref<WebCore::PlatformCALayer> clone(WebCore::PlatformCALayerClient* owner) const override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -52,6 +52,13 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemoteCustom::create(PlatformLayer *pl
     return WTFMove(layer);
 }
 
+Ref<PlatformCALayerRemote> PlatformCALayerRemoteCustom::create(LayerHostingContextID hostedContextIdentifier, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+{
+    auto layer = adoptRef(*new PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType::LayerTypeCustom, hostedContextIdentifier, owner, context));
+    context.layerDidEnterContext(layer.get(), layer->layerType());
+    return WTFMove(layer);
+}
+
 #if HAVE(AVKIT)
 Ref<PlatformCALayerRemote> PlatformCALayerRemoteCustom::create(WebCore::HTMLVideoElement& videoElement, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
 {
@@ -61,10 +68,15 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemoteCustom::create(WebCore::HTMLVide
 }
 #endif
 
-PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(HTMLVideoElement& videoElement, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
-    : PlatformCALayerRemote(PlatformCALayer::LayerType::LayerTypeAVPlayerLayer, owner, context)
+PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType layerType, LayerHostingContextID hostedContextIdentifier, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+    : PlatformCALayerRemote(layerType, owner, context)
 {
-    m_layerHostingContext = LayerHostingContext::createTransportLayerForRemoteHosting(videoElement.layerHostingContextID());
+    m_layerHostingContext = LayerHostingContext::createTransportLayerForRemoteHosting(hostedContextIdentifier);
+}
+
+PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(HTMLVideoElement& videoElement, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+    : PlatformCALayerRemoteCustom(PlatformCALayer::LayerType::LayerTypeAVPlayerLayer, videoElement.layerHostingContextID(), owner, context)
+{
     m_hasVideo = true;
 }
 


### PR DESCRIPTION
#### 11061972c7486a8ddd132affabbc3396aa2ca961
<pre>
Model Process CA layer hosting
<a href="https://rdar.apple.com/123273873">rdar://123273873</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=269762">https://bugs.webkit.org/show_bug.cgi?id=269762</a>

Reviewed by Tim Horton.

Hosts a dummy green CALayer in Model process and display it for
&lt;model&gt; tag, as a precursor to actually hosting the 3D model.

The hosting mechanism utilizes the same PlatformCALayerRemoteCustom
as that used by HTMLVideoElement, with some minor generalization.

We have created a new ContentsLayerPurpose::HostedModel to
distinguish between the existing in-process Model path and the
Model process path, as a temporary measure.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::layerHostingContextIdentifier const):
(WebCore::HTMLModelElement::didUpdateLayerHostingContextIdentifier):
The hosting context identifier comes back in an async manner, so this
callback will ultimately re-create the correct hosting layer
pointing to this new hosting context identifier.

* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
(WebCore::DummyModelPlayer::layerHostingContextIdentifier):
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::setContentsToPlatformLayerCustom):
A generic way to utilize a PlatformLayerCustom with any
given hosting context identifier and purpose.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createPlatformCALayerCustom):
(WebCore::GraphicsLayerCA::setContentsToPlatformLayerCustom):
A platformCALayerCustom essentially does one thing - hosts
another CALayer in another process. So this fits our purpose
well.

(WebCore::GraphicsLayerCA::purposeNameForInnerLayer const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
The handling for the existing &quot;Model&quot; layer purpose is quite
distinct from what we are going to do. So let&apos;s introduce
a new &quot;HostedModel&quot; layer purpose for the time being. We could
remove the old &quot;Model&quot; one once the new HostedModel implementation
is fully in parity.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
If we have a hosting context identifier, we are ready to
create a layer that displays the hosted CA layer. This
identifier is not always available, because its hosted
CALayer is created out of process and therefore is async.
The identifier will be nullopt before the async message
comes back.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h: Renamed from Source/WebKit/ModelProcess/ModelProcessModelPlayerProxy.h.
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in: Renamed from Source/WebKit/ModelProcess/ModelProcessModelPlayerProxy.messages.in.
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm: Renamed from Source/WebKit/ModelProcess/ModelProcessModelPlayerProxy.cpp.
(WebKit::ModelProcessModelPlayerProxy::create):
(WebKit::ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy):
(WebKit::ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy):
(WebKit::ModelProcessModelPlayerProxy::invalidate):
(WebKit::ModelProcessModelPlayerProxy::send):
(WebKit::ModelProcessModelPlayerProxy::createLayer):
(WebKit::ModelProcessModelPlayerProxy::loadModel):
(WebKit::ModelProcessModelPlayerProxy::sizeDidChange):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Model.sb.in:
Allows CARenderServer connection from Model process since we need to
create a hosted CALayer.

* Source/WebKit/Scripts/process-entitlements.sh:
Specify the correct sandbox profile name instead of re-using WebContent&apos;s.

* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
Now that WebProcess vends a different PlatformCALayer for Model process path,
we no longer need to guard this site. This site is now only used by
in-process path.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::~ModelProcessModelPlayer):
(WebKit::ModelProcessModelPlayer::send):
(WebKit::ModelProcessModelPlayer::didCreateLayer):
(WebKit::ModelProcessModelPlayer::load):
(WebKit::ModelProcessModelPlayer::sizeDidChange):
(WebKit::ModelProcessModelPlayer::didLoad): Deleted.
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
(WebKit::ModelProcessModelPlayer::layerHostingContextIdentifier):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp:
(WebKit::ModelProcessModelPlayerManager::createModelProcessModelPlayer):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::createPlatformCALayerCustom):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::create):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::create):
(WebKit::PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom):
Re-wire HTMLVideoElement&apos;s creation into the new initializer since they&apos;re
doing very much the same thing.

Canonical link: <a href="https://commits.webkit.org/275453@main">https://commits.webkit.org/275453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd0e9573bb827ba1454470ad72ab7be12e78a7af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34406 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15071 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/41497 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40958 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13496 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39375 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18061 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9385 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->