### PR TITLE
instanceof should not get RHS prototype when LHS is primitive

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1013,9 +1013,6 @@ test/language/expressions/dynamic-import/import-assertions/2nd-param-assert-valu
 test/language/expressions/dynamic-import/import-assertions/2nd-param-get-assert-error.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected an error, but observed no error'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected an error, but observed no error'
-test/language/expressions/instanceof/prototype-getter-with-primitive.js:
-  default: "Test262Error: getter for 'prototype' called"
-  strict mode: "Test262Error: getter for 'prototype' called"
 test/language/expressions/logical-assignment/lgcl-and-assignment-operator-non-simple-lhs.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/expressions/logical-assignment/lgcl-nullish-assignment-operator-non-simple-lhs.js:


### PR DESCRIPTION
#### 2a1f6c179e546b6219dcee2d55add5dc8c7c6b3e
<pre>
instanceof should not get RHS prototype when LHS is primitive
<a href="https://bugs.webkit.org/show_bug.cgi?id=270065">https://bugs.webkit.org/show_bug.cgi?id=270065</a>

Reviewed by Justin Michaud.

The expression `x instanceof obj` should not access obj.prototype when x is primitive per the spec,
but our implementation eagerly grabs the prototype in order to hand it off to OpInstanceof.

    <a href="https://tc39.es/ecma262/multipage/abstract-operations.html#sec-ordinaryhasinstance">https://tc39.es/ecma262/multipage/abstract-operations.html#sec-ordinaryhasinstance</a>
    7.3.21 OrdinaryHasInstance ( C, O )
        ...
        3. If O is not an Object, return false.
        4. Let P be ? Get(C, &quot;prototype&quot;).
        ...

We could refactor OpInstanceof to take the RHS directly instead of its prototype, but it suffices to add a couple of
lines to InstanceOfNode::emitBytecode. (And while we&apos;re at it, we can also do a bit better with temp register reuse.)

* JSTests/test262/expectations.yaml: Mark two tests as passing.
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::InstanceOfNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/275318@main">https://commits.webkit.org/275318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e8166c1ec2ea85ae67354bf8e5297d9bb76702d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44058 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37583 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17835 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34306 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45418 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34944 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40811 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41117 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39220 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17925 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48128 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9302 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17980 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9828 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->