### PR TITLE
[git-webkit revert] Should have an option to utilize landing with --unsafe

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -29,6 +29,7 @@ from .command import Command
 from .branch import Branch
 from .pull_request import PullRequest
 from .commit import Commit as CommitProgram
+from .land import Land
 
 from webkitbugspy import Tracker, bugzilla, radar
 from webkitcorepy import arguments, run, Terminal, string_utils
@@ -44,20 +45,18 @@ class Revert(Command):
 
     @classmethod
     def parser(cls, parser, loggers=None):
-        PullRequest.parser(parser, loggers=loggers)
+        Land.parser(parser, loggers=loggers)
         parser.add_argument(
             'commit_id',
             nargs='+',
             help='git hash, svn revision or identifier of commits to revert'
         )
-
         parser.add_argument(
             '--reason', '--why', '-w',
             dest='reason',
             type=str,
             help='Reason for the revert'
         )
-
         parser.add_argument(
             '--pr', '--no-pr',
             default=True,
@@ -291,6 +290,9 @@ class Revert(Command):
 
         if cls.relate_issues(args, repository, issue, commit_issues, revert_reason):
             return 1
+
+        if args.safe is not None and args.pr:
+            return Land.main(args, repository, identifier_template=None, canonical_svn=False, hooks=None)
 
         if args.pr:
             return PullRequest.create_pull_request(repository, args, branch_point)


### PR DESCRIPTION
#### b5b2c45431e6de0f83813a35e518ac3c1358b283
<pre>
[git-webkit revert] Should have an option to utilize landing with --unsafe
<a href="https://bugs.webkit.org/show_bug.cgi?id=268729">https://bugs.webkit.org/show_bug.cgi?id=268729</a>
<a href="https://rdar.apple.com/problem/122033841">rdar://problem/122033841</a>

Reviewed by Jonathan Bedard.

Adds arguments from git-webkit land to automatically land reverts with --safe and --unsafe.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.parser):
(Revert.get_issue_info):
(Revert.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(TestRevert):
(TestRevert.webserver):
(test_land_safe):
(test_land_unsafe):

Canonical link: <a href="https://commits.webkit.org/275336@main">https://commits.webkit.org/275336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7661334f007dae8c70232475c078143ef2976716

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44121 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17896 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15021 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/41422 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37115 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13447 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41599 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17986 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5556 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->