### PR TITLE
HTMLDataListElement::childrenChanged doesn't call HTMLElement::childrenChanged

### DIFF
--- a/LayoutTests/fast/dom/datalist-children-changed-crash-expected.txt
+++ b/LayoutTests/fast/dom/datalist-children-changed-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if WebKit does not hit any ASAN assertions.
+PASS

--- a/LayoutTests/fast/dom/datalist-children-changed-crash.html
+++ b/LayoutTests/fast/dom/datalist-children-changed-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+function runTest() {
+    document.all.length;
+    document.all[0];
+    span.cloneNode(false);
+    document.getElementById('datalist').innerHTML = '';
+    if (window.GCController)
+        GCController.collect();
+    document.all.length;
+    document.body.innerHTML = 'This test passes if WebKit does not hit any ASAN assertions.<br>PASS';
+}
+</script>
+<body onload=runTest()><span id="span">U<datalist id="datalist"><span>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -151,8 +151,13 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
 
     ASSERT_WITH_SECURITY_IMPLICATION(!document().selection().selection().isOrphan());
 
-    if (deferChildrenChanged == DeferChildrenChanged::No)
+    if (deferChildrenChanged == DeferChildrenChanged::No) {
+#if ASSERT_ENABLED
+        auto treeVersion = document().domTreeVersion();
+#endif
         childrenChanged(childChange);
+        ASSERT_WITH_SECURITY_IMPLICATION(document().domTreeVersion() > treeVersion);
+    }
 
     return hadElementChild ? DidRemoveElements::Yes : DidRemoveElements::No;
 }

--- a/Source/WebCore/html/HTMLDataListElement.cpp
+++ b/Source/WebCore/html/HTMLDataListElement.cpp
@@ -77,6 +77,7 @@ Ref<HTMLCollection> HTMLDataListElement::options()
 
 void HTMLDataListElement::childrenChanged(const ChildChange& change)
 {
+    HTMLElement::childrenChanged(change);
     if (change.source == ChildChange::Source::API)
         optionElementChildrenChanged();
 }


### PR DESCRIPTION
#### 9a1d1c7db2182ce4eab131e2cdcc55a9995b4351
<pre>
HTMLDataListElement::childrenChanged doesn&apos;t call HTMLElement::childrenChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=269959">https://bugs.webkit.org/show_bug.cgi?id=269959</a>
&lt;<a href="https://rdar.apple.com/123388053">rdar://123388053</a>&gt;

Reviewed by Chris Dumez.

This can lead to an inconsistent state in DOM so call that.

* LayoutTests/fast/dom/datalist-children-changed-crash-expected.txt: Added.
* LayoutTests/fast/dom/datalist-children-changed-crash.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion): Added a debug
assertion to catch a similar mistake in the future.
* Source/WebCore/html/HTMLDataListElement.cpp:
(WebCore::HTMLDataListElement::childrenChanged):

Canonical link: <a href="https://commits.webkit.org/275221@main">https://commits.webkit.org/275221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b3bb2ecaca67418a426fb7a8b534ae0b98ae81e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41226 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37318 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17570 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14748 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40565 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35789 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17712 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5500 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->