### PR TITLE
Make IDBRequestData::transactionIdentifier return std::optional

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -187,13 +187,22 @@ void IDBServer::abortTransaction(const IDBResourceIdentifier& transactionIdentif
     transaction->abort();
 }
 
+UniqueIDBDatabaseTransaction* IDBServer::idbTransaction(const IDBRequestData& requestData) const
+{
+    auto transactionIdentifier = requestData.transactionIdentifier();
+    if (!transactionIdentifier)
+        return nullptr;
+
+    return m_transactions.get(*transactionIdentifier);
+}
+
 void IDBServer::createObjectStore(const IDBRequestData& requestData, const IDBObjectStoreInfo& info)
 {
     LOG(IndexedDB, "IDBServer::createObjectStore");
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -207,7 +216,7 @@ void IDBServer::deleteObjectStore(const IDBRequestData& requestData, const Strin
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -221,7 +230,7 @@ void IDBServer::renameObjectStore(const IDBRequestData& requestData, uint64_t ob
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -235,7 +244,7 @@ void IDBServer::clearObjectStore(const IDBRequestData& requestData, uint64_t obj
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -248,7 +257,7 @@ void IDBServer::createIndex(const IDBRequestData& requestData, const IDBIndexInf
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -262,7 +271,7 @@ void IDBServer::deleteIndex(const IDBRequestData& requestData, uint64_t objectSt
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -276,7 +285,7 @@ void IDBServer::renameIndex(const IDBRequestData& requestData, uint64_t objectSt
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -290,7 +299,7 @@ void IDBServer::putOrAdd(const IDBRequestData& requestData, const IDBKeyData& ke
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -303,7 +312,7 @@ void IDBServer::getRecord(const IDBRequestData& requestData, const IDBGetRecordD
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -316,7 +325,7 @@ void IDBServer::getAllRecords(const IDBRequestData& requestData, const IDBGetAll
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -329,7 +338,7 @@ void IDBServer::getCount(const IDBRequestData& requestData, const IDBKeyRangeDat
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -342,7 +351,7 @@ void IDBServer::deleteRecord(const IDBRequestData& requestData, const IDBKeyRang
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -355,7 +364,7 @@ void IDBServer::openCursor(const IDBRequestData& requestData, const IDBCursorInf
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -368,7 +377,7 @@ void IDBServer::iterateCursor(const IDBRequestData& requestData, const IDBIterat
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(requestData.transactionIdentifier());
+    auto transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -104,6 +104,7 @@ public:
 
 private:
     UniqueIDBDatabase& getOrCreateUniqueIDBDatabase(const IDBDatabaseIdentifier&);
+    UniqueIDBDatabaseTransaction* idbTransaction(const IDBRequestData&) const;
 
     void upgradeFilesIfNecessary();
     String upgradedDatabaseDirectory(const WebCore::IDBDatabaseIdentifier&);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -860,7 +860,8 @@ void UniqueIDBDatabase::putOrAdd(const IDBRequestData& requestData, const IDBKey
     IDBError error;
     bool usedKeyIsGenerated = false;
     uint64_t keyNumber;
-    auto transactionIdentifier = requestData.transactionIdentifier();
+    ASSERT(requestData.transactionIdentifier());
+    auto transactionIdentifier = *requestData.transactionIdentifier();
     auto generatedKeyResetter = makeScopeExit([this, transactionIdentifier, objectStoreIdentifier, &keyNumber, &usedKeyIsGenerated]() {
         if (usedKeyIsGenerated)
             m_backingStore->revertGeneratedKeyNumber(transactionIdentifier, objectStoreIdentifier, keyNumber);
@@ -917,7 +918,8 @@ void UniqueIDBDatabase::putOrAddAfterSpaceCheck(const IDBRequestData& requestDat
 
     uint64_t keyNumber = isKeyGenerated ? keyData.number() : 0;
     auto objectStoreIdentifier = objectStoreInfo.identifier();
-    auto transactionIdentifier = requestData.transactionIdentifier();
+    ASSERT(requestData.transactionIdentifier());
+    auto transactionIdentifier = *requestData.transactionIdentifier();
     auto generatedKeyResetter = makeScopeExit([this, transactionIdentifier, objectStoreIdentifier, &keyNumber, &isKeyGenerated]() {
         if (isKeyGenerated)
             m_backingStore->revertGeneratedKeyNumber(transactionIdentifier, objectStoreIdentifier, keyNumber);
@@ -967,10 +969,12 @@ void UniqueIDBDatabase::getRecord(const IDBRequestData& requestData, const IDBGe
     IDBGetResult result;
     IDBError error;
 
+    ASSERT(requestData.transactionIdentifier());
+    auto transactionIdentifier = *requestData.transactionIdentifier();
     if (uint64_t indexIdentifier = requestData.indexIdentifier())
-        error = m_backingStore->getIndexRecord(requestData.transactionIdentifier(), requestData.objectStoreIdentifier(), indexIdentifier, requestData.indexRecordType(), getRecordData.keyRangeData, result);
+        error = m_backingStore->getIndexRecord(transactionIdentifier, requestData.objectStoreIdentifier(), indexIdentifier, requestData.indexRecordType(), getRecordData.keyRangeData, result);
     else
-        error = m_backingStore->getRecord(requestData.transactionIdentifier(), requestData.objectStoreIdentifier(), getRecordData.keyRangeData, getRecordData.type, result);
+        error = m_backingStore->getRecord(transactionIdentifier, requestData.objectStoreIdentifier(), getRecordData.keyRangeData, getRecordData.type, result);
 
     callback(error, result);
 }
@@ -998,7 +1002,8 @@ void UniqueIDBDatabase::getAllRecords(const IDBRequestData& requestData, const I
         return callback(IDBError { ExceptionCode::InvalidStateError, "Backing store is closed"_s }, IDBGetAllResult { });
 
     IDBGetAllResult result;
-    auto error = m_backingStore->getAllRecords(requestData.transactionIdentifier(), getAllRecordsData, result);
+    ASSERT(requestData.transactionIdentifier());
+    auto error = m_backingStore->getAllRecords(*requestData.transactionIdentifier(), getAllRecordsData, result);
 
     callback(error, result);
 }
@@ -1026,7 +1031,8 @@ void UniqueIDBDatabase::getCount(const IDBRequestData& requestData, const IDBKey
         return callback(IDBError { ExceptionCode::InvalidStateError, "Backing store is closed"_s }, 0);
 
     uint64_t count = 0;
-    auto error = m_backingStore->getCount(requestData.transactionIdentifier(), requestData.objectStoreIdentifier(), requestData.indexIdentifier(), range, count);
+    ASSERT(requestData.transactionIdentifier());
+    auto error = m_backingStore->getCount(*requestData.transactionIdentifier(), requestData.objectStoreIdentifier(), requestData.indexIdentifier(), range, count);
 
     callback(error, count);
 }
@@ -1053,7 +1059,8 @@ void UniqueIDBDatabase::deleteRecord(const IDBRequestData& requestData, const ID
     if (!m_backingStore)
         return callback(IDBError { ExceptionCode::InvalidStateError, "Backing store is closed"_s });
 
-    auto error = m_backingStore->deleteRange(requestData.transactionIdentifier(), requestData.objectStoreIdentifier(), keyRangeData);
+    ASSERT(requestData.transactionIdentifier());
+    auto error = m_backingStore->deleteRange(*requestData.transactionIdentifier(), requestData.objectStoreIdentifier(), keyRangeData);
 
     callback(error);
 }
@@ -1081,7 +1088,8 @@ void UniqueIDBDatabase::openCursor(const IDBRequestData& requestData, const IDBC
         return callback(IDBError { ExceptionCode::InvalidStateError, "Backing store is closed"_s }, IDBGetResult { });
 
     IDBGetResult result;
-    auto error = m_backingStore->openCursor(requestData.transactionIdentifier(), info, result);
+    ASSERT(requestData.transactionIdentifier());
+    auto error = m_backingStore->openCursor(*requestData.transactionIdentifier(), info, result);
 
     callback(error, result);
 }
@@ -1110,8 +1118,9 @@ void UniqueIDBDatabase::iterateCursor(const IDBRequestData& requestData, const I
 
     IDBGetResult result;
     auto transactionIdentifier = requestData.transactionIdentifier();
+    ASSERT(transactionIdentifier);
     auto cursorIdentifier = requestData.cursorIdentifier();
-    auto error = m_backingStore->iterateCursor(transactionIdentifier, cursorIdentifier, data, result);
+    auto error = m_backingStore->iterateCursor(*transactionIdentifier, cursorIdentifier, data, result);
 
     callback(error, result);
 }

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -156,7 +156,7 @@ void UniqueIDBDatabaseTransaction::createObjectStore(const IDBRequestData& reque
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::createObjectStore");
 
     ASSERT(isVersionChange());
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -182,7 +182,7 @@ void UniqueIDBDatabaseTransaction::deleteObjectStore(const IDBRequestData& reque
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteObjectStore");
 
     ASSERT(isVersionChange());
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -208,7 +208,7 @@ void UniqueIDBDatabaseTransaction::renameObjectStore(const IDBRequestData& reque
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::renameObjectStore");
 
     ASSERT(isVersionChange());
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -233,7 +233,7 @@ void UniqueIDBDatabaseTransaction::clearObjectStore(const IDBRequestData& reques
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::clearObjectStore");
 
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -259,7 +259,7 @@ void UniqueIDBDatabaseTransaction::createIndex(const IDBRequestData& requestData
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::createIndex");
 
     ASSERT(isVersionChange());
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -285,7 +285,7 @@ void UniqueIDBDatabaseTransaction::deleteIndex(const IDBRequestData& requestData
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteIndex");
 
     ASSERT(isVersionChange());
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -311,7 +311,7 @@ void UniqueIDBDatabaseTransaction::renameIndex(const IDBRequestData& requestData
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::renameIndex");
 
     ASSERT(isVersionChange());
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -338,7 +338,7 @@ void UniqueIDBDatabaseTransaction::putOrAdd(const IDBRequestData& requestData, c
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::putOrAdd");
 
     ASSERT(!isReadOnly());
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -363,7 +363,7 @@ void UniqueIDBDatabaseTransaction::getRecord(const IDBRequestData& requestData, 
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getRecord");
 
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -388,7 +388,7 @@ void UniqueIDBDatabaseTransaction::getAllRecords(const IDBRequestData& requestDa
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getAllRecords");
 
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -413,7 +413,7 @@ void UniqueIDBDatabaseTransaction::getCount(const IDBRequestData& requestData, c
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getCount");
 
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -438,7 +438,7 @@ void UniqueIDBDatabaseTransaction::deleteRecord(const IDBRequestData& requestDat
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteRecord");
 
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -463,7 +463,7 @@ void UniqueIDBDatabaseTransaction::openCursor(const IDBRequestData& requestData,
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::openCursor");
 
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -488,7 +488,7 @@ void UniqueIDBDatabaseTransaction::iterateCursor(const IDBRequestData& requestDa
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::iterateCursor");
 
-    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
+    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
@@ -121,10 +121,9 @@ IDBResourceIdentifier IDBRequestData::requestIdentifier() const
     return m_requestIdentifier;
 }
 
-IDBResourceIdentifier IDBRequestData::transactionIdentifier() const
+std::optional<IDBResourceIdentifier> IDBRequestData::transactionIdentifier() const
 {
-    ASSERT(m_transactionIdentifier);
-    return *m_transactionIdentifier;
+    return m_transactionIdentifier;
 }
 
 IDBResourceIdentifier IDBRequestData::cursorIdentifier() const

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
@@ -58,7 +58,7 @@ public:
 
     IDBConnectionIdentifier serverConnectionIdentifier() const;
     WEBCORE_EXPORT IDBResourceIdentifier requestIdentifier() const;
-    WEBCORE_EXPORT IDBResourceIdentifier transactionIdentifier() const;
+    WEBCORE_EXPORT std::optional<IDBResourceIdentifier> transactionIdentifier() const;
     uint64_t objectStoreIdentifier() const;
     uint64_t indexIdentifier() const;
     IndexedDB::IndexRecordType indexRecordType() const;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -53,6 +53,10 @@ class SharedFileHandle;
 }
 
 namespace WebCore {
+namespace IDBServer {
+class UniqueIDBDatabaseTransaction;
+}
+
 class IDBCursorInfo;
 class IDBKeyData;
 class IDBIndexInfo;
@@ -242,6 +246,7 @@ private:
     void performEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     OriginQuotaManager::Parameters originQuotaManagerParameters(const WebCore::ClientOrigin&);
+    WebCore::IDBServer::UniqueIDBDatabaseTransaction* idbTransaction(const WebCore::IDBRequestData&);
 
     WeakPtr<NetworkProcess> m_process;
     PAL::SessionID m_sessionID;


### PR DESCRIPTION
#### f87c4a69b3d1a24dc298f1cc59371daae04a2731
<pre>
Make IDBRequestData::transactionIdentifier return std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=269957">https://bugs.webkit.org/show_bug.cgi?id=269957</a>
<a href="https://rdar.apple.com/123479310">rdar://123479310</a>

Reviewed by Alex Christensen.

IDBRequestData can be constructed based on IPC messages sent from web process, so we should not assume
IDBRequestData::m_transactionIdentifier is always valid. To fix that, this patch makes
IDBRequestData::transactionIdentifier return std::optional and adds null checks in the caller side.

* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::idbTransaction const):
(WebCore::IDBServer::IDBServer::createObjectStore):
(WebCore::IDBServer::IDBServer::deleteObjectStore):
(WebCore::IDBServer::IDBServer::renameObjectStore):
(WebCore::IDBServer::IDBServer::clearObjectStore):
(WebCore::IDBServer::IDBServer::createIndex):
(WebCore::IDBServer::IDBServer::deleteIndex):
(WebCore::IDBServer::IDBServer::renameIndex):
(WebCore::IDBServer::IDBServer::putOrAdd):
(WebCore::IDBServer::IDBServer::getRecord):
(WebCore::IDBServer::IDBServer::getAllRecords):
(WebCore::IDBServer::IDBServer::getCount):
(WebCore::IDBServer::IDBServer::deleteRecord):
(WebCore::IDBServer::IDBServer::openCursor):
(WebCore::IDBServer::IDBServer::iterateCursor):
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAddAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::getRecord):
(WebCore::IDBServer::UniqueIDBDatabase::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabase::getCount):
(WebCore::IDBServer::UniqueIDBDatabase::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabase::openCursor):
(WebCore::IDBServer::UniqueIDBDatabase::iterateCursor):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::clearObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getCount):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::openCursor):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::iterateCursor):
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp:
(WebCore::IDBRequestData::transactionIdentifier const):
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::idbTransaction):
(WebKit::NetworkStorageManager::createObjectStore):
(WebKit::NetworkStorageManager::deleteObjectStore):
(WebKit::NetworkStorageManager::renameObjectStore):
(WebKit::NetworkStorageManager::clearObjectStore):
(WebKit::NetworkStorageManager::createIndex):
(WebKit::NetworkStorageManager::deleteIndex):
(WebKit::NetworkStorageManager::renameIndex):
(WebKit::NetworkStorageManager::putOrAdd):
(WebKit::NetworkStorageManager::getRecord):
(WebKit::NetworkStorageManager::getAllRecords):
(WebKit::NetworkStorageManager::getCount):
(WebKit::NetworkStorageManager::deleteRecord):
(WebKit::NetworkStorageManager::openCursor):
(WebKit::NetworkStorageManager::iterateCursor):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/275222@main">https://commits.webkit.org/275222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee2eff2f1c5dec258671d3f89e2b1f4535bdd976

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34087 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41780 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17141 "Found 1 new test failure: http/wpt/background-fetch/background-fetch-persistency.window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14732 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40547 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38931 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17640 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9247 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->