### PR TITLE
Adjust storage access quirk prompt based on feedback

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -448,6 +448,12 @@
 /* Message for requesting cross-site cookie and website data access. */
 "Do you want to allow “%@” to use cookies and website data while browsing “%@”?" = "Do you want to allow “%@” to use cookies and website data while browsing “%@”?";
 
+/* Message for requesting cross-site cookie and website data access. */
+"Do you want to allow %@ websites to access one another's cookies and website data?" = "Do you want to allow %@ websites to access one another's cookies and website data?";
+
+/* Informative text for requesting cross-site cookie and website data access. */
+"Logging into this website requires %s and %s to access one another's cookies and website data. Allowing access is necessary for the website to work correctly." = "Logging into this website requires %s and %s to access one another's cookies and website data. Allowing access is necessary for the website to work correctly.";
+
 /* Codec Strings */
 "Dolby Vision Codec String" = "Dolby Vision";
 

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h
@@ -44,7 +44,7 @@ namespace WebKit {
 void presentStorageAccessAlert(WKWebView *, const WebCore::RegistrableDomain& requestingDomain, const WebCore::RegistrableDomain& currentDomain, CompletionHandler<void(bool)>&&);
 void presentStorageAccessAlertQuirk(WKWebView *, const WebCore::RegistrableDomain& firstRequestingDomain, const WebCore::RegistrableDomain& secondRequestingDomain, const WebCore::RegistrableDomain& current, CompletionHandler<void(bool)>&&);
 void presentStorageAccessAlertSSOQuirk(WKWebView *, const String& organizationName, const HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>>&, CompletionHandler<void(bool)>&&);
-void displayStorageAccessAlert(WKWebView *, NSString *, NSString *, NSArray<NSString *> *, CompletionHandler<void(bool)>&&);
+void displayStorageAccessAlert(WKWebView *, NSString *, NSString *, CompletionHandler<void(bool)>&&);
 
 }
 


### PR DESCRIPTION
#### ae6662f21ce28a857a72e5f80b2d4c8acc2e6b24
<pre>
Adjust storage access quirk prompt based on feedback
<a href="https://bugs.webkit.org/show_bug.cgi?id=269970">https://bugs.webkit.org/show_bug.cgi?id=269970</a>
<a href="https://rdar.apple.com/123490355">rdar://123490355</a>

Reviewed by Charlie Wolfe.

Adjust storage access quirk prompt based on feedback. This change removes the
accessory text, so we get rid of that complexity (which I introduced in
271821@main), as well.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h:
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(WebKit::presentStorageAccessAlert):
(WebKit::presentStorageAccessAlertQuirk):
(WebKit::presentStorageAccessAlertSSOQuirk):
(WebKit::displayStorageAccessAlert):

Canonical link: <a href="https://commits.webkit.org/275891@main">https://commits.webkit.org/275891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a53eb68594161e63873586c4118e4117352a1efc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35262 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37715 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/649 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46688 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41957 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19030 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40571 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9606 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->