### PR TITLE
[WGSL] Serialization of constant structs is not implemented

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructureMember.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructureMember.h
@@ -47,6 +47,7 @@ public:
 
     NodeKind kind() const final;
     Identifier& name() { return m_name; }
+    Identifier& originalName() { return m_originalName; }
     Expression& type() { return m_type; }
     Attribute::List& attributes() { return m_attributes; }
 
@@ -65,11 +66,13 @@ private:
     StructureMember(SourceSpan span, Identifier&& name, Expression::Ref&& type, Attribute::List&& attributes)
         : Node(span)
         , m_name(WTFMove(name))
+        , m_originalName(m_name)
         , m_attributes(WTFMove(attributes))
         , m_type(WTFMove(type))
     { }
 
     Identifier m_name;
+    Identifier m_originalName;
     Attribute::List m_attributes;
     Expression::Ref m_type;
 

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -2484,9 +2484,15 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
             }
             m_stringBuilder.append(")");
         },
-        [&](const Struct&) {
-            // Not supported yet
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](const Struct& structType) {
+            auto& constantStruct = std::get<ConstantStruct>(value);
+            m_stringBuilder.append(structType.structure.name(), " { ");
+            for (auto& member : structType.structure.members()) {
+                m_stringBuilder.append(".", member.name(), " = ");
+                serializeConstant(structType.fields.get(member.originalName()), constantStruct.fields.get(member.originalName()));
+                m_stringBuilder.append(", ");
+            }
+            m_stringBuilder.append(" }");
         },
         [&](const PrimitiveStruct& primitiveStruct) {
             auto& constantStruct = std::get<ConstantStruct>(value);


### PR DESCRIPTION
#### ca4cb03cffc676534681333693789bc5d7a159e8
<pre>
[WGSL] Serialization of constant structs is not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=269921">https://bugs.webkit.org/show_bug.cgi?id=269921</a>
<a href="https://rdar.apple.com/123445698">rdar://123445698</a>

Reviewed by Mike Wyrzykowski.

Constant structs were implemented in 275043@main, but serialization was missing.

* Source/WebGPU/WGSL/AST/ASTStructureMember.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::serializeConstant):

Canonical link: <a href="https://commits.webkit.org/275234@main">https://commits.webkit.org/275234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51c1c8f8db93ce795ed21ecee622dcbfae399806

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37194 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17446 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34031 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14663 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14810 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44979 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40467 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38843 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17536 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9255 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->