### PR TITLE
[GStreamer] Make GstMappedFrame assert when it is not initialized

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -229,73 +229,68 @@ public:
         m_isValid = gst_video_frame_map(&m_frame, info, buffer, flags);
     }
 
-    GstMappedFrame(GRefPtr<GstSample> sample, GstMapFlags flags)
+    GstMappedFrame(const GRefPtr<GstSample>& sample, GstMapFlags flags)
     {
         GstVideoInfo info;
 
-        if (!gst_video_info_from_caps(&info, gst_sample_get_caps(sample.get()))) {
-            m_isValid = false;
+        if (!gst_video_info_from_caps(&info, gst_sample_get_caps(sample.get())))
             return;
-        }
 
         m_isValid = gst_video_frame_map(&m_frame, &info, gst_sample_get_buffer(sample.get()), flags);
     }
 
     GstVideoFrame* get()
     {
-        if (!m_isValid) {
-            GST_INFO("Invalid frame, returning NULL");
-
-            return nullptr;
-        }
-
+        RELEASE_ASSERT(m_isValid);
         return &m_frame;
     }
 
     uint8_t* ComponentData(int comp) const
     {
+        RELEASE_ASSERT(m_isValid);
         return GST_VIDEO_FRAME_COMP_DATA(&m_frame, comp);
     }
 
     int ComponentStride(int stride) const
     {
+        RELEASE_ASSERT(m_isValid);
         return GST_VIDEO_FRAME_COMP_STRIDE(&m_frame, stride);
     }
 
     GstVideoInfo* info()
     {
-        if (!m_isValid) {
-            GST_INFO("Invalid frame, returning NULL");
-
-            return nullptr;
-        }
-
+        RELEASE_ASSERT(m_isValid);
         return &m_frame.info;
     }
 
     int width() const
     {
-        return m_isValid ? GST_VIDEO_FRAME_WIDTH(&m_frame) : -1;
+        RELEASE_ASSERT(m_isValid);
+        return GST_VIDEO_FRAME_WIDTH(&m_frame);
     }
 
     int height() const
     {
-        return m_isValid ? GST_VIDEO_FRAME_HEIGHT(&m_frame) : -1;
+        RELEASE_ASSERT(m_isValid);
+        return GST_VIDEO_FRAME_HEIGHT(&m_frame);
     }
 
     int format() const
     {
-        return m_isValid ? GST_VIDEO_FRAME_FORMAT(&m_frame) : GST_VIDEO_FORMAT_UNKNOWN;
+        RELEASE_ASSERT(m_isValid);
+        return GST_VIDEO_FRAME_FORMAT(&m_frame);
     }
 
     void* planeData(uint32_t planeIndex) const
     {
-        return m_isValid ? GST_VIDEO_FRAME_PLANE_DATA(&m_frame, planeIndex) : nullptr;
+        RELEASE_ASSERT(m_isValid);
+        return GST_VIDEO_FRAME_PLANE_DATA(&m_frame, planeIndex);
     }
 
     int planeStride(uint32_t planeIndex) const
     {
-        return m_isValid ? GST_VIDEO_FRAME_PLANE_STRIDE(&m_frame, planeIndex) : -1;
+        RELEASE_ASSERT(m_isValid);
+        return GST_VIDEO_FRAME_PLANE_STRIDE(&m_frame, planeIndex);
     }
 
     ~GstMappedFrame()
@@ -305,7 +300,9 @@ public:
         m_isValid = false;
     }
 
+    bool isValid() const { return m_isValid; }
     explicit operator bool() const { return m_isValid; }
+    bool operator!() const { return !m_isValid; }
 
 private:
     GstVideoFrame m_frame;

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -368,6 +368,12 @@ void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFo
     auto* inputCaps = gst_sample_get_caps(sample);
     gst_video_info_from_caps(&inputInfo, inputCaps);
     GstMappedFrame inputFrame(inputBuffer, &inputInfo, GST_MAP_READ);
+    if (!inputFrame) {
+        GST_WARNING("could not map the input frame");
+        ASSERT_NOT_REACHED_WITH_MESSAGE("could not map the input frame");
+        callback({ });
+        return;
+    }
 
     GST_TRACE("Copying frame data to pixel format %d", static_cast<int>(pixelFormat));
     if (pixelFormat == VideoPixelFormat::NV12) {

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -76,7 +76,8 @@ rtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC::To
 {
     GstMappedFrame inFrame(m_sample, GST_MAP_READ);
     if (!inFrame) {
-        GST_WARNING("Could not map frame");
+        GST_WARNING("Could not map input frame");
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Could not map input frame");
         return nullptr;
     }
 
@@ -90,6 +91,11 @@ rtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC::To
 
         auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&outInfo), nullptr));
         GstMappedFrame outFrame(buffer.get(), &outInfo, GST_MAP_WRITE);
+        if (!outFrame) {
+            GST_WARNING("Could not map output frame");
+            ASSERT_NOT_REACHED_WITH_MESSAGE("Could not map output frame");
+            return nullptr;
+        }
         GUniquePtr<GstVideoConverter> videoConverter(gst_video_converter_new(inFrame.info(), &outInfo, gst_structure_new("GstVideoConvertConfig",
             GST_VIDEO_CONVERTER_OPT_THREADS, G_TYPE_UINT, std::max(std::thread::hardware_concurrency(), 1u), nullptr)));
 


### PR DESCRIPTION
#### 8ce9ffa7193733b471ead3e2ec7b67bfaaccf9c7
<pre>
[GStreamer] Make GstMappedFrame assert when it is not initialized
<a href="https://bugs.webkit.org/show_bug.cgi?id=269980">https://bugs.webkit.org/show_bug.cgi?id=269980</a>

Reviewed by Carlos Garcia Campos.

This way we can align the implementation of GstMappedFrame with GstMappedBuffer and assert when its data is accessed but
it was not properly mapped at initialization.

Even when now it is properly protected at members access, additional checks were added in some places where its
instantiation was not being checked.

A fly-by improvement is making the constructor taking GRefPtr&lt;GstSample&gt; to take const &amp; to avoid unnecessary ref/unref.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::GstMappedFrame::GstMappedFrame):
(WebCore::GstMappedFrame::get):
(WebCore::GstMappedFrame::ComponentData const):
(WebCore::GstMappedFrame::ComponentStride const):
(WebCore::GstMappedFrame::info):
(WebCore::GstMappedFrame::width const):
(WebCore::GstMappedFrame::height const):
(WebCore::GstMappedFrame::format const):
(WebCore::GstMappedFrame::planeData const):
(WebCore::GstMappedFrame::planeStride const):
(WebCore::GstMappedFrame::isValid const):
(WebCore::GstMappedFrame::operator! const):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::copyTo):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp:
(WebCore::GStreamerVideoFrameLibWebRTC::ToI420):

Canonical link: <a href="https://commits.webkit.org/275320@main">https://commits.webkit.org/275320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cdc7c770f73a0f8596a332dbba5dfc59f04106e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44095 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17871 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35769 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/41397 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45465 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37094 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16342 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39266 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17961 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9305 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->