### PR TITLE
Disable Web Transport-related IPC endpoints when the feature is disabled at runtime

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -432,6 +432,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/MonotonicObjectIdentifier.serialization.in
     Shared/NavigationActionData.serialization.in
     Shared/NetworkProcessConnectionParameters.serialization.in
+    Shared/NetworkProcessPreferencesForWebProcess.serialization.in
     Shared/Pasteboard.serialization.in
     Shared/PlatformPopupMenuData.serialization.in
     Shared/PolicyDecision.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -308,6 +308,7 @@ $(PROJECT_DIR)/Shared/ModelProcessConnectionParameters.serialization.in
 $(PROJECT_DIR)/Shared/MonotonicObjectIdentifier.serialization.in
 $(PROJECT_DIR)/Shared/NavigationActionData.serialization.in
 $(PROJECT_DIR)/Shared/NetworkProcessConnectionParameters.serialization.in
+$(PROJECT_DIR)/Shared/NetworkProcessPreferencesForWebProcess.serialization.in
 $(PROJECT_DIR)/Shared/Notifications/NotificationManagerMessageHandler.messages.in
 $(PROJECT_DIR)/Shared/Notifications/NotificationManagerProxy.messages.in
 $(PROJECT_DIR)/Shared/PALArgumentCoders.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -632,6 +632,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/MonotonicObjectIdentifier.serialization.in \
 	Shared/NavigationActionData.serialization.in \
 	Shared/NetworkProcessConnectionParameters.serialization.in \
+	Shared/NetworkProcessPreferencesForWebProcess.serialization.in \
 	Shared/Pasteboard.serialization.in \
 	Shared/PlatformPopupMenuData.serialization.in \
 	Shared/PolicyDecision.serialization.in \

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -139,6 +139,7 @@ NetworkConnectionToWebProcess::NetworkConnectionToWebProcess(NetworkProcess& net
     , m_webProcessIdentifier(webProcessIdentifier)
     , m_schemeRegistry(NetworkSchemeRegistry::create())
     , m_originAccessPatterns(makeUniqueRef<NetworkOriginAccessPatterns>())
+    , m_preferencesForWebProcess(parameters.preferencesForWebProcess)
     , m_allowTestOnlyIPC(parameters.allowTestOnlyIPC)
 {
     RELEASE_ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -29,6 +29,7 @@
 #include "DownloadID.h"
 #include "NetworkActivityTracker.h"
 #include "NetworkMDNSRegister.h"
+#include "NetworkProcessPreferencesForWebProcess.h"
 #include "NetworkRTCProvider.h"
 #include "NetworkResourceLoadIdentifier.h"
 #include "NetworkResourceLoadMap.h"
@@ -141,6 +142,8 @@ public:
 
     IPC::Connection& connection() { return m_connection.get(); }
     NetworkProcess& networkProcess() { return m_networkProcess.get(); }
+
+    bool isWebTransportEnabled() const { return m_preferencesForWebProcess.isWebTransportEnabled; }
 
     void didCleanupResourceLoader(NetworkResourceLoader&);
     void transferKeptAliveLoad(NetworkResourceLoader&);
@@ -477,6 +480,7 @@ private:
     using BlobURLKey = std::pair<URL, std::optional<WebCore::SecurityOriginData>>;
     HashSet<BlobURLKey> m_blobURLs;
     HashCountedSet<BlobURLKey> m_blobURLHandles;
+    NetworkProcessPreferencesForWebProcess m_preferencesForWebProcess;
 #if ENABLE(IPC_TESTING_API)
     IPCTester m_ipcTester;
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -133,8 +133,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     NavigatorGetPushPermissionState(URL scopeURL) -> (Expected<uint8_t, WebCore::ExceptionData> result)
 #endif
 
-    InitializeWebTransportSession(URL url) -> (std::optional<WebKit::WebTransportSessionIdentifier> identifier)
-    DestroyWebTransportSession(WebKit::WebTransportSessionIdentifier identifier)
+    [EnabledIf='isWebTransportEnabled()'] InitializeWebTransportSession(URL url) -> (std::optional<WebKit::WebTransportSessionIdentifier> identifier)
+    [EnabledIf='isWebTransportEnabled()'] DestroyWebTransportSession(WebKit::WebTransportSessionIdentifier identifier)
 
     ClearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier frameID)
 }

--- a/Source/WebKit/Shared/NetworkProcessPreferencesForWebProcess.h
+++ b/Source/WebKit/Shared/NetworkProcessPreferencesForWebProcess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,16 +25,12 @@
 
 #pragma once
 
-#include "NetworkProcessPreferencesForWebProcess.h"
-
 namespace WebKit {
 
-struct NetworkProcessConnectionParameters {
-    bool allowTestOnlyIPC { false };
-#if ENABLE(IPC_TESTING_API)
-    bool ignoreInvalidMessageForTesting { false };
-#endif
-    NetworkProcessPreferencesForWebProcess preferencesForWebProcess;
+struct NetworkProcessPreferencesForWebProcess {
+    bool isWebTransportEnabled { false };
+
+    friend bool operator==(const NetworkProcessPreferencesForWebProcess&, const NetworkProcessPreferencesForWebProcess&) = default;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/NetworkProcessPreferencesForWebProcess.serialization.in
+++ b/Source/WebKit/Shared/NetworkProcessPreferencesForWebProcess.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,10 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-struct WebKit::NetworkProcessConnectionParameters {
-    bool allowTestOnlyIPC;
-#if ENABLE(IPC_TESTING_API)
-    bool ignoreInvalidMessageForTesting;
-#endif
-    WebKit::NetworkProcessPreferencesForWebProcess preferencesForWebProcess;
+struct WebKit::NetworkProcessPreferencesForWebProcess {
+    bool isWebTransportEnabled;
 };

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -135,7 +135,7 @@ void PageConfiguration::setPageGroup(RefPtr<WebPageGroup>&& pageGroup)
     m_data.pageGroup = WTFMove(pageGroup);
 }
 
-WebPreferences* PageConfiguration::preferences()
+WebPreferences* PageConfiguration::preferences() const
 {
     return m_data.preferences.get();
 }
@@ -277,5 +277,15 @@ WebKit::GPUProcessPreferencesForWebProcess PageConfiguration::preferencesForGPUP
     };
 }
 #endif
+
+WebKit::NetworkProcessPreferencesForWebProcess PageConfiguration::preferencesForNetworkProcess() const
+{
+    RefPtr preferences = m_data.preferences;
+    RELEASE_ASSERT(preferences);
+
+    return {
+        preferences->webTransportEnabled(),
+    };
+}
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -51,6 +51,7 @@ class WebUserContentControllerProxy;
 class WebsiteDataStore;
 
 struct GPUProcessPreferencesForWebProcess;
+struct NetworkProcessPreferencesForWebProcess;
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 class WebExtensionController;
@@ -105,7 +106,7 @@ public:
     WebKit::WebPageGroup* pageGroup();
     void setPageGroup(RefPtr<WebKit::WebPageGroup>&&);
 
-    WebKit::WebPreferences* preferences();
+    WebKit::WebPreferences* preferences() const;
     void setPreferences(RefPtr<WebKit::WebPreferences>&&);
 
     WebKit::WebPageProxy* relatedPage() const;
@@ -235,6 +236,7 @@ public:
 #if ENABLE(GPU_PROCESS)
     WebKit::GPUProcessPreferencesForWebProcess preferencesForGPUProcess() const;
 #endif
+    WebKit::NetworkProcessPreferencesForWebProcess preferencesForNetworkProcess() const;
 
 private:
     struct Data {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -304,6 +304,10 @@ void NetworkProcessProxy::getNetworkProcessConnection(WebProcessProxy& webProces
 #if ENABLE(IPC_TESTING_API)
     parameters.ignoreInvalidMessageForTesting = webProcessProxy.ignoreInvalidMessageForTesting();
 #endif
+    // The WebProcess shouldn't request a connection to the network process before we've had a chance to
+    // initialize the preferences for the network process.
+    ASSERT(webProcessProxy.preferencesForNetworkProcess());
+    parameters.preferencesForWebProcess = *webProcessProxy.preferencesForNetworkProcess();
     sendWithAsyncReply(Messages::NetworkProcess::CreateNetworkConnectionToWebProcess { webProcessProxy.coreProcessIdentifier(), webProcessProxy.sessionID(), parameters }, [this, weakThis = WeakPtr { *this }, reply = WTFMove(reply)](auto&& identifier, auto cookieAcceptPolicy) mutable {
         if (!weakThis) {
             RELEASE_LOG_ERROR(Process, "NetworkProcessProxy::getNetworkProcessConnection: NetworkProcessProxy deallocated during connection establishment");

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -64,7 +64,7 @@ RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(Web
             && process->crossOriginMode() != CrossOriginMode::Isolated
             && process->lockdownMode() == lockdownMode
             && !process->wasTerminated()
-            && process->hasSameGPUProcessPreferencesAs(pageConfiguration)) {
+            && process->hasSameGPUAndNetworkProcessPreferencesAs(pageConfiguration)) {
             return process;
         }
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -462,6 +462,7 @@ struct LoadParameters;
 struct ModelIdentifier;
 struct NavigationActionData;
 struct NetworkResourceLoadIdentifierType;
+struct NetworkProcessPreferencesForWebProcess;
 struct PDFContextMenu;
 struct PDFPluginIdentifierType;
 struct PlatformPopupMenuData;
@@ -592,9 +593,10 @@ public:
 #if ENABLE(GPU_PROCESS)
     GPUProcessPreferencesForWebProcess preferencesForGPUProcess() const;
 #endif
+    NetworkProcessPreferencesForWebProcess preferencesForNetworkProcess() const;
 
-    bool hasSameGPUProcessPreferencesAs(const API::PageConfiguration&) const;
-    bool hasSameGPUProcessPreferencesAs(const WebPageProxy& page) const { return hasSameGPUProcessPreferencesAs(page.configuration()); }
+    bool hasSameGPUAndNetworkProcessPreferencesAs(const API::PageConfiguration&) const;
+    bool hasSameGPUAndNetworkProcessPreferencesAs(const WebPageProxy& page) const { return hasSameGPUAndNetworkProcessPreferencesAs(page.configuration()); }
 
     void processIsNoLongerAssociatedWithPage(WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -165,7 +165,7 @@ RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::RegistrableD
     if (it->value->process().lockdownMode() != lockdownMode)
         return nullptr;
 
-    if (!it->value->process().hasSameGPUProcessPreferencesAs(pageConfiguration))
+    if (!it->value->process().hasSameGPUAndNetworkProcessPreferencesAs(pageConfiguration))
         return nullptr;
 
     auto process = it->value->takeProcess();

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -570,7 +570,7 @@ private:
     std::tuple<Ref<WebProcessProxy>, SuspendedPageProxy*, ASCIILiteral> processForNavigationInternal(WebPageProxy&, const API::Navigation&, Ref<WebProcessProxy>&& sourceProcess, const URL& sourceURL, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, const FrameInfoData&, Ref<WebsiteDataStore>&&);
     void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, const WebCore::RegistrableDomain&, const API::Navigation&, WebProcessProxy::LockdownMode, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
 
-    RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode);
+    RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, const API::PageConfiguration&);
 
     void initializeNewWebProcess(WebProcessProxy&, WebsiteDataStore*, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -443,26 +443,43 @@ void WebProcessProxy::updateRegistrationWithDataStore()
     }
 }
 
-void WebProcessProxy::initializePreferencesForGPUProcess(const WebPageProxy& page)
+void WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses(const WebPageProxy& page)
 {
 #if ENABLE(GPU_PROCESS)
     if (!m_preferencesForGPUProcess)
         m_preferencesForGPUProcess = page.preferencesForGPUProcess();
     else
         ASSERT(*m_preferencesForGPUProcess == page.preferencesForGPUProcess());
-#else
-    UNUSED_PARAM(page);
 #endif
+    if (!m_preferencesForNetworkProcess)
+        m_preferencesForNetworkProcess = page.preferencesForNetworkProcess();
+    else
+        ASSERT(*m_preferencesForNetworkProcess == page.preferencesForNetworkProcess());
 }
 
-bool WebProcessProxy::hasSameGPUProcessPreferencesAs(const API::PageConfiguration& pageConfiguration) const
+void WebProcessProxy::initializePreferencesForNetworkProcess(const API::PageConfiguration& pageConfiguration)
+{
+    ASSERT(!m_preferencesForNetworkProcess);
+    m_preferencesForNetworkProcess = pageConfiguration.preferencesForNetworkProcess();
+}
+
+void WebProcessProxy::initializePreferencesForNetworkProcess(const WebPreferencesStore& preferences)
+{
+    ASSERT(!m_preferencesForNetworkProcess);
+    m_preferencesForNetworkProcess = NetworkProcessPreferencesForWebProcess {
+        preferences.getBoolValueForKey(WebPreferencesKey::webTransportEnabledKey()),
+    };
+}
+
+bool WebProcessProxy::hasSameGPUAndNetworkProcessPreferencesAs(const API::PageConfiguration& pageConfiguration) const
 {
 #if ENABLE(GPU_PROCESS)
-    return !m_preferencesForGPUProcess || *m_preferencesForGPUProcess == pageConfiguration.preferencesForGPUProcess();
-#else
-    UNUSED_PARAM(pageConfiguration);
-    return true;
+    if (m_preferencesForGPUProcess && *m_preferencesForGPUProcess != pageConfiguration.preferencesForGPUProcess())
+        return false;
 #endif
+    if (m_preferencesForNetworkProcess && *m_preferencesForNetworkProcess != pageConfiguration.preferencesForNetworkProcess())
+        return false;
+    return true;
 }
 
 void WebProcessProxy::addProvisionalPageProxy(ProvisionalPageProxy& provisionalPage)
@@ -473,7 +490,7 @@ void WebProcessProxy::addProvisionalPageProxy(ProvisionalPageProxy& provisionalP
     ASSERT(!m_provisionalPages.contains(provisionalPage));
     markProcessAsRecentlyUsed();
     m_provisionalPages.add(provisionalPage);
-    initializePreferencesForGPUProcess(provisionalPage.protectedPage());
+    initializePreferencesForGPUAndNetworkProcesses(provisionalPage.protectedPage());
     updateRegistrationWithDataStore();
 }
 
@@ -498,7 +515,7 @@ void WebProcessProxy::addRemotePageProxy(RemotePageProxy& remotePage)
     ASSERT(!m_remotePages.contains(remotePage));
     m_remotePages.add(remotePage);
     markProcessAsRecentlyUsed();
-    initializePreferencesForGPUProcess(*remotePage.protectedPage());
+    initializePreferencesForGPUAndNetworkProcesses(*remotePage.protectedPage());
 }
 
 void WebProcessProxy::removeRemotePageProxy(RemotePageProxy& remotePage)
@@ -792,7 +809,7 @@ void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataS
         protectedProcessPool()->pageBeginUsingWebsiteDataStore(webPage, webPage.protectedWebsiteDataStore());
     }
 
-    initializePreferencesForGPUProcess(webPage);
+    initializePreferencesForGPUAndNetworkProcesses(webPage);
 
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
     if (webPage.preferences().backgroundWebContentRunningBoardThrottlingEnabled())

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -30,6 +30,7 @@
 #include "BackgroundProcessResponsivenessTimer.h"
 #include "GPUProcessPreferencesForWebProcess.h"
 #include "MessageReceiverMap.h"
+#include "NetworkProcessPreferencesForWebProcess.h"
 #include "NetworkProcessProxy.h"
 #include "ProcessLauncher.h"
 #include "ProcessTerminationReason.h"
@@ -178,6 +179,9 @@ public:
 #if ENABLE(GPU_PROCESS)
     const std::optional<GPUProcessPreferencesForWebProcess>& preferencesForGPUProcess() const { return m_preferencesForGPUProcess; }
 #endif
+    const std::optional<NetworkProcessPreferencesForWebProcess>& preferencesForNetworkProcess() const { return m_preferencesForNetworkProcess; }
+    void initializePreferencesForNetworkProcess(const API::PageConfiguration&);
+    void initializePreferencesForNetworkProcess(const WebPreferencesStore&);
 
     bool isMatchingRegistrableDomain(const WebCore::RegistrableDomain& domain) const { return m_registrableDomain ? *m_registrableDomain == domain : false; }
     WebCore::RegistrableDomain registrableDomain() const { return valueOrDefault(m_registrableDomain); }
@@ -394,7 +398,7 @@ public:
     void sendAudioComponentRegistrations();
 #endif
 
-    bool hasSameGPUProcessPreferencesAs(const API::PageConfiguration&) const;
+    bool hasSameGPUAndNetworkProcessPreferencesAs(const API::PageConfiguration&) const;
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
     void enableRemoteInspectorIfNeeded();
@@ -540,7 +544,7 @@ private:
     static WebPageProxyMap& globalPageMap();
     static Vector<Ref<WebPageProxy>> globalPages();
 
-    void initializePreferencesForGPUProcess(const WebPageProxy&);
+    void initializePreferencesForGPUAndNetworkProcesses(const WebPageProxy&);
 
     void reportProcessDisassociatedWithPageIfNecessary(WebPageProxyIdentifier);
     bool isAssociatedWithPage(WebPageProxyIdentifier) const;
@@ -773,6 +777,7 @@ private:
 #if ENABLE(GPU_PROCESS)
     mutable std::optional<GPUProcessPreferencesForWebProcess> m_preferencesForGPUProcess;
 #endif
+    mutable std::optional<NetworkProcessPreferencesForWebProcess> m_preferencesForNetworkProcess;
 
     ProcessThrottleState m_throttleStateForStatistics { ProcessThrottleState::Suspended };
     MonotonicTime m_throttleStateForStatisticsTimestamp;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1121,6 +1121,7 @@
 		46C916AA2799D0A2001A4E7C /* WebSharedWorkerServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 46C916A92799D09D001A4E7C /* WebSharedWorkerServer.h */; };
 		46CE3B1123D8C8490016A96A /* WebBackForwardListCounts.h in Headers */ = {isa = PBXBuildFile; fileRef = 46CE3B1023D8C83D0016A96A /* WebBackForwardListCounts.h */; };
 		46D246262AFE956500F24C94 /* PlatformCAAnimationRemoteProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 46D246242AFE954F00F24C94 /* PlatformCAAnimationRemoteProperties.h */; };
+		46D3F7BB2B844E9F0044D45F /* NetworkProcessPreferencesForWebProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 46D3F7BA2B844E8F0044D45F /* NetworkProcessPreferencesForWebProcess.h */; };
 		46D48FCE2799D7E1007D2014 /* WebSharedWorkerServerToContextConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 46D48FCD2799D7DE007D2014 /* WebSharedWorkerServerToContextConnection.h */; };
 		46DBC28C2AF96B9F00E6B63A /* ITPThirdPartyData.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DBC28A2AF96B9700E6B63A /* ITPThirdPartyData.h */; };
 		46DBC28D2AF96BA400E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h in Headers */ = {isa = PBXBuildFile; fileRef = 46DBC28B2AF96B9700E6B63A /* ITPThirdPartyDataForSpecificFirstParty.h */; };
@@ -5357,6 +5358,8 @@
 		46CE3B1023D8C83D0016A96A /* WebBackForwardListCounts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBackForwardListCounts.h; sourceTree = "<group>"; };
 		46D246242AFE954F00F24C94 /* PlatformCAAnimationRemoteProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformCAAnimationRemoteProperties.h; sourceTree = "<group>"; };
 		46D246252AFE954F00F24C94 /* PlatformCAAnimationRemoteProperties.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PlatformCAAnimationRemoteProperties.serialization.in; sourceTree = "<group>"; };
+		46D3F7B92B844E8F0044D45F /* NetworkProcessPreferencesForWebProcess.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = NetworkProcessPreferencesForWebProcess.serialization.in; sourceTree = "<group>"; };
+		46D3F7BA2B844E8F0044D45F /* NetworkProcessPreferencesForWebProcess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkProcessPreferencesForWebProcess.h; sourceTree = "<group>"; };
 		46D48FCC2799D7DD007D2014 /* WebSharedWorkerServerToContextConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSharedWorkerServerToContextConnection.cpp; sourceTree = "<group>"; };
 		46D48FCD2799D7DE007D2014 /* WebSharedWorkerServerToContextConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSharedWorkerServerToContextConnection.h; sourceTree = "<group>"; };
 		46DA285727B73E760089D339 /* WebGeolocationManagerProxyCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGeolocationManagerProxyCocoa.cpp; sourceTree = "<group>"; };
@@ -9022,6 +9025,8 @@
 				86D1968129A512590083B077 /* NavigationActionData.serialization.in */,
 				86D1970829AE4E930083B077 /* NetworkProcessConnectionParameters.h */,
 				86D1970729AE4E8A0083B077 /* NetworkProcessConnectionParameters.serialization.in */,
+				46D3F7BA2B844E8F0044D45F /* NetworkProcessPreferencesForWebProcess.h */,
+				46D3F7B92B844E8F0044D45F /* NetworkProcessPreferencesForWebProcess.serialization.in */,
 				5CD748B523C8EB190092A9B5 /* NetworkResourceLoadIdentifier.h */,
 				8657EE3928EDB8C500FF9B40 /* Pasteboard.serialization.in */,
 				7AFBD36E21E546E3005DBACB /* PersistencyUtils.cpp */,
@@ -16295,6 +16300,7 @@
 				5C1426ED1C23F80900D41183 /* NetworkProcessCreationParameters.h in Headers */,
 				5163199516289A6300E22F00 /* NetworkProcessMessages.h in Headers */,
 				E14A954A16E016A40068DE82 /* NetworkProcessPlatformStrategies.h in Headers */,
+				46D3F7BB2B844E9F0044D45F /* NetworkProcessPreferencesForWebProcess.h in Headers */,
 				5179556E162877B300FA43B6 /* NetworkProcessProxy.h in Headers */,
 				513A163D163088F6005D7D22 /* NetworkProcessProxyMessages.h in Headers */,
 				5C1426EE1C23F80900D41183 /* NetworkProcessSupplement.h in Headers */,

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -123,7 +123,7 @@ void NetworkProcessConnection::didReceiveMessage(IPC::Connection& connection, IP
         WebProcess::singleton().fileSystemStorageConnection().didReceiveMessage(connection, decoder);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebTransportSession::messageReceiverName()) {
+    if (decoder.messageReceiverName() == Messages::WebTransportSession::messageReceiverName() && WebProcess::singleton().isWebTransportEnabled()) {
         if (auto* webTransportSession = WebProcess::singleton().webTransportSession(WebTransportSessionIdentifier(decoder.destinationID())))
             webTransportSession->didReceiveMessage(connection, decoder);
         return;

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -55,6 +55,7 @@ WebTransportSession::WebTransportSession(WebTransportSessionIdentifier identifie
     : m_identifier(identifier)
 {
     ASSERT(RunLoop::isMain());
+    RELEASE_ASSERT(WebProcess::singleton().isWebTransportEnabled());
     WebProcess::singleton().addWebTransportSession(m_identifier, *this);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7302,6 +7302,11 @@ void WebPage::setSmartInsertDeleteEnabled(bool enabled)
     }
 }
 
+bool WebPage::isWebTransportEnabled() const
+{
+    return m_page->settings().webTransportEnabled();
+}
+
 bool WebPage::isSelectTrailingWhitespaceEnabled() const
 {
     return m_page->settings().selectTrailingWhitespaceEnabled();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1119,6 +1119,8 @@ public:
     bool isSmartInsertDeleteEnabled();
     void setSmartInsertDeleteEnabled(bool);
 
+    bool isWebTransportEnabled() const;
+
     bool isSelectTrailingWhitespaceEnabled() const;
     void setSelectTrailingWhitespaceEnabled(bool);
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -685,6 +685,17 @@ bool WebProcess::areAllPagesSuspended() const
     return true;
 }
 
+void WebProcess::updateIsWebTransportEnabled()
+{
+    for (auto& page : m_pageMap.values()) {
+        if (page->isWebTransportEnabled()) {
+            m_isWebTransportEnabled = true;
+            return;
+        }
+    }
+    m_isWebTransportEnabled = false;
+}
+
 void WebProcess::setHasSuspendedPageProxy(bool hasSuspendedPageProxy)
 {
     ASSERT(m_hasSuspendedPageProxy != hasSuspendedPageProxy);
@@ -884,6 +895,7 @@ void WebProcess::createWebPage(PageIdentifier pageID, WebPageCreationParameters&
         // Balanced by an enableTermination in removeWebPage.
         disableTermination();
         updateCPULimit();
+        updateIsWebTransportEnabled();
 #if OS(LINUX)
         RealTimeThreads::singleton().setEnabled(hasVisibleWebPage());
 #endif
@@ -908,6 +920,7 @@ void WebProcess::removeWebPage(PageIdentifier pageID)
 
     enableTermination();
     updateCPULimit();
+    updateIsWebTransportEnabled();
 #if OS(LINUX)
     RealTimeThreads::singleton().setEnabled(hasVisibleWebPage());
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -206,6 +206,7 @@ public:
     void removeWebPage(WebCore::PageIdentifier);
     WebPage* focusedWebPage() const;
     bool hasEverHadAnyWebPages() const { return m_hasEverHadAnyWebPages; }
+    bool isWebTransportEnabled() const { return m_isWebTransportEnabled; }
 
     InjectedBundle* injectedBundle() const { return m_injectedBundle.get(); }
     
@@ -823,6 +824,8 @@ private:
     HashCountedSet<WebCore::ServiceWorkerRegistrationIdentifier> m_swRegistrationCounts;
 
     HashMap<StorageAreaMapIdentifier, WeakPtr<StorageAreaMap>> m_storageAreaMaps;
+
+    void updateIsWebTransportEnabled();
     
     // Prewarmed WebProcesses do not have an associated sessionID yet, which is why this is an optional.
     // By the time the WebProcess gets a WebPage, it is guaranteed to have a sessionID.
@@ -854,6 +857,7 @@ private:
     bool m_imageAnimationEnabled { true };
     bool m_hasEverHadAnyWebPages { false };
     bool m_hasPendingAccessibilityUnsuspension { false };
+    bool m_isWebTransportEnabled { false };
 #if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
     bool m_prefersNonBlinkingCursor { false };
 #endif


### PR DESCRIPTION
#### 809e3920b67fb7167c2dd9328ca85508f0ddb80b
<pre>
Disable Web Transport-related IPC endpoints when the feature is disabled at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=269742">https://bugs.webkit.org/show_bug.cgi?id=269742</a>
<a href="https://rdar.apple.com/122108912">rdar://122108912</a>

Reviewed by Alex Christensen.

Follow the same pattern as for the GPUProcess, introduce a
NetworkProcessPreferencesForWebProcess struct which contains the set of
WebProcess preferences the NetworkProcess needs to know about (for now
&quot;isWebTransportEnabled&quot;). These preferences are passed to the network
process when the WebProcess initiates the connection to the network
process.

The NetworkProcess can then use these preferences to decide whether
or not to enable particular IPC endpoints with the WebProcess, using
[EnabledIf] in messages.in.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
(WebKit::NetworkConnectionToWebProcess::isWebTransportEnabled const):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/Shared/NetworkProcessConnectionParameters.h:
* Source/WebKit/Shared/NetworkProcessConnectionParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::preferences const):
(API::PageConfiguration::preferencesForNetworkProcess const):
(API::PageConfiguration::preferences): Deleted.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getNetworkProcessConnection):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::findReusableSuspendedPageProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs const):
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::preferencesForNetworkProcess const):
(WebKit::WebPageProxy::hasSameGPUProcessPreferencesAs const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::takeProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcessPool::tryTakePrewarmedProcess):
(WebKit::WebProcessPool::processForRegistrableDomain):
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses):
(WebKit::WebProcessProxy::initializePreferencesForNetworkProcess):
(WebKit::WebProcessProxy::hasSameGPUAndNetworkProcessPreferencesAs const):
(WebKit::WebProcessProxy::addProvisionalPageProxy):
(WebKit::WebProcessProxy::addRemotePageProxy):
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::initializePreferencesForGPUProcess): Deleted.
(WebKit::WebProcessProxy::hasSameGPUProcessPreferencesAs const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::preferencesForNetworkProcess const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::didReceiveMessage):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::WebTransportSession):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::isWebTransportEnabled const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::updateIsWebTransportEnabled):
(WebKit::WebProcess::createWebPage):
(WebKit::WebProcess::removeWebPage):
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::isWebTransportEnabled const):

Canonical link: <a href="https://commits.webkit.org/275270@main">https://commits.webkit.org/275270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fe9d96e06a2fda1f122a6786b5306e2d6e671b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37455 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34194 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14855 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15021 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45299 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40704 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13271 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39106 "5 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17850 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5524 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->