### PR TITLE
Adopt dynamicDowncast<> across page/scrolling

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -191,8 +191,8 @@ class LayerTreeHitTestLocker {
 public:
     LayerTreeHitTestLocker(ScrollingCoordinator* scrollingCoordinator)
     {
-        if (is<AsyncScrollingCoordinator>(scrollingCoordinator)) {
-            m_scrollingTree = downcast<AsyncScrollingCoordinator>(*scrollingCoordinator).scrollingTree();
+        if (auto* asyncScrollingCoordinator = dynamicDowncast<AsyncScrollingCoordinator>(scrollingCoordinator)) {
+            m_scrollingTree = asyncScrollingCoordinator->scrollingTree();
             if (m_scrollingTree)
                 m_scrollingTree->lockLayersForHitTesting();
         }

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -50,8 +50,8 @@ ScrollAnchoringController::~ScrollAnchoringController()
 
 LocalFrameView& ScrollAnchoringController::frameView()
 {
-    if (is<RenderLayerScrollableArea>(m_owningScrollableArea))
-        return downcast<RenderLayerScrollableArea>(m_owningScrollableArea).layer().renderer().view().frameView();
+    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea))
+        return renderLayerScrollableArea->layer().renderer().view().frameView();
     return downcast<LocalFrameView>(downcast<ScrollView>(m_owningScrollableArea));
 }
 
@@ -62,8 +62,8 @@ static bool elementIsScrollableArea(const Element& element, const ScrollableArea
 
 static Element* elementForScrollableArea(ScrollableArea& scrollableArea)
 {
-    if (is<RenderLayerScrollableArea>(scrollableArea))
-        return downcast<RenderLayerScrollableArea>(scrollableArea).layer().renderer().element();
+    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(scrollableArea))
+        return renderLayerScrollableArea->layer().renderer().element();
     if (auto* document = downcast<LocalFrameView>(downcast<ScrollView>(scrollableArea)).frame().document())
         return document->documentElement();
     return nullptr;
@@ -91,8 +91,8 @@ void ScrollAnchoringController::invalidateAnchorElement()
 
 static IntRect boundingRectForScrollableArea(ScrollableArea& scrollableArea)
 {
-    if (is<RenderLayerScrollableArea>(scrollableArea))
-        return downcast<RenderLayerScrollableArea>(scrollableArea).layer().renderer().absoluteBoundingBoxRect();
+    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(scrollableArea))
+        return renderLayerScrollableArea->layer().renderer().absoluteBoundingBoxRect();
 
     return IntRect(downcast<LocalFrameView>(downcast<ScrollView>(scrollableArea)).layoutViewportRect());
 }
@@ -194,9 +194,9 @@ bool ScrollAnchoringController::didFindPriorityCandidate(Document& document)
 
 static bool absolutePositionedElementOutsideScroller(RenderElement& renderer, ScrollableArea& scroller)
 {
-    if (is<RenderLayerScrollableArea>(scroller) && renderer.hasLayer()) {
+    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(scroller); renderLayerScrollableArea && renderer.hasLayer()) {
         if (auto* layerForRenderer = downcast<RenderLayerModelObject>(renderer).layer())
-            return !layerForRenderer->ancestorLayerIsInContainingBlockChain(downcast<RenderLayerScrollableArea>(scroller).layer());
+            return !layerForRenderer->ancestorLayerIsInContainingBlockChain(renderLayerScrollableArea->layer());
     }
     return false;
 }

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -141,9 +141,10 @@ EventTrackingRegions ScrollingCoordinator::absoluteEventTrackingRegionsForFrame(
     }
 
     for (auto& widget : frameView->widgetsInRenderTree()) {
-        if (!is<PluginViewBase>(widget))
+        auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget.get());
+        if (!pluginViewBase)
             continue;
-        if (!downcast<PluginViewBase>(widget.get()).wantsWheelEvents())
+        if (!pluginViewBase->wantsWheelEvents())
             continue;
         auto* renderWidget = RenderWidget::find(widget);
         if (!renderWidget)
@@ -309,9 +310,10 @@ bool ScrollingCoordinator::hasVisibleSlowRepaintViewportConstrainedObjects(const
         return false;
 
     for (auto& viewportConstrainedObject : *viewportConstrainedObjects) {
-        if (!is<RenderBoxModelObject>(viewportConstrainedObject) || !viewportConstrainedObject.hasLayer())
+        auto* viewportConstrainedBoxModelObject = dynamicDowncast<RenderBoxModelObject>(viewportConstrainedObject);
+        if (!viewportConstrainedBoxModelObject || !viewportConstrainedBoxModelObject->hasLayer())
             return true;
-        auto& layer = *downcast<RenderBoxModelObject>(viewportConstrainedObject).layer();
+        auto& layer = *viewportConstrainedBoxModelObject->layer();
         // Any explicit reason that a fixed position element is not composited shouldn't cause slow scrolling.
         if (!layer.isComposited() && layer.viewportConstrainedNotCompositedReason() == RenderLayer::NoNotCompositedReason)
             return true;

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
@@ -101,9 +101,8 @@ FloatPoint ScrollingStateStickyNode::computeLayerPosition(const LayoutRect& view
     };
 
     for (auto ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
-        if (is<ScrollingStateOverflowScrollProxyNode>(*ancestor)) {
-            auto& overflowProxyNode = downcast<ScrollingStateOverflowScrollProxyNode>(*ancestor);
-            auto overflowNode = scrollingStateTree().stateNodeForID(overflowProxyNode.overflowScrollingNode());
+        if (auto* overflowProxyNode = dynamicDowncast<ScrollingStateOverflowScrollProxyNode>(*ancestor)) {
+            auto overflowNode = scrollingStateTree().stateNodeForID(overflowProxyNode->overflowScrollingNode());
             if (!overflowNode)
                 break;
 
@@ -113,8 +112,8 @@ FloatPoint ScrollingStateStickyNode::computeLayerPosition(const LayoutRect& view
         if (is<ScrollingStateScrollingNode>(*ancestor))
             return computeLayerPositionForScrollingNode(*ancestor);
 
-        if (is<ScrollingStateStickyNode>(*ancestor))
-            offsetFromStickyAncestors += downcast<ScrollingStateStickyNode>(*ancestor).scrollDeltaSinceLastCommit(viewportRect);
+        if (auto* stickyNode = dynamicDowncast<ScrollingStateStickyNode>(*ancestor))
+            offsetFromStickyAncestors += stickyNode->scrollDeltaSinceLastCommit(viewportRect);
 
         if (is<ScrollingStateFixedNode>(*ancestor)) {
             // FIXME: Do we need scrolling tree nodes at all for nested cases?

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
@@ -51,12 +51,12 @@ ScrollingTreeFrameHostingNode::~ScrollingTreeFrameHostingNode() = default;
 
 bool ScrollingTreeFrameHostingNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (!is<ScrollingStateFrameHostingNode>(stateNode))
+    auto* state = dynamicDowncast<ScrollingStateFrameHostingNode>(stateNode);
+    if (!state)
         return false;
 
-    const auto& state = downcast<ScrollingStateFrameHostingNode>(stateNode);
-    if (state.hasChangedProperty(ScrollingStateNode::Property::LayerHostingContextIdentifier))
-        setLayerHostingContextIdentifier(state.layerHostingContextIdentifier());
+    if (state->hasChangedProperty(ScrollingStateNode::Property::LayerHostingContextIdentifier))
+        setLayerHostingContextIdentifier(state->layerHostingContextIdentifier());
     return true;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
@@ -50,45 +50,44 @@ bool ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(const ScrollingS
     if (!ScrollingTreeScrollingNode::commitStateBeforeChildren(stateNode))
         return false;
 
-    if (!is<ScrollingStateFrameScrollingNode>(stateNode))
+    auto* state = dynamicDowncast<ScrollingStateFrameScrollingNode>(stateNode);
+    if (!state)
         return false;
 
-    const auto& state = downcast<ScrollingStateFrameScrollingNode>(stateNode);
+    if (state->hasChangedProperty(ScrollingStateNode::Property::FrameScaleFactor))
+        m_frameScaleFactor = state->frameScaleFactor();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::FrameScaleFactor))
-        m_frameScaleFactor = state.frameScaleFactor();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::HeaderHeight))
+        m_headerHeight = state->headerHeight();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::HeaderHeight))
-        m_headerHeight = state.headerHeight();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::FooterHeight))
+        m_footerHeight = state->footerHeight();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::FooterHeight))
-        m_footerHeight = state.footerHeight();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::BehaviorForFixedElements))
+        m_behaviorForFixed = state->scrollBehaviorForFixedElements();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::BehaviorForFixedElements))
-        m_behaviorForFixed = state.scrollBehaviorForFixedElements();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::TopContentInset))
+        m_topContentInset = state->topContentInset();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::TopContentInset))
-        m_topContentInset = state.topContentInset();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::VisualViewportIsSmallerThanLayoutViewport))
+        m_visualViewportIsSmallerThanLayoutViewport = state->visualViewportIsSmallerThanLayoutViewport();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::VisualViewportIsSmallerThanLayoutViewport))
-        m_visualViewportIsSmallerThanLayoutViewport = state.visualViewportIsSmallerThanLayoutViewport();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::FixedElementsLayoutRelativeToFrame))
+        m_fixedElementsLayoutRelativeToFrame = state->fixedElementsLayoutRelativeToFrame();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::FixedElementsLayoutRelativeToFrame))
-        m_fixedElementsLayoutRelativeToFrame = state.fixedElementsLayoutRelativeToFrame();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::LayoutViewport))
+        m_layoutViewport = state->layoutViewport();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::LayoutViewport))
-        m_layoutViewport = state.layoutViewport();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::MinLayoutViewportOrigin))
+        m_minLayoutViewportOrigin = state->minLayoutViewportOrigin();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::MinLayoutViewportOrigin))
-        m_minLayoutViewportOrigin = state.minLayoutViewportOrigin();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::MaxLayoutViewportOrigin))
+        m_maxLayoutViewportOrigin = state->maxLayoutViewportOrigin();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::MaxLayoutViewportOrigin))
-        m_maxLayoutViewportOrigin = state.maxLayoutViewportOrigin();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::OverrideVisualViewportSize))
+        m_overrideVisualViewportSize = state->overrideVisualViewportSize();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::OverrideVisualViewportSize))
-        m_overrideVisualViewportSize = state.overrideVisualViewportSize();
-
-    if (state.hasChangedProperty(ScrollingStateNode::Property::LayoutViewport)) {
+    if (state->hasChangedProperty(ScrollingStateNode::Property::LayoutViewport)) {
         // This requires that minLayoutViewportOrigin and maxLayoutViewportOrigin have been updated.
         updateViewportForCurrentScrollPosition({ });
     }

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
@@ -44,13 +44,12 @@ ScrollingTreeOverflowScrollProxyNode::~ScrollingTreeOverflowScrollProxyNode() = 
 
 bool ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (!is<ScrollingStateOverflowScrollProxyNode>(stateNode))
+    auto* overflowProxyStateNode = dynamicDowncast<ScrollingStateOverflowScrollProxyNode>(stateNode);
+    if (!overflowProxyStateNode)
         return false;
 
-    const auto& overflowProxyStateNode = downcast<ScrollingStateOverflowScrollProxyNode>(stateNode);
-
-    if (overflowProxyStateNode.hasChangedProperty(ScrollingStateNode::Property::OverflowScrollingNode))
-        m_overflowScrollingNodeID = overflowProxyStateNode.overflowScrollingNode();
+    if (overflowProxyStateNode->hasChangedProperty(ScrollingStateNode::Property::OverflowScrollingNode))
+        m_overflowScrollingNodeID = overflowProxyStateNode->overflowScrollingNode();
 
     if (m_overflowScrollingNodeID) {
         auto& relatedNodes = scrollingTree().overflowRelatedNodes();
@@ -66,10 +65,8 @@ bool ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const Scrol
 
 FloatSize ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit() const
 {
-    if (auto* node = scrollingTree().nodeForID(m_overflowScrollingNodeID)) {
-        if (is<ScrollingTreeOverflowScrollingNode>(node))
-            return downcast<ScrollingTreeOverflowScrollingNode>(*node).scrollDeltaSinceLastCommit();
-    }
+    if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree().nodeForID(m_overflowScrollingNodeID)))
+        return node->scrollDeltaSinceLastCommit();
 
     return { };
 }
@@ -77,12 +74,8 @@ FloatSize ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit() con
 FloatPoint ScrollingTreeOverflowScrollProxyNode::computeLayerPosition() const
 {
     FloatPoint scrollOffset;
-    if (auto* node = scrollingTree().nodeForID(m_overflowScrollingNodeID)) {
-        if (is<ScrollingTreeOverflowScrollingNode>(node)) {
-            auto& overflowNode = downcast<ScrollingTreeOverflowScrollingNode>(*node);
-            scrollOffset = overflowNode.currentScrollOffset();
-        }
-    }
+    if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree().nodeForID(m_overflowScrollingNodeID)))
+        scrollOffset = node->currentScrollOffset();
     return scrollOffset;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp
@@ -46,16 +46,15 @@ ScrollingTreePositionedNode::~ScrollingTreePositionedNode() = default;
 
 bool ScrollingTreePositionedNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (!is<ScrollingStatePositionedNode>(stateNode))
+    auto* positionedStateNode = dynamicDowncast<ScrollingStatePositionedNode>(stateNode);
+    if (!positionedStateNode)
         return false;
 
-    const auto& positionedStateNode = downcast<ScrollingStatePositionedNode>(stateNode);
+    if (positionedStateNode->hasChangedProperty(ScrollingStateNode::Property::RelatedOverflowScrollingNodes))
+        m_relatedOverflowScrollingNodes = positionedStateNode->relatedOverflowScrollingNodes();
 
-    if (positionedStateNode.hasChangedProperty(ScrollingStateNode::Property::RelatedOverflowScrollingNodes))
-        m_relatedOverflowScrollingNodes = positionedStateNode.relatedOverflowScrollingNodes();
-
-    if (positionedStateNode.hasChangedProperty(ScrollingStateNode::Property::LayoutConstraintData))
-        m_constraints = positionedStateNode.layoutConstraints();
+    if (positionedStateNode->hasChangedProperty(ScrollingStateNode::Property::LayoutConstraintData))
+        m_constraints = positionedStateNode->layoutConstraints();
 
     if (!m_relatedOverflowScrollingNodes.isEmpty())
         scrollingTree().activePositionedNodes().add(*this);
@@ -67,12 +66,8 @@ FloatSize ScrollingTreePositionedNode::scrollDeltaSinceLastCommit() const
 {
     FloatSize delta;
     for (auto nodeID : m_relatedOverflowScrollingNodes) {
-        if (auto* node = scrollingTree().nodeForID(nodeID)) {
-            if (is<ScrollingTreeOverflowScrollingNode>(node)) {
-                auto& overflowNode = downcast<ScrollingTreeOverflowScrollingNode>(*node);
-                delta += overflowNode.scrollDeltaSinceLastCommit();
-            }
-        }
+        if (auto* node = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(scrollingTree().nodeForID(nodeID)))
+            delta += node->scrollDeltaSinceLastCommit();
     }
 
     // Positioned nodes compensate for scrolling, so negate the scroll delta.

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -50,72 +50,71 @@ ScrollingTreeScrollingNode::~ScrollingTreeScrollingNode() = default;
 
 bool ScrollingTreeScrollingNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (!is<ScrollingStateScrollingNode>(stateNode))
+    auto* state = dynamicDowncast<ScrollingStateScrollingNode>(stateNode);
+    if (!state)
         return false;
 
-    const auto& state = downcast<ScrollingStateScrollingNode>(stateNode);
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaSize))
+        m_scrollableAreaSize = state->scrollableAreaSize();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaSize))
-        m_scrollableAreaSize = state.scrollableAreaSize();
-
-    if (state.hasChangedProperty(ScrollingStateNode::Property::TotalContentsSize)) {
+    if (state->hasChangedProperty(ScrollingStateNode::Property::TotalContentsSize)) {
         if (scrollingTree().isRubberBandInProgressForNode(scrollingNodeID()))
             m_totalContentsSizeForRubberBand = m_totalContentsSize;
         else
-            m_totalContentsSizeForRubberBand = state.totalContentsSize();
+            m_totalContentsSizeForRubberBand = state->totalContentsSize();
 
-        m_totalContentsSize = state.totalContentsSize();
+        m_totalContentsSize = state->totalContentsSize();
     }
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::ReachableContentsSize))
-        m_reachableContentsSize = state.reachableContentsSize();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ReachableContentsSize))
+        m_reachableContentsSize = state->reachableContentsSize();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::ScrollPosition)) {
-        m_lastCommittedScrollPosition = state.scrollPosition();
-        if (m_isFirstCommit && !state.hasScrollPositionRequest())
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ScrollPosition)) {
+        m_lastCommittedScrollPosition = state->scrollPosition();
+        if (m_isFirstCommit && !state->hasScrollPositionRequest())
             m_currentScrollPosition = m_lastCommittedScrollPosition;
     }
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::ScrollOrigin))
-        m_scrollOrigin = state.scrollOrigin();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ScrollOrigin))
+        m_scrollOrigin = state->scrollOrigin();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::SnapOffsetsInfo))
-        m_snapOffsetsInfo = state.snapOffsetsInfo();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::SnapOffsetsInfo))
+        m_snapOffsetsInfo = state->snapOffsetsInfo();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex))
-        m_currentHorizontalSnapPointIndex = state.currentHorizontalSnapPointIndex();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::CurrentHorizontalSnapOffsetIndex))
+        m_currentHorizontalSnapPointIndex = state->currentHorizontalSnapPointIndex();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex))
-        m_currentVerticalSnapPointIndex = state.currentVerticalSnapPointIndex();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex))
+        m_currentVerticalSnapPointIndex = state->currentVerticalSnapPointIndex();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams))
-        m_scrollableAreaParameters = state.scrollableAreaParameters();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams))
+        m_scrollableAreaParameters = state->scrollableAreaParameters();
 
 #if ENABLE(SCROLLING_THREAD)
-    if (state.hasChangedProperty(ScrollingStateNode::Property::ReasonsForSynchronousScrolling))
-        m_synchronousScrollingReasons = state.synchronousScrollingReasons();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ReasonsForSynchronousScrolling))
+        m_synchronousScrollingReasons = state->synchronousScrollingReasons();
 #endif
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
-        m_scrollContainerLayer = state.scrollContainerLayer();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
+        m_scrollContainerLayer = state->scrollContainerLayer();
 
-    if (state.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
-        m_scrolledContentsLayer = state.scrolledContentsLayer();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
+        m_scrolledContentsLayer = state->scrolledContentsLayer();
 
     return true;
 }
 
 bool ScrollingTreeScrollingNode::commitStateAfterChildren(const ScrollingStateNode& stateNode)
 {
-    if (!is<ScrollingStateScrollingNode>(stateNode))
+    auto* scrollingStateNode = dynamicDowncast<ScrollingStateScrollingNode>(stateNode);
+    if (!scrollingStateNode)
         return false;
 
-    const auto& scrollingStateNode = downcast<ScrollingStateScrollingNode>(stateNode);
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition))
-        handleScrollPositionRequest(scrollingStateNode.requestedScrollData());
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition))
+        handleScrollPositionRequest(scrollingStateNode->requestedScrollData());
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::KeyboardScrollData))
-        requestKeyboardScroll(scrollingStateNode.keyboardScrollData());
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::KeyboardScrollData))
+        requestKeyboardScroll(scrollingStateNode->keyboardScrollData());
 
     // This synthetic bit is added back in ScrollingTree::propagateSynchronousScrollingReasons().
 #if ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
@@ -50,12 +50,12 @@ ScrollingTreeFixedNodeCocoa::~ScrollingTreeFixedNodeCocoa() = default;
 
 bool ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (!is<ScrollingStateFixedNode>(stateNode))
+    auto* fixedStateNode = dynamicDowncast<ScrollingStateFixedNode>(stateNode);
+    if (!fixedStateNode)
         return false;
 
-    const auto& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
-    if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
-        m_layer = static_cast<CALayer*>(fixedStateNode.layer());
+    if (fixedStateNode->hasChangedProperty(ScrollingStateNode::Property::Layer))
+        m_layer = static_cast<CALayer*>(fixedStateNode->layer());
 
     return ScrollingTreeFixedNode::commitStateBeforeChildren(stateNode);
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -75,37 +75,36 @@ bool ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(const Scrolli
     if (!ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(stateNode))
         return false;
 
-    if (!is<ScrollingStateFrameScrollingNode>(stateNode))
+    auto* scrollingStateNode = dynamicDowncast<ScrollingStateFrameScrollingNode>(stateNode);
+    if (!scrollingStateNode)
         return false;
 
-    const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::RootContentsLayer))
+        m_rootContentsLayer = static_cast<CALayer*>(scrollingStateNode->rootContentsLayer());
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RootContentsLayer))
-        m_rootContentsLayer = static_cast<CALayer*>(scrollingStateNode.rootContentsLayer());
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer))
+        m_counterScrollingLayer = static_cast<CALayer*>(scrollingStateNode->counterScrollingLayer());
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer))
-        m_counterScrollingLayer = static_cast<CALayer*>(scrollingStateNode.counterScrollingLayer());
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::InsetClipLayer))
+        m_insetClipLayer = static_cast<CALayer*>(scrollingStateNode->insetClipLayer());
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::InsetClipLayer))
-        m_insetClipLayer = static_cast<CALayer*>(scrollingStateNode.insetClipLayer());
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ContentShadowLayer))
+        m_contentShadowLayer = static_cast<CALayer*>(scrollingStateNode->contentShadowLayer());
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ContentShadowLayer))
-        m_contentShadowLayer = static_cast<CALayer*>(scrollingStateNode.contentShadowLayer());
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::HeaderLayer))
+        m_headerLayer = static_cast<CALayer*>(scrollingStateNode->headerLayer());
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HeaderLayer))
-        m_headerLayer = static_cast<CALayer*>(scrollingStateNode.headerLayer());
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::FooterLayer))
-        m_footerLayer = static_cast<CALayer*>(scrollingStateNode.footerLayer());
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::FooterLayer))
+        m_footerLayer = static_cast<CALayer*>(scrollingStateNode->footerLayer());
 
     bool logScrollingMode = !m_hadFirstUpdate;
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ReasonsForSynchronousScrolling))
+    if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ReasonsForSynchronousScrolling))
         logScrollingMode = true;
 
     if (logScrollingMode && isRootNode() && scrollingTree().scrollingPerformanceTestingEnabled())
         scrollingTree().reportSynchronousScrollingReasonsChanged(MonotonicTime::now(), synchronousScrollingReasons());
 
-    m_delegate->updateFromStateNode(scrollingStateNode);
+    m_delegate->updateFromStateNode(*scrollingStateNode);
 
     m_hadFirstUpdate = true;
     return true;
@@ -116,14 +115,14 @@ bool ScrollingTreeFrameScrollingNodeMac::commitStateAfterChildren(const Scrollin
     if (!ScrollingTreeFrameScrollingNode::commitStateAfterChildren(stateNode))
         return false;
 
-    if (!is<ScrollingStateScrollingNode>(stateNode))
+    auto* scrollingStateNode = dynamicDowncast<ScrollingStateScrollingNode>(stateNode);
+    if (!scrollingStateNode)
         return false;
 
-    const auto& scrollingStateNode = downcast<ScrollingStateScrollingNode>(stateNode);
     if (isRootNode()
-        && (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer)
-        || scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::TotalContentsSize)
-        || scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaSize)))
+        && (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer)
+        || scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::TotalContentsSize)
+        || scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaSize)))
         updateMainFramePinAndRubberbandState();
 
     return true;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -112,14 +112,14 @@ static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNod
             return true;
 
         auto* scrollingNode = tree.nodeForID(nodeID);
-        if (is<ScrollingTreeOverflowScrollProxyNode>(scrollingNode)) {
-            ScrollingNodeID actingOverflowScrollingNodeID = downcast<ScrollingTreeOverflowScrollProxyNode>(*scrollingNode).overflowScrollingNodeID();
+        if (auto* proxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(scrollingNode)) {
+            auto actingOverflowScrollingNodeID = proxyNode->overflowScrollingNodeID();
             if (actingOverflowScrollingNodeID == scrollingNodeID)
                 return true;
         }
 
-        if (is<ScrollingTreePositionedNode>(scrollingNode)) {
-            if (downcast<ScrollingTreePositionedNode>(*scrollingNode).relatedOverflowScrollingNodes().contains(scrollingNodeID))
+        if (auto* positionedNode = dynamicDowncast<ScrollingTreePositionedNode>(scrollingNode)) {
+            if (positionedNode->relatedOverflowScrollingNodes().contains(scrollingNodeID))
                 return false;
         }
     }

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
@@ -66,10 +66,11 @@ bool ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren(const Scro
     if (!ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode))
         return false;
 
-    if (!is<ScrollingStateOverflowScrollingNode>(stateNode))
+    auto* state = dynamicDowncast<ScrollingStateOverflowScrollingNode>(stateNode);
+    if (!state)
         return false;
 
-    m_delegate->updateFromStateNode(downcast<ScrollingStateOverflowScrollingNode>(stateNode));
+    m_delegate->updateFromStateNode(*state);
     return true;
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
@@ -66,10 +66,11 @@ bool ScrollingTreePluginScrollingNodeMac::commitStateBeforeChildren(const Scroll
     if (!ScrollingTreePluginScrollingNode::commitStateBeforeChildren(stateNode))
         return false;
 
-    if (!is<ScrollingStatePluginScrollingNode>(stateNode))
+    auto* state = dynamicDowncast<ScrollingStatePluginScrollingNode>(stateNode);
+    if (!state)
         return false;
 
-    m_delegate->updateFromStateNode(downcast<ScrollingStatePluginScrollingNode>(stateNode));
+    m_delegate->updateFromStateNode(*state);
     return true;
 }
 


### PR DESCRIPTION
#### e3441ec2e3924c92c954b4d83534f9fbea4ace8a
<pre>
Adopt dynamicDowncast&lt;&gt; across page/scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=269918">https://bugs.webkit.org/show_bug.cgi?id=269918</a>

Reviewed by Chris Dumez.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::scrollableAreaScrollbarLayerDidChange):
(WebCore::AsyncScrollingCoordinator::setNodeLayers):
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
(WebCore::AsyncScrollingCoordinator::setRelatedOverflowScrollingNodes):
(WebCore::AsyncScrollingCoordinator::setSynchronousScrollingReasons):
(WebCore::AsyncScrollingCoordinator::synchronousScrollingReasons const):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
(WebCore::LayerTreeHitTestLocker::LayerTreeHitTestLocker):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::frameView):
(WebCore::elementForScrollableArea):
(WebCore::boundingRectForScrollableArea):
(WebCore::absolutePositionedElementOutsideScroller):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::absoluteEventTrackingRegionsForFrame const):
(WebCore::ScrollingCoordinator::hasVisibleSlowRepaintViewportConstrainedObjects const):
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp:
(WebCore::ScrollingStateStickyNode::computeLayerPosition const):
* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp:
(WebCore::ScrollingTreeFixedNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeFixedNode::computeLayerPosition const):
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp:
(WebCore::ScrollingTreeFrameHostingNode::commitStateBeforeChildren):
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp:
(WebCore::ScrollingTreeFrameScrollingNode::commitStateBeforeChildren):
* Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp:
(WebCore::ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit const):
(WebCore::ScrollingTreeOverflowScrollProxyNode::computeLayerPosition const):
* Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp:
(WebCore::ScrollingTreePositionedNode::commitStateBeforeChildren):
(WebCore::ScrollingTreePositionedNode::scrollDeltaSinceLastCommit const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeScrollingNode::commitStateAfterChildren):
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeStickyNode::computeLayerPosition const):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::didCommitTreeOnScrollingThread):
(WebCore::ThreadedScrollingTree::propagateSynchronousScrollingReasons):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm:
(WebCore::ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren):
(WebCore::ScrollingTreeFrameScrollingNodeMac::commitStateAfterChildren):
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(isScrolledBy):
* Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm:
(WebCore::ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren):
* Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm:
(WebCore::ScrollingTreePluginScrollingNodeMac::commitStateBeforeChildren):

Canonical link: <a href="https://commits.webkit.org/275209@main">https://commits.webkit.org/275209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b5c1f5d0c4ad693feca61efe6351d654615d0c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43679 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34040 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14676 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44996 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36728 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40479 "Found 1 new test failure: http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38855 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17551 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9240 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->