### PR TITLE
Delay creation of InputType and user agent shadow trees during cloning

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -58,7 +58,7 @@ struct InputElementClickState {
 
 enum class WasSetByJavaScript : bool { No, Yes };
 
-class HTMLInputElement : public HTMLTextFormControlElement {
+class HTMLInputElement final : public HTMLTextFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLInputElement);
 public:
     static Ref<HTMLInputElement> create(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
@@ -345,14 +345,16 @@ public:
     bool isSwitchVisuallyOn() const;
     float switchAnimationPressedProgress() const;
 
-    void parserInitializeInputType();
+    void initializeInputTypeAfterParsingOrCloning();
 
-protected:
-    HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
+private:
+    enum class CreationType : uint8_t { Normal, ByParser, ByCloning };
+    HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, CreationType);
 
     void defaultEventHandler(Event&) final;
 
-private:
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&) override;
+
     enum AutoCompleteSetting : uint8_t { Uninitialized, On, Off };
     static constexpr int defaultSize = 20;
 

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -61,7 +61,7 @@ public:
     WEBCORE_EXPORT bool isFocusingWithValidationMessage() const;
     // This must be called when a validation constraint or control value is changed.
     void updateValidity();
-    void setCustomValidity(const String&) override;
+    WEBCORE_EXPORT void setCustomValidity(const String&) override;
 
     void setDisabledByAncestorFieldset(bool isDisabled);
     virtual void reset() { }


### PR DESCRIPTION
#### f6dbc5c5c7258d5fd40c7010373c3eb3018b82d8
<pre>
Delay creation of InputType and user agent shadow trees during cloning
<a href="https://bugs.webkit.org/show_bug.cgi?id=269900">https://bugs.webkit.org/show_bug.cgi?id=269900</a>

Reviewed by Yusuke Suzuki.

This PR delays the construction of InputType and user agent shadow tree when cloning an input element
such that InputType is initialized after all the attributes are cloned, and its shadow tree is
constructed as the element becomes connected to a document.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::parserSetAttributes):
(WebCore::Element::cloneAttributesFromElement): Call initializeInputTypeAfterParsingOrCloning.
(WebCore::Element::cloneDataFromElement): Added an assertion to make sure the UA shadow tree&apos;s
construction has not happened yet.
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::HTMLInputElement):
(WebCore::HTMLInputElement::create):
(WebCore::HTMLInputElement::cloneElementWithoutAttributesAndChildren): Added.
(WebCore::HTMLInputElement::initializeInputTypeAfterParsingOrCloning): Renamed from
parserInitializeInputType.
(WebCore::HTMLInputElement::attributeChanged):
(WebCore::HTMLInputElement::copyNonAttributePropertiesFromElement): Don&apos;t update the shadow tree unless
we have already created it.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/ValidatedFormListedElement.h:

Canonical link: <a href="https://commits.webkit.org/275200@main">https://commits.webkit.org/275200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa3fc008cf1ebf67ea5119c8c4d3a87e40ecc7f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17469 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14685 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38865 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17611 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5487 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->