### PR TITLE
More adoption of dynamicDowncast<> in assorted layout code

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
@@ -191,12 +191,10 @@ static std::optional<InlineItemPosition> inlineItemPositionForDisplayBox(const I
     auto startOffset = displayBox.text().start();
     while (true) {
         auto inlineTextItemRange = [&]() -> WTF::Range<unsigned> {
-            if (is<InlineTextItem>(inlineItemList[inlineItemIndex])) {
-                auto& inlineTextItem = downcast<InlineTextItem>(inlineItemList[inlineItemIndex]);
-                return { inlineTextItem.start(), inlineTextItem.end() };
-            }
-            if (is<InlineSoftLineBreakItem>(inlineItemList[inlineItemIndex])) {
-                auto startPosition = downcast<InlineSoftLineBreakItem>(inlineItemList[inlineItemIndex]).position();
+            if (auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItemList[inlineItemIndex]))
+                return { inlineTextItem->start(), inlineTextItem->end() };
+            if (auto* inlineSoftBreakItem = dynamicDowncast<InlineSoftLineBreakItem>(inlineItemList[inlineItemIndex])) {
+                auto startPosition = inlineSoftBreakItem->position();
                 return { startPosition, startPosition + 1 };
             }
             ASSERT_NOT_REACHED();
@@ -229,7 +227,8 @@ static std::optional<InlineItemPosition> inlineItemPositionForDamagedContentPosi
     }
 
     auto startPosition = [&](auto& inlineItem) {
-        return is<InlineTextItem>(inlineItem) ? downcast<InlineTextItem>(inlineItem).start() : downcast<InlineSoftLineBreakItem>(inlineItem).position();
+        auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem);
+        return inlineTextItem ? inlineTextItem->start() : downcast<InlineSoftLineBreakItem>(inlineItem).position();
     };
 
     auto contentOffset = startPosition(candidateInlineItem) + candidatePosition.offset;

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -74,8 +74,8 @@ static Layout::Box::ElementAttributes elementAttributes(const RenderElement& ren
             return Layout::Box::NodeType::ListMarker;
         if (is<RenderReplaced>(renderer))
             return is<RenderImage>(renderer) ? Layout::Box::NodeType::Image : Layout::Box::NodeType::ReplacedElement;
-        if (is<RenderLineBreak>(renderer))
-            return downcast<RenderLineBreak>(renderer).isWBR() ? Layout::Box::NodeType::WordBreakOpportunity : Layout::Box::NodeType::LineBreak;
+        if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer))
+            return renderLineBreak->isWBR() ? Layout::Box::NodeType::WordBreakOpportunity : Layout::Box::NodeType::LineBreak;
         return Layout::Box::NodeType::GenericElement;
     }();
 
@@ -109,9 +109,10 @@ BoxTree::~BoxTree()
         if (!renderer)
             continue;
 
-        bool isLFCInlineBlock = is<RenderBlockFlow>(*renderer) && downcast<RenderBlockFlow>(*renderer).modernLineLayout();
+        auto* renderBlockFlow = dynamicDowncast<RenderBlockFlow>(*renderer);
+        auto isLFCInlineBlock = renderBlockFlow && renderBlockFlow->modernLineLayout();
         if (isLFCInlineBlock) {
-            auto detachedBox = renderer->layoutBox()->removeFromParent();
+            auto detachedBox = renderBlockFlow->layoutBox()->removeFromParent();
             initialContainingBlock().appendChild(WTFMove(detachedBox));
             continue;
         }
@@ -144,10 +145,9 @@ void BoxTree::adjustStyleIfNeeded(const RenderElement& renderer, RenderStyle& st
             }
             return;
         }
-        if (is<RenderInline>(renderer)) {
-            auto& renderInline = downcast<RenderInline>(renderer);
-            auto shouldNotRetainBorderPaddingAndMarginStart = renderInline.isContinuation();
-            auto shouldNotRetainBorderPaddingAndMarginEnd = !renderInline.isContinuation() && renderInline.inlineContinuation();
+        if (auto* renderInline = dynamicDowncast<RenderInline>(renderer)) {
+            auto shouldNotRetainBorderPaddingAndMarginStart = renderInline->isContinuation();
+            auto shouldNotRetainBorderPaddingAndMarginEnd = !renderInline->isContinuation() && renderInline->inlineContinuation();
             // This looks like continuation renderer.
             if (shouldNotRetainBorderPaddingAndMarginStart) {
                 styleToAdjust.setMarginStart(RenderStyle::initialMargin());
@@ -159,11 +159,11 @@ void BoxTree::adjustStyleIfNeeded(const RenderElement& renderer, RenderStyle& st
                 styleToAdjust.resetBorderRight();
                 styleToAdjust.setPaddingRight(RenderStyle::initialPadding());
             }
-            if ((styleToAdjust.display() == DisplayType::RubyBase || styleToAdjust.display() == DisplayType::RubyAnnotation) && renderInline.parent()->style().display() != DisplayType::Ruby)
+            if ((styleToAdjust.display() == DisplayType::RubyBase || styleToAdjust.display() == DisplayType::RubyAnnotation) && renderInline->parent()->style().display() != DisplayType::Ruby)
                 styleToAdjust.setDisplay(DisplayType::Inline);
             return;
         }
-        if (renderer.isRenderLineBreak()) {
+        if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer)) {
             if (!styleToAdjust.hasOutOfFlowPosition()) {
                 // Force in-flow display value to inline (see webkit.org/b/223151).
                 styleToAdjust.setDisplay(DisplayType::Inline);
@@ -172,7 +172,7 @@ void BoxTree::adjustStyleIfNeeded(const RenderElement& renderer, RenderStyle& st
             // Clear property should only apply on block elements, however,
             // it appears that browsers seem to ignore it on <br> inline elements.
             // https://drafts.csswg.org/css2/#propdef-clear
-            if (downcast<RenderLineBreak>(renderer).isWBR())
+            if (renderLineBreak->isWBR())
                 styleToAdjust.setClear(Clear::None);
             return;
         }
@@ -186,26 +186,27 @@ UniqueRef<Layout::Box> BoxTree::createLayoutBox(RenderObject& renderer)
 {
     std::unique_ptr<RenderStyle> firstLineStyle = firstLineStyleFor(renderer);
 
-    if (is<RenderText>(renderer)) {
-        auto& textRenderer = downcast<RenderText>(renderer);
-
-        auto style = RenderStyle::createAnonymousStyleWithDisplay(textRenderer.style(), DisplayType::Inline);
-        auto isCombinedText = is<RenderCombineText>(textRenderer) && downcast<RenderCombineText>(textRenderer).isCombined();
+    if (auto* textRenderer = dynamicDowncast<RenderText>(renderer)) {
+        auto style = RenderStyle::createAnonymousStyleWithDisplay(textRenderer->style(), DisplayType::Inline);
+        auto isCombinedText = [&]() {
+            auto* combineTextRenderer = dynamicDowncast<RenderCombineText>(*textRenderer);
+            return combineTextRenderer && combineTextRenderer->isCombined();
+        }();
         auto text = style.textSecurity() == TextSecurity::None
-            ? (isCombinedText ? textRenderer.originalText() : textRenderer.text())
-            : RenderBlock::updateSecurityDiscCharacters(style, isCombinedText ? textRenderer.originalText() : String { textRenderer.text() });
+            ? (isCombinedText ? textRenderer->originalText() : textRenderer->text())
+            : RenderBlock::updateSecurityDiscCharacters(style, isCombinedText ? textRenderer->originalText() : String { textRenderer->text() });
 
-        auto canUseSimpleFontCodePath = textRenderer.canUseSimpleFontCodePath();
-        auto canUseSimplifiedTextMeasuring = textRenderer.canUseSimplifiedTextMeasuring();
+        auto canUseSimpleFontCodePath = textRenderer->canUseSimpleFontCodePath();
+        auto canUseSimplifiedTextMeasuring = textRenderer->canUseSimplifiedTextMeasuring();
         if (!canUseSimplifiedTextMeasuring) {
             canUseSimplifiedTextMeasuring = canUseSimpleFontCodePath && Layout::TextUtil::canUseSimplifiedTextMeasuring(text, style, firstLineStyle.get());
-            textRenderer.setCanUseSimplifiedTextMeasuring(*canUseSimplifiedTextMeasuring);
+            textRenderer->setCanUseSimplifiedTextMeasuring(*canUseSimplifiedTextMeasuring);
         }
 
-        auto hasPositionDependentContentWidth = textRenderer.hasPositionDependentContentWidth();
+        auto hasPositionDependentContentWidth = textRenderer->hasPositionDependentContentWidth();
         if (!hasPositionDependentContentWidth) {
             hasPositionDependentContentWidth = Layout::TextUtil::hasPositionDependentContentWidth(text);
-            textRenderer.setHasPositionDependentContentWidth(*hasPositionDependentContentWidth);
+            textRenderer->setHasPositionDependentContentWidth(*hasPositionDependentContentWidth);
         }
 
         auto contentCharacteristic = OptionSet<Layout::InlineTextBox::ContentCharacteristic> { };
@@ -224,14 +225,13 @@ UniqueRef<Layout::Box> BoxTree::createLayoutBox(RenderObject& renderer)
     auto style = RenderStyle::clone(renderer.style());
     adjustStyleIfNeeded(renderElement, style, firstLineStyle.get());
 
-    if (is<RenderListMarker>(renderElement)) {
-        auto& listMarkerRenderer = downcast<RenderListMarker>(renderElement);
+    if (auto* listMarkerRenderer = dynamicDowncast<RenderListMarker>(renderElement)) {
         OptionSet<Layout::ElementBox::ListMarkerAttribute> listMarkerAttributes;
-        if (listMarkerRenderer.isImage())
+        if (listMarkerRenderer->isImage())
             listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
-        if (!listMarkerRenderer.isInside())
+        if (!listMarkerRenderer->isInside())
             listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
-        if (listMarkerRenderer.listItem() && !listMarkerRenderer.listItem()->notInList())
+        if (listMarkerRenderer->listItem() && !listMarkerRenderer->listItem()->notInList())
             listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::HasListElementAncestor);
         return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), listMarkerAttributes, WTFMove(style), WTFMove(firstLineStyle));
     }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
@@ -42,16 +42,10 @@ TextBoxIterator TextBox::nextTextBox() const
     return TextBoxIterator(*this).traverseNextTextBox();
 }
 
-bool TextBox::isCombinedText() const
-{
-    auto& renderer = this->renderer();
-    return is<RenderCombineText>(renderer) && downcast<RenderCombineText>(renderer).isCombined();
-}
-
 const FontCascade& TextBox::fontCascade() const
 {
-    if (isCombinedText())
-        return downcast<RenderCombineText>(renderer()).textCombineFont();
+    if (auto* renderer = dynamicDowncast<RenderCombineText>(this->renderer()); renderer && renderer->isCombined())
+        return renderer->textCombineFont();
 
     return style().fontCascade();
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
@@ -45,7 +45,6 @@ public:
 
     TextBoxSelectableRange selectableRange() const;
 
-    bool isCombinedText() const;
     const FontCascade& fontCascade() const;
 
     inline TextRun textRun(TextRunMode = TextRunMode::Painting) const;

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -250,8 +250,8 @@ void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, s
     boxGeometry.setPadding(padding);
 
     auto hasNonSyntheticBaseline = [&] {
-        if (is<RenderListMarker>(renderBox))
-            return !downcast<RenderListMarker>(renderBox).isImage();
+        if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderBox))
+            return !renderListMarker->isImage();
 
         if ((is<RenderReplaced>(renderBox) && renderBox.style().display() == DisplayType::Inline)
             || is<RenderListBox>(renderBox)
@@ -271,11 +271,11 @@ void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, s
             // These are special RenderBlock renderers that override the default baseline position behavior of the inline block box.
             return true;
         }
-        if (!is<RenderBlockFlow>(renderBox))
+        auto* blockFlow = dynamicDowncast<RenderBlockFlow>(renderBox);
+        if (!blockFlow)
             return false;
-        auto& blockFlow = downcast<RenderBlockFlow>(renderBox);
-        auto hasAppareance = blockFlow.style().hasEffectiveAppearance() && !blockFlow.theme().isControlContainer(blockFlow.style().effectiveAppearance());
-        return hasAppareance || !blockFlow.childrenInline() || blockFlow.hasLines() || blockFlow.hasLineIfEmpty();
+        auto hasAppareance = blockFlow->style().hasEffectiveAppearance() && !blockFlow->theme().isControlContainer(blockFlow->style().effectiveAppearance());
+        return hasAppareance || !blockFlow->childrenInline() || blockFlow->hasLines() || blockFlow->hasLineIfEmpty();
     }();
     if (hasNonSyntheticBaseline) {
         auto baseline = renderBox.baselinePosition(AlphabeticBaseline, false /* firstLine */, blockFlowDirection == BlockFlowDirection::TopToBottom || blockFlowDirection == BlockFlowDirection::BottomToTop ? HorizontalLine : VerticalLine, PositionOnContainingLine);
@@ -338,16 +338,16 @@ void BoxGeometryUpdater::setGeometriesForLayout()
             updateLayoutBoxDimensions(downcast<RenderBox>(renderer));
             continue;
         }
-        if (is<RenderListMarker>(renderer)) {
-            updateListMarkerDimensions(downcast<RenderListMarker>(renderer));
+        if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderer)) {
+            updateListMarkerDimensions(*renderListMarker);
             continue;
         }
-        if (is<RenderLineBreak>(renderer)) {
-            updateLineBreakBoxDimensions(downcast<RenderLineBreak>(renderer));
+        if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer)) {
+            updateLineBreakBoxDimensions(*renderLineBreak);
             continue;
         }
-        if (is<RenderInline>(renderer)) {
-            updateInlineBoxDimensions(downcast<RenderInline>(renderer));
+        if (auto* renderInline = dynamicDowncast<RenderInline>(renderer)) {
+            updateInlineBoxDimensions(*renderInline);
             continue;
         }
     }
@@ -358,12 +358,12 @@ void BoxGeometryUpdater::setGeometriesForIntrinsicWidth(Layout::IntrinsicWidthMo
     for (auto walker = InlineWalker(downcast<RenderBlockFlow>(boxTree().rootRenderer())); !walker.atEnd(); walker.advance()) {
         auto& renderer = *walker.current();
 
-        if (is<RenderLineBreak>(renderer)) {
-            updateLineBreakBoxDimensions(downcast<RenderLineBreak>(renderer));
+        if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer)) {
+            updateLineBreakBoxDimensions(*renderLineBreak);
             continue;
         }
-        if (is<RenderInline>(renderer)) {
-            updateInlineBoxDimensions(downcast<RenderInline>(renderer), intrinsicWidthMode);
+        if (auto* renderInline = dynamicDowncast<RenderInline>(renderer)) {
+            updateInlineBoxDimensions(*renderInline, intrinsicWidthMode);
             continue;
         }
         ASSERT(is<RenderText>(renderer));

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -137,15 +137,16 @@ bool Box::establishesInlineFormattingContext() const
     if (!isBlockContainer())
         return false;
 
-    if (!isElementBox())
+    auto* elementBox = dynamicDowncast<ElementBox>(*this);
+    if (!elementBox)
         return false;
 
     // FIXME ???
-    if (!downcast<ElementBox>(*this).firstInFlowChild())
+    if (!elementBox->firstInFlowChild())
         return false;
 
     // It's enough to check the first in-flow child since we can't have both block and inline level sibling boxes.
-    return downcast<ElementBox>(*this).firstInFlowChild()->isInlineLevelBox();
+    return elementBox->firstInFlowChild()->isInlineLevelBox();
 }
 
 bool Box::establishesTableFormattingContext() const
@@ -397,9 +398,12 @@ bool Box::isOverflowVisible() const
     }
     if (is<InitialContainingBlock>(*this)) {
         auto* documentBox = downcast<ElementBox>(*this).firstChild();
-        if (!documentBox || !documentBox->isDocumentBox() || !is<ElementBox>(documentBox))
+        if (!documentBox || !documentBox->isDocumentBox())
             return isOverflowVisible;
-        auto* bodyBox = downcast<ElementBox>(documentBox)->firstChild();
+        auto* elementBox = dynamicDowncast<ElementBox>(*documentBox);
+        if (!elementBox)
+            return isOverflowVisible;
+        auto* bodyBox = elementBox->firstChild();
         if (!bodyBox || !bodyBox->isBodyBox())
             return isOverflowVisible;
         auto& bodyBoxStyle = bodyBox->style();

--- a/Source/WebCore/layout/layouttree/LayoutIterator.h
+++ b/Source/WebCore/layout/layouttree/LayoutIterator.h
@@ -63,8 +63,8 @@ inline const Box* firstChild(U& object)
 
 inline const Box* firstChild(const Box& box)
 {
-    if (is<ElementBox>(box))
-        return downcast<ElementBox>(box).firstChild();
+    if (auto* elementBox = dynamicDowncast<ElementBox>(box))
+        return elementBox->firstChild();
     return nullptr;
 }
 

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -176,18 +176,17 @@ std::unique_ptr<Box> TreeBuilder::createLayoutBox(const ElementBox& parentContai
     };
 
     std::unique_ptr<Box> childLayoutBox = nullptr;
-    if (is<RenderText>(childRenderer)) {
-        auto& textRenderer = downcast<RenderText>(childRenderer);
+    if (auto* textRenderer = dynamicDowncast<RenderText>(childRenderer)) {
         // RenderText::text() has already applied text-transform and text-security properties.
-        String text = textRenderer.text();
+        String text = textRenderer->text();
         auto useSimplifiedTextMeasuring = canUseSimplifiedTextMeasuring(text, parentContainer.style().fontCascade(), parentContainer.style().collapseWhiteSpace());
-        auto hasPositionDependentContentWidth = textRenderer.hasPositionDependentContentWidth();
+        auto hasPositionDependentContentWidth = textRenderer->hasPositionDependentContentWidth();
         if (!hasPositionDependentContentWidth)
             hasPositionDependentContentWidth = TextUtil::hasPositionDependentContentWidth(text);
         if (parentContainer.style().display() == DisplayType::Inline)
-            childLayoutBox = createTextBox(text, is<RenderCombineText>(childRenderer), useSimplifiedTextMeasuring, textRenderer.canUseSimpleFontCodePath(), *hasPositionDependentContentWidth, RenderStyle::clone(parentContainer.style()));
+            childLayoutBox = createTextBox(text, is<RenderCombineText>(childRenderer), useSimplifiedTextMeasuring, textRenderer->canUseSimpleFontCodePath(), *hasPositionDependentContentWidth, RenderStyle::clone(parentContainer.style()));
         else
-            childLayoutBox = createTextBox(text, is<RenderCombineText>(childRenderer), useSimplifiedTextMeasuring, textRenderer.canUseSimpleFontCodePath(), *hasPositionDependentContentWidth, RenderStyle::createAnonymousStyleWithDisplay(parentContainer.style(), DisplayType::Inline));
+            childLayoutBox = createTextBox(text, is<RenderCombineText>(childRenderer), useSimplifiedTextMeasuring, textRenderer->canUseSimpleFontCodePath(), *hasPositionDependentContentWidth, RenderStyle::createAnonymousStyleWithDisplay(parentContainer.style(), DisplayType::Inline));
     } else {
         auto& renderer = downcast<RenderElement>(childRenderer);
         auto displayType = renderer.style().display();
@@ -219,16 +218,15 @@ std::unique_ptr<Box> TreeBuilder::createLayoutBox(const ElementBox& parentContai
             tableWrapperBoxStyle.setMarginRight(Length { renderer.style().marginRight() });
 
             childLayoutBox = createContainer(Box::ElementAttributes { Box::NodeType::TableWrapperBox, Box::IsAnonymous::Yes }, WTFMove(tableWrapperBoxStyle));
-        } else if (is<RenderReplaced>(renderer)) {
+        } else if (auto* replacedRenderer = dynamicDowncast<RenderReplaced>(renderer)) {
             auto replacedAttributes = ElementBox::ReplacedAttributes {
-                downcast<RenderReplaced>(renderer).intrinsicSize()
+                replacedRenderer->intrinsicSize()
             };
-            if (is<RenderImage>(renderer)) {
-                auto& imageRenderer = downcast<RenderImage>(renderer);
-                if (imageRenderer.shouldDisplayBrokenImageIcon())
+            if (auto* imageRenderer = dynamicDowncast<RenderImage>(*replacedRenderer)) {
+                if (imageRenderer->shouldDisplayBrokenImageIcon())
                     replacedAttributes.intrinsicRatio = 1;
-                if (imageRenderer.cachedImage())
-                    replacedAttributes.cachedImage = imageRenderer.cachedImage();
+                if (imageRenderer->cachedImage())
+                    replacedAttributes.cachedImage = imageRenderer->cachedImage();
             }
             childLayoutBox = createReplacedBox(elementAttributes(renderer), WTFMove(replacedAttributes), WTFMove(clonedStyle));
         } else {
@@ -268,12 +266,11 @@ std::unique_ptr<Box> TreeBuilder::createLayoutBox(const ElementBox& parentContai
 
         if (is<RenderTableCell>(renderer)) {
             auto* tableCellElement = renderer.element();
-            if (is<HTMLTableCellElement>(tableCellElement)) {
-                auto& cellElement = downcast<HTMLTableCellElement>(*tableCellElement);
-                auto rowSpan = cellElement.rowSpan();
+            if (auto* cellElement = dynamicDowncast<HTMLTableCellElement>(tableCellElement)) {
+                auto rowSpan = cellElement->rowSpan();
                 if (rowSpan > 1)
                     childLayoutBox->setRowSpan(rowSpan);
-                auto columnSpan = cellElement.colSpan();
+                auto columnSpan = cellElement->colSpan();
                 if (columnSpan > 1)
                     childLayoutBox->setColumnSpan(columnSpan);
             }
@@ -364,8 +361,8 @@ void TreeBuilder::buildSubTree(const RenderElement& parentRenderer, ElementBox& 
         auto& childLayoutBox = appendChild(parentContainer, createLayoutBox(parentContainer, childRenderer));
         if (childLayoutBox.isTableWrapperBox())
             buildTableStructure(downcast<RenderTable>(childRenderer), downcast<ElementBox>(childLayoutBox));
-        else if (is<ElementBox>(childLayoutBox))
-            buildSubTree(downcast<RenderElement>(childRenderer), downcast<ElementBox>(childLayoutBox));
+        else if (auto* elementBox = dynamicDowncast<ElementBox>(childLayoutBox))
+            buildSubTree(downcast<RenderElement>(childRenderer), *elementBox);
     }
 }
 
@@ -507,8 +504,8 @@ static void outputLayoutBox(TextStream& stream, const Box& layoutBox, const BoxG
         stream << " at (" << borderBox.left() << "," << borderBox.top() << ") size " << borderBox.width() << "x" << borderBox.height();
     }
     stream << " (" << &layoutBox << ")";
-    if (is<InlineTextBox>(layoutBox)) {
-        auto textContent = downcast<InlineTextBox>(layoutBox).content();
+    if (auto* inlineTextBox = dynamicDowncast<InlineTextBox>(layoutBox)) {
+        auto textContent = inlineTextBox->content();
         stream << " length->(" << textContent.length() << ")";
 
         textContent = makeStringByReplacingAll(textContent, '\\', "\\\\"_s);
@@ -538,8 +535,8 @@ static void outputLayoutTree(const LayoutState* layoutState, TextStream& stream,
         } else
             outputLayoutBox(stream, child, nullptr, depth);
 
-        if (is<ElementBox>(child))
-            outputLayoutTree(layoutState, stream, downcast<ElementBox>(child), depth + 1);
+        if (auto* elementBox = dynamicDowncast<ElementBox>(child))
+            outputLayoutTree(layoutState, stream, *elementBox, depth + 1);
     }
 }
 


### PR DESCRIPTION
#### 1633be9a5c726d0044aa7cfd2f0b6e6b7a36c7fe
<pre>
More adoption of dynamicDowncast&lt;&gt; in assorted layout code
<a href="https://bugs.webkit.org/show_bug.cgi?id=269983">https://bugs.webkit.org/show_bug.cgi?id=269983</a>

Reviewed by Alan Baradlay.

Improving security &amp; performance.

* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::collectInlineItems):
(WebCore::Layout::buildBidiParagraph):
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp:
(WebCore::Layout::inlineItemPositionForDisplayBox):
(WebCore::Layout::inlineItemPositionForDamagedContentPosition):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::elementAttributes):
(WebCore::LayoutIntegration::BoxTree::~BoxTree):
(WebCore::LayoutIntegration::BoxTree::adjustStyleIfNeeded):
(WebCore::LayoutIntegration::BoxTree::createLayoutBox):
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::TextBox::fontCascade const):
(WebCore::InlineIterator::TextBox::isCombinedText const): Deleted.

Inline isCombinedText() as it only has a single caller.

* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateLayoutBoxDimensions):
(WebCore::LayoutIntegration::BoxGeometryUpdater::setGeometriesForLayout):
(WebCore::LayoutIntegration::BoxGeometryUpdater::setGeometriesForIntrinsicWidth):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::blockContainer):
(WebCore::LayoutIntegration::LineLayout::containing):
(WebCore::LayoutIntegration::LineLayout::hitTest):
(WebCore::LayoutIntegration::LineLayout::insertedIntoTree):
(WebCore::LayoutIntegration::LineLayout::removedFromTree):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::establishesInlineFormattingContext const):
(WebCore::Layout::Box::isOverflowVisible const):
* Source/WebCore/layout/layouttree/LayoutIterator.h:
(WebCore::Layout::LayoutBoxTraversal::firstChild):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::TreeBuilder::createLayoutBox):
(WebCore::Layout::TreeBuilder::buildSubTree):
(WebCore::Layout::outputLayoutBox):
(WebCore::Layout::outputLayoutTree):

Canonical link: <a href="https://commits.webkit.org/275275@main">https://commits.webkit.org/275275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1a43dac1ce0dad7c6fe162420dbd67c9a5c3c0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43972 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34223 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17346 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14886 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45322 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40723 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16221 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39125 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17840 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9277 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->