### PR TITLE
Add and use `twoPiDouble` / `twoPiFloat` to `MathExtras.h`

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -71,6 +71,9 @@ constexpr double sqrtOfTwoDouble = M_SQRT2;
 constexpr float sqrtOfTwoFloat = static_cast<float>(M_SQRT2);
 #endif
 
+constexpr double twoPiDouble = piDouble * 2.0;
+constexpr float twoPiFloat = piFloat * 2.0f;
+
 #if COMPILER(MSVC)
 
 // Work around a bug in Win, where atan2(+-infinity, +-infinity) yields NaN instead of specific values.

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -117,7 +117,7 @@ void applyWindow(float* p, size_t n)
     
     for (unsigned i = 0; i < n; ++i) {
         double x = static_cast<double>(i) / static_cast<double>(n);
-        double window = a0 - a1 * cos(2 * piDouble * x) + a2 * cos(4 * piDouble * x);
+        double window = a0 - a1 * cos(twoPiDouble * x) + a2 * cos(2.0 * twoPiDouble * x);
         p[i] *= float(window);
     }
 }

--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -142,7 +142,6 @@ ExceptionOr<void> CanvasPath::arcTo(float x1, float y1, float x2, float y2, floa
 
 static void normalizeAngles(float& startAngle, float& endAngle, bool anticlockwise)
 {
-    constexpr auto twoPiFloat = 2 * piFloat;
     float newStartAngle = fmodf(startAngle, twoPiFloat);
     if (newStartAngle < 0)
         newStartAngle += twoPiFloat;

--- a/Source/WebCore/platform/audio/DownSampler.cpp
+++ b/Source/WebCore/platform/audio/DownSampler.cpp
@@ -70,7 +70,7 @@ void DownSampler::initializeKernel()
 
         // Compute Blackman window, matching the offset of the sinc().
         double x = static_cast<double>(i) / n;
-        double window = a0 - a1 * cos(2.0 * piDouble * x) + a2 * cos(4.0 * piDouble * x);
+        double window = a0 - a1 * cos(twoPiDouble * x) + a2 * cos(2.0 * twoPiDouble * x);
 
         // Window the sinc() function.
         // Then store only the odd terms in the kernel.

--- a/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
@@ -278,7 +278,7 @@ void DynamicsCompressorKernel::process(const float* sourceChannels[],
         float desiredGain = m_detectorAverage;
 
         // Pre-warp so we get desiredGain after sin() warp below.
-        float scaledDesiredGain = asinf(desiredGain) / (0.5f * piFloat);
+        float scaledDesiredGain = asinf(desiredGain) / (piOverTwoFloat);
 
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         // Deal with envelopes
@@ -410,7 +410,7 @@ void DynamicsCompressorKernel::process(const float* sourceChannels[],
                 }
 
                 // Warp pre-compression gain to smooth out sharp exponential transition points.
-                float postWarpCompressorGain = sinf(0.5f * piFloat * compressorGain);
+                float postWarpCompressorGain = sinf(piOverTwoFloat * compressorGain);
 
                 // Calculate total gain using master gain and effect blend.
                 float totalGain = dryMix + wetMix * masterLinearGain * postWarpCompressorGain;

--- a/Source/WebCore/platform/audio/FFTFrame.cpp
+++ b/Source/WebCore/platform/audio/FFTFrame.cpp
@@ -140,21 +140,21 @@ void FFTFrame::interpolateFrequencyComponents(const FFTFrame& frame1, const FFTF
 
         // Unwrap phase deltas
         if (deltaPhase1 > piDouble)
-            deltaPhase1 -= 2.0 * piDouble;
+            deltaPhase1 -= twoPiDouble;
         if (deltaPhase1 < -piDouble)
-            deltaPhase1 += 2.0 * piDouble;
+            deltaPhase1 += twoPiDouble;
         if (deltaPhase2 > piDouble)
-            deltaPhase2 -= 2.0 * piDouble;
+            deltaPhase2 -= twoPiDouble;
         if (deltaPhase2 < -piDouble)
-            deltaPhase2 += 2.0 * piDouble;
+            deltaPhase2 += twoPiDouble;
 
         // Blend group-delays
         double deltaPhaseBlend;
 
         if (deltaPhase1 - deltaPhase2 > piDouble)
-            deltaPhaseBlend = s1 * deltaPhase1 + s2 * (2.0 * piDouble + deltaPhase2);
+            deltaPhaseBlend = s1 * deltaPhase1 + s2 * (twoPiDouble + deltaPhase2);
         else if (deltaPhase2 - deltaPhase1 > piDouble)
-            deltaPhaseBlend = s1 * (2.0 * piDouble + deltaPhase1) + s2 * deltaPhase2;
+            deltaPhaseBlend = s1 * (twoPiDouble + deltaPhase1) + s2 * deltaPhase2;
         else
             deltaPhaseBlend = s1 * deltaPhase1 + s2 * deltaPhase2;
 
@@ -162,9 +162,9 @@ void FFTFrame::interpolateFrequencyComponents(const FFTFrame& frame1, const FFTF
 
         // Unwrap
         if (phaseAccum > piDouble)
-            phaseAccum -= 2.0 * piDouble;
+            phaseAccum -= twoPiDouble;
         if (phaseAccum < -piDouble)
-            phaseAccum += 2.0 * piDouble;
+            phaseAccum += twoPiDouble;
 
         std::complex<double> c = std::polar(mag, phaseAccum);
 
@@ -218,7 +218,7 @@ double FFTFrame::extractAverageGroupDelay()
 
     int halfSize = fftSize() / 2;
 
-    const double kSamplePhaseDelay = (2.0 * piDouble) / double(fftSize());
+    const double kSamplePhaseDelay = (twoPiDouble) / double(fftSize());
 
     // Calculate weighted average group delay
     for (int i = 0; i < halfSize; i++) {
@@ -231,9 +231,9 @@ double FFTFrame::extractAverageGroupDelay()
 
         // Unwrap
         if (deltaPhase < -piDouble)
-            deltaPhase += 2.0 * piDouble;
+            deltaPhase += twoPiDouble;
         if (deltaPhase > piDouble)
-            deltaPhase -= 2.0 * piDouble;
+            deltaPhase -= twoPiDouble;
 
         aveSum += mag * deltaPhase;
         weightSum += mag;
@@ -263,7 +263,7 @@ void FFTFrame::addConstantGroupDelay(double sampleFrameDelay)
     auto& realP = realData();
     auto& imagP = imagData();
 
-    const double kSamplePhaseDelay = (2.0 * piDouble) / double(fftSize());
+    const double kSamplePhaseDelay = (twoPiDouble) / double(fftSize());
 
     double phaseAdj = -sampleFrameDelay * kSamplePhaseDelay;
 

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -193,7 +193,7 @@ void SincResampler::initializeKernel()
 
             // Compute Blackman window, matching the offset of the sinc().
             double x = (i - subsampleOffset) / n;
-            double window = a0 - a1 * cos(2.0 * piDouble * x) + a2 * cos(4.0 * piDouble * x);
+            double window = a0 - a1 * cos(twoPiDouble * x) + a2 * cos(2.0 * twoPiDouble * x);
 
             // Window the sinc() function and store at the correct offset.
             m_kernelStorage[i + offsetIndex * kernelSize] = sinc * window;

--- a/Source/WebCore/platform/audio/UpSampler.cpp
+++ b/Source/WebCore/platform/audio/UpSampler.cpp
@@ -65,7 +65,7 @@ void UpSampler::initializeKernel()
 
         // Compute Blackman window, matching the offset of the sinc().
         double x = (i - subsampleOffset) / n;
-        double window = a0 - a1 * cos(2.0 * piDouble * x) + a2 * cos(4.0 * piDouble * x);
+        double window = a0 - a1 * cos(twoPiDouble * x) + a2 * cos(2.0 * twoPiDouble * x);
 
         // Window the sinc() function.
         m_kernel[i] = sinc * window;

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -79,7 +79,7 @@ bool FEGaussianBlur::setEdgeMode(EdgeModeType edgeMode)
 
 static inline float gaussianKernelFactor()
 {
-    return 3 / 4.f * sqrtf(2 * piFloat);
+    return 3 / 4.f * sqrtf(twoPiFloat);
 }
 
 static int clampedToKernelSize(float value)

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
@@ -347,14 +347,14 @@ void AffineTransform::blend(const AffineTransform& from, double progress, Compos
     }
 
     // Don't rotate the long way around.
-    srA.angle = fmod(srA.angle, 2 * piDouble);
-    srB.angle = fmod(srB.angle, 2 * piDouble);
+    srA.angle = fmod(srA.angle, twoPiDouble);
+    srB.angle = fmod(srB.angle, twoPiDouble);
 
     if (std::abs(srA.angle - srB.angle) > piDouble) {
         if (srA.angle > srB.angle)
-            srA.angle -= piDouble * 2;
+            srA.angle -= twoPiDouble;
         else
-            srB.angle -= piDouble * 2;
+            srB.angle -= twoPiDouble;
     }
     
     srA.scaleX += progress * (srB.scaleX - srA.scaleX);

--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -466,9 +466,9 @@ bool SVGPathParser::decomposeArcToCubic(float angle, float rx, float ry, FloatPo
 
     float thetaArc = theta2 - theta1;
     if (thetaArc < 0 && sweepFlag)
-        thetaArc += 2 * piFloat;
+        thetaArc += twoPiFloat;
     else if (thetaArc > 0 && !sweepFlag)
-        thetaArc -= 2 * piFloat;
+        thetaArc -= twoPiFloat;
 
     pointTransform.makeIdentity();
     pointTransform.rotate(angle);


### PR DESCRIPTION
<pre>
Add and use `twoPiDouble` / `twoPiFloat` to `MathExtras.h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=269966">https://bugs.webkit.org/show_bug.cgi?id=269966</a>

Reviewed by NOBODY (OOPS!).

This patch adds `twoPiDouble` and `twoPiFloat` in `MathExtras.h` and
use it throughout our code rather than (2 * piFloat or 2 * piDouble).

* Source/WTF/wtf/MathExtras.h:
(twoPiDouble):
(twoPiFloat):
* Source/WebCore/svg/SVGPathParser.cpp:
(SVGPathParser::decomposeArcToCubic):
* Source/WebCore/platform/graphics/transforms/AffineTransform.cpp:
(AffineTransform::blend):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(gaussianKernelFactor):
* Source/WebCore/platform/audio/UpSampler.cpp:
(UpSampler::initializeKernel):
* Source/WebCore/platform/audio/SincResampler.cpp:
(SincResampler::initializeKernel):
* Source/WebCore/platform/audio/FFTFrame.cpp:
(FFTFrame::interpolateFrequencyComponents):
(FFTFrame::extractAverageGroupDelay):
(FFTFrame::addConstantGroupDelay):
* Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp:
(DynamicsCompressorKernel::process):
* Source/WebCore/platform/audio/DownSampler.cpp:
(DownSampler::initializeKernel):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(applyWindow):
* Source/WebCore/html/canvas/CanvasPath.cpp:
(normalizeAngles):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eee9ddf4efce95dd24b79db69dd6ba6f65baed45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34098 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45107 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34674 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40559 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40847 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38947 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17655 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47858 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17707 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9785 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->