### PR TITLE
Back identifier tokens in custom properties with string literals

### DIFF
--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -45,7 +45,7 @@ template<typename CharacterType> void CSSVariableData::updateBackingStringsInTok
 {
     auto* currentOffset = m_backingString.characters<CharacterType>();
     for (auto& token : m_tokens) {
-        if (!token.hasStringBacking())
+        if (!token.hasStringBacking() || token.isBackedByStringLiteral())
             continue;
         unsigned length = token.value().length();
         token.updateCharacters(currentOffset, length);
@@ -60,14 +60,18 @@ bool CSSVariableData::operator==(const CSSVariableData& other) const
 }
 
 CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSParserContext& context)
-    : m_context(context)
+    : m_tokens(range.begin(), range.size())
+    , m_context(context)
 {
     StringBuilder stringBuilder;
-    m_tokens = WTF::map(range, [&](auto& token) {
-        if (token.hasStringBacking())
-            stringBuilder.append(token.value());
-        return token;
-    });
+    for (auto& token : m_tokens) {
+        if (!token.hasStringBacking())
+            continue;
+        if (token.tryUseStringLiteralBacking())
+            continue;
+        stringBuilder.append(token.value());
+    }
+
     if (!stringBuilder.isEmpty()) {
         m_backingString = stringBuilder.toString();
         if (m_backingString.is8Bit())

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -133,6 +133,8 @@ public:
     CSSValueID functionId() const;
 
     bool hasStringBacking() const;
+    bool tryUseStringLiteralBacking();
+    bool isBackedByStringLiteral() const { return m_isBackedByStringLiteral; }
 
     CSSPropertyID parseAsCSSPropertyID() const;
 
@@ -149,27 +151,29 @@ public:
     template<typename CharacterType>
     void updateCharacters(const CharacterType* characters, unsigned length);
 
-    CSSParserToken copyWithUpdatedString(StringView) const;
-
 private:
     void initValueFromStringView(StringView string)
     {
         m_valueLength = string.length();
         m_valueIs8Bit = string.is8Bit();
         m_valueDataCharRaw = string.rawCharacters();
+        m_isBackedByStringLiteral = false;
     }
-    unsigned m_type : 6; // CSSParserTokenType
-    unsigned m_blockType : 2; // BlockType
-    unsigned m_numericValueType : 1; // NumericValueType
-    unsigned m_numericSign : 2; // NumericSign
-    unsigned m_unit : 7; // CSSUnitType
-    unsigned m_nonUnitPrefixLength : 4; // Only for DimensionType, only needs to be long enough for UnicodeRange parsing.
+    CSSValueID identOrFunctionId() const;
+
+    unsigned m_type : 6 { 0 }; // CSSParserTokenType
+    unsigned m_blockType : 2 { 0 }; // BlockType
+    unsigned m_numericValueType : 1 { 0 }; // NumericValueType
+    unsigned m_numericSign : 2 { 0 }; // NumericSign
+    unsigned m_unit : 7 { 0 }; // CSSUnitType
+    unsigned m_nonUnitPrefixLength : 4 { 0 }; // Only for DimensionType, only needs to be long enough for UnicodeRange parsing.
 
     // m_value... is an unpacked StringView so that we can pack it
     // tightly with the rest of this object for a smaller object size.
-    bool m_valueIs8Bit : 1;
-    unsigned m_valueLength;
-    const void* m_valueDataCharRaw; // Either LChar* or UChar*.
+    bool m_valueIs8Bit : 1 { false };
+    bool m_isBackedByStringLiteral : 1 { false };
+    unsigned m_valueLength { 0 };
+    const void* m_valueDataCharRaw { nullptr }; // Either LChar* or UChar*.
 
     union {
         UChar m_delimiter;


### PR DESCRIPTION
#### a24a25b87e86c3c62d9e4ca0cc1e8f4d3939c8eb
<pre>
Back identifier tokens in custom properties with string literals
<a href="https://bugs.webkit.org/show_bug.cgi?id=269986">https://bugs.webkit.org/show_bug.cgi?id=269986</a>
<a href="https://rdar.apple.com/123506269">rdar://123506269</a>

Reviewed by Cameron McCormack.

Tokens don&apos;t own the underlying string so we construct a separate backing string for tokens that need it.
Identifier tokens can in mosts cases be backed by their string literals, saving memory and work.

* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::updateBackingStringsInTokens):
(WebCore::CSSVariableData::CSSVariableData):

Point the string backing to a literal if possible.

* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::id const):
(WebCore::CSSParserToken::functionId const):
(WebCore::CSSParserToken::identOrFunctionId const):
(WebCore::CSSParserToken::tryUseStringLiteralBacking):

Known identifier tokens can use literal backing if cases match (usually all lowercase).

(WebCore::CSSParserToken::copyWithUpdatedString const): Deleted.

Remove unsed function.

* Source/WebCore/css/parser/CSSParserToken.h:
(WebCore::CSSParserToken::isBackedByStringLiteral const):
(WebCore::CSSParserToken::initValueFromStringView):

* Source/WebCore/css/parser/CSSParserToken.h:

Canonical link: <a href="https://commits.webkit.org/275375@main">https://commits.webkit.org/275375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7571606c73095e8088e4afd15cbbd84fc9b029bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18039 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15127 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39420 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18129 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9339 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17773 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->