### PR TITLE
Eliminate some unneeded header inclusions

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -38,7 +38,6 @@
 
 namespace WebCore {
 
-class GraphicsLayer;
 class TextureMapperGLData;
 class TextureMapperShaderProgram;
 class FilterOperations;

--- a/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -31,7 +31,6 @@
 #include <WebCore/NicosiaContentLayer.h>
 #include <WebCore/NicosiaImageBacking.h>
 #include <WebCore/NicosiaScene.h>
-#include <WebCore/TextureMapperBackingStore.h>
 #include <WebCore/TextureMapperLayer.h>
 #include <wtf/Atomics.h>
 

--- a/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.h
@@ -22,19 +22,14 @@
 
 #if USE(COORDINATED_GRAPHICS)
 
-#include <WebCore/GraphicsContext.h>
-#include <WebCore/GraphicsLayer.h>
-#include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/NicosiaImageBackingStore.h>
 #include <WebCore/NicosiaPlatformLayer.h>
 #include <WebCore/NicosiaScene.h>
 #include <WebCore/TextureMapper.h>
-#include <WebCore/TextureMapperBackingStore.h>
 #include <WebCore/TextureMapperFPSCounter.h>
 #include <WebCore/TextureMapperLayer.h>
 #include <WebCore/TextureMapperPlatformLayerProxy.h>
-#include <WebCore/Timer.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>


### PR DESCRIPTION
#### 36e27eaf8bd45b13ef0a99d9be290866485afbe8
<pre>
Eliminate some unneeded header inclusions

<a href="https://bugs.webkit.org/show_bug.cgi?id=149343">https://bugs.webkit.org/show_bug.cgi?id=149343</a>

Reviewed by Tim Nguyen.

Credits: Emanuele Aina  &lt;emanuele.aina@collabora.com&gt;

This patch removes unneeded headers from two files and redundant class from another.

* Source/WebCore/platform/graphics/texmap/TextureMapper.h: Remove `GraphicsLayer` class
* Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
* Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.h:

Canonical link: <a href="https://commits.webkit.org/275294@main">https://commits.webkit.org/275294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aae660aefb01e470d2621fec2e6a281ec2710fe5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37543 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34265 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40764 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39167 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17885 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9289 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->