### PR TITLE
Stop using near-suspended assertion on Mac

### DIFF
--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -222,7 +222,7 @@ bool defaultShouldDropNearSuspendedAssertionAfterDelay()
 
 bool defaultShouldTakeNearSuspendedAssertion()
 {
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
     static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::FullySuspendsBackgroundContentImmediately);
     return !newSDK;
 #else

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -36,6 +36,7 @@
 
 namespace WebKit {
 
+class ProcessThrottlerActivity;
 class WebProcessPool;
 class WebsiteDataStore;
 
@@ -89,6 +90,7 @@ private:
         RunLoop::Timer m_evictionTimer;
 #if PLATFORM(MAC) || PLATFORM(GTK) || PLATFORM(WPE)
         RunLoop::Timer m_suspensionTimer;
+        std::unique_ptr<ProcessThrottlerActivity> m_backgroundActivity;
 #endif
     };
 


### PR DESCRIPTION
#### e954cf3227f1d0672e1d61645e37400059d29e58
<pre>
Stop using near-suspended assertion on Mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=270037">https://bugs.webkit.org/show_bug.cgi?id=270037</a>
<a href="https://rdar.apple.com/121058651">rdar://121058651</a>

Reviewed by Chris Dumez.

In 272937@main we stopped using the near-suspended process state on iOS so that background processes
suspended more promptly. However, we held off on doing that on the Mac because it caused a
regression in PLT5.

In this patch, we now stop using the near-suspended state on Mac as well. To fix the benchmark
regression, we preserve the old behavior of allowing cached processes to run in the background for
30 seconds after they enter the process cache by explicitly taking a background activity when the
process enters the cache.

* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultShouldTakeNearSuspendedAssertion):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::CachedProcess::takeProcess):
(WebKit::WebProcessCache::CachedProcess::startSuspensionTimer):
(WebKit::WebProcessCache::CachedProcess::suspensionTimerFired):
* Source/WebKit/UIProcess/WebProcessCache.h:

Canonical link: <a href="https://commits.webkit.org/275349@main">https://commits.webkit.org/275349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ffeb61fe4622013fe0d6e4e209bc808229d1198

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37508 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34236 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14897 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15077 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40736 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39138 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17850 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9318 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17904 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->