### PR TITLE
run-webkit-tests --print-expectations -v lists all considered TextExpectations lines

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -754,14 +754,33 @@ class Manager(object):
 
     def _print_expectation_line_for_test(self, format_string, test, device_type):
         test_path = test.test_path
-        line = self._expectations[device_type].model().get_expectation_line(test_path)
-        print(format_string.format(test_path,
-                                   line.expected_behavior,
-                                   self._expectations[device_type].readable_filename_and_line_number(line),
-                                   line.original_string or ''))
+        main_line = self._expectations[device_type].model().get_expectation_line(test_path)
+        if not self._options.verbose:
+            print(format_string.format(test_path,
+                                       "",
+                                       main_line.expected_behavior,
+                                       self._expectations[device_type].readable_filename_and_line_number(main_line),
+                                       main_line.original_string or ''))
+        else:
+            lines = self._expectations[device_type].model().get_expectation_lines(test_path)
+            before_main_line = True
+            decision = ""
+            for line in lines:
+                if line == main_line:
+                    decision = "-> "
+                    before_main_line = False
+                elif before_main_line:
+                    decision = "v  "
+                else:
+                    decision = "^  "
+                print(format_string.format(test_path,
+                                           decision,
+                                           line.expected_behavior,
+                                           self._expectations[device_type].readable_filename_and_line_number(line),
+                                           line.original_string or ''))
 
     def _print_expectations_for_subset(self, device_type, test_col_width, tests_to_run, tests_to_skip=None):
-        format_string = '{{:{width}}} {{}} {{}} {{}}'.format(width=test_col_width)
+        format_string = '{{:{width}}} {{}}{{}} {{}} {{}}'.format(width=test_col_width)
         if tests_to_skip:
             print('')
             print('Tests to skip ({})'.format(len(tests_to_skip)))

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py
@@ -29,12 +29,17 @@
 
 """Unit tests for manager.py."""
 
+from collections import OrderedDict
+from io import StringIO
+import sys
 import time
 import unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.layout_tests.controllers.manager import Manager
 from webkitpy.layout_tests.models import test_expectations
+from webkitpy.layout_tests.models.test import Test
+from webkitpy.layout_tests.models.test_expectations import *
 from webkitpy.layout_tests.models.test_run_results import TestRunResults
 from webkitpy.port.test import TestPort
 from webkitpy.thirdparty.mock import Mock
@@ -43,17 +48,94 @@ from webkitpy.xcode.device_type import DeviceType
 
 
 class ManagerTest(unittest.TestCase):
+    def _get_manager(self):
+        host = MockHost()
+        port = host.port_factory.get('test-mac-leopard')
+        manager = Manager(port, options=MockOptions(test_list=None, http=True, verbose=False), printer=Mock())
+        return manager
+
     def test_look_for_new_crash_logs(self):
-        def get_manager():
-            host = MockHost()
-            port = host.port_factory.get('test-mac-leopard')
-            manager = Manager(port, options=MockOptions(test_list=None, http=True), printer=Mock())
-            return manager
         host = MockHost()
         port = host.port_factory.get('test-mac-leopard')
         tests = ['failures/expected/crash.html']
         expectations = test_expectations.TestExpectations(port, tests)
         expectations.parse_all_expectations()
         run_results = TestRunResults(expectations, len(tests))
-        manager = get_manager()
+        manager = self._get_manager()
         manager._look_for_new_crash_logs(run_results, time.time())
+
+    def test_print_expectations_for_subset(self):
+        def get_test_names():
+            return ['failures/expected/text.html',
+                    'failures/expected/image_checksum.html',
+                    'failures/expected/crash.html',
+                    'failures/expected/leak.html',
+                    'failures/expected/flaky-leak.html',
+                    'failures/expected/missing_text.html',
+                    'failures/expected/image.html',
+                    'failures/expected/reftest.html',
+                    'failures/expected/leaky-reftest.html',
+                    'passes/text.html']
+
+        def get_tests():
+            return [Test(test) for test in get_test_names()]
+
+        def get_expectations():
+            return """
+Bug(test) failures/expected/text.html [ Failure ]
+Bug(test) failures/expected/crash.html [ WontFix ]
+Bug(test) failures/expected/leak.html [ Leak ]
+Bug(test) failures/expected/flaky-leak.html [ Failure Leak ]
+Bug(test) failures/expected/missing_image.html [ Rebaseline Missing ]
+Bug(test) failures/expected/image_checksum.html [ WontFix ]
+Bug(test) failures/expected/image.html [ WontFix Mac ]
+Bug(test) failures/expected/reftest.html [ ImageOnlyFailure ]
+Bug(test) failures/expected/leaky-reftest.html [ ImageOnlyFailure Leak ]
+"""
+
+        def get_printed_expectations():
+            # There are trailing whitespaces in this string, they are as intended.
+            return """
+Tests to run for DEVICE_TYPE (10)
+failures/expected/crash.html           ['SKIP'] expectations:3 Bug(test) failures/expected/crash.html [ WontFix ]
+failures/expected/flaky-leak.html      ['FAIL', 'LEAK'] expectations:5 Bug(test) failures/expected/flaky-leak.html [ Failure Leak ]
+failures/expected/image.html           ['PASS']  
+failures/expected/image_checksum.html  ['SKIP'] expectations:7 Bug(test) failures/expected/image_checksum.html [ WontFix ]
+failures/expected/leak.html            ['LEAK'] expectations:4 Bug(test) failures/expected/leak.html [ Leak ]
+failures/expected/leaky-reftest.html   ['IMAGE', 'LEAK'] expectations:10 Bug(test) failures/expected/leaky-reftest.html [ ImageOnlyFailure Leak ]
+failures/expected/missing_text.html    ['PASS']  
+failures/expected/reftest.html         ['IMAGE'] expectations:9 Bug(test) failures/expected/reftest.html [ ImageOnlyFailure ]
+failures/expected/text.html            ['FAIL'] expectations:2 Bug(test) failures/expected/text.html [ Failure ]
+passes/text.html                       ['PASS']  
+"""
+
+        def parse_exp(test_names, expectations):
+            expectations_dict = OrderedDict()
+            expectations_dict['expectations'] = expectations
+            host = MockHost()
+            port = host.port_factory.get('test-win-xp', None)
+            port.expectations_dict = lambda **kwargs: expectations_dict
+            exp = TestExpectations(port, test_names)
+            exp.parse_all_expectations()
+            return exp
+
+        manager = self._get_manager()
+        device_type = "DEVICE_TYPE"
+        manager._expectations[device_type] = parse_exp(get_test_names(), get_expectations())
+        test_col_width = max(len(test) for test in get_test_names()) + 1
+
+        initial_stdout = sys.stdout
+        stringIO = StringIO()
+        sys.stdout = stringIO
+        try:
+            manager._print_expectations_for_subset(device_type, test_col_width, get_tests())
+        finally:
+            sys.stdout = initial_stdout
+
+        out = stringIO.getvalue()
+        self.maxDiff = None
+
+        # Note: Buildbots compare `--print-expectations` outputs between revisions,
+        # so if the output is not *exactly* as expected including whitespaces, this
+        # could lead to unwanted effects, like blocking builds for a long time.
+        self.assertEqual(get_printed_expectations(), out)

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
@@ -585,6 +585,7 @@ class TestExpectationsModel(object):
 
         # Maps a test to a TestExpectationLine instance.
         self._test_to_expectation_line = {}  # type: Dict[str, TestExpectationLine]
+        self._test_to_expectation_lines = {}  # type: Dict[str, List[TestExpectationLine]]
 
         self._modifier_to_tests = self._dict_of_sets(TestExpectations.MODIFIERS)  # type: Dict[int, Set[str]]
         self._expectation_to_tests = self._dict_of_sets(TestExpectations.EXPECTATIONS)  # type: Dict[int, Set[str]]
@@ -664,6 +665,10 @@ class TestExpectationsModel(object):
         # type: (str) -> Optional[TestExpectationLine]
         return self._test_to_expectation_line.get(test)
 
+    def get_expectation_lines(self, test):
+        # type: (str) -> Optional[List[TestExpectationLine]]
+        return self._test_to_expectation_lines.get(test)
+
     def get_expectations(self, test):
         # type: (str) -> Set[int]
         return self._test_to_expectations[test]
@@ -715,6 +720,8 @@ class TestExpectationsModel(object):
             return
 
         for test in expectation_line.matching_tests:
+            self._test_to_expectation_lines.setdefault(test, []).append(expectation_line)
+
             if not in_skipped and self._already_seen_better_match(test, expectation_line):
                 continue
 

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -350,7 +350,7 @@ def parse_args(args):
             help=("Makes sure the test files parse for all configurations. Does not run any tests.")),
         optparse.make_option(
             "--print-expectations", action="store_true", default=False,
-            help=("Print the expected outcome for the given test, or all tests listed in TestExpectations. Does not run any tests.")),
+            help=("Print the expected outcome for the given test, or all tests listed in TestExpectations. Does not run any tests. With --verbose, also show discarded TestExpectations lines.")),
         optparse.make_option(
             "--print-summary", action="store_true", default=False,
             help=("Print a summary of how tests are expected to run, grouped by directory. Does not run any tests.")),


### PR DESCRIPTION
#### 70c0d8553e42c0cb5209bab2b8ffd6f813e42d0c
<pre>
run-webkit-tests --print-expectations -v lists all considered TextExpectations lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=269895">https://bugs.webkit.org/show_bug.cgi?id=269895</a>
<a href="https://rdar.apple.com/123424189">rdar://123424189</a>

Reviewed by Sam Sneddon.

Instead of only showing the one line that was used to set a test&apos;s expectations,
we can now show all the lines that were also considered before and/or after.

A unit test was added to verify that the non-verbose output matches exactly with
the expected output, to avoid issues with buildbots that crudely diff this
output between revisions.

* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager._print_expectation_line_for_test):
(Manager._print_expectations_for_subset):
* Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py:
(ManagerTest._get_manager):
(ManagerTest.test_look_for_new_crash_logs):
(ManagerTest):
(ManagerTest.test_print_expectations_for_subset):
(ManagerTest.test_print_expectations_for_subset.get_test_names):
(ManagerTest.test_print_expectations_for_subset.get_tests):
(ManagerTest.test_print_expectations_for_subset.get_expectations):
(get_printed_expectations):
(parse_exp):
(ManagerTest.test_look_for_new_crash_logs.get_manager): Deleted.
* Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py:
(TestExpectationsModel.__init__):
(TestExpectationsModel.get_expectation_lines):
(TestExpectationsModel.add_expectation_line):
* Tools/Scripts/webkitpy/layout_tests/models/test_expectations_unittest.py:
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):

Canonical link: <a href="https://commits.webkit.org/283176@main">https://commits.webkit.org/283176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c49b6c9733d4a80e7b686acebcf6a0730a03a889

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65371 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69395 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52494 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11051 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/41404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33118 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/64883 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13954 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14854 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71100 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56640 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60093 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/list-markers, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/component/scroll-to, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14427 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1357 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40551 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->