### PR TITLE
Try to fix the visionOS build

### DIFF
--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(LinearMediaKit)
+#if os(visionOS)
 
 import AVFoundation
 import Combine
@@ -135,11 +135,15 @@ private class SwiftOnlyData: NSObject {
 
     func makeViewController() -> PlayableViewController {
         let viewController = PlayableViewController()
+#if canImport(LinearMediaKit, _version: 205)
         viewController.playable = self
+#endif
         viewController.prefersAutoDimming = true
         return viewController
     }
 }
+
+#if canImport(LinearMediaKit, _version: 205)
 
 extension WKSLinearMediaPlayer: @retroactive Playable {
     public var selectedPlaybackRatePublisher: AnyPublisher<Double, Never> {
@@ -504,11 +508,9 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func makeDefaultEntity() -> Entity? {
-#if canImport(LinearMediaKit, _version: 205)
         if let captionLayer = captionLayer {
             return ContentType.makeEntity(captionLayer: captionLayer)
         }
-#endif
         return nil
     }
 
@@ -565,4 +567,6 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 }
 
-#endif // canImport(LinearMediaKit)
+#endif // canImport(LinearMediaKit, _version: 205)
+
+#endif // os(visionOS)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -23,6 +23,7 @@
 
 #if os(visionOS)
 
+import LinearMediaKit
 import WebKitSwift
 
 // MARK: Objective-C Implementations
@@ -44,10 +45,6 @@ import WebKitSwift
         self.localizedDisplayName = localizedDisplayName
     }
 }
-
-#if canImport(LinearMediaKit)
-
-import LinearMediaKit
 
 // MARK: LinearMediaKit Extensions
 
@@ -181,9 +178,9 @@ extension WKSLinearMediaTimeRange {
     }
 }
 
+#if canImport(LinearMediaKit, _version: 205)
 extension WKSLinearMediaTrack: @retroactive Track {
 }
-
-#endif // canImport(LinearMediaKit)
+#endif
 
 #endif // os(visionOS)


### PR DESCRIPTION
#### 8e5cdd60e829600d8d6f15121f73d0cafa897974
<pre>
Try to fix the visionOS build
<a href="https://bugs.webkit.org/show_bug.cgi?id=269998">https://bugs.webkit.org/show_bug.cgi?id=269998</a>
<a href="https://rdar.apple.com/123520955">rdar://123520955</a>

Unreviewed build fix for visionOS SDKs that do not have required LinearMediaKit APIs.

* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.makeViewController):
(WKSLinearMediaPlayer.makeDefaultEntity):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:

Canonical link: <a href="https://commits.webkit.org/275254@main">https://commits.webkit.org/275254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff9cf06ea07d9fb9c2caf24c57b508f05c0934d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/41312 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/20326 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/43690 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43876 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37404 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/23404 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/17656 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/43876 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/41886 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/23404 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/43690 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43876 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/23404 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/43690 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45210 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/23404 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/43690 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/45210 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16127 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/17656 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45210 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17746 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/43690 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5515 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->