### PR TITLE
[UnifiedPDF] Flashing when interacting with form controls

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -286,7 +286,7 @@ void UnifiedPDFPlugin::setNeedsRepaintInDocumentRect(OptionSet<RepaintRequiremen
     auto contentsRect = convertUp(CoordinateSpace::PDFDocumentLayout, CoordinateSpace::Contents, rectInDocumentCoordinates);
     if (repaintRequirements.contains(RepaintRequirement::PDFContent)) {
         if (RefPtr asyncRenderer = asyncRendererIfExists())
-            asyncRenderer->invalidateTilesForPaintingRect(m_scaleFactor, contentsRect);
+            asyncRenderer->updateTilesForPaintingRect(m_scaleFactor, contentsRect);
     }
 
     RefPtr { m_contentsLayer }->setNeedsDisplayInRect(contentsRect);


### PR DESCRIPTION
#### c6069f49ce6b011ecf978e53ce4875f39cea3727
<pre>
[UnifiedPDF] Flashing when interacting with form controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=269958">https://bugs.webkit.org/show_bug.cgi?id=269958</a>
<a href="https://rdar.apple.com/123479307">rdar://123479307</a>

Reviewed by Tim Horton.

Currently when PDF content is invalidated (e.g. by a form control action) we throw
away the rendered tiles for that rect, and asynchronously regenerate them. That results
in flashes.

Instead, we can keep the existing tile, and update it from a asynchronously-rendered
buffer containing the invalidated rect for that tile. This means that paints may use
a stale tile, but that&apos;s better than flashing.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::paintingToTileTransform):
(WebKit::AsyncPDFRenderer::enqueuePaintWithClip):
(WebKit::AsyncPDFRenderer::paintTileOnWorkQueue):
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer):
(WebKit::AsyncPDFRenderer::transferBufferToMainThread):
(WebKit::AsyncPDFRenderer::didCompleteNewTileRender):
(WebKit::AsyncPDFRenderer::didCompleteTileUpdateRender):
(WebKit::AsyncPDFRenderer::updateTilesForPaintingRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setNeedsRepaintInDocumentRect):

Canonical link: <a href="https://commits.webkit.org/275253@main">https://commits.webkit.org/275253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab862dbf1670f081098c0d60773c26349cd36cac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37297 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34086 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41779 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17135 "Found 1 new test failure: http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14731 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14872 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45110 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37386 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40557 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38945 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17639 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9268 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->