### PR TITLE
REGRESSION (274442@main): [ MacOS wk2 ] media/media-source/media-source-seek-complete.html is a flaky timeout

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2010,6 +2010,4 @@ webkit.org/b/269581 http/tests/site-isolation/mouse-events/context-menu-event-tw
 [ Monterey+ ] http/tests/navigation/ping-attribute/area-cross-origin-from-https.html [ Pass Failure ]
 [ Monterey+ ] http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html [ Pass Failure ]
 
-webkit.org/b/269814 [ Monterey+ ] media/media-source/media-source-seek-complete.html [ Pass Timeout ]
-
 webkit.org/b/123404489 [ Monterey+ Debug ] imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-detach-element.html [ Skip ]

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -310,13 +310,10 @@ MediaTime MediaSource::duration() const
 
 MediaTime MediaSource::currentTime() const
 {
-    if (isClosed())
-        return MediaTime::zeroTime();
-
     if (m_pendingSeekTarget)
         return m_pendingSeekTarget->time;
 
-    return m_private->currentTime();
+    return m_private ? m_private->currentTime() : MediaTime::zeroTime();
 }
 
 PlatformTimeRanges MediaSource::buffered() const

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -488,6 +488,7 @@ void MediaPlayerPrivateRemote::rateChanged(double rate)
 
 void MediaPlayerPrivateRemote::playbackStateChanged(bool paused, MediaTime&& mediaTime, MonotonicTime&& wallTime)
 {
+    INFO_LOG(LOGIDENTIFIER, mediaTime);
     m_cachedState.paused = paused;
     m_currentTimeEstimator.setTime(mediaTime, wallTime);
     if (auto player = m_player.get())
@@ -517,6 +518,9 @@ void MediaPlayerPrivateRemote::sizeChanged(WebCore::FloatSize naturalSize)
 
 void MediaPlayerPrivateRemote::currentTimeChanged(const MediaTime& mediaTime, const MonotonicTime& queryTime, bool timeIsProgressing)
 {
+    INFO_LOG(LOGIDENTIFIER, mediaTime, " seeking:", bool(m_seeking));
+    if (m_seeking)
+        return;
     auto oldCachedTime = m_currentTimeEstimator.cachedTime();
     auto oldTimeIsProgressing = m_currentTimeEstimator.timeIsProgressing();
     auto reverseJump = mediaTime < oldCachedTime;


### PR DESCRIPTION
#### 53463ea1c60fe6de4120dab418a8bafa5e6471dd
<pre>
REGRESSION (274442@main): [ MacOS wk2 ] media/media-source/media-source-seek-complete.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=269814">https://bugs.webkit.org/show_bug.cgi?id=269814</a>
<a href="https://rdar.apple.com/123338097">rdar://123338097</a>

Reviewed by Jer Noble.

If a `currentTimeChanged` message between the GPUP and WP was mid-flight when a new seek operation was
started it would have set the current time to a stale value, so the time would appear to go backward
and the seek would never complete.

Prior 274442@main it *usually* didn&apos;t matter as the HTMLMediaElement cached the seeked time and would
partially hide the time going backward. Following this change however, the MediaPlayerPrivate became
the time reference, and so issues with the time being wrong became more problematic.
This issue could explain a series of intermittent failures we have seen ever since the MediaPlayer
was moved to the GPUP, including several changes made to prevent the time from ever going backward.

The explanation above likely explains on why we needed such workaround in the first place.

Also, before 274442@main if a seek was pending, it would have always returned the seek time when
querying MediaSource::currentTime; we changed it to return 0 whenever the MediaSource was closed.
We return to the original behaviour.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::currentTime const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::playbackStateChanged): Add log.
(WebKit::MediaPlayerPrivateRemote::currentTimeChanged): return early if currently seeking. Add log

Canonical link: <a href="https://commits.webkit.org/275231@main">https://commits.webkit.org/275231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d499439e022c95f77502c09131ef2f77d1a0187

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34107 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14761 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40588 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38975 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17675 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9252 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->