### PR TITLE
Allow top layer elements to be nested within popovers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-anchor.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-anchor.tentative-expected.txt
@@ -4,34 +4,34 @@ Nested popover=auto ancestors
 Nested popover=auto ancestors, target is outer
 Top layer inside of nested element
 
-FAIL Single popover=auto ancestor with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Single popover=auto ancestor with dialog
 PASS Single popover=auto ancestor with dialog, top layer element *is* a popover
 FAIL Single popover=auto ancestor with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
-FAIL Single popover=auto ancestor with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Single popover=auto ancestor with fullscreen
 PASS Single popover=auto ancestor with fullscreen, top layer element *is* a popover
 FAIL Single popover=auto ancestor with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Single popover=manual ancestor with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Single popover=manual ancestor with dialog
 PASS Single popover=manual ancestor with dialog, top layer element *is* a popover
 FAIL Single popover=manual ancestor with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
-FAIL Single popover=manual ancestor with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Single popover=manual ancestor with fullscreen
 PASS Single popover=manual ancestor with fullscreen, top layer element *is* a popover
 FAIL Single popover=manual ancestor with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Nested popover=auto ancestors with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Nested popover=auto ancestors with dialog
 PASS Nested popover=auto ancestors with dialog, top layer element *is* a popover
 FAIL Nested popover=auto ancestors with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
-FAIL Nested popover=auto ancestors with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Nested popover=auto ancestors with fullscreen
 PASS Nested popover=auto ancestors with fullscreen, top layer element *is* a popover
 FAIL Nested popover=auto ancestors with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Nested popover=auto ancestors, target is outer with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Nested popover=auto ancestors, target is outer with dialog
 PASS Nested popover=auto ancestors, target is outer with dialog, top layer element *is* a popover
 FAIL Nested popover=auto ancestors, target is outer with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
-FAIL Nested popover=auto ancestors, target is outer with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Nested popover=auto ancestors, target is outer with fullscreen
 PASS Nested popover=auto ancestors, target is outer with fullscreen, top layer element *is* a popover
 FAIL Nested popover=auto ancestors, target is outer with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Top layer inside of nested element with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Top layer inside of nested element with dialog
 PASS Top layer inside of nested element with dialog, top layer element *is* a popover
 FAIL Top layer inside of nested element with dialog, anchor attribute assert_equals: Incorrect behavior expected true but got false
-FAIL Top layer inside of nested element with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Top layer inside of nested element with fullscreen
 PASS Top layer inside of nested element with fullscreen, top layer element *is* a popover
 FAIL Top layer inside of nested element with fullscreen, anchor attribute promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-expected.txt
@@ -4,24 +4,24 @@ Nested popover=auto ancestors
 Nested popover=auto ancestors, target is outer
 Top layer inside of nested element
 
-FAIL Single popover=auto ancestor with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Single popover=auto ancestor with dialog
 PASS Single popover=auto ancestor with dialog, top layer element *is* a popover
-FAIL Single popover=auto ancestor with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Single popover=auto ancestor with fullscreen
 PASS Single popover=auto ancestor with fullscreen, top layer element *is* a popover
-FAIL Single popover=manual ancestor with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Single popover=manual ancestor with dialog
 PASS Single popover=manual ancestor with dialog, top layer element *is* a popover
 FAIL Single popover=manual ancestor with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Type error"
 PASS Single popover=manual ancestor with fullscreen, top layer element *is* a popover
-FAIL Nested popover=auto ancestors with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Nested popover=auto ancestors with dialog
 PASS Nested popover=auto ancestors with dialog, top layer element *is* a popover
-FAIL Nested popover=auto ancestors with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Nested popover=auto ancestors with fullscreen
 PASS Nested popover=auto ancestors with fullscreen, top layer element *is* a popover
-FAIL Nested popover=auto ancestors, target is outer with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Nested popover=auto ancestors, target is outer with dialog
 PASS Nested popover=auto ancestors, target is outer with dialog, top layer element *is* a popover
 FAIL Nested popover=auto ancestors, target is outer with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Type error"
 PASS Nested popover=auto ancestors, target is outer with fullscreen, top layer element *is* a popover
-FAIL Top layer inside of nested element with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Top layer inside of nested element with dialog
 PASS Top layer inside of nested element with dialog, top layer element *is* a popover
-FAIL Top layer inside of nested element with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Top layer inside of nested element with fullscreen
 PASS Top layer inside of nested element with fullscreen, top layer element *is* a popover
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.tentative-expected.txt
@@ -8,19 +8,19 @@ PASS Single popover=hint ancestor with dialog
 PASS Single popover=hint ancestor with dialog, top layer element *is* a popover
 PASS Single popover=hint ancestor with fullscreen
 PASS Single popover=hint ancestor with fullscreen, top layer element *is* a popover
-FAIL Nested auto/hint ancestors with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Nested auto/hint ancestors with dialog
 PASS Nested auto/hint ancestors with dialog, top layer element *is* a popover
 FAIL Nested auto/hint ancestors with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Type error"
 PASS Nested auto/hint ancestors with fullscreen, top layer element *is* a popover
-FAIL Nested auto/hint ancestors, target is auto with dialog assert_equals: Incorrect behavior expected true but got false
+FAIL Nested auto/hint ancestors, target is auto with dialog assert_equals: Incorrect behavior expected false but got true
 PASS Nested auto/hint ancestors, target is auto with dialog, top layer element *is* a popover
-FAIL Nested auto/hint ancestors, target is auto with fullscreen assert_equals: Incorrect behavior expected true but got false
+FAIL Nested auto/hint ancestors, target is auto with fullscreen assert_equals: Incorrect behavior expected false but got true
 PASS Nested auto/hint ancestors, target is auto with fullscreen, top layer element *is* a popover
 FAIL Unrelated hint, target=hint with dialog assert_equals: Incorrect behavior expected true but got false
 PASS Unrelated hint, target=hint with dialog, top layer element *is* a popover
 FAIL Unrelated hint, target=hint with fullscreen promise_test: Unhandled rejection with value: object "TypeError: Type error"
 PASS Unrelated hint, target=hint with fullscreen, top layer element *is* a popover
-FAIL Unrelated hint, target=auto with dialog assert_equals: Incorrect behavior expected true but got false
+FAIL Unrelated hint, target=auto with dialog assert_equals: Incorrect behavior expected false but got true
 PASS Unrelated hint, target=auto with dialog, top layer element *is* a popover
 FAIL Unrelated hint, target=auto with fullscreen assert_equals: Incorrect behavior expected true but got false
 PASS Unrelated hint, target=auto with fullscreen, top layer element *is* a popover

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -64,6 +64,7 @@ class ElementRareData;
 class FormAssociatedCustomElement;
 class FormListedElement;
 class HTMLDocument;
+class HTMLElement;
 class HTMLFormControlElement;
 class IntSize;
 class JSCustomElementInterface;
@@ -191,6 +192,9 @@ public:
     inline const AtomString& attributeWithoutSynchronization(const QualifiedName&) const;
     inline const AtomString& attributeWithDefaultARIA(const QualifiedName&) const;
     inline String attributeTrimmedWithDefaultARIA(const QualifiedName&) const;
+
+    enum class TopLayerElementType : bool { Other, Popover };
+    HTMLElement* topmostPopoverAncestor(TopLayerElementType topLayerType);
 
 #if DUMP_NODE_STATISTICS
     bool hasNamedNodeMap() const;

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -32,6 +32,7 @@
 #include "ChromeClient.h"
 #include "Document.h"
 #include "DocumentInlines.h"
+#include "Element.h"
 #include "ElementInlines.h"
 #include "EventLoop.h"
 #include "EventNames.h"
@@ -545,7 +546,9 @@ bool FullscreenManager::willEnterFullscreen(Element& element, HTMLMediaElementEn
     } while ((ancestor = ancestor->document().ownerElement()));
 
     for (auto ancestor : makeReversedRange(ancestorsInTreeOrder)) {
-        ancestor->document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
+        auto hideUntil = ancestor->topmostPopoverAncestor(Element::TopLayerElementType::Other);
+
+        ancestor->document().hideAllPopoversUntil(hideUntil, FocusPreviousElement::No, FireEvents::No);
 
         auto containingBlockBeforeStyleResolution = SingleThreadWeakPtr<RenderBlock> { };
         if (auto* renderer = ancestor->renderer())

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -31,6 +31,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "FocusOptions.h"
+#include "HTMLElement.h"
 #include "HTMLNames.h"
 #include "PopoverData.h"
 #include "PseudoClassChangeInvalidation.h"
@@ -64,7 +65,9 @@ ExceptionOr<void> HTMLDialogElement::show()
 
     m_previouslyFocusedElement = document().focusedElement();
 
-    document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
+    auto hideUntil = topmostPopoverAncestor(TopLayerElementType::Other);
+
+    document().hideAllPopoversUntil(hideUntil, FocusPreviousElement::No, FireEvents::No);
 
     runFocusingSteps();
     return { };
@@ -104,7 +107,9 @@ ExceptionOr<void> HTMLDialogElement::showModal()
 
     m_previouslyFocusedElement = document().focusedElement();
 
-    document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
+    auto hideUntil = topmostPopoverAncestor(TopLayerElementType::Other);
+
+    document().hideAllPopoversUntil(hideUntil, FocusPreviousElement::No, FireEvents::No);
 
     runFocusingSteps();
 


### PR DESCRIPTION
#### 7742091ae26092602ec5cfe5acff453f0430cacb
<pre>
Allow top layer elements to be nested within popovers
<a href="https://bugs.webkit.org/show_bug.cgi?id=269928">https://bugs.webkit.org/show_bug.cgi?id=269928</a>

Reviewed by Tim Nguyen.

This implements the changes to the spec as defined by
<a href="https://github.com/whatwg/html/pull/10116">https://github.com/whatwg/html/pull/10116</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-anchor.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints.tentative-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::topmostPopoverAncestor):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::willEnterFullscreen):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::showModal):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::showPopover):
(WebCore::topmostPopoverAncestor): Deleted.

Canonical link: <a href="https://commits.webkit.org/279874@main">https://commits.webkit.org/279874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a01fc77e8ee18b96c56e426a10d323dcccfd402

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43818 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3211 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2976 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58972 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51235 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50635 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12041 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->