### PR TITLE
REGRESSION(274325@main): Find matches can not be selected after calling `findMatchesForString`

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -209,10 +209,12 @@ void FindController::updateFindUIAfterPageScroll(bool found, const String& strin
         // If we're doing a multi-result search and just updating the indicator,
         // this would blow away the results for the other matches.
         // FIXME: This whole class needs a much clearer division between these two paths.
-        m_findMatches.clear();
-        if (auto range = m_webPage->corePage()->selection().firstRange()) {
-            matchRects = RenderObject::absoluteTextRects(*range);
-            m_findMatches.append(*range);
+        if (idOfFrameContainingString) {
+            m_findMatches.clear();
+            if (auto range = m_webPage->corePage()->selection().firstRange()) {
+                matchRects = RenderObject::absoluteTextRects(*range);
+                m_findMatches.append(*range);
+            }
         }
     }
 


### PR DESCRIPTION
#### 467125332e143e71f853f6c873f2087d248bdf60
<pre>
REGRESSION(274325@main): Find matches can not be selected after calling `findMatchesForString`
<a href="https://bugs.webkit.org/show_bug.cgi?id=269825">https://bugs.webkit.org/show_bug.cgi?id=269825</a>
<a href="https://rdar.apple.com/123465751">rdar://123465751</a>

Reviewed by Aditya Keerthi.

Before 274325@main, `FindController::updateFindUIAfterPageScroll` would clear `m_findMatches` only if it
was called from `FindController::findString`. After 274325@main, all call sites will clear it, so a
client will not be able to set selection after calling `findMatchesForString`. To match the previous
behavior we can check if a frame identifier was passed, since that will only be provided by
`FindController::findString`.

* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::updateFindUIAfterPageScroll):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/275219@main">https://commits.webkit.org/275219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb7a38df4deba1c8d321ef4b1cbf272811b58453

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34081 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41764 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17127 "Found 3 new test failures: fast/forms/datalist/datalist-option-labels.html, fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html, http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40534 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38925 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17676 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5499 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->