### PR TITLE
Adds Quirk so that booking.com sends simple JPEG to WebKit on iOS

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3212,7 +3212,7 @@ void FrameLoader::updateRequestAndAddExtraFields(ResourceRequest& request, IsMai
     applyUserAgentIfNeeded(request);
 
     if (isMainResource)
-        request.setHTTPHeaderField(HTTPHeaderName::Accept, CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type::MainResource));
+        request.setHTTPHeaderField(HTTPHeaderName::Accept, CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type::MainResource, request, protectedFrame().ptr()));
 
     if (RefPtr document = m_frame->document(); document && frame().settings().privateTokenUsageByThirdPartyEnabled() && !frame().loader().client().isRemoteWorkerFrameLoaderClient())
         request.setIsPrivateTokenUsageByThirdPartyAllowed(isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::PrivateToken, *document, LogFeaturePolicyFailure::No));

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -910,7 +910,7 @@ void CachedResourceLoader::prepareFetch(CachedResource::Type type, CachedResourc
             request.setSelectedServiceWorkerRegistrationIdentifierIfNeeded(activeServiceWorker->registrationIdentifier());
     }
 
-    request.setAcceptHeaderIfNone(type);
+    request.setAcceptHeaderIfNone(type, protectedFrame().get());
 
     // Accept-Language value is handled in underlying port-specific code.
     // FIXME: Decide whether to support client hints

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -166,10 +166,14 @@ static String acceptHeaderValueForImageResource()
     return builder.toString();
 }
 
-String CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type type)
+String CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type type, ResourceRequest& request, LocalFrame* frame)
 {
+    auto url = request.url();
+
     switch (type) {
     case CachedResource::Type::MainResource:
+        if (Quirks::shouldSendLongerAcceptHeaderQuirk(url, frame))
+            return "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"_s;
         return "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"_s;
     case CachedResource::Type::ImageResource:
         return acceptHeaderValueForImageResource();
@@ -187,10 +191,10 @@ String CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type typ
     }
 }
 
-void CachedResourceRequest::setAcceptHeaderIfNone(CachedResource::Type type)
+void CachedResourceRequest::setAcceptHeaderIfNone(CachedResource::Type type, LocalFrame* frame)
 {
     if (!m_resourceRequest.hasHTTPHeader(HTTPHeaderName::Accept))
-        m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::Accept, acceptHeaderValueFromType(type));
+        m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::Accept, acceptHeaderValueFromType(type, m_resourceRequest, frame));
 }
 
 void CachedResourceRequest::disableCachingIfNeeded()

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -86,7 +86,7 @@ public:
     void updateReferrerAndOriginHeaders(FrameLoader&);
     void updateUserAgentHeader(FrameLoader&);
     void upgradeInsecureRequestIfNeeded(Document&, ContentSecurityPolicy::AlwaysUpgradeRequest = ContentSecurityPolicy::AlwaysUpgradeRequest::No);
-    void setAcceptHeaderIfNone(CachedResource::Type);
+    void setAcceptHeaderIfNone(CachedResource::Type, LocalFrame*);
     void updateAccordingCacheMode();
     void updateAcceptEncodingHeader();
     void updateCacheModeIfNeeded(CachePolicy);
@@ -113,7 +113,7 @@ public:
     void clearFragmentIdentifier() { m_fragmentIdentifier = { }; }
 
     static String splitFragmentIdentifierFromRequestURL(ResourceRequest&);
-    static String acceptHeaderValueFromType(CachedResource::Type);
+    static String acceptHeaderValueFromType(CachedResource::Type, ResourceRequest&, LocalFrame*);
 
     void setClientIdentifierIfNeeded(ScriptExecutionContextIdentifier);
     void setSelectedServiceWorkerRegistrationIdentifierIfNeeded(ServiceWorkerRegistrationIdentifier);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1716,6 +1716,20 @@ bool Quirks::shouldDisableNavigatorStandaloneQuirk() const
     return false;
 }
 
+// booking.com https://webkit.org/b/269875
+// FIXME: booking.com https://webkit.org/b/269876 when outreach has been successful.
+bool Quirks::shouldSendLongerAcceptHeaderQuirk(const URL& url, LocalFrame* frame)
+{
+    if (frame && !frame->settings().needsSiteSpecificQuirks())
+        return false;
+
+    auto host = url.host();
+    if (host == "booking.com"_s || host.endsWith(".booking.com"_s))
+        return true;
+
+    return false;
+}
+
 // This section is dedicated to UA override for iPad. iPads (but iPad Mini) are sending a desktop user agent
 // to websites. In some cases, the website breaks in some ways, not expecting a touch interface for the website.
 // Controls not active or too small, form factor, etc. In this case it is better to send the iPad Mini UA.

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -83,6 +83,7 @@ public:
     bool shouldExposeShowModalDialog() const;
     bool shouldNavigatorPluginsBeEmpty() const;
     bool shouldDisableNavigatorStandaloneQuirk() const;
+    static bool shouldSendLongerAcceptHeaderQuirk(const URL&, LocalFrame*);
 
     WEBCORE_EXPORT bool shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const;
     WEBCORE_EXPORT bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const;


### PR DESCRIPTION
#### 7c18c3da4148c58fdb27ede24514d32ab6bd3ab6
<pre>
Adds Quirk so that booking.com sends simple JPEG to WebKit on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=269875">https://bugs.webkit.org/show_bug.cgi?id=269875</a>
<a href="https://rdar.apple.com/123408770">rdar://123408770</a>

Reviewed by Chris Dumez.

In webkit.org/b/178758, the support for JPEG2000 was removed from
WebKit. Booking.com is doing content negociation on both the
User-Agent string and the HTTP accept header. The website sends
JPEG2000 assets to Safari on iOS. An outreach effort has been started
to make sure that booking fixes their servers.
See <a href="https://github.com/webcompat/web-bugs/issues/133697">https://github.com/webcompat/web-bugs/issues/133697</a>

No other breakage has been detected yet, but we know that Cloudinary
is currently JPEG2000 images for some websites on both iOS and macOS.
It might break once this release of WebKit reaches Safari. An ongoing
effort has started to avoid this so that Cloudinary can adjust their
rules and warn their customers.

In the meantime this Quirk sends a different HTTP Accept header for
booking.com tricking the server into sending compatible image resources
for HTML requests instead of JPEG2000.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::acceptHeaderValueFromType):
(WebCore::CachedResourceRequest::setAcceptHeaderIfNone):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldSendLongerAcceptHeaderQuirk):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/275216@main">https://commits.webkit.org/275216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb62249d79557fcd33df91a80f3708ba8874a1cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34066 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41735 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17102 "Found 1 new test failure: http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45044 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40515 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38893 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17595 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17647 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5497 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->