### PR TITLE
NEW TEST [ MacOS ] imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-detach-element.html is a flaky crash

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2004,8 +2004,6 @@ webkit.org/b/269581 http/tests/site-isolation/mouse-events/context-menu-event-tw
 [ Monterey+ ] http/tests/navigation/ping-attribute/area-cross-origin-from-https.html [ Pass Failure ]
 [ Monterey+ ] http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html [ Pass Failure ]
 
-webkit.org/b/269871 [ Monterey+ Debug ] imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-detach-element.html [ Skip ]
-
 webkit.org/b/269996 [ Monterey+ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/offscreen-element-modified-before-coming-onscreen.html [ Skip ]
 
 # webkit.org/b/270014 REGRESSION (275227@main): [ macOS wk2 Debug ] ASSERTION FAILED fixedPositionContainerLayer result of 5 tests in imported/w3c/web-platform-tests/css/css-view-transitions to flaky crash or constant failure

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -57,9 +57,6 @@ RemoteMediaSourceProxy::~RemoteMediaSourceProxy()
 
 void RemoteMediaSourceProxy::disconnect()
 {
-    for (auto& sourceBuffer : m_sourceBuffers)
-        sourceBuffer->disconnect();
-
     if (!m_connectionToWebProcess)
         return;
 
@@ -165,6 +162,9 @@ void RemoteMediaSourceProxy::shutdown()
 {
     if (!m_connectionToWebProcess)
         return;
+
+    for (auto sourceBuffer : m_sourceBuffers)
+        sourceBuffer->shutdown();
 
     m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::MediaSourcePrivateRemoteMessageReceiver::MediaSourcePrivateShuttingDown(), [this, protectedThis = Ref { *this }, protectedConnection = Ref { *m_connectionToWebProcess }] {
         disconnect();

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -330,6 +330,16 @@ void RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID(TrackID trackID, ui
     m_sourceBufferPrivate->setMaximumQueueDepthForTrackID(trackID, depth);
 }
 
+void RemoteSourceBufferProxy::shutdown()
+{
+    if (!m_connectionToWebProcess)
+        return;
+
+    m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateShuttingDown(), [this, protectedThis = Ref { *this }, protectedConnection = Ref { *m_connectionToWebProcess }] {
+        disconnect();
+    }, m_identifier);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -61,7 +61,7 @@ public:
     static Ref<RemoteSourceBufferProxy> create(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
     virtual ~RemoteSourceBufferProxy();
 
-    void disconnect();
+    void shutdown();
 
 private:
     RemoteSourceBufferProxy(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
@@ -109,6 +109,7 @@ private:
     void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime);
     void minimumUpcomingPresentationTimeForTrackID(TrackID, CompletionHandler<void(MediaTime)>&&);
     void setMaximumQueueDepthForTrackID(TrackID, uint64_t);
+    void disconnect();
 
     WeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
     RemoteSourceBufferIdentifier m_identifier;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -270,8 +270,6 @@ void MediaSourcePrivateRemote::MessageReceiver::mediaSourcePrivateShuttingDown(C
     if (RefPtr parent = m_parent.get()) {
         parent->m_shutdown = true;
         parent->m_mediaPlayerReadyState = MediaPlayer::ReadyState::HaveNothing;
-        for (auto& sourceBuffer : parent->m_sourceBuffers)
-            downcast<SourceBufferPrivateRemote>(sourceBuffer)->disconnect();
     };
     completionHandler();
 }

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
@@ -33,6 +33,7 @@ messages -> SourceBufferPrivateRemoteMessageReceiver NotRefCounted {
     SourceBufferPrivateDurationChanged(MediaTime duration) -> ()
     SourceBufferPrivateDidDropSample()
     SourceBufferPrivateDidReceiveRenderingError(int64_t errorCode)
+    SourceBufferPrivateShuttingDown() -> ()
 }
 
 #endif


### PR DESCRIPTION
#### 5f3622e3b24527b6a58d4b50c69f1a68e4709eea
<pre>
NEW TEST [ MacOS ] imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-detach-element.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=269871">https://bugs.webkit.org/show_bug.cgi?id=269871</a>
<a href="https://rdar.apple.com/123404489">rdar://123404489</a>

Reviewed by Youenn Fablet.

When shutting down the RemoteMediaSourceProxy in the GPUP we would send
a asynchronous message to the MediaSourcePrivateRemote in the WP which in
turn would have disconnected all the SourceBufferPrivateRemote.
However, it was possible at this stage that the MediaSource in a worker
to itself have started to shutdown and detaching all existing SourceBuffer.
At this stage, the MediaSourcePrivateRemote::m_sourceBuffers would have
been emptied and be unable to disconnect them.

So we split the shutdown of the RemoteMediaSourceProxy and of the
RemoteSourceBufferProxy so that they each inform their respective
remotes to start shutting down.
Similar to what the RemoteMediaSourceProxy does when being shutdown by
the RemoteMediaPlayerProxy, it will now tell all RemoteSourceBufferProxies
to shutdown, which in turn will shutdown the source buffers in the
web process.
Only once that message been sent that it will continue tearing down the
proxies.

Covered by re-enabled test.
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::disconnect):
(WebKit::RemoteMediaSourceProxy::shutdown):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::shutdown):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::MessageReceiver::mediaSourcePrivateShuttingDown):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::removedFromMediaSource):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateShuttingDown):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in:

Canonical link: <a href="https://commits.webkit.org/275268@main">https://commits.webkit.org/275268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de37e421726907b06a81f0f7536ced2db322d6f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43956 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17735 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41965 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14872 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45300 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39107 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9272 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->