### PR TITLE
Migrate EventTarget to use EventTargetInterfaceType enum class instead of EventTargetInterface enum

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -148,7 +148,7 @@ private:
     Ref<GPUPipelineLayout> createAutoPipelineLayout();
 
     // EventTarget.
-    EventTargetInterface eventTargetInterface() const final { return GPUDeviceEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::GPUDevice; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -110,7 +110,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget.
-    EventTargetInterface eventTargetInterface() const override { return ApplePaySessionEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const override { return EventTargetInterfaceType::ApplePaySession; }
     ScriptExecutionContext* scriptExecutionContext() const override { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -90,9 +90,9 @@ Navigator* Clipboard::navigator()
     return m_navigator.get();
 }
 
-EventTargetInterface Clipboard::eventTargetInterface() const
+enum EventTargetInterfaceType Clipboard::eventTargetInterface() const
 {
-    return ClipboardEventTargetInterfaceType;
+    return EventTargetInterfaceType::Clipboard;
 }
 
 ScriptExecutionContext* Clipboard::scriptExecutionContext() const

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.h
@@ -45,7 +45,7 @@ public:
     static Ref<Clipboard> create(Navigator&);
     ~Clipboard();
 
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
 
     LocalFrame* frame() const;

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -59,7 +59,7 @@ private:
     explicit DOMAudioSession(ScriptExecutionContext*);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return DOMAudioSessionEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::DOMAudioSession; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -541,9 +541,9 @@ bool CookieStore::virtualHasPendingActivity() const
     return m_hasChangeEventListener;
 }
 
-EventTargetInterface CookieStore::eventTargetInterface() const
+enum EventTargetInterfaceType CookieStore::eventTargetInterface() const
 {
-    return CookieStoreEventTargetInterfaceType;
+    return EventTargetInterfaceType::CookieStore;
 }
 
 ScriptExecutionContext* CookieStore::scriptExecutionContext() const

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -80,7 +80,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -108,7 +108,7 @@ private:
     PlatformDisplayID displayID() final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const override { return MediaKeySessionEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const override { return EventTargetInterfaceType::MediaKeySession; }
     ScriptExecutionContext* scriptExecutionContext() const override { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -80,7 +80,7 @@ private:
     const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
 
-    EventTargetInterface eventTargetInterface() const final { return WebKitMediaKeySessionEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebKitMediaKeySession; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -74,7 +74,7 @@ public:
     void renameIndex(IDBIndex&, const String& newName);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return IDBDatabaseEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::IDBDatabase; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ThreadSafeRefCounted<IDBDatabase>::ref(); }
     void derefEventTarget() final { ThreadSafeRefCounted<IDBDatabase>::deref(); }

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -246,11 +246,11 @@ IndexedDB::IndexRecordType IDBRequest::requestedIndexRecordType() const
     return m_requestedIndexRecordType;
 }
 
-EventTargetInterface IDBRequest::eventTargetInterface() const
+enum EventTargetInterfaceType IDBRequest::eventTargetInterface() const
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    return IDBRequestEventTargetInterfaceType;
+    return EventTargetInterfaceType::IDBRequest;
 }
 
 const char* IDBRequest::activeDOMObjectName() const

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -148,7 +148,7 @@ private:
     IDBRequest(ScriptExecutionContext&, IDBObjectStore&, IndexedDB::ObjectStoreRecordType, IDBTransaction&);
     IDBRequest(ScriptExecutionContext&, IDBIndex&, IndexedDB::IndexRecordType, IDBTransaction&);
 
-    EventTargetInterface eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const override;
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -84,7 +84,7 @@ public:
     ExceptionOr<void> abort();
     ExceptionOr<void> commit();
 
-    EventTargetInterface eventTargetInterface() const final { return IDBTransactionEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::IDBTransaction; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ThreadSafeRefCounted::ref(); }
     void derefEventTarget() final { ThreadSafeRefCounted::deref(); }

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -94,7 +94,7 @@ private:
     // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final { return MediaRecorderEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaRecorder; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     // ActiveDOMObject API.

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -83,7 +83,7 @@ private:
     // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final { return MediaSessionCoordinatorEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaSessionCoordinator; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void eventListenersDidChange() final;
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1307,9 +1307,9 @@ ScriptExecutionContext* MediaSource::scriptExecutionContext() const
     return ActiveDOMObject::scriptExecutionContext();
 }
 
-EventTargetInterface MediaSource::eventTargetInterface() const
+enum EventTargetInterfaceType MediaSource::eventTargetInterface() const
 {
-    return MediaSourceEventTargetInterfaceType;
+    return EventTargetInterfaceType::MediaSource;
 }
 
 URLRegistry& MediaSource::registry() const

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -204,7 +204,7 @@ private:
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
 
     URLRegistry& registry() const final;
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -190,7 +190,7 @@ private:
     void videoTrackSelectedChanged(VideoTrack&) final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return SourceBufferEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SourceBuffer; }
 
     bool isRemoved() const;
     void scheduleEvent(const AtomString& eventName);

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -66,7 +66,7 @@ public:
     size_t size() const { return m_list.size(); }
 
     // EventTarget interface
-    EventTargetInterface eventTargetInterface() const final { return SourceBufferListEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SourceBufferList; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
     using RefCounted<SourceBufferList>::ref;

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -114,7 +114,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget.
-    EventTargetInterface eventTargetInterface() const final { return MediaDevicesEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaDevices; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -94,7 +94,7 @@ public:
     void stopProducingData();
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return MediaStreamEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaStream; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
     using RefCounted<MediaStream>::ref;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -199,7 +199,7 @@ private:
     // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final { return MediaStreamTrackEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaStreamTrack; }
 
     // MediaStreamTrackPrivate::Observer
     void trackStarted(MediaStreamTrackPrivate&) final;

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -59,7 +59,7 @@ private:
     void stop() final;
     const char* activeDOMObjectName() const final;
 
-    EventTargetInterface eventTargetInterface() const final { return RTCDTMFSenderEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDTMFSender; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     bool virtualHasPendingActivity() const final { return m_isPendingPlayoutTask; }
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -100,7 +100,7 @@ private:
     void scheduleDispatchEvent(Ref<Event>&&);
     void removeFromDataChannelLocalMapIfNeeded();
 
-    EventTargetInterface eventTargetInterface() const final { return RTCDataChannelEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDataChannel; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -60,7 +60,7 @@ private:
     RTCDtlsTransport(ScriptExecutionContext&, UniqueRef<RTCDtlsTransportBackend>&&, Ref<RTCIceTransport>&&);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return RTCDtlsTransportEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDtlsTransport; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -72,7 +72,7 @@ private:
     RTCIceTransport(ScriptExecutionContext&, UniqueRef<RTCIceTransportBackend>&&, RTCPeerConnection&);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return RTCIceTransportEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCIceTransport; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -163,7 +163,7 @@ public:
     WEBCORE_EXPORT void gatherDecoderImplementationName(Function<void(String&&)>&&);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return RTCPeerConnectionEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCPeerConnection; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     using RefCounted::ref;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -86,7 +86,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return RTCRtpSFrameTransformEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCRtpSFrameTransform; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -57,7 +57,7 @@ private:
     RTCSctpTransport(ScriptExecutionContext&, UniqueRef<RTCSctpTransportBackend>&&, Ref<RTCDtlsTransport>&&);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return RTCSctpTransportEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCSctpTransport; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -136,7 +136,7 @@ private:
     Notification(ScriptExecutionContext&, WTF::UUID, const String& title, Options&&, Ref<SerializedScriptValue>&&);
 
     NotificationClient* clientFromContext();
-    EventTargetInterface eventTargetInterface() const final { return NotificationEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::Notification; }
 
     void stopResourcesLoader();
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -133,7 +133,7 @@ private:
     void suspend(ReasonForSuspension) final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return PaymentRequestEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::PaymentRequest; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     bool isPaymentRequest() const final { return true; }
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -105,7 +105,7 @@ private:
     void suspend(ReasonForSuspension) final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return PaymentResponseEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::PaymentResponse; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -62,7 +62,7 @@ private:
 
     // EventTarget
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
-    EventTargetInterface eventTargetInterface() const final { return PermissionStatusEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::PermissionStatus; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h
@@ -61,7 +61,7 @@ private:
     // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const override { return PictureInPictureWindowEventTargetInterfaceType; };
+    enum EventTargetInterfaceType eventTargetInterface() const override { return EventTargetInterfaceType::PictureInPictureWindow; };
     ScriptExecutionContext* scriptExecutionContext() const override { return ActiveDOMObject::scriptExecutionContext(); };
 
     IntSize m_size;

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -92,7 +92,7 @@ private:
     const char* activeDOMObjectName() const final;
 
     // EventTarget.
-    EventTargetInterface eventTargetInterface() const final { return RemotePlaybackEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RemotePlayback; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h
@@ -61,7 +61,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return WakeLockSentinelEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WakeLockSentinel; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -97,7 +97,7 @@ private:
 
     // EventTarget
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
-    EventTargetInterface eventTargetInterface() const final { return SpeechRecognitionEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SpeechRecognition; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -107,7 +107,7 @@ private:
 
     // EventTarget
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
-    EventTargetInterface eventTargetInterface() const final { return SpeechSynthesisEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SpeechSynthesis; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -90,7 +90,7 @@ private:
 
     // EventTarget
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
-    EventTargetInterface eventTargetInterface() const final { return SpeechSynthesisUtteranceEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SpeechSynthesisUtterance; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -445,9 +445,9 @@ void AudioNode::initializeDefaultNodeOptions(unsigned count, ChannelCountMode mo
     m_channelInterpretation = interpretation;
 }
 
-EventTargetInterface AudioNode::eventTargetInterface() const
+enum EventTargetInterfaceType AudioNode::eventTargetInterface() const
 {
-    return AudioNodeEventTargetInterfaceType;
+    return EventTargetInterfaceType::AudioNode;
 }
 
 ScriptExecutionContext* AudioNode::scriptExecutionContext() const

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -239,7 +239,7 @@ private:
     static WeakOrStrongContext toWeakOrStrongContext(BaseAudioContext&, NodeType);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const override;
     ScriptExecutionContext* scriptExecutionContext() const final;
 
     volatile bool m_isInitialized { false };

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -777,9 +777,9 @@ void BaseAudioContext::removeMarkedSummingJunction(AudioSummingJunction* summing
     m_dirtySummingJunctions.remove(summingJunction);
 }
 
-EventTargetInterface BaseAudioContext::eventTargetInterface() const
+enum EventTargetInterfaceType BaseAudioContext::eventTargetInterface() const
 {
-    return BaseAudioContextEventTargetInterfaceType;
+    return EventTargetInterfaceType::BaseAudioContext;
 }
 
 void BaseAudioContext::markAudioNodeOutputDirty(AudioNodeOutput* output)

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -258,7 +258,7 @@ private:
     void handleDeferredDecrementConnectionCounts();
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -86,7 +86,7 @@ private:
     // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final { return WebCodecsAudioDecoderEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsAudioDecoder; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     ExceptionOr<void> closeDecoder(Exception&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -86,7 +86,7 @@ private:
     // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final { return WebCodecsAudioEncoderEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsAudioEncoder; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     ExceptionOr<void> closeEncoder(Exception&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -84,7 +84,7 @@ private:
     // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final { return WebCodecsVideoDecoderEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsVideoDecoder; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     ExceptionOr<void> closeDecoder(Exception&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -85,7 +85,7 @@ private:
     // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final { return WebCodecsVideoEncoderEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebCodecsVideoEncoder; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     ExceptionOr<void> closeEncoder(Exception&&);

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -479,9 +479,9 @@ void WebSocket::setBinaryType(BinaryType binaryType)
     m_binaryType = binaryType;
 }
 
-EventTargetInterface WebSocket::eventTargetInterface() const
+enum EventTargetInterfaceType WebSocket::eventTargetInterface() const
 {
-    return WebSocketEventTargetInterfaceType;
+    return EventTargetInterfaceType::WebSocket;
 }
 
 ScriptExecutionContext* WebSocket::scriptExecutionContext() const

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -108,7 +108,7 @@ private:
     void stop() final;
     const char* activeDOMObjectName() const final;
 
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/webxr/WebXRLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.h
@@ -56,7 +56,7 @@ protected:
 
 private:
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return WebXRLayerEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebXRLayer; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 };

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -110,7 +110,7 @@ private:
     WebXRSession(Document&, WebXRSystem&, XRSessionMode, PlatformXR::Device&, FeatureList&&);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const override { return WebXRSessionEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const override { return EventTargetInterfaceType::WebXRSession; }
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }
 

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -65,7 +65,7 @@ protected:
 
 private:
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return WebXRSpaceEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebXRSpace; }
 
     Ref<WebXRRigidTransform> m_originOffset;
 };

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -86,7 +86,7 @@ public:
 
 protected:
     // EventTarget
-    EventTargetInterface eventTargetInterface() const override { return WebXRSystemEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const override { return EventTargetInterfaceType::WebXRSystem; }
     ScriptExecutionContext* scriptExecutionContext() const override { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -211,7 +211,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return WebAnimationEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WebAnimation; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/bindings/scripts/InFilesCompiler.pm
+++ b/Source/WebCore/bindings/scripts/InFilesCompiler.pm
@@ -246,7 +246,7 @@ sub generateInterfacesHeader()
     }
 
     if ($namespace eq "EventTarget") {
-        print F "    ${suffix} = $count,\n";
+        print F "    ${namespace} = $count,\n";
         $count++;
     }
 

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -107,7 +107,7 @@ private:
     const char* activeDOMObjectName() const final { return "FontFaceSet"; }
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return FontFaceSetEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::FontFaceSet; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -59,7 +59,7 @@ private:
 
     void setMatches(bool);
 
-    EventTargetInterface eventTargetInterface() const final { return MediaQueryListEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaQueryList; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -89,7 +89,7 @@ private:
     void addDependentSignal(AbortSignal&);
 
     // EventTarget.
-    EventTargetInterface eventTargetInterface() const final { return AbortSignalEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::AbortSignal; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -72,7 +72,7 @@ private:
     bool isEligibleForMessaging() const;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return BroadcastChannelEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::BroadcastChannel; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void derefEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -87,7 +87,7 @@ public:
     inline void ref(); // Defined in Node.h.
     inline void deref(); // Defined in Node.h.
 
-    virtual EventTargetInterface eventTargetInterface() const = 0;
+    virtual enum EventTargetInterfaceType eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;
 
     WEBCORE_EXPORT virtual bool isPaymentRequest() const;

--- a/Source/WebCore/dom/EventTargetConcrete.h
+++ b/Source/WebCore/dom/EventTargetConcrete.h
@@ -45,7 +45,7 @@ public:
 private:
     explicit EventTargetConcrete(ScriptExecutionContext&);
 
-    EventTargetInterface eventTargetInterface() const final { return EventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::EventTarget; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -86,7 +86,7 @@ public:
     const MessagePortIdentifier& remoteIdentifier() const { return m_remoteIdentifier; }
 
     // EventTarget.
-    EventTargetInterface eventTargetInterface() const final { return MessagePortEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MessagePort; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -61,24 +61,8 @@ MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, con
     init(m_isSimulated, windowLocation);
 }
 
-// FIXME: Remove this variant.
-MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
-    MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, IsSimulated isSimulated, IsTrusted isTrusted)
-    : MouseRelatedEvent(EventInterfaceType::Invalid, eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation,
-        movementX, movementY, modifiers, isSimulated, isTrusted)
-{
-}
-
 MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, const AtomString& type, IsCancelable isCancelable, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, const IntPoint& globalLocation, OptionSet<Modifier> modifiers)
     : MouseRelatedEvent(eventInterface, type, CanBubble::Yes, isCancelable, IsComposed::Yes, timestamp,
-        WTFMove(view), 0, globalLocation, globalLocation /* Converted in init */, 0, 0, modifiers, IsSimulated::No)
-{
-}
-
-// FIXME: Remove this variant.
-MouseRelatedEvent::MouseRelatedEvent(const AtomString& type, IsCancelable isCancelable, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, const IntPoint& globalLocation, OptionSet<Modifier> modifiers)
-    : MouseRelatedEvent(EventInterfaceType::Invalid, type, CanBubble::Yes, isCancelable, IsComposed::Yes, timestamp,
         WTFMove(view), 0, globalLocation, globalLocation /* Converted in init */, 0, 0, modifiers, IsSimulated::No)
 {
 }
@@ -91,12 +75,6 @@ MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, con
 {
     ASSERT_UNUSED(isTrusted, isTrusted == IsTrusted::No);
     init(false, IntPoint(0, 0));
-}
-
-// FIXME: Remove this variant.
-MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, const MouseRelatedEventInit& initializer, IsTrusted isTrusted)
-    : MouseRelatedEvent(EventInterfaceType::Invalid, eventType, initializer, isTrusted)
-{
 }
 
 static inline bool isMoveEventType(const AtomString& eventType)

--- a/Source/WebCore/dom/MouseRelatedEvent.h
+++ b/Source/WebCore/dom/MouseRelatedEvent.h
@@ -79,13 +79,8 @@ protected:
     MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime, RefPtr<WindowProxy>&&, int detail,
         const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers,
         IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
-    MouseRelatedEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers,
-        IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
-    MouseRelatedEvent(const AtomString& type, IsCancelable, MonotonicTime, RefPtr<WindowProxy>&&, const IntPoint& globalLocation, OptionSet<Modifier>);
     MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, IsCancelable, MonotonicTime, RefPtr<WindowProxy>&&, const IntPoint& globalLocation, OptionSet<Modifier>);
     MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, const MouseRelatedEventInit&, IsTrusted = IsTrusted::No);
-    MouseRelatedEvent(const AtomString& type, const MouseRelatedEventInit&, IsTrusted = IsTrusted::No);
 
     void initCoordinates();
     void initCoordinates(const LayoutPoint& clientLocation);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2159,9 +2159,9 @@ Element* Node::enclosingLinkEventParentOrSelf()
     return nullptr;
 }
 
-EventTargetInterface Node::eventTargetInterface() const
+enum EventTargetInterfaceType Node::eventTargetInterface() const
 {
-    return NodeEventTargetInterfaceType;
+    return EventTargetInterfaceType::Node;
 }
 
 template <typename MoveNodeFunction, typename MoveShadowRootFunction>

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -507,7 +507,7 @@ public:
 
     WEBCORE_EXPORT unsigned short compareDocumentPosition(Node&);
 
-    EventTargetInterface eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const override;
     ScriptExecutionContext* scriptExecutionContext() const final; // Implemented in DocumentInlines.h.
 
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;

--- a/Source/WebCore/dom/TouchEvent.cpp
+++ b/Source/WebCore/dom/TouchEvent.cpp
@@ -41,7 +41,7 @@ TouchEvent::TouchEvent() = default;
 
 TouchEvent::TouchEvent(TouchList* touches, TouchList* targetTouches, TouchList* changedTouches, const AtomString& type,
     RefPtr<WindowProxy>&& view, const IntPoint& globalLocation, OptionSet<Modifier> modifiers)
-    : MouseRelatedEvent(type, IsCancelable::Yes, MonotonicTime::now(), WTFMove(view), globalLocation, modifiers)
+    : MouseRelatedEvent(EventInterfaceType::TouchEvent, type, IsCancelable::Yes, MonotonicTime::now(), WTFMove(view), globalLocation, modifiers)
     , m_touches(touches)
     , m_targetTouches(targetTouches)
     , m_changedTouches(changedTouches)
@@ -49,7 +49,7 @@ TouchEvent::TouchEvent(TouchList* touches, TouchList* targetTouches, TouchList* 
 }
 
 TouchEvent::TouchEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : MouseRelatedEvent(type, initializer, isTrusted)
+    : MouseRelatedEvent(EventInterfaceType::TouchEvent, type, initializer, isTrusted)
     , m_touches(initializer.touches ? initializer.touches : TouchList::create())
     , m_targetTouches(initializer.targetTouches ? initializer.targetTouches : TouchList::create())
     , m_changedTouches(initializer.changedTouches ? initializer.changedTouches : TouchList::create())

--- a/Source/WebCore/dom/make_event_factory.pl
+++ b/Source/WebCore/dom/make_event_factory.pl
@@ -106,7 +106,10 @@ sub generateImplementation()
         print F "JSC::JSValue toJS(JSC::JSGlobalObject* state, JSDOMGlobalObject* globalObject, ${namespace}& impl)\n";
         print F "{\n";
         print F "    switch (impl.${interfaceMethodName}()) {\n";
-        print F "    case EventTargetInterfaceType:\n";
+        print F "    case ${namespace}InterfaceType::Invalid:\n";
+        print F "        ASSERT_NOT_REACHED();\n";
+        print F "        break;\n";
+        print F "    case ${namespace}InterfaceType::${namespace}:\n";
         print F "        break;\n";
     }
 
@@ -129,10 +132,10 @@ sub generateImplementation()
             print F "$conditionals\n";
         }
         if ($factoryFunction eq "toNewlyCreated") {
-            print F "    case EventInterfaceType::${interfaceName}:\n";
+            print F "    case ${namespace}InterfaceType::${interfaceName}:\n";
             print F "        return createWrapper<$interfaceName$suffix>(globalObject, WTFMove(impl));\n";
         } else {
-            print F "    case ${interfaceName}${suffix}InterfaceType:\n";
+            print F "    case ${namespace}InterfaceType::${interfaceName}:\n";
             print F "        return toJS(state, globalObject, static_cast<$interfaceName&>(impl));\n";
         }
         print F "#endif\n" if $conditional;

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -86,7 +86,7 @@ private:
     void stop() final;
     bool virtualHasPendingActivity() const final;
 
-    EventTargetInterface eventTargetInterface() const final { return FileReaderEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::FileReader; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -99,7 +99,7 @@ private:
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
-    EventTargetInterface eventTargetInterface() const final { return MediaControllerEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaController; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); };
 
     void addMediaElement(HTMLMediaElement&);

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -166,7 +166,7 @@ private:
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
-    EventTargetInterface eventTargetInterface() const final { return OffscreenCanvasEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::OffscreenCanvas; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -103,9 +103,9 @@ AudioTrack* AudioTrackList::getTrackById(TrackID id) const
     return nullptr;
 }
 
-EventTargetInterface AudioTrackList::eventTargetInterface() const
+enum EventTargetInterfaceType AudioTrackList::eventTargetInterface() const
 {
-    return AudioTrackListEventTargetInterfaceType;
+    return EventTargetInterfaceType::AudioTrackList;
 }
 
 const char* AudioTrackList::activeDOMObjectName() const

--- a/Source/WebCore/html/track/AudioTrackList.h
+++ b/Source/WebCore/html/track/AudioTrackList.h
@@ -54,7 +54,7 @@ public:
     void remove(TrackBase&, bool scheduleEvent = true) final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const override;
 
 private:
     AudioTrackList(ScriptExecutionContext*);

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -150,7 +150,7 @@ protected:
     WeakHashSet<TextTrackClient> m_clients;
 
 private:
-    EventTargetInterface eventTargetInterface() const final { return TextTrackEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::TextTrack; }
 
     bool enabled() const override;
 

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -149,7 +149,7 @@ private:
     void derefEventTarget() final { deref(); }
     using EventTarget::dispatchEvent;
     void dispatchEvent(Event&) final;
-    EventTargetInterface eventTargetInterface() const final { return TextTrackCueEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::TextTrackCue; }
     ScriptExecutionContext* scriptExecutionContext() const final;
 
     // ActiveDOMObject

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -258,9 +258,9 @@ bool TextTrackList::contains(TrackBase& track) const
     return tracks->find(&track) != notFound;
 }
 
-EventTargetInterface TextTrackList::eventTargetInterface() const
+enum EventTargetInterfaceType TextTrackList::eventTargetInterface() const
 {
-    return TextTrackListEventTargetInterfaceType;
+    return EventTargetInterfaceType::TextTrackList;
 }
 
 const char* TextTrackList::activeDOMObjectName() const

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -63,7 +63,7 @@ public:
     const MediaTime& duration() const { return m_duration; }
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const override;
 
 private:
     TextTrackList(ScriptExecutionContext*);

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -56,7 +56,7 @@ public:
     virtual RefPtr<TrackBase> find(TrackID) const;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const override = 0;
+    enum EventTargetInterfaceType eventTargetInterface() const override = 0;
     using RefCounted<TrackListBase>::ref;
     using RefCounted<TrackListBase>::deref;
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -109,9 +109,9 @@ VideoTrack* VideoTrackList::selectedItem() const
     return item(selectedIndex);
 }
 
-EventTargetInterface VideoTrackList::eventTargetInterface() const
+enum EventTargetInterfaceType VideoTrackList::eventTargetInterface() const
 {
-    return VideoTrackListEventTargetInterfaceType;
+    return EventTargetInterfaceType::VideoTrackList;
 }
 
 const char* VideoTrackList::activeDOMObjectName() const

--- a/Source/WebCore/html/track/VideoTrackList.h
+++ b/Source/WebCore/html/track/VideoTrackList.h
@@ -54,7 +54,7 @@ public:
     void append(Ref<VideoTrack>&&);
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const override;
+    enum EventTargetInterfaceType eventTargetInterface() const override;
 
 private:
     VideoTrackList(ScriptExecutionContext*);

--- a/Source/WebCore/loader/appcache/DOMApplicationCache.h
+++ b/Source/WebCore/loader/appcache/DOMApplicationCache.h
@@ -54,7 +54,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    EventTargetInterface eventTargetInterface() const final { return DOMApplicationCacheEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::DOMApplicationCache; }
     ScriptExecutionContext* scriptExecutionContext() const final;
 
     ApplicationCacheHost* applicationCacheHost() const;

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -79,7 +79,7 @@ protected:
 
     ExceptionOr<RefPtr<SecurityOrigin>> createTargetOriginForPostMessage(const String&, Document&);
 
-    EventTargetInterface eventTargetInterface() const final { return LocalDOMWindowEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::LocalDOMWindow; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -77,7 +77,7 @@ public:
 private:
     EventSource(ScriptExecutionContext&, const URL&, const Init&);
 
-    EventTargetInterface eventTargetInterface() const final { return EventSourceEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::EventSource; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -511,5 +511,5 @@ inline String LocalDOMWindow::status() const
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LocalDOMWindow)
     static bool isType(const WebCore::DOMWindow& window) { return window.isLocalDOMWindow(); }
-    static bool isType(const WebCore::EventTarget& target) { return target.eventTargetInterface() == WebCore::LocalDOMWindowEventTargetInterfaceType; }
+    static bool isType(const WebCore::EventTarget& target) { return target.eventTargetInterface() == WebCore::EventTargetInterfaceType::LocalDOMWindow; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -101,9 +101,9 @@ ScriptExecutionContext* Navigation::scriptExecutionContext() const
     return ContextDestructionObserver::scriptExecutionContext();
 }
 
-EventTargetInterface Navigation::eventTargetInterface() const
+enum EventTargetInterfaceType Navigation::eventTargetInterface() const
 {
-    return NavigationEventTargetInterfaceType;
+    return EventTargetInterfaceType::Navigation;
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-early-error-result

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -96,7 +96,7 @@ public:
 private:
     Navigation(ScriptExecutionContext*, LocalDOMWindow&);
 
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -63,9 +63,9 @@ ScriptExecutionContext* NavigationHistoryEntry::scriptExecutionContext() const
     return ContextDestructionObserver::scriptExecutionContext();
 }
 
-EventTargetInterface NavigationHistoryEntry::eventTargetInterface() const
+enum EventTargetInterfaceType NavigationHistoryEntry::eventTargetInterface() const
 {
-    return NavigationHistoryEntryEventTargetInterfaceType;
+    return EventTargetInterfaceType::NavigationHistoryEntry;
 }
 
 uint64_t NavigationHistoryEntry::index() const

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -62,7 +62,7 @@ private:
     NavigationHistoryEntry(ScriptExecutionContext*, Ref<HistoryItem>&);
     NavigationHistoryEntry(ScriptExecutionContext*, const URL&);
 
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -127,7 +127,7 @@ private:
 
     void contextDestroyed() override;
 
-    EventTargetInterface eventTargetInterface() const final { return PerformanceEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::Performance; }
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -74,7 +74,7 @@ private:
     void screenOrientationDidChange(ScreenOrientationType) final;
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return ScreenOrientationEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ScreenOrientation; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }

--- a/Source/WebCore/page/VisualViewport.cpp
+++ b/Source/WebCore/page/VisualViewport.cpp
@@ -45,9 +45,9 @@ VisualViewport::VisualViewport(LocalDOMWindow& window)
 {
 }
 
-EventTargetInterface VisualViewport::eventTargetInterface() const
+enum EventTargetInterfaceType VisualViewport::eventTargetInterface() const
 {
-    return VisualViewportEventTargetInterfaceType;
+    return EventTargetInterfaceType::VisualViewport;
 }
 
 ScriptExecutionContext* VisualViewport::scriptExecutionContext() const

--- a/Source/WebCore/page/VisualViewport.h
+++ b/Source/WebCore/page/VisualViewport.h
@@ -37,7 +37,7 @@ public:
     static Ref<VisualViewport> create(LocalDOMWindow& window) { return adoptRef(*new VisualViewport(window)); }
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
 

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -79,9 +79,9 @@ DedicatedWorkerGlobalScope::~DedicatedWorkerGlobalScope()
     removeFromContextsMap();
 }
 
-EventTargetInterface DedicatedWorkerGlobalScope::eventTargetInterface() const
+enum EventTargetInterfaceType DedicatedWorkerGlobalScope::eventTargetInterface() const
 {
-    return DedicatedWorkerGlobalScopeEventTargetInterfaceType;
+    return EventTargetInterfaceType::DedicatedWorkerGlobalScope;
 }
 
 void DedicatedWorkerGlobalScope::prepareForDestruction()

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -96,7 +96,7 @@ private:
 
     Type type() const final { return Type::DedicatedWorker; }
 
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
 
     void prepareForDestruction() final;
 

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -92,7 +92,7 @@ public:
 private:
     Worker(ScriptExecutionContext&, JSC::RuntimeFlags, WorkerOptions&&);
 
-    EventTargetInterface eventTargetInterface() const final { return WorkerEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::Worker; }
 
     void didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse&) final;
     void notifyFinished() final;

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -127,9 +127,9 @@ ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, 
     return { };
 }
 
-EventTargetInterface ServiceWorker::eventTargetInterface() const
+enum EventTargetInterfaceType ServiceWorker::eventTargetInterface() const
 {
-    return ServiceWorkerEventTargetInterfaceType;
+    return EventTargetInterfaceType::ServiceWorker;
 }
 
 ScriptExecutionContext* ServiceWorker::scriptExecutionContext() const

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -74,7 +74,7 @@ private:
     ServiceWorker(ScriptExecutionContext&, ServiceWorkerData&&);
     void updatePendingActivityForEventDispatch();
 
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -134,7 +134,7 @@ private:
     const char* activeDOMObjectName() const final;
     
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
-    EventTargetInterface eventTargetInterface() const final { return ServiceWorkerContainerEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ServiceWorkerContainer; }
     void refEventTarget() final;
     void derefEventTarget() final;
     void stop() final;

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -159,9 +159,9 @@ void ServiceWorkerGlobalScope::skipWaiting(Ref<DeferredPromise>&& promise)
     });
 }
 
-EventTargetInterface ServiceWorkerGlobalScope::eventTargetInterface() const
+enum EventTargetInterfaceType ServiceWorkerGlobalScope::eventTargetInterface() const
 {
-    return ServiceWorkerGlobalScopeEventTargetInterfaceType;
+    return EventTargetInterfaceType::ServiceWorkerGlobalScope;
 }
 
 ServiceWorkerThread& ServiceWorkerGlobalScope::thread()

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -67,7 +67,7 @@ public:
     
     void skipWaiting(Ref<DeferredPromise>&&);
 
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
 
     ServiceWorkerThread& thread();
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -244,9 +244,9 @@ void ServiceWorkerRegistration::queueTaskToFireUpdateFoundEvent()
     queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().updatefoundEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-EventTargetInterface ServiceWorkerRegistration::eventTargetInterface() const
+enum EventTargetInterfaceType ServiceWorkerRegistration::eventTargetInterface() const
 {
-    return ServiceWorkerRegistrationEventTargetInterfaceType;
+    return EventTargetInterfaceType::ServiceWorkerRegistration;
 }
 
 ScriptExecutionContext* ServiceWorkerRegistration::scriptExecutionContext() const

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -111,7 +111,7 @@ public:
 private:
     ServiceWorkerRegistration(ScriptExecutionContext&, Ref<ServiceWorkerContainer>&&, ServiceWorkerRegistrationData&&);
 
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
@@ -76,7 +76,7 @@ private:
     ServiceWorkerRegistrationIdentifier registrationIdentifier() const { return m_information.registrationIdentifier; }
 
     // EventTarget
-    EventTargetInterface eventTargetInterface() const final { return BackgroundFetchRegistrationEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::BackgroundFetchRegistration; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -142,9 +142,9 @@ const char* SharedWorker::activeDOMObjectName() const
     return "SharedWorker";
 }
 
-EventTargetInterface SharedWorker::eventTargetInterface() const
+enum EventTargetInterfaceType SharedWorker::eventTargetInterface() const
 {
-    return SharedWorkerEventTargetInterfaceType;
+    return EventTargetInterfaceType::SharedWorker;
 }
 
 void SharedWorker::didFinishLoading(const ResourceError& error)

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -60,7 +60,7 @@ private:
     SharedWorker(Document&, const SharedWorkerKey&, Ref<MessagePort>&&);
 
     // EventTarget.
-    EventTargetInterface eventTargetInterface() const final;
+    enum EventTargetInterfaceType eventTargetInterface() const final;
 
     // ActiveDOMObject.
     const char* activeDOMObjectName() const final;

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
@@ -54,7 +54,7 @@ public:
 private:
     SharedWorkerGlobalScope(const String& name, const WorkerParameters&, Ref<SecurityOrigin>&&, SharedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
 
-    EventTargetInterface eventTargetInterface() const final { return SharedWorkerGlobalScopeEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SharedWorkerGlobalScope; }
     FetchOptions::Destination destination() const final { return FetchOptions::Destination::Sharedworker; }
 
     String m_name;

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -96,7 +96,7 @@ private:
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final { ASSERT_NOT_REACHED(); return nullptr; }
 
     // EventTarget.
-    EventTargetInterface eventTargetInterface() const final { return WorkletGlobalScopeEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::WorkletGlobalScope; }
 
     bool isWorkletGlobalScope() const final { return true; }
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -71,7 +71,7 @@ public:
 
     virtual void didReachTimeout();
 
-    EventTargetInterface eventTargetInterface() const override { return XMLHttpRequestEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const override { return EventTargetInterfaceType::XMLHttpRequest; }
     ScriptExecutionContext* scriptExecutionContext() const override { return ActiveDOMObject::scriptExecutionContext(); }
 
     using SendTypes = std::variant<RefPtr<Document>, RefPtr<Blob>, RefPtr<JSC::ArrayBufferView>, RefPtr<JSC::ArrayBuffer>, RefPtr<DOMFormData>, String, RefPtr<URLSearchParams>>;

--- a/Source/WebCore/xml/XMLHttpRequestUpload.h
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.h
@@ -50,7 +50,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    EventTargetInterface eventTargetInterface() const final { return XMLHttpRequestUploadEventTargetInterfaceType; }
+    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::XMLHttpRequestUpload; }
     ScriptExecutionContext* scriptExecutionContext() const final { return m_request.scriptExecutionContext(); }
 
     XMLHttpRequest& m_request;


### PR DESCRIPTION
#### ffdb8dd1da9260284b42045286910bf544d6bc97
<pre>
Migrate EventTarget to use EventTargetInterfaceType enum class instead of EventTargetInterface enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=269960">https://bugs.webkit.org/show_bug.cgi?id=269960</a>

Reviewed by Chris Dumez.

Moved EventTarget::eventTargetInterface from EventTargetInterface enum to EventTargetInterfaceType enum class.
For now, we need to explicitly say &quot;enum EventTargetInterfaceType&quot; because there is an enum value of
EventTargetInterfaceType in EventTargetInterface enum.

* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::eventTargetInterface const):
* Source/WebCore/Modules/async-clipboard/Clipboard.h:
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::eventTargetInterface const):
* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::eventTargetInterface const):
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::eventTargetInterface const):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.h:
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureWindow.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.h:
* Source/WebCore/Modules/speech/SpeechRecognition.h:
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::eventTargetInterface const):
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::eventTargetInterface const):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::eventTargetInterface const):
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/webxr/WebXRLayer.h:
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSpace.h:
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/bindings/scripts/InFilesCompiler.pm:
(generateInterfacesHeader):
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/MediaQueryList.h:
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/EventTargetConcrete.h:
* Source/WebCore/dom/EventTargetFactory.in:
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/MouseRelatedEvent.cpp:
* Source/WebCore/dom/MouseRelatedEvent.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::eventTargetInterface const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/make_event_factory.pl:
(generateImplementation):
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/html/MediaController.h:
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/track/AudioTrackList.cpp:
(WebCore::AudioTrackList::eventTargetInterface const):
* Source/WebCore/html/track/AudioTrackList.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TextTrackList.cpp:
(WebCore::TextTrackList::eventTargetInterface const):
* Source/WebCore/html/track/TextTrackList.h:
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/html/track/VideoTrackList.cpp:
(WebCore::VideoTrackList::eventTargetInterface const):
* Source/WebCore/html/track/VideoTrackList.h:
* Source/WebCore/loader/appcache/DOMApplicationCache.h:
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/LocalDOMWindow.h:
(isType):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::eventTargetInterface const):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::eventTargetInterface const):
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/page/VisualViewport.cpp:
(WebCore::VisualViewport::eventTargetInterface const):
* Source/WebCore/page/VisualViewport.h:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::eventTargetInterface const):
* Source/WebCore/workers/DedicatedWorkerGlobalScope.h:
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::eventTargetInterface const):
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::eventTargetInterface const):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::eventTargetInterface const):
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::eventTargetInterface const):
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebCore/xml/XMLHttpRequestUpload.h:

Canonical link: <a href="https://commits.webkit.org/275233@main">https://commits.webkit.org/275233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1907ee4bf383ae19ee503a1b0124c1ee6d193a88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41257 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37349 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34118 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14775 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40593 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38979 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17743 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5505 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->