### PR TITLE
Drop LockHolder alias

### DIFF
--- a/Source/JavaScriptCore/heap/IsoSubspacePerVM.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspacePerVM.cpp
@@ -41,7 +41,7 @@ IsoSubspacePerVM::~IsoSubspacePerVM()
     UNREACHABLE_FOR_PLATFORM();
 }
 
-IsoSubspace& IsoSubspacePerVM::isoSubspaceforHeap(LockHolder&, JSC::Heap& heap)
+IsoSubspace& IsoSubspacePerVM::isoSubspaceforHeap(Locker<Lock>&, JSC::Heap& heap)
 {
     auto result = m_subspacePerHeap.add(&heap, nullptr);
     if (result.isNewEntry) {

--- a/Source/JavaScriptCore/heap/IsoSubspacePerVM.h
+++ b/Source/JavaScriptCore/heap/IsoSubspacePerVM.h
@@ -75,7 +75,7 @@ public:
     void releaseClientIsoSubspace(VM&);
 
 private:
-    IsoSubspace& isoSubspaceforHeap(LockHolder&, Heap&);
+    IsoSubspace& isoSubspaceforHeap(Locker<Lock>&, Heap&);
 
     Lock m_lock;
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -689,7 +689,7 @@ public:
 #endif // ENABLE(LIBPAS_JIT_HEAP)
 
 #if ENABLE(JUMP_ISLANDS)
-    void handleWillBeReleased(const LockHolder& locker, ExecutableMemoryHandle& handle)
+    void handleWillBeReleased(const Locker<Lock>& locker, ExecutableMemoryHandle& handle)
     {
         if (m_islandsForJumpSourceLocation.isEmpty())
             return;
@@ -741,7 +741,7 @@ private:
         return result;
     }
 
-    void freeJumpIslands(const LockHolder&, Islands* islands)
+    void freeJumpIslands(const Locker<Lock>&, Islands* islands)
     {
         for (CodeLocationLabel<ExecutableMemoryPtrTag> jumpIsland : islands->jumpIslands) {
             uintptr_t untaggedJumpIsland = bitwise_cast<uintptr_t>(jumpIsland.dataLocation());
@@ -752,14 +752,14 @@ private:
         islands->jumpIslands.clear();
     }
 
-    void freeIslands(const LockHolder& locker, Islands* islands)
+    void freeIslands(const Locker<Lock>& locker, Islands* islands)
     {
         freeJumpIslands(locker, islands);
         m_islandsForJumpSourceLocation.remove(islands);
         delete islands;
     }
 
-    void* islandForJumpLocation(const LockHolder& locker, uintptr_t jumpLocation, uintptr_t target, bool concurrently, bool useMemcpy)
+    void* islandForJumpLocation(const Locker<Lock>& locker, uintptr_t jumpLocation, uintptr_t target, bool concurrently, bool useMemcpy)
     {
         Islands* islands = m_islandsForJumpSourceLocation.findExact(bitwise_cast<void*>(jumpLocation));
         if (islands) {
@@ -921,7 +921,7 @@ private:
         }
 
 #if !ENABLE(LIBPAS_JIT_HEAP)
-        void release(const LockHolder& locker, MetaAllocatorHandle& handle) final
+        void release(const Locker<Lock>& locker, MetaAllocatorHandle& handle) final
         {
             AssemblyCommentRegistry::singleton().unregisterCodeRange(handle.start().untaggedPtr(), handle.end().untaggedPtr());
             m_fixedAllocator.handleWillBeReleased(locker, handle);

--- a/Source/JavaScriptCore/runtime/ConcurrentJSLock.h
+++ b/Source/JavaScriptCore/runtime/ConcurrentJSLock.h
@@ -32,7 +32,7 @@
 namespace JSC {
 
 using ConcurrentJSLock = Lock;
-using ConcurrentJSLockerImpl = LockHolder;
+using ConcurrentJSLockerImpl = Locker<Lock>;
 
 static_assert(sizeof(ConcurrentJSLock) == 1, "Regardless of status of concurrent JS flag, size of ConurrentJSLock is always one byte.");
 

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -368,11 +368,11 @@ void SamplingProfiler::takeSample(Seconds& stackTraceProcessingTime)
 
         Locker machineThreadsLocker { m_vm.heap.machineThreads().getLock() };
         Locker codeBlockSetLocker { m_vm.heap.codeBlockSet().getLock() };
-        std::optional<LockHolder> executableAllocatorLocker;
+        std::optional<Locker<Lock>> executableAllocatorLocker;
         if (Options::useJIT())
             executableAllocatorLocker.emplace(ExecutableAllocator::singleton().getLock());
 
-        std::optional<LockHolder> wasmCalleesLocker;
+        std::optional<Locker<Lock>> wasmCalleesLocker;
 #if ENABLE(WEBASSEMBLY)
         if (Wasm::isSupported())
             wasmCalleesLocker.emplace(NativeCalleeRegistry::singleton().getLock());

--- a/Source/WTF/wtf/Lock.h
+++ b/Source/WTF/wtf/Lock.h
@@ -200,9 +200,6 @@ private:
 Locker(Lock&) -> Locker<Lock>;
 Locker(AdoptLockTag, Lock&) -> Locker<Lock>;
 
-using LockHolder = Locker<Lock>;
-
 } // namespace WTF
 
 using WTF::Lock;
-using WTF::LockHolder;

--- a/Source/WTF/wtf/MetaAllocator.cpp
+++ b/Source/WTF/wtf/MetaAllocator.cpp
@@ -62,7 +62,7 @@ void MetaAllocatorTracker::release(MetaAllocatorHandle& handle)
     m_allocations.remove(&handle);
 }
 
-void MetaAllocator::release(const LockHolder&, MetaAllocatorHandle& handle)
+void MetaAllocator::release(const Locker<Lock>&, MetaAllocatorHandle& handle)
 {
     if (handle.sizeInBytes()) {
         MemoryPtr start = handle.start();
@@ -154,7 +154,7 @@ MetaAllocator::MetaAllocator(Lock& lock, size_t allocationGranule, size_t pageSi
     ASSERT(static_cast<size_t>(1) << m_logAllocationGranule == m_allocationGranule);
 }
 
-RefPtr<MetaAllocatorHandle> MetaAllocator::allocate(const LockHolder&, size_t sizeInBytes)
+RefPtr<MetaAllocatorHandle> MetaAllocator::allocate(const Locker<Lock>&, size_t sizeInBytes)
 {
     if (!sizeInBytes)
         return nullptr;
@@ -198,7 +198,7 @@ RefPtr<MetaAllocatorHandle> MetaAllocator::allocate(const LockHolder&, size_t si
     return handle;
 }
 
-MetaAllocator::Statistics MetaAllocator::currentStatistics(const LockHolder&)
+MetaAllocator::Statistics MetaAllocator::currentStatistics(const Locker<Lock>&)
 {
     Statistics result;
     result.bytesAllocated = m_bytesAllocated;

--- a/Source/WTF/wtf/MetaAllocator.h
+++ b/Source/WTF/wtf/MetaAllocator.h
@@ -74,7 +74,7 @@ public:
         Locker locker { m_lock };
         return allocate(locker, sizeInBytes);
     }
-    WTF_EXPORT_PRIVATE RefPtr<MetaAllocatorHandle> allocate(const LockHolder&, size_t sizeInBytes);
+    WTF_EXPORT_PRIVATE RefPtr<MetaAllocatorHandle> allocate(const Locker<Lock>&, size_t sizeInBytes);
 
     void trackAllocations(MetaAllocatorTracker* tracker)
     {
@@ -98,7 +98,7 @@ public:
         Locker locker { m_lock };
         return currentStatistics(locker);
     }
-    WTF_EXPORT_PRIVATE Statistics currentStatistics(const LockHolder&);
+    WTF_EXPORT_PRIVATE Statistics currentStatistics(const Locker<Lock>&);
 
     // Add more free space to the allocator. Call this directly from
     // the constructor if you wish to operate the allocator within a
@@ -134,7 +134,7 @@ protected:
     // as there are Handles that refer to it.
 
     // Release a MetaAllocatorHandle.
-    WTF_EXPORT_PRIVATE virtual void release(const LockHolder&, MetaAllocatorHandle&);
+    WTF_EXPORT_PRIVATE virtual void release(const Locker<Lock>&, MetaAllocatorHandle&);
 private:
     
     friend class MetaAllocatorHandle;

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -230,7 +230,7 @@ struct Hashtable {
             // This is not fast and it's not data-access parallel, but that's fine, because
             // hashtable resizing is guaranteed to be rare and it will never happen in steady
             // state.
-            WordLockHolder locker(hashtablesLock);
+            Locker locker(hashtablesLock);
             if (!hashtables)
                 hashtables = new Vector<Hashtable*>();
             hashtables->append(result);
@@ -243,7 +243,7 @@ struct Hashtable {
     {
         {
             // This is not fast, but that's OK. See comment in create().
-            WordLockHolder locker(hashtablesLock);
+            Locker locker(hashtablesLock);
             hashtables->removeFirst(hashtable);
         }
         

--- a/Source/WTF/wtf/WordLock.h
+++ b/Source/WTF/wtf/WordLock.h
@@ -100,9 +100,6 @@ protected:
     Atomic<uintptr_t> m_word { 0 };
 };
 
-using WordLockHolder = Locker<WordLock>;
-
 } // namespace WTF
 
 using WTF::WordLock;
-using WTF::WordLockHolder;

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -39,13 +39,13 @@ using namespace Unicode;
 
 #if USE(WEB_THREAD)
 
-class AtomStringTableLocker : public LockHolder {
+class AtomStringTableLocker : public Locker<Lock> {
     WTF_MAKE_NONCOPYABLE(AtomStringTableLocker);
 
     static Lock s_stringTableLock;
 public:
     AtomStringTableLocker()
-        : LockHolder(s_stringTableLock)
+        : Locker<Lock>(s_stringTableLock)
     {
     }
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -404,19 +404,19 @@ RefPtr<Uint8Array> CDMSessionAVContentKeySession::generateKeyReleaseMessage(unsi
 
 bool CDMSessionAVContentKeySession::hasContentKeyRequest() const
 {
-    LockHolder holder { m_keyRequestLock };
+    Locker holder { m_keyRequestLock };
     return m_keyRequest;
 }
 
 RetainPtr<AVContentKeyRequest> CDMSessionAVContentKeySession::contentKeyRequest()
 {
-    LockHolder holder { m_keyRequestLock };
+    Locker holder { m_keyRequestLock };
     return RetainPtr { m_keyRequest.get() };
 }
 
 void CDMSessionAVContentKeySession::didProvideContentKeyRequest(AVContentKeyRequest *keyRequest)
 {
-    LockHolder holder { m_keyRequestLock };
+    Locker holder { m_keyRequestLock };
     m_keyRequest = keyRequest;
     m_hasKeyRequestSemaphore.signal();
 }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -490,7 +490,7 @@ static GstStateChangeReturn changeState(GstElement* element, GstStateChange tran
     case GST_STATE_CHANGE_READY_TO_PAUSED: {
         GST_DEBUG_OBJECT(self, "READY->PAUSED");
 
-        LockHolder locker(priv->lock);
+        Locker locker(priv->lock);
         priv->isStopped = false;
         break;
     }
@@ -498,7 +498,7 @@ static GstStateChangeReturn changeState(GstElement* element, GstStateChange tran
         // We need to do this here instead of after the , otherwise we won't be able to break the wait.
         GST_DEBUG_OBJECT(self, "PAUSED->READY");
 
-        LockHolder locker(priv->lock);
+        Locker locker(priv->lock);
         priv->isStopped = true;
         priv->condition.notifyOne();
         if (priv->cdmProxy)

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaSceneIntegration.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaSceneIntegration.h
@@ -65,7 +65,7 @@ public:
 
     private:
         Ref<SceneIntegration> m_sceneIntegration;
-        LockHolder m_locker;
+        Locker<Lock> m_locker;
     };
 
     std::unique_ptr<UpdateScope> createUpdateScope();

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -152,7 +152,7 @@ void MediaRecorderPrivateBackend::stopRecording(CompletionHandler<void()>&& comp
 
     bool isEOS = false;
     while (!isEOS) {
-        LockHolder lock(m_eosLock);
+        Locker lock(m_eosLock);
         m_eosCondition.waitFor(m_eosLock, 200_ms, [weakThis = ThreadSafeWeakPtr { *this }]() -> bool {
             if (auto protectedThis = weakThis.get())
                 return protectedThis->m_eos;
@@ -412,7 +412,7 @@ void MediaRecorderPrivateBackend::processSample(GRefPtr<GstSample>&& sample)
 void MediaRecorderPrivateBackend::notifyEOS()
 {
     GST_DEBUG("EOS received");
-    LockHolder lock(m_eosLock);
+    Locker lock(m_eosLock);
     m_eos = true;
     m_eosCondition.notifyAll();
 }

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -78,7 +78,7 @@ void Instance::scheduleWork(WorkItem&& workItem)
 
 void Instance::defaultScheduleWork(WGPUWorkItem&& workItem)
 {
-    LockHolder lockHolder(m_lock);
+    Locker locker(m_lock);
     m_pendingWork.append(WTFMove(workItem));
 }
 
@@ -87,7 +87,7 @@ void Instance::processEvents()
     while (true) {
         Deque<WGPUWorkItem> localWork;
         {
-            LockHolder lockHolder(m_lock);
+            Locker locker(m_lock);
             std::swap(m_pendingWork, localWork);
         }
         if (localWork.isEmpty())

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp
@@ -106,7 +106,7 @@ void CompositingRunLoop::scheduleUpdate()
     scheduleUpdate(stateLocker);
 }
 
-void CompositingRunLoop::scheduleUpdate(LockHolder& stateLocker)
+void CompositingRunLoop::scheduleUpdate(Locker<Lock>& stateLocker)
 {
     // An update was requested. Depending on the state:
     //  - if Idle, enter the Scheduled state and start the update timer,
@@ -140,7 +140,7 @@ void CompositingRunLoop::stopUpdates()
     m_state.pendingUpdate = false;
 }
 
-void CompositingRunLoop::updateCompleted(LockHolder& stateLocker)
+void CompositingRunLoop::updateCompleted(Locker<Lock>& stateLocker)
 {
     // Scene update has been signaled as completed. Depending on the state:
     //  - if Idle, Scheduled or InProgress, do nothing,

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
@@ -58,7 +58,7 @@ public:
     void scheduleUpdate();
     void stopUpdates();
 
-    void updateCompleted(LockHolder&);
+    void updateCompleted(Locker<Lock>&);
 
     RunLoop& runLoop() const { return m_runLoop.get(); }
 
@@ -69,7 +69,7 @@ private:
         InProgress,
     };
 
-    void scheduleUpdate(LockHolder&);
+    void scheduleUpdate(Locker<Lock>&);
     void updateTimerFired();
 
     Ref<RunLoop> m_runLoop;


### PR DESCRIPTION
#### 0a519d863ac1cd38d5fe58cef8d447267641b8c5
<pre>
Drop LockHolder alias
<a href="https://bugs.webkit.org/show_bug.cgi?id=270010">https://bugs.webkit.org/show_bug.cgi?id=270010</a>

Reviewed by Darin Adler.

Drop LockHolder alias for `Locker&lt;Lock&gt;`. `Locker&lt;Lock&gt;` is not much longer and we
can often use the shorter `Locker` thanks to template parameter detection nowadays.

* Source/JavaScriptCore/heap/IsoSubspacePerVM.cpp:
(JSC::IsoSubspacePerVM::isoSubspaceforHeap):
* Source/JavaScriptCore/heap/IsoSubspacePerVM.h:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/JavaScriptCore/runtime/ConcurrentJSLock.h:
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::takeSample):
* Source/WTF/wtf/Lock.h:
* Source/WTF/wtf/MetaAllocator.cpp:
(WTF::MetaAllocator::release):
(WTF::MetaAllocator::allocate):
(WTF::MetaAllocator::currentStatistics):
* Source/WTF/wtf/MetaAllocator.h:
* Source/WTF/wtf/ParkingLot.cpp:
* Source/WTF/wtf/WordLock.h:
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringTableLocker::AtomStringTableLocker):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::hasContentKeyRequest const):
(WebCore::CDMSessionAVContentKeySession::contentKeyRequest):
(WebCore::CDMSessionAVContentKeySession::didProvideContentKeyRequest):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(changeState):
* Source/WebCore/platform/graphics/nicosia/NicosiaSceneIntegration.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::stopRecording):
(WebCore::MediaRecorderPrivateBackend::notifyEOS):
* Source/WebGPU/WebGPU/Instance.mm:
(WebGPU::Instance::defaultScheduleWork):
(WebGPU::Instance::processEvents):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp:
(WebKit::CompositingRunLoop::scheduleUpdate):
(WebKit::CompositingRunLoop::updateCompleted):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h:

Canonical link: <a href="https://commits.webkit.org/275271@main">https://commits.webkit.org/275271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/863836dd4db107576931a60cb68865c20d348317

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43904 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37432 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15008 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36611 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45264 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34793 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40687 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/40966 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39091 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17774 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/47977 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9274 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17827 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9804 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->