### PR TITLE
getOutputTimestamp() seems to use wrong time scale

### DIFF
--- a/LayoutTests/webaudio/getOutputTimestamp-expected.txt
+++ b/LayoutTests/webaudio/getOutputTimestamp-expected.txt
@@ -1,0 +1,11 @@
+Validate the value returned by AudioContext.getOutputTimestamp()
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS contextTime > 0.090 is true
+PASS contextTime <= audioContext.currentTime is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/getOutputTimestamp.html
+++ b/LayoutTests/webaudio/getOutputTimestamp.html
@@ -1,0 +1,28 @@
+<DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Validate the value returned by AudioContext.getOutputTimestamp()");
+jsTestIsAsync = true;
+
+const audioContext = new AudioContext();
+const gainNode = new GainNode(audioContext, { gain: 0.01 });
+const oscillatorNode = new OscillatorNode(audioContext);
+
+oscillatorNode.connect(gainNode).connect(audioContext.destination);
+oscillatorNode.start();
+
+handle = setInterval(() => {
+    if (audioContext.currentTime < 0.100)
+        return;
+    clearInterval(handle);
+
+    contextTime = audioContext.getOutputTimestamp().contextTime;
+    shouldBeTrue("contextTime > 0.090");
+    shouldBeTrue("contextTime <= audioContext.currentTime");
+    finishJSTest();
+}, 10);
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
@@ -109,7 +109,7 @@ size_t AudioDestinationResampler::pullRendered(size_t numberOfFrames)
 bool AudioDestinationResampler::render(double sampleTime, MonotonicTime hostTime,  size_t framesToRender)
 {
     m_outputTimestamp = {
-        Seconds { sampleTime / sampleRate() },
+        Seconds { sampleTime },
         hostTime
     };
     // When there is a AudioWorklet, we do rendering on the AudioWorkletThread.


### PR DESCRIPTION
#### 33172dfe163a1a3445e76b23bc9a9b705516fc11
<pre>
getOutputTimestamp() seems to use wrong time scale
<a href="https://bugs.webkit.org/show_bug.cgi?id=264247">https://bugs.webkit.org/show_bug.cgi?id=264247</a>
<a href="https://rdar.apple.com/118323705">rdar://118323705</a>

Reviewed by Eric Carlson.

The time returned by getOutputTimestamp() was incorrectly divided by the
sample rate. Fix this so the value returned is correct and matches Chrome
and Firefox.

* LayoutTests/webaudio/getOutputTimestamp-expected.txt: Added.
* LayoutTests/webaudio/getOutputTimestamp.html: Added.
* Source/WebCore/platform/audio/AudioDestinationResampler.cpp:
(WebCore::AudioDestinationResampler::render):

Canonical link: <a href="https://commits.webkit.org/275237@main">https://commits.webkit.org/275237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea27cc3fff40c4f8a417fd77ac7e9984a05be82d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37321 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34102 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14751 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45117 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40564 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38952 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35793 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17715 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5506 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->