### PR TITLE
[Navigation] Throw exceptions in navigation methods if in detached state

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6907,6 +6907,11 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fr
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-with-target.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-userInitiated.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-already-detached.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-detach-in-serialization.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-already-detached.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-detach-in-serialization.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-already-detached.html [ Pass ]
 
 # -- View Transitions -- #
 # Reftest failures:

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-already-detached-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-already-detached-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL reload() in a detached window assert_array_equals: lengths differ, expected array ["committed", "finished"] length 2, got ["todo"] length 1
+PASS reload() in a detached window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-detach-in-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-detach-in-serialization-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL reload() promise rejections when detaching an iframe inside state serialization assert_array_equals: lengths differ, expected array ["committed", "finished"] length 2, got ["todo"] length 1
+PASS reload() promise rejections when detaching an iframe inside state serialization
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-already-detached-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-already-detached-expected.txt
@@ -1,4 +1,3 @@
 
-
-FAIL traverseTo() in a detached window promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'iWindow.navigation.currentEntry.key')"
+PASS traverseTo() in a detached window
 

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -280,6 +280,10 @@ template<typename T> struct IDLPromise : IDLWrapper<DOMPromise> {
     using InnerType = T;
 };
 
+template<typename T> struct IDLPromiseIgnoringSuspension : IDLWrapper<DOMPromise> {
+    using InnerType = T;
+};
+
 struct IDLError : IDLUnsupportedType { };
 struct IDLDOMException : IDLUnsupportedType { };
 

--- a/Source/WebCore/bindings/js/JSDOMConvertPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertPromise.h
@@ -68,6 +68,8 @@ template<typename T> struct Converter<IDLPromise<T>> : DefaultConverter<IDLPromi
     }
 };
 
+template<typename T> struct Converter<IDLPromiseIgnoringSuspension<T>> : public Converter<IDLPromise<T>> { };
+
 template<typename T> struct JSConverter<IDLPromise<T>> {
     static constexpr bool needsState = true;
     static constexpr bool needsGlobalObject = true;
@@ -77,7 +79,7 @@ template<typename T> struct JSConverter<IDLPromise<T>> {
         return promise.promise();
     }
 
-    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, RefPtr<DOMPromise> promise)
+    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const RefPtr<DOMPromise>& promise)
     {
         return promise->promise();
     }
@@ -86,6 +88,18 @@ template<typename T> struct JSConverter<IDLPromise<T>> {
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, U<T>& promiseProxy)
     {
         return promiseProxy.promise(lexicalGlobalObject, globalObject);
+    }
+};
+
+template<typename T> struct JSConverter<IDLPromiseIgnoringSuspension<T>> : public JSConverter<IDLPromise<T>> {
+    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, DOMPromise& promise)
+    {
+        return promise.guardedObject();
+    }
+
+    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const RefPtr<DOMPromise>& promise)
+    {
+        return promise->guardedObject();
     }
 };
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferredForward.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferredForward.h
@@ -54,22 +54,23 @@ struct IDLByteString;
 struct IDLUSVString;
 struct IDLObject;
 
-template<typename T> struct IDLInterface;
-template<typename T> struct IDLCallbackInterface;
-template<typename T> struct IDLCallbackFunction;
-template<typename T> struct IDLDictionary;
-template<typename T> struct IDLEnumeration;
-template<typename T> struct IDLNullable;
-template<typename T> struct IDLSequence;
-template<typename T> struct IDLFrozenArray;
-template<typename K, typename V> struct IDLRecord;
-template<typename T> struct IDLPromise;
+template<typename> struct IDLInterface;
+template<typename> struct IDLCallbackInterface;
+template<typename> struct IDLCallbackFunction;
+template<typename> struct IDLDictionary;
+template<typename> struct IDLEnumeration;
+template<typename> struct IDLNullable;
+template<typename> struct IDLSequence;
+template<typename> struct IDLFrozenArray;
+template<typename, typename> struct IDLRecord;
+template<typename> struct IDLPromise;
+template<typename> struct IDLPromiseIgnoringSuspension;
 
 struct IDLError;
 struct IDLDOMException;
 
-template<typename... Ts> struct IDLUnion;
-template<typename T> struct IDLBufferSource;
+template<typename...> struct IDLUnion;
+template<typename> struct IDLBufferSource;
 
 struct IDLArrayBuffer;
 struct IDLArrayBufferView;

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -7351,7 +7351,10 @@ sub GetBaseIDLType
     return "IDLSequence<" . GetIDLType($interface, @{$type->subtypes}[0]) . ">" if $codeGenerator->IsSequenceType($type);
     return "IDLFrozenArray<" . GetIDLType($interface, @{$type->subtypes}[0]) . ">" if $codeGenerator->IsFrozenArrayType($type);
     return "IDLRecord<" . GetIDLType($interface, @{$type->subtypes}[0]) . ", " . GetIDLType($interface, @{$type->subtypes}[1]) . ">" if $codeGenerator->IsRecordType($type);
-    return "IDLPromise<" . GetIDLType($interface, @{$type->subtypes}[0]) . ">" if $codeGenerator->IsPromiseType($type);
+    if ($codeGenerator->IsPromiseType($type)) {
+        my $promiseType = $type->extendedAttributes->{BypassDocumentFullyActiveCheck} ? "IDLPromiseIgnoringSuspension" : "IDLPromise";
+        return "${promiseType}<" . GetIDLType($interface, @{$type->subtypes}[0]) . ">";
+    }
     return "IDLUnion<" . join(", ", GetIDLUnionMemberTypes($interface, $type)) . ">" if $type->isUnion;
     return "IDLCallbackFunction<" . GetCallbackClassName($type->name) . ">" if $codeGenerator->IsCallbackFunction($type);
     return "IDLCallbackInterface<" . GetCallbackClassName($type->name) . ">" if $codeGenerator->IsCallbackInterface($type);

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -396,6 +396,9 @@
             "contextsAllowed": ["type"],
             "values": ["*"]
         },
+        "BypassDocumentFullyActiveCheck": {
+            "contextsAllowed": ["type"]
+        },
         "PassContext": {
             "contextsAllowed": ["operation"],
             "notes" : "Only used by WebKitTestRunner and DumpRenderTree"

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -45,8 +45,8 @@ dictionary NavigationReloadOptions : NavigationOptions {
     JSGenerateToJSObject,
 ] 
 dictionary NavigationResult {
-  Promise<NavigationHistoryEntry> committed;
-  Promise<NavigationHistoryEntry> finished;
+  [BypassDocumentFullyActiveCheck] Promise<NavigationHistoryEntry> committed;
+  [BypassDocumentFullyActiveCheck] Promise<NavigationHistoryEntry> finished;
 };
 
 enum NavigationHistoryBehavior {


### PR DESCRIPTION
#### 7e1ce4ca4dde839299bd340169b10fdd6cdd6e65
<pre>
[Navigation] Throw exceptions in navigation methods if in detached state
<a href="https://bugs.webkit.org/show_bug.cgi?id=269987">https://bugs.webkit.org/show_bug.cgi?id=269987</a>

Reviewed by Darin Adler.

The back/forward/traverseTo implementation needs to check whether the document is fully active and throw an exception if not [1].
Similar rules apply to reload [2] and navigate [3].

To fix the frame/document detachment, add an IDL attribute [BypassDocumentFullyActiveCheck], which ignores the script execution context being suspended and avoids the ASSERT in DOMPromise::promise().
This behaviour matches callPromiseFunction, which simply returns the JSPromise and ignores the script execution context.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal">https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal</a> (step 5)
[2] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-reload">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-reload</a> (step 5)
[3] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate</a> (step 7)

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-already-detached-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-detach-in-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-already-detached-expected.txt:
* Source/WebCore/bindings/IDLTypes.h:
* Source/WebCore/bindings/js/JSDOMConvertPromise.h:
(WebCore::JSConverter&lt;IDLPromiseIgnoringSuspension&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMPromiseDeferredForward.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GetBaseIDLType):
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::reload):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::updateCurrentEntry):
* Source/WebCore/page/Navigation.idl:

Canonical link: <a href="https://commits.webkit.org/277487@main">https://commits.webkit.org/277487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e089ed17de0d6b0165a0f95b3a1650aa482a6b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38840 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20137 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42390 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52296 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46143 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24028 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45177 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10534 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24816 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->