### PR TITLE
[UnifiedPDF] Cursor updates are incorrect over text/image elements for untagged PDFs.

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
@@ -37,7 +37,9 @@
 #endif // PLATFORM(IOS_FAMILY)
 
 #import <PDFKit/PDFDocumentPriv.h>
+#import <PDFKit/PDFPagePriv.h>
 #import <PDFKit/PDFSelectionPriv.h>
+
 #if __has_include(<PDFKit/PDFActionPriv.h>)
 #import <PDFKit/PDFActionPriv.h>
 #else
@@ -119,6 +121,23 @@
 #if HAVE(COREGRAPHICS_WITH_PDF_AREA_OF_INTEREST_SUPPORT)
 @interface PDFPage (IPI)
 - (CGPDFPageLayoutRef) pageLayout;
+@end
+#endif
+
+#if HAVE(PDFPAGE_AREA_OF_INTEREST_AT_POINT)
+#define PDFAreaOfInterest NSInteger
+
+#define kPDFTextArea        (1UL << 1)
+#define kPDFAnnotationArea  (1UL << 2)
+#define kPDFLinkArea        (1UL << 3)
+#define kPDFControlArea     (1UL << 4)
+#define kPDFTextFieldArea   (1UL << 5)
+#define kPDFIconArea        (1UL << 6)
+#define kPDFPopupArea       (1UL << 7)
+#define kPDFImageArea       (1UL << 8)
+
+@interface PDFPage (Staging_119217538)
+- (PDFAreaOfInterest)areaOfInterestAtPoint:(PDFPoint)point;
 @end
 #endif
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1624,6 +1624,38 @@ auto UnifiedPDFPlugin::pdfElementTypesForPluginPoint(const IntPoint& point) cons
 
     PDFElementTypes pdfElementTypes { PDFElementType::Page };
 
+#if HAVE(PDFPAGE_AREA_OF_INTEREST_AT_POINT)
+    if ([page respondsToSelector:@selector(areaOfInterestAtPoint:)]) {
+        PDFAreaOfInterest areaOfInterest = [page areaOfInterestAtPoint:pointInPDFPageSpace];
+
+        if (areaOfInterest & kPDFTextArea)
+            pdfElementTypes.add(PDFElementType::Text);
+
+        if (areaOfInterest & kPDFAnnotationArea)
+            pdfElementTypes.add(PDFElementType::Annotation);
+
+        if ((areaOfInterest & kPDFLinkArea) && annotationIsLinkWithDestination([page annotationAtPoint:pointInPDFPageSpace]))
+            pdfElementTypes.add(PDFElementType::Link);
+
+        if (areaOfInterest & kPDFControlArea)
+            pdfElementTypes.add(PDFElementType::Control);
+
+        if (areaOfInterest & kPDFTextFieldArea)
+            pdfElementTypes.add(PDFElementType::TextField);
+
+        if (areaOfInterest & kPDFIconArea)
+            pdfElementTypes.add(PDFElementType::Icon);
+
+        if (areaOfInterest & kPDFPopupArea)
+            pdfElementTypes.add(PDFElementType::Popup);
+
+        if (areaOfInterest & kPDFImageArea)
+            pdfElementTypes.add(PDFElementType::Image);
+
+        return pdfElementTypes;
+    }
+#endif
+
     if (auto annotation = [page annotationAtPoint:pointInPDFPageSpace]) {
         pdfElementTypes.add(PDFElementType::Annotation);
 
@@ -1657,8 +1689,6 @@ auto UnifiedPDFPlugin::pdfElementTypesForPluginPoint(const IntPoint& point) cons
             pdfElementTypes.add(PDFElementType::Image);
     }
 #endif
-
-    // FIXME: <https://webkit.org/b/265908> Cursor updates are incorrect over text/image elements for untagged PDFs.
 
     return pdfElementTypes;
 }


### PR DESCRIPTION
#### bcb2f892a5d1c79d21b6df3222186a81f014e059
<pre>
[UnifiedPDF] Cursor updates are incorrect over text/image elements for untagged PDFs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265908">https://bugs.webkit.org/show_bug.cgi?id=265908</a>
<a href="https://rdar.apple.com/119217538">rdar://119217538</a>

Reviewed by Tim Horton.

The CGPDFPageLayoutGetAreaOfInterestAtPoint interface does not correctly
identify text/image elements on Untagged PDF files. This made our hit
test results incomplete on said PDF files. To address this issue, we
adopt new PDFPage API `areaOfInterestAtPoint`, which not only hit tests
for annotations, but also for text and image on a page, thus subsuming
both -[PDFPage annotationAtPoint:] and CGPDFPageLayoutGetAreaOfInterestAtPoint
while maintaining correctness across tagged and untagged PDFs.

* Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::pdfElementTypesForPluginPoint const):

Canonical link: <a href="https://commits.webkit.org/275287@main">https://commits.webkit.org/275287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5a5e065cd9d63be601cfaa59b95e6c2426a7555

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37517 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34243 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15085 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45343 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40742 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39144 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17859 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9284 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17913 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->