### PR TITLE
[UnifiedPDF] Fix coordinate space for accessibility.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -179,9 +179,6 @@ public:
     WebCore::IntPoint convertFromPluginToRootView(const WebCore::IntPoint&) const;
     WebCore::IntRect convertFromPluginToRootView(const WebCore::IntRect&) const;
     WebCore::IntRect boundsOnScreen() const;
-    WebCore::FloatRect convertFromPDFViewToScreenForAccessibility(const WebCore::FloatRect&) const;
-    WebCore::IntPoint convertFromPDFViewToRootView(const WebCore::IntPoint&) const;
-    WebCore::IntPoint convertFromRootViewToPDFView(const WebCore::IntPoint&) const;
 
     bool showContextMenuAtPoint(const WebCore::IntPoint&);
     WebCore::AXObjectCache* axObjectCache() const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -121,6 +121,11 @@ public:
 
     float documentFittingScale() const { return m_documentLayout.scale(); }
 
+#if PLATFORM(MAC)
+    WebCore::FloatRect convertFromPDFPageToScreenForAccessibility(const WebCore::FloatRect&, PDFDocumentLayout::PageIndex) const;
+    void accessibilityScrollToPage(PDFDocumentLayout::PageIndex);
+#endif
+
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
     bool isUnifiedPDFPlugin() const override { return true; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h
@@ -25,9 +25,11 @@
 
 #pragma once
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#if ENABLE(UNIFIED_PDF) && PLATFORM(MAC)
 
+#include "PDFDocumentLayout.h"
 #include "PDFPluginBase.h"
+#include "UnifiedPDFPlugin.h"
 #include <PDFKit/PDFKit.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -41,7 +43,7 @@ class WeakPtrImplWithEventTargetData;
 @interface WKAccessibilityPDFDocumentObject: NSObject {
     RetainPtr<PDFDocument> _pdfDocument;
     WeakObjCPtr<NSObject> _parent;
-    ThreadSafeWeakPtr<WebKit::PDFPluginBase> _pdfPlugin;
+    ThreadSafeWeakPtr<WebKit::UnifiedPDFPlugin> _pdfPlugin;
 }
 
 @property (assign) WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> pluginElement;
@@ -49,11 +51,12 @@ class WeakPtrImplWithEventTargetData;
 - (id)initWithPDFDocument:(RetainPtr<PDFDocument>)document andElement:(WebCore::HTMLPlugInElement*)element;
 - (void)setParent:(NSObject *)parent;
 - (void)setPDFDocument:(RetainPtr<PDFDocument>)document;
-- (void)setPDFPlugin:(WebKit::PDFPluginBase*)plugin;
+- (void)setPDFPlugin:(WebKit::UnifiedPDFPlugin*)plugin;
 - (PDFDocument *)document;
-- (NSObject *)parent;
+- (NSObject *)accessibilityParent;
 - (id)accessibilityHitTest:(NSPoint)point;
 - (void)gotoDestination:(PDFDestination *)destination;
+- (NSRect)convertFromPDFPageToScreenForAccessibility:(NSRect)rectInPageCoordinate pageIndex:(WebKit::PDFDocumentLayout::PageIndex)pageIndex;
 
 @end
 


### PR DESCRIPTION
#### 0d1d56d4da989bb82028ad08c8d392dc2b3ab51e
<pre>
[UnifiedPDF] Fix coordinate space for accessibility.

Reviewed by Abrar Rahman Protyasha.

- Fix VO cursor position does not match the focused element in unified pdf.
There are 2 parts of this change. One in pdfKit and one in webKit
- Update the plugin in WKAccessibilityDocumentObject to UnifiedPDFPlugin
- Remove extra functions
- Add new accessibility support api.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::convertFromPDFViewToRootView const): Deleted.
(WebKit::PDFPluginBase::convertFromPDFViewToScreenForAccessibility const): Deleted.
(WebKit::PDFPluginBase::convertFromRootViewToPDFView const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::UnifiedPDFPlugin::accessibilityScrollToPage):
(WebKit::UnifiedPDFPlugin::convertFromPDFPageToScreenForAccessibility const):
(WebKit::UnifiedPDFPlugin::accessibilityHitTestIntPoint const):
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h:
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject setPDFPlugin:]):
(-[WKAccessibilityPDFDocumentObject accessibilityFocusedUIElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityWindow]):
(-[WKAccessibilityPDFDocumentObject accessibilityTopLevelUIElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityVisibleChildren]):
(-[WKAccessibilityPDFDocumentObject accessibilitySubrole]):
(-[WKAccessibilityPDFDocumentObject accessibilityFrame]):
(-[WKAccessibilityPDFDocumentObject accessibilityParent]):
(-[WKAccessibilityPDFDocumentObject accessibilityAttributeValue:]):
(-[WKAccessibilityPDFDocumentObject accessibilityArrayAttributeCount:]):
(-[WKAccessibilityPDFDocumentObject accessibilityChildren]):
(-[WKAccessibilityPDFDocumentObject convertFromPDFPageToScreenForAccessibility:pageIndex:]):
(-[WKAccessibilityPDFDocumentObject accessibilityHitTest:]):
(-[WKAccessibilityPDFDocumentObject gotoDestination:]):
(-[WKAccessibilityPDFDocumentObject parent]): Deleted.

[UnifiedPDF] Fix coordinate space for accessibility <a href="https://bugs.webkit.org/show_bug.cgi?id=269956">https://bugs.webkit.org/show_bug.cgi?id=269956</a> <a href="https://rdar.apple.com/123459892">rdar://123459892</a>

Reviewed by Abrar Rahman Protyasha.

- Fix VO cursor position does not match the focused element in unified pdf.
There are 2 parts of this change. One in pdfKit and one in webKit
- Update the plugin in WKAccessibilityDocumentObject to UnifiedPDFPlugin
- Remove extra functions
- Add new accessibility support api

Canonical link: <a href="https://commits.webkit.org/275848@main">https://commits.webkit.org/275848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c906a4714ea74b24b6547c8ffe2fb5584ba43f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45633 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39134 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35564 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16661 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1065 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47173 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42349 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19461 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41004 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9586 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->