### PR TITLE
getUserMedia camera stream lost on history pushState in iOS 17.4 Beta 4

### DIFF
--- a/Source/WebKit/Platform/cocoa/MediaCapability.h
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.h
@@ -30,11 +30,11 @@
 #include "ExtensionCapability.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/URL.h>
+#include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class RegistrableDomain;
+class SecurityOrigin;
 }
 
 OBJC_CLASS BEMediaEnvironment;
@@ -46,7 +46,7 @@ class ExtensionCapabilityGrant;
 class MediaCapability final : public ExtensionCapability, public CanMakeWeakPtr<MediaCapability> {
     WTF_MAKE_NONCOPYABLE(MediaCapability);
 public:
-    explicit MediaCapability(URL);
+    explicit MediaCapability(Ref<WebCore::SecurityOrigin>&&);
     MediaCapability(MediaCapability&&) = default;
     MediaCapability& operator=(MediaCapability&&) = default;
 
@@ -61,8 +61,7 @@ public:
     void setState(State state) { m_state = state; }
     bool isActivatingOrActive() const;
 
-    const URL& url() const { return m_url; }
-    WebCore::RegistrableDomain registrableDomain() const;
+    const WebCore::SecurityOrigin& securityOrigin() const { return m_securityOrigin.get(); }
 
     // ExtensionCapability
     String environmentIdentifier() const final;
@@ -71,7 +70,7 @@ public:
 
 private:
     State m_state { State::Inactive };
-    URL m_url;
+    Ref<WebCore::SecurityOrigin> m_securityOrigin;
     RetainPtr<BEMediaEnvironment> m_mediaEnvironment;
 };
 

--- a/Source/WebKit/Platform/cocoa/MediaCapability.mm
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.mm
@@ -29,18 +29,16 @@
 #if ENABLE(EXTENSION_CAPABILITIES)
 
 #import <BrowserEngineKit/BECapability.h>
-#import <WebCore/RegistrableDomain.h>
+#import <WebCore/SecurityOrigin.h>
 #import <wtf/text/WTFString.h>
 
 #import "ExtensionKitSoftLink.h"
 
 namespace WebKit {
 
-using WebCore::RegistrableDomain;
-
-MediaCapability::MediaCapability(URL url)
-    : m_url { WTFMove(url) }
-    , m_mediaEnvironment(adoptNS([[BEMediaEnvironment alloc] initWithWebPageURL:m_url]))
+MediaCapability::MediaCapability(Ref<WebCore::SecurityOrigin>&& securityOrigin)
+    : m_securityOrigin { WTFMove(securityOrigin) }
+    , m_mediaEnvironment { adoptNS([[BEMediaEnvironment alloc] initWithWebPageURL:m_securityOrigin->toURL()]) }
 {
     setPlatformCapability([BEProcessCapability mediaPlaybackAndCaptureWithEnvironment:m_mediaEnvironment.get()]);
 }
@@ -58,11 +56,6 @@ bool MediaCapability::isActivatingOrActive() const
 
     RELEASE_ASSERT_NOT_REACHED();
     return false;
-}
-
-RegistrableDomain MediaCapability::registrableDomain() const
-{
-    return RegistrableDomain { m_url };
 }
 
 String MediaCapability::environmentIdentifier() const

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1032,23 +1032,29 @@ const std::optional<MediaCapability>& WebPageProxy::mediaCapability() const
 
 void WebPageProxy::setMediaCapability(std::optional<MediaCapability>&& capability)
 {
-    if (auto oldCapability = std::exchange(internals().mediaCapability, std::nullopt)) {
-        WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: deactivating (envID=%{public}s) for registrable domain '%{sensitive}s'", oldCapability->environmentIdentifier().utf8().data(), oldCapability->registrableDomain().string().utf8().data());
-        Ref processPool { protectedProcess()->protectedProcessPool() };
-        processPool->extensionCapabilityGranter().setMediaCapabilityActive(*oldCapability, false);
-        processPool->extensionCapabilityGranter().revoke(*oldCapability);
-    }
+    if (auto oldCapability = std::exchange(internals().mediaCapability, std::nullopt))
+        deactivateMediaCapability(*oldCapability);
 
     internals().mediaCapability = WTFMove(capability);
 
-    if (auto& newCapability = internals().mediaCapability) {
-        WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: creating (envID=%{public}s) for registrable domain '%{sensitive}s'", newCapability->environmentIdentifier().utf8().data(), newCapability->registrableDomain().string().utf8().data());
-        send(Messages::WebPage::SetMediaEnvironment(newCapability->environmentIdentifier()));
-    } else
+    if (!internals().mediaCapability) {
         send(Messages::WebPage::SetMediaEnvironment({ }));
+        return;
+    }
+
+    WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: creating (envID=%{public}s) for host '%{sensitive}s'", internals().mediaCapability->environmentIdentifier().utf8().data(), internals().mediaCapability->securityOrigin().host().utf8().data());
+    send(Messages::WebPage::SetMediaEnvironment(internals().mediaCapability->environmentIdentifier()));
 }
 
-void WebPageProxy::updateMediaCapability()
+void WebPageProxy::deactivateMediaCapability(MediaCapability& capability)
+{
+    WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "deactivateMediaCapability: deactivating (envID=%{public}s) for host '%{sensitive}s'", capability.environmentIdentifier().utf8().data(), capability.securityOrigin().host().utf8().data());
+    Ref processPool { protectedProcess()->protectedProcessPool() };
+    processPool->extensionCapabilityGranter().setMediaCapabilityActive(capability, false);
+    processPool->extensionCapabilityGranter().revoke(capability);
+}
+
+void WebPageProxy::resetMediaCapability()
 {
     if (!preferences().mediaCapabilityGrantsEnabled())
         return;
@@ -1060,15 +1066,20 @@ void WebPageProxy::updateMediaCapability()
         return;
     }
 
-    if (!mediaCapability() || !equalIgnoringFragmentIdentifier(mediaCapability()->url(), currentURL))
-        setMediaCapability(MediaCapability { currentURL });
+    Ref securityOrigin = SecurityOrigin::create(currentURL);
 
+    if (!mediaCapability() || !mediaCapability()->securityOrigin().isSameOriginAs(securityOrigin.get()))
+        setMediaCapability(MediaCapability { WTFMove(securityOrigin) });
+}
+
+void WebPageProxy::updateMediaCapability()
+{
     auto& mediaCapability = internals().mediaCapability;
     if (!mediaCapability)
         return;
 
     if (shouldDeactivateMediaCapability()) {
-        setMediaCapability(std::nullopt);
+        deactivateMediaCapability(*mediaCapability);
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2367,6 +2367,7 @@ public:
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     const std::optional<MediaCapability>& mediaCapability() const;
+    void resetMediaCapability();
     void updateMediaCapability();
 #endif
     void setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&&);
@@ -2976,6 +2977,7 @@ private:
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     void setMediaCapability(std::optional<MediaCapability>&&);
+    void deactivateMediaCapability(MediaCapability&);
     bool shouldActivateMediaCapability() const;
     bool shouldDeactivateMediaCapability() const;
 #endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -19725,7 +19725,9 @@
 		};
 		5C400E6A29DB8AB500446F6F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
 			targetProxy = 5C400E6929DB8AB500446F6F /* PBXContainerItemProxy */;
 		};
@@ -19741,19 +19743,25 @@
 		};
 		5CE4B60729CEBB760038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
 			targetProxy = 5CE4B60629CEBB760038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62329CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
 			targetProxy = 5CE4B62229CF880B0038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62529CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
 			targetProxy = 5CE4B62429CF880B0038F565 /* PBXContainerItemProxy */;
 		};


### PR DESCRIPTION
#### d97f5a09e4f10a05d93ad47f08ac293180c75f77
<pre>
getUserMedia camera stream lost on history pushState in iOS 17.4 Beta 4
<a href="https://bugs.webkit.org/show_bug.cgi?id=269846">https://bugs.webkit.org/show_bug.cgi?id=269846</a>
<a href="https://rdar.apple.com/123381737">rdar://123381737</a>

Reviewed by Eric Carlson and Youenn Fablet.

When WebKit adopted media capability grants for camera capture we chose to tie the lifetime of the
media environment to the top frame document&apos;s current URL, such that if the URL changes (ignoring
fragment identifiers) then the current media environment is destroyed and a new one is created. If
a capture session is active when the media environment changes then the system will pause the
capture session as it&apos;s no longer associated with the current media environment. The logic of
comparing URLs was meant as a proxy for detecting cross-document navigations but failed to account
for same-document navigations that changed the path of the current URL (e.g., via pushState). Since
the origin associated with the media environment does not change during a same-document navigation
there is no need to recreate the media environment.

Addressed this by moving the logic for creating and destroying media environments to
WebPageProxy::didChangeMainDocument. Further, since only the top document&apos;s origin is displayed to
the user in iOS&apos;s privacy accounting UI, changed MediaCapability to only track a SecurityOrigin.
The logic for when to activate and deactivate a media environment&apos;s capability remains unchanged.

Manually verified that this resolves the issue reported in bug #269846. Unfortunately no new tests
are possible since the underlying platform support for media capabilities is not available in
iOS Simulator.

* Source/WebKit/Platform/cocoa/MediaCapability.h:
* Source/WebKit/Platform/cocoa/MediaCapability.mm:
(WebKit::MediaCapability::MediaCapability):
(WebKit::m_mediaEnvironment):
(WebKit::MediaCapability::registrableDomain const): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setMediaCapability):
(WebKit::WebPageProxy::deactivateMediaCapability):
(WebKit::WebPageProxy::resetMediaCapability):
(WebKit::WebPageProxy::updateMediaCapability):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didChangeMainDocument):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/275244@main">https://commits.webkit.org/275244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d35585d19c25fd0a7d01b991b2a533b06611ab2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43776 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37305 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34090 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41787 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17145 "Found 1 new test failure: http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14735 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14880 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40545 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38929 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17647 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9261 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->