### PR TITLE
MSE player will have readyState oscillate between readyState HAVE_CURRENT_DATA and HAVE_ENOUGH_DATA

### DIFF
--- a/LayoutTests/media/media-source/media-source-canplaythrough-withfuturegap-expected.txt
+++ b/LayoutTests/media/media-source/media-source-canplaythrough-withfuturegap-expected.txt
@@ -1,0 +1,42 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(init = makeAInit(100, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]))
+RUN(sourceBuffer.appendBuffer(init))
+EVENT(loadedmetadata)
+EVENT(update)
+RUN(sample = makeASample(0, 0, 10, 1, 1, SAMPLE_FLAG.SYNC, 1))
+RUN(sourceBuffer.appendBuffer(sample))
+EVENT(loadeddata)
+EVENT(canplay)
+EVENT(canplaythrough)
+EVENT(update)
+EXPECTED (video.readyState == '4') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '10') OK
+RUN(sample = makeASample(11, 11, 10, 1, 1, SAMPLE_FLAG.SYNC, 1))
+RUN(sourceBuffer.appendBuffer(sample))
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '2') OK
+EXPECTED (sourceBuffer.buffered.end(1) == '21') OK
+RUN(video.currentTime = 9)
+EVENT(seeked)
+EXPECTED (video.readyState == '3') OK
+RUN(sample = makeASample(10, 10, 1, 1, 1, SAMPLE_FLAG.SYNC, 1))
+RUN(sourceBuffer.appendBuffer(sample))
+EVENT(canplaythrough)
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '21') OK
+EXPECTED (video.readyState == '4') OK
+RUN(video.currentTime = 11)
+EVENT(seeked)
+EXPECTED (video.readyState == '4') OK
+RUN(video.currentTime = 20)
+EVENT(seeked)
+EXPECTED (video.readyState == '3') OK
+RUN(video.currentTime = 21)
+EVENT(seeked)
+EXPECTED (video.readyState == '2') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-canplaythrough-withfuturegap.html
+++ b/LayoutTests/media/media-source/media-source-canplaythrough-withfuturegap.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mock-media-source</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var init;
+    var sample;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    async function runTest()
+    {
+        findMediaElement();
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer('video/mock; codecs="mock"');
+
+        // Make an init segment with 1 video track
+        run("init = makeAInit(100, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)])");
+        run('sourceBuffer.appendBuffer(init)');
+        await Promise.all([
+            waitFor(sourceBuffer, 'update'),
+            waitFor(video, 'loadedmetadata')
+        ]);
+
+        run('sample = makeASample(0, 0, 10, 1, 1, SAMPLE_FLAG.SYNC, 1)');
+
+        // This append changes the ready state to HAVE_ENOUGH_DATA and fires the playing event.
+        run('sourceBuffer.appendBuffer(sample)');
+
+        await Promise.all([
+            waitFor(video, 'loadeddata'),
+            waitFor(video, 'canplay'),
+            waitFor(sourceBuffer, 'update'),
+            waitFor(video, 'canplaythrough'),
+            testExpectedEventuallySilent('video.readyState', video.HAVE_ENOUGH_DATA)
+        ]);
+        testExpected('video.readyState', video.HAVE_ENOUGH_DATA);
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpected('sourceBuffer.buffered.end(0)', 10);
+
+        run('sample = makeASample(11, 11, 10, 1, 1, SAMPLE_FLAG.SYNC, 1)');
+        run('sourceBuffer.appendBuffer(sample)');
+        await waitFor(sourceBuffer, 'update'),
+        testExpected('sourceBuffer.buffered.length', 2);
+        testExpected('sourceBuffer.buffered.end(1)', 21);
+
+        run('video.currentTime = 9');
+        await waitFor(video, 'seeked');
+        testExpected('video.readyState', video.HAVE_FUTURE_DATA); // There's a gap ahead, can't play through.
+
+        // Fill gap.
+        run('sample = makeASample(10, 10, 1, 1, 1, SAMPLE_FLAG.SYNC, 1)');
+        run('sourceBuffer.appendBuffer(sample)');
+
+        waitForAndFail(video, 'canplay'); // canplay should never be fired as it means we went from HAVE_CURRENT_DATA to HAVE_FUTURE_DATA
+
+        await Promise.all([
+            waitFor(sourceBuffer, 'update'),
+            waitFor(video, 'canplaythrough')
+        ]);
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpected('sourceBuffer.buffered.end(0)', 21);
+        testExpected('video.readyState', video.HAVE_ENOUGH_DATA);
+
+        run('video.currentTime = 11');
+        await waitFor(video, 'seeked'),
+        testExpected('video.readyState', video.HAVE_ENOUGH_DATA);
+
+        run('video.currentTime = 20');
+        await waitFor(video, 'seeked'),
+        testExpected('video.readyState', video.HAVE_FUTURE_DATA);
+
+        run('video.currentTime = 21');
+        await waitFor(video, 'seeked');
+        testExpected('video.readyState', video.HAVE_CURRENT_DATA);
+
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video controls width=960 height=510></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort-expected.txt
+++ b/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort-expected.txt
@@ -7,9 +7,18 @@ RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
 RUN(sourceBuffer.abort())
 RUN(sourceBuffer.appendBuffer(loader.initSegment()))
 EVENT(update)
+EXPECTED (video.readyState == '1') OK
 Append a media segment.
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
 EVENT(update)
+EVENT(loadeddata)
+EVENT(canplay)
+EXPECTED (video.readyState == '3') OK
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) >= '1.9') OK
+RUN(source.endOfStream())
+EVENT(sourceended)
 EVENT(canplaythrough)
+EXPECTED (video.readyState == '4') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html
+++ b/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html
@@ -34,14 +34,28 @@
 
             run('sourceBuffer.appendBuffer(loader.initSegment())');
             await waitFor(sourceBuffer, 'update');
+            testExpected('video.readyState', video.HAVE_METADATA);
 
             consoleWrite('Append a media segment.')
             run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
-            await waitFor(sourceBuffer, 'update');
-
             failTestIn(2000);
 
-            await waitFor(video, 'canplaythrough');
+            await Promise.all([
+                waitFor(video, 'loadeddata'),
+                waitFor(video, 'canplay'),
+                waitFor(sourceBuffer, 'update'),
+            ]);
+            testExpected('video.readyState', video.HAVE_FUTURE_DATA);
+            testExpected('sourceBuffer.buffered.length', 1);
+            testExpected('sourceBuffer.buffered.end(0)', 1.9, '>=');
+            run('source.endOfStream()');
+            await Promise.all([
+                waitFor(source, 'sourceended'),
+                waitFor(video, 'canplaythrough'),
+                testExpectedEventuallySilent('video.readyState', video.HAVE_ENOUGH_DATA)
+            ]);
+            testExpected('video.readyState', video.HAVE_ENOUGH_DATA);
+
             endTest();
         } catch (e) {
             failTest(`Caught exception: "${e}"`);

--- a/LayoutTests/media/video-test.js
+++ b/LayoutTests/media/video-test.js
@@ -112,12 +112,17 @@ function sleepFor(duration) {
     });
 }
 
-function testExpectedEventually(testFuncString, expected, comparison, timeout)
+function testExpectedEventuallySilent(testFuncString, expected, comparison, timeout)
 {
-    return testExpectedEventuallyWhileRunningBetweenTests(testFuncString, expected, comparison, timeout, null);
+    return testExpectedEventuallyWhileRunningBetweenTests(testFuncString, expected, comparison, timeout, null, true);
 }
 
-function testExpectedEventuallyWhileRunningBetweenTests(testFuncString, expected, comparison, timeout, work)
+function testExpectedEventually(testFuncString, expected, comparison, timeout)
+{
+    return testExpectedEventuallyWhileRunningBetweenTests(testFuncString, expected, comparison, timeout, null, false);
+}
+
+function testExpectedEventuallyWhileRunningBetweenTests(testFuncString, expected, comparison, timeout, work, silent = false)
 {
     return new Promise(async resolve => {
         var success;
@@ -129,7 +134,8 @@ function testExpectedEventuallyWhileRunningBetweenTests(testFuncString, expected
             try {
                 ({success, observed} = compare(testFuncString, expected, comparison));
                 if (success) {
-                    reportExpected(success, testFuncString, comparison, expected, observed);
+                    if (!silent)
+                        reportExpected(success, testFuncString, comparison, expected, observed);
                     resolve();
                     return;
                 }

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -94,40 +94,6 @@ void ManagedMediaSource::setStreaming(bool streaming)
     notifyElementUpdateMediaState();
 }
 
-bool ManagedMediaSource::isBuffered(const PlatformTimeRanges& ranges) const
-{
-    if (ranges.length() < 1 || isClosed())
-        return true;
-
-    ASSERT(ranges.length() == 1);
-
-    auto bufferedRanges = m_private->buffered();
-    if (!bufferedRanges.length())
-        return false;
-    bufferedRanges.intersectWith(ranges);
-
-    if (!bufferedRanges.length())
-        return false;
-
-    auto hasBufferedTime = [&] (const MediaTime& time) {
-        return abs(bufferedRanges.nearest(time) - time) <= m_private->timeFudgeFactor();
-    };
-
-    if (!hasBufferedTime(ranges.minimumBufferedTime()) || !hasBufferedTime(ranges.maximumBufferedTime()))
-        return false;
-
-    if (bufferedRanges.length() == 1)
-        return true;
-
-    // Ensure that if we have a gap in the buffered range, it is smaller than the fudge factor;
-    for (unsigned i = 1; i < bufferedRanges.length(); i++) {
-        if (bufferedRanges.end(i) - bufferedRanges.start(i-1) > m_private->timeFudgeFactor())
-            return false;
-    }
-
-    return true;
-}
-
 void ManagedMediaSource::ensurePrefsRead()
 {
     ASSERT(scriptExecutionContext());

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -53,7 +53,6 @@ private:
     explicit ManagedMediaSource(ScriptExecutionContext&);
     void monitorSourceBuffers() final;
     void elementDetached() final;
-    bool isBuffered(const PlatformTimeRanges&) const;
     void setStreaming(bool);
     void streamingTimerFired();
     void ensurePrefsRead();

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -496,6 +496,40 @@ bool MediaSource::hasFutureTime()
     return m_private->hasFutureTime(currentTime());
 }
 
+bool MediaSource::isBuffered(const PlatformTimeRanges& ranges) const
+{
+    if (ranges.length() < 1 || isClosed())
+        return true;
+
+    ASSERT(ranges.length() == 1);
+
+    auto bufferedRanges = m_private->buffered();
+    if (!bufferedRanges.length())
+        return false;
+    bufferedRanges.intersectWith(ranges);
+
+    if (!bufferedRanges.length())
+        return false;
+
+    auto hasBufferedTime = [&] (const MediaTime& time) {
+        return abs(bufferedRanges.nearest(time) - time) <= m_private->timeFudgeFactor();
+    };
+
+    if (!hasBufferedTime(ranges.minimumBufferedTime()) || !hasBufferedTime(ranges.maximumBufferedTime()))
+        return false;
+
+    if (bufferedRanges.length() == 1)
+        return true;
+
+    // Ensure that if we have a gap in the buffered range, it is smaller than the fudge factor;
+    for (unsigned i = 1; i < bufferedRanges.length(); i++) {
+        if (bufferedRanges.end(i) - bufferedRanges.start(i-1) > m_private->timeFudgeFactor())
+            return false;
+    }
+
+    return true;
+}
+
 void MediaSource::monitorSourceBuffers()
 {
     // 2.4.4 SourceBuffer Monitoring
@@ -526,9 +560,17 @@ void MediaSource::monitorSourceBuffers()
 
     // ↳ If HTMLMediaElement.buffered contains a TimeRange that includes the current
     //  playback position and enough data to ensure uninterrupted playback:
-    if (std::all_of(m_activeSourceBuffers->begin(), m_activeSourceBuffers->end(), [&](auto& sourceBuffer) {
-        return sourceBuffer->canPlayThroughRange(m_private->buffered());
-    })) {
+
+    // If we have data up to 3s ahead, we can assume that we can play without interruption.
+    constexpr double kHaveEnoughDataThreshold = 3;
+    auto currentTime = this->currentTime();
+    auto limitAhead = [&] (double upper) {
+        MediaTime aheadTime = currentTime + MediaTime::createWithDouble(upper);
+        return isEnded() ? std::min(duration(), aheadTime) : aheadTime;
+    };
+    PlatformTimeRanges neededBufferedRange { currentTime, std::max(currentTime, limitAhead(kHaveEnoughDataThreshold)) };
+
+    if (isBuffered(neededBufferedRange)) {
         // 1. Set the HTMLMediaElement.readyState attribute to HAVE_ENOUGH_DATA.
         // 2. Queue a task to fire a simple event named canplaythrough at the media element.
         // 3. Playback may resume at this point if it was previously suspended by a transition to HAVE_CURRENT_DATA.

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -177,6 +177,7 @@ protected:
     bool hasBufferedTime(const MediaTime&);
     bool hasCurrentTime();
     bool hasFutureTime();
+    bool isBuffered(const PlatformTimeRanges&) const;
 
     void scheduleEvent(const AtomString& eventName);
     void notifyElementUpdateMediaState() const;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1280,30 +1280,6 @@ void SourceBuffer::sourceBufferPrivateDidDropSample()
     m_source->incrementDroppedFrameCount();
 }
 
-bool SourceBuffer::canPlayThroughRange(const PlatformTimeRanges& ranges)
-{
-    if (isRemoved())
-        return false;
-
-    MediaTime duration = m_source->duration();
-    if (!duration.isValid())
-        return false;
-
-    MediaTime currentTime = m_source->currentTime();
-    if (duration <= currentTime)
-        return true;
-
-    // If we have data up to the mediasource's duration or 3s ahead, we can
-    // assume that we can play without interruption.
-    MediaTime bufferedEnd = ranges.maximumBufferedTime();
-    // Same tolerance as contiguousFrameTolerance in SourceBufferPrivate::processMediaSample(),
-    // to account for small errors.
-    const MediaTime tolerance = MediaTime(1, 1000);
-    MediaTime timeAhead = std::min(duration, currentTime + MediaTime(3, 1)) - tolerance;
-
-    return bufferedEnd >= timeAhead;
-}
-
 void SourceBuffer::reportExtraMemoryAllocated(uint64_t extraMemory)
 {
     uint64_t extraMemoryCost = extraMemory;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -115,8 +115,6 @@ public:
     Ref<ComputeSeekPromise> computeSeekTime(const SeekTarget&);
     void seekToTime(const MediaTime&);
 
-    bool canPlayThroughRange(const PlatformTimeRanges&);
-
     bool hasVideo() const;
 
     bool active() const { return m_active; }

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -983,7 +983,6 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
         // For instance, most WebM files are muxed rounded to the millisecond (the default TimecodeScale of the format)
         // but their durations use a finer timescale (causing a sub-millisecond overlap). More rarely, there are also
         // MP4 files with slightly off tfdt boxes, presenting a similar problem at the beginning of each fragment.
-        // Same as tolerance in SourceBuffer::canPlayThroughRange().
         const MediaTime contiguousFrameTolerance = MediaTime(1, 1000);
 
         // If highest presentation timestamp for track buffer is set and less than or equal to presentation timestamp


### PR DESCRIPTION
#### 747f80b0591ceda287ec87a45cb512c39e05444c
<pre>
MSE player will have readyState oscillate between readyState HAVE_CURRENT_DATA and HAVE_ENOUGH_DATA
<a href="https://bugs.webkit.org/show_bug.cgi?id=270050">https://bugs.webkit.org/show_bug.cgi?id=270050</a>
<a href="https://rdar.apple.com/123597692">rdar://123597692</a>

Reviewed by Eric Carlson.

272762@main incorrectly assumed that if we had buffered data 3s in the future,
the media could always be played through, ignoring any potential gap ahead which would
have stalled playback.

Since following 272762@main, the SourceBuffer no longer monitors its own append rate
there&apos;s no need to have the SourceBuffer check for its own buffered range, the MediaSource
has more information about it which accounts for different gaps between SourceBuffer.

We use the isBuffered() function that was before only used for ManagedMediaSource to determine
the level of buffered data ahead of currentTime and move it to MediaSource.

* LayoutTests/media/media-source/media-source-canplaythrough-withfuturegap-expected.txt: Added.
* LayoutTests/media/media-source/media-source-canplaythrough-withfuturegap.html: Added.
* LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort-expected.txt:
* LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html: The test was invalid.
It assumed that canplaythrough would be fired if we only added 2s of data. There&apos;s no specs stating as such.
Only should the MediaSource be ended would it guarantee that the readyState moved to HAVE_ENOUGH_DATA
while being paused. Correct and amend the test.
* LayoutTests/media/video-test.js: Add testExpectedEventuallySilent. Sometimes the order in which events are fired is
not deterministic. We don&apos;t want to log them to prevent expectations failure, but we need to check the event is received.
(testExpectedEventually):
(testExpectedEventuallyWhileRunningBetweenTests):
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::isBuffered const): Deleted.
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::isBuffered const):
(WebCore::MediaSource::monitorSourceBuffers):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::canPlayThroughRange): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::processMediaSample):

Canonical link: <a href="https://commits.webkit.org/275348@main">https://commits.webkit.org/275348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc62b83157c31067d82c22cf1e443b068a915bf6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34316 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14977 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15159 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45458 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40853 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39260 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36026 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9317 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->