### PR TITLE
Some more adoption of dynamicDowncast<> in layout code

### DIFF
--- a/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.cpp
@@ -204,19 +204,19 @@ bool BlockMarginCollapse::marginBeforeCollapsesWithFirstInFlowChildMarginBefore(
     if (hasPaddingBefore(layoutBox))
         return false;
 
-    if (!is<ElementBox>(layoutBox.firstInFlowChild()))
+    auto* firstInFlowChild = dynamicDowncast<ElementBox>(layoutBox.firstInFlowChild());
+    if (!firstInFlowChild)
         return false;
 
-    auto& firstInFlowChild = downcast<ElementBox>(*layoutBox.firstInFlowChild());
-    if (!firstInFlowChild.isBlockLevelBox())
+    if (!firstInFlowChild->isBlockLevelBox())
         return false;
 
     // ...and the child has no clearance.
-    if (hasClearance(firstInFlowChild))
+    if (hasClearance(*firstInFlowChild))
         return false;
 
     // Margins of inline-block boxes do not collapse.
-    if (firstInFlowChild.isInlineBlockBox())
+    if (firstInFlowChild->isInlineBlockBox())
         return false;
 
     return true;
@@ -316,11 +316,11 @@ bool BlockMarginCollapse::marginAfterCollapsesWithLastInFlowChildMarginAfter(con
     if (establishesBlockFormattingContext(layoutBox))
         return false;
 
-    if (!is<ElementBox>(layoutBox.lastInFlowChild()))
+    auto* lastInFlowChild = dynamicDowncast<ElementBox>(layoutBox.lastInFlowChild());
+    if (!lastInFlowChild)
         return false;
 
-    auto& lastInFlowChild = downcast<ElementBox>(*layoutBox.lastInFlowChild());
-    if (!lastInFlowChild.isBlockLevelBox())
+    if (!lastInFlowChild->isBlockLevelBox())
         return false;
 
     // The bottom margin of an in-flow block box with a 'height' of 'auto' collapses with its last in-flow block-level child's bottom margin, if:
@@ -336,23 +336,23 @@ bool BlockMarginCollapse::marginAfterCollapsesWithLastInFlowChildMarginAfter(con
         return false;
 
     // the child's bottom margin neither collapses with a top margin that has clearance...
-    if (marginAfterCollapsesWithSiblingMarginBeforeWithClearance(lastInFlowChild))
+    if (marginAfterCollapsesWithSiblingMarginBeforeWithClearance(*lastInFlowChild))
         return false;
 
     // nor (if the box's min-height is non-zero) with the box's top margin.
     auto computedMinHeight = layoutBox.style().logicalMinHeight();
     if (!computedMinHeight.isAuto() && computedMinHeight.value()
-        && (marginAfterCollapsesWithParentMarginBefore(lastInFlowChild) || hasClearance(lastInFlowChild)))
+        && (marginAfterCollapsesWithParentMarginBefore(*lastInFlowChild) || hasClearance(*lastInFlowChild)))
         return false;
 
     // Margins of inline-block boxes do not collapse.
-    if (lastInFlowChild.isInlineBlockBox())
+    if (lastInFlowChild->isInlineBlockBox())
         return false;
 
     // This is a quirk behavior: When the margin after of the last inflow child (or a previous sibling with collapsed through margins)
     // collapses with a quirk parent's the margin before, then the same margin after does not collapses with the parent's margin after.
     auto shouldIgnoreCollapsedMargin = inQuirksMode() && BlockFormattingQuirks::shouldIgnoreCollapsedQuirkMargin(layoutBox);
-    if (shouldIgnoreCollapsedMargin && marginAfterCollapsesWithParentMarginBefore(lastInFlowChild))
+    if (shouldIgnoreCollapsedMargin && marginAfterCollapsesWithParentMarginBefore(*lastInFlowChild))
         return false;
 
     return true;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
@@ -51,23 +51,24 @@ static bool containsTrailingSoftHyphen(const InlineItem& inlineItem)
 {
     if (inlineItem.style().hyphens() == Hyphens::None)
         return false;
-    if (!inlineItem.isText())
+    auto* textItem = dynamicDowncast<InlineTextItem>(inlineItem);
+    if (!textItem)
         return false;
-    return downcast<InlineTextItem>(inlineItem).hasTrailingSoftHyphen();
+    return textItem->hasTrailingSoftHyphen();
 }
 
 static bool containsPreservedTab(const InlineItem& inlineItem)
 {
-    if (!inlineItem.isText())
+    auto* textItem = dynamicDowncast<InlineTextItem>(inlineItem);
+    if (!textItem)
         return false;
-    const auto& textItem = downcast<InlineTextItem>(inlineItem);
-    if (!textItem.isWhitespace())
+    if (!textItem->isWhitespace())
         return false;
-    const auto& textBox = textItem.inlineTextBox();
+    const auto& textBox = textItem->inlineTextBox();
     if (!TextUtil::shouldPreserveSpacesAndTabs(textBox))
         return false;
-    auto start = textItem.start();
-    auto length = textItem.length();
+    auto start = textItem->start();
+    auto length = textItem->length();
     const auto& textContent = textBox.content();
     for (size_t index = start; index < start + length; index++) {
         if (textContent[index] == tabCharacter)
@@ -427,9 +428,8 @@ bool InlineContentBalancer::shouldTrimLeading(size_t inlineItemIndex, bool useFi
     if (inlineItem.isLineBreak())
         return true;
 
-    if (inlineItem.isText()) {
-        auto& textItem = downcast<InlineTextItem>(inlineItem);
-        if (textItem.isWhitespace()) {
+    if (auto* textItem = dynamicDowncast<InlineTextItem>(inlineItem)) {
+        if (textItem->isWhitespace()) {
             bool isFirstLineLeadingPreservedWhiteSpace = style.whiteSpaceCollapse() == WhiteSpaceCollapse::Preserve && isFirstLineInChunk;
             return !isFirstLineLeadingPreservedWhiteSpace && style.whiteSpaceCollapse() != WhiteSpaceCollapse::BreakSpaces;
         }
@@ -451,9 +451,8 @@ bool InlineContentBalancer::shouldTrimTrailing(size_t inlineItemIndex, bool useF
     if (inlineItem.isLineBreak())
         return true;
 
-    if (inlineItem.isText()) {
-        auto& textItem = downcast<InlineTextItem>(inlineItem);
-        if (textItem.isWhitespace())
+    if (auto* textItem = dynamicDowncast<InlineTextItem>(inlineItem)) {
+        if (textItem->isWhitespace())
             return style.whiteSpaceCollapse() != WhiteSpaceCollapse::BreakSpaces;
         return false;
     }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -309,14 +309,13 @@ InlineItemPosition InlineFormattingUtils::leadingInlineItemPositionForNextLine(I
 InlineLayoutUnit InlineFormattingUtils::inlineItemWidth(const InlineItem& inlineItem, InlineLayoutUnit contentLogicalLeft, bool useFirstLineStyle) const
 {
     ASSERT(inlineItem.layoutBox().isInlineLevelBox());
-    if (is<InlineTextItem>(inlineItem)) {
-        auto& inlineTextItem = downcast<InlineTextItem>(inlineItem);
-        if (auto contentWidth = inlineTextItem.width())
+    if (auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem)) {
+        if (auto contentWidth = inlineTextItem->width())
             return *contentWidth;
-        auto& fontCascade = useFirstLineStyle ? inlineTextItem.firstLineStyle().fontCascade() : inlineTextItem.style().fontCascade();
-        if (!inlineTextItem.isWhitespace() || InlineTextItem::shouldPreserveSpacesAndTabs(inlineTextItem))
-            return TextUtil::width(inlineTextItem, fontCascade, contentLogicalLeft);
-        return TextUtil::width(inlineTextItem, fontCascade, inlineTextItem.start(), inlineTextItem.start() + 1, contentLogicalLeft);
+        auto& fontCascade = useFirstLineStyle ? inlineTextItem->firstLineStyle().fontCascade() : inlineTextItem->style().fontCascade();
+        if (!inlineTextItem->isWhitespace() || InlineTextItem::shouldPreserveSpacesAndTabs(*inlineTextItem))
+            return TextUtil::width(*inlineTextItem, fontCascade, contentLogicalLeft);
+        return TextUtil::width(*inlineTextItem, fontCascade, inlineTextItem->start(), inlineTextItem->start() + 1, contentLogicalLeft);
     }
 
     if (inlineItem.isLineBreak() || inlineItem.isWordBreakOpportunity())
@@ -418,9 +417,9 @@ bool InlineFormattingUtils::isAtSoftWrapOpportunity(const InlineItem& previous, 
     if (&previous.layoutBox().parent() == &next.layoutBox().parent() && !mayWrapPrevious && !mayWrapNext)
         return false;
 
-    if (previous.isText() && next.isText()) {
-        auto& previousInlineTextItem = downcast<InlineTextItem>(previous);
-        auto& nextInlineTextItem = downcast<InlineTextItem>(next);
+    if (is<InlineTextItem>(previous) && is<InlineTextItem>(next)) {
+        auto& previousInlineTextItem = uncheckedDowncast<InlineTextItem>(previous);
+        auto& nextInlineTextItem = uncheckedDowncast<InlineTextItem>(next);
         if (previousInlineTextItem.isWhitespace() || nextInlineTextItem.isWhitespace()) {
             // For soft wrap opportunities created by characters that disappear at the line break (e.g. U+0020 SPACE), properties on the box directly
             // containing that character control the line breaking at that opportunity.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -460,7 +460,8 @@ static inline void buildBidiParagraph(const RenderStyle& rootStyle, const Inline
                     replaceNonPreservedNewLineAndTabCharactersAndAppend(*inlineTextBox, paragraphContentBuilder);
                     lastInlineTextBox = &layoutBox;
                 }
-                inlineItemOffsetList.append({ inlineTextBoxOffset + (is<InlineTextItem>(inlineItem) ? downcast<InlineTextItem>(inlineItem).start() : downcast<InlineSoftLineBreakItem>(inlineItem).position()) });
+                auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem);
+                inlineItemOffsetList.append({ inlineTextBoxOffset + (inlineTextItem ? inlineTextItem->start() : downcast<InlineSoftLineBreakItem>(inlineItem).position()) });
             } else if (auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem)) {
                 inlineItemOffsetList.append({ paragraphContentBuilder.length() });
                 paragraphContentBuilder.append(StringView(inlineTextItem->inlineTextBox().content()).substring(inlineTextItem->start(), inlineTextItem->length()));

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -579,7 +579,6 @@ void Line::appendLineBreak(const InlineItem& inlineItem, const RenderStyle& styl
         return m_runs.append({ inlineItem, style, lastRunLogicalRight() });
     }
     // Soft line breaks (preserved new line characters) require inline text boxes for compatibility reasons.
-    ASSERT(inlineItem.isSoftLineBreak());
     m_runs.append({ downcast<InlineSoftLineBreakItem>(inlineItem), inlineItem.style(), lastRunLogicalRight() });
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -191,15 +191,14 @@ InlineItemPosition TextOnlySimpleLineBuilder::placeInlineTextContent(const Inlin
         auto& inlineItem = m_inlineItemList[nextItemIndex++];
         ASSERT(inlineItem.isText() || inlineItem.isLineBreak());
 
-        if (inlineItem.isText()) {
-            auto& inlineTextItem = downcast<InlineTextItem>(inlineItem);
+        if (auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem)) {
             auto contentWidth = [&] {
-                if (auto logicalWidth = inlineTextItem.width())
+                if (auto logicalWidth = inlineTextItem->width())
                     return *logicalWidth;
-                return measuredInlineTextItem(inlineTextItem, rootStyle, m_line.contentLogicalRight() + candidateContent.logicalWidth);
+                return measuredInlineTextItem(*inlineTextItem, rootStyle, m_line.contentLogicalRight() + candidateContent.logicalWidth);
             };
             candidateContent.append(contentWidth());
-            if (isAtSoftWrapOpportunityOrContentEnd(inlineTextItem))
+            if (isAtSoftWrapOpportunityOrContentEnd(*inlineTextItem))
                 isEndOfLine = processCandidateContent();
             continue;
         }
@@ -232,11 +231,11 @@ InlineItemPosition TextOnlySimpleLineBuilder::placeNonWrappingInlineTextContent(
     while (!isEndOfLine) {
         auto& inlineItem = m_inlineItemList[nextItemIndex];
         ASSERT(inlineItem.isText() || inlineItem.isLineBreak());
-        if (inlineItem.isText()) {
+        if (auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem)) {
             auto contentWidth = [&] {
-                if (auto logicalWidth = downcast<InlineTextItem>(inlineItem).width())
+                if (auto logicalWidth = inlineTextItem->width())
                     return *logicalWidth;
-                return measuredInlineTextItem(downcast<InlineTextItem>(inlineItem), rootStyle, candidateContent.logicalWidth);
+                return measuredInlineTextItem(*inlineTextItem, rootStyle, candidateContent.logicalWidth);
             };
             candidateContent.append(contentWidth());
         } else if (inlineItem.isLineBreak())

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
@@ -164,18 +164,18 @@ LeafBoxIterator closestBoxForHorizontalPosition(const LineBox& lineBox, float ho
 RenderObject::HighlightState LineBox::ellipsisSelectionState() const
 {
     auto lastLeafBox = this->lastLeafBox();
-    if (!lastLeafBox || !lastLeafBox->isText())
+    if (!lastLeafBox)
         return RenderObject::HighlightState::None;
 
-    auto& text = downcast<InlineIterator::TextBox>(*lastLeafBox);
-    if (text.selectionState() == RenderObject::HighlightState::None)
+    auto* text = dynamicDowncast<InlineIterator::TextBox>(*lastLeafBox);
+    if (!text || text->selectionState() == RenderObject::HighlightState::None)
         return RenderObject::HighlightState::None;
 
-    auto selectionRange = text.selectableRange();
+    auto selectionRange = text->selectableRange();
     if (!selectionRange.truncation)
         return RenderObject::HighlightState::None;
 
-    auto [selectionStart, selectionEnd] = formattingContextRoot().view().selection().rangeForTextBox(text.renderer(), selectionRange);
+    auto [selectionStart, selectionEnd] = formattingContextRoot().view().selection().rangeForTextBox(text->renderer(), selectionRange);
     return selectionStart <= *selectionRange.truncation && selectionEnd >= *selectionRange.truncation ? RenderObject::HighlightState::Inside : RenderObject::HighlightState::None;
 }
 


### PR DESCRIPTION
#### 2f4677a0ea4557844e43e5d3f60f7ddcb857d2e6
<pre>
Some more adoption of dynamicDowncast&lt;&gt; in layout code
<a href="https://bugs.webkit.org/show_bug.cgi?id=270039">https://bugs.webkit.org/show_bug.cgi?id=270039</a>

Reviewed by Alan Baradlay.

For security and performance.

* Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.cpp:
(WebCore::Layout::BlockMarginCollapse::marginBeforeCollapsesWithFirstInFlowChildMarginBefore const):
(WebCore::Layout::BlockMarginCollapse::marginAfterCollapsesWithLastInFlowChildMarginAfter const):
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp:
(WebCore::Layout::containsTrailingSoftHyphen):
(WebCore::Layout::containsPreservedTab):
(WebCore::Layout::InlineContentBalancer::shouldTrimLeading const):
(WebCore::Layout::InlineContentBalancer::shouldTrimTrailing const):
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp:
(WebCore::Layout::isWhitespaceOnlyContent):
(WebCore::Layout::InlineContentBreaker::tryHyphenationAcrossOverflowingInlineTextItems const):
(WebCore::Layout::InlineContentBreaker::processOverflowingContentWithText const):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::inlineItemWidth const):
(WebCore::Layout::InlineFormattingUtils::isAtSoftWrapOpportunity const):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::buildBidiParagraph):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
(WebCore::Layout::Line::appendLineBreak):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::hasTrailingSoftWrapOpportunity):
(WebCore::Layout::LineCandidate::InlineContent::appendInlineItem):
(WebCore::Layout::LineBuilder::initialize):
(WebCore::Layout::LineBuilder::trailingPunctuationOrStopOrCommaWidthForLineCandiate const):
(WebCore::Layout::LineBuilder::candidateContentForLine):
(WebCore::Layout::LineBuilder::isLastLineWithInlineContent const):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::placeInlineTextContent):
(WebCore::Layout::TextOnlySimpleLineBuilder::placeNonWrappingInlineTextContent):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp:
(WebCore::InlineIterator::LineBox::ellipsisSelectionState const):

Canonical link: <a href="https://commits.webkit.org/275459@main">https://commits.webkit.org/275459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95a1bff1d57d4905086d4c90de45ff0c0632ac41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37969 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18219 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36066 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45867 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37412 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13706 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18308 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9388 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->