### PR TITLE
Remove Event::eventInterface

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp
@@ -43,11 +43,6 @@ GPUError GPUUncapturedErrorEvent::error() const
     return m_uncapturedErrorEventInit.error;
 }
 
-EventInterface GPUUncapturedErrorEvent::eventInterface() const
-{
-    return GPUUncapturedErrorEventInterfaceType;
-}
-
 }
 
 

--- a/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.h
+++ b/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.h
@@ -46,7 +46,6 @@ public:
     }
 
     GPUError error() const;
-    EventInterface eventInterface() const override;
 
 private:
     GPUUncapturedErrorEvent(const AtomString&, GPUUncapturedErrorEventInit&&);

--- a/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.h
+++ b/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.h
@@ -51,8 +51,6 @@ public:
 
     String availability() const { return m_availability; }
 
-    EventInterface eventInterface() const override { return WebKitPlaybackTargetAvailabilityEventInterfaceType; }
-
 private:
     explicit WebKitPlaybackTargetAvailabilityEvent(const AtomString& eventType, bool available);
     WebKitPlaybackTargetAvailabilityEvent(const AtomString& eventType, const Init&, IsTrusted);

--- a/Source/WebCore/Modules/applepay/ApplePayCancelEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayCancelEvent.cpp
@@ -46,11 +46,6 @@ ApplePaySessionError ApplePayCancelEvent::sessionError() const
     return m_sessionError.sessionError();
 }
 
-EventInterface ApplePayCancelEvent::eventInterface() const
-{
-    return ApplePayCancelEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/Modules/applepay/ApplePayCancelEvent.h
+++ b/Source/WebCore/Modules/applepay/ApplePayCancelEvent.h
@@ -47,9 +47,6 @@ public:
 private:
     explicit ApplePayCancelEvent(const AtomString&, PaymentSessionError&&);
 
-    // Event.
-    EventInterface eventInterface() const final;
-
     PaymentSessionError m_sessionError;
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.cpp
@@ -42,11 +42,6 @@ ApplePayCouponCodeChangedEvent::ApplePayCouponCodeChangedEvent(const AtomString&
 
 ApplePayCouponCodeChangedEvent::~ApplePayCouponCodeChangedEvent() = default;
 
-EventInterface ApplePayCouponCodeChangedEvent::eventInterface() const
-{
-    return ApplePayCouponCodeChangedEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(APPLE_PAY_COUPON_CODE)

--- a/Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.h
+++ b/Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.h
@@ -47,9 +47,6 @@ public:
 private:
     ApplePayCouponCodeChangedEvent(const AtomString& type, String&&);
 
-    // Event
-    EventInterface eventInterface() const override;
-
     const String m_couponCode;
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.cpp
@@ -43,11 +43,6 @@ ApplePayPaymentAuthorizedEvent::ApplePayPaymentAuthorizedEvent(const AtomString&
 
 ApplePayPaymentAuthorizedEvent::~ApplePayPaymentAuthorizedEvent() = default;
 
-EventInterface ApplePayPaymentAuthorizedEvent::eventInterface() const
-{
-    return ApplePayPaymentAuthorizedEventInterfaceType;
-}
-
 }
 
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.h
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.h
@@ -49,9 +49,6 @@ public:
 private:
     ApplePayPaymentAuthorizedEvent(const AtomString& type, unsigned version, const Payment&);
 
-    // Event.
-    EventInterface eventInterface() const override;
-
     const ApplePayPayment m_payment;
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.cpp
@@ -43,11 +43,6 @@ ApplePayPaymentMethodSelectedEvent::ApplePayPaymentMethodSelectedEvent(const Ato
 
 ApplePayPaymentMethodSelectedEvent::~ApplePayPaymentMethodSelectedEvent() = default;
 
-EventInterface ApplePayPaymentMethodSelectedEvent::eventInterface() const
-{
-    return ApplePayPaymentMethodSelectedEventInterfaceType;
-}
-
 }
 
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.h
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.h
@@ -49,9 +49,6 @@ public:
 private:
     ApplePayPaymentMethodSelectedEvent(const AtomString& type, const PaymentMethod&);
 
-    // Event.
-    EventInterface eventInterface() const override;
-
     const ApplePayPaymentMethod m_paymentMethod;
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp
@@ -43,11 +43,6 @@ ApplePayShippingContactSelectedEvent::ApplePayShippingContactSelectedEvent(const
 
 ApplePayShippingContactSelectedEvent::~ApplePayShippingContactSelectedEvent() = default;
 
-EventInterface ApplePayShippingContactSelectedEvent::eventInterface() const
-{
-    return ApplePayShippingContactSelectedEventInterfaceType;
-}
-
 }
 
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.h
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.h
@@ -49,9 +49,6 @@ public:
 private:
     ApplePayShippingContactSelectedEvent(const AtomString& type, unsigned version, const PaymentContact&);
 
-    // Event.
-    EventInterface eventInterface() const override;
-
     const ApplePayPaymentContact m_shippingContact;
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.cpp
@@ -43,11 +43,6 @@ ApplePayShippingMethodSelectedEvent::ApplePayShippingMethodSelectedEvent(const A
 
 ApplePayShippingMethodSelectedEvent::~ApplePayShippingMethodSelectedEvent() = default;
 
-EventInterface ApplePayShippingMethodSelectedEvent::eventInterface() const
-{
-    return ApplePayShippingMethodSelectedEventInterfaceType;
-}
-
 }
 
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.h
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.h
@@ -47,9 +47,6 @@ public:
 private:
     ApplePayShippingMethodSelectedEvent(const AtomString& type, const ApplePayShippingMethod&);
 
-    // Event.
-    EventInterface eventInterface() const override;
-
     const ApplePayShippingMethod m_shippingMethod;
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.cpp
@@ -42,11 +42,6 @@ ApplePayValidateMerchantEvent::ApplePayValidateMerchantEvent(const AtomString& t
 
 ApplePayValidateMerchantEvent::~ApplePayValidateMerchantEvent() = default;
 
-EventInterface ApplePayValidateMerchantEvent::eventInterface() const
-{
-    return ApplePayValidateMerchantEventInterfaceType;
-}
-
 }
 
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.h
+++ b/Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.h
@@ -47,9 +47,6 @@ public:
 private:
     ApplePayValidateMerchantEvent(const AtomString& type, URL&& validationURL);
 
-    // Event.
-    EventInterface eventInterface() const override;
-
     const URL m_validationURL;
 };
 

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp
@@ -49,9 +49,4 @@ CookieChangeEvent::CookieChangeEvent(const AtomString& type, CookieChangeEventIn
 
 CookieChangeEvent::~CookieChangeEvent() = default;
 
-EventInterface CookieChangeEvent::eventInterface() const
-{
-    return CookieChangeEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEvent.h
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEvent.h
@@ -47,9 +47,6 @@ public:
 private:
     CookieChangeEvent(const AtomString& type, CookieChangeEventInit&&, IsTrusted);
 
-    // Event
-    EventInterface eventInterface() const final;
-
     Vector<CookieListItem> m_changed;
     Vector<CookieListItem> m_deleted;
 };

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp
@@ -49,9 +49,4 @@ ExtendableCookieChangeEvent::ExtendableCookieChangeEvent(const AtomString& type,
 
 ExtendableCookieChangeEvent::~ExtendableCookieChangeEvent() = default;
 
-EventInterface ExtendableCookieChangeEvent::eventInterface() const
-{
-    return ExtendableCookieChangeEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.h
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.h
@@ -47,9 +47,6 @@ public:
 private:
     ExtendableCookieChangeEvent(const AtomString& type, ExtendableCookieChangeEventInit&&, IsTrusted);
 
-    // ExtendableEvent
-    EventInterface eventInterface() const final;
-
     Vector<CookieListItem> m_changed;
     Vector<CookieListItem> m_deleted;
 };

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.cpp
@@ -48,11 +48,6 @@ MediaKeyMessageEvent::MediaKeyMessageEvent(const AtomString& type, const MediaKe
 
 MediaKeyMessageEvent::~MediaKeyMessageEvent() = default;
 
-EventInterface MediaKeyMessageEvent::eventInterface() const
-{
-    return MediaKeyMessageEventInterfaceType;
-}
-
 RefPtr<JSC::ArrayBuffer> MediaKeyMessageEvent::message() const
 {
     return m_message;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.h
@@ -57,9 +57,6 @@ public:
 private:
     MediaKeyMessageEvent(const AtomString&, const MediaKeyMessageEventInit&, IsTrusted);
 
-    // Event
-    EventInterface eventInterface() const override;
-
     MediaKeyMessageType m_messageType;
     RefPtr<JSC::ArrayBuffer> m_message;
 };

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp
@@ -52,11 +52,6 @@ WebKitMediaKeyMessageEvent::WebKitMediaKeyMessageEvent(const AtomString& type, c
 
 WebKitMediaKeyMessageEvent::~WebKitMediaKeyMessageEvent() = default;
 
-EventInterface WebKitMediaKeyMessageEvent::eventInterface() const
-{
-    return WebKitMediaKeyMessageEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.h
@@ -53,8 +53,6 @@ public:
         return adoptRef(*new WebKitMediaKeyMessageEvent(type, initializer, isTrusted));
     }
 
-    EventInterface eventInterface() const override;
-
     Uint8Array* message() const { return m_message.get(); }
     String destinationURL() const { return m_destinationURL; }
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp
@@ -49,11 +49,6 @@ WebKitMediaKeyNeededEvent::WebKitMediaKeyNeededEvent(const AtomString& type, con
 
 WebKitMediaKeyNeededEvent::~WebKitMediaKeyNeededEvent() = default;
 
-EventInterface WebKitMediaKeyNeededEvent::eventInterface() const
-{
-    return WebKitMediaKeyNeededEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.h
@@ -51,8 +51,6 @@ public:
         return adoptRef(*new WebKitMediaKeyNeededEvent(type, initializer, isTrusted));
     }
 
-    EventInterface eventInterface() const override;
-
     Uint8Array* initData() const { return m_initData.get(); }
 
 private:

--- a/Source/WebCore/Modules/gamepad/GamepadEvent.h
+++ b/Source/WebCore/Modules/gamepad/GamepadEvent.h
@@ -54,8 +54,6 @@ public:
 
     Gamepad* gamepad() const { return m_gamepad.get(); }
 
-    EventInterface eventInterface() const override { return GamepadEventInterfaceType; }
-
 private:
     explicit GamepadEvent(const AtomString& eventType, Gamepad&);
     GamepadEvent(const AtomString& eventType, const Init&, IsTrusted);

--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.cpp
@@ -50,9 +50,4 @@ IDBVersionChangeEvent::IDBVersionChangeEvent(const AtomString& name, const Init&
 {
 }
 
-EventInterface IDBVersionChangeEvent::eventInterface() const
-{
-    return IDBVersionChangeEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.h
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.h
@@ -64,8 +64,6 @@ private:
     IDBVersionChangeEvent(const IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion, const AtomString& eventType);
     IDBVersionChangeEvent(const AtomString&, const Init&, IsTrusted);
 
-    EventInterface eventInterface() const;
-
     IDBResourceIdentifier m_requestIdentifier;
     uint64_t m_oldVersion;
     std::optional<uint64_t> m_newVersion;

--- a/Source/WebCore/Modules/mediarecorder/BlobEvent.cpp
+++ b/Source/WebCore/Modules/mediarecorder/BlobEvent.cpp
@@ -47,11 +47,6 @@ BlobEvent::BlobEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
 }
 
-EventInterface BlobEvent::eventInterface() const
-{
-    return BlobEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_RECORDER)

--- a/Source/WebCore/Modules/mediarecorder/BlobEvent.h
+++ b/Source/WebCore/Modules/mediarecorder/BlobEvent.h
@@ -48,10 +48,7 @@ public:
 private:
     BlobEvent(const AtomString&, Init&&, IsTrusted);
     BlobEvent(const AtomString&, CanBubble, IsCancelable, Ref<Blob>&&);
-    
-    // Event
-    EventInterface eventInterface() const final;
-    
+
     Ref<Blob> m_blob;
     double m_timecode { 0 };
 };

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp
@@ -58,11 +58,6 @@ MediaRecorderErrorEvent::MediaRecorderErrorEvent(const AtomString& type, Excepti
 {
 }
 
-EventInterface MediaRecorderErrorEvent::eventInterface() const
-{
-    return MediaRecorderErrorEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_RECORDER)

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h
@@ -46,9 +46,6 @@ public:
 private:
     MediaRecorderErrorEvent(const AtomString&, Init&&, Ref<DOMException>&&, IsTrusted);
     MediaRecorderErrorEvent(const AtomString&, Exception&&);
-    
-    // Event
-    EventInterface eventInterface() const override;
 
     Ref<DOMException> m_domError;
 };

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp
@@ -63,11 +63,6 @@ RefPtr<TimeRanges> BufferedChangeEvent::removedRanges() const
     return m_removed;
 }
 
-EventInterface BufferedChangeEvent::eventInterface() const
-{
-    return BufferedChangeEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.h
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.h
@@ -59,7 +59,6 @@ public:
 private:
     BufferedChangeEvent(RefPtr<TimeRanges>&& added, RefPtr<TimeRanges>&& removed);
     BufferedChangeEvent(const AtomString& type, Init&&);
-    EventInterface eventInterface() const final;
 
     RefPtr<TimeRanges> m_added;
     RefPtr<TimeRanges> m_removed;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp
@@ -63,11 +63,6 @@ MediaStreamTrack* MediaStreamTrackEvent::track() const
     return m_track.get();
 }
 
-EventInterface MediaStreamTrackEvent::eventInterface() const
-{
-    return MediaStreamTrackEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.h
@@ -47,9 +47,6 @@ public:
 
     MediaStreamTrack* track() const;
 
-    // Event
-    EventInterface eventInterface() const override;
-
 private:
     MediaStreamTrackEvent(const AtomString& type, CanBubble, IsCancelable, RefPtr<MediaStreamTrack>&&);
     MediaStreamTrackEvent(const AtomString& type, const Init&, IsTrusted);

--- a/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.h
@@ -56,7 +56,6 @@ public:
     }
 
     OverconstrainedError* error() const { return m_error.get(); }
-    EventInterface eventInterface() const override { return OverconstrainedErrorEventInterfaceType; }
 
 private:
     explicit OverconstrainedErrorEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, OverconstrainedError* error)

--- a/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp
@@ -64,11 +64,6 @@ const String& RTCDTMFToneChangeEvent::tone() const
     return m_tone;
 }
 
-EventInterface RTCDTMFToneChangeEvent::eventInterface() const
-{
-    return RTCDTMFToneChangeEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.h
@@ -47,8 +47,6 @@ public:
 
     const String& tone() const;
 
-    virtual EventInterface eventInterface() const;
-
 private:
     explicit RTCDTMFToneChangeEvent(const String& tone);
     RTCDTMFToneChangeEvent(const AtomString& type, const Init&, IsTrusted);

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp
@@ -62,11 +62,6 @@ RTCDataChannel& RTCDataChannelEvent::channel()
     return m_channel.get();
 }
 
-EventInterface RTCDataChannelEvent::eventInterface() const
-{
-    return RTCDataChannelEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.h
@@ -45,8 +45,6 @@ public:
 
     RTCDataChannel& channel();
 
-    virtual EventInterface eventInterface() const;
-
 private:
     RTCDataChannelEvent(const AtomString& type, CanBubble, IsCancelable, Ref<RTCDataChannel>&&);
     RTCDataChannelEvent(const AtomString& type, Init&&, IsTrusted);

--- a/Source/WebCore/Modules/mediastream/RTCErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCErrorEvent.h
@@ -46,9 +46,6 @@ public:
 private:
     RTCErrorEvent(const AtomString& type, Init&&, IsTrusted);
 
-    // Event
-    EventInterface eventInterface() const final { return RTCErrorEventInterfaceType; }
-
     Ref<RTCError> m_error;
 };
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.cpp
@@ -58,11 +58,6 @@ RTCPeerConnectionIceErrorEvent::RTCPeerConnectionIceErrorEvent(const AtomString&
 
 RTCPeerConnectionIceErrorEvent::~RTCPeerConnectionIceErrorEvent() = default;
 
-EventInterface RTCPeerConnectionIceErrorEvent::eventInterface() const
-{
-    return RTCPeerConnectionIceErrorEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.h
@@ -55,8 +55,6 @@ public:
     uint16_t errorCode() const { return m_errorCode; }
     const String& errorText() const { return m_errorText; }
 
-    virtual EventInterface eventInterface() const;
-
 private:
     RTCPeerConnectionIceErrorEvent(const AtomString& type, CanBubble, IsCancelable, String&& address, std::optional<uint16_t> port, String&& url, uint16_t errorCode, String&& errorText);
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp
@@ -60,11 +60,6 @@ RTCIceCandidate* RTCPeerConnectionIceEvent::candidate() const
     return m_candidate.get();
 }
 
-EventInterface RTCPeerConnectionIceEvent::eventInterface() const
-{
-    return RTCPeerConnectionIceEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
@@ -48,8 +48,6 @@ public:
     RTCIceCandidate* candidate() const;
     const String& url() const { return m_url; }
 
-    virtual EventInterface eventInterface() const;
-
 private:
     RTCPeerConnectionIceEvent(const AtomString& type, CanBubble, IsCancelable, RefPtr<RTCIceCandidate>&&, String&& serverURL);
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.cpp
@@ -54,11 +54,6 @@ RTCRtpSFrameTransformErrorEvent::RTCRtpSFrameTransformErrorEvent(const AtomStrin
 
 RTCRtpSFrameTransformErrorEvent::~RTCRtpSFrameTransformErrorEvent() = default;
 
-EventInterface RTCRtpSFrameTransformErrorEvent::eventInterface() const
-{
-    return RTCRtpSFrameTransformErrorEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.h
@@ -47,8 +47,6 @@ public:
 
     Type errorType() const { return m_errorType; }
 
-    virtual EventInterface eventInterface() const;
-
 private:
     RTCRtpSFrameTransformErrorEvent(const AtomString& type, CanBubble, IsCancelable, Type);
 

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.h
@@ -62,8 +62,6 @@ public:
     const MediaStreamArray& streams() const  { return m_streams; }
     RTCRtpTransceiver* transceiver() const  { return m_transceiver.get(); }
 
-    virtual EventInterface eventInterface() const { return RTCTrackEventInterfaceType; }
-
 private:
     RTCTrackEvent(const AtomString& type, CanBubble, IsCancelable, RefPtr<RTCRtpReceiver>&&, RefPtr<MediaStreamTrack>&&, MediaStreamArray&&, RefPtr<RTCRtpTransceiver>&&);
     RTCTrackEvent(const AtomString& type, const Init&, IsTrusted);

--- a/Source/WebCore/Modules/mediastream/RTCTransformEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCTransformEvent.cpp
@@ -49,11 +49,6 @@ RTCRtpScriptTransformer& RTCTransformEvent::transformer()
     return m_transformer.get();
 }
 
-EventInterface RTCTransformEvent::eventInterface() const
-{
-    return RTCTransformEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCTransformEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCTransformEvent.h
@@ -39,8 +39,6 @@ public:
 
     RTCRtpScriptTransformer& transformer();
 
-    EventInterface eventInterface() const final;
-
 private:
     RTCTransformEvent(const AtomString& type, Ref<RTCRtpScriptTransformer>&&, IsTrusted);
 

--- a/Source/WebCore/Modules/notifications/NotificationEvent.h
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.h
@@ -49,8 +49,6 @@ public:
     static Ref<NotificationEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     static Ref<NotificationEvent> create(const AtomString&, Notification*, const String& action, IsTrusted = IsTrusted::No);
 
-    EventInterface eventInterface() const final { return NotificationEventInterfaceType; }
-
     Notification* notification() { return m_notification.get(); }
     const String& action() { return m_action; }
 

--- a/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp
@@ -75,11 +75,6 @@ MerchantValidationEvent::MerchantValidationEvent(const AtomString& type, String&
     ASSERT(m_validationURL.isValid());
 }
 
-EventInterface MerchantValidationEvent::eventInterface() const
-{
-    return MerchantValidationEventInterfaceType;
-}
-
 ExceptionOr<void> MerchantValidationEvent::complete(Ref<DOMPromise>&& merchantSessionPromise)
 {
     if (!isTrusted())

--- a/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.h
@@ -54,9 +54,6 @@ private:
     MerchantValidationEvent(const AtomString& type, const String& methodName, URL&& validationURL);
     MerchantValidationEvent(const AtomString& type, String&& methodName, URL&& validationURL, Init&&);
 
-    // Event
-    EventInterface eventInterface() const final;
-
     bool m_isCompleted { false };
     String m_methodName;
     URL m_validationURL;

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
@@ -34,11 +34,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(PaymentMethodChangeEvent);
 
-EventInterface PaymentMethodChangeEvent::eventInterface() const
-{
-    return PaymentMethodChangeEventInterfaceType;
-}
-
 PaymentMethodChangeEvent::PaymentMethodChangeEvent(const AtomString& type, Init&& eventInit)
     : PaymentRequestUpdateEvent { EventInterfaceType::PaymentMethodChangeEvent, type, eventInit }
     , m_methodName { WTFMove(eventInit.methodName) }

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h
@@ -54,9 +54,6 @@ public:
     const MethodDetailsType& methodDetails() const { return m_methodDetails; }
     JSValueInWrappedObject& cachedMethodDetails() { return m_cachedMethodDetails; }
 
-    // Event
-    EventInterface eventInterface() const override;
-    
     struct Init final : PaymentRequestUpdateEventInit {
         String methodName;
         JSC::Strong<JSC::JSObject> methodDetails;

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp
@@ -81,11 +81,6 @@ ExceptionOr<void> PaymentRequestUpdateEvent::updateWith(Ref<DOMPromise>&& detail
     return { };
 }
 
-EventInterface PaymentRequestUpdateEvent::eventInterface() const
-{
-    return PaymentRequestUpdateEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(PAYMENT_REQUEST)

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h
@@ -51,9 +51,6 @@ protected:
     explicit PaymentRequestUpdateEvent(enum EventInterfaceType, const AtomString& type);
     PaymentRequestUpdateEvent(enum EventInterfaceType, const AtomString& type, const PaymentRequestUpdateEventInit&);
 
-    // Event
-    EventInterface eventInterface() const override;
-
 private:
     bool m_waitForUpdate { false };
 };

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.h
@@ -45,8 +45,6 @@ public:
 
     PictureInPictureWindow& pictureInPictureWindow() const { return m_pictureInPictureWindow.get(); }
 
-    EventInterface eventInterface() const final { return PictureInPictureEventInterfaceType; }
-
 private:
     PictureInPictureEvent(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
 

--- a/Source/WebCore/Modules/push-api/PushEvent.h
+++ b/Source/WebCore/Modules/push-api/PushEvent.h
@@ -39,7 +39,6 @@ public:
     static Ref<PushEvent> create(const AtomString&, ExtendableEventInit&&, std::optional<Vector<uint8_t>>&&, IsTrusted);
     ~PushEvent();
 
-    EventInterface eventInterface() const final { return PushEventInterfaceType; }
     PushMessageData* data() { return m_data.get(); }
 
 private:

--- a/Source/WebCore/Modules/push-api/PushNotificationEvent.h
+++ b/Source/WebCore/Modules/push-api/PushNotificationEvent.h
@@ -54,8 +54,6 @@ public:
 private:
     PushNotificationEvent(const AtomString&, ExtendableEventInit&&, Notification*, std::optional<uint64_t> proposedAppBadge, IsTrusted);
 
-    EventInterface eventInterface() const final { return PushNotificationEventInterfaceType; }
-
     RefPtr<Notification> m_proposedNotification;
     std::optional<uint64_t> m_proposedAppBadge;
     std::optional<NotificationData> m_updatedNotificationData;

--- a/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.h
@@ -37,7 +37,6 @@ public:
     static Ref<PushSubscriptionChangeEvent> create(const AtomString&, ExtendableEventInit&&, RefPtr<PushSubscription>&& newSubscription, RefPtr<PushSubscription>&& oldSubscription, IsTrusted);
     ~PushSubscriptionChangeEvent();
 
-    EventInterface eventInterface() const final { return PushSubscriptionChangeEventInterfaceType; }
     PushSubscription* newSubscription() { return m_newSubscription.get(); }
     PushSubscription* oldSubscription() { return m_oldSubscription.get(); }
 

--- a/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp
@@ -57,9 +57,4 @@ SpeechRecognitionErrorEvent::SpeechRecognitionErrorEvent(const AtomString& type,
 {
 }
 
-EventInterface SpeechRecognitionErrorEvent::eventInterface() const
-{
-    return SpeechRecognitionErrorEventInterfaceType;
-}
-
 }; // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.h
@@ -48,8 +48,6 @@ private:
     SpeechRecognitionErrorEvent(const AtomString&, Init&&, IsTrusted);
     SpeechRecognitionErrorEvent(const AtomString&, SpeechRecognitionErrorCode, const String&);
 
-    EventInterface eventInterface() const final;
-
     SpeechRecognitionErrorCode m_error;
     String m_message;
 

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp
@@ -57,9 +57,4 @@ SpeechRecognitionEvent::SpeechRecognitionEvent(const AtomString& type, uint64_t 
 {
 }
 
-EventInterface SpeechRecognitionEvent::eventInterface() const
-{
-    return SpeechRecognitionEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.h
@@ -49,8 +49,6 @@ private:
     SpeechRecognitionEvent(const AtomString&, Init&&, IsTrusted);
     SpeechRecognitionEvent(const AtomString&, uint64_t resultIndex, RefPtr<SpeechRecognitionResultList>&&);
 
-    EventInterface eventInterface() const final;
-
     uint64_t m_resultIndex;
     RefPtr<SpeechRecognitionResultList> m_results;
 };

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h
@@ -41,8 +41,6 @@ public:
 
     SpeechSynthesisErrorCode error() const { return m_error; }
 
-    virtual EventInterface eventInterface() const { return SpeechSynthesisErrorEventInterfaceType; }
-
 private:
     SpeechSynthesisErrorEvent(const AtomString& type, const SpeechSynthesisErrorEventInit&);
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.h
@@ -45,8 +45,6 @@ public:
     float elapsedTime() const { return m_elapsedTime; }
     const String& name() const { return m_name; }
 
-    virtual EventInterface eventInterface() const { return SpeechSynthesisEventInterfaceType; }
-
 protected:
     SpeechSynthesisEvent(enum EventInterfaceType, const AtomString& type, const SpeechSynthesisEventInit&);
 

--- a/Source/WebCore/Modules/webaudio/AudioProcessingEvent.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioProcessingEvent.cpp
@@ -64,11 +64,6 @@ AudioProcessingEvent::AudioProcessingEvent(const AtomString& eventType, AudioPro
 
 AudioProcessingEvent::~AudioProcessingEvent() = default;
 
-EventInterface AudioProcessingEvent::eventInterface() const
-{
-    return AudioProcessingEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioProcessingEvent.h
+++ b/Source/WebCore/Modules/webaudio/AudioProcessingEvent.h
@@ -49,8 +49,6 @@ public:
     AudioBuffer* outputBuffer() { return m_outputBuffer.get(); }
     double playbackTime() const { return m_playbackTime; }
 
-    EventInterface eventInterface() const override;
-
 private:
     AudioProcessingEvent(RefPtr<AudioBuffer>&& inputBuffer, RefPtr<AudioBuffer>&& outputBuffer, double playbackTime);
     AudioProcessingEvent(const AtomString&, AudioProcessingEventInit&&);

--- a/Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.cpp
@@ -64,11 +64,6 @@ OfflineAudioCompletionEvent::OfflineAudioCompletionEvent(const AtomString& event
 
 OfflineAudioCompletionEvent::~OfflineAudioCompletionEvent() = default;
 
-EventInterface OfflineAudioCompletionEvent::eventInterface() const
-{
-    return OfflineAudioCompletionEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.h
@@ -41,8 +41,6 @@ public:
 
     AudioBuffer& renderedBuffer() { return m_renderedBuffer.get(); }
 
-    EventInterface eventInterface() const override;
-
 private:
     explicit OfflineAudioCompletionEvent(Ref<AudioBuffer>&& renderedBuffer);
     OfflineAudioCompletionEvent(const AtomString& eventType, OfflineAudioCompletionEventInit&&);

--- a/Source/WebCore/Modules/websockets/CloseEvent.h
+++ b/Source/WebCore/Modules/websockets/CloseEvent.h
@@ -58,9 +58,6 @@ public:
     unsigned short code() const { return m_code; }
     String reason() const { return m_reason; }
 
-    // Event function.
-    EventInterface eventInterface() const override { return CloseEventInterfaceType; }
-
 private:
     CloseEvent(bool wasClean, int code, const String& reason)
         : Event(EventInterfaceType::CloseEvent, eventNames().closeEvent, CanBubble::No, IsCancelable::No)

--- a/Source/WebCore/Modules/webxr/XRInputSourceEvent.h
+++ b/Source/WebCore/Modules/webxr/XRInputSourceEvent.h
@@ -50,8 +50,6 @@ public:
     const WebXRInputSource& inputSource() const;
     void setFrameActive(bool);
 
-    EventInterface eventInterface() const final { return XRInputSourceEventInterfaceType; }
-
 private:
     XRInputSourceEvent(const AtomString&, const Init&, IsTrusted);
 

--- a/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.h
+++ b/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.h
@@ -52,8 +52,6 @@ public:
     const Vector<RefPtr<WebXRInputSource>>& added() const;
     const Vector<RefPtr<WebXRInputSource>>& removed() const;
 
-    EventInterface eventInterface() const final { return XRInputSourcesChangeEventInterfaceType; }
-
 private:
     XRInputSourcesChangeEvent(const AtomString&, const Init&, IsTrusted);
 

--- a/Source/WebCore/Modules/webxr/XRSessionEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRSessionEvent.cpp
@@ -49,11 +49,6 @@ XRSessionEvent::XRSessionEvent(const AtomString& type, const Init& initializer, 
 
 XRSessionEvent::~XRSessionEvent() = default;
 
-EventInterface XRSessionEvent::eventInterface() const
-{
-    return XRSessionEventInterfaceType;
-}
-
 const WebXRSession& XRSessionEvent::session() const
 {
     ASSERT(m_session);

--- a/Source/WebCore/Modules/webxr/XRSessionEvent.h
+++ b/Source/WebCore/Modules/webxr/XRSessionEvent.h
@@ -52,9 +52,6 @@ public:
 private:
     XRSessionEvent(const AtomString&, const Init&, IsTrusted);
 
-    // Event.
-    EventInterface eventInterface() const final;
-
     RefPtr<WebXRSession> m_session;
 };
 

--- a/Source/WebCore/accessibility/AccessibleSetValueEvent.h
+++ b/Source/WebCore/accessibility/AccessibleSetValueEvent.h
@@ -44,9 +44,6 @@ public:
 private:
     AccessibleSetValueEvent(const AtomString& type, const AtomString& value);
 
-    // Event.
-    EventInterface eventInterface() const override { return AccessibleSetValueEventInterfaceType; }
-
     const AtomString m_value;
 };
 

--- a/Source/WebCore/animation/AnimationPlaybackEvent.h
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.h
@@ -54,8 +54,6 @@ public:
     std::optional<double> bindingsCurrentTime() const;
     std::optional<Seconds> currentTime() const { return m_currentTime; }
 
-    EventInterface eventInterface() const override { return AnimationPlaybackEventInterfaceType; }
-
 private:
     AnimationPlaybackEvent(const AtomString&, WebAnimation*, std::optional<Seconds> scheduledTime, std::optional<Seconds> timelineTime, std::optional<Seconds> currentTime);
     AnimationPlaybackEvent(const AtomString&, const AnimationPlaybackEventInit&, IsTrusted);

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -54,8 +54,6 @@ public:
 
     const String& animationName() const { return m_animationName; }
 
-    EventInterface eventInterface() const override { return CSSAnimationEventInterfaceType; }
-
 private:
     CSSAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&, const String& animationName);
     CSSAnimationEvent(const AtomString&, const Init&, IsTrusted);

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -55,8 +55,6 @@ public:
 
     const String& propertyName() const { return m_propertyName; }
 
-    EventInterface eventInterface() const override { return CSSTransitionEventInterfaceType; }
-
 private:
     CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&, const String propertyName);
     CSSTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted);

--- a/Source/WebCore/bindings/scripts/InFilesCompiler.pm
+++ b/Source/WebCore/bindings/scripts/InFilesCompiler.pm
@@ -257,32 +257,6 @@ sub generateInterfacesHeader()
 
     print F "};\n";
     print F "\n";
-    print F "enum ${namespace}Interface {\n";
-
-    $count = 1;
-    for my $conditional (sort keys %interfacesByConditional) {
-        my $preferredConditional = $object->preferredConditional($conditional);
-        print F "#if " . $object->conditionalStringFromAttributeValue($conditional) . "\n";
-        for my $interface (sort keys %{ $interfacesByConditional{$conditional} }) {
-            next if defined($unconditionalInterfaces{$interface});
-            print F "    ${interface}${suffix} = $count,\n";
-            $count++;
-        }
-        print F "#endif\n";
-    }
-
-    if ($namespace eq "EventTarget") {
-        print F "    ${suffix} = $count,\n";
-        $count++;
-    }
-
-    for my $interface (sort keys %unconditionalInterfaces) {
-        print F "    ${interface}${suffix} = $count,\n";
-        $count++;
-    }
-
-    print F "};\n";
-    print F "\n";
     print F "} // namespace WebCore\n";
 
     close F;

--- a/Source/WebCore/css/MediaQueryListEvent.h
+++ b/Source/WebCore/css/MediaQueryListEvent.h
@@ -43,8 +43,6 @@ public:
     const String& media() const { return m_media; }
     bool matches() const { return m_matches; }
 
-    EventInterface eventInterface() const final { return MediaQueryListEventInterfaceType; }
-
 private:
     MediaQueryListEvent(const AtomString& type, const String& media, bool matches);
     MediaQueryListEvent(const AtomString& type, const Init&, IsTrusted);

--- a/Source/WebCore/dom/BeforeTextInsertedEvent.cpp
+++ b/Source/WebCore/dom/BeforeTextInsertedEvent.cpp
@@ -40,10 +40,4 @@ BeforeTextInsertedEvent::BeforeTextInsertedEvent(const String& text)
 
 BeforeTextInsertedEvent::~BeforeTextInsertedEvent() = default;
 
-EventInterface BeforeTextInsertedEvent::eventInterface() const
-{
-    // Notice that there is no BeforeTextInsertedEvent.idl.
-    return EventInterfaceType;
-}
-
 }

--- a/Source/WebCore/dom/BeforeTextInsertedEvent.h
+++ b/Source/WebCore/dom/BeforeTextInsertedEvent.h
@@ -39,8 +39,6 @@ public:
         return adoptRef(*new BeforeTextInsertedEvent(text));
     }
 
-    EventInterface eventInterface() const override;
-
     const String& text() const { return m_text; }
     void setText(const String& s) { m_text = s; }
 

--- a/Source/WebCore/dom/BeforeUnloadEvent.h
+++ b/Source/WebCore/dom/BeforeUnloadEvent.h
@@ -49,7 +49,6 @@ private:
     BeforeUnloadEvent();
     BeforeUnloadEvent(ForBindingsFlag);
 
-    EventInterface eventInterface() const final { return BeforeUnloadEventInterfaceType; }
     bool isBeforeUnloadEvent() const final;
 
     String m_returnValue;

--- a/Source/WebCore/dom/ClipboardEvent.cpp
+++ b/Source/WebCore/dom/ClipboardEvent.cpp
@@ -44,11 +44,6 @@ ClipboardEvent::ClipboardEvent(const AtomString& type, const Init& init)
 
 ClipboardEvent::~ClipboardEvent() = default;
 
-EventInterface ClipboardEvent::eventInterface() const
-{
-    return ClipboardEventInterfaceType;
-}
-
 bool ClipboardEvent::isClipboardEvent() const
 {
     return true;

--- a/Source/WebCore/dom/ClipboardEvent.h
+++ b/Source/WebCore/dom/ClipboardEvent.h
@@ -54,7 +54,6 @@ private:
     ClipboardEvent(const AtomString& type, Ref<DataTransfer>&&);
     ClipboardEvent(const AtomString& type, const Init&);
 
-    EventInterface eventInterface() const final;
     bool isClipboardEvent() const final;
 
     RefPtr<DataTransfer> m_clipboardData;

--- a/Source/WebCore/dom/CompositionEvent.cpp
+++ b/Source/WebCore/dom/CompositionEvent.cpp
@@ -62,11 +62,6 @@ void CompositionEvent::initCompositionEvent(const AtomString& type, bool canBubb
     m_data = data;
 }
 
-EventInterface CompositionEvent::eventInterface() const
-{
-    return CompositionEventInterfaceType;
-}
-
 bool CompositionEvent::isCompositionEvent() const
 {
     return true;

--- a/Source/WebCore/dom/CompositionEvent.h
+++ b/Source/WebCore/dom/CompositionEvent.h
@@ -58,8 +58,6 @@ public:
 
     String data() const { return m_data; }
 
-    EventInterface eventInterface() const override;
-
 private:
     CompositionEvent();
     CompositionEvent(const AtomString& type, RefPtr<WindowProxy>&&, const String&);

--- a/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.h
+++ b/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.h
@@ -45,8 +45,6 @@ public:
 
     bool skipped() const { return m_skipped; }
 
-    EventInterface eventInterface() const override { return ContentVisibilityAutoStateChangeEventInterfaceType; }
-
 private:
     ContentVisibilityAutoStateChangeEvent(const AtomString&, const Init&, IsTrusted);
 

--- a/Source/WebCore/dom/CustomEvent.cpp
+++ b/Source/WebCore/dom/CustomEvent.cpp
@@ -70,9 +70,4 @@ void CustomEvent::initCustomEvent(const AtomString& type, bool canBubble, bool c
     m_cachedDetail.clear();
 }
 
-EventInterface CustomEvent::eventInterface() const
-{
-    return CustomEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/CustomEvent.h
+++ b/Source/WebCore/dom/CustomEvent.h
@@ -54,8 +54,6 @@ private:
     CustomEvent(IsTrusted);
     CustomEvent(const AtomString& type, const Init& initializer, IsTrusted);
 
-    EventInterface eventInterface() const final;
-
     JSValueInWrappedObject m_detail;
     JSValueInWrappedObject m_cachedDetail;
 };

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -133,18 +133,6 @@ void DeviceMotionEvent::initDeviceMotionEvent(const AtomString& type, bool bubbl
     m_deviceMotionData = DeviceMotionData::create(convert(WTFMove(acceleration)), convert(WTFMove(accelerationIncludingGravity)), convert(WTFMove(rotationRate)), interval);
 }
 
-EventInterface DeviceMotionEvent::eventInterface() const
-{
-#if ENABLE(DEVICE_ORIENTATION)
-    return DeviceMotionEventInterfaceType;
-#else
-    // FIXME: ENABLE(DEVICE_ORIENTATION) seems to be in a strange state where
-    // it is half-guarded by #ifdefs. DeviceMotionEvent.idl is guarded
-    // but DeviceMotionEvent.cpp itself is required by ungarded code.
-    return EventInterfaceType;
-#endif
-}
-
 #if ENABLE(DEVICE_ORIENTATION)
 void DeviceMotionEvent::requestPermission(Document& document, PermissionPromise&& promise)
 {

--- a/Source/WebCore/dom/DeviceMotionEvent.h
+++ b/Source/WebCore/dom/DeviceMotionEvent.h
@@ -81,8 +81,6 @@ private:
     DeviceMotionEvent();
     DeviceMotionEvent(const AtomString& eventType, DeviceMotionData*);
 
-    EventInterface eventInterface() const override;
-
     RefPtr<DeviceMotionData> m_deviceMotionData;
 };
 

--- a/Source/WebCore/dom/DeviceOrientationEvent.cpp
+++ b/Source/WebCore/dom/DeviceOrientationEvent.cpp
@@ -119,18 +119,6 @@ void DeviceOrientationEvent::initDeviceOrientationEvent(const AtomString& type, 
 
 #endif
 
-EventInterface DeviceOrientationEvent::eventInterface() const
-{
-#if ENABLE(DEVICE_ORIENTATION)
-    return DeviceOrientationEventInterfaceType;
-#else
-    // FIXME: ENABLE(DEVICE_ORIENTATION) seems to be in a strange state where
-    // it is half-guarded by #ifdefs. DeviceOrientationEvent.idl is guarded
-    // but DeviceOrientationEvent.cpp itself is required by ungarded code.
-    return EventInterfaceType;
-#endif
-}
-
 #if ENABLE(DEVICE_ORIENTATION)
 void DeviceOrientationEvent::requestPermission(Document& document, PermissionPromise&& promise)
 {

--- a/Source/WebCore/dom/DeviceOrientationEvent.h
+++ b/Source/WebCore/dom/DeviceOrientationEvent.h
@@ -75,8 +75,6 @@ private:
     DeviceOrientationEvent();
     DeviceOrientationEvent(const AtomString& eventType, DeviceOrientationData*);
 
-    EventInterface eventInterface() const override;
-
     RefPtr<DeviceOrientationData> m_orientation;
 };
 

--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -72,9 +72,4 @@ DragEvent::DragEvent()
 {
 }
 
-EventInterface DragEvent::eventInterface() const
-{
-    return DragEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/DragEvent.h
+++ b/Source/WebCore/dom/DragEvent.h
@@ -59,8 +59,6 @@ private:
         EventTarget* relatedTarget, double force, SyntheticClickType, DataTransfer*, IsSimulated, IsTrusted);
     DragEvent();
 
-    EventInterface eventInterface() const final;
-
     RefPtr<DataTransfer> m_dataTransfer;
 };
 

--- a/Source/WebCore/dom/ErrorEvent.cpp
+++ b/Source/WebCore/dom/ErrorEvent.cpp
@@ -70,11 +70,6 @@ ErrorEvent::ErrorEvent(const String& message, const String& fileName, unsigned l
 
 ErrorEvent::~ErrorEvent() = default;
 
-EventInterface ErrorEvent::eventInterface() const
-{
-    return ErrorEventInterfaceType;
-}
-
 JSValue ErrorEvent::error(JSGlobalObject& globalObject)
 {    
     if (!m_error)

--- a/Source/WebCore/dom/ErrorEvent.h
+++ b/Source/WebCore/dom/ErrorEvent.h
@@ -76,8 +76,6 @@ public:
     const JSValueInWrappedObject& originalError() const { return m_error; }
     SerializedScriptValue* serializedError() const { return m_serializedError.get(); }
 
-    EventInterface eventInterface() const override;
-
     RefPtr<SerializedScriptValue> trySerializeError(JSC::JSGlobalObject&);
 
 private:

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -72,7 +72,7 @@ public:
     const AtomString& type() const { return m_type; }
     void setType(const AtomString& type) { m_type = type; }
 
-    enum EventInterfaceType interfaceType() const { return m_eventInterface ? static_cast<enum EventInterfaceType>(m_eventInterface) : static_cast<enum EventInterfaceType>(eventInterface()); }
+    enum EventInterfaceType interfaceType() const { return static_cast<enum EventInterfaceType>(m_eventInterface); }
 
     EventTarget* target() const { return m_target.get(); }
     void setTarget(RefPtr<EventTarget>&&);
@@ -103,8 +103,6 @@ public:
 
     bool legacyReturnValue() const { return !m_wasCanceled; }
     void setLegacyReturnValue(bool);
-
-    virtual EventInterface eventInterface() const { return EventInterfaceType; }
 
     virtual bool isBeforeTextInsertedEvent() const { return false; }
     virtual bool isBeforeUnloadEvent() const { return false; }

--- a/Source/WebCore/dom/FocusEvent.cpp
+++ b/Source/WebCore/dom/FocusEvent.cpp
@@ -33,11 +33,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(FocusEvent);
 
-EventInterface FocusEvent::eventInterface() const
-{
-    return FocusEventInterfaceType;
-}
-
 bool FocusEvent::isFocusEvent() const
 {
     return true;

--- a/Source/WebCore/dom/FocusEvent.h
+++ b/Source/WebCore/dom/FocusEvent.h
@@ -62,7 +62,6 @@ private:
     FocusEvent(const AtomString& type, CanBubble, IsCancelable, RefPtr<WindowProxy>&&, int, RefPtr<EventTarget>&&);
     FocusEvent(const AtomString& type, const Init&);
 
-    EventInterface eventInterface() const final;
     bool isFocusEvent() const final;
 
     void setRelatedTarget(RefPtr<EventTarget>&& relatedTarget) final { m_relatedTarget = WTFMove(relatedTarget); }

--- a/Source/WebCore/dom/FormDataEvent.cpp
+++ b/Source/WebCore/dom/FormDataEvent.cpp
@@ -55,9 +55,4 @@ FormDataEvent::FormDataEvent(const AtomString& eventType, CanBubble canBubble, I
 {
 }
 
-EventInterface FormDataEvent::eventInterface() const
-{
-    return FormDataEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/FormDataEvent.h
+++ b/Source/WebCore/dom/FormDataEvent.h
@@ -47,8 +47,7 @@ public:
 private:
     FormDataEvent(const AtomString&, Init&&);
     FormDataEvent(const AtomString&, CanBubble, IsCancelable, IsComposed, Ref<DOMFormData>&&);
-    EventInterface eventInterface() const final;
-    
+
     Ref<DOMFormData> m_formData;
 };
 

--- a/Source/WebCore/dom/HashChangeEvent.h
+++ b/Source/WebCore/dom/HashChangeEvent.h
@@ -62,8 +62,6 @@ public:
     const String& oldURL() const { return m_oldURL; }
     const String& newURL() const { return m_newURL; }
 
-    EventInterface eventInterface() const override { return HashChangeEventInterfaceType; }
-
 private:
     HashChangeEvent()
         : Event(EventInterfaceType::HashChangeEvent)

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -53,7 +53,6 @@ public:
     }
 
     bool isInputEvent() const override { return true; }
-    EventInterface eventInterface() const final { return InputEventInterfaceType; }
     const String& inputType() const { return m_inputType; }
     const String& data() const { return m_data; }
     RefPtr<DataTransfer> dataTransfer() const;

--- a/Source/WebCore/dom/InvokeEvent.cpp
+++ b/Source/WebCore/dom/InvokeEvent.cpp
@@ -56,11 +56,6 @@ Ref<InvokeEvent> InvokeEvent::createForBindings()
     return adoptRef(*new InvokeEvent);
 }
 
-EventInterface InvokeEvent::eventInterface() const
-{
-    return InvokeEventInterfaceType;
-}
-
 bool InvokeEvent::isInvokeEvent() const
 {
     return true;

--- a/Source/WebCore/dom/InvokeEvent.h
+++ b/Source/WebCore/dom/InvokeEvent.h
@@ -54,7 +54,6 @@ private:
     InvokeEvent();
     InvokeEvent(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
 
-    EventInterface eventInterface() const final;
     bool isInvokeEvent() const final;
 
     void setInvoker(RefPtr<Element>&& invoker) { m_invoker = WTFMove(invoker); }

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -226,11 +226,6 @@ int KeyboardEvent::charCode() const
     return m_underlyingPlatformEvent->text().characterStartingAt(0);
 }
 
-EventInterface KeyboardEvent::eventInterface() const
-{
-    return KeyboardEventInterfaceType;
-}
-
 bool KeyboardEvent::isKeyboardEvent() const
 {
     return true;

--- a/Source/WebCore/dom/KeyboardEvent.h
+++ b/Source/WebCore/dom/KeyboardEvent.h
@@ -82,7 +82,6 @@ public:
     WEBCORE_EXPORT int keyCode() const; // key code for keydown and keyup, character for keypress
     WEBCORE_EXPORT int charCode() const; // character code for keypress, 0 for keydown and keyup
 
-    EventInterface eventInterface() const final;
     bool isKeyboardEvent() const final;
     unsigned which() const final;
 

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -128,11 +128,6 @@ void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool
     m_cachedPorts.clear();
 }
 
-EventInterface MessageEvent::eventInterface() const
-{
-    return MessageEventInterfaceType;
-}
-
 size_t MessageEvent::memoryCost() const
 {
     Locker locker { m_concurrentDataAccessLock };

--- a/Source/WebCore/dom/MessageEvent.h
+++ b/Source/WebCore/dom/MessageEvent.h
@@ -88,8 +88,6 @@ private:
     MessageEvent(const AtomString& type, Init&&, IsTrusted);
     MessageEvent(const AtomString& type, DataType&&, const String& origin, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<RefPtr<MessagePort>>&& = { });
 
-    EventInterface eventInterface() const final;
-
     DataType m_data WTF_GUARDED_BY_LOCK(m_concurrentDataAccessLock);
     String m_origin;
     String m_lastEventId;

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -144,11 +144,6 @@ void MouseEvent::initMouseEvent(const AtomString& type, bool canBubble, bool can
     setIsSimulated(false);
 }
 
-EventInterface MouseEvent::eventInterface() const
-{
-    return MouseEventInterfaceType;
-}
-
 bool MouseEvent::isMouseEvent() const
 {
     return true;

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -103,7 +103,6 @@ protected:
 
 private:
     bool isMouseEvent() const final;
-    EventInterface eventInterface() const override;
 
     void setRelatedTarget(RefPtr<EventTarget>&& relatedTarget) final { m_relatedTarget = WTFMove(relatedTarget); }
 

--- a/Source/WebCore/dom/MutationEvent.cpp
+++ b/Source/WebCore/dom/MutationEvent.cpp
@@ -56,9 +56,4 @@ void MutationEvent::initMutationEvent(const AtomString& type, bool canBubble, bo
     m_attrChange = attrChange;
 }
 
-EventInterface MutationEvent::eventInterface() const
-{
-    return MutationEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/MutationEvent.h
+++ b/Source/WebCore/dom/MutationEvent.h
@@ -59,8 +59,6 @@ private:
     MutationEvent();
     MutationEvent(const AtomString& type, CanBubble, IsCancelable, Node* relatedNode, const String& prevValue, const String& newValue);
 
-    EventInterface eventInterface() const final;
-
     RefPtr<Node> m_relatedNode;
     String m_prevValue;
     String m_newValue;

--- a/Source/WebCore/dom/OverflowEvent.cpp
+++ b/Source/WebCore/dom/OverflowEvent.cpp
@@ -64,11 +64,6 @@ OverflowEvent::OverflowEvent(const AtomString& type, const Init& initializer, Is
 {
 }
 
-EventInterface OverflowEvent::eventInterface() const
-{
-    return OverflowEventInterfaceType;
-}
-
 void OverflowEvent::initOverflowEvent(unsigned short orient, bool horizontalOverflow, bool verticalOverflow)
 {
     if (isBeingDispatched())

--- a/Source/WebCore/dom/OverflowEvent.h
+++ b/Source/WebCore/dom/OverflowEvent.h
@@ -65,8 +65,6 @@ public:
     bool horizontalOverflow() const { return m_horizontalOverflow; }
     bool verticalOverflow() const { return m_verticalOverflow; }
 
-    EventInterface eventInterface() const override;
-
 private:
     OverflowEvent();
     OverflowEvent(bool horizontalOverflowChanged, bool horizontalOverflow, bool verticalOverflowChanged, bool verticalOverflow);

--- a/Source/WebCore/dom/PageTransitionEvent.cpp
+++ b/Source/WebCore/dom/PageTransitionEvent.cpp
@@ -46,9 +46,4 @@ PageTransitionEvent::PageTransitionEvent(const AtomString& type, const Init& ini
 
 PageTransitionEvent::~PageTransitionEvent() = default;
 
-EventInterface PageTransitionEvent::eventInterface() const
-{
-    return PageTransitionEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/PageTransitionEvent.h
+++ b/Source/WebCore/dom/PageTransitionEvent.h
@@ -48,8 +48,6 @@ public:
 
     virtual ~PageTransitionEvent();
 
-    EventInterface eventInterface() const override;
-
     bool persisted() const { return m_persisted; }
 
 private:

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -122,9 +122,4 @@ PointerEvent::PointerEvent(const AtomString& type, PointerID pointerId, const St
 
 PointerEvent::~PointerEvent() = default;
 
-EventInterface PointerEvent::eventInterface() const
-{
-    return PointerEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -114,7 +114,6 @@ public:
     RefPtr<Node> toElement() const final { return nullptr; }
     RefPtr<Node> fromElement() const final { return nullptr; }
 
-    EventInterface eventInterface() const override;
     static bool typeIsUpOrDown(const AtomString& type);
     static MouseButton buttonForType(const AtomString& type) { return !typeIsUpOrDown(type) ? MouseButton::PointerHasNotChanged : MouseButton::Left; }
 

--- a/Source/WebCore/dom/PopStateEvent.cpp
+++ b/Source/WebCore/dom/PopStateEvent.cpp
@@ -84,9 +84,4 @@ RefPtr<SerializedScriptValue> PopStateEvent::trySerializeState(JSC::JSGlobalObje
     return m_serializedState;
 }
 
-EventInterface PopStateEvent::eventInterface() const
-{
-    return PopStateEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/PopStateEvent.h
+++ b/Source/WebCore/dom/PopStateEvent.h
@@ -63,8 +63,6 @@ private:
     PopStateEvent(const AtomString&, const Init&, IsTrusted);
     PopStateEvent(RefPtr<SerializedScriptValue>&&, History*);
 
-    EventInterface eventInterface() const final;
-
     JSValueInWrappedObject m_state;
     RefPtr<SerializedScriptValue> m_serializedState;
     bool m_triedToSerialize { false };

--- a/Source/WebCore/dom/ProgressEvent.cpp
+++ b/Source/WebCore/dom/ProgressEvent.cpp
@@ -48,9 +48,4 @@ ProgressEvent::ProgressEvent(enum EventInterfaceType eventInterface, const AtomS
 {
 }
 
-EventInterface ProgressEvent::eventInterface() const
-{
-    return ProgressEventInterfaceType;
-}
-
 }

--- a/Source/WebCore/dom/ProgressEvent.h
+++ b/Source/WebCore/dom/ProgressEvent.h
@@ -52,8 +52,6 @@ public:
     unsigned long long loaded() const { return m_loaded; }
     unsigned long long total() const { return m_total; }
 
-    EventInterface eventInterface() const override;
-
 protected:
     ProgressEvent(enum EventInterfaceType, const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total);
     ProgressEvent(enum EventInterfaceType, const AtomString&, const Init&, IsTrusted);

--- a/Source/WebCore/dom/PromiseRejectionEvent.h
+++ b/Source/WebCore/dom/PromiseRejectionEvent.h
@@ -50,8 +50,6 @@ public:
     DOMPromise& promise() const { return m_promise.get(); }
     const JSValueInWrappedObject& reason() const { return m_reason; }
 
-    EventInterface eventInterface() const override { return PromiseRejectionEventInterfaceType; }
-
 private:
     PromiseRejectionEvent(const AtomString&, const Init&, IsTrusted);
 

--- a/Source/WebCore/dom/SecurityPolicyViolationEvent.h
+++ b/Source/WebCore/dom/SecurityPolicyViolationEvent.h
@@ -72,8 +72,6 @@ public:
     unsigned lineNumber() const { return m_lineNumber; }
     unsigned columnNumber() const { return m_columnNumber; }
 
-    EventInterface eventInterface() const final { return SecurityPolicyViolationEventInterfaceType; }
-
 private:
     SecurityPolicyViolationEvent()
         : Event(EventInterfaceType::SecurityPolicyViolationEvent)

--- a/Source/WebCore/dom/TextEvent.cpp
+++ b/Source/WebCore/dom/TextEvent.cpp
@@ -126,11 +126,6 @@ void TextEvent::initTextEvent(const AtomString& type, bool canBubble, bool cance
     m_dictationAlternatives = { };
 }
 
-EventInterface TextEvent::eventInterface() const
-{
-    return TextEventInterfaceType;
-}
-
 bool TextEvent::isTextEvent() const
 {
     return true;

--- a/Source/WebCore/dom/TextEvent.h
+++ b/Source/WebCore/dom/TextEvent.h
@@ -52,8 +52,6 @@ namespace WebCore {
     
         String data() const { return m_data; }
 
-        EventInterface eventInterface() const override;
-
         bool isLineBreak() const { return m_inputType == TextEventInputLineBreak; }
         bool isComposition() const { return m_inputType == TextEventInputComposition; }
         bool isBackTab() const { return m_inputType == TextEventInputBackTab; }

--- a/Source/WebCore/dom/ToggleEvent.cpp
+++ b/Source/WebCore/dom/ToggleEvent.cpp
@@ -66,9 +66,4 @@ Ref<ToggleEvent> ToggleEvent::createForBindings()
     return adoptRef(*new ToggleEvent);
 }
 
-EventInterface ToggleEvent::eventInterface() const
-{
-    return ToggleEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/ToggleEvent.h
+++ b/Source/WebCore/dom/ToggleEvent.h
@@ -52,8 +52,6 @@ private:
 
     bool isToggleEvent() const final { return true; }
 
-    EventInterface eventInterface() const final;
-
     String m_oldState;
     String m_newState;
 };

--- a/Source/WebCore/dom/TouchEvent.cpp
+++ b/Source/WebCore/dom/TouchEvent.cpp
@@ -58,11 +58,6 @@ TouchEvent::TouchEvent(const AtomString& type, const Init& initializer, IsTruste
 
 TouchEvent::~TouchEvent() = default;
 
-EventInterface TouchEvent::eventInterface() const
-{
-    return TouchEventInterfaceType;
-}
-
 bool TouchEvent::isTouchEvent() const
 {
     return true;

--- a/Source/WebCore/dom/TouchEvent.h
+++ b/Source/WebCore/dom/TouchEvent.h
@@ -71,8 +71,6 @@ public:
 
     bool isTouchEvent() const override;
 
-    EventInterface eventInterface() const override;
-
 private:
     TouchEvent();
     TouchEvent(TouchList* touches, TouchList* targetTouches, TouchList* changedTouches, const AtomString& type,

--- a/Source/WebCore/dom/UIEvent.cpp
+++ b/Source/WebCore/dom/UIEvent.cpp
@@ -76,11 +76,6 @@ bool UIEvent::isUIEvent() const
     return true;
 }
 
-EventInterface UIEvent::eventInterface() const
-{
-    return UIEventInterfaceType;
-}
-
 int UIEvent::layerX()
 {
     return 0;

--- a/Source/WebCore/dom/UIEvent.h
+++ b/Source/WebCore/dom/UIEvent.h
@@ -55,8 +55,6 @@ public:
     WindowProxy* view() const { return m_view.get(); }
     int detail() const { return m_detail; }
 
-    EventInterface eventInterface() const override;
-
     virtual int layerX();
     virtual int layerY();
 

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -89,11 +89,6 @@ Ref<WheelEvent> WheelEvent::create(const AtomString& type, const Init& initializ
     return adoptRef(*new WheelEvent(type, initializer));
 }
 
-EventInterface WheelEvent::eventInterface() const
-{
-    return WheelEventInterfaceType;
-}
-
 bool WheelEvent::isWheelEvent() const
 {
     return true;

--- a/Source/WebCore/dom/WheelEvent.h
+++ b/Source/WebCore/dom/WheelEvent.h
@@ -76,8 +76,6 @@ private:
     WheelEvent(const AtomString&, const Init&);
     WheelEvent(const PlatformWheelEvent&, RefPtr<WindowProxy>&&, IsCancelable);
 
-    EventInterface eventInterface() const final;
-
     bool isWheelEvent() const final;
 
     IntPoint m_wheelDelta;

--- a/Source/WebCore/html/MediaEncryptedEvent.cpp
+++ b/Source/WebCore/html/MediaEncryptedEvent.cpp
@@ -47,11 +47,6 @@ MediaEncryptedEvent::MediaEncryptedEvent(const AtomString& type, const MediaEncr
 
 MediaEncryptedEvent::~MediaEncryptedEvent() = default;
 
-EventInterface MediaEncryptedEvent::eventInterface() const
-{
-    return MediaEncryptedEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/html/MediaEncryptedEvent.h
+++ b/Source/WebCore/html/MediaEncryptedEvent.h
@@ -57,9 +57,6 @@ public:
 private:
     MediaEncryptedEvent(const AtomString&, const MediaEncryptedEventInit&, IsTrusted);
 
-    // Event
-    EventInterface eventInterface() const override;
-
     String m_initDataType;
     RefPtr<JSC::ArrayBuffer> m_initData;
 };

--- a/Source/WebCore/html/SubmitEvent.cpp
+++ b/Source/WebCore/html/SubmitEvent.cpp
@@ -54,9 +54,4 @@ SubmitEvent::SubmitEvent(RefPtr<HTMLElement>&& submitter)
     , m_submitter(WTFMove(submitter))
 { }
 
-EventInterface SubmitEvent::eventInterface() const
-{
-    return SubmitEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/html/SubmitEvent.h
+++ b/Source/WebCore/html/SubmitEvent.h
@@ -49,8 +49,6 @@ private:
     SubmitEvent(const AtomString& type, Init&&);
     explicit SubmitEvent(RefPtr<HTMLElement>&& submitter);
 
-    EventInterface eventInterface() const final;
-
     RefPtr<HTMLElement> m_submitter;
 };
 

--- a/Source/WebCore/html/canvas/WebGLContextEvent.cpp
+++ b/Source/WebCore/html/canvas/WebGLContextEvent.cpp
@@ -48,11 +48,6 @@ WebGLContextEvent::WebGLContextEvent(const AtomString& type, const Init& initial
 
 WebGLContextEvent::~WebGLContextEvent() = default;
 
-EventInterface WebGLContextEvent::eventInterface() const
-{
-    return WebGLContextEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/WebGLContextEvent.h
+++ b/Source/WebCore/html/canvas/WebGLContextEvent.h
@@ -51,8 +51,6 @@ public:
 
     const String& statusMessage() const { return m_statusMessage; }
 
-    EventInterface eventInterface() const override;
-
 private:
     WebGLContextEvent(const AtomString& type, CanBubble, IsCancelable, const String& statusMessage);
     WebGLContextEvent(const AtomString&, const Init&, IsTrusted);

--- a/Source/WebCore/html/track/TrackEvent.cpp
+++ b/Source/WebCore/html/track/TrackEvent.cpp
@@ -65,11 +65,6 @@ TrackEvent::TrackEvent(const AtomString& type, Init&& initializer, IsTrusted isT
 
 TrackEvent::~TrackEvent() = default;
 
-EventInterface TrackEvent::eventInterface() const
-{
-    return TrackEventInterfaceType;
-}
-
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/html/track/TrackEvent.h
+++ b/Source/WebCore/html/track/TrackEvent.h
@@ -61,8 +61,6 @@ private:
     TrackEvent(const AtomString& type, CanBubble, IsCancelable, Ref<TrackBase>&&);
     TrackEvent(const AtomString& type, Init&& initializer, IsTrusted);
 
-    EventInterface eventInterface() const override;
-
     std::optional<TrackEventTrack> m_track;
 };
 

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -60,9 +60,4 @@ void NavigateEvent::scroll()
 {
 }
 
-EventInterface NavigateEvent::eventInterface() const
-{
-    return NavigateEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -87,8 +87,6 @@ public:
 private:
     NavigateEvent(const AtomString& type, const Init&);
 
-    EventInterface eventInterface() const override;
-
     NavigationNavigationType m_navigationType;
     RefPtr<NavigationDestination> m_destination;
     RefPtr<AbortSignal> m_signal;

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp
@@ -44,9 +44,4 @@ Ref<NavigationCurrentEntryChangeEvent> NavigationCurrentEntryChangeEvent::create
     return adoptRef(*new NavigationCurrentEntryChangeEvent(type, init));
 }
 
-EventInterface NavigationCurrentEntryChangeEvent::eventInterface() const
-{
-    return NavigationCurrentEntryChangeEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.h
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.h
@@ -48,8 +48,6 @@ public:
 private:
     NavigationCurrentEntryChangeEvent(const AtomString& type, const Init&);
 
-    EventInterface eventInterface() const override;
-
     std::optional<NavigationNavigationType> m_navigationType;
     RefPtr<NavigationHistoryEntry> m_from;
 };

--- a/Source/WebCore/storage/StorageEvent.cpp
+++ b/Source/WebCore/storage/StorageEvent.cpp
@@ -89,9 +89,4 @@ void StorageEvent::initStorageEvent(const AtomString& type, bool canBubble, bool
     m_storageArea = storageArea;
 }
 
-EventInterface StorageEvent::eventInterface() const
-{
-    return StorageEventInterfaceType;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/storage/StorageEvent.h
+++ b/Source/WebCore/storage/StorageEvent.h
@@ -60,8 +60,6 @@ public:
     // Needed once we support init<blank>EventNS
     // void initStorageEventNS(in DOMString namespaceURI, in DOMString typeArg, in boolean canBubbleArg, in boolean cancelableArg, in DOMString keyArg, in DOMString oldValueArg, in DOMString newValueArg, in DOMString urlArg, Storage storageAreaArg);
 
-    EventInterface eventInterface() const override;
-
 private:
     StorageEvent();
     StorageEvent(const AtomString& type, const String& key, const String& oldValue, const String& newValue, const String& url, Storage* storageArea);

--- a/Source/WebCore/workers/service/ExtendableEvent.h
+++ b/Source/WebCore/workers/service/ExtendableEvent.h
@@ -43,8 +43,6 @@ public:
 
     ~ExtendableEvent();
 
-    EventInterface eventInterface() const override { return ExtendableEventInterfaceType; }
-
     ExceptionOr<void> waitUntil(Ref<DOMPromise>&&);
     unsigned pendingPromiseCount() const { return m_pendingPromiseCount; }
 

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.h
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.h
@@ -71,8 +71,6 @@ public:
     const std::optional<ExtendableMessageEventSource>& source() const { return m_source; }
     const Vector<RefPtr<MessagePort>>& ports() const { return m_ports; }
 
-    EventInterface eventInterface() const final { return ExtendableMessageEventInterfaceType; }
-
 private:
     ExtendableMessageEvent(JSC::JSGlobalObject&, const AtomString&, const Init&, IsTrusted);
     ExtendableMessageEvent(RefPtr<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<ExtendableMessageEventSource>&&, Vector<RefPtr<MessagePort>>&&);

--- a/Source/WebCore/workers/service/FetchEvent.h
+++ b/Source/WebCore/workers/service/FetchEvent.h
@@ -61,8 +61,6 @@ public:
     }
     ~FetchEvent();
 
-    EventInterface eventInterface() const final { return FetchEventInterfaceType; }
-
     ExceptionOr<void> respondWith(Ref<DOMPromise>&&);
 
     using ResponseCallback = CompletionHandler<void(Expected<Ref<FetchResponse>, std::optional<ResourceError>>&&)>;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h
@@ -38,8 +38,6 @@ public:
     using Init = BackgroundFetchEventInit;
     static Ref<BackgroundFetchEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
 
-    EventInterface eventInterface() const override { return BackgroundFetchEventInterfaceType; }
-
     RefPtr<BackgroundFetchRegistration> registration() const;
 
 protected:

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.h
@@ -40,8 +40,6 @@ public:
 
     ~BackgroundFetchUpdateUIEvent();
 
-    EventInterface eventInterface() const final { return BackgroundFetchUpdateUIEventInterfaceType; }
-
     void updateUI(BackgroundFetchUIOptions&&, DOMPromiseDeferred<void>&&);
 
 private:

--- a/Source/WebCore/xml/XMLHttpRequestProgressEvent.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEvent.h
@@ -41,8 +41,6 @@ public:
     unsigned long long position() const { return loaded(); }
     unsigned long long totalSize() const { return total(); }
 
-    EventInterface eventInterface() const override { return XMLHttpRequestProgressEventInterfaceType; }
-
 private:
     XMLHttpRequestProgressEvent(const AtomString& type, bool lengthComputable, unsigned long long loaded, unsigned long long total)
         : ProgressEvent(EventInterfaceType::XMLHttpRequestProgressEvent, type, lengthComputable, loaded, total)


### PR DESCRIPTION
#### e73497e992e4e234534153d64106dbd4946485ca
<pre>
Remove Event::eventInterface
<a href="https://bugs.webkit.org/show_bug.cgi?id=270018">https://bugs.webkit.org/show_bug.cgi?id=270018</a>

Reviewed by Chris Dumez and Yusuke Suzuki.

Removed Event::eventInterface, EventInterface enum, and EventTargetInterface enum
since they&apos;re no longer useful / used.

* Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp:
(WebCore::GPUUncapturedErrorEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.h:
* Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.h:
* Source/WebCore/Modules/applepay/ApplePayCancelEvent.cpp:
(WebCore::ApplePayCancelEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/applepay/ApplePayCancelEvent.h:
* Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.cpp:
(WebCore::ApplePayCouponCodeChangedEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/applepay/ApplePayCouponCodeChangedEvent.h:
* Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.cpp:
(WebCore::ApplePayPaymentAuthorizedEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizedEvent.h:
* Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.cpp:
(WebCore::ApplePayPaymentMethodSelectedEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/applepay/ApplePayPaymentMethodSelectedEvent.h:
* Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp:
(WebCore::ApplePayShippingContactSelectedEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.h:
* Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.cpp:
(WebCore::ApplePayShippingMethodSelectedEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/applepay/ApplePayShippingMethodSelectedEvent.h:
* Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.cpp:
(WebCore::ApplePayValidateMerchantEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/applepay/ApplePayValidateMerchantEvent.h:
* Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp:
(WebCore::CookieChangeEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/cookie-store/CookieChangeEvent.h:
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp:
(WebCore::ExtendableCookieChangeEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.cpp:
(WebCore::MediaKeyMessageEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp:
(WebCore::WebKitMediaKeyMessageEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp:
(WebCore::WebKitMediaKeyNeededEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.h:
* Source/WebCore/Modules/gamepad/GamepadEvent.h:
* Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.cpp:
(WebCore::IDBVersionChangeEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.h:
* Source/WebCore/Modules/mediarecorder/BlobEvent.cpp:
(WebCore::BlobEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediarecorder/BlobEvent.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp:
(WebCore::MediaRecorderErrorEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h:
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp:
(WebCore::BufferedChangeEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp:
(WebCore::MediaStreamTrackEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.h:
* Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.h:
* Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp:
(WebCore::RTCDTMFToneChangeEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.h:
* Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp:
(WebCore::RTCDataChannelEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediastream/RTCDataChannelEvent.h:
* Source/WebCore/Modules/mediastream/RTCErrorEvent.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.cpp:
(WebCore::RTCPeerConnectionIceErrorEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp:
(WebCore::RTCPeerConnectionIceEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.cpp:
(WebCore::RTCRtpSFrameTransformErrorEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.h:
* Source/WebCore/Modules/mediastream/RTCTrackEvent.h:
* Source/WebCore/Modules/mediastream/RTCTransformEvent.cpp:
(WebCore::RTCTransformEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/mediastream/RTCTransformEvent.h:
* Source/WebCore/Modules/notifications/NotificationEvent.h:
* Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp:
(WebCore::MerchantValidationEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.h:
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp:
(WebCore::PaymentMethodChangeEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp:
(WebCore::PaymentRequestUpdateEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.h:
* Source/WebCore/Modules/push-api/PushEvent.h:
* Source/WebCore/Modules/push-api/PushNotificationEvent.h:
* Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.h:
* Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp:
(WebCore::SpeechRecognitionErrorEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.h:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp:
(WebCore::SpeechRecognitionEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.h:
* Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h:
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.h:
(WebCore::SpeechSynthesisEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/webaudio/AudioProcessingEvent.cpp:
(WebCore::AudioProcessingEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/webaudio/AudioProcessingEvent.h:
* Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.cpp:
(WebCore::OfflineAudioCompletionEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.h:
* Source/WebCore/Modules/websockets/CloseEvent.h:
* Source/WebCore/Modules/webxr/XRInputSourceEvent.h:
* Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.h:
* Source/WebCore/Modules/webxr/XRSessionEvent.cpp:
(WebCore::XRSessionEvent::eventInterface const): Deleted.
* Source/WebCore/Modules/webxr/XRSessionEvent.h:
* Source/WebCore/accessibility/AccessibleSetValueEvent.h:
* Source/WebCore/animation/AnimationPlaybackEvent.h:
* Source/WebCore/animation/CSSAnimationEvent.h:
* Source/WebCore/animation/CSSTransitionEvent.h:
* Source/WebCore/bindings/scripts/InFilesCompiler.pm:
(generateInterfacesHeader):
* Source/WebCore/css/MediaQueryListEvent.h:
* Source/WebCore/dom/BeforeTextInsertedEvent.cpp:
(WebCore::BeforeTextInsertedEvent::eventInterface const): Deleted.
* Source/WebCore/dom/BeforeTextInsertedEvent.h:
* Source/WebCore/dom/BeforeUnloadEvent.h:
* Source/WebCore/dom/ClipboardEvent.cpp:
(WebCore::ClipboardEvent::eventInterface const): Deleted.
* Source/WebCore/dom/ClipboardEvent.h:
* Source/WebCore/dom/CompositionEvent.cpp:
(WebCore::CompositionEvent::eventInterface const): Deleted.
* Source/WebCore/dom/CompositionEvent.h:
* Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.h:
* Source/WebCore/dom/CustomEvent.cpp:
(WebCore::CustomEvent::eventInterface const): Deleted.
* Source/WebCore/dom/CustomEvent.h:
* Source/WebCore/dom/DeviceMotionEvent.cpp:
(WebCore::DeviceMotionEvent::eventInterface const): Deleted.
* Source/WebCore/dom/DeviceMotionEvent.h:
* Source/WebCore/dom/DeviceOrientationEvent.cpp:
(WebCore::DeviceOrientationEvent::eventInterface const): Deleted.
* Source/WebCore/dom/DeviceOrientationEvent.h:
* Source/WebCore/dom/DragEvent.cpp:
(WebCore::DragEvent::eventInterface const): Deleted.
* Source/WebCore/dom/DragEvent.h:
* Source/WebCore/dom/ErrorEvent.cpp:
(WebCore::ErrorEvent::eventInterface const): Deleted.
* Source/WebCore/dom/ErrorEvent.h:
* Source/WebCore/dom/Event.h:
(WebCore::Event::interfaceType const):
(WebCore::Event::eventInterface const): Deleted.
* Source/WebCore/dom/FocusEvent.cpp:
(WebCore::FocusEvent::eventInterface const): Deleted.
* Source/WebCore/dom/FocusEvent.h:
* Source/WebCore/dom/FormDataEvent.cpp:
(WebCore::FormDataEvent::eventInterface const): Deleted.
* Source/WebCore/dom/FormDataEvent.h:
* Source/WebCore/dom/HashChangeEvent.h:
* Source/WebCore/dom/InputEvent.h:
* Source/WebCore/dom/InvokeEvent.cpp:
(WebCore::InvokeEvent::eventInterface const): Deleted.
* Source/WebCore/dom/InvokeEvent.h:
* Source/WebCore/dom/KeyboardEvent.cpp:
(WebCore::KeyboardEvent::eventInterface const): Deleted.
* Source/WebCore/dom/KeyboardEvent.h:
* Source/WebCore/dom/MessageEvent.cpp:
(WebCore::MessageEvent::eventInterface const): Deleted.
* Source/WebCore/dom/MessageEvent.h:
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::eventInterface const): Deleted.
* Source/WebCore/dom/MouseEvent.h:
* Source/WebCore/dom/MutationEvent.cpp:
(WebCore::MutationEvent::eventInterface const): Deleted.
* Source/WebCore/dom/MutationEvent.h:
* Source/WebCore/dom/OverflowEvent.cpp:
(WebCore::OverflowEvent::eventInterface const): Deleted.
* Source/WebCore/dom/OverflowEvent.h:
* Source/WebCore/dom/PageTransitionEvent.cpp:
(WebCore::PageTransitionEvent::eventInterface const): Deleted.
* Source/WebCore/dom/PageTransitionEvent.h:
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::eventInterface const): Deleted.
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/PopStateEvent.cpp:
(WebCore::PopStateEvent::eventInterface const): Deleted.
* Source/WebCore/dom/PopStateEvent.h:
* Source/WebCore/dom/ProgressEvent.cpp:
(WebCore::ProgressEvent::eventInterface const): Deleted.
* Source/WebCore/dom/ProgressEvent.h:
* Source/WebCore/dom/PromiseRejectionEvent.h:
* Source/WebCore/dom/SecurityPolicyViolationEvent.h:
* Source/WebCore/dom/TextEvent.cpp:
(WebCore::TextEvent::eventInterface const): Deleted.
* Source/WebCore/dom/TextEvent.h:
* Source/WebCore/dom/ToggleEvent.cpp:
(WebCore::ToggleEvent::eventInterface const): Deleted.
* Source/WebCore/dom/ToggleEvent.h:
* Source/WebCore/dom/TouchEvent.cpp:
(WebCore::TouchEvent::eventInterface const): Deleted.
* Source/WebCore/dom/TouchEvent.h:
* Source/WebCore/dom/UIEvent.cpp:
(WebCore::UIEvent::eventInterface const): Deleted.
* Source/WebCore/dom/UIEvent.h:
* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::WheelEvent::eventInterface const): Deleted.
* Source/WebCore/dom/WheelEvent.h:
* Source/WebCore/html/MediaEncryptedEvent.cpp:
(WebCore::MediaEncryptedEvent::eventInterface const): Deleted.
* Source/WebCore/html/MediaEncryptedEvent.h:
* Source/WebCore/html/SubmitEvent.cpp:
(WebCore::SubmitEvent::eventInterface const): Deleted.
* Source/WebCore/html/SubmitEvent.h:
* Source/WebCore/html/canvas/WebGLContextEvent.cpp:
(WebCore::WebGLContextEvent::eventInterface const): Deleted.
* Source/WebCore/html/canvas/WebGLContextEvent.h:
* Source/WebCore/html/track/TrackEvent.cpp:
(WebCore::TrackEvent::eventInterface const): Deleted.
* Source/WebCore/html/track/TrackEvent.h:
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::eventInterface const): Deleted.
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp:
(WebCore::NavigationCurrentEntryChangeEvent::eventInterface const): Deleted.
* Source/WebCore/page/NavigationCurrentEntryChangeEvent.h:
* Source/WebCore/storage/StorageEvent.cpp:
(WebCore::StorageEvent::eventInterface const): Deleted.
* Source/WebCore/storage/StorageEvent.h:
* Source/WebCore/workers/service/ExtendableEvent.h:
* Source/WebCore/workers/service/ExtendableMessageEvent.h:
* Source/WebCore/workers/service/FetchEvent.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h:
(): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.h:
* Source/WebCore/xml/XMLHttpRequestProgressEvent.h:

Canonical link: <a href="https://commits.webkit.org/275267@main">https://commits.webkit.org/275267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cf951e69cbcafc8817d2db34fd1b70a399131da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17706 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45267 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34815 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40685 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39083 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17849 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5522 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->