### PR TITLE
[GStreamer][LibWebRTC] Conflict between two GStreamerVideoDecoder classes can lead to crash

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -48,9 +48,9 @@ typedef struct {
     int64_t renderTimeMs;
 } InputTimestamps;
 
-class GStreamerVideoDecoder : public webrtc::VideoDecoder {
+class GStreamerWebRTCVideoDecoder : public webrtc::VideoDecoder {
 public:
-    GStreamerVideoDecoder()
+    GStreamerWebRTCVideoDecoder()
         : m_pictureId(0)
         , m_width(0)
         , m_height(0)
@@ -112,12 +112,12 @@ public:
 
             auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
             gst_bus_enable_sync_message_emission(bus.get());
-            g_signal_connect_swapped(bus.get(), "sync-message::warning", G_CALLBACK(+[](GStreamerVideoDecoder* decoder, GstMessage* message) {
+            g_signal_connect_swapped(bus.get(), "sync-message::warning", G_CALLBACK(+[](GStreamerWebRTCVideoDecoder* decoder, GstMessage* message) {
                 GUniqueOutPtr<GError> error;
                 gst_message_parse_warning(message, &error.outPtr(), nullptr);
                 decoder->handleError(error.get());
             }), this);
-            g_signal_connect_swapped(bus.get(), "sync-message::error", G_CALLBACK(+[](GStreamerVideoDecoder* decoder, GstMessage* message) {
+            g_signal_connect_swapped(bus.get(), "sync-message::error", G_CALLBACK(+[](GStreamerWebRTCVideoDecoder* decoder, GstMessage* message) {
                 GUniqueOutPtr<GError> error;
                 gst_message_parse_error(message, &error.outPtr(), nullptr);
                 decoder->handleError(error.get());
@@ -332,7 +332,7 @@ private:
     GstClockTime m_firstBufferDts;
 };
 
-class H264Decoder : public GStreamerVideoDecoder {
+class H264Decoder : public GStreamerWebRTCVideoDecoder {
 public:
     H264Decoder() { m_requireParse = true; }
 
@@ -341,7 +341,7 @@ public:
         if (codecSettings.codec_type() != webrtc::kVideoCodecH264)
             return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
 
-        return GStreamerVideoDecoder::Configure(codecSettings);
+        return GStreamerWebRTCVideoDecoder::Configure(codecSettings);
     }
 
     GstCaps* GetCapsForFrame(const webrtc::EncodedImage& image) final
@@ -366,7 +366,7 @@ public:
     }
 };
 
-class VP8Decoder : public GStreamerVideoDecoder {
+class VP8Decoder : public GStreamerWebRTCVideoDecoder {
 public:
     VP8Decoder() { }
     const gchar* Caps() final { return "video/x-vp8"; }
@@ -387,7 +387,7 @@ public:
     }
 };
 
-class VP9Decoder : public GStreamerVideoDecoder {
+class VP9Decoder : public GStreamerWebRTCVideoDecoder {
 public:
     VP9Decoder(bool isSupportingVP9Profile0 = true, bool isSupportingVP9Profile2 = true)
         : m_isSupportingVP9Profile0(isSupportingVP9Profile0)


### PR DESCRIPTION
#### 91dc14fd908d68d00a582840163c1342f304efb3
<pre>
[GStreamer][LibWebRTC] Conflict between two GStreamerVideoDecoder classes can lead to crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=269915">https://bugs.webkit.org/show_bug.cgi?id=269915</a>

Reviewed by Philippe Normand.

In the GStreamer ports, there are two different implementations of the
WebCore::GStreamerVideoDecoder class:
- one for WebRTC in Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
- one for WebCodecs in Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp

This can lead to a crash in WebRTC usage, since the
WebCore::GStreamerVideoDecoder destructor from the WebCodecs class can
be mistakenly used instead of the one from the WebRTC class.

Rename the WebRTC class as GStreamerWebRTCVideoDecoder.

* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:
(WebCore::GStreamerWebRTCVideoDecoder::GStreamerWebRTCVideoDecoder):
(WebCore::GStreamerVideoDecoder::GStreamerVideoDecoder): Deleted.
(WebCore::GStreamerVideoDecoder::decodebinPadAddedCb): Deleted.
(WebCore::GStreamerVideoDecoder::pipeline): Deleted.
(WebCore::GStreamerVideoDecoder::makeElement): Deleted.
(WebCore::GStreamerVideoDecoder::handleError): Deleted.
(WebCore::GStreamerVideoDecoder::CreateFilter): Deleted.
(WebCore::GStreamerVideoDecoder::pullSample): Deleted.
(WebCore::GStreamerVideoDecoder::GetCapsForFrame): Deleted.
(WebCore::GStreamerVideoDecoder::AddDecoderIfSupported): Deleted.
(WebCore::GStreamerVideoDecoder::ConfigureSupportedDecoder): Deleted.
(WebCore::GStreamerVideoDecoder::GstDecoderFactory): Deleted.
(WebCore::GStreamerVideoDecoder::HasGstDecoder): Deleted.

Canonical link: <a href="https://commits.webkit.org/275235@main">https://commits.webkit.org/275235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eebadab5e3058c5d8cd86c10cd7439b71a5c83fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34025 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44973 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40459 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38835 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17530 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9256 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->