### PR TITLE
Unreviewed, reverting 275247@main

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1192,7 +1192,7 @@ class RunWebDriverTests(shell.Test):
         if additionalArguments:
             self.command += additionalArguments
 
-        self.appendCustomBuildFlags(self.getProperty('platform'), self.getProperty('fullPlatform'))
+        appendCustomBuildFlags(self, self.getProperty('platform'), self.getProperty('fullPlatform'))
 
         self.log_observer = logobserver.BufferLogObserver()
         self.addLogObserver('stdio', self.log_observer)


### PR DESCRIPTION
#### 512b50c95ed9397745f266088a03d12d51590ba1
<pre>
Unreviewed, reverting 275247@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=267969">https://bugs.webkit.org/show_bug.cgi?id=267969</a>
<a href="https://rdar.apple.com/121476415">rdar://121476415</a>

Reviewed by NOBODY (OOPS!).

Testing git-webkit revert automatic landing functionality.
This should not actually be landed.

Reverted change:

[build.webkit.org] Replace shell.Test with shell.TestNewStyle (Follow-up fix)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256970">https://bugs.webkit.org/show_bug.cgi?id=256970</a>
<a href="https://rdar.apple.com/109516328">rdar://109516328</a>
https://commits.webkit.org/275247@main
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/512b50c95ed9397745f266088a03d12d51590ba1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20325 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/43689 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43875 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37403 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17655 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34164 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41885 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17249 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/43689 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/14822 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; 3 api tests failed or timed out; re-run-api-tests (cancelled)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/14977 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/43689 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45208 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37497 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/43689 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40645 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16126 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13232 "Build was cancelled. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39036 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41358 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17745 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/43689 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9267 "") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17798 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17389 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->