### PR TITLE
Deadlock under ~PluginView() with PDFPlugin.

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not timeout.
+
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html
@@ -1,0 +1,17 @@
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  onload = async () => {
+    let iframe0 = document.createElement('iframe');
+    iframe0.src = 'data:application/pdf,x';
+    document.body.append(iframe0);
+
+    await caches.has('a');
+    await caches.has('a');
+
+    $vm.print('before');
+    iframe0.remove();
+    $vm.print('after');
+  };
+</script>
+<p>This test passes if it does not timeout.</p>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -82,6 +82,7 @@ private:
     void transitionToMainThreadDocument();
 
     bool documentFinishedLoading() const;
+    bool hasBeenDestroyed() const;
 
     void ensureDataBufferLength(uint64_t);
     void appendAccumulatedDataToDataBuffer(ByteRangeRequest&);
@@ -118,6 +119,7 @@ private:
 
     RetainPtr<PDFDocument> m_backgroundThreadDocument;
     RefPtr<Thread> m_pdfThread;
+    NSNotificationCenter * __weak m_center { [NSNotificationCenter defaultCenter] };
 
     Ref<PDFPluginStreamLoaderClient> m_streamLoaderClient;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -243,6 +243,7 @@ public:
 
 private:
     bool documentFinishedLoading() const { return m_documentFinishedLoading; }
+    bool hasBeenDestroyed() const { return m_hasBeenDestroyed; }
     uint64_t streamedBytes() const { return m_streamedBytes; }
     void ensureDataBufferLength(uint64_t);
 


### PR DESCRIPTION
#### 169eef8ec91a13161640e1bd812dcd7146a82d12
<pre>
Deadlock under ~PluginView() with PDFPlugin.
<a href="https://rdar.apple.com/108489643">rdar://108489643</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268536">https://bugs.webkit.org/show_bug.cgi?id=268536</a>

Reviewed by NOBODY (OOPS!).

dataProviderGetBytesAtPosition might be invoked recursively from CG, and it highly increased the possiblity when the main runloop is destructing the PDFPlugin,
while the another main runloop is dispatched from dataProviderGetBytesAtPosition and does not get chance to signal semaphore as it is waiting current runloop to finish,
that causes deadlock. This change is to stop dispatch main runloop when plugin has been destroyed and use notification observer to signal the semaphore,
before main thread calling waitForCompletion for m_pdfThread.

* LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt: Added.
* LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html: Added.
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::pdfThreadIsExitingNotificationName):
(WebKit::PDFIncrementalLoader::clear):
(WebKit::PDFIncrementalLoader::hasBeenDestroyed const):
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::hasBeenDestroyed const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/169eef8ec91a13161640e1bd812dcd7146a82d12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37818 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34485 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17694 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35932 "Found 3 new API test failures: TestWebKitAPI.WKWebView.PageZoomAfterPDF, TestWebKitAPI.WebKit.PDFLinkReferrer, TestWebKitAPI.PDF.PrintSize (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45688 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37938 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37304 "Found 9 new test failures: accessibility/mac/bounds-for-range-crash.html, accessibility/mac/iframe-relative-frame.html, accessibility/mac/search-predicate-container-not-included.html, fast/dom/object-load-pdf-data-url.html, fast/replaced/pdf-as-embed-with-no-mime-type-is-not-blank.html, fast/replaced/pdf-iframe-load-crash.html, http/tests/cache/disk-cache/shattered-deduplication.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-param-url.html, platform/mac-wk2/plugins/script-object-access-fails-during-slow-initialization.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41027 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39459 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36232 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->