### PR TITLE
[build.webkit.org] Replace shell.Test with shell.TestNewStyle (Follow-up fix)

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1149,16 +1149,10 @@ class RunGLibAPITests(shell.TestNewStyle):
         if messages:
             self.statusLine = ["API tests: %s" % ", ".join(messages)]
 
-        defer.returnValue(rc)
-
-    def evaluateCommand(self, cmd):
         if self.totalFailedTests > 0:
-            return FAILURE
-
-        if cmd.rc != 0:
-            return FAILURE
-
-        return SUCCESS
+            defer.returnValue(FAILURE)
+        else:
+            defer.returnValue(SUCCESS if rc == 0 else FAILURE)
 
     def getText(self, cmd, results):
         return self.getText2(cmd, results)


### PR DESCRIPTION
#### f1618b20c06ce81c30f4d2913338d74d52962b89
<pre>
[build.webkit.org] Replace shell.Test with shell.TestNewStyle (Follow-up fix)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256970">https://bugs.webkit.org/show_bug.cgi?id=256970</a>
<a href="https://rdar.apple.com/109516328">rdar://109516328</a>

Unreviewed follow-up fix.

* Tools/CISupport/build-webkit-org/steps.py:
(RunGLibAPITests.run): Move &quot;evaluateCommand&quot; computation into &quot;run&quot;
(RunGLibAPITests.evaluateCommand): Deleted.

Canonical link: <a href="https://commits.webkit.org/275260@main">https://commits.webkit.org/275260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b25087ec536d36e563f9e8459533c3da30bc71e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41342 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/20356 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/43720 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43906 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43649 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/23439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/17686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/43906 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41916 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/23439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/43720 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/43906 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/23439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/43720 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45244 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/23439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/43720 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/45244 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/17686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45244 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41389 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/17776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/43720 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/17829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5520 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->