### PR TITLE
More adoption of dynamicDowncast<> in platform/graphics

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FilterOperation.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.cpp
@@ -45,10 +45,8 @@ namespace WebCore {
     
 bool DefaultFilterOperation::operator==(const FilterOperation& operation) const
 {
-    if (!isSameType(operation))
-        return false;
-    
-    return representedType() == downcast<DefaultFilterOperation>(operation).representedType();
+    auto* defaultOperation = dynamicDowncast<DefaultFilterOperation>(operation);
+    return defaultOperation && representedType() == defaultOperation->representedType();
 }
 
 FilterOperation::Type DefaultFilterOperation::representedType() const
@@ -67,10 +65,8 @@ ReferenceFilterOperation::~ReferenceFilterOperation() = default;
     
 bool ReferenceFilterOperation::operator==(const FilterOperation& operation) const
 {
-    if (!isSameType(operation))
-        return false;
-    
-    return m_url == downcast<ReferenceFilterOperation>(operation).m_url;
+    auto* referenceOperation = dynamicDowncast<ReferenceFilterOperation>(operation);
+    return referenceOperation && m_url == referenceOperation->m_url;
 }
 
 bool ReferenceFilterOperation::isIdentity() const
@@ -181,10 +177,8 @@ bool BasicColorMatrixFilterOperation::transformColor(SRGBA<float>& color) const
 
 inline bool BasicColorMatrixFilterOperation::operator==(const FilterOperation& operation) const
 {
-    if (!isSameType(operation))
-        return false;
-    const BasicColorMatrixFilterOperation& other = downcast<BasicColorMatrixFilterOperation>(operation);
-    return m_amount == other.m_amount;
+    auto* basicOperation = dynamicDowncast<BasicColorMatrixFilterOperation>(operation);
+    return basicOperation && m_amount == basicOperation->m_amount;
 }
 
 double BasicColorMatrixFilterOperation::passthroughAmount() const
@@ -255,10 +249,8 @@ bool BasicComponentTransferFilterOperation::transformColor(SRGBA<float>& color) 
 
 inline bool BasicComponentTransferFilterOperation::operator==(const FilterOperation& operation) const
 {
-    if (!isSameType(operation))
-        return false;
-    const BasicComponentTransferFilterOperation& other = downcast<BasicComponentTransferFilterOperation>(operation);
-    return m_amount == other.m_amount;
+    auto* basicOperation = dynamicDowncast<BasicComponentTransferFilterOperation>(operation);
+    return basicOperation && m_amount == basicOperation->m_amount;
 }
 
 double BasicComponentTransferFilterOperation::passthroughAmount() const
@@ -401,10 +393,8 @@ bool InvertLightnessFilterOperation::inverseTransformColor(SRGBA<float>& color) 
 
 bool BlurFilterOperation::operator==(const FilterOperation& operation) const
 {
-    if (!isSameType(operation))
-        return false;
-    
-    return m_stdDeviation == downcast<BlurFilterOperation>(operation).stdDeviation();
+    auto* blurOperation = dynamicDowncast<BlurFilterOperation>(operation);
+    return blurOperation && m_stdDeviation == blurOperation->stdDeviation();
 }
     
 RefPtr<FilterOperation> BlurFilterOperation::blend(const FilterOperation* from, const BlendingContext& context, bool blendToPassthrough)
@@ -435,10 +425,11 @@ IntOutsets BlurFilterOperation::outsets() const
 
 bool DropShadowFilterOperation::operator==(const FilterOperation& operation) const
 {
-    if (!isSameType(operation))
-        return false;
-    const DropShadowFilterOperation& other = downcast<DropShadowFilterOperation>(operation);
-    return m_location == other.m_location && m_stdDeviation == other.m_stdDeviation && m_color == other.m_color;
+    auto* dropShadowOperation = dynamicDowncast<DropShadowFilterOperation>(operation);
+    return dropShadowOperation
+        && m_location == dropShadowOperation->m_location
+        && m_stdDeviation == dropShadowOperation->m_stdDeviation
+        && m_color == dropShadowOperation->m_color;
 }
     
 RefPtr<FilterOperation> DropShadowFilterOperation::blend(const FilterOperation* from, const BlendingContext& context, bool blendToPassthrough)

--- a/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp
@@ -45,7 +45,8 @@ Matrix3DTransformOperation::Matrix3DTransformOperation(const TransformationMatri
 
 bool Matrix3DTransformOperation::operator==(const TransformOperation& other) const
 {
-    return isSameType(other) && m_matrix == downcast<Matrix3DTransformOperation>(other).m_matrix;
+    auto* otherOperation = dynamicDowncast<Matrix3DTransformOperation>(other);
+    return otherOperation && m_matrix == otherOperation->m_matrix;
 }
 
 static Ref<TransformOperation> createOperation(TransformationMatrix& to, TransformationMatrix& from, const BlendingContext& context)

--- a/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.cpp
@@ -46,10 +46,14 @@ MatrixTransformOperation::MatrixTransformOperation(const TransformationMatrix& t
 
 bool MatrixTransformOperation::operator==(const TransformOperation& other) const
 {
-    if (!isSameType(other))
-        return false;
-    const MatrixTransformOperation& m = downcast<MatrixTransformOperation>(other);
-    return m_a == m.m_a && m_b == m.m_b && m_c == m.m_c && m_d == m.m_d && m_e == m.m_e && m_f == m.m_f;
+    auto* otherOperation = dynamicDowncast<MatrixTransformOperation>(other);
+    return otherOperation
+        && m_a == otherOperation->m_a
+        && m_b == otherOperation->m_b
+        && m_c == otherOperation->m_c
+        && m_d == otherOperation->m_d
+        && m_e == otherOperation->m_e
+        && m_f == otherOperation->m_f;
 }
 
 Ref<TransformOperation> MatrixTransformOperation::blend(const TransformOperation* from, const BlendingContext& context, bool blendToIdentity)

--- a/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp
@@ -46,9 +46,8 @@ PerspectiveTransformOperation::PerspectiveTransformOperation(const std::optional
 
 bool PerspectiveTransformOperation::operator==(const TransformOperation& other) const
 {
-    if (!isSameType(other))
-        return false;
-    return m_p == downcast<PerspectiveTransformOperation>(other).m_p;
+    auto* otherOperation = dynamicDowncast<PerspectiveTransformOperation>(other);
+    return otherOperation && m_p == otherOperation->m_p;
 }
 
 Ref<TransformOperation> PerspectiveTransformOperation::blend(const TransformOperation* from, const BlendingContext& context, bool blendToIdentity)

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
@@ -46,10 +46,12 @@ RotateTransformOperation::RotateTransformOperation(double x, double y, double z,
 
 bool RotateTransformOperation::operator==(const TransformOperation& other) const
 {
-    if (!isSameType(other))
-        return false;
-    const RotateTransformOperation& r = downcast<RotateTransformOperation>(other);
-    return m_angle == r.m_angle && m_x == r.m_x && m_y == r.m_y && m_z == r.m_z;
+    auto* otherOperation = dynamicDowncast<RotateTransformOperation>(other);
+    return otherOperation
+        && m_angle == otherOperation->m_angle
+        && m_x == otherOperation->m_x
+        && m_y == otherOperation->m_y
+        && m_z == otherOperation->m_z;
 }
 
 Ref<TransformOperation> RotateTransformOperation::blend(const TransformOperation* from, const BlendingContext& context, bool blendToIdentity)

--- a/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp
@@ -43,10 +43,11 @@ ScaleTransformOperation::ScaleTransformOperation(double sx, double sy, double sz
 
 bool ScaleTransformOperation::operator==(const TransformOperation& other) const
 {
-    if (!isSameType(other))
-        return false;
-    const ScaleTransformOperation& s = downcast<ScaleTransformOperation>(other);
-    return m_x == s.m_x && m_y == s.m_y && m_z == s.m_z;
+    auto* otherOperation = dynamicDowncast<ScaleTransformOperation>(other);
+    return otherOperation
+        && m_x == otherOperation->m_x
+        && m_y == otherOperation->m_y
+        && m_z == otherOperation->m_z;
 }
 
 static double blendScaleComponent(double from, double to, const BlendingContext& context)

--- a/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp
@@ -42,10 +42,8 @@ SkewTransformOperation::SkewTransformOperation(double angleX, double angleY, Tra
 
 bool SkewTransformOperation::operator==(const TransformOperation& other) const
 {
-    if (!isSameType(other))
-        return false;
-    const SkewTransformOperation& s = downcast<SkewTransformOperation>(other);
-    return m_angleX == s.m_angleX && m_angleY == s.m_angleY;
+    auto* otherOperation = dynamicDowncast<SkewTransformOperation>(other);
+    return otherOperation && m_angleX == otherOperation->m_angleX && m_angleY == otherOperation->m_angleY;
 }
 
 Ref<TransformOperation> SkewTransformOperation::blend(const TransformOperation* from, const BlendingContext& context, bool blendToIdentity)

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
@@ -44,10 +44,11 @@ TranslateTransformOperation::TranslateTransformOperation(const Length& tx, const
 
 bool TranslateTransformOperation::operator==(const TransformOperation& other) const
 {
-    if (!isSameType(other))
-        return false;
-    const TranslateTransformOperation& t = downcast<TranslateTransformOperation>(other);
-    return m_x == t.m_x && m_y == t.m_y && m_z == t.m_z;
+    auto* otherOperation = dynamicDowncast<TranslateTransformOperation>(other);
+    return otherOperation
+        && m_x == otherOperation->m_x
+        && m_y == otherOperation->m_y
+        && m_z == otherOperation->m_z;
 }
 
 Ref<TransformOperation> TranslateTransformOperation::blend(const TransformOperation* from, const BlendingContext& context, bool blendToIdentity)


### PR DESCRIPTION
#### b0b5f8ce3f09a5b655f28e5b413832a48554bdde
<pre>
More adoption of dynamicDowncast&lt;&gt; in platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=269991">https://bugs.webkit.org/show_bug.cgi?id=269991</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/filters/FilterOperation.cpp:
(WebCore::DefaultFilterOperation::operator== const):
(WebCore::ReferenceFilterOperation::operator== const):
(WebCore::BasicColorMatrixFilterOperation::operator== const):
(WebCore::BasicComponentTransferFilterOperation::operator== const):
(WebCore::BlurFilterOperation::operator== const):
(WebCore::DropShadowFilterOperation::operator== const):
* Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp:
(WebCore::Matrix3DTransformOperation::operator== const):
* Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.cpp:
(WebCore::MatrixTransformOperation::operator== const):
* Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp:
(WebCore::PerspectiveTransformOperation::operator== const):
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp:
(WebCore::RotateTransformOperation::operator== const):
* Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp:
(WebCore::ScaleTransformOperation::operator== const):
* Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp:
(WebCore::SkewTransformOperation::operator== const):
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp:
(WebCore::TranslateTransformOperation::operator== const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0b5f8ce3f09a5b655f28e5b413832a48554bdde

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17634 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34147 "Found 5 new test failures: css3/color-filters/color-filter-parsing.html, css3/filters/backdrop/animation.html, css3/filters/backdrop/backdropfilter-property-computed-style.html, css3/filters/unprefixed.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41864 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17229 "Found 4 new test failures: compositing/scrolling/async-overflow-scrolling/transform-change-scrollbar-position.html, css3/color-filters/color-filter-parsing.html, css3/filters/backdrop/animation.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14959 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36565 "Found 5 new test failures: css3/color-filters/color-filter-parsing.html, css3/filters/backdrop/animation.html, fast/repaint/incorrect-repaint-when-child-layer-overflows.html, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37476 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36883 "Found 5 new test failures: compositing/scrolling/async-overflow-scrolling/transform-change-scrollbar-position.html, css3/color-filters/color-filter-parsing.html, css3/filters/backdrop/animation.html, fast/repaint/incorrect-repaint-when-child-layer-overflows.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40631 "Found 6 new test failures: css3/color-filters/color-filter-parsing.html, css3/filters/backdrop/animation.html, css3/filters/backdrop/backdropfilter-property-computed-style.html, css3/filters/unprefixed.html, fast/repaint/incorrect-repaint-when-child-layer-overflows.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16105 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13212 "Found 6 new test failures: compositing/scrolling/async-overflow-scrolling/transform-change-scrollbar-position.html, css3/color-filters/color-filter-parsing.html, css3/filters/backdrop/animation.html, fast/repaint/incorrect-repaint-when-child-layer-overflows.html, imported/w3c/web-platform-tests/css/css-view-transitions/offscreen-element-modified-before-coming-onscreen.html, webanimations/css-transition-retargeting-to-same-value-upon-completion-with-timeout.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39020 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17724 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->