### PR TITLE
[MSE] Media from the TimeRange containing currentTime can be evicted when it shouldn't

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-eviction-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-eviction-expected.txt
@@ -1,0 +1,44 @@
+
+EXPECTED (source.readyState == 'closed') OK
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.disableRemotePlayback = true)
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(sourceBuffer.onbufferedchange = bufferedChange)
+RUN(initSegment = makeAInit(10, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 10)))
+onbufferedchange called.
+e.addedRanges = [0, 10)
+e.removedRanges = []
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(syncSampleRun(10, 15)))
+onbufferedchange called.
+e.addedRanges = [10, 15)
+e.removedRanges = []
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(syncSampleRun(15, 20)))
+onbufferedchange called.
+e.addedRanges = [15, 20)
+e.removedRanges = []
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+RUN(sourceBuffer.appendBuffer(syncSampleRun(22, 30)))
+onbufferedchange called.
+e.addedRanges = [22, 30)
+e.removedRanges = []
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '2') OK
+RUN(video.currentTime = 9)
+EVENT(seeked)
+RUN(internals.beginSimulatedMemoryPressure())
+onbufferedchange called.
+e.addedRanges = []
+e.removedRanges = [22, 30)
+EVENT(bufferedchange)
+RUN(internals.endSimulatedMemoryPressure())
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '20') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-eviction.html
+++ b/LayoutTests/media/media-source/media-managedmse-eviction.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource-memoryPressure</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initsegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    function syncSampleRun(start, end, stepSync = 9999999999) {
+        const samples = [];
+        for (let time = start; time < end; time++)
+            samples.push(makeASample(time, time, 1, 1, 1, (time - start) % stepSync == 0 ? SAMPLE_FLAG.SYNC : SAMPLE_FLAG.NONE));
+        return concatenateSamples(samples);
+    }
+
+    function bufferedChange(e) {
+        consoleWrite('onbufferedchange called.')
+        consoleWrite(`e.addedRanges = ${ timeRangesToString(e.addedRanges) }`);
+        consoleWrite(`e.removedRanges = ${ timeRangesToString(e.removedRanges) }`);
+    };
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new ManagedMediaSource();
+
+        testExpected('source.readyState', 'closed');
+        run('video.src = URL.createObjectURL(source)');
+        run('video.disableRemotePlayback = true');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        run('sourceBuffer.onbufferedchange = bufferedChange');
+
+        run("initSegment = makeAInit(10, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)])");
+
+        run('sourceBuffer.appendBuffer(initSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.appendBuffer(syncSampleRun(0, 10))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(syncSampleRun(10, 15))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(syncSampleRun(15, 20))');
+        await waitFor(sourceBuffer, 'update');
+        testExpected('sourceBuffer.buffered.length', '1');
+
+        run('sourceBuffer.appendBuffer(syncSampleRun(22, 30))');
+        await waitFor(sourceBuffer, 'update');
+        testExpected('sourceBuffer.buffered.length', '2');
+
+        run('video.currentTime = 9');
+        await waitFor(video, 'seeked');
+        run('internals.beginSimulatedMemoryPressure()');
+        await waitFor(sourceBuffer, 'bufferedchange');
+        run('internals.endSimulatedMemoryPressure()');
+        testExpected('sourceBuffer.buffered.length', '1');
+        testExpected('sourceBuffer.buffered.end(0)', '20');
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1067,6 +1067,7 @@ webkit.org/b/265919 media/track/media-source-audio-track.html [ Failure ]
 # WebProcess's MemoryPressureHandler are disabled, test is nonfunctional
 media/media-source/media-managedmse-memorypressure.html [ Timeout ]
 media/media-source/media-managedmse-memorypressure-inactive.html [ Timeout ]
+media/media-source/media-managedmse-eviction.html [ Timeout ]
 # No AirPlay on glib platforms.
 media/media-source/media-managedmse-airplay.html [ Skip ]
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1237,8 +1237,11 @@ bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, uint64_t maximumBuff
             size_t currentTimeRange = buffered.find(currentTime);
             size_t startTimeRange = buffered.find(rangeStart);
             if (currentTimeRange != notFound && startTimeRange == currentTimeRange) {
-                size_t endTimeRange = buffered.find(rangeEnd);
-                if (endTimeRange == currentTimeRange)
+                currentTimeRange++;
+                if (currentTimeRange == buffered.length())
+                    break;
+                rangeStart = buffered.start(currentTimeRange);
+                if (rangeStart >= rangeEnd)
                     break;
             }
 


### PR DESCRIPTION
#### 19f884773fcae860a4dfb9346d56c55a89c630f4
<pre>
[MSE] Media from the TimeRange containing currentTime can be evicted when it shouldn&apos;t
<a href="https://bugs.webkit.org/show_bug.cgi?id=270034">https://bugs.webkit.org/show_bug.cgi?id=270034</a>
<a href="https://rdar.apple.com/problem/123556056">rdar://problem/123556056</a>

Reviewed by Eric Carlson.

We want none of the data contiguous from the currentTime to the next discontinuity to be
evicted to ensure continuous playback.
This is inline with Google&apos;s proposal for having Eviction Policies.

The comments in the eviction code indicated as such, but a logic error would have made
the end of the current range be truncated if it was followed by another range
after a discontinuity.

* LayoutTests/media/media-source/media-managedmse-eviction-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-eviction.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::evictFrames):

Canonical link: <a href="https://commits.webkit.org/275306@main">https://commits.webkit.org/275306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28e62525d48710c48b8047ff7ce2392215b43787

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17827 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45409 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37048 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16298 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39210 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9296 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17561 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->