### PR TITLE
[WebDriver][socket] Titles containing multibyte characters cannot be retrieved correctly

### DIFF
--- a/Source/WebDriver/socket/HTTPServerSocket.cpp
+++ b/Source/WebDriver/socket/HTTPServerSocket.cpp
@@ -127,7 +127,7 @@ String HTTPRequestHandler::packHTTPMessage(HTTPRequestHandler::Response&& respon
     builder.append(EOL);
 
     if (!response.data.isNull())
-        builder.append(response.data.span());
+        builder.append(String::fromUTF8(response.data.span()));
 
     return builder.toString();
 }

--- a/WebDriverTests/imported/w3c/webdriver/tests/classic/get_title/get.py
+++ b/WebDriverTests/imported/w3c/webdriver/tests/classic/get_title/get.py
@@ -1,4 +1,4 @@
-from tests.support.asserts import assert_error, assert_success
+﻿from tests.support.asserts import assert_error, assert_success
 
 
 def get_title(session):
@@ -54,3 +54,17 @@ def test_strip_and_collapse(session, inline):
 
     result = get_title(session)
     assert_success(result, "a b c d e")
+
+
+def test_title_included_entity_references(session, inline):
+    session.url = inline("<title>&reg; &copy; &cent; &pound; &yen;</title>")
+
+    result = get_title(session)
+    assert_success(result, u'® © ¢ £ ¥')
+
+
+def test_title_included_multibyte_char(session, inline):
+    session.url = inline(u"<title>日本語</title>")
+
+    result = get_title(session)
+    assert_success(result, u"日本語")


### PR DESCRIPTION
#### 0a3175f4f36add1cbc3e595fa45ce59081303f8c
<pre>
[WebDriver][socket] Titles containing multibyte characters cannot be retrieved correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=270063">https://bugs.webkit.org/show_bug.cgi?id=270063</a>

Reviewed by Alexey Proskuryakov.

If the document title contains multibyte characters such as Japanese
or entity references, the &quot;Get Title&quot; result will be garbled.

The title string is obtained by JavaScript&apos;s &quot;document.title()&quot;,
and this data is encoded in UTF8.
However, the StringBuilder.append() function used to create HTTP messages
uses fromLatin1() internally to generate strings from byte data.
This seems to be causing the multibyte characters to be garbled.

This patch changes to use String::fromUTF8() before concatenation to
restore the correct WTF::String even if it contains multibyte characters.

Also, the change of get.py is regression test for this issue.
This is an export from <a href="https://github.com/web-platform-tests/wpt/pull/46584.">https://github.com/web-platform-tests/wpt/pull/46584.</a>

* Source/WebDriver/socket/HTTPServerSocket.cpp:
(WebDriver::HTTPRequestHandler::packHTTPMessage const):
* WebDriverTests/imported/w3c/webdriver/tests/classic/get_title/get.py:
(test_strip_and_collapse):
(test_title_included_entity_references):
(test_title_included_multibyte_char):

Canonical link: <a href="https://commits.webkit.org/279767@main">https://commits.webkit.org/279767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29c4dd444ed4e7d76ea481df9508ba7904bd3e23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5050 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43987 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3362 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56412 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31909 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25122 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28716 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4364 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3193 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29535 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51411 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50768 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11887 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->