### PR TITLE
[UnifiedPDF] Track PageCoverage for each rendered tile

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -111,6 +111,7 @@ private:
     AsyncPDFRenderer(UnifiedPDFPlugin&);
 
     struct TileRenderInfo {
+        WebCore::FloatRect tileRect;
         PDFPageCoverage pageCoverage;
         PDFConfigurationIdentifier configurationIdentifier;
     };
@@ -121,9 +122,9 @@ private:
     void willRepaintAllTiles(WebCore::TileGridIndex) final;
 
     void enqueuePaintWithClip(const TileForGrid&, const WebCore::FloatRect& tileRect);
-    void paintTileOnWorkQueue(RetainPtr<PDFDocument>&&, const TileForGrid&, const WebCore::FloatRect& tileRect, const TileRenderInfo&);
-    void paintPDFIntoBuffer(RetainPtr<PDFDocument>&&, Ref<WebCore::ImageBuffer>, const TileForGrid&, const WebCore::FloatRect& tileRect, const TileRenderInfo&);
-    void transferBufferToMainThread(RefPtr<WebCore::ImageBuffer>&&, const TileForGrid&, const WebCore::FloatRect& tileRect, const TileRenderInfo&);
+    void paintTileOnWorkQueue(RetainPtr<PDFDocument>&&, const TileForGrid&, const TileRenderInfo&);
+    void paintPDFIntoBuffer(RetainPtr<PDFDocument>&&, Ref<WebCore::ImageBuffer>, const TileForGrid&, const TileRenderInfo&);
+    void transferBufferToMainThread(RefPtr<WebCore::ImageBuffer>&&, const TileForGrid&, const TileRenderInfo&);
 
     void clearRequestsAndCachedTiles();
 
@@ -138,12 +139,11 @@ private:
 
     HashMap<TileForGrid, TileRenderInfo> m_enqueuedTileRenders;
 
-    struct BufferAndClip {
+    struct RenderedTile {
         RefPtr<WebCore::ImageBuffer> buffer;
-        WebCore::FloatRect tileClip;
-        PDFConfigurationIdentifier configurationIdentifier;
+        TileRenderInfo tileInfo;
     };
-    HashMap<TileForGrid, BufferAndClip> m_rendereredTiles;
+    HashMap<TileForGrid, RenderedTile> m_rendereredTiles;
 
     std::atomic<bool> m_showDebugBorders { false };
 };


### PR DESCRIPTION
#### 241d9ab4f0c9a478c19560d63cd2743691228320
<pre>
[UnifiedPDF] Track PageCoverage for each rendered tile
<a href="https://bugs.webkit.org/show_bug.cgi?id=269887">https://bugs.webkit.org/show_bug.cgi?id=269887</a>
<a href="https://rdar.apple.com/123416384">rdar://123416384</a>

Reviewed by Tim Horton.

In order to store PDFPageCoverage per rendered tile, reshuffle the data structures
in AsyncPDFRenderer a little.

We can fold the `tileRect` into `TileRenderInfo`, which means it gets passed to the
decoding callback and back to the main thread in that struct so we no longer need
to track it separately.

Then we can store a `TileRenderInfo` in what used to be called `BufferAndClip`,
and is here renamed to `RenderedTile`. That then now tracks the tileRect,
the configurationIdentifier and the PDFPageCoverage.

No behavior change.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::enqueuePaintWithClip):
(WebKit::AsyncPDFRenderer::paintTileOnWorkQueue):
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer):
(WebKit::AsyncPDFRenderer::transferBufferToMainThread):
(WebKit::AsyncPDFRenderer::paintTilesForPaintingRect):
(WebKit::AsyncPDFRenderer::invalidateTilesForPaintingRect):

Canonical link: <a href="https://commits.webkit.org/275151@main">https://commits.webkit.org/275151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f169c267daf0dce4a8165c512891b469479c22b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37106 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17358 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14712 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38775 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17448 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9204 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->