### PR TITLE
And more adoption of dynamicDowncast<> in layout code

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -775,16 +775,18 @@ void InlineDisplayContentBuilder::processBidiContent(const LineLayoutResult& lin
                     // FIXME: Maybe we should not tag ruby bases with annotation boxes only contentful?
                     if (!lineBox.inlineLevelBoxFor(lineRun).hasContent())
                         return true;
-                    if (!layoutBox.isRubyBase() || !is<ElementBox>(layoutBox))
+                    if (!layoutBox.isRubyBase())
                         return false;
-                    auto& rubyBaseLayoutBox = downcast<ElementBox>(layoutBox);
+                    auto* rubyBaseLayoutBox = dynamicDowncast<ElementBox>(layoutBox);
+                    if (!rubyBaseLayoutBox)
+                        return false;
                     // Let's create empty inline boxes for ruby bases with annotation only.
-                    if (!rubyBaseLayoutBox.firstChild() || (rubyBaseLayoutBox.firstChild() == rubyBaseLayoutBox.lastChild() && rubyBaseLayoutBox.firstChild()->isRubyAnnotationBox()))
+                    if (!rubyBaseLayoutBox->firstChild() || (rubyBaseLayoutBox->firstChild() == rubyBaseLayoutBox->lastChild() && rubyBaseLayoutBox->firstChild()->isRubyAnnotationBox()))
                         return true;
                     // Let's check if we actually don't have a contentful run inside this ruby base.
                     for (size_t nextLogicalRunIndex = logicalIndex + 1; nextLogicalRunIndex < inlineContent.size(); ++nextLogicalRunIndex) {
                         auto& lineRun = inlineContent[nextLogicalRunIndex];
-                        if (lineRun.isInlineBoxEnd() && &lineRun.layoutBox() == &rubyBaseLayoutBox)
+                        if (lineRun.isInlineBoxEnd() && &lineRun.layoutBox() == rubyBaseLayoutBox)
                             break;
                         if (lineRun.isContentful())
                             return false;

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
@@ -158,14 +158,14 @@ bool RubyFormattingContext::isAtSoftWrapOpportunity(const InlineItem& previous, 
 
         if (current.isInlineBoxStart()) {
             // At the beginning of <ruby>.
-            if (!previous.isText())
+            auto* leadingTextItem = dynamicDowncast<InlineTextItem>(previous);
+            if (!leadingTextItem)
                 return true;
-            auto& leadingTextItem = downcast<InlineTextItem>(previous);
-            if (!leadingTextItem.length()) {
+            if (!leadingTextItem->length()) {
                 // FIXME: This needs to know prior context.
                 return true;
             }
-            auto lastCharacter = leadingTextItem.inlineTextBox().content()[leadingTextItem.end() - 1];
+            auto lastCharacter = leadingTextItem->inlineTextBox().content()[leadingTextItem->end() - 1];
             return canBreakAtCharacter(lastCharacter);
         }
         // Don't break between base end and <ruby> end.
@@ -182,14 +182,14 @@ bool RubyFormattingContext::isAtSoftWrapOpportunity(const InlineItem& previous, 
 
         if (previous.isInlineBoxEnd()) {
             // At the end of <ruby>
-            if (!current.isText())
+            auto* trailingTextItem = dynamicDowncast<InlineTextItem>(current);
+            if (!trailingTextItem)
                 return true;
-            auto& trailingTextItem = downcast<InlineTextItem>(current);
-            if (!trailingTextItem.length()) {
+            if (!trailingTextItem->length()) {
                 // FIXME: This should be turned into one of those "can't decide it yet" cases.
                 return true;
             }
-            auto firstCharacter = trailingTextItem.inlineTextBox().content()[trailingTextItem.start()];
+            auto firstCharacter = trailingTextItem->inlineTextBox().content()[trailingTextItem->start()];
             return canBreakAtCharacter(firstCharacter);
         }
         // We should handled this case already when looking at current: base, previous: ruby.

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -188,7 +188,7 @@ UniqueRef<Layout::Box> BoxTree::createLayoutBox(RenderObject& renderer)
 
     if (auto* textRenderer = dynamicDowncast<RenderText>(renderer)) {
         auto style = RenderStyle::createAnonymousStyleWithDisplay(textRenderer->style(), DisplayType::Inline);
-        auto isCombinedText = [&]() {
+        auto isCombinedText = [&] {
             auto* combineTextRenderer = dynamicDowncast<RenderCombineText>(*textRenderer);
             return combineTextRenderer && combineTextRenderer->isCombined();
         }();
@@ -294,7 +294,10 @@ void BoxTree::updateContent(const RenderText& textRenderer)
 {
     auto& inlineTextBox = downcast<Layout::InlineTextBox>(layoutBoxForRenderer(textRenderer));
     auto& style = inlineTextBox.style();
-    auto isCombinedText = is<RenderCombineText>(textRenderer) && downcast<RenderCombineText>(textRenderer).isCombined();
+    auto isCombinedText = [&] {
+        auto* combineTextRenderer = dynamicDowncast<RenderCombineText>(textRenderer);
+        return combineTextRenderer && combineTextRenderer->isCombined();
+    }();
     auto text = style.textSecurity() == TextSecurity::None ? (isCombinedText ? textRenderer.originalText() : String { textRenderer.text() }) : RenderBlock::updateSecurityDiscCharacters(style, isCombinedText ? textRenderer.originalText() : String { textRenderer.text() });
     auto contentCharacteristic = OptionSet<Layout::InlineTextBox::ContentCharacteristic> { };
     if (textRenderer.canUseSimpleFontCodePath())

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -144,8 +144,8 @@ bool shouldInvalidateLineLayoutPathAfterChangeFor(const RenderBlockFlow& rootBlo
             return true;
         if (is<RenderReplaced>(renderer))
             return typeOfChange == TypeOfChangeForInvalidation::NodeInsertion;
-        if (is<RenderInline>(renderer))
-            return typeOfChange == TypeOfChangeForInvalidation::NodeInsertion && !downcast<RenderInline>(renderer).firstChild();
+        if (auto* inlineRenderer = dynamicDowncast<RenderInline>(renderer))
+            return typeOfChange == TypeOfChangeForInvalidation::NodeInsertion && !inlineRenderer->firstChild();
         return false;
     };
     if (!isSupportedRendererWithChange(renderer))
@@ -164,8 +164,8 @@ bool shouldInvalidateLineLayoutPathAfterChangeFor(const RenderBlockFlow& rootBlo
     auto isBidiContent = [&] {
         if (lineLayout.contentNeedsVisualReordering())
             return true;
-        if (is<RenderText>(renderer))
-            return Layout::TextUtil::containsStrongDirectionalityText(downcast<RenderText>(renderer).text());
+        if (auto* textRenderer = dynamicDowncast<RenderText>(renderer))
+            return Layout::TextUtil::containsStrongDirectionalityText(textRenderer->text());
         if (is<RenderInline>(renderer)) {
             auto& style = renderer.style();
             return !style.isLeftToRightDirection() || (style.rtlOrdering() == Order::Logical && style.unicodeBidi() != UnicodeBidi::Normal);

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
@@ -109,10 +109,9 @@ FloatRect Box::visualRect() const
 
 RenderObject::HighlightState Box::selectionState() const
 {
-    if (isText()) {
-        auto& text = downcast<TextBox>(*this);
-        auto& renderer = text.renderer();
-        return renderer.view().selection().highlightStateForTextBox(renderer, text.selectableRange());
+    if (auto* text = dynamicDowncast<TextBox>(*this)) {
+        auto& renderer = text->renderer();
+        return renderer.view().selection().highlightStateForTextBox(renderer, text->selectableRange());
     }
     return renderer().selectionState();
 }


### PR DESCRIPTION
#### b6d185a6c1d83414734cfed22120a006c366a8b7
<pre>
And more adoption of dynamicDowncast&lt;&gt; in layout code
<a href="https://bugs.webkit.org/show_bug.cgi?id=270048">https://bugs.webkit.org/show_bug.cgi?id=270048</a>

Reviewed by Alan Baradlay.

For security &amp; performance.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::processBidiContent):
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp:
(WebCore::Layout::RubyFormattingContext::isAtSoftWrapOpportunity):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::BoxTree::updateContent):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::shouldInvalidateLineLayoutPathAfterChangeFor):
* Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp:
(WebCore::InlineIterator::Box::selectionState const):

Canonical link: <a href="https://commits.webkit.org/275310@main">https://commits.webkit.org/275310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c054b27cb74bed53dd9e4c180307140fa3cd7fff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17834 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45417 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37054 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16305 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39216 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17924 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9298 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->