### PR TITLE
[JSC] Check `this` type of Number#toString in DFG

### DIFF
--- a/JSTests/stress/number-prototype-to-string-type-error-for-non-number-radix-10.js
+++ b/JSTests/stress/number-prototype-to-string-type-error-for-non-number-radix-10.js
@@ -1,0 +1,27 @@
+let successCount = 0, errorCount = 0;
+
+function numberToString(thisValue) {
+    try {
+        Number.prototype.toString.call(thisValue, 10);
+        successCount++;
+    } catch {
+        errorCount++;
+    }
+}
+
+(function() {
+    const runs = 1e4;
+
+    for (let i = 0; i < runs; i++) {
+        numberToString(null);
+        numberToString(undefined);
+        numberToString(true);
+        numberToString(i);
+    }
+
+    if (successCount !== runs)
+        throw new Error(`Bad success value: ${successCount}!`);
+
+    if (errorCount !== runs * 3)
+        throw new Error(`Bad errors value: ${errorCount}!`);
+})();

--- a/JSTests/stress/number-prototype-to-string-type-error-for-non-number.js
+++ b/JSTests/stress/number-prototype-to-string-type-error-for-non-number.js
@@ -1,0 +1,27 @@
+let successCount = 0, errorCount = 0;
+
+function numberToString(thisValue) {
+    try {
+        Number.prototype.toString.call(thisValue);
+        successCount++;
+    } catch {
+        errorCount++;
+    }
+}
+
+(function() {
+    const runs = 1e4;
+
+    for (let i = 0; i < runs; i++) {
+        numberToString(null);
+        numberToString(undefined);
+        numberToString(true);
+        numberToString(i);
+    }
+
+    if (successCount !== runs)
+        throw new Error(`Bad success value: ${successCount}!`);
+
+    if (errorCount !== runs * 3)
+        throw new Error(`Bad errors value: ${errorCount}!`);
+})();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3987,6 +3987,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             insertChecks();
             Node* thisNumber = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            addToGraph(Check, Edge(thisNumber, NumberUse));
             if (argumentCountIncludingThis == 1) {
                 Node* resultNode = addToGraph(NumberToStringWithValidRadixConstant, OpInfo(10), thisNumber);
                 setResult(resultNode);


### PR DESCRIPTION
#### 176539222f3843d68158f9aa56bec1f0cebb5d82
<pre>
[JSC] Check `this` type of Number#toString in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=244190">https://bugs.webkit.org/show_bug.cgi?id=244190</a>

Reviewed by NOBODY (OOPS!).

After DFG, Number.prototype.toString does not throw a TypeError when the this value is null, undefined, or true.
This patch changes it to check if the this value is a Number.

* JSTests/stress/number-prototype-to-string-type-error-for-non-number-radix-10.js: Added.
(numberToString):
* JSTests/stress/number-prototype-to-string-type-error-for-non-number.js: Added.
(numberToString):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/176539222f3843d68158f9aa56bec1f0cebb5d82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44071 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37595 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34318 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14979 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45432 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/34956 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40828 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41129 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39236 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17937 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48140 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17992 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9830 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->