### PR TITLE
[build.webkit.org] Report DNS name, not HOSTNAME to results.webkit.org

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -56,6 +56,10 @@ Interpolate = properties.Interpolate
 THRESHOLD_FOR_EXCESSIVE_LOGS = 1000000
 MSG_FOR_EXCESSIVE_LOGS = f'Stopped due to excessive logging, limit: {THRESHOLD_FOR_EXCESSIVE_LOGS}'
 
+DNS_NAME = CURRENT_HOSTNAME
+if DNS_NAME in BUILD_WEBKIT_HOSTNAMES:
+    DNS_NAME = 'build.webkit.org'
+
 
 class CustomFlagsMixin(object):
 
@@ -628,7 +632,7 @@ class RunJavaScriptCoreTests(TestWithFailureCount, CustomFlagsMixin):
         "--builder-name", WithProperties("%(buildername)s"),
         "--build-number", WithProperties("%(buildnumber)s"),
         "--buildbot-worker", WithProperties("%(workername)s"),
-        "--buildbot-master", CURRENT_HOSTNAME,
+        "--buildbot-master", DNS_NAME,
         "--report", RESULTS_WEBKIT_URL,
     ]
     commandExtra = ['--treat-failing-as-flaky=0.7,10,20']
@@ -723,7 +727,7 @@ class RunWebKitTests(shell.TestNewStyle, CustomFlagsMixin):
                "--builder-name", WithProperties("%(buildername)s"),
                "--build-number", WithProperties("%(buildnumber)s"),
                "--buildbot-worker", WithProperties("%(workername)s"),
-               "--buildbot-master", CURRENT_HOSTNAME,
+               "--buildbot-master", DNS_NAME,
                "--report", RESULTS_WEBKIT_URL,
                "--exit-after-n-crashes-or-timeouts", "50",
                "--exit-after-n-failures", "500",
@@ -859,7 +863,7 @@ class RunAPITests(TestWithFailureCount, CustomFlagsMixin):
         f"--json-output={jsonFileName}",
         WithProperties("--%(configuration)s"),
         "--verbose",
-        "--buildbot-master", CURRENT_HOSTNAME,
+        "--buildbot-master", DNS_NAME,
         "--builder-name", WithProperties("%(buildername)s"),
         "--build-number", WithProperties("%(buildnumber)s"),
         "--buildbot-worker", WithProperties("%(workername)s"),
@@ -947,7 +951,7 @@ class RunWebKitPyTests(RunPythonTests):
         "python3",
         "Tools/Scripts/test-webkitpy",
         "--verbose",
-        "--buildbot-master", CURRENT_HOSTNAME,
+        "--buildbot-master", DNS_NAME,
         "--builder-name", WithProperties("%(buildername)s"),
         "--build-number", WithProperties("%(buildnumber)s"),
         "--buildbot-worker", WithProperties("%(workername)s"),
@@ -1015,7 +1019,7 @@ class RunLLINTCLoopTests(TestWithFailureCount):
         "--builder-name", WithProperties("%(buildername)s"),
         "--build-number", WithProperties("%(buildnumber)s"),
         "--buildbot-worker", WithProperties("%(workername)s"),
-        "--buildbot-master", CURRENT_HOSTNAME,
+        "--buildbot-master", DNS_NAME,
         "--report", RESULTS_WEBKIT_URL,
     ]
     failedTestsFormatString = "%d regression%s found."
@@ -1056,7 +1060,7 @@ class Run32bitJSCTests(TestWithFailureCount):
         "--builder-name", WithProperties("%(buildername)s"),
         "--build-number", WithProperties("%(buildnumber)s"),
         "--buildbot-worker", WithProperties("%(workername)s"),
-        "--buildbot-master", CURRENT_HOSTNAME,
+        "--buildbot-master", DNS_NAME,
         "--report", RESULTS_WEBKIT_URL,
     ]
     failedTestsFormatString = "%d regression%s found."


### PR DESCRIPTION
#### 53197ed1596b020918bbc8daadda1be875388c14
<pre>
[build.webkit.org] Report DNS name, not HOSTNAME to results.webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=269990">https://bugs.webkit.org/show_bug.cgi?id=269990</a>
<a href="https://rdar.apple.com/123508951">rdar://123508951</a>

Reviewed by Aakash Jain.

* Tools/CISupport/build-webkit-org/steps.py:
(RunJavaScriptCoreTests): Use DNS_NAME instead of CURRENT_HOSTNAME.
(RunWebKitTests): Ditto.
(RunAPITests): Ditto.
(RunWebKitPyTests): Ditto.
(RunLLINTCLoopTests): Ditto.
(Run32bitJSCTests): Ditto.

Canonical link: <a href="https://commits.webkit.org/275238@main">https://commits.webkit.org/275238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcd39107b3947c28fdf038b583b7ca47c67d2cf2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41287 "Failed to checkout and rebase branch from PR 25015") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43851 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17631 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41861 "Failed to checkout and rebase branch from PR 25015") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45180 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/36888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41334 "Failed to checkout and rebase branch from PR 25015") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5507 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->