### PR TITLE
Remove gender-differentiating test expectations for family emoji.

### DIFF
--- a/LayoutTests/fast/text/emoji-single-parent-family-3-expected-mismatch.html
+++ b/LayoutTests/fast/text/emoji-single-parent-family-3-expected-mismatch.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body style="font: 100px Times;">&#x1F468;&zwj;&#x1F467;</body>
-</html>

--- a/LayoutTests/fast/text/emoji-single-parent-family-3.html
+++ b/LayoutTests/fast/text/emoji-single-parent-family-3.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body style="font: 100px Times;">&#x1F468;&zwj;&#x1F466;</body>
-</html>

--- a/LayoutTests/fast/text/emoji-single-parent-family-expected-mismatch.html
+++ b/LayoutTests/fast/text/emoji-single-parent-family-expected-mismatch.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body style="font: 100px Times;">&#x1F469;&zwj;&#x1F466;</body>
-</html>

--- a/LayoutTests/fast/text/emoji-single-parent-family.html
+++ b/LayoutTests/fast/text/emoji-single-parent-family.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body style="font: 100px Times;">&#x1F468;&zwj;&#x1F466;</body>
-</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -972,7 +972,6 @@ webkit.org/b/160120 editing/deleting/delete-emoji-6.html [ Skip ]
 webkit.org/b/160120 editing/deleting/delete-emoji-7.html [ Skip ]
 webkit.org/b/160120 editing/deleting/delete-emoji-8.html [ Skip ]
 webkit.org/b/160120 editing/deleting/delete-emoji-9.html [ Skip ]
-webkit.org/b/160120 fast/text/emoji-single-parent-family.html [ Skip ]
 webkit.org/b/160120 editing/caret/emoji.html [ Skip ]
 
 # No support for font-variant-* properties in @font-face declarations


### PR DESCRIPTION
#### 3108fccd7c8ae9b1cedc0d23e9868808a093c0d9
<pre>
Remove gender-differentiating test expectations for family emoji.
<a href="https://bugs.webkit.org/show_bug.cgi?id=269947">https://bugs.webkit.org/show_bug.cgi?id=269947</a>
<a href="https://rdar.apple.com/122569544">rdar://122569544</a>

Reviewed by Anne van Kesteren.

Unicode ESC&apos;s latest recommendations are to render all gendered family emoji
as gender-neutral, see:
- <a href="https://www.unicode.org/L2/L2022/22276-family-emoji-guidelines.pdf">https://www.unicode.org/L2/L2022/22276-family-emoji-guidelines.pdf</a>
- <a href="https://www.unicode.org/L2/L2023/23029-family-emoji.pdf">https://www.unicode.org/L2/L2023/23029-family-emoji.pdf</a>

Therefore our tests requiring that they mismatch need to be removed.

* LayoutTests/fast/text/emoji-single-parent-family-3-expected-mismatch.html: Removed.
* LayoutTests/fast/text/emoji-single-parent-family-expected-mismatch.html: Removed.
* LayoutTests/platform/gtk/TestExpectations: Remove corresponding skip line.

Canonical link: <a href="https://commits.webkit.org/275427@main">https://commits.webkit.org/275427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd9316bc796526b91cece3faf46deaf4384bf260

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18117 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34525 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45743 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41071 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39527 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18206 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18264 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5600 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->