### PR TITLE
Safari is hanging on launch in WebExtension::resourceFileURLForPath.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -426,6 +426,9 @@ NSURL *WebExtension::resourceFileURLForPath(NSString *path)
 {
     ASSERT(path);
 
+    if ([path hasPrefix:@"/"])
+        path = [path substringFromIndex:1];
+
     if (!path.length || !m_resourceBaseURL)
         return nil;
 


### PR DESCRIPTION
#### 36c6dd79307be994ccb7ca9a819775c6e904564c
<pre>
Safari is hanging on launch in WebExtension::resourceFileURLForPath.
<a href="https://webkit.org/b/269972">https://webkit.org/b/269972</a>
<a href="https://rdar.apple.com/123470286">rdar://123470286</a>

Reviewed by Brian Weinstein.

Three things were happening here to cause the hang:

* The incorrect logic for checking null strings in `clearCustomizations()` was causing the
notification to fire all the time. When the action cleared, Ghostery would set custom icons
and an empty badge string again (likely detecting the change in results from browser.action
APIs.) This would cause rapid cycles of change and reset.

* The icon paths Ghostery uses start with a `/`. This was causing our `resourceFileURLForPath()`
function to truncate the file URL back to the root and return nil for the icons path. This caused
the action icon image to fail to load and show a blank icon.

* Not all of the action properties were properly tracking changes, always sending the changed
notification when nothing had changed.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::clearCustomizations): Correct the null string checks.
(WebKit::WebExtensionAction::setIconsDictionary): Early return if nothing changed.
(WebKit::WebExtensionAction::setHasUnreadBadgeText): Ditto.
(WebKit::WebExtensionAction::incrementBlockedResourceCount): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceFileURLForPath): Remove prefix if present.

Canonical link: <a href="https://commits.webkit.org/275225@main">https://commits.webkit.org/275225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2234b80021485dbe2ccb0cc45f56130b61460f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17590 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41820 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14766 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45135 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36846 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16061 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13169 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/38969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17732 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5503 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->