### PR TITLE
REGRESSION (274409@main): [ macOS wk2 ] 2 tests in http/tests/navigation/ping-attribute are flaky

### DIFF
--- a/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html
@@ -9,9 +9,6 @@ if (window.testRunner && window.internals) {
     testRunner.waitUntilDone();
 }
 
-if (location.protocol != "https:")
-    location = "https://127.0.0.1:8443/navigation/ping-attribute/area-cross-origin-from-https.html"
-
 function test()
 {
     clickElement(document.querySelector("img"));
@@ -19,7 +16,10 @@ function test()
 
 window.onload = function ()
 {
-    clearLastPingResultAndRunTest(test);
+    if (location.protocol != "https:")
+        location = "https://127.0.0.1:8443/navigation/ping-attribute/area-cross-origin-from-https.html"
+    else
+        clearLastPingResultAndRunTest(test);
 }
 </script>
 </head>

--- a/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https.html
@@ -9,9 +9,6 @@ if (window.testRunner && window.internals) {
     testRunner.waitUntilDone();
 }
 
-if (location.protocol != "https:")
-    location = "https://127.0.0.1:8443/navigation/ping-attribute/area-cross-origin-from-https.html"
-
 function test()
 {
     clickElement(document.querySelector("img"));
@@ -19,7 +16,10 @@ function test()
 
 window.onload = function ()
 {
-    clearLastPingResultAndRunTest(test);
+    if (location.protocol != "https:")
+        location = "https://127.0.0.1:8443/navigation/ping-attribute/area-cross-origin-from-https.html"
+    else
+        clearLastPingResultAndRunTest(test);
 }
 </script>
 </head>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1889,10 +1889,6 @@ webkit.org/b/264001 [ Debug ] imported/w3c/web-platform-tests/requestidlecallbac
 
 webkit.org/b/268398 [ Sonoma+ ] compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back.html [ Pass Failure ]
 
-# webkit.org/b/269798 REGRESSION (274409@main): [ macOS wk2 ] 2 tests in http/tests/navigation/ping-attribute are flaky
-[ Monterey+ ] http/tests/navigation/ping-attribute/area-cross-origin-from-https.html [ Pass Failure ]
-[ Monterey+ ] http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html [ Pass Failure ]
-
 imported/w3c/web-platform-tests/css/css-view-transitions/inline-element-size.html [ ImageOnlyFailure ]
 
 # webkit.org/b/270092  (REGRESSION (275274@main): [ Sonoma+ wk2 ] Multiple compositing/plugins/pdf/pdf are constant failures)


### PR DESCRIPTION
#### 252452ae30653f87ce0c6d9f6fb21cbb68df1dfd
<pre>
REGRESSION (274409@main): [ macOS wk2 ] 2 tests in http/tests/navigation/ping-attribute are flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=269798">https://bugs.webkit.org/show_bug.cgi?id=269798</a>
<a href="https://rdar.apple.com/123321229">rdar://123321229</a>

Reviewed by Charlie Wolfe.

These tests have been flakey since 274409@main. Apparently there&apos;s a race
condition between the the xhr request that deletes any stale pings and the
script-based location redirect. This change attempts to avoid that issue by
only deleting cookies if we&apos;re not going to load a different page.

* LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html:
* LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/278329@main">https://commits.webkit.org/278329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aba651ab04956ad1bdcd0e1f5b1f55afa505dc8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/801 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40903 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21994 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/375 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8488 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54950 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25207 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48297 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43309 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47309 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27331 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7257 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->