### PR TITLE
Call ContainerNode::removedFromAncestor at the beginning of Element::removedFromAncestor

### DIFF
--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -138,8 +138,6 @@ inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomString& key, const Tre
         for (Ref element : descendantsOfType<Element>(downcast<ContainerNode>(removedTree.get()))) {
             if (!keyMatches(key, element))
                 continue;
-            bool removedFromAncestorHasNotBeenCalledYet = element->isConnected();
-            ASSERT(removedFromAncestorHasNotBeenCalledYet);
             return nullptr;
         }
     }


### PR DESCRIPTION
#### db97835b972965876624d9dbe8cb091df15b41d6
<pre>
Call ContainerNode::removedFromAncestor at the beginning of Element::removedFromAncestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=270032">https://bugs.webkit.org/show_bug.cgi?id=270032</a>

Reviewed by Chris Dumez.

This PR moves the call to ContainerNode::removedFromAncestor in Element::removedFromAncestor
to the beginning of the function instead of in the middle of a bunch of code in order to
prepare this code for more optimizations in near future.

* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::get const): Removed the debug assertion that isConnected() is
still true for the element that is being removed since we clear the node flag before calling
updateIdForTreeScope now.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::updateName):
(WebCore::Element::updateNameForDocument):
(WebCore::Element::updateId):
(WebCore::Element::updateIdForTreeScope):
(WebCore::Element::updateIdForDocument):

Canonical link: <a href="https://commits.webkit.org/275777@main">https://commits.webkit.org/275777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1815bb3d420fe6817846c104eb46f8b0e9ed22d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38935 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35422 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16386 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16465 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37910 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/867 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46936 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42157 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19263 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40796 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19427 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5795 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->