### PR TITLE
[git-webkit] Support repositories where commit signing enabled

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -498,6 +498,9 @@ class Git(Scm):
     def branches(self):
         return self.branches_for()
 
+    def commit_signing_enabled(self, cached=None):
+        return self.config(cached=cached).get('commit.gpgsign', 'false') == 'true'
+
     def tags(self, remote=None):
         if not remote:
             tags = run([self.executable(), 'tag'], cwd=self.root_path, capture_output=True, encoding='utf-8')
@@ -1157,17 +1160,34 @@ class Git(Scm):
         base = self._to_git_ref(base)
         head = self._to_git_ref(head)
 
-        code = run([self.executable(), 'rebase', '--onto', target, base or target, head], cwd=self.root_path).returncode
+        need_commit_signature = self.commit_signing_enabled()
+
+        command = [self.executable()]
+        if need_commit_signature:
+            command += ['-c', 'commit.gpgsign=false']
+        code = run(
+            command + ['rebase', '--onto', target, base or target, head],
+            cwd=self.root_path,
+        ).returncode
         if self.cache:
             self.cache.clear(head if head != 'HEAD' else self.branch)
         if code or not recommit:
             return code
-        return run([
+
+        command = [
             self.executable(), 'filter-branch', '-f',
             '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}'".format(
                 date='{} -{}'.format(int(time.time()), self.gmtoffset())
-            ), 'refs/heads/{}...{}'.format(target, head),
-        ], cwd=self.root_path, env={'FILTER_BRANCH_SQUELCH_WARNING': '1'}, capture_output=True).returncode
+            ),
+        ]
+        if need_commit_signature:
+            command += ['--commit-filter', 'git commit-tree -S "$@"']
+        return run(
+            command + ['refs/heads/{}...{}'.format(target, head)],
+            cwd=self.root_path,
+            env={'FILTER_BRANCH_SQUELCH_WARNING': '1'},
+            capture_output=True,
+        ).returncode
 
     def fetch(self, branch, remote=None, prune=None):
         remote = remote or self.default_remote
@@ -1184,11 +1204,16 @@ class Git(Scm):
         remote = remote or self.default_remote
         commit = self.commit() if self.is_svn or branch else None
 
+        need_commit_signature = self.commit_signing_enabled()
+
         code = 0
         if branch and self.branch != branch:
             code = self.fetch(branch=branch, remote=remote, prune=prune)
         if not code:
-            command = [self.executable(), 'pull'] + ([remote, branch] if branch else [])
+            command = [self.executable()]
+            if rebase is not False and need_commit_signature:
+                command += ['-c', 'commit.gpgsign=false']
+            command += ['pull'] + ([remote, branch] if branch else [])
             if rebase is True:
                 command += ['--rebase=True', '--autostash']
             elif rebase is False:
@@ -1200,13 +1225,20 @@ class Git(Scm):
         if not code and branch and rebase:
             result = run([self.executable(), 'rev-parse', 'HEAD'], cwd=self.root_path, capture_output=True, encoding='utf-8')
             if not result.returncode and result.stdout.rstrip() != commit.hash:
-                code = run([
+                command = [
                     self.executable(),
                     'filter-branch', '-f',
                     '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}'".format(
                         date='{} -{}'.format(int(time.time()), self.gmtoffset())
-                    ), 'HEAD...{}'.format('{}/{}'.format(remote, branch)),
-                ], cwd=self.root_path, env={'FILTER_BRANCH_SQUELCH_WARNING': '1'}).returncode
+                    ),
+                ]
+                if need_commit_signature:
+                    command += ['--commit-filter', 'git commit-tree -S "$@"']
+                code = run(
+                    command + ['HEAD...{}'.format('{}/{}'.format(remote, branch))],
+                    cwd=self.root_path,
+                    env={'FILTER_BRANCH_SQUELCH_WARNING': '1'},
+                ).returncode
 
         if not code and self.is_svn and commit.revision:
             return run([

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py
@@ -109,9 +109,13 @@ class Canonicalize(Command):
                 ),
             ] if args.identifier else []
 
+            resign_commands = []
+            if repository.commit_signing_enabled():
+                resign_commands = ['--commit-filter', 'git commit-tree -S "$@"']
+
             with open(os.devnull, 'w') as devnull:
                 subprocess.check_call([
-                    repository.executable(), 'filter-branch', '-f',
+                    repository.executable(), 'filter-branch', '-f'] + resign_commands + [
                     '--env-filter', '''{overwrite_message}
 committerOutput=$({python} {committer_py} {contributor_json})
 KEY=''

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
@@ -218,13 +218,20 @@ class Land(Command):
                     string_utils.join([p.name for p in pull_request.approvers]),
                     's' if len(pull_request.approvers) > 1 else '',
                 ))
-                if run([
+                command = [
                     repository.executable(), 'filter-branch', '-f',
                     '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}'".format(
                         date='{} -{}'.format(int(time.time()), repository.gmtoffset())
                     ), '--msg-filter', 'sed "s/NOBODY (OO*PP*S!*)/{}/g"'.format(string_utils.join([p.name for p in pull_request.approvers])),
-                    '{}...{}'.format(source_branch, branch_point.hash),
-                ], cwd=repository.root_path, env={'FILTER_BRANCH_SQUELCH_WARNING': '1'}, capture_output=True).returncode:
+                ]
+                if repository.commit_signing_enabled():
+                    command += ['--commit-filter', 'git commit-tree -S "$@"']
+                if run(
+                    command + ['{}...{}'.format(source_branch, branch_point.hash)],
+                    cwd=repository.root_path,
+                    env={'FILTER_BRANCH_SQUELCH_WARNING': '1'},
+                    capture_output=True,
+                ).returncode:
                     sys.stderr.write('Failed to set reviewers\n')
                     return 1
                 commits = list(repository.commits(begin=dict(hash=branch_point.hash), end=dict(branch=source_branch)))


### PR DESCRIPTION
#### 797bcc905aa6fcba0033710f3f384fa91bbedadc
<pre>
[git-webkit] Support repositories where commit signing enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=270029">https://bugs.webkit.org/show_bug.cgi?id=270029</a>
<a href="https://rdar.apple.com/123539145">rdar://123539145</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.commit_signing_enabled): Check if commit.gpgsign is set.
(Git.rebase): Re-sign commits when setting committer.
(Git.pull): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py:
(Canonicalize.main): Re-sign commits when adding identifier.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:
(Land.main): Re-sign commits when adding reviewer.

Canonical link: <a href="https://commits.webkit.org/275417@main">https://commits.webkit.org/275417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1609898f3602e3e2981346006026c9ec381c0fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/41789 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/20803 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/44171 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/44367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/44096 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/23948 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/18134 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/44367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/42363 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/23948 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/44171 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/44367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/41660 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/23948 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/44171 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45760 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/23948 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/44171 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/45760 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/18134 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45760 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/41836 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/44171 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5594 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->