### PR TITLE
[Skia] Implement NativeImage::singlePixelSolidColor()

### DIFF
--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -30,6 +30,13 @@
 
 #include "GraphicsContextSkia.h"
 #include "NotImplemented.h"
+#include "PlatformDisplay.h"
+#include <skia/core/SkData.h>
+#include <skia/core/SkImage.h>
+
+IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/core/SkPixmap.h>
+IGNORE_CLANG_WARNINGS_END
 
 namespace WebCore {
 
@@ -62,8 +69,25 @@ Color NativeImage::singlePixelSolidColor() const
     if (size() != IntSize(1, 1))
         return Color();
 
-    notImplemented();
-    return Color();
+    auto platformImage = this->platformImage();
+    if (platformImage->isTextureBacked()) {
+        GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+        auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
+        GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+        const auto& imageInfo = platformImage->imageInfo();
+        uint32_t pixel;
+        SkPixmap pixmap(imageInfo, &pixel, imageInfo.minRowBytes());
+        if (!platformImage->readPixels(grContext, pixmap, 0, 0))
+            return Color();
+
+        return pixmap.getColor(0, 0);
+    }
+
+    SkPixmap pixmap;
+    if (!platformImage->peekPixels(&pixmap))
+        return Color();
+
+    return pixmap.getColor(0, 0);
 }
 
 void NativeImage::draw(GraphicsContext& context, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions options)


### PR DESCRIPTION
#### 2b5742cba30a6551c279ae3a16083852f18b6353
<pre>
[Skia] Implement NativeImage::singlePixelSolidColor()
<a href="https://bugs.webkit.org/show_bug.cgi?id=269979">https://bugs.webkit.org/show_bug.cgi?id=269979</a>

Reviewed by Nikolas Zimmermann.

* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::singlePixelSolidColor const):

Canonical link: <a href="https://commits.webkit.org/275309@main">https://commits.webkit.org/275309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8e0d1a596e22df901a3029c6c21023e2d77ecf0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34121 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14778 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45163 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40608 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38996 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17745 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5543 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->