### PR TITLE
[Skia] Add Color operators to easily convert from/to SkColor and SkColor4f

### DIFF
--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -22,6 +22,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 platform/graphics/skia/TransformationMatrixSkia.cpp
+platform/graphics/skia/ColorSkia.cpp
 platform/graphics/skia/ComplexTextControllerSkia.cpp
 platform/graphics/skia/DrawGlyphsRecorderSkia.cpp
 platform/graphics/skia/FloatRectSkia.cpp

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -38,6 +38,10 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
+#if USE(SKIA)
+#include <skia/core/SkColor.h>
+#endif
+
 #if USE(CG)
 typedef struct CGColor* CGColorRef;
 #endif
@@ -150,6 +154,14 @@ public:
 #if PLATFORM(GTK)
     Color(const GdkRGBA&);
     operator GdkRGBA() const;
+#endif
+
+#if USE(SKIA)
+    Color(const SkColor&);
+    operator SkColor() const;
+
+    Color(const SkColor4f&);
+    operator SkColor4f() const;
 #endif
 
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/skia/ColorSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ColorSkia.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Color.h"
+
+#if USE(SKIA)
+
+namespace WebCore {
+
+Color::Color(const SkColor& skColor)
+    : Color(SRGBA<uint8_t> { static_cast<uint8_t>(SkColorGetR(skColor)), static_cast<uint8_t>(SkColorGetG(skColor)), static_cast<uint8_t>(SkColorGetB(skColor)), static_cast<uint8_t>(SkColorGetA(skColor)) })
+{
+}
+
+Color::operator SkColor() const
+{
+    auto [r, g, b, a] = toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+    return SkColorSetARGB(a, r, g, b);
+}
+
+Color::Color(const SkColor4f& skColor)
+    : Color(convertColor<SRGBA<uint8_t>>(SRGBA<float> { skColor.fR, skColor.fG, skColor.fB, skColor.fA }))
+{
+}
+
+Color::operator SkColor4f() const
+{
+    auto [r, g, b, a] = toColorTypeLossy<SRGBA<float>>().resolved();
+    return { r, g, b, a };
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)
+

--- a/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
@@ -85,14 +85,12 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
             colors.append(SkColors::kTransparent);
         } else if (stops.begin()->offset > 0) {
             positions.append(webCoreDoubleToSkScalar(0));
-            auto [r, g, b, a] = stops.begin()->color.toColorTypeLossy<SRGBA<float>>().resolved();
-            colors.append(SkColor4f { r, g, b, a * globalAlpha });
+            colors.append(stops.begin()->color.colorWithAlphaMultipliedBy(globalAlpha));
         }
 
         for (size_t i = 0; i < stops.size(); i++) {
             positions.append(webCoreDoubleToSkScalar(stops[i].offset));
-            auto [r, g, b, a] = stops[i].color.toColorTypeLossy<SRGBA<float>>().resolved();
-            colors.append(SkColor4f { r, g, b, a * globalAlpha });
+            colors.append(stops[i].color.colorWithAlphaMultipliedBy(globalAlpha));
         }
 
         if (positions.last() < 1) {


### PR DESCRIPTION
#### fc13b190064d364d3046e56370ce5202826655fc
<pre>
[Skia] Add Color operators to easily convert from/to SkColor and SkColor4f
<a href="https://bugs.webkit.org/show_bug.cgi?id=269978">https://bugs.webkit.org/show_bug.cgi?id=269978</a>

Reviewed by Nikolas Zimmermann.

We avoid duplicated code and simplify the use of colors.

* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/Color.h:
* Source/WebCore/platform/graphics/skia/ColorSkia.cpp: Added.
(WebCore::Color::Color):
(WebCore::Color::operator SkColor const):
(WebCore::Color::operator SkColor4f const):
* Source/WebCore/platform/graphics/skia/GradientSkia.cpp:
(WebCore::Gradient::shader):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::createDropShadowFilterIfNeeded const):
(WebCore::GraphicsContextSkia::createFillPaint const):
(WebCore::GraphicsContextSkia::createStrokePaint const):

Canonical link: <a href="https://commits.webkit.org/275308@main">https://commits.webkit.org/275308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d660103efe76d0792de06d10a8ba9255ff3e867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37350 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34120 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45148 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40597 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38983 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17744 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5542 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->