### PR TITLE
Refactor TextExtraction support in WKWebView to use a promise instead of a Swift block

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -82,6 +82,7 @@
 #import "WKSecurityOriginInternal.h"
 #import "WKSharedAPICast.h"
 #import "WKSnapshotConfigurationPrivate.h"
+#import "WKTextExtractionItem.h"
 #import "WKTextExtractionUtilities.h"
 #import "WKUIDelegate.h"
 #import "WKUIDelegatePrivate.h"
@@ -4242,6 +4243,13 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
 @end
 
 @implementation WKWebView (WKTextExtraction)
+
+- (void)_requestTextExtractionForSwift:(WKTextExtractionRequest *)context
+{
+    [self _requestTextExtraction:context.rectInWebView completionHandler:makeBlockPtr([context = retainPtr(context)](WKTextExtractionItem *result) {
+        [context fulfill:result];
+    }).get()];
+}
 
 - (void)_requestTextExtraction:(CGRect)rectInWebView completionHandler:(void(^)(WKTextExtractionItem *))completionHandler
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -106,6 +106,7 @@ class ViewGestureController;
 @class WKSafeBrowsingWarning;
 @class WKScrollView;
 @class WKTextExtractionItem;
+@class WKTextExtractionRequest;
 @class WKWebViewContentProviderRegistry;
 @class _WKFrameHandle;
 
@@ -389,5 +390,6 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const WebCore::ExceptionDetails&)
 #endif
 
 @interface WKWebView (WKTextExtraction)
+- (void)_requestTextExtractionForSwift:(WKTextExtractionRequest *)context;
 - (void)_requestTextExtraction:(CGRect)rect completionHandler:(void(^)(WKTextExtractionItem *))completionHandler;
 @end

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.h
@@ -82,3 +82,8 @@ typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *altText;
 @end
+
+@interface WKTextExtractionRequest : NSObject
+- (void)fulfill:(WKTextExtractionItem *)result;
+@property (nonatomic, readonly) CGRect rectInWebView;
+@end

--- a/Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift
+++ b/Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift
@@ -120,3 +120,19 @@ import Foundation
         super.init(with: rectInRootView, children: children)
     }
 }
+
+@objc(WKTextExtractionRequest) class WKTextExtractionRequest: NSObject {
+    @objc public let rectInWebView: CGRect
+    private var completionHandler: ((WKTextExtractionItem?) -> Void)?
+
+    @objc public init(rectInWebView: CGRect, _ completionHandler: @escaping (WKTextExtractionItem?) -> Void) {
+        self.rectInWebView = rectInWebView
+        self.completionHandler = completionHandler
+    }
+
+    @objc(fulfill:) public func fulfill(item: WKTextExtractionItem) {
+        guard let completionHandler = self.completionHandler else { return }
+        completionHandler(item)
+        self.completionHandler = nil
+    }
+}


### PR DESCRIPTION
#### cb875ef24116b4a39bab32f2aec4bdb16ebdf16f
<pre>
Refactor TextExtraction support in WKWebView to use a promise instead of a Swift block
<a href="https://bugs.webkit.org/show_bug.cgi?id=270031">https://bugs.webkit.org/show_bug.cgi?id=270031</a>
<a href="https://rdar.apple.com/123542653">rdar://123542653</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Refactor this code to use a dedicated object (`WKTextExtractionRequest`) used to represent an
asynchronously-fulfilled promise, rather than taking a completion handler directly. As it turns out,
completion handler blocks in Swift-only API end up getting passed as `nil` into Objective-C methods
expecting blocks, when using `perform(with:…:)` to invoke ObjC-exposed selectors.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtractionForSwift:]):

Wrap the existing call to request text extraction.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.h:
* Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift:
(WKTextExtractionRequest.completionHandler):
(WKTextExtractionRequest.fulfill(_:)):

Canonical link: <a href="https://commits.webkit.org/275286@main">https://commits.webkit.org/275286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d673a7b2d74b630b412dce742b4af39f8c9591b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37518 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34244 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15086 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45345 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40744 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39147 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17860 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9283 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->