### PR TITLE
[Skia] Make sure the Skia GL context is current when calling SkCanvas draw operations for 2D canvas

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -39,7 +39,7 @@ namespace WebCore {
 
 class WEBCORE_EXPORT GraphicsContextSkia final : public GraphicsContext {
 public:
-    explicit GraphicsContextSkia(sk_sp<SkSurface>&&);
+    GraphicsContextSkia(sk_sp<SkSurface>&&, RenderingMode, RenderingPurpose);
     virtual ~GraphicsContextSkia();
 
     bool hasPlatformContext() const final;
@@ -109,6 +109,8 @@ public:
 private:
     SkCanvas& canvas() const;
 
+    bool makeGLContextCurrentIfNeeded() const;
+
     class SkiaState {
     public:
         SkiaState() = default;
@@ -122,6 +124,8 @@ private:
     };
 
     sk_sp<SkSurface> m_surface;
+    RenderingMode m_renderingMode { RenderingMode::Accelerated };
+    RenderingPurpose m_renderingPurpose { RenderingPurpose::Unspecified };
     SkiaState m_skiaState;
     Vector<SkiaState, 1> m_skiaStateStack;
 };

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
 }
 
 ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface)
-    : ImageBufferSkiaSurfaceBackend(parameters, WTFMove(surface))
+    : ImageBufferSkiaSurfaceBackend(parameters, WTFMove(surface), RenderingMode::Accelerated)
 {
 }
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
@@ -58,10 +58,10 @@ size_t ImageBufferSkiaSurfaceBackend::calculateMemoryCost(const Parameters& para
     return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
 }
 
-ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface)
+ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface, RenderingMode renderingMode)
     : ImageBufferSkiaBackend(parameters)
     , m_surface(WTFMove(surface))
-    , m_context(sk_ref_sp(m_surface.get()))
+    , m_context(sk_ref_sp(m_surface.get()), renderingMode, parameters.purpose)
 {
 }
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
@@ -42,7 +42,7 @@ public:
     static size_t calculateMemoryCost(const Parameters&);
 
 protected:
-    ImageBufferSkiaSurfaceBackend(const Parameters&, sk_sp<SkSurface>&&);
+    ImageBufferSkiaSurfaceBackend(const Parameters&, sk_sp<SkSurface>&&, RenderingMode);
 
     GraphicsContext& context() final { return m_context; }
     unsigned bytesPerRow() const final;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnaccelerate
 }
 
 ImageBufferSkiaUnacceleratedBackend::ImageBufferSkiaUnacceleratedBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface)
-    : ImageBufferSkiaSurfaceBackend(parameters, WTFMove(surface))
+    : ImageBufferSkiaSurfaceBackend(parameters, WTFMove(surface), RenderingMode::Unaccelerated)
 {
 }
 

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -288,7 +288,7 @@ bool PathSkia::strokeContains(const FloatPoint& point, const Function<void(Graph
     if (isEmpty() || !std::isfinite(point.x()) || !std::isfinite(point.y()))
         return false;
 
-    GraphicsContextSkia graphicsContext(SkSurfaces::Null(1, 1));
+    GraphicsContextSkia graphicsContext(SkSurfaces::Null(1, 1), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified);
     strokeStyleApplier(graphicsContext);
 
     // FIXME: Compute stroke precision.
@@ -313,7 +313,7 @@ FloatRect PathSkia::strokeBoundingRect(const Function<void(GraphicsContext&)>& s
     if (isEmpty())
         return { };
 
-    GraphicsContextSkia graphicsContext(SkSurfaces::Null(1, 1));
+    GraphicsContextSkia graphicsContext(SkSurfaces::Null(1, 1), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified);
     strokeStyleApplier(graphicsContext);
 
     // Skia stroke resolution scale for reduced-precision requirements.

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
     auto surface = SkSurfaces::WrapPixels(m_configuration.imageInfo(), data(), bytesPerRow(), [](void*, void* context) {
         static_cast<ShareableBitmap*>(context)->deref();
     }, this);
-    return makeUnique<GraphicsContextSkia>(WTFMove(surface));
+    return makeUnique<GraphicsContextSkia>(WTFMove(surface), RenderingMode::Unaccelerated, RenderingPurpose::ShareableSnapshot);
 }
 
 void ShareableBitmap::paint(GraphicsContext& context, const IntPoint& dstPoint, const IntRect& srcRect)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
@@ -62,7 +62,7 @@ Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& tileRect
     auto paintBuffer = [&](Nicosia::Buffer& buffer) {
         buffer.beginPainting();
 
-        GraphicsContextSkia context(sk_ref_sp(buffer.surface()));
+        GraphicsContextSkia context(sk_ref_sp(buffer.surface()), buffer.isBackedByOpenGL() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated, RenderingPurpose::LayerBacking);
         paintIntoGraphicsContext(context);
 
         buffer.completePainting();
@@ -89,7 +89,7 @@ Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& tileRect
 
         workerPool->postTask([buffer = Ref { buffer }, recordingContext = WTFMove(recordingContext)] {
             RELEASE_ASSERT(buffer->surface());
-            GraphicsContextSkia context(sk_ref_sp(buffer->surface()));
+            GraphicsContextSkia context(sk_ref_sp(buffer->surface()), RenderingMode::Unaccelerated, RenderingPurpose::LayerBacking);
             recordingContext->replayDisplayList(context);
             buffer->completePainting();
         });
@@ -108,7 +108,7 @@ Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintImage(Image& image)
     // Always render unaccelerated here for now.
     auto buffer = Nicosia::UnacceleratedBuffer::create(IntSize(image.size()), !image.currentFrameKnownToBeOpaque() ? Nicosia::Buffer::SupportsAlpha : Nicosia::Buffer::NoFlags);
     buffer->beginPainting();
-    GraphicsContextSkia context(sk_ref_sp(buffer->surface()));
+    GraphicsContextSkia context(sk_ref_sp(buffer->surface()), RenderingMode::Unaccelerated, RenderingPurpose::LayerBacking);
     IntRect rect { IntPoint::zero(), IntSize { image.size() } };
     context.drawImage(image, rect, rect, ImagePaintingOptions(CompositeOperator::Copy));
     buffer->completePainting();


### PR DESCRIPTION
#### 832bcc5229f97a3f10f2387c9b9da94723ce9834
<pre>
[Skia] Make sure the Skia GL context is current when calling SkCanvas draw operations for 2D canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=269984">https://bugs.webkit.org/show_bug.cgi?id=269984</a>

Reviewed by Nikolas Zimmermann.

When rendering layer contents, we make the Skia GL context current
before rendering the layer contents and it remains current, but in the
case of 2D canvas, we can&apos;t make sure the context is current when the
draw operations are called. This is causing rendering issues in some
cases that only happen with the GL renderer. This patch adds RenderingMode
and RenderingPurpose parameters to GraphicsContextSkia, and a helper
function makeGLContextCurrentIfNeeded() that makes the Skia GL context
current when the RenderingMode is Accelerated and RenderingPurpose is Canvas.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::GraphicsContextSkia):
(WebCore::GraphicsContextSkia::makeGLContextCurrentIfNeeded):
(WebCore::GraphicsContextSkia::drawRect):
(WebCore::GraphicsContextSkia::drawNativeImageInternal):
(WebCore::GraphicsContextSkia::drawLine):
(WebCore::GraphicsContextSkia::drawEllipse):
(WebCore::GraphicsContextSkia::fillPath):
(WebCore::GraphicsContextSkia::strokePath):
(WebCore::GraphicsContextSkia::fillRect):
(WebCore::GraphicsContextSkia::beginTransparencyLayer):
(WebCore::GraphicsContextSkia::endTransparencyLayer):
(WebCore::GraphicsContextSkia::clearRect):
(WebCore::GraphicsContextSkia::strokeRect):
(WebCore::GraphicsContextSkia::fillRoundedRectImpl):
(WebCore::GraphicsContextSkia::fillRectWithRoundedHole):
(WebCore::GraphicsContextSkia::drawPattern):
(WebCore::GraphicsContextSkia::renderingMode const): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp:
(WebCore::ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp:
(WebCore::ImageBufferSkiaUnacceleratedBackend::ImageBufferSkiaUnacceleratedBackend):
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::strokeContains const):
(WebCore::PathSkia::strokeBoundingRect const):
* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmap::createGraphicsContext):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
(WebCore::CoordinatedGraphicsLayer::paintImage):

Canonical link: <a href="https://commits.webkit.org/275432@main">https://commits.webkit.org/275432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64142b916db89bba9944dc79ace80bac2120be4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34466 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45670 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41009 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39437 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18200 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5604 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->