### PR TITLE
[WPE] Enable autoplay and WebRTC in MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -356,6 +356,7 @@ static void activate(GApplication* application, WPEToolingBackends::ViewBackend*
         "enable-developer-extras", TRUE,
         "enable-webgl", TRUE,
         "enable-media-stream", TRUE,
+        "enable-webrtc", TRUE,
         "enable-encrypted-media", TRUE,
         nullptr);
 
@@ -393,6 +394,10 @@ static void activate(GApplication* application, WPEToolingBackends::ViewBackend*
         delete static_cast<WPEToolingBackends::ViewBackend*>(data);
     }, backend) : nullptr;
 
+    auto* defaultWebsitePolicies = webkit_website_policies_new_with_policies(
+        "autoplay", WEBKIT_AUTOPLAY_ALLOW,
+        nullptr);
+
     auto* webView = WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
         "backend", viewBackend,
         "web-context", webContext,
@@ -402,8 +407,10 @@ static void activate(GApplication* application, WPEToolingBackends::ViewBackend*
         "settings", settings,
         "user-content-manager", userContentManager,
         "is-controlled-by-automation", automationMode,
+        "website-policies", defaultWebsitePolicies,
         nullptr));
     g_object_unref(settings);
+    g_object_unref(defaultWebsitePolicies);
 
     if (backend) {
         backend->setInputClient(std::make_unique<InputClient>(application, webView));


### PR DESCRIPTION
#### d11c7e88e250b8266e38c729da505e2f9b1f98d4
<pre>
[WPE] Enable autoplay and WebRTC in MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=269920">https://bugs.webkit.org/show_bug.cgi?id=269920</a>

Reviewed by Michael Catanzaro.

Before 264689@main, the autoplay setting was not properly applied and
was always WEBKIT_AUTOPLAY_ALLOW for WPE. Now, the default setting of
WEBKIT_AUTOPLAY_ALLOW_WITHOUT_SOUND is really applied.

This prevents some pages with minimal UI from playing videos, and
MiniBrowser does not have the UI to enable autoplay.
It is easier to enable it by default.

Also enable WebRTC, which has been made opt-in in 251951@main, and now
needs to be enabled in addition to MediaStream.

* Tools/MiniBrowser/wpe/main.cpp:
(activate):

Canonical link: <a href="https://commits.webkit.org/275241@main">https://commits.webkit.org/275241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f59fc6ff71d3e5888ca32681d7973fe4c4ffe3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34131 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14788 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14938 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40607 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38994 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17704 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9259 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->