### PR TITLE
REGRESSION (iOS 17.2) Script can not always start audio playback in the background

### DIFF
--- a/LayoutTests/media/audio-background-playback-playlist-expected.txt
+++ b/LayoutTests/media/audio-background-playback-playlist-expected.txt
@@ -10,6 +10,7 @@ RUN(audio.currentTime = audio.duration - 0.1)
 EVENT(ended)
 RUN(audio.src = "")
 RUN(audio.load())
+EVENT(error)
 EXPECTED (internals.bestMediaElementForRemoteControls("NowPlaying") == 'null') OK
 RUN(audio.src = findMediaFile("audio", "content/test"))
 RUN(audio.load())

--- a/LayoutTests/media/audio-background-playback-playlist.html
+++ b/LayoutTests/media/audio-background-playback-playlist.html
@@ -17,6 +17,7 @@
         await waitFor(audio, 'ended');
         run('audio.src = ""');
         run('audio.load()');
+        await waitFor(audio, 'error');
         testExpected('internals.bestMediaElementForRemoteControls("NowPlaying")', null);
         run('audio.src = findMediaFile("audio", "content/test")');
         run('audio.load()');

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -571,11 +571,13 @@ bool MediaElementSession::canShowControlsManager(PlaybackControlsPurpose purpose
         return true;
     }
 
-    if (client().presentationType() == MediaType::Audio
-        && purpose == PlaybackControlsPurpose::NowPlaying
-        && !isLongEnoughForMainContent()) {
-        INFO_LOG(LOGIDENTIFIER, "returning FALSE: audio too short for NowPlaying");
-        return false;
+    if (client().presentationType() == MediaType::Audio && purpose == PlaybackControlsPurpose::NowPlaying) {
+        if (!m_element.hasSource()
+            || m_element.error()
+            || (!isLongEnoughForMainContent() && !PlatformMediaSessionManager::sharedManager().registeredAsNowPlayingApplication())) {
+            INFO_LOG(LOGIDENTIFIER, "returning FALSE: audio too short for NowPlaying");
+            return false;
+        }
     }
 
     if (client().presentationType() == MediaType::Audio && (purpose == PlaybackControlsPurpose::ControlsManager || purpose == PlaybackControlsPurpose::MediaSession)) {

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -663,8 +663,10 @@ void PlatformMediaSessionManager::maybeDeactivateAudioSession()
 bool PlatformMediaSessionManager::maybeActivateAudioSession()
 {
 #if USE(AUDIO_SESSION)
-    if (!activeAudioSessionRequired())
+    if (!activeAudioSessionRequired()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "active audio session not required");
         return true;
+    }
 
     m_becameActive = AudioSession::sharedSession().tryToSetActive(true);
     ALWAYS_LOG(LOGIDENTIFIER, m_becameActive ? "successfully activated" : "failed to activate", " AudioSession");

--- a/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm
@@ -103,6 +103,8 @@ bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
             NSError *error = nil;
             if (supportsSetActive)
                 [[PAL::getAVAudioSessionClass() sharedInstance] setActive:YES withOptions:0 error:&error];
+            if (error)
+                RELEASE_LOG_ERROR(Media, "failed to activate audio session, error: %@", error.localizedDescription);
             success = !error;
         });
         return success;
@@ -112,6 +114,8 @@ bool AudioSessionCocoa::tryToSetActiveInternal(bool active)
         NSError *error = nil;
         if (supportsSetActive)
             [[PAL::getAVAudioSessionClass() sharedInstance] setActive:NO withOptions:0 error:&error];
+        if (error)
+            RELEASE_LOG_ERROR(Media, "failed to deactivate audio session, error: %@", error.localizedDescription);
     });
     setEligibleForSmartRouting(false);
 #else

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1038,6 +1038,7 @@ void WebPageProxy::setMediaCapability(std::optional<MediaCapability>&& capabilit
     internals().mediaCapability = WTFMove(capability);
 
     if (!internals().mediaCapability) {
+        WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: clearing media capability");
         send(Messages::WebPage::SetMediaEnvironment({ }));
         return;
     }
@@ -1115,6 +1116,9 @@ bool WebPageProxy::shouldDeactivateMediaCapability() const
         return false;
 
     if (internals().mediaState.containsAny(MediaProducerMediaState::HasAudioOrVideo))
+        return false;
+
+    if (hasValidAudibleActivity())
         return false;
 
     return true;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2405,6 +2405,8 @@ public:
     void sendScrollPositionChangedForNode(std::optional<WebCore::FrameIdentifier>, WebCore::ScrollingNodeID, const WebCore::FloatPoint& scrollPosition, std::optional<WebCore::FloatPoint> layoutViewportOrigin, bool syncLayerPosition, bool isLastUpdate);
 #endif
 
+    bool hasValidAudibleActivity() const;
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2287,6 +2287,7 @@ WebProcessWithAudibleMediaToken WebProcessPool::webProcessWithAudibleMediaToken(
 
 void WebProcessPool::clearAudibleActivity()
 {
+    WEBPROCESSPOOL_RELEASE_LOG(ProcessSuspension, "clearAudibleActivity: The number of processes playing audible media is now zero. Releasing UI process assertion.");
     ASSERT(!m_webProcessWithAudibleMediaCounter.value());
     m_audibleMediaActivity = std::nullopt;
 }
@@ -2294,7 +2295,7 @@ void WebProcessPool::clearAudibleActivity()
 void WebProcessPool::updateAudibleMediaAssertions()
 {
     if (!m_webProcessWithAudibleMediaCounter.value()) {
-        WEBPROCESSPOOL_RELEASE_LOG(ProcessSuspension, "updateAudibleMediaAssertions: The number of processes playing audible media now zero. Releasing UI process assertion.");
+        WEBPROCESSPOOL_RELEASE_LOG(ProcessSuspension, "updateAudibleMediaAssertions: Starting timer to clear audible activity in %g seconds because we are no longer playing audio", audibleActivityClearDelay.seconds());
         // We clear the audible activity on a timer for 2 reasons:
         // 1. Media may start playing shortly after (e.g. switching from one track to another)
         // 2. It minimizes the risk of the GPUProcess getting suspended while shutting down the media stack.


### PR DESCRIPTION
#### b39392ba956ea7216e38fc3ae39689556a8a524d
<pre>
REGRESSION (iOS 17.2) Script can not always start audio playback in the background
<a href="https://bugs.webkit.org/show_bug.cgi?id=269938">https://bugs.webkit.org/show_bug.cgi?id=269938</a>
<a href="https://rdar.apple.com/121268089">rdar://121268089</a>

Reviewed by Andy Estes.

Don&apos;t deactivate the media activity during the 10 second foreground activity &quot;grace period&quot;
so script has a chance to start playback, e.g. for a playlist, when the application is in
the background.

* LayoutTests/media/audio-background-playback-playlist-expected.txt:
* LayoutTests/media/audio-background-playback-playlist.html: Update test to wait for the
&apos;error&apos; event before checking NowPlaying eligibility.

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::canShowControlsManager const): Don&apos;t say an element that
has a source and is not in an error state is ineligible to activate NowPlaying if we are
already registered as the NowPlaying app.

* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::maybeActivateAudioSession): Log when we return
`false` because an active audio session is not needed to make future debugging easier.

* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm:
(WebCore::AudioSessionCocoa::tryToSetActiveInternal): Log when activating or deactivating
the audio session fails.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setMediaCapability): log when the media capability is cleared.
(WebKit::WebPageProxy::shouldDeactivateMediaCapability const): Return false if there is
valid audio activity so we wait to deactivate the capability while the foreground
activity timer is active.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateThrottleState): Log when starting or stopping the foreground
activity &quot;grace period&quot; timer.
(WebKit::WebPageProxy::clearAudibleActivity): Fix logging. Call `updateMediaCapability`.
(WebKit::WebPageProxy::hasValidAudibleActivity const):
* Source/WebKit/UIProcess/WebPageProxy.h:

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::clearAudibleActivity): Add logging.
(WebKit::WebProcessPool::updateAudibleMediaAssertions): Clarify log message.

Canonical link: <a href="https://commits.webkit.org/275285@main">https://commits.webkit.org/275285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54846dcb558c10419ba31464c877e4c24eddc300

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34201 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14862 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15072 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36626 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45282 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40693 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39093 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35908 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9281 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17862 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->