### PR TITLE
Adopt smart pointers in CollectionIndexCache

### DIFF
--- a/Source/WebCore/dom/CollectionIndexCache.h
+++ b/Source/WebCore/dom/CollectionIndexCache.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+class WeakPtrImplWithEventTargetData;
+
 WEBCORE_EXPORT void reportExtraMemoryAllocatedForCollectionIndexCache(size_t);
 
 template <class Collection, class Iterator>
@@ -59,7 +61,7 @@ private:
     Iterator m_current { };
     unsigned m_currentIndex { 0 };
     unsigned m_nodeCount { 0 };
-    Vector<NodeType*> m_cachedList;
+    Vector<WeakPtr<NodeType, WeakPtrImplWithEventTargetData>> m_cachedList;
     bool m_nodeCountValid : 1;
     bool m_listValid : 1;
 };

--- a/Source/WebCore/dom/CollectionIndexCacheInlines.h
+++ b/Source/WebCore/dom/CollectionIndexCacheInlines.h
@@ -52,7 +52,7 @@ unsigned CollectionIndexCache<Collection, Iterator>::computeNodeCountUpdatingLis
 
     unsigned oldCapacity = m_cachedList.capacity();
     while (current) {
-        m_cachedList.append(&*current);
+        m_cachedList.append(*current);
         unsigned traversed;
         collection.collectionTraverseForward(current, 1, traversed);
         ASSERT(traversed == (current ? 1 : 0));
@@ -131,7 +131,7 @@ inline typename CollectionIndexCache<Collection, Iterator>::NodeType* Collection
         return nullptr;
 
     if (m_listValid)
-        return m_cachedList[index];
+        return m_cachedList[index].get();
 
     if (m_current) {
         if (index > m_currentIndex)


### PR DESCRIPTION
#### b16773e25a22a1a0f403b6a0947f787a682558e0
<pre>
Adopt smart pointers in CollectionIndexCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=269967">https://bugs.webkit.org/show_bug.cgi?id=269967</a>

Reviewed by Ryosuke Niwa.

Adopt smart pointers in CollectionIndexCache. This tested as performance
neutral on Speedometer 2 &amp; 3.

* Source/WebCore/dom/CollectionIndexCache.h:
* Source/WebCore/dom/CollectionIndexCacheInlines.h:
(WebCore::Iterator&gt;::computeNodeCountUpdatingListCache):
(WebCore::Iterator&gt;::nodeAt):

Canonical link: <a href="https://commits.webkit.org/275220@main">https://commits.webkit.org/275220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d5a89d8bad3a372231a2b349a9103568a26064b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17567 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14744 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45109 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16038 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38946 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17657 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9246 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->