### PR TITLE
[LBSE] Implement support for filters

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2873,6 +2873,8 @@ rendering/svg/RenderSVGPath.cpp
 rendering/svg/RenderSVGRect.cpp
 rendering/svg/RenderSVGResourceClipper.cpp
 rendering/svg/RenderSVGResourceContainer.cpp
+rendering/svg/RenderSVGResourceFilter.cpp
+rendering/svg/RenderSVGResourceFilterPrimitive.cpp
 rendering/svg/RenderSVGResourceGradient.cpp
 rendering/svg/RenderSVGResourceLinearGradient.cpp
 rendering/svg/RenderSVGResourceMarker.cpp

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -37,6 +37,7 @@
 #include "GraphicsContextSwitcher.h"
 #include "LegacyRenderSVGResourceFilter.h"
 #include "Logging.h"
+#include "RenderSVGShape.h"
 #include "RenderStyleInlines.h"
 #include <wtf/NeverDestroyed.h>
 
@@ -145,8 +146,13 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
         expandedDirtyRect.expand(flippedOutsets);
     }
 
-    // Calculate targetBoundingBox since it will be used if the filter is created.
-    targetBoundingBox = intersection(filterBoxRect, expandedDirtyRect);
+    if (is<RenderSVGShape>(renderer))
+        targetBoundingBox = enclosingLayoutRect(renderer.objectBoundingBox());
+    else {
+        // Calculate targetBoundingBox since it will be used if the filter is created.
+        targetBoundingBox = intersection(filterBoxRect, expandedDirtyRect);
+    }
+
     if (targetBoundingBox.isEmpty())
         return nullptr;
 
@@ -160,11 +166,13 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
         return nullptr;
 
     auto& filter = *m_filter;
+    auto filterRegion = m_targetBoundingBox;
 
-    // For CSSFilter, filterRegion = targetBoundingBox + filter->outsets()
-    auto filterRegion = targetBoundingBox;
-    if (filter.hasFilterThatMovesPixels())
+    if (filter.hasFilterThatMovesPixels()) {
+        // For CSSFilter, filterRegion = targetBoundingBox + filter->outsets()
         filterRegion.expand(toLayoutBoxExtent(outsets));
+    } else if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer))
+        filterRegion = shape->currentSVGLayoutRect();
 
     if (filterRegion.isEmpty())
         return nullptr;
@@ -175,6 +183,8 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
         m_filterRegion = filterRegion;
         hasUpdatedBackingStore = true;
     }
+
+    filter.setFilterRegion(m_filterRegion);
 
     if (!filter.hasFilterThatMovesPixels())
         m_repaintRect = dirtyRect;
@@ -187,10 +197,15 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     }
 
     resetDirtySourceRect();
-    filter.setFilterRegion(m_filterRegion);
 
-    if (!m_targetSwitcher || hasUpdatedBackingStore)
-        m_targetSwitcher = GraphicsContextSwitcher::create(context, m_targetBoundingBox, DestinationColorSpace::SRGB(), { &filter });
+    if (!m_targetSwitcher || hasUpdatedBackingStore) {
+        FloatRect sourceImageRect;
+        if (is<RenderSVGShape>(renderer))
+            sourceImageRect = renderer.strokeBoundingBox();
+        else
+            sourceImageRect = m_targetBoundingBox;
+        m_targetSwitcher = GraphicsContextSwitcher::create(context, sourceImageRect, DestinationColorSpace::SRGB(), { &filter });
+    }
 
     if (!m_targetSwitcher)
         return nullptr;

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -39,6 +39,7 @@
 #include "RenderSVGBlock.h"
 #include "RenderSVGModelObject.h"
 #include "RenderSVGResourceClipper.h"
+#include "RenderSVGResourceFilter.h"
 #include "RenderSVGResourceLinearGradient.h"
 #include "RenderSVGResourceMarker.h"
 #include "RenderSVGResourceMasker.h"
@@ -47,6 +48,7 @@
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
 #include "SVGClipPathElement.h"
+#include "SVGFilterElement.h"
 #include "SVGGraphicsElement.h"
 #include "SVGMarkerElement.h"
 #include "SVGMaskElement.h"
@@ -470,6 +472,30 @@ RenderSVGResourceClipper* RenderLayerModelObject::svgClipperResourceFromStyle() 
 
     if (auto* svgElement = dynamicDowncast<SVGElement>(this->element()))
         document().addPendingSVGResource(referenceClipPathOperation->fragment(), *svgElement);
+
+    return nullptr;
+}
+
+RenderSVGResourceFilter* RenderLayerModelObject::svgFilterResourceFromStyle() const
+{
+    if (!document().settings().layerBasedSVGEngineEnabled())
+        return nullptr;
+
+    const auto& operations = style().filter();
+    if (operations.size() != 1)
+        return nullptr;
+
+    RefPtr referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(operations.at(0));
+    if (!referenceFilterOperation)
+        return nullptr;
+
+    if (RefPtr referencedFilterElement = ReferencedSVGResources::referencedFilterElement(treeScopeForSVGReferences(), *referenceFilterOperation)) {
+        if (auto* referencedFilterRenderer = dynamicDowncast<RenderSVGResourceFilter>(referencedFilterElement->renderer()))
+            return referencedFilterRenderer;
+    }
+
+    if (auto* svgElement = dynamicDowncast<SVGElement>(this->element()))
+        document().addPendingSVGResource(referenceFilterOperation->fragment(), *svgElement);
 
     return nullptr;
 }

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -31,6 +31,7 @@ namespace WebCore {
 class BlendingKeyframes;
 class RenderLayer;
 class RenderSVGResourceClipper;
+class RenderSVGResourceFilter;
 class RenderSVGResourceMarker;
 class RenderSVGResourceMasker;
 class RenderSVGResourcePaintServer;
@@ -100,6 +101,7 @@ public:
     RenderSVGResourcePaintServer* svgStrokePaintServerResourceFromStyle(const RenderStyle&) const;
 
     RenderSVGResourceClipper* svgClipperResourceFromStyle() const;
+    RenderSVGResourceFilter* svgFilterResourceFromStyle() const;
     RenderSVGResourceMasker* svgMaskerResourceFromStyle() const;
     RenderSVGResourceMarker* svgMarkerStartResourceFromStyle() const;
     RenderSVGResourceMarker* svgMarkerMidResourceFromStyle() const;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -214,6 +214,8 @@ public:
         LegacySVGPath,
         LegacySVGRect,
         LegacySVGResourceClipper,
+        LegacySVGResourceFilter,
+        LegacySVGResourceFilterPrimitive,
         LegacySVGResourceLinearGradient,
         LegacySVGResourceMarker,
         LegacySVGResourceMasker,
@@ -558,7 +560,7 @@ public:
     bool isLegacyRenderSVGViewportContainer() const { return type() == Type::LegacySVGViewportContainer; }
     bool isRenderSVGGradientStop() const { return type() == Type::SVGGradientStop; }
     bool isLegacyRenderSVGHiddenContainer() const { return type() == Type::LegacySVGHiddenContainer || isLegacyRenderSVGResourceContainer(); }
-    bool isRenderSVGHiddenContainer() const { return type() == Type::SVGHiddenContainer || isRenderSVGResourceContainer(); }
+    bool isRenderSVGHiddenContainer() const { return type() == Type::SVGHiddenContainer || isRenderSVGResourceContainer() || isRenderSVGResourceFilterPrimitive(); }
     bool isLegacyRenderSVGPath() const { return type() == Type::LegacySVGPath; }
     bool isRenderSVGPath() const { return type() == Type::SVGPath; }
     bool isRenderSVGShape() const { return isRenderSVGModelObject() && m_typeSpecificFlags.svgFlags().contains(SVGModelObjectFlag::IsShape); }
@@ -574,14 +576,16 @@ public:
     bool isRenderSVGForeignObject() const { return type() == Type::SVGForeignObject; }
     bool isLegacyRenderSVGResourceContainer() const { return isLegacyRenderSVGModelObject() && m_typeSpecificFlags.svgFlags().contains(SVGModelObjectFlag::IsResourceContainer); }
     bool isRenderSVGResourceContainer() const { return isRenderSVGModelObject() && m_typeSpecificFlags.svgFlags().contains(SVGModelObjectFlag::IsResourceContainer); }
+    bool isLegacyRenderSVGResourceFilter() const { return type() == Type::LegacySVGResourceFilter; }
     bool isRenderSVGResourceFilter() const { return type() == Type::SVGResourceFilter; }
     bool isLegacyRenderSVGResourceClipper() const { return type() == Type::LegacySVGResourceClipper; }
     bool isLegacyRenderSVGResourceMarker() const { return type() == Type::LegacySVGResourceMarker; }
     bool isLegacyRenderSVGResourceMasker() const { return type() == Type::LegacySVGResourceMasker; }
     bool isRenderSVGResourceGradient() const { return type() == Type::SVGResourceLinearGradient || type() == Type::SVGResourceRadialGradient; }
-    bool isRenderSVGResourcePaintServer() const { return isRenderSVGResourceGradient() || isRenderSVGResourcePattern(); }
+    bool isRenderSVGResourcePaintServer() const { return isRenderSVGResourceFilter() || isRenderSVGResourceGradient() || isRenderSVGResourcePattern(); }
     bool isRenderSVGResourcePattern() const { return type() == Type::SVGResourcePattern; }
     bool isRenderSVGResourceClipper() const { return type() == Type::SVGResourceClipper; }
+    bool isLegacyRenderSVGResourceFilterPrimitive() const { return type() == Type::LegacySVGResourceFilterPrimitive; }
     bool isRenderSVGResourceFilterPrimitive() const { return type() == Type::SVGResourceFilterPrimitive; }
     bool isRenderSVGResourceLinearGradient() const { return type() == Type::SVGResourceLinearGradient; }
     bool isRenderSVGResourceMarker() const { return type() == Type::SVGResourceMarker; }
@@ -593,6 +597,7 @@ public:
     bool isRenderOrLegacyRenderSVGImage() const { return isRenderSVGImage() || isLegacyRenderSVGImage(); }
     bool isRenderOrLegacyRenderSVGForeignObject() const { return isRenderSVGForeignObject() || isLegacyRenderSVGForeignObject(); }
     bool isRenderOrLegacyRenderSVGModelObject() const { return isRenderSVGModelObject() || isLegacyRenderSVGModelObject(); }
+    bool isRenderOrLegacyRenderSVGResourceFilterPrimitive() const { return isRenderSVGResourceFilterPrimitive() || isLegacyRenderSVGResourceFilterPrimitive(); }
     bool isSVGLayerAwareRenderer() const { return isRenderSVGRoot() || isRenderSVGModelObject() || isRenderSVGText() || isRenderSVGInline() || isRenderSVGForeignObject(); }
     bool isSVGRenderer() const { return isRenderOrLegacyRenderSVGRoot() || isLegacyRenderSVGModelObject() || isRenderSVGModelObject() || isRenderSVGBlock() || isRenderSVGInline(); }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RenderSVGResourceFilter.h"
+
+#include "RenderSVGResourceFilterInlines.h"
+#include "SVGFilterElement.h"
+#include "SVGUseElement.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceFilter);
+
+RenderSVGResourceFilter::RenderSVGResourceFilter(SVGElement& element, RenderStyle&& style)
+    : RenderSVGResourcePaintServer(Type::SVGResourceFilter, element, WTFMove(style))
+{
+    ASSERT(isRenderSVGResourceFilter());
+}
+
+RenderSVGResourceFilter::~RenderSVGResourceFilter() = default;
+
+FloatRect RenderSVGResourceFilter::resourceBoundingBox(const RenderObject& object, RepaintRectCalculation)
+{
+    Ref filterElement = this->filterElement();
+    return SVGLengthContext::resolveRectangle<SVGFilterElement>(filterElement.ptr(), filterElement->filterUnits(), object.objectBoundingBox());
+}
+
+void RenderSVGResourceFilter::invalidateFilter()
+{
+    repaintAllClients();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderSVGResourcePaintServer.h"
+#include "SVGUnitTypes.h"
+#include <wtf/IsoMalloc.h>
+
+namespace WebCore {
+
+class SVGFilterElement;
+
+class RenderSVGResourceFilter final : public RenderSVGResourcePaintServer {
+    WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceFilter);
+
+public:
+    RenderSVGResourceFilter(SVGElement&, RenderStyle&&);
+    virtual ~RenderSVGResourceFilter();
+
+    inline SVGFilterElement& filterElement() const;
+    inline Ref<SVGFilterElement> protectedFilterElement() const;
+
+    inline SVGUnitTypes::SVGUnitType filterUnits() const;
+    inline SVGUnitTypes::SVGUnitType primitiveUnits() const;
+
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation);
+
+    void invalidateFilter();
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceFilter, isRenderSVGResourceFilter())

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderSVGResourceFilter.h"
+#include "SVGFilterElement.h"
+
+namespace WebCore {
+
+inline SVGFilterElement& RenderSVGResourceFilter::filterElement() const
+{
+    return downcast<SVGFilterElement>(RenderSVGResourceContainer::element());
+}
+
+inline Ref<SVGFilterElement> RenderSVGResourceFilter::protectedFilterElement() const
+{
+    return filterElement();
+}
+
+inline SVGUnitTypes::SVGUnitType RenderSVGResourceFilter::filterUnits() const
+{
+    return filterElement().filterUnits();
+}
+
+inline SVGUnitTypes::SVGUnitType RenderSVGResourceFilter::primitiveUnits() const
+{
+    return filterElement().primitiveUnits();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RenderSVGResourceFilterPrimitive.h"
+
+#include "RenderSVGResourceFilter.h"
+#include "SVGFilterPrimitiveStandardAttributes.h"
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceFilterPrimitive);
+
+RenderSVGResourceFilterPrimitive::RenderSVGResourceFilterPrimitive(SVGFilterPrimitiveStandardAttributes& element, RenderStyle&& style)
+    : RenderSVGHiddenContainer(Type::SVGResourceFilterPrimitive, element, WTFMove(style))
+{
+    ASSERT(isRenderSVGResourceFilterPrimitive());
+}
+
+void RenderSVGResourceFilterPrimitive::markFilterEffectForRepaint(FilterEffect* effect)
+{
+    if (!effect)
+        return;
+
+    CheckedPtr parent = dynamicDowncast<RenderSVGResourceFilter>(this->parent());
+    if (!parent)
+        return;
+
+    parent->invalidateFilter();
+}
+
+void RenderSVGResourceFilterPrimitive::markFilterEffectForRebuild()
+{
+    CheckedPtr parent = dynamicDowncast<RenderSVGResourceFilter>(this->parent());
+    if (!parent)
+        return;
+
+    parent->invalidateFilter();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderSVGHiddenContainer.h"
+
+namespace WebCore {
+
+class FilterEffect;
+
+class SVGFilterPrimitiveStandardAttributes;
+
+class RenderSVGResourceFilterPrimitive final : public RenderSVGHiddenContainer {
+    WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceFilterPrimitive);
+public:
+    RenderSVGResourceFilterPrimitive(SVGFilterPrimitiveStandardAttributes&, RenderStyle&&);
+
+    void markFilterEffectForRepaint(FilterEffect*);
+    void markFilterEffectForRebuild();
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceFilterPrimitive, isRenderSVGResourceFilterPrimitive())

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePaintServer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePaintServer.h
@@ -34,8 +34,8 @@ class RenderSVGResourcePaintServer : public RenderSVGResourceContainer {
 public:
     virtual ~RenderSVGResourcePaintServer();
 
-    virtual bool prepareFillOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) = 0;
-    virtual bool prepareStrokeOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) = 0;
+    virtual bool prepareFillOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) { return false; }
+    virtual bool prepareStrokeOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) { return false; }
 
 protected:
     RenderSVGResourcePaintServer(Type, SVGElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -31,6 +31,7 @@
 #include "RenderSVGInline.h"
 #include "RenderSVGPath.h"
 #include "RenderSVGResourceClipper.h"
+#include "RenderSVGResourceFilter.h"
 #include "RenderSVGResourceMarker.h"
 #include "RenderSVGResourceMasker.h"
 #include "RenderSVGRoot.h"
@@ -256,8 +257,12 @@ void SVGBoundingBoxComputation::adjustBoxForClippingAndEffects(const SVGBounding
         }
     }
 
-    // FIXME: Implement filter support.
-    UNUSED_PARAM(includeFilter);
+    if (includeFilter) {
+        if (auto* referencedFilterRenderer = m_renderer->svgFilterResourceFromStyle()) {
+            auto repaintRectCalculation = options.contains(DecorationOption::CalculateFastRepaintRect) ? RepaintRectCalculation::Fast : RepaintRectCalculation::Accurate;
+            box.intersect(referencedFilterRenderer->resourceBoundingBox(m_renderer, repaintRectCalculation));
+        }
+    }
 
     if (options.contains(DecorationOption::IncludeClippers)) {
         if (CheckedPtr referencedClipperRenderer = m_renderer->svgClipperResourceFromStyle()) {

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -522,7 +522,7 @@ void writeSVGResourceContainer(TextStream& ts, const LegacyRenderSVGResourceCont
 void writeSVGContainer(TextStream& ts, const LegacyRenderSVGContainer& container, OptionSet<RenderAsTextFlag> behavior)
 {
     // Currently RenderSVGResourceFilterPrimitive has no meaningful output.
-    if (container.isRenderSVGResourceFilterPrimitive())
+    if (container.isRenderOrLegacyRenderSVGResourceFilterPrimitive())
         return;
     writeStandardPrefix(ts, container, behavior);
     writePositionAndStyle(ts, container, behavior);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(FilterData);
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGResourceFilter);
 
 LegacyRenderSVGResourceFilter::LegacyRenderSVGResourceFilter(SVGFilterElement& element, RenderStyle&& style)
-    : LegacyRenderSVGResourceContainer(Type::SVGResourceFilter, element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(Type::LegacySVGResourceFilter, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
@@ -95,6 +95,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, FilterData::FilterDataState);
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceFilter)
-    static bool isType(const WebCore::RenderObject& renderer) { return renderer.isRenderSVGResourceFilter(); }
+    static bool isType(const WebCore::RenderObject& renderer) { return renderer.isLegacyRenderSVGResourceFilter(); }
     static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::FilterResourceType; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
@@ -44,7 +44,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGResourceFilterPrimitive);
 
 LegacyRenderSVGResourceFilterPrimitive::LegacyRenderSVGResourceFilterPrimitive(SVGFilterPrimitiveStandardAttributes& filterPrimitiveElement, RenderStyle&& style)
-    : LegacyRenderSVGHiddenContainer(Type::SVGResourceFilterPrimitive, filterPrimitiveElement, WTFMove(style))
+    : LegacyRenderSVGHiddenContainer(Type::LegacySVGResourceFilterPrimitive, filterPrimitiveElement, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h
@@ -53,4 +53,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGResourceFilterPrimitive, isRenderSVGResourceFilterPrimitive())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGResourceFilterPrimitive, isLegacyRenderSVGResourceFilterPrimitive())

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
@@ -154,7 +154,7 @@ void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, StyleDiffere
     // so we don't return early just when diff == StyleDifference::Equal. But
     // this isn't necessary for filter primitives, to which the filter property
     // doesn't apply, so we check for it here too.
-    if (renderer.isRenderSVGResourceFilterPrimitive() && (diff == StyleDifference::Equal || diff == StyleDifference::Repaint || diff == StyleDifference::RepaintIfText))
+    if (renderer.isLegacyRenderSVGResourceFilterPrimitive() && (diff == StyleDifference::Equal || diff == StyleDifference::Repaint || diff == StyleDifference::RepaintIfText))
         return;
 
     auto hasStyleDifferencesAffectingResources = [&] {

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -457,6 +457,7 @@ static inline bool isSVGLayerAwareElement(const SVGElement& element)
     case SVG::clipPath:
     case SVG::defs:
     case SVG::ellipse:
+    case SVG::filter:
     case SVG::foreignObject:
     case SVG::g:
     case SVG::image:

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -25,6 +25,7 @@
 #include "DocumentInlines.h"
 #include "FEConvolveMatrix.h"
 #include "NodeName.h"
+#include "SVGDocumentExtensions.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -23,6 +23,7 @@
 
 #include "FEDiffuseLighting.h"
 #include "NodeName.h"
+#include "RenderElement.h"
 #include "RenderStyle.h"
 #include "SVGFELightElement.h"
 #include "SVGNames.h"

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -23,6 +23,7 @@
 
 #include "NodeName.h"
 #include "RenderStyle.h"
+#include "SVGFilter.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include "SVGRenderStyle.h"

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -25,6 +25,8 @@
 #include "DocumentInlines.h"
 #include "FEGaussianBlur.h"
 #include "NodeName.h"
+#include "SVGDocumentExtensions.h"
+#include "SVGFilter.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -121,7 +121,7 @@ void SVGFELightElement::svgAttributeChanged(const QualifiedName& attrName)
             return;
 
         CheckedPtr renderer = parent->renderer();
-        if (!renderer || !renderer->isRenderSVGResourceFilterPrimitive())
+        if (!renderer || !renderer->isRenderOrLegacyRenderSVGResourceFilterPrimitive())
             return;
 
         if (auto* lightingElement = dynamicDowncast<SVGFEDiffuseLightingElement>(*parent)) {

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -24,6 +24,7 @@
 
 #include "FEMorphology.h"
 #include "NodeName.h"
+#include "SVGFilter.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -25,6 +25,7 @@
 
 #include "FESpecularLighting.h"
 #include "NodeName.h"
+#include "RenderElement.h"
 #include "RenderStyle.h"
 #include "SVGFELightElement.h"
 #include "SVGNames.h"

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -28,6 +28,7 @@
 
 #include "LegacyRenderSVGResourceFilter.h"
 #include "NodeName.h"
+#include "RenderSVGResourceFilter.h"
 #include "SVGElementInlines.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
 #include "SVGNames.h"
@@ -124,11 +125,20 @@ void SVGFilterElement::childrenChanged(const ChildChange& change)
     if (change.source == ChildChange::Source::Parser)
         return;
 
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        if (auto* filterRenderer = dynamicDowncast<RenderSVGResourceFilter>(renderer()))
+            filterRenderer->invalidateFilter();
+        return;
+    }
+
     updateSVGRendererForElementChange();
 }
 
 RenderPtr<RenderElement> SVGFilterElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
+    if (document().settings().layerBasedSVGEngineEnabled())
+        return createRenderer<RenderSVGResourceFilter>(*this, WTFMove(style));
+
     return createRenderer<LegacyRenderSVGResourceFilter>(*this, WTFMove(style));
 }
 

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -22,8 +22,7 @@
 #pragma once
 
 #include "FilterEffectGeometry.h"
-#include "LegacyRenderSVGResourceFilter.h"
-#include "LegacyRenderSVGResourceFilterPrimitive.h"
+#include "FilterEffectVector.h"
 #include "SVGElement.h"
 #include "SVGNames.h"
 #include <wtf/RefPtr.h>
@@ -59,6 +58,7 @@ public:
     RefPtr<FilterEffect> filterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext);
 
     void primitiveAttributeChanged(const QualifiedName&);
+    void markFilterEffectForRepaint();
     void markFilterEffectForRebuild();
 
     static void invalidateFilterPrimitiveParent(SVGElement*);


### PR DESCRIPTION
#### 2e6697f25fa78aa53674ff616810fae8e6dc503d
<pre>
[LBSE] Implement support for filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=265140">https://bugs.webkit.org/show_bug.cgi?id=265140</a>
<a href="https://rdar.apple.com/118834403">rdar://118834403</a>

Reviewed by Nikolas Zimmermann.

Implement support for filters, based on the new paint server logic. The SVG
&lt;filter&gt; element will be handled as CSS filter with one ReferenceFilterOperation.

In future patches, the geometry of CSSFilter will be similar to the geometry of
the current SVGFilter.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::svgFilterResourceFromStyle const):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderSVGHiddenContainer const):
(WebCore::RenderObject::isLegacyRenderSVGResourceFilter const):
(WebCore::RenderObject::isRenderSVGResourcePaintServer const):
(WebCore::RenderObject::isLegacyRenderSVGResourceFilterPrimitive const):
(WebCore::RenderObject::isRenderOrLegacyRenderSVGResourceFilterPrimitive const):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp: Copied from Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h.
(WebCore::RenderSVGResourceFilter::RenderSVGResourceFilter):
(WebCore::RenderSVGResourceFilter::resourceBoundingBox):
(WebCore::RenderSVGResourceFilter::invalidateFilter):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h: Copied from Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h.
* Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h: Added.
(WebCore::RenderSVGResourceFilter::filterElement const):
(WebCore::RenderSVGResourceFilter::protectedFilterElement const):
(WebCore::RenderSVGResourceFilter::filterUnits const):
(WebCore::RenderSVGResourceFilter::primitiveUnits const):
* Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp: Copied from Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h.
(WebCore::RenderSVGResourceFilterPrimitive::RenderSVGResourceFilterPrimitive):
(WebCore::RenderSVGResourceFilterPrimitive::markFilterEffectForRepaint):
(WebCore::RenderSVGResourceFilterPrimitive::markFilterEffectForRebuild):
* Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h: Copied from Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h.
* Source/WebCore/rendering/svg/RenderSVGResourcePaintServer.h:
(WebCore::RenderSVGResourcePaintServer::prepareFillOperation):
(WebCore::RenderSVGResourcePaintServer::prepareStrokeOperation):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::adjustBoxForClippingAndEffects const):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::LegacyRenderSVGResourceFilter):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp:
(WebCore::LegacyRenderSVGResourceFilterPrimitive::LegacyRenderSVGResourceFilterPrimitive):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::clientStyleChanged):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::isSVGLayerAwareElement):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::childrenChanged):
(WebCore::SVGFilterElement::createElementRenderer):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::primitiveAttributeChanged):
(WebCore::SVGFilterPrimitiveStandardAttributes::primitiveAttributeOnChildChanged):
(WebCore::SVGFilterPrimitiveStandardAttributes::markFilterEffectForRepaint):
(WebCore::SVGFilterPrimitiveStandardAttributes::markFilterEffectForRebuild):
(WebCore::SVGFilterPrimitiveStandardAttributes::createElementRenderer):
(WebCore::SVGFilterPrimitiveStandardAttributes::invalidateFilterPrimitiveParent):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:

Canonical link: <a href="https://commits.webkit.org/280190@main">https://commits.webkit.org/280190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5195f5476628729c81ce060ff8b7324d3603721d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6385 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45060 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4413 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5574 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4528 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60539 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52487 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12402 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31106 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32190 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->