### PR TITLE
[build.webkit.org] jscore-test step fails with error: RunJavaScriptCoreTests object has no attribute 'setCommand'

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -73,7 +73,7 @@ class CustomFlagsMixin(object):
             platform = platform + '-simulator'
         elif platform in ['ios', 'tvos', 'watchos']:
             platform = platform + '-device'
-        self.setCommand(self.command + ['--' + platform])
+        self.command += ['--' + platform]
 
     def appendCustomTestingFlags(self, platform, device_model):
         if platform not in ('gtk', 'wincairo', 'ios', 'jsc-only', 'wpe'):
@@ -659,10 +659,10 @@ class RunJavaScriptCoreTests(TestWithFailureCount, CustomFlagsMixin):
         # Linux bots have currently problems with JSC tests that try to use large amounts of memory.
         # Check: https://bugs.webkit.org/show_bug.cgi?id=175140
         if platform in ('gtk', 'wpe', 'jsc-only'):
-            self.setCommand(self.command + ['--memory-limited', '--verbose'])
+            self.command += ['--memory-limited', '--verbose']
         # WinCairo uses the Windows command prompt, not Cygwin.
         elif platform == 'wincairo':
-            self.setCommand(self.command + ['--test-writer=ruby'])
+            self.command += ['--test-writer=ruby']
 
         self.appendCustomBuildFlags(platform, self.getProperty('fullPlatform'))
         return super().run()
@@ -1247,7 +1247,7 @@ class RunWebKit1LeakTests(RunWebKit1Tests):
     warnOnWarnings = True
 
     def start(self):
-        self.setCommand(self.command + ["--leaks", "--result-report-flavor", "Leaks"])
+        self.command += ["--leaks", "--result-report-flavor", "Leaks"]
         return RunWebKit1Tests.start(self)
 
 


### PR DESCRIPTION
#### db3c1f74b07a7ebe2b91351fe38acab6cf6de492
<pre>
[build.webkit.org] jscore-test step fails with error: RunJavaScriptCoreTests object has no attribute &apos;setCommand&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=269929">https://bugs.webkit.org/show_bug.cgi?id=269929</a>
<a href="https://rdar.apple.com/123456878">rdar://123456878</a>

Reviewed by Aakash Jain.

* Tools/CISupport/build-webkit-org/steps.py:
(CustomFlagsMixin.appendCustomBuildFlags): Directly modify command member.
(RunJavaScriptCoreTests.run): Ditto.
(RunWebKit1LeakTests.start): Ditto.

Canonical link: <a href="https://commits.webkit.org/275190@main">https://commits.webkit.org/275190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d41a049a669e32ee35394f66f055b03a638fdd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41128 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/20141 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/43506 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43690 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43435 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/23181 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/43690 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41702 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/23181 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/43506 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43690 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/23181 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/43506 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45008 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/23181 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/43506 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/15943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41175 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/43506 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5481 "Failed to checkout and rebase branch from PR 24961") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->