### PR TITLE
Serialization and equality comparison of CSS number tokens in custom properties should use the original string

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
@@ -1525,7 +1525,7 @@ PASS e.style['color'] = "color(from color(xyz-d65 7 -20.5 100 / none) xyz-d65 x 
 FAIL e.style['color'] = "color(from currentColor xyz-d65 x y z)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "rgb(from var(--bg-color) r g b / 80%)" should set the property value
 PASS e.style['color'] = "lch(from var(--color) calc(l / 2) c h)" should set the property value
-FAIL e.style['color'] = "rgb(from var(--color) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11))" should set the property value assert_equals: serialization should be canonical expected "rgb(from var(--color) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11))" but got "rgb(from var(--color) calc(r * 0.3 + g * 0.59 + b * 0.11) calc(r * 0.3 + g * 0.59 + b * 0.11) calc(r * 0.3 + g * 0.59 + b * 0.11))"
+PASS e.style['color'] = "rgb(from var(--color) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11))" should set the property value
 PASS e.style['color'] = "lch(from var(--color) l 0 h)" should set the property value
 FAIL e.style['color'] = "rgb(from indianred 255 g b)" should set the property value Colors do not match.
 Actual:   rgb(255, 92, 92)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt
@@ -6,5 +6,5 @@ PASS No declaration value
 PASS Unknown CSS property after 'or'
 PASS Not a style function with space before '('
 FAIL Spaces preserved in custom property value assert_equals: expected "style(--foo: bar   baz)" but got "style(--foo: bar baz)"
-FAIL Original string number in custom property value assert_equals: expected "style(--foo: 2.100)" but got "style(--foo: 2.1)"
+PASS Original string number in custom property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
@@ -70,6 +70,6 @@ PASS Match registered <length> custom property with em in computed value.
 FAIL Match registered <length> custom property with cqi unit. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Match registered <length> custom property with initial value.
 PASS Match registered <length> custom property with initial value via initial keyword.
-FAIL Should only match exact string for numbers in non-registered custom properties assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Should only match exact string for numbers in non-registered custom properties
 PASS Spaces should not collapse in non-registered custom properties
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-custom-props-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-custom-props-expected.txt
@@ -16,7 +16,7 @@ PASS An unregistered custom prop can take a 12-digit integer
 PASS An <integer> custom prop can take a 12-digit integer
 PASS z-index can take a custom property set to a 12-digit integer
 PASS z-index can take a 25-digit integer
-FAIL An unregistered custom prop can take a 25-digit integer assert_equals: expected "1111111111111111111111111" but got "1.1111111111111111e+24"
-FAIL An <integer> custom prop can take a 25-digit integer assert_equals: expected "1111111111111111111111111" but got "1.1111111111111111e+24"
+PASS An unregistered custom prop can take a 25-digit integer
+PASS An <integer> custom prop can take a 25-digit integer
 PASS z-index can take a custom property set to a 25-digit integer
 

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -107,7 +107,7 @@ String CSSCustomPropertyValue::customCSSText() const
         }, [&](const CSSValueID& value) {
             return nameString(value).string();
         }, [&](const Ref<CSSVariableData>& value) {
-            return value->tokenRange().serialize();
+            return value->serialize();
         }, [&](const SyntaxValue& syntaxValue) {
             return serializeSyntaxValue(syntaxValue);
         }, [&](const SyntaxValueList& syntaxValueList) {

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -67,7 +67,7 @@ String CSSPropertyRule::initialValue() const
     if (!m_propertyRule->descriptor().initialValue)
         return nullString();
 
-    return m_propertyRule->descriptor().initialValue->tokenRange().serialize();
+    return m_propertyRule->descriptor().initialValue->serialize();
 }
 
 String CSSPropertyRule::cssText() const

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -77,4 +77,9 @@ CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSPars
     }
 }
 
+String CSSVariableData::serialize() const
+{
+    return tokenRange().serialize(CSSParserToken::SerializationMode::CustomProperty);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSVariableData.h
+++ b/Source/WebCore/css/CSSVariableData.h
@@ -51,6 +51,8 @@ public:
 
     bool operator==(const CSSVariableData& other) const;
 
+    String serialize() const;
+
 private:
     CSSVariableData(const CSSParserTokenRange&, const CSSParserContext&);
     template<typename CharacterType> void updateBackingStringsInTokens();

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -69,7 +69,7 @@ bool CSSVariableReferenceValue::equals(const CSSVariableReferenceValue& other) c
 String CSSVariableReferenceValue::customCSSText() const
 {
     if (m_stringValue.isNull())
-        m_stringValue = m_data->tokenRange().serialize();
+        m_stringValue = m_data->serialize();
     return m_stringValue;
 }
 

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -135,7 +135,11 @@ public:
 
     CSSPropertyID parseAsCSSPropertyID() const;
 
-    void serialize(StringBuilder&, const CSSParserToken* nextToken = nullptr) const;
+    enum class SerializationMode : bool {
+        Normal,
+        CustomProperty // Custom properties don't collapse whitespace and serialize numbers as original strings.
+    };
+    void serialize(StringBuilder&, const CSSParserToken* nextToken = nullptr, SerializationMode = SerializationMode::Normal) const;
 
     template<typename CharacterType>
     void updateCharacters(const CharacterType* characters, unsigned length);

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -120,11 +120,11 @@ const CSSParserToken& CSSParserTokenRange::consumeLast()
     return *--m_last;
 }
 
-String CSSParserTokenRange::serialize() const
+String CSSParserTokenRange::serialize(CSSParserToken::SerializationMode mode) const
 {
     StringBuilder builder;
     for (const CSSParserToken* it = m_first; it < m_last; ++it)
-        it->serialize(builder, it + 1 == m_last ? nullptr : it + 1);
+        it->serialize(builder, it + 1 == m_last ? nullptr : it + 1, mode);
     return builder.toString();
 }
 

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -96,7 +96,7 @@ public:
 
     CSSParserTokenRange consumeAll() { return { std::exchange(m_first, m_last), m_last }; }
 
-    String serialize() const;
+    String serialize(CSSParserToken::SerializationMode = CSSParserToken::SerializationMode::Normal) const;
 
     const CSSParserToken* begin() const { return m_first; }
 


### PR DESCRIPTION
#### 11c57336e700b00fa2a46d465be30274518e0816
<pre>
Serialization and equality comparison of CSS number tokens in custom properties should use the original string
<a href="https://bugs.webkit.org/show_bug.cgi?id=269910">https://bugs.webkit.org/show_bug.cgi?id=269910</a>
<a href="https://rdar.apple.com/123435602">rdar://123435602</a>

Reviewed by Matthieu Dubet.

Custom property value &quot;0.10&quot; should serialize as such and not as &quot;0.1&quot;. Also they shouldn&apos;t compare equal.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-custom-props-expected.txt:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::customCSSText const):
* Source/WebCore/css/CSSPropertyRule.cpp:
(WebCore::CSSPropertyRule::initialValue const):
* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::serialize const):

Use the custom property serialization mode.

* Source/WebCore/css/CSSVariableData.h:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::customCSSText const):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::originalText const):
(WebCore::CSSParserToken::operator== const):

Use string equality for numbers. This is used for custom properties only.

(WebCore::CSSParserToken::serialize const):

Add a separate serialization mode for custom properties. It returns the original string for number values.
It will later also preserve whitespace.

* Source/WebCore/css/parser/CSSParserToken.h:
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
(WebCore::CSSParserTokenRange::serialize const):
* Source/WebCore/css/parser/CSSParserTokenRange.h:

Serialize the original text.

Canonical link: <a href="https://commits.webkit.org/275196@main">https://commits.webkit.org/275196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/461c613c68e698624cc3831543153f99146c0c73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17465 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45001 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36739 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40487 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15936 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38863 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17555 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9233 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->