### PR TITLE
REGRESSION (Safari 17.2): Does not respect mousemove events in an iframe when the mouse is clicked from outside of an iframe

### DIFF
--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html
@@ -7,8 +7,8 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 
-var unexpectedMouseMove = false;
-var unexpectedMouseUp = false;
+var mouseMoveInOtherFrame = false;
+var mouseUpInOtherFrame = false;
 
 function log(msg) {
     var msgNode = document.createTextNode(msg);
@@ -40,7 +40,7 @@ window.onload = function() {
         eventSender.mouseMoveTo(endX, endY);
         eventSender.mouseUp();
     } finally {
-        if (unexpectedMouseUp || unexpectedMouseMove)
+        if (mouseUpInOtherFrame || mouseMoveInOtherFrame)
             log("FAIL! Received unexpected mouse event on other frame.");
         else
             log("PASS!");

--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame-expected.txt
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame-expected.txt
@@ -2,6 +2,6 @@ This tests that dragging from an element that returns false from its mousedown h
 Drag Me!
 
 Drag started
-Root frame received mouse move
-Root frame received mouseup event
+Subframe received mousemove event
+Subframe received mouseup event
 PASS!

--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html
@@ -7,37 +7,22 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 
+var mouseMoveInOtherFrame = false;
+var mouseUpInOtherFrame = false;
+
 function log(msg) {
     var msgNode = document.createTextNode(msg);
     var li = document.createElement("li");
     li.appendChild(msgNode);
     document.getElementById("log").appendChild(li);
 }
-var dragging = false;
-var waitingForUp = false;
-function dragStarted() {
-    if (dragging || waitingForUp) {
-        log("Unexpected drag start");
-        return;
-    }
-    log("Drag started");
-    dragging = true;
-}
 
-window.onmousemove = function() {
-    if (!dragging || waitingForUp)
-        return;
-    log("Root frame received mouse move");
-    waitingForUp = true;
+function dragStarted() {
+    log("Drag started");
 }
 
 window.onmouseup = function() {
-    if (!waitingForUp) {
-        log("Unexpected mouseup");
-        return;
-    }
-    log("Root frame received mouseup event");
-    log("PASS!");
+    log("FAIL! Received unexpected mouseup on root frame");
 }
 
 window.onload = function() {
@@ -61,6 +46,11 @@ window.onload = function() {
         eventSender.mouseMoveTo(endX, endY);
         eventSender.mouseUp();
     } finally {
+        if (mouseUpInOtherFrame && mouseMoveInOtherFrame)
+            log("PASS!");
+        else
+            log("FAIL! Drag was not reflected in subframe");
+
         if (window.testRunner)
             testRunner.notifyDone();
     }

--- a/LayoutTests/fast/events/resources/mouse-drag-from-frame-target-subframe.html
+++ b/LayoutTests/fast/events/resources/mouse-drag-from-frame-target-subframe.html
@@ -1,3 +1,3 @@
-<body onmousemove="parent.log('Received unexpected mousemove'); parent.unexpectedMouseMove = true;" onmouseup="parent.log('Received unexpected mouseup'); parent.unexpectedMouseUp = true;">
+<body onmousemove="parent.log('Subframe received mousemove event'); parent.mouseMoveInOtherFrame = true;" onmouseup="parent.log('Subframe received mouseup event'); parent.mouseUpInOtherFrame = true;">
 
 </body>


### PR DESCRIPTION
#### 50f43b731d2067d9ecc9be6d21ac8cbdefcd6e9e
<pre>
REGRESSION (Safari 17.2): Does not respect mousemove events in an iframe when the mouse is clicked from outside of an iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=269886">https://bugs.webkit.org/show_bug.cgi?id=269886</a>
<a href="https://rdar.apple.com/120540148">rdar://120540148</a>

Reviewed by Wenson Hsieh.

In 269246@main, we introduced a behavior change where initiating a drag
gesture from a cancelled mousedown event causes all mousemove events to
be routed to the originating frame till the drag gesture terminates with
a corresponding mouseup event. This was a web compatibility regression
since users expect to receive mouse events in the inner frame when we
are dragging the pointer over it.

Instead, this patch limits this mouse event target capturing behavior to
subframes only, and not the outer frame. This patch makes mouse event
targets independent of mousedown event cancellation when the pointer is
dragged out of a subframe. This change in behavior aligns us with other
major browser vendors&apos; behavior.

Finally, we update cancel-mousedown-and-drag-to-frame.html since the new
behavior is essentially the opposite of what the test had been
expecting.

* LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html:
* LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame-expected.txt:
* LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html:
* LayoutTests/fast/events/resources/mouse-drag-from-frame-target-subframe.html:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):

Canonical link: <a href="https://commits.webkit.org/275157@main">https://commits.webkit.org/275157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d6e6f3c92953b630fd082448f88b2b28da68371

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44904 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40402 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38778 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35616 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9210 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->