### PR TITLE
[Unified PDF] Document turns blank white, flashes / flickers, while scrolling/zooming

### DIFF
--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -70,6 +70,7 @@ public:
     virtual void willRepaintTile(TileGridIndex, TileIndex, const FloatRect& tileClip, const FloatRect& paintDirtyRect) = 0;
     virtual void willRemoveTile(TileGridIndex, TileIndex) = 0;
     virtual void willRepaintAllTiles(TileGridIndex) = 0;
+    virtual void coverageRectDidChange(const FloatRect&) = 0;
 };
 
 

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -233,6 +233,11 @@ void TileController::setCoverageRect(const FloatRect& rect)
 
     m_coverageRect = rect;
     setNeedsRevalidateTiles();
+
+    if (!m_client)
+        return;
+
+    m_client->coverageRectDidChange(m_coverageRect);
 }
 
 bool TileController::tilesWouldChangeForCoverageRect(const FloatRect& rect) const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(UNIFIED_PDF)
 
+#include "PDFDocumentLayout.h"
 #include "PDFPageCoverage.h"
 #include <WebCore/FloatRect.h>
 #include <WebCore/GraphicsLayer.h>
@@ -79,8 +80,6 @@ template<> struct DefaultHash<WebKit::TileForGrid> : TileForGridHash { };
 
 } // namespace WTF
 
-
-
 namespace WebKit {
 
 class UnifiedPDFPlugin;
@@ -99,13 +98,17 @@ public:
 
     void setupWithLayer(WebCore::GraphicsLayer&);
     void teardown();
-    bool paintTilesForPaintingRect(WebCore::GraphicsContext&, float pageScaleFactor, const WebCore::FloatRect& paintingRect);
+    bool paintTilesForPage(WebCore::GraphicsContext&, float pageScaleFactor, float documentScale, const WebCore::FloatRect& clipRect, const WebCore::FloatRect& pageBoundsInPaintingCoordinates, PDFDocumentLayout::PageIndex);
 
     // Throws away existing tiles. Can result in flashing.
     void invalidateTilesForPaintingRect(float pageScaleFactor, const WebCore::FloatRect& paintingRect);
 
     // Updates existing tiles. Can result in temporarily stale content.
     void updateTilesForPaintingRect(float pageScaleFactor, const WebCore::FloatRect& paintingRect);
+
+    void generatePreviewImageForPage(PDFDocumentLayout::PageIndex, float scale);
+    RefPtr<WebCore::ImageBuffer> previewImageForPage(PDFDocumentLayout::PageIndex) const;
+    void removePreviewForPage(PDFDocumentLayout::PageIndex);
 
     void setShowDebugBorders(bool);
 
@@ -130,6 +133,7 @@ private:
     void willRepaintTile(WebCore::TileGridIndex, WebCore::TileIndex, const WebCore::FloatRect& tileRect, const WebCore::FloatRect& tileDirtyRect) final;
     void willRemoveTile(WebCore::TileGridIndex, WebCore::TileIndex) final;
     void willRepaintAllTiles(WebCore::TileGridIndex) final;
+    void coverageRectDidChange(const WebCore::FloatRect&) final;
 
     void enqueuePaintWithClip(const TileForGrid&, const WebCore::FloatRect& tileRect);
     void paintTileOnWorkQueue(RetainPtr<PDFDocument>&&, const TileForGrid&, const TileRenderInfo&, TileRenderRequestType);
@@ -140,6 +144,15 @@ private:
     void didCompleteTileUpdateRender(RefPtr<WebCore::ImageBuffer>&&, const TileForGrid&, const TileRenderInfo&);
 
     void clearRequestsAndCachedTiles();
+
+    struct PagePreviewRequest {
+        PDFDocumentLayout::PageIndex pageIndex;
+        WebCore::FloatRect normalizedPageBounds;
+        float scale;
+    };
+
+    void paintPagePreviewOnWorkQueue(RetainPtr<PDFDocument>&&, const PagePreviewRequest&);
+    void paintPDFPageIntoBuffer(RetainPtr<PDFDocument>&&, Ref<WebCore::ImageBuffer>, PDFDocumentLayout::PageIndex, const WebCore::FloatRect& pageBounds);
 
     static WebCore::FloatRect convertTileRectToPaintingCoords(const WebCore::FloatRect&, float pageScaleFactor);
     static WebCore::AffineTransform tileToPaintingTransform(float pageScaleFactor);
@@ -159,6 +172,13 @@ private:
         TileRenderInfo tileInfo;
     };
     HashMap<TileForGrid, RenderedTile> m_rendereredTiles;
+
+    using PDFPageIndexSet = HashSet<PDFDocumentLayout::PageIndex, IntHash<PDFDocumentLayout::PageIndex>, WTF::UnsignedWithZeroKeyHashTraits<PDFDocumentLayout::PageIndex>>;
+    using PDFPageIndexToPreviewHash = HashMap<PDFDocumentLayout::PageIndex, PagePreviewRequest, IntHash<PDFDocumentLayout::PageIndex>, WTF::UnsignedWithZeroKeyHashTraits<PDFDocumentLayout::PageIndex>>;
+    using PDFPageIndexToBufferHash = HashMap<PDFDocumentLayout::PageIndex, RefPtr<WebCore::ImageBuffer>, IntHash<PDFDocumentLayout::PageIndex>, WTF::UnsignedWithZeroKeyHashTraits<PDFDocumentLayout::PageIndex>>;
+
+    PDFPageIndexToPreviewHash m_enqueuedPagePreviews;
+    PDFPageIndexToBufferHash m_pagePreviews;
 
     std::atomic<bool> m_showDebugBorders { false };
 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -145,7 +145,8 @@ private:
     WebCore::IntSize documentSize() const;
     WebCore::IntSize contentsSize() const override;
     unsigned firstPageHeight() const override;
-    unsigned heightForPage(PDFDocumentLayout::PageIndex) const;
+    unsigned heightForPageAtIndex(PDFDocumentLayout::PageIndex) const;
+    WebCore::FloatRect layoutBoundsForPageAtIndex(PDFDocumentLayout::PageIndex) const;
 
     void scheduleRenderingUpdate();
 
@@ -409,6 +410,8 @@ private:
 
     Ref<AsyncPDFRenderer> asyncRenderer();
     RefPtr<AsyncPDFRenderer> asyncRendererIfExists() const;
+
+    void paintBackgroundLayerForPage(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&);
 
     PDFDocumentLayout m_documentLayout;
     RefPtr<WebCore::GraphicsLayer> m_rootLayer;


### PR DESCRIPTION
#### 463c4d367dff65f9fdfda6ad0726d27c3a900f25
<pre>
[Unified PDF] Document turns blank white, flashes / flickers, while scrolling/zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=270042">https://bugs.webkit.org/show_bug.cgi?id=270042</a>
<a href="https://rdar.apple.com/123458964">rdar://123458964</a>

Reviewed by Tim Horton.

With async tile rendering, we don&apos;t always have tiles to paint for a given rect, resulting
in flashing, e.g. when resizing the window or zooming.

Ameliorate this by generating a preview for each page, and painting this when we don&apos;t have
tiles. Currently we generate previews at 0.5x scale for a 1x page scale.

AsyncPDFRenderer takes care of generating page previews, using a new callback from the
TiledBacking client when page coverage changes. The page previews are generated on the
concurrent work queue. Unlike tiles, these page previews are not invalidate on configuration
changes (there&apos;s a FIXME to update them when PDF content changes).

* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setCoverageRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::generatePreviewImageForPage):
(WebKit::AsyncPDFRenderer::removePreviewForPage):
(WebKit::AsyncPDFRenderer::paintPagePreviewOnWorkQueue):
(WebKit::AsyncPDFRenderer::previewImageForPage const):
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::paintPDFPageIntoBuffer):
(WebKit::AsyncPDFRenderer::paintTilesForPage):
(WebKit::AsyncPDFRenderer::updateTilesForPaintingRect):
(WebKit::AsyncPDFRenderer::paintTilesForPaintingRect): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paintPDFContent): drawingRect was unused. Move documentScale out of the loop. Rename pageBoundsInDocumentCoordinates.
(WebKit::UnifiedPDFPlugin::heightForPageAtIndex const): Rename.
(WebKit::UnifiedPDFPlugin::firstPageHeight const):
(WebKit::UnifiedPDFPlugin::layoutBoundsForPageAtIndex const):
(WebKit::UnifiedPDFPlugin::scrollToPDFDestination):
(WebKit::UnifiedPDFPlugin::heightForPage const): Deleted.

Canonical link: <a href="https://commits.webkit.org/275289@main">https://commits.webkit.org/275289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c638a583feea7fd2f19b231424b29ca95c842e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34242 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14903 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45340 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40740 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39142 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17857 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9286 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->