### PR TITLE
[ Ventura Debug WK2 arm64 EWS ] ASSERTION FAILED: m_shutdown in WebKit::RemoteMediaResource::~RemoteMediaResource() seen with http/tests/media/hls/track-in-band-multiple-cues.html

### DIFF
--- a/LayoutTests/platform/mac-ventura/TestExpectations
+++ b/LayoutTests/platform/mac-ventura/TestExpectations
@@ -1,5 +1,3 @@
 # Failing after OS migration rdar://112624778 (Migrate macOS Sonoma test expectations to OpenSource, add expectation files to Down-Levels (259373))
 
 webkit.org/b/268789 [ Debug ] imported/w3c/web-platform-tests/css/css-break/table/repeated-section/special-elements-crash.html [ Skip ]
-
-webkit.org/b/269403 http/tests/media/hls/track-in-band-multiple-cues.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2631,8 +2631,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-eleme
 fast/html/transient-activation.html [ Skip ]
 fast/html/history-action-user-activation.html [ Skip ]
 
-webkit.org/b/259485 [ Ventura+ ] http/tests/media/hls/track-in-band-multiple-cues.html [ Crash ]
-
 webkit.org/b/259546 [ Debug ] media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html [ Skip ]
 
 webkit.org/b/260070 fast/selectors/style-invalidation-hover-change-descendants.html [ Pass Failure ]

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -132,7 +132,7 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
 @interface WebCoreNSURLSessionDataTask : NSObject {
     WeakObjCPtr<WebCoreNSURLSession> _session; // Accesssed from operation queue, main and loader thread. Must be accessed through Obj-C property.
     RefPtr<WTF::WorkQueue> _targetQueue;
-    RefPtr<WebCore::PlatformMediaResource> _resource; // Accesssed from main and loader thread. Must be accessed through Obj-C property.
+    RefPtr<WebCore::PlatformMediaResource> _resource; // Accesssed from loader thread.
     RetainPtr<NSURLResponse> _response; // Set on operation queue.
     NSUInteger _taskIdentifier;
     RetainPtr<NSURLRequest> _originalRequest; // Set on construction, never modified.
@@ -145,6 +145,7 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
     RetainPtr<NSError> _error; // Unused, always nil.
     RetainPtr<NSString> _taskDescription; // Only set / read on the user's thread.
     float _priority;
+    uint32_t _resumeSessionID; // Accesssed from loader thread.
 }
 
 @property NSUInteger taskIdentifier;


### PR DESCRIPTION
#### 08cf48f399ffdf6357e45edb8bc7f47b303a8b18
<pre>
[ Ventura Debug WK2 arm64 EWS ] ASSERTION FAILED: m_shutdown in WebKit::RemoteMediaResource::~RemoteMediaResource() seen with http/tests/media/hls/track-in-band-multiple-cues.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=269403">https://bugs.webkit.org/show_bug.cgi?id=269403</a>
<a href="https://rdar.apple.com/122967706">rdar://122967706</a>

Reviewed by Youenn Fablet.

Following 273804@main, a PlatformMediaResource is accessed on the MediaResourceLoader&apos;s target.
The AVPlayer runs on its own thread while the MediaPlayer runs in the main thread.

As such, we can have concurrent, and conflicting access to the MediaResource from both the AVPlayer
and the MediaPlayer.

The MediaPlayer could be shutting down, cancelling the WebCoreNSURLSessionDataTask, while the
AVPlayer is attempting to suspend and the resume download.

Under such circumstances we had two issues:
1- It was possible that following a cancel, a suspend be received, this would trigger a second
call to `loadFinishedWithError` which would assert as the task hasn&apos;t already been removed from
the map
2- If the task was cancelled while we were in the middle of resume operation the newly allocated
resource woulb be deleted without first being shutdown.

For 1) We check that the previous task&apos;s state wasn&apos;t NSURLSessionTaskStateCompleted and abort if so.
For 2) We check that the task&apos;s state hasn&apos;t changed mid-way and if so shutdown the resource and stop.

Another issue resolved here, is that it was possible for the MediaResource to call its client with
data immediately after creation, before the session had finished being setup, if so the callback
would be ignored which resulted in some tests intermittently timing out.
We now set the MediaSource&apos;s client immediately and allow processing the callbacks (this resolves
bug 259485).

We also change the structure so that the task&apos;s resource is only ever accessed on the loader&apos;s tarket.
We can remove the locking operation around the resource access as a result.

Covered by existing tests.
* LayoutTests/platform/mac-ventura/TestExpectations:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSessionDataTask resource]):
(-[WebCoreNSURLSessionDataTask setResource:]):
(-[WebCoreNSURLSessionDataTask suspend]):
(-[WebCoreNSURLSessionDataTask resume]):
(-[WebCoreNSURLSessionDataTask dealloc]):

Canonical link: <a href="https://commits.webkit.org/275217@main">https://commits.webkit.org/275217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44504f5777ad69ef65a563afc339b46e9b710dd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43565 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43750 "") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17531 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/43750 "") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41761 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17124 "Found 1 new test failure: http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35467 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/43750 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14861 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36469 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40537 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38919 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17621 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9244 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->