### PR TITLE
REGRESSION (275156@main): [ macOS Debug ] 3 tests in imported/w3c/web-platform-tests/css/css-view-transitions are constant crash

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2013,8 +2013,3 @@ webkit.org/b/269581 http/tests/site-isolation/mouse-events/context-menu-event-tw
 webkit.org/b/269814 [ Monterey+ ] media/media-source/media-source-seek-complete.html [ Pass Timeout ]
 
 webkit.org/b/123404489 [ Monterey+ Debug ] imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-detach-element.html [ Skip ]
-
-# webkit.org/b/269927 REGRESSION (275156@main): [ macOS Debug ] 3 tests in imported/w3c/web-platform-tests/css/css-view-transitions are constant crash
-[ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-animated.html [ Skip ]
-[ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/new-content-is-inline.html [ Skip ]
-[ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/old-content-is-inline.html [ Skip ]

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -54,6 +54,22 @@ inline WTF::TextStream& operator<<(WTF::TextStream& ts, const PseudoElementIdent
     return ts;
 }
 
+inline bool isNamedViewTransitionPseudoElement(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+{
+    if (!pseudoElementIdentifier)
+        return false;
+
+    switch (pseudoElementIdentifier->pseudoId) {
+    case PseudoId::ViewTransitionGroup:
+    case PseudoId::ViewTransitionImagePair:
+    case PseudoId::ViewTransitionOld:
+    case PseudoId::ViewTransitionNew:
+        return true;
+    default:
+        return false;
+    }
+};
+
 } // namespace WebCore
 
 namespace WTF {


### PR DESCRIPTION
#### 85d80fb2ccd246e3faa97ccb7ba5c8822c700fdc
<pre>
REGRESSION (275156@main): [ macOS Debug ] 3 tests in imported/w3c/web-platform-tests/css/css-view-transitions are constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=269927">https://bugs.webkit.org/show_bug.cgi?id=269927</a>
<a href="https://rdar.apple.com/123454964">rdar://123454964</a>

Reviewed by Matt Woodrow.

Animation sort order needs to be defined for view transition named pseudo-elements. The sort order follows tree order, so assuming Y follows X in the named elements map:

1) ::view-transition
2) ::view-transition-group(X)
3) ::view-transition-image-pair(X)
4) ::view-transition-old(X)
5) ::view-transition-new(X)
6) ::view-transition-group(Y)
7) ::view-transition-image-pair(Y)
8) ::view-transition-old(Y)
9) ::view-transition-new(Y)

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder):
* Source/WebCore/style/PseudoElementIdentifier.h:
(WebCore::Style::isNamedViewTransitionPseudoElement):

Canonical link: <a href="https://commits.webkit.org/275206@main">https://commits.webkit.org/275206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05112b6771dc060b01a2c4df29e3275daef3f2a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41185 "Failed to checkout and rebase branch from PR 24963") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43563 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/43492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23243 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/17529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/43748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/41759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45069 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/17529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5495 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->