### PR TITLE
Preserve whitespace when serializing custom properties

### DIFF
--- a/LayoutTests/css-custom-properties-api/crash.html
+++ b/LayoutTests/css-custom-properties-api/crash.html
@@ -26,10 +26,10 @@ test(function() {
 
 test(function() {
   inlineStyle.setProperty('--baz', '   40px');
-  assert_equals(computedStyle.getPropertyValue('--baz'), ' 40px');
+  assert_equals(computedStyle.getPropertyValue('--baz'), '40px');
   assert_equals(computedStyle.getPropertyValue('--foo'), '');
   assert_equals(computedStyle.getPropertyValue('--bar'), '');
-  assert_equals(computedStyle.getPropertyValue('--baz'), ' 40px');
+  assert_equals(computedStyle.getPropertyValue('--baz'), '40px');
   assert_equals(computedStyle.getPropertyValue('font-size'), '30px');
   inlineStyle.removeProperty('--baz');
   assert_equals(computedStyle.getPropertyValue('--baz'), '');

--- a/LayoutTests/css-custom-properties-api/inline.html
+++ b/LayoutTests/css-custom-properties-api/inline.html
@@ -84,11 +84,11 @@ test(function() {
 }, "Valid values can be set on inline styles");
 
 test(function() {
-  inlineStyle.setProperty('--b', ' 20px');
+  inlineStyle.setProperty('--b', '20px');
   inlineStyle.setProperty('--a', 'calc(var(--b) + 10px)');
-  assert_equals(inlineStyle.getPropertyValue('--b'), ' 20px');
+  assert_equals(inlineStyle.getPropertyValue('--b'), '20px');
   assert_equals(inlineStyle.getPropertyValue('--a'), 'calc(var(--b) + 10px)');
-  assert_equals(computedStyle.getPropertyValue('--b'), ' 20px');
+  assert_equals(computedStyle.getPropertyValue('--b'), '20px');
   assert_equals(computedStyle.getPropertyValue('--a'), '30px');
 }, "Var values are accepted");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt
@@ -5,6 +5,6 @@ PASS Empty declaration value
 PASS No declaration value
 PASS Unknown CSS property after 'or'
 PASS Not a style function with space before '('
-FAIL Spaces preserved in custom property value assert_equals: expected "style(--foo: bar   baz)" but got "style(--foo: bar baz)"
+PASS Spaces preserved in custom property value
 PASS Original string number in custom property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries.html
@@ -415,7 +415,7 @@
       color: green;
     }
   }
-  @container style(--number: a b) {
+  @container style(--spaces: a b) {
     #original-text-spaces {
       color: red;
     }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL Rule that looks like a custom property declaration is ignored assert_equals: expected 2 but got 3
 FAIL Rule that looks like an invalid custom property declaration is ignored assert_equals: expected 2 but got 3
-FAIL Nested rule that looks like a custom property declaration assert_equals: expected "hover { }\n    .b { }" but got "hover { } .b { }"
+FAIL Nested rule that looks like a custom property declaration assert_equals: expected "hover { }\n    .b { }" but got "hover { }     .b { }"
 FAIL Nested rule that looks like an invalid custom property declaration assert_equals: expected 1 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cssText-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cssText-expected.txt
@@ -9,5 +9,5 @@ PASS target7
 PASS target8
 PASS target9
 PASS target10
-FAIL target11 assert_equals: expected "color: var(--prop)  /* kept comment */ var(--prop);" but got "color: var(--prop)  var(--prop);"
+FAIL target11 assert_equals: expected "color: var(--prop)  /* kept comment */ var(--prop);" but got "color: var(--prop)   var(--prop);"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition-expected.txt
@@ -17,7 +17,7 @@ PASS  leading white space (single space)
 PASS  middle white space (single space)
 PASS  trailing white space (single space)
 PASS  leading white space (double space) 2
-FAIL  middle white space (double space) 2 assert_equals: Expected Value should match actual value expected "value1  value2" but got "value1 value2"
+PASS  middle white space (double space) 2
 PASS  trailing white space (double space) 2
 PASS !important
 PASS !important 2
@@ -40,7 +40,7 @@ PASS  leading white space (single space) (Computed Style)
 PASS  middle white space (single space) (Computed Style)
 PASS  trailing white space (single space) (Computed Style)
 PASS  leading white space (double space) 2 (Computed Style)
-FAIL  middle white space (double space) 2 (Computed Style) assert_equals: Expected Value should match actual value expected "value1  value2" but got "value1 value2"
+PASS  middle white space (double space) 2 (Computed Style)
 PASS  trailing white space (double space) 2 (Computed Style)
 PASS !important (Computed Style)
 PASS !important 2 (Computed Style)
@@ -63,7 +63,7 @@ PASS  leading white space (single space) (Cascading)
 PASS  middle white space (single space) (Cascading)
 PASS  trailing white space (single space) (Cascading)
 PASS  leading white space (double space) 2 (Cascading)
-FAIL  middle white space (double space) 2 (Cascading) assert_equals: Expected Value should match actual value expected "value1  value2" but got "value1 value2"
+PASS  middle white space (double space) 2 (Cascading)
 PASS  trailing white space (double space) 2 (Cascading)
 PASS !important (Cascading)
 PASS !important 2 (Cascading)

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -131,7 +131,12 @@ CSSParser::ParseResult CSSParserImpl::parseValue(MutableStyleProperties& declara
 CSSParser::ParseResult CSSParserImpl::parseCustomPropertyValue(MutableStyleProperties& declaration, const AtomString& propertyName, const String& string, bool important, const CSSParserContext& context)
 {
     CSSParserImpl parser(context, string);
-    parser.consumeCustomPropertyValue(parser.tokenizer()->tokenRange(), propertyName, important);
+
+    auto range = parser.tokenizer()->tokenRange();
+    range.consumeWhitespace();
+    range.trimTrailingWhitespace();
+    parser.consumeCustomPropertyValue(range, propertyName, important);
+
     if (parser.topContext().m_parsedProperties.isEmpty())
         return CSSParser::ParseResult::Error;
     return declaration.addParsedProperties(parser.topContext().m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -358,6 +358,13 @@ CSSParserToken::CSSParserToken(CSSParserTokenType type, BlockType blockType)
 {
 }
 
+CSSParserToken::CSSParserToken(unsigned whitespaceCount)
+    : m_type(WhitespaceToken)
+    , m_blockType(NotBlock)
+    , m_whitespaceCount(whitespaceCount)
+{
+}
+
 // Just a helper used for Delimiter tokens.
 CSSParserToken::CSSParserToken(CSSParserTokenType type, UChar c)
     : m_type(type)
@@ -570,6 +577,8 @@ bool CSSParserToken::operator==(const CSSParserToken& other) const
     case NumberToken:
     case PercentageToken:
         return originalText() == other.originalText();
+    case WhitespaceToken:
+        return m_whitespaceCount == other.m_whitespaceCount;
     default:
         return true;
     }
@@ -723,9 +732,12 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
     case BadUrlToken:
         builder.append("url(()");
         break;
-    case WhitespaceToken:
-        builder.append(' ');
+    case WhitespaceToken: {
+        auto count = mode == SerializationMode::CustomProperty ? m_whitespaceCount : 1;
+        for (auto i = 0u; i < count; ++i)
+            builder.append(' ');
         break;
+    }
     case ColonToken:
         builder.append(':');
         break;

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -101,6 +101,7 @@ public:
     CSSParserToken(CSSParserTokenType, BlockType = NotBlock);
     CSSParserToken(CSSParserTokenType, StringView, BlockType = NotBlock);
 
+    explicit CSSParserToken(unsigned whitespaceCount); // WhitespaceToken
     CSSParserToken(CSSParserTokenType, UChar); // for DelimiterToken
     CSSParserToken(double, NumericValueType, NumericSign, StringView originalText); // for NumberToken
 
@@ -137,7 +138,11 @@ public:
 
     enum class SerializationMode : bool {
         Normal,
-        CustomProperty // Custom properties don't collapse whitespace and serialize numbers as original strings.
+        // "Specified values of custom properties must be serialized exactly as specified by the author.
+        // Simplifications that might occur in other properties, such as dropping comments, normalizing whitespace,
+        // reserializing numeric tokens from their value, etc., must not occur."
+        // https://drafts.csswg.org/css-variables-2/#serializing-custom-props
+        CustomProperty
     };
     void serialize(StringBuilder&, const CSSParserToken* nextToken = nullptr, SerializationMode = SerializationMode::Normal) const;
 
@@ -171,6 +176,7 @@ private:
         HashTokenType m_hashTokenType;
         double m_numericValue;
         mutable int m_id;
+        unsigned m_whitespaceCount;
     };
 };
 

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -166,8 +166,11 @@ UChar CSSTokenizer::consume()
 
 CSSParserToken CSSTokenizer::whiteSpace(UChar /*cc*/)
 {
+    auto startOffset = m_input.offset();
     m_input.advanceUntilNonWhitespace();
-    return CSSParserToken(WhitespaceToken);
+    // FIXME: This does not preserve whitespace type (like tabs).
+    auto whitespaceCount = 1 + (m_input.offset() - startOffset);
+    return CSSParserToken(whitespaceCount);
 }
 
 CSSParserToken CSSTokenizer::blockStart(CSSParserTokenType type)


### PR DESCRIPTION
#### 262c7e61cab2ef3cdeeab58d28d932aafc4cac39
<pre>
Preserve whitespace when serializing custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=269971">https://bugs.webkit.org/show_bug.cgi?id=269971</a>
<a href="https://rdar.apple.com/123491915">rdar://123491915</a>

Reviewed by Anne van Kesteren.

&quot;Specified values of custom properties must be serialized exactly as specified by the author. Simplifications
that might occur in other properties, such as dropping comments, normalizing whitespace, reserializing numeric
tokens from their value, etc., must not occur.&quot;

<a href="https://drafts.csswg.org/css-variables-2/#serializing-custom-props">https://drafts.csswg.org/css-variables-2/#serializing-custom-props</a>

* LayoutTests/css-custom-properties-api/crash.html:
* LayoutTests/css-custom-properties-api/inline.html

Update the tests. Leading and trailing whitespaces should be trimmed also when using CSSStyleDeclaration.setProperty().
This matches other browsers.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries.html:

Fix a bug in this WPT. It was checking a wrong property and not testing anything.

* LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cssText-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parseCustomPropertyValue):

Also fix trimming of leading and trailing whitespace in CSSStyleDeclaration.setProperty() API.

* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::CSSParserToken):

Remember the number of whitespaces represented by a whitespace token.

(WebCore::CSSParserToken::operator== const):

Also take the space count into account in equality comparison.
This is used for custom properties only.

(WebCore::CSSParserToken::serialize const):

Preserve the spaces in custom property serialization mode.

* Source/WebCore/css/parser/CSSParserToken.h:
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::whiteSpace):

Count the spaces.

Canonical link: <a href="https://commits.webkit.org/275236@main">https://commits.webkit.org/275236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d4493ee892fa23506280260861d660e94d617b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17608 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36864 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38993 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9254 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17342 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->