### PR TITLE
REGRESSION(274853@main): [WPE][GTK][Debug] ASSERTION FAILED: context.isDocument()

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
@@ -32,6 +32,7 @@ enum PreferredQuality {
 [
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
+    ConditionalForWorker=MEDIA_SOURCE_IN_WORKERS,
     EnabledBySetting=ManagedMediaSourceEnabled,
     EnabledForContext,
     Exposed=(Window,DedicatedWorker)

--- a/Source/WebCore/Modules/mediasource/MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/MediaSource.idl
@@ -44,6 +44,7 @@ enum ReadyState {
     JSGenerateToNativeObject,
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
+    ConditionalForWorker=MEDIA_SOURCE_IN_WORKERS,
     EnabledBySetting=MediaSourceEnabled,
     EnabledForContext,
     Exposed=(Window,DedicatedWorker)

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.idl
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.idl
@@ -38,6 +38,7 @@
     JSGenerateToNativeObject,
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
+    ConditionalForWorker=MEDIA_SOURCE_IN_WORKERS,
     EnabledBySetting=MediaSourceEnabled,
     ExportMacro=WEBCORE_EXPORT,
     GenerateAddOpaqueRoot,

--- a/Source/WebCore/bindings/scripts/preprocess-idls.pl
+++ b/Source/WebCore/bindings/scripts/preprocess-idls.pl
@@ -490,7 +490,7 @@ sub GenerateConstructorAttributes
     my $globalContext = shift;
 
     # FIXME: Rather than being ConditionalForWorker=FOO, we need a syntax like ConditionalForContext=(Worker:FOO).
-    if ($extendedAttributes->{"ConditionalForWorker"} && $globalContext eq "Worker") {
+    if ($extendedAttributes->{"ConditionalForWorker"} && ($globalContext eq "Worker" || $globalContext eq "DedicatedWorker" )) {
       my $conditionalForWorker = $extendedAttributes->{"ConditionalForWorker"};
       my $existingConditional = $extendedAttributes->{"Conditional"};
       if ($existingConditional) {


### PR DESCRIPTION
#### 73bf87126bb540ddfe001061821e93c0e3a78fdf
<pre>
REGRESSION(274853@main): [WPE][GTK][Debug] ASSERTION FAILED: context.isDocument()
<a href="https://bugs.webkit.org/show_bug.cgi?id=269912">https://bugs.webkit.org/show_bug.cgi?id=269912</a>

Reviewed by Chris Dumez.

Starting from 274853@main, we allow `MediaSource` to be constructed in
a `DedicatedWorker` but only if `MEDIA_SOURCE_IN_WORKERS` is enabled.

We should enforce this requirement in `MediaSource.idl` using
`ConditionalForWorker` extended attribute to ensure that its constructor
will not be exposed on worker.
The same applies to `Managed Media Source` and `Source Buffer`.

We also must make `preprocess-idls.pl` to check this condition not only
for `Worker` but also for `DedicatedWorker` global context.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.idl:
* Source/WebCore/Modules/mediasource/MediaSource.idl:
* Source/WebCore/Modules/mediasource/SourceBuffer.idl:
* Source/WebCore/bindings/scripts/preprocess-idls.pl:
(GenerateConstructorAttributes):

Canonical link: <a href="https://commits.webkit.org/275188@main">https://commits.webkit.org/275188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a78eb764590d93b248702b9e2577f586255417a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43651 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34019 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14653 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40454 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38830 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17523 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9231 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->