### PR TITLE
[UnifiedPDF] PDFPluginChoiceAnnotations have incorrect font size.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -118,6 +118,7 @@ public:
     WebCore::FloatRect convertFromPDFViewToScreen(const WebCore::FloatRect&) const;
 
     CGFloat scaleFactor() const override;
+    float contentScaleFactor() const final;
     CGSize contentSizeRespectingZoom() const;
 
 private:

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1540,6 +1540,11 @@ CGFloat PDFPlugin::scaleFactor() const
     return [m_pdfLayerController contentScaleFactor];
 }
 
+float PDFPlugin::contentScaleFactor() const
+{
+    return scaleFactor();
+}
+
 bool PDFPlugin::handleWheelEvent(const WebWheelEvent& event)
 {
     PDFDisplayMode displayMode = [m_pdfLayerController displayMode];

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -113,6 +113,7 @@ public:
     virtual void paint(WebCore::GraphicsContext&, const WebCore::IntRect&) { }
 
     virtual CGFloat scaleFactor() const = 0;
+    virtual float contentScaleFactor() const = 0;
 
     virtual CGFloat minScaleFactor() const { return 0.25; }
     virtual CGFloat maxScaleFactor() const { return 5; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -52,7 +52,7 @@ void PDFPluginChoiceAnnotation::updateGeometry()
     PDFPluginAnnotation::updateGeometry();
 
     RefPtr styledElement = downcast<StyledElement>(element());
-    styledElement->setInlineStyleProperty(CSSPropertyFontSize, choiceAnnotation().font.pointSize * plugin()->scaleFactor(), CSSUnitType::CSS_PX);
+    styledElement->setInlineStyleProperty(CSSPropertyFontSize, choiceAnnotation().font.pointSize * plugin()->contentScaleFactor(), CSSUnitType::CSS_PX);
 }
 
 void PDFPluginChoiceAnnotation::commit()

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -31,7 +31,6 @@
 #import "PDFAnnotationTextWidgetDetails.h"
 #import "PDFLayerControllerSPI.h"
 #import "PDFPlugin.h"
-#import "UnifiedPDFPlugin.h"
 #import <Quartz/Quartz.h>
 #import <WebCore/AddEventListenerOptions.h>
 #import <WebCore/CSSPrimitiveValue.h>
@@ -110,12 +109,7 @@ void PDFPluginTextAnnotation::updateGeometry()
     PDFPluginAnnotation::updateGeometry();
 
     StyledElement* styledElement = static_cast<StyledElement*>(element());
-    auto scaleFactor = plugin()->scaleFactor();
-#if ENABLE(UNIFIED_PDF)
-    if (plugin()->isUnifiedPDFPlugin())
-        scaleFactor *= downcast<UnifiedPDFPlugin>(plugin())->documentFittingScale();
-#endif
-    styledElement->setInlineStyleProperty(CSSPropertyFontSize, textAnnotation().font.pointSize * scaleFactor, CSSUnitType::CSS_PX);
+    styledElement->setInlineStyleProperty(CSSPropertyFontSize, textAnnotation().font.pointSize * plugin()->contentScaleFactor(), CSSUnitType::CSS_PX);
 }
 
 void PDFPluginTextAnnotation::commit()

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -136,6 +136,7 @@ private:
     float scaleForFitToView() const;
 
     CGFloat scaleFactor() const override;
+    float contentScaleFactor() const final;
 
     void didBeginMagnificationGesture() override;
     void didEndMagnificationGesture() override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -859,6 +859,11 @@ CGFloat UnifiedPDFPlugin::scaleFactor() const
     return m_scaleFactor;
 }
 
+float UnifiedPDFPlugin::contentScaleFactor() const
+{
+    return m_scaleFactor * m_documentLayout.scale();
+}
+
 float UnifiedPDFPlugin::deviceScaleFactor() const
 {
     return PDFPluginBase::deviceScaleFactor();
@@ -1355,7 +1360,7 @@ void UnifiedPDFPlugin::updateSnapOffsets()
         // FIXME: Factor out documentToContents from pageToContents?
         auto destinationRect = m_documentLayout.layoutBoundsForPageAtIndex(i);
         destinationRect.inflate(PDFDocumentLayout::pageMargin);
-        destinationRect.scale(m_documentLayout.scale() * m_scaleFactor);
+        destinationRect.scale(contentScaleFactor());
         snapAreas.append(LayoutRect { destinationRect });
 
         bool isLargerThanViewport = destinationRect.height() > m_size.height();
@@ -2727,7 +2732,7 @@ bool UnifiedPDFPlugin::performDictionaryLookupAtLocation(const FloatPoint& rootV
 
 bool UnifiedPDFPlugin::searchInDictionary(const RetainPtr<PDFSelection>& lookupSelection)
 {
-    RetainPtr scaledString = [lookupSelection attributedStringScaled:(m_scaleFactor * m_documentLayout.scale())];
+    RetainPtr scaledString = [lookupSelection attributedStringScaled:(contentScaleFactor())];
 
     if (auto selectionBounds = selectionBoundsForFirstPageInDocumentSpace(lookupSelection))
         return showDefinitionForAttributedString(WTFMove(scaledString), *selectionBounds);


### PR DESCRIPTION
#### a2247463abb0064a8213ab4d24a23c9d38378514
<pre>
[UnifiedPDF] PDFPluginChoiceAnnotations have incorrect font size.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269923">https://bugs.webkit.org/show_bug.cgi?id=269923</a>
<a href="https://rdar.apple.com/123119103">rdar://123119103</a>

Reviewed by Simon Fraser.

The PDFPluginChoiceAnnotation sets its font size
based on the size of the font in the underlying
annotation within the document and then scales it
based on its scale factor. The UnifiedPDFPlugin&apos;s
scale factor is its zoom scale factor, but we
could also have scaled the document to fit in the
available width. PDFPluginTextAnnotations take
into consideration both scale factors so we should
do the same here.

In order to do this more cleanly, I introduced
contentScaleFactor on the plugins. For the legacy
PDF plugin this is just the same as its
scaleFactor, but for the UnifiedPDFPlugin this is
both the document fitting scale and the zoom
scale (it seems like this is what the legacy
plugin considers to be its scaleFactor as well).

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::contentScaleFactor const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
(WebKit::PDFPluginChoiceAnnotation::updateGeometry):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
(WebKit::PDFPluginTextAnnotation::updateGeometry):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::contentScaleFactor const):
(WebKit::UnifiedPDFPlugin::updateSnapOffsets):
(WebKit::UnifiedPDFPlugin::searchInDictionary):

Canonical link: <a href="https://commits.webkit.org/275264@main">https://commits.webkit.org/275264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77ad5affc838cd9d9cfa3f7ae0594057d012180c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37443 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17695 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14848 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40675 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39073 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17785 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9271 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17838 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->