### PR TITLE
[MultiRep HEIC] Hide image controls menu button

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -876,9 +876,14 @@ void HTMLImageElement::setAllowsAnimation(std::optional<bool> allowsAnimation)
 void HTMLImageElement::setAttachmentElement(Ref<HTMLAttachmentElement>&& attachment)
 {
     AttachmentAssociatedElement::setAttachmentElement(WTFMove(attachment));
+
 #if ENABLE(SERVICE_CONTROLS)
-    setImageMenuEnabled(true);
+    bool shouldEnableImageMenu = true;
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    shouldEnableImageMenu = !isMultiRepresentationHEIC();
 #endif
+    setImageMenuEnabled(shouldEnableImageMenu);
+#endif // ENABLE(SERVICE_CONTROLS)
 }
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)


### PR DESCRIPTION
#### dac9a5386216c78d7d6898932b24729c098d2890
<pre>
[MultiRep HEIC] Hide image controls menu button
<a href="https://bugs.webkit.org/show_bug.cgi?id=269898">https://bugs.webkit.org/show_bug.cgi?id=269898</a>
<a href="https://rdar.apple.com/123425639">rdar://123425639</a>

Reviewed by Tim Nguyen.

Multi-representation HEIC attachments should never show the image controls menu button.

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::setAttachmentElement):

Canonical link: <a href="https://commits.webkit.org/275205@main">https://commits.webkit.org/275205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7af9b2f7ad66dbf9290e600cece27b2e4c87bc96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33994 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40427 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38805 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17546 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5494 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->