### PR TITLE
Bug 269902 - [Curl] Add null check in WebSocketTaskCurl/NetworkDataTask/NetworkSession

### DIFF
--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
@@ -42,9 +42,11 @@ using namespace WebCore;
 NetworkSessionCurl::NetworkSessionCurl(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
     : NetworkSession(networkProcess, parameters)
 {
-    if (!parameters.cookiePersistentStorageFile.isEmpty())
-        networkStorageSession()->setCookieDatabase(makeUniqueRef<CookieJarDB>(parameters.cookiePersistentStorageFile));
-    networkStorageSession()->setProxySettings(parameters.proxySettings);
+    if (auto* storageSession = networkStorageSession()) {
+        if (!parameters.cookiePersistentStorageFile.isEmpty())
+            storageSession->setCookieDatabase(makeUniqueRef<CookieJarDB>(parameters.cookiePersistentStorageFile));
+        storageSession->setProxySettings(parameters.proxySettings);
+    }
 
     m_resourceLoadStatisticsDirectory = parameters.resourceLoadStatisticsParameters.directory;
     m_shouldIncludeLocalhostInResourceLoadStatistics = parameters.resourceLoadStatisticsParameters.shouldIncludeLocalhost ? ShouldIncludeLocalhost::Yes : ShouldIncludeLocalhost::No;
@@ -60,7 +62,8 @@ NetworkSessionCurl::~NetworkSessionCurl()
 
 void NetworkSessionCurl::clearAlternativeServices(WallTime)
 {
-    networkStorageSession()->clearAlternativeServices();
+    if (auto* storageSession = networkStorageSession())
+        storageSession->clearAlternativeServices();
 }
 
 std::unique_ptr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin& clientOrigin, bool, bool, OptionSet<WebCore::AdvancedPrivacyProtections>, ShouldRelaxThirdPartyCookieBlocking, StoredCredentialsPolicy)

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -121,10 +121,12 @@ void WebSocketTask::didOpen(WebCore::CurlStreamID)
     CString cookieHeader;
 
     if (m_request.allowCookies()) {
-        auto includeSecureCookies = m_request.url().protocolIs("wss"_s) ? WebCore::IncludeSecureCookies::Yes : WebCore::IncludeSecureCookies::No;
-        auto cookieHeaderField = m_channel.session()->networkStorageSession()->cookieRequestHeaderFieldValue(m_request.firstPartyForCookies(), WebCore::SameSiteInfo::create(m_request), m_request.url(), std::nullopt, std::nullopt, includeSecureCookies, WebCore::ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
-        if (!cookieHeaderField.isEmpty())
-            cookieHeader = makeString("Cookie: "_s, cookieHeaderField, "\r\n"_s).utf8();
+        if (auto* storageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr) {
+            auto includeSecureCookies = m_request.url().protocolIs("wss"_s) ? WebCore::IncludeSecureCookies::Yes : WebCore::IncludeSecureCookies::No;
+            auto cookieHeaderField = storageSession->cookieRequestHeaderFieldValue(m_request.firstPartyForCookies(), WebCore::SameSiteInfo::create(m_request), m_request.url(), std::nullopt, std::nullopt, includeSecureCookies, WebCore::ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
+            if (!cookieHeaderField.isEmpty())
+                cookieHeader = makeString("Cookie: "_s, cookieHeaderField, "\r\n"_s).utf8();
+        }
     }
 
     auto originalMessage = m_handshake->clientHandshakeMessage();
@@ -300,8 +302,10 @@ Expected<bool, String> WebSocketTask::validateOpeningHandshake()
     }
 
     auto serverSetCookie = m_handshake->serverSetCookie();
-    if (!serverSetCookie.isEmpty())
-        m_channel.session()->networkStorageSession()->setCookiesFromHTTPResponse(m_request.firstPartyForCookies(), m_request.url(), serverSetCookie);
+    if (!serverSetCookie.isEmpty()) {
+        if (auto* storageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr)
+            storageSession->setCookiesFromHTTPResponse(m_request.firstPartyForCookies(), m_request.url(), serverSetCookie);
+    }
 
     m_state = State::Opened;
     m_didCompleteOpeningHandshake = true;


### PR DESCRIPTION
#### 55dbfac13e1f1133bb160bae62cfaffed01659f3
<pre>
Bug 269902 - [Curl] Add null check in WebSocketTaskCurl/NetworkDataTask/NetworkSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=269902">https://bugs.webkit.org/show_bug.cgi?id=269902</a>

Reviewed by Fujii Hironori.

m_channel.session() referenced in WebSocketTaskCurl is defined as WeakPtr&lt;NetworkSession&gt;.
Therefore, nullptr may be returned depending on the timing, so check for null before using them.

Also, NetworkSession::networkStorageSession() referenced by NetworkDataTaskCurl and NetworkSession
can return nullptr, so do a null check before using them.

* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp:
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:

Canonical link: <a href="https://commits.webkit.org/275304@main">https://commits.webkit.org/275304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0faec52940e88d871de84d1b25fe5557a022a1b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37162 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17414 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33998 "Found 1 new test failure: fullscreen/exit-full-screen-video-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14631 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14754 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44944 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40431 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38808 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17556 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5541 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->