### PR TITLE
[JSC] try/catch should not intercept errors originated in [[Construct]] of derived class

### DIFF
--- a/JSTests/stress/regress-268411.js
+++ b/JSTests/stress/regress-268411.js
@@ -1,0 +1,71 @@
+function assert(x) {
+  if (!x)
+    throw new Error("Bad assertion!");
+}
+
+(function superCallReturnPrimitive() {
+  var iterations = 1e4;
+  var caughtInner = 0;
+  var caughtOuter = 0;
+
+  class C extends class {} {
+    constructor(i) {
+      super();
+
+      {
+        if (typeof i === "number") {
+          try {
+            return i;
+          } catch {
+            caughtInner++;
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  for (var i = 0; i < iterations; i++) {
+    try {
+      new C(i);
+    } catch (err) {
+      if (err instanceof TypeError)
+        caughtOuter++;
+    }
+  }
+
+  assert(caughtInner === 0);
+  assert(caughtOuter === iterations);
+})();
+
+(function noSuperCallReturnThis() {
+  var iterations = 1e4;
+  var caughtInner = 0;
+  var caughtOuter = 0;
+
+  class C extends class {} {
+    constructor(i) {
+      {
+        if (typeof i === "number") {
+          try {
+            return;
+          } catch {
+            caughtInner++;
+          }
+        }
+      }
+    }
+  }
+
+  for (var i = 0; i < iterations; i++) {
+    try {
+      new C(i);
+    } catch (err) {
+      if (err instanceof ReferenceError)
+        caughtOuter++;
+    }
+  }
+
+  assert(caughtInner === 0);
+  assert(caughtOuter === iterations);
+})();

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1108,15 +1108,6 @@ test/language/statements/class/subclass/default-constructor-spread-override.js:
 test/language/statements/class/subclass/derived-class-return-override-catch-finally-arrow.js:
   default: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
   strict mode: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
-test/language/statements/class/subclass/derived-class-return-override-catch-super-arrow.js:
-  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-test/language/statements/class/subclass/derived-class-return-override-catch-super.js:
-  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-test/language/statements/class/subclass/derived-class-return-override-catch.js:
-  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/language/statements/class/subclass/derived-class-return-override-finally-super-arrow.js:
   default: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
   strict mode: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4046,7 +4046,6 @@ void BlockNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 
 void EmptyStatementNode::emitBytecode(BytecodeGenerator&, RegisterID*)
 {
-    RELEASE_ASSERT(needsDebugHook());
 }
 
 // ------------------------------ DebuggerStatementNode ---------------------------

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -2027,6 +2027,7 @@ private:
         int assignmentCount { 0 };
         int nonLHSCount { 0 };
         int nonTrivialExpressionCount { 0 };
+        int returnStatementCount { 0 };
         int unaryTokenStackDepth { 0 };
         FunctionParsePhase functionParsePhase { FunctionParsePhase::Body };
         const Identifier* lastIdentifier { nullptr };


### PR DESCRIPTION
#### ad689935bb77e592b0b622143a71ff5520d6456b
<pre>
[JSC] try/catch should not intercept errors originated in [[Construct]] of derived class
<a href="https://bugs.webkit.org/show_bug.cgi?id=268411">https://bugs.webkit.org/show_bug.cgi?id=268411</a>
&lt;<a href="https://rdar.apple.com/problem/121959506">rdar://problem/121959506</a>&gt;

Reviewed by Justin Michaud.

Before this change, if a `return` statement of a derived class constructor was inside a `try` .. `catch`
statement, errors thrown at steps 10-12 of [1] were caught by the `catch` block, which is obviously
wrong since the userland code should have been evaluated during step 9 of [1].

It&apos;s infeasible to perform these checks (super() wasn&apos;t called / returned non-undefined primitive) in
`op_construct` because we can&apos;t distinguish derived class constructors in a performant way, plus accounting
for inlining would be challenging.

Rather than introducing a mechanism of &quot;fake returns&quot; that jump out from `try` block to perform
above-mentioned checks before actually returning, which would be quite complicated, this patch leverages
existing emitJumpViaFinallyIfNeeded() logic by creating an empty `finally` block right inside a parser.

I argue that containing this whole workaround cohesively in parseTryStatement() is better than passing
a CodeFeature that `try` block contains a `return` all the way to TryNode::emitBytecode().

Aligns JSC with the spec [1], V8, and SpiderMonkey. Until very recently, V8 used to have the same bug.

[1]: <a href="https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget">https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget</a>

* JSTests/stress/regress-268411.js: Added.
* JSTests/test262/expectations.yaml: Mark 6 tests as passing.
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::EmptyStatementNode::emitBytecode):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseReturnStatement):
(JSC::Parser&lt;LexerType&gt;::parseTryStatement):
* Source/JavaScriptCore/parser/Parser.h:

Canonical link: <a href="https://commits.webkit.org/275353@main">https://commits.webkit.org/275353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f1960ed88a1de3b9d3bba3e5d5294e04ff0b5eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37431 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34181 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14842 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45240 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34792 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40666 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40965 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39063 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17773 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47976 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17826 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9803 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5567 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->