### PR TITLE
REGRESSION(274626main): Unable to exit fullscreen on tvOS

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -84,6 +84,8 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPictureInPictureContentViewController)
 @property (nonatomic, assign /* weak */) RefPtr<WebCore::VideoPresentationInterfaceAVKit> fullscreenInterface;
 #if !PLATFORM(APPLETV)
 - (BOOL)playerViewController:(AVPlayerViewController *)playerViewController shouldExitFullScreenWithReason:(AVPlayerViewControllerExitFullScreenReason)reason;
+#else
+- (BOOL)playerViewControllerShouldDismiss:(AVPlayerViewController *)playerViewController;
 #endif
 @end
 
@@ -173,6 +175,17 @@ static WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason convertToE
     UNUSED_PARAM(playerViewController);
     if (auto fullscreenInterface = self.fullscreenInterface)
         return fullscreenInterface->shouldExitFullscreenWithReason(convertToExitFullScreenReason(reason));
+
+    return YES;
+}
+
+#else
+
+- (BOOL)playerViewControllerShouldDismiss:(AVPlayerViewController *)playerViewController
+{
+    UNUSED_PARAM(playerViewController);
+    if (auto fullscreenInterface = self.fullscreenInterface)
+        return fullscreenInterface->shouldExitFullscreenWithReason(WebCore::VideoPresentationInterfaceAVKit::ExitFullScreenReason::PinchGestureHandled);
 
     return YES;
 }


### PR DESCRIPTION
#### c515c4be3ed61124f16cd57e1dfedd9c7709ef26
<pre>
REGRESSION(274626main): Unable to exit fullscreen on tvOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=270020">https://bugs.webkit.org/show_bug.cgi?id=270020</a>
<a href="https://rdar.apple.com/123534305">rdar://123534305</a>

Reviewed by Jer Noble.

When refactoring VideoPresentationInterfaceAVKit in 274626main we inadvertently removed
WebAVPlayerViewControllerDelegate&apos;s conformance to -playerViewControllerShouldDismiss:, which broke
the ability to exit fullscreen on tvOS. Restored the delegate method.

* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm:
(-[WebAVPlayerViewControllerDelegate playerViewControllerShouldDismiss:]):

Canonical link: <a href="https://commits.webkit.org/275295@main">https://commits.webkit.org/275295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54732fa77e2ecd71c77a89ee917243fa26f07e0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37556 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17808 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34279 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45386 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40779 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39182 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17898 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9291 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->