### PR TITLE
[CMake] Centralize Nicosia sources

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -28,17 +28,6 @@ list(APPEND WebCore_SOURCES
     page/playstation/ResourceUsageOverlayPlayStation.cpp
     page/playstation/ResourceUsageThreadPlayStation.cpp
 
-    page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp
-    page/scrolling/nicosia/ScrollingStateNodeNicosia.cpp
-    page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
-    page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
-    page/scrolling/nicosia/ScrollingTreeNicosia.cpp
-    page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
-    page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
-    page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
-    page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
-    page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
-
     platform/ScrollAnimationKinetic.cpp
     platform/ScrollAnimationSmooth.cpp
 

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -50,17 +50,6 @@ page/gtk/DragControllerGtk.cpp
 page/linux/ResourceUsageOverlayLinux.cpp
 page/linux/ResourceUsageThreadLinux.cpp
 
-page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp
-page/scrolling/nicosia/ScrollingStateNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
-
 platform/gamepad/manette/ManetteGamepad.cpp
 platform/gamepad/manette/ManetteGamepadProvider.cpp
 

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -48,17 +48,6 @@ loader/soup/ResourceLoaderSoup.cpp
 page/linux/ResourceUsageOverlayLinux.cpp
 page/linux/ResourceUsageThreadLinux.cpp
 
-page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp
-page/scrolling/nicosia/ScrollingStateNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
-page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
-
 platform/gamepad/libwpe/GamepadLibWPE.cpp
 platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
 

--- a/Source/WebCore/platform/SourcesNicosia.txt
+++ b/Source/WebCore/platform/SourcesNicosia.txt
@@ -1,0 +1,46 @@
+// Copyright (C) 2024 Sony Interactive Entertainment Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp
+page/scrolling/nicosia/ScrollingStateNodeNicosia.cpp
+page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
+page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
+page/scrolling/nicosia/ScrollingTreeNicosia.cpp
+page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
+page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
+page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
+page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
+page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
+
+platform/graphics/nicosia/NicosiaAnimation.cpp
+platform/graphics/nicosia/NicosiaBackingStore.cpp
+platform/graphics/nicosia/NicosiaBuffer.cpp
+platform/graphics/nicosia/NicosiaContentLayer.cpp
+platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
+platform/graphics/nicosia/NicosiaImageBacking.cpp
+platform/graphics/nicosia/NicosiaImageBackingStore.cpp
+platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
+platform/graphics/nicosia/NicosiaScene.cpp
+platform/graphics/nicosia/NicosiaSceneIntegration.cpp
+
+platform/graphics/texmap/GraphicsContextGLTextureMapperANGLENicosia.cpp

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -1,11 +1,8 @@
 list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/platform/graphics/texmap"
-    "${WEBCORE_DIR}/platform/graphics/nicosia"
 )
 
 list(APPEND WebCore_SOURCES
-    platform/graphics/nicosia/NicosiaAnimation.cpp
-
     platform/graphics/texmap/BitmapTexture.cpp
     platform/graphics/texmap/BitmapTexturePool.cpp
     platform/graphics/texmap/ClipStack.cpp
@@ -20,8 +17,6 @@ list(APPEND WebCore_SOURCES
 )
 
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
-    platform/graphics/nicosia/NicosiaAnimation.h
-
     platform/graphics/texmap/BitmapTexture.h
     platform/graphics/texmap/BitmapTexturePool.h
     platform/graphics/texmap/ClipStack.h
@@ -54,7 +49,6 @@ endif ()
 
 if (USE_COORDINATED_GRAPHICS)
     list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
-        "${WEBCORE_DIR}/page/scrolling/nicosia"
         "${WEBCORE_DIR}/platform/graphics/texmap/coordinated"
     )
     list(APPEND WebCore_SOURCES
@@ -75,25 +69,48 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/TiledBackingStoreClient.h
     )
 
-    # FIXME: Move this into Nicosia.cmake once the component is set for long-term use.
+    if (USE_CAIRO)
+        list(APPEND WebCore_SOURCES
+            platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
+        )
+    elseif (USE_SKIA)
+        list(APPEND WebCore_SOURCES
+            platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
+        )
+    endif ()
+else ()
+    list(APPEND WebCore_SOURCES
+        platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
+        platform/graphics/texmap/TextureMapperTiledBackingStore.cpp
+    )
+
+    # FIXME: Share NicosiaAnimation since its used outside of Nicosia
     list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
-        "${WEBCORE_DIR}/platform/graphics/nicosia/texmap"
+        "${WEBCORE_DIR}/platform/graphics/nicosia"
     )
     list(APPEND WebCore_SOURCES
-        platform/graphics/nicosia/NicosiaBackingStore.cpp
-        platform/graphics/nicosia/NicosiaBuffer.cpp
-        platform/graphics/nicosia/NicosiaContentLayer.cpp
-        platform/graphics/nicosia/NicosiaImageBacking.cpp
-        platform/graphics/nicosia/NicosiaImageBackingStore.cpp
-        platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
-        platform/graphics/nicosia/NicosiaScene.cpp
-        platform/graphics/nicosia/NicosiaSceneIntegration.cpp
+        platform/graphics/nicosia/NicosiaAnimation.cpp
+    )
+    list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/graphics/nicosia/NicosiaAnimation.h
+    )
+endif ()
+
+if (USE_NICOSIA)
+    list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBCORE_DIR}/page/scrolling/nicosia"
+        "${WEBCORE_DIR}/platform/graphics/nicosia"
+        "${WEBCORE_DIR}/platform/graphics/nicosia/texmap"
+    )
+    list(APPEND WebCore_UNIFIED_SOURCE_LIST_FILES
+        "platform/SourcesNicosia.txt"
     )
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
         page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.h
         page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.h
 
         platform/graphics/nicosia/NicosiaAnimatedBackingStoreClient.h
+        platform/graphics/nicosia/NicosiaAnimation.h
         platform/graphics/nicosia/NicosiaBackingStore.h
         platform/graphics/nicosia/NicosiaBuffer.h
         platform/graphics/nicosia/NicosiaCompositionLayer.h
@@ -112,6 +129,9 @@ if (USE_COORDINATED_GRAPHICS)
         list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
             platform/graphics/nicosia/NicosiaPaintingEngine.h
         )
+
+        # Currently NicosiaPaintingContext.cpp will cause a compilation error
+        # when building without USE_CAIRO so these are not in unified sources
         list(APPEND WebCore_SOURCES
             platform/graphics/nicosia/NicosiaPaintingContext.cpp
             platform/graphics/nicosia/NicosiaPaintingEngine.cpp
@@ -120,27 +140,8 @@ if (USE_COORDINATED_GRAPHICS)
 
             platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
             platform/graphics/nicosia/cairo/NicosiaPaintingContextCairo.cpp
-
-            platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerCairo.cpp
-        )
-    elseif (USE_SKIA)
-        list(APPEND WebCore_SOURCES
-            platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
         )
     endif ()
-else ()
-    list(APPEND WebCore_SOURCES
-        platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
-        platform/graphics/texmap/TextureMapperTiledBackingStore.cpp
-    )
-endif ()
-
-if (ENABLE_WEBGL)
-    list(APPEND WebCore_SOURCES
-        platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
-
-        platform/graphics/texmap/GraphicsContextGLTextureMapperANGLENicosia.cpp
-    )
 endif ()
 
 if (USE_GRAPHICS_LAYER_WC)

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
@@ -29,7 +29,7 @@
 #include "config.h"
 #include "NicosiaGCGLANGLELayer.h"
 
-#if USE(NICOSIA) && USE(TEXTURE_MAPPER)
+#if ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(NICOSIA)
 
 #include "GraphicsContextGLTextureMapperANGLE.h"
 #include "TextureMapperFlags.h"
@@ -107,4 +107,4 @@ GCGLANGLELayer::~GCGLANGLELayer()
 
 } // namespace Nicosia
 
-#endif // USE(NICOSIA) && USE(TEXTURE_MAPPER)
+#endif // ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(NICOSIA)

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#if USE(NICOSIA) && USE(TEXTURE_MAPPER)
+#if ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(NICOSIA)
 
 #include "NicosiaContentLayer.h"
 
@@ -62,4 +62,4 @@ private:
 
 } // namespace Nicosia
 
-#endif // USE(NICOSIA) && USE(TEXTURE_MAPPER)
+#endif // ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(NICOSIA)


### PR DESCRIPTION
#### 1c162458ba708e0aba191d5e2e4b0c81466426d7
<pre>
[CMake] Centralize Nicosia sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=269935">https://bugs.webkit.org/show_bug.cgi?id=269935</a>

Reviewed by Adrian Perez de Castro.

Move `USE(NICOSIA)` sources into `SourcesNicosia.txt`. Some are unable to be
moved because they will break the `USE(SKIA)` build.

Organize the `TextureMapper.cmake` file to check for `USE_NICOSIA`.

Fix some guards around ANGLE code.

* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/SourcesNicosia.txt: Added.
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp:
* Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.h:

Canonical link: <a href="https://commits.webkit.org/275245@main">https://commits.webkit.org/275245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91b0fd5e3beff30afd429437f1fdeca57d0f5821

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34060 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41724 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17092 "Found 1 new test failure: http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14833 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36452 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45033 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40511 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38889 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17584 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9262 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17228 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->