### PR TITLE
[Skia][GStreamer] Implement ImageGStreamer

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -220,12 +220,13 @@ private:
 };
 
 class GstMappedFrame {
+    WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(GstMappedFrame);
 public:
 
-    GstMappedFrame(GstBuffer* buffer, GstVideoInfo info, GstMapFlags flags)
+    GstMappedFrame(GstBuffer* buffer, GstVideoInfo* info, GstMapFlags flags)
     {
-        m_isValid = gst_video_frame_map(&m_frame, &info, buffer, flags);
+        m_isValid = gst_video_frame_map(&m_frame, info, buffer, flags);
     }
 
     GstMappedFrame(GRefPtr<GstSample> sample, GstMapFlags flags)
@@ -251,12 +252,12 @@ public:
         return &m_frame;
     }
 
-    uint8_t* ComponentData(int comp)
+    uint8_t* ComponentData(int comp) const
     {
         return GST_VIDEO_FRAME_COMP_DATA(&m_frame, comp);
     }
 
-    int ComponentStride(int stride)
+    int ComponentStride(int stride) const
     {
         return GST_VIDEO_FRAME_COMP_STRIDE(&m_frame, stride);
     }
@@ -272,19 +273,29 @@ public:
         return &m_frame.info;
     }
 
-    int width()
+    int width() const
     {
         return m_isValid ? GST_VIDEO_FRAME_WIDTH(&m_frame) : -1;
     }
 
-    int height()
+    int height() const
     {
         return m_isValid ? GST_VIDEO_FRAME_HEIGHT(&m_frame) : -1;
     }
 
-    int format()
+    int format() const
     {
         return m_isValid ? GST_VIDEO_FRAME_FORMAT(&m_frame) : GST_VIDEO_FORMAT_UNKNOWN;
+    }
+
+    void* planeData(uint32_t planeIndex) const
+    {
+        return m_isValid ? GST_VIDEO_FRAME_PLANE_DATA(&m_frame, planeIndex) : nullptr;
+    }
+
+    int planeStride(uint32_t planeIndex) const
+    {
+        return m_isValid ? GST_VIDEO_FRAME_PLANE_STRIDE(&m_frame, planeIndex) : -1;
     }
 
     ~GstMappedFrame()

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
@@ -23,22 +23,80 @@
 #if ENABLE(VIDEO) && USE(GSTREAMER) && USE(SKIA)
 
 #include "GStreamerCommon.h"
-#include "NotImplemented.h"
 #include <gst/gst.h>
 #include <gst/video/gstvideometa.h>
+#include <skia/core/SkImage.h>
+
+IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/core/SkPixmap.h>
+IGNORE_CLANG_WARNINGS_END
 
 namespace WebCore {
 
 ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
     : m_sample(WTFMove(sample))
 {
-    notImplemented();
+    GstBuffer* buffer = gst_sample_get_buffer(m_sample.get());
+    if (UNLIKELY(!GST_IS_BUFFER(buffer)))
+        return;
+
+    GstVideoInfo videoInfo;
+    if (!gst_video_info_from_caps(&videoInfo, gst_sample_get_caps(m_sample.get())))
+        return;
+
+    auto videoFrame = makeUnique<GstMappedFrame>(buffer, &videoInfo, GST_MAP_READ);
+    if (!*videoFrame)
+        return;
+
+    // The frame has to be RGB so we can paint it.
+    ASSERT(GST_VIDEO_INFO_IS_RGB(&videoInfo));
+
+    // The video buffer may have these formats in these cases:
+    // { BGRx, BGRA } on little endian
+    // { xRGB, ARGB } on big endian:
+    // { RGBx, RGBA }
+    SkColorType colorType = kUnknown_SkColorType;
+    SkAlphaType alphaType = kUnknown_SkAlphaType;
+    switch (videoFrame->format()) {
+    case GST_VIDEO_FORMAT_BGRx:
+        colorType = kBGRA_8888_SkColorType;
+        alphaType = kOpaque_SkAlphaType;
+        break;
+    case GST_VIDEO_FORMAT_BGRA:
+        colorType = kBGRA_8888_SkColorType;
+        alphaType = kUnpremul_SkAlphaType;
+        break;
+    case GST_VIDEO_FORMAT_xRGB:
+    case GST_VIDEO_FORMAT_ARGB:
+        // FIXME: we need a conversion here.
+        notImplemented();
+        return;
+    case GST_VIDEO_FORMAT_RGBx:
+        colorType = kRGB_888x_SkColorType;
+        alphaType = kOpaque_SkAlphaType;
+        break;
+    case GST_VIDEO_FORMAT_RGBA:
+        colorType = kRGBA_8888_SkColorType;
+        alphaType = kUnpremul_SkAlphaType;
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    auto imageInfo = SkImageInfo::Make(videoFrame->width(), videoFrame->height(), colorType, alphaType);
+    SkPixmap pixmap(imageInfo, videoFrame->planeData(0), videoFrame->planeStride(0));
+    auto image = SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
+        std::unique_ptr<GstMappedFrame> videoFrame(static_cast<GstMappedFrame*>(context));
+    }, videoFrame.release());
+
+    m_image = BitmapImage::create(WTFMove(image));
+
+    if (auto* cropMeta = gst_buffer_get_video_crop_meta(buffer))
+        m_cropRect = FloatRect(cropMeta->x, cropMeta->y, cropMeta->width, cropMeta->height);
 }
 
-ImageGStreamer::~ImageGStreamer()
-{
-    notImplemented();
-}
+ImageGStreamer::~ImageGStreamer() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -367,7 +367,7 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
     auto* inputBuffer = gst_sample_get_buffer(sample);
     auto* inputCaps = gst_sample_get_caps(sample);
     gst_video_info_from_caps(&inputInfo, inputCaps);
-    GstMappedFrame inputFrame(inputBuffer, inputInfo, GST_MAP_READ);
+    GstMappedFrame inputFrame(inputBuffer, &inputInfo, GST_MAP_READ);
 
     GST_TRACE("Copying frame data to pixel format %d", static_cast<int>(pixelFormat));
     if (pixelFormat == VideoPixelFormat::NV12) {

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -89,7 +89,7 @@ rtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC::To
         outInfo.fps_d = info->fps_d;
 
         auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&outInfo), nullptr));
-        GstMappedFrame outFrame(buffer.get(), outInfo, GST_MAP_WRITE);
+        GstMappedFrame outFrame(buffer.get(), &outInfo, GST_MAP_WRITE);
         GUniquePtr<GstVideoConverter> videoConverter(gst_video_converter_new(inFrame.info(), &outInfo, gst_structure_new("GstVideoConvertConfig",
             GST_VIDEO_CONVERTER_OPT_THREADS, G_TYPE_UINT, std::max(std::thread::hardware_concurrency(), 1u), nullptr)));
 


### PR DESCRIPTION
#### 5afce8e3f3a69057b9eb565af0c341d72d23ce62
<pre>
[Skia][GStreamer] Implement ImageGStreamer
<a href="https://bugs.webkit.org/show_bug.cgi?id=269907">https://bugs.webkit.org/show_bug.cgi?id=269907</a>

Reviewed by Philippe Normand.

* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
(WebCore::ImageGStreamer::~ImageGStreamer):

Canonical link: <a href="https://commits.webkit.org/275224@main">https://commits.webkit.org/275224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c76b0e09de60eddde0a62351c5ba2bb9328285aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34034 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41678 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17109 "Found 1 new test failure: http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40473 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38849 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17590 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5502 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->