### PR TITLE
Make openTemporaryFile return file handle

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -445,8 +445,7 @@ JSC_DEFINE_HOST_FUNCTION(dumpAndClearSamplingProfilerSamples, (JSGlobalObject* g
 
     auto jsonData = json->toJSONString();
     {
-        FileSystem::PlatformFileHandle fileHandle;
-        String tempFilePath = FileSystem::openTemporaryFile(filenamePrefix, fileHandle);
+        auto [tempFilePath, fileHandle] = FileSystem::openTemporaryFile(filenamePrefix);
         if (!FileSystem::isHandleValid(fileHandle)) {
             dataLogLn("Dumping sampling profiler samples failed to open temporary file");
             return JSValue::encode(jsUndefined());

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -823,6 +823,13 @@ String parentPath(const String& path)
     return fromStdFileSystemPath(toStdFileSystemPath(path).parent_path());
 }
 
+String createTemporaryFile(StringView prefix, StringView suffix)
+{
+    auto [path, handle] = openTemporaryFile(prefix, suffix);
+    closeFile(handle);
+    return path;
+}
+
 #if !PLATFORM(PLAYSTATION)
 String realPath(const String& path)
 {

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -159,7 +159,8 @@ WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> readEntireFile(const String& p
 WTF_EXPORT_PRIVATE int overwriteEntireFile(const String& path, std::span<uint8_t>);
 
 // Prefix is what the filename should be prefixed with, not the full path.
-WTF_EXPORT_PRIVATE String openTemporaryFile(StringView prefix, PlatformFileHandle&, StringView suffix = { });
+WTF_EXPORT_PRIVATE std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, StringView suffix = { });
+WTF_EXPORT_PRIVATE String createTemporaryFile(StringView prefix, StringView suffix = { });
 WTF_EXPORT_PRIVATE PlatformFileHandle openFile(const String& path, FileOpenMode, FileAccessPermission = FileAccessPermission::All, bool failIfFileExists = false);
 WTF_EXPORT_PRIVATE void closeFile(PlatformFileHandle&);
 // Returns the resulting offset from the beginning of the file if successful, -1 otherwise.

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -93,13 +93,13 @@ String createTemporaryZipArchive(const String& path)
     return temporaryFile;
 }
 
-String openTemporaryFile(StringView prefix, PlatformFileHandle& platformFileHandle, StringView suffix)
+std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, StringView suffix)
 {
-    platformFileHandle = invalidPlatformFileHandle;
+    PlatformFileHandle platformFileHandle = invalidPlatformFileHandle;
 
     Vector<char> temporaryFilePath(PATH_MAX);
     if (!confstr(_CS_DARWIN_USER_TEMP_DIR, temporaryFilePath.data(), temporaryFilePath.size()))
-        return String();
+        return { String(), invalidPlatformFileHandle };
 
     // Shrink the vector.
     temporaryFilePath.shrink(strlen(temporaryFilePath.data()));
@@ -118,9 +118,9 @@ String openTemporaryFile(StringView prefix, PlatformFileHandle& platformFileHand
 
     platformFileHandle = mkstemps(temporaryFilePath.data(), suffixUTF8.length());
     if (platformFileHandle == invalidPlatformFileHandle)
-        return String();
+        return { nullString(), invalidPlatformFileHandle };
 
-    return String::fromUTF8(temporaryFilePath.data());
+    return { String::fromUTF8(temporaryFilePath.data()), platformFileHandle };
 }
 
 NSString *createTemporaryDirectory(NSString *directoryPrefix)

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -259,8 +259,9 @@ static const char* temporaryFileDirectory()
 #endif
 }
 
-String openTemporaryFile(StringView prefix, PlatformFileHandle& handle, StringView suffix)
+std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, StringView suffix)
 {
+    PlatformFileHandle handle = invalidPlatformFileHandle;
     // Suffix is not supported because that's incompatible with mkstemp.
     // This is OK for now since the code using it is built on macOS only.
     ASSERT_UNUSED(suffix, suffix.isEmpty());
@@ -273,11 +274,11 @@ String openTemporaryFile(StringView prefix, PlatformFileHandle& handle, StringVi
     if (handle < 0)
         goto end;
 
-    return String::fromUTF8(buffer);
+    return { String::fromUTF8(buffer), handle };
 
 end:
     handle = invalidPlatformFileHandle;
-    return String();
+    return { String(), handle };
 }
 #endif // !PLATFORM(COCOA)
 

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -185,12 +185,12 @@ static String generateTemporaryPath(const Function<bool(const String&)>& action)
     return proposedPath;
 }
 
-String openTemporaryFile(StringView, PlatformFileHandle& handle, StringView suffix)
+std::pair<String, PlatformFileHandle> openTemporaryFile(StringView, StringView suffix)
 {
     // FIXME: Suffix is not supported, but OK for now since the code using it is macOS-port-only.
     ASSERT_UNUSED(suffix, suffix.isEmpty());
 
-    handle = INVALID_HANDLE_VALUE;
+    PlatformFileHandle handle = INVALID_HANDLE_VALUE;
 
     String proposedPath = generateTemporaryPath([&handle](const String& proposedPath) {
         // use CREATE_NEW to avoid overwriting an existing file with the same name
@@ -200,9 +200,9 @@ String openTemporaryFile(StringView, PlatformFileHandle& handle, StringView suff
     });
 
     if (!isHandleValid(handle))
-        return String();
+        return { String(), handle };
 
-    return proposedPath;
+    return { proposedPath, handle };
 }
 
 PlatformFileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission, bool failIfFileExists)

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
@@ -101,8 +101,7 @@ static RetainPtr<NSURL> writeToTemporaryFile(WebCore::Model& modelSource)
     // to support reading USD files from its [SCNSceneSource initWithData:options:],
     // initializer but currently that does not work.
 
-    FileSystem::PlatformFileHandle fileHandle;
-    auto filePath = FileSystem::openTemporaryFile("ModelFile"_s, fileHandle, ".usdz"_s);
+    auto [filePath, fileHandle] = FileSystem::openTemporaryFile("ModelFile"_s, ".usdz"_s);
     ASSERT(FileSystem::isHandleValid(fileHandle));
 
     size_t byteCount = FileSystem::writeToFile(fileHandle, modelSource.data()->makeContiguous()->data(), modelSource.data()->size());

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -141,8 +141,7 @@ void GCController::deleteAllLinkedCode(DeleteAllCodeEffort effort)
 
 void GCController::dumpHeapForVM(VM& vm)
 {
-    FileSystem::PlatformFileHandle fileHandle;
-    String tempFilePath = FileSystem::openTemporaryFile("GCHeap"_s, fileHandle);
+    auto [tempFilePath, fileHandle] = FileSystem::openTemporaryFile("GCHeap"_s);
     if (!FileSystem::isHandleValid(fileHandle)) {
         WTFLogAlways("Dumping GC heap failed to open temporary file");
         return;

--- a/Source/WebCore/contentextensions/SerializedNFA.cpp
+++ b/Source/WebCore/contentextensions/SerializedNFA.cpp
@@ -51,8 +51,7 @@ bool writeAllToFile(FileSystem::PlatformFileHandle file, const T& container)
 
 std::optional<SerializedNFA> SerializedNFA::serialize(NFA&& nfa)
 {
-    auto file = FileSystem::invalidPlatformFileHandle;
-    auto filename = FileSystem::openTemporaryFile("SerializedNFA"_s, file);
+    auto [filename, file] = FileSystem::openTemporaryFile("SerializedNFA"_s);
     if (!FileSystem::isHandleValid(file))
         return std::nullopt;
 

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -67,9 +67,7 @@ static String transcodeImage(const String& path, const String& destinationUTI, c
     // It is important to add the appropriate file extension to the temporary file path.
     // The File object depends solely on the extension to know the MIME type of the file.
     auto suffix = makeString('.', destinationExtension);
-
-    FileSystem::PlatformFileHandle destinationFileHandle;
-    String destinationPath = FileSystem::openTemporaryFile("tempImage"_s, destinationFileHandle, suffix);
+    auto [destinationPath, destinationFileHandle] = FileSystem::openTemporaryFile("tempImage"_s, suffix);
     if (destinationFileHandle == FileSystem::invalidPlatformFileHandle) {
         RELEASE_LOG_ERROR(Images, "transcodeImage: Destination image could not be created: %s %s\n", path.utf8().data(), destinationUTI.utf8().data());
         return nullString();

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -387,8 +387,7 @@ void BlobRegistryImpl::writeBlobsToTemporaryFilesForIndexedDB(const Vector<Strin
     blobUtilityQueue().dispatch([blobsForWriting = WTFMove(blobsForWriting), completionHandler = WTFMove(completionHandler)]() mutable {
         Vector<String> filePaths;
         for (auto& blob : blobsForWriting) {
-            FileSystem::PlatformFileHandle file;
-            String tempFilePath = FileSystem::openTemporaryFile("Blob"_s, file);
+            auto [tempFilePath, file] = FileSystem::openTemporaryFile("Blob"_s);
             if (!writeFilePathsOrDataBuffersToFile(blob.filePathsOrDataBuffers, file, tempFilePath)) {
                 filePaths.clear();
                 break;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5253,8 +5253,7 @@ String Internals::createTemporaryFile(const String& name, const String& contents
     if (name.isEmpty())
         return nullString();
 
-    auto file = FileSystem::invalidPlatformFileHandle;
-    auto path = FileSystem::openTemporaryFile(makeString("WebCoreTesting-", name), file);
+    auto [path, file] = FileSystem::openTemporaryFile(makeString("WebCoreTesting-", name));
     if (!FileSystem::isHandleValid(file))
         return nullString();
 

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -127,7 +127,9 @@ bool WebMemorySampler::isRunning() const
     
 void WebMemorySampler::initializeTempLogFile()
 {
-    m_sampleLogFilePath = FileSystem::openTemporaryFile(processName(), m_sampleLogFile);
+    auto result = FileSystem::openTemporaryFile(processName());
+    m_sampleLogFilePath = result.first;
+    m_sampleLogFile = result.second;
     writeHeaders();
 }
 

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -359,8 +359,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
         bool m_fileError { false };
     };
 
-    auto temporaryFileHandle = invalidPlatformFileHandle;
-    WTF::String temporaryFilePath = openTemporaryFile("ContentRuleList"_s, temporaryFileHandle);
+    auto [temporaryFilePath, temporaryFileHandle] = openTemporaryFile("ContentRuleList"_s);
     if (temporaryFileHandle == invalidPlatformFileHandle) {
         WTFLogAlways("Content Rule List compiling failed: Opening temporary file failed.");
         return makeUnexpected(ContentRuleListStore::Error::CompileFailed);

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -321,7 +321,9 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
         return ".usdz"_s;
     }();
 
-    _filePath = FileSystem::openTemporaryFile("SystemPreview"_s, _fileHandle, fileExtension);
+    auto result = FileSystem::openTemporaryFile("SystemPreview"_s, fileExtension);
+    _filePath = result.first;
+    _fileHandle = result.second;
     ASSERT(FileSystem::isHandleValid(_fileHandle));
 
     _previewController->loadStarted(URL::fileURLWithFileSystemPath(_filePath));

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -52,39 +52,29 @@ public:
         WTF::initializeMainThread();
 
         // create temp file.
-        FileSystem::PlatformFileHandle handle;
-        m_tempFilePath = FileSystem::openTemporaryFile("tempTestFile"_s, handle);
+        auto result = FileSystem::openTemporaryFile("tempTestFile"_s);
+        m_tempFilePath = result.first;
+        auto handle = result.second;
         FileSystem::writeToFile(handle, FileSystemTestData, strlen(FileSystemTestData));
         FileSystem::closeFile(handle);
 
-        m_tempFileSymlinkPath = FileSystem::openTemporaryFile("tempTestFile-symlink"_s, handle);
-        FileSystem::closeFile(handle);
+        m_tempFileSymlinkPath = FileSystem::createTemporaryFile("tempTestFile-symlink"_s);
         FileSystem::deleteFile(m_tempFileSymlinkPath);
         FileSystem::createSymbolicLink(m_tempFilePath, m_tempFileSymlinkPath);
 
         // Create temp directory.
-        FileSystem::PlatformFileHandle temporaryFile;
-        m_tempEmptyFolderPath = FileSystem::openTemporaryFile("tempEmptyFolder"_s, temporaryFile);
-        FileSystem::closeFile(temporaryFile);
+        m_tempEmptyFolderPath = FileSystem::createTemporaryFile("tempEmptyFolder"_s);
         FileSystem::deleteFile(m_tempEmptyFolderPath);
         FileSystem::makeAllDirectories(m_tempEmptyFolderPath);
 
-        m_tempEmptyFolderSymlinkPath = FileSystem::openTemporaryFile("tempEmptyFolder-symlink"_s, temporaryFile);
-        FileSystem::closeFile(temporaryFile);
+        m_tempEmptyFolderSymlinkPath = FileSystem::createTemporaryFile("tempEmptyFolder-symlink"_s);
         FileSystem::deleteFile(m_tempEmptyFolderSymlinkPath);
         FileSystem::createSymbolicLink(m_tempEmptyFolderPath, m_tempEmptyFolderSymlinkPath);
 
-        m_tempEmptyFilePath = FileSystem::openTemporaryFile("tempEmptyTestFile"_s, handle);
-        FileSystem::closeFile(handle);
-
-        m_spaceContainingFilePath = FileSystem::openTemporaryFile("temp Empty Test File"_s, handle);
-        FileSystem::closeFile(handle);
-
-        m_bangContainingFilePath = FileSystem::openTemporaryFile("temp!Empty!Test!File"_s, handle);
-        FileSystem::closeFile(handle);
-
-        m_quoteContainingFilePath = FileSystem::openTemporaryFile("temp\"Empty\"TestFile"_s, handle);
-        FileSystem::closeFile(handle);
+        m_tempEmptyFilePath = FileSystem::createTemporaryFile("tempEmptyTestFile"_s);
+        m_spaceContainingFilePath = FileSystem::createTemporaryFile("temp Empty Test File"_s);
+        m_bangContainingFilePath = FileSystem::createTemporaryFile("temp!Empty!Test!File"_s);
+        m_quoteContainingFilePath = FileSystem::createTemporaryFile("temp\"Empty\"TestFile"_s);
     }
 
     void TearDown() override
@@ -168,9 +158,7 @@ TEST_F(FileSystemTest, fileType)
     EXPECT_EQ(FileSystem::fileType(symlinkToFileSymlinkPath), FileSystem::FileType::SymbolicLink);
 
     // Symlink to directory symlink case.
-    FileSystem::PlatformFileHandle handle;
-    auto symlinkToDirectorySymlinkPath = FileSystem::openTemporaryFile("tempTestFile-symlink"_s, handle);
-    FileSystem::closeFile(handle);
+    auto symlinkToDirectorySymlinkPath = FileSystem::createTemporaryFile("tempTestFile-symlink"_s);
     FileSystem::deleteFile(symlinkToDirectorySymlinkPath);
     EXPECT_TRUE(FileSystem::createSymbolicLink(tempEmptyFolderSymlinkPath(), symlinkToDirectorySymlinkPath));
     EXPECT_EQ(FileSystem::fileType(symlinkToDirectorySymlinkPath), FileSystem::FileType::SymbolicLink);
@@ -200,9 +188,7 @@ TEST_F(FileSystemTest, fileTypeFollowingSymlinks)
     EXPECT_EQ(FileSystem::fileTypeFollowingSymlinks(symlinkToFileSymlinkPath), FileSystem::FileType::Regular);
 
     // Symlink to directory symlink case.
-    FileSystem::PlatformFileHandle handle;
-    auto symlinkToDirectorySymlinkPath = FileSystem::openTemporaryFile("tempTestFile-symlink"_s, handle);
-    FileSystem::closeFile(handle);
+    auto symlinkToDirectorySymlinkPath = FileSystem::createTemporaryFile("tempTestFile-symlink"_s);
     FileSystem::deleteFile(symlinkToDirectorySymlinkPath);
     EXPECT_TRUE(FileSystem::createSymbolicLink(tempEmptyFolderSymlinkPath(), symlinkToDirectorySymlinkPath));
     EXPECT_EQ(FileSystem::fileTypeFollowingSymlinks(symlinkToDirectorySymlinkPath), FileSystem::FileType::Directory);
@@ -362,9 +348,7 @@ TEST_F(FileSystemTest, openNonExistingFileReadOnly)
 
 TEST_F(FileSystemTest, deleteNonEmptyDirectory)
 {
-    FileSystem::PlatformFileHandle temporaryFile;
-    auto temporaryTestFolder = FileSystem::openTemporaryFile("deleteNonEmptyDirectoryTest"_s, temporaryFile);
-    FileSystem::closeFile(temporaryFile);
+    auto temporaryTestFolder = FileSystem::createTemporaryFile("deleteNonEmptyDirectoryTest"_s);
 
     EXPECT_TRUE(FileSystem::deleteFile(temporaryTestFolder));
     EXPECT_TRUE(FileSystem::makeAllDirectories(FileSystem::pathByAppendingComponents(temporaryTestFolder, { "subfolder"_s })));
@@ -551,9 +535,7 @@ TEST_F(FileSystemTest, moveFileOverwritesDestination)
 
 TEST_F(FileSystemTest, moveDirectory)
 {
-    FileSystem::PlatformFileHandle temporaryFile;
-    auto temporaryTestFolder = FileSystem::openTemporaryFile("moveDirectoryTest"_s, temporaryFile);
-    FileSystem::closeFile(temporaryFile);
+    auto temporaryTestFolder = FileSystem::createTemporaryFile("moveDirectoryTest"_s);
 
     EXPECT_TRUE(FileSystem::deleteFile(temporaryTestFolder));
     EXPECT_TRUE(FileSystem::makeAllDirectories(temporaryTestFolder));

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -54,10 +54,11 @@ public:
         WTF::initializeMainThread();
         
         // create temp file
-        FileSystem::PlatformFileHandle handle;
-        m_tempFilePath = FileSystem::openTemporaryFile("tempTestFile"_s, handle);
+        auto result = FileSystem::openTemporaryFile("tempTestFile"_s);
+        m_tempFilePath = result.first;
+        auto handle = result.second;
         ASSERT_NE(handle, FileSystem::invalidPlatformFileHandle);
-        
+
         int rc = FileSystem::writeToFile(handle, FileMonitorTestData.utf8().data(), FileMonitorTestData.length());
         ASSERT_NE(rc, -1);
         

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
@@ -80,10 +80,7 @@ static HashSet<String> getTopicsFromRecords(const T& records) {
 
 static String makeTemporaryDatabasePath()
 {
-    FileSystem::PlatformFileHandle handle;
-    auto path = FileSystem::openTemporaryFile("PushDatabase"_s, handle, ".db"_s);
-    FileSystem::closeFile(handle);
-    return path;
+    return FileSystem::createTemporaryFile("PushDatabase"_s, ".db"_s);
 }
 
 static std::unique_ptr<PushDatabase> createDatabaseSync(const String& path)

--- a/Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp
@@ -43,18 +43,10 @@ public:
         WTF::initializeMainThread();
 
         // create temp file
-        FileSystem::PlatformFileHandle handle;
-        m_tempFilePath = FileSystem::openTemporaryFile("tempTestFile"_s, handle);
-        FileSystem::closeFile(handle);
-        
-        m_spaceContainingFilePath = FileSystem::openTemporaryFile("temp Empty Test File"_s, handle);
-        FileSystem::closeFile(handle);
-        
-        m_bangContainingFilePath = FileSystem::openTemporaryFile("temp!Empty!Test!File"_s, handle);
-        FileSystem::closeFile(handle);
-        
-        m_quoteContainingFilePath = FileSystem::openTemporaryFile("temp\"Empty\"TestFile"_s, handle);
-        FileSystem::closeFile(handle);
+        m_tempFilePath = FileSystem::createTemporaryFile("tempTestFile"_s);
+        m_spaceContainingFilePath = FileSystem::createTemporaryFile("temp Empty Test File"_s);
+        m_bangContainingFilePath = FileSystem::createTemporaryFile("temp!Empty!Test!File"_s);
+        m_quoteContainingFilePath = FileSystem::createTemporaryFile("temp\"Empty\"TestFile"_s);
     }
 
     void TearDown() override

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp
@@ -36,13 +36,12 @@ void FragmentedSharedBufferTest::SetUp()
     WTF::initializeMainThread();
 
     // create temp file
-    FileSystem::PlatformFileHandle handle;
-    m_tempFilePath = FileSystem::openTemporaryFile("tempTestFile"_s, handle);
-    FileSystem::writeToFile(handle, testData(), strlen(testData()));
-    FileSystem::closeFile(handle);
+    auto result = FileSystem::openTemporaryFile("tempTestFile"_s);
+    m_tempFilePath = result.first;
+    FileSystem::writeToFile(result.second, testData(), strlen(testData()));
+    FileSystem::closeFile(result.second);
 
-    m_tempEmptyFilePath = FileSystem::openTemporaryFile("tempEmptyTestFile"_s, handle);
-    FileSystem::closeFile(handle);
+    m_tempEmptyFilePath = FileSystem::createTemporaryFile("tempEmptyTestFile"_s);
 }
 
 void FragmentedSharedBufferTest::TearDown()

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm
@@ -40,10 +40,7 @@ namespace TestWebKitAPI {
 
 TEST(DatabaseTracker, DeleteDatabaseFileIfEmpty)
 {
-    FileSystem::PlatformFileHandle handle;
-    String databaseFilePath = FileSystem::openTemporaryFile("tempEmptyDatabase"_s, handle);
-    FileSystem::closeFile(handle);
-
+    auto databaseFilePath = FileSystem::createTemporaryFile("tempEmptyDatabase"_s);
     auto fileSize = FileSystem::fileSize(databaseFilePath).value_or(0);
     EXPECT_EQ(0U, fileSize);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -112,10 +112,8 @@ IGNORE_WARNINGS_END
     EXPECT_TRUE(hasReceivedResponse);
     EXPECT_EQ(_download, download);
 
-    FileSystem::PlatformFileHandle fileHandle;
-    _destinationPath = FileSystem::openTemporaryFile("TestWebKitAPI"_s, fileHandle);
-    EXPECT_TRUE(fileHandle != FileSystem::invalidPlatformFileHandle);
-    FileSystem::closeFile(fileHandle);
+    _destinationPath = FileSystem::createTemporaryFile("TestWebKitAPI"_s);
+    EXPECT_TRUE(!_destinationPath.isEmpty());
 
     *allowOverwrite = YES;
     return _destinationPath;
@@ -418,10 +416,8 @@ IGNORE_WARNINGS_END
     EXPECT_TRUE(hasReceivedResponse);
     EXPECT_EQ(_download, download);
 
-    FileSystem::PlatformFileHandle fileHandle;
-    _destinationPath = FileSystem::openTemporaryFile("TestWebKitAPI"_s, fileHandle);
-    EXPECT_TRUE(fileHandle != FileSystem::invalidPlatformFileHandle);
-    FileSystem::closeFile(fileHandle);
+    _destinationPath = FileSystem::createTemporaryFile("TestWebKitAPI"_s);
+    EXPECT_TRUE(!_destinationPath.isEmpty());
 
     *allowOverwrite = YES;
     return _destinationPath;
@@ -478,10 +474,8 @@ IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 - (NSString *)_download:(_WKDownload *)download decideDestinationWithSuggestedFilename:(NSString *)filename allowOverwrite:(BOOL *)allowOverwrite
 IGNORE_WARNINGS_END
 {
-    FileSystem::PlatformFileHandle fileHandle;
-    _destinationPath = FileSystem::openTemporaryFile("TestWebKitAPI"_s, fileHandle);
-    EXPECT_TRUE(fileHandle != FileSystem::invalidPlatformFileHandle);
-    FileSystem::closeFile(fileHandle);
+    _destinationPath = FileSystem::createTemporaryFile("TestWebKitAPI"_s);
+    EXPECT_TRUE(!_destinationPath.isEmpty());
     *allowOverwrite = YES;
     return _destinationPath;
 }
@@ -653,10 +647,8 @@ TEST(_WKDownload, DownloadCanceledWhileDecidingDestination)
 {
     EXPECT_TRUE([filename hasSuffix:@".usdz"]);
 
-    FileSystem::PlatformFileHandle fileHandle;
-    _destinationPath = FileSystem::openTemporaryFile(String { filename }, fileHandle);
-    EXPECT_TRUE(fileHandle != FileSystem::invalidPlatformFileHandle);
-    FileSystem::closeFile(fileHandle);
+    _destinationPath = FileSystem::createTemporaryFile(String { filename });
+    EXPECT_TRUE(!_destinationPath.isEmpty());
 
     completionHandler(YES, _destinationPath);
 }
@@ -1077,10 +1069,8 @@ TEST(WebKit, DownloadNavigationResponseFromMemoryCache)
 
 - (void)_download:(_WKDownload *)download decideDestinationWithSuggestedFilename:(NSString *)filename completionHandler:(void (^)(BOOL allowOverwrite, NSString *destination))completionHandler
 {
-    FileSystem::PlatformFileHandle fileHandle;
-    _path = FileSystem::openTemporaryFile("TestWebKitAPI"_s, fileHandle);
-    EXPECT_TRUE(fileHandle != FileSystem::invalidPlatformFileHandle);
-    FileSystem::closeFile(fileHandle);
+    _path = FileSystem::createTemporaryFile("TestWebKitAPI"_s);
+    EXPECT_TRUE(_path && [_path.get() length]);
     completionHandler(YES, _path.get());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
@@ -392,10 +392,8 @@ static void* progressObservingContext = &progressObservingContext;
 {
     EXPECT_EQ(download, m_download.get());
 
-    FileSystem::PlatformFileHandle fileHandle;
-    RetainPtr<NSString> path = (NSString *)FileSystem::openTemporaryFile("TestWebKitAPI"_s, fileHandle);
-    EXPECT_TRUE(fileHandle != FileSystem::invalidPlatformFileHandle);
-    FileSystem::closeFile(fileHandle);
+    RetainPtr<NSString> path = (NSString *)FileSystem::createTemporaryFile("TestWebKitAPI"_s);
+    EXPECT_TRUE(path && [path.get() length]);
 
     completionHandler(YES, path.get());
 }


### PR DESCRIPTION
#### 6fcc39010e1efaba89120aecf868f3057c1d9ab8
<pre>
Make openTemporaryFile return file handle
<a href="https://bugs.webkit.org/show_bug.cgi?id=269968">https://bugs.webkit.org/show_bug.cgi?id=269968</a>
<a href="https://rdar.apple.com/123489546">rdar://123489546</a>

Reviewed by Justin Michaud.

This will make code more clean as callers do not need to pass in a file handle reference.
Also, add a new createTemporaryFile function so callers do not need to close the file handle if they only want the
path.

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::createTemporaryFile):
* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::openTemporaryFile):
(WTF::FileSystemImpl::createTemporaryFile):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm:
(WebCore::writeToTemporaryFile):
* Source/WebCore/bindings/js/GCController.cpp:
(WebCore::GCController::dumpHeap):
* Source/WebCore/contentextensions/SerializedNFA.cpp:
(WebCore::ContentExtensions::SerializedNFA::serialize):
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::transcodeImage):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::BlobRegistryImpl::writeBlobsToTemporaryFilesForIndexedDB):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::createTemporaryFile):
* Source/WebKit/Shared/WebMemorySampler.cpp:
(WebKit::WebMemorySampler::initializeTempLogFile):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::compiledToFile):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(TestWebKitAPI::makeTemporaryDatabasePath):
* Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp:
(TestWebKitAPI::FragmentedSharedBufferTest::SetUp):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(-[DownloadDelegate _download:decideDestinationWithSuggestedFilename:allowOverwrite:]):
(-[BlobDownloadDelegate _download:decideDestinationWithSuggestedFilename:allowOverwrite:]):
(-[RedirectedDownloadDelegate _download:decideDestinationWithSuggestedFilename:allowOverwrite:]):
(-[BlobWithUSDZExtensionDownloadDelegate _download:decideDestinationWithSuggestedFilename:completionHandler:]):
(-[DownloadCancelingDelegate _download:decideDestinationWithSuggestedFilename:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm:
(-[DownloadProgressTestRunner _download:decideDestinationWithSuggestedFilename:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/275418@main">https://commits.webkit.org/275418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68d32ae006264083fa77863440583f82cb3d44c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37674 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34379 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15040 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45522 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35035 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37767 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40899 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41208 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39310 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18016 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48219 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9366 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18072 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9837 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->