### PR TITLE
More dynamicDowncast<> adoption in platform code

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
@@ -187,7 +187,6 @@ void AudioSampleDataSource::pushSamples(const AudioStreamBasicDescription& sampl
 
 void AudioSampleDataSource::pushSamples(const MediaTime& sampleTime, const PlatformAudioData& audioData, size_t sampleCount)
 {
-    ASSERT(is<WebAudioBufferList>(audioData));
     pushSamplesInternal(*downcast<WebAudioBufferList>(audioData).list(), sampleTime, sampleCount);
 }
 

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -94,11 +94,9 @@ RetainPtr<NSImage> dissolveDragImageToFraction(RetainPtr<NSImage> image, float d
 
 RetainPtr<NSImage> createDragImageFromImage(Image* image, ImageOrientation orientation)
 {
-    if (is<BitmapImage>(*image)) {
-        BitmapImage& bitmapImage = downcast<BitmapImage>(*image);
-
+    if (auto* bitmapImage = dynamicDowncast<BitmapImage>(*image)) {
         if (orientation == ImageOrientation::Orientation::FromImage)
-            orientation = bitmapImage.orientationForCurrentFrame();
+            orientation = bitmapImage->orientationForCurrentFrame();
 
         if (orientation != ImageOrientation::Orientation::None) {
             // Construct a correctly-rotated copy of the image to use as the drag image.

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -342,47 +342,47 @@ void PlaybackSessionModelMediaElement::selectLegibleMediaOption(uint64_t index)
 void PlaybackSessionModelMediaElement::toggleFullscreen()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    ASSERT(is<HTMLVideoElement>(*m_mediaElement));
-    if (!is<HTMLVideoElement>(*m_mediaElement))
+    auto* element = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
+    ASSERT(element);
+    if (!element)
         return;
 
-    auto& element = downcast<HTMLVideoElement>(*m_mediaElement);
-    if (element.fullscreenMode() == MediaPlayerEnums::VideoFullscreenModeStandard)
-        element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
+    if (element->fullscreenMode() == MediaPlayerEnums::VideoFullscreenModeStandard)
+        element->setPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
     else
-        element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::Fullscreen);
+        element->setPresentationMode(HTMLVideoElement::VideoPresentationMode::Fullscreen);
 #endif
 }
 
 void PlaybackSessionModelMediaElement::togglePictureInPicture()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    ASSERT(is<HTMLVideoElement>(*m_mediaElement));
-    if (!is<HTMLVideoElement>(*m_mediaElement))
+    auto* element = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
+    ASSERT(element);
+    if (!element)
         return;
 
-    auto& element = downcast<HTMLVideoElement>(*m_mediaElement);
-    if (element.fullscreenMode() == MediaPlayerEnums::VideoFullscreenModePictureInPicture)
-        element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
+    if (element->fullscreenMode() == MediaPlayerEnums::VideoFullscreenModePictureInPicture)
+        element->setPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
     else
-        element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::PictureInPicture);
+        element->setPresentationMode(HTMLVideoElement::VideoPresentationMode::PictureInPicture);
 #endif
 }
 
 void PlaybackSessionModelMediaElement::toggleInWindowFullscreen()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    ASSERT(is<HTMLVideoElement>(*m_mediaElement));
-    if (!is<HTMLVideoElement>(*m_mediaElement))
+    auto* element = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
+    ASSERT(element);
+    if (!element)
         return;
 
-    auto& element = downcast<HTMLVideoElement>(*m_mediaElement);
-    UserGestureIndicator indicator(IsProcessingUserGesture::Yes, &element.document());
+    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, &element->document() };
 
-    if (element.fullscreenMode() == MediaPlayerEnums::VideoFullscreenModeInWindow)
-        element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
+    if (element->fullscreenMode() == MediaPlayerEnums::VideoFullscreenModeInWindow)
+        element->setPresentationMode(HTMLVideoElement::VideoPresentationMode::Inline);
     else
-        element.setPresentationMode(HTMLVideoElement::VideoPresentationMode::InWindow);
+        element->setPresentationMode(HTMLVideoElement::VideoPresentationMode::InWindow);
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -44,7 +44,6 @@ public:
             return;
         m_enabled = enabled;
         notifyClients([enabled](auto& client) {
-            ASSERT(is<AudioTrackPrivateClient>(client));
             downcast<AudioTrackPrivateClient>(client).enabledChanged(enabled);
         });
         if (m_enabledChangedCallback)
@@ -68,7 +67,6 @@ public:
             return;
         m_configuration = WTFMove(configuration);
         notifyClients([configuration = m_configuration](auto& client) {
-            ASSERT(is<AudioTrackPrivateClient>(client));
             downcast<AudioTrackPrivateClient>(client).configurationChanged(configuration);
         });
     }

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -44,7 +44,6 @@ public:
             return;
         m_selected = selected;
         notifyClients([selected](auto& client) {
-            ASSERT(is<VideoTrackPrivateClient>(client));
             downcast<VideoTrackPrivateClient>(client).selectedChanged(selected);
         });
         if (m_selectedChangedCallback)
@@ -69,7 +68,6 @@ public:
             return;
         m_configuration = WTFMove(configuration);
         notifyClients([configuration = m_configuration](auto& client) {
-            ASSERT(is<VideoTrackPrivateClient>(client));
             downcast<VideoTrackPrivateClient>(client).configurationChanged(configuration);
         });
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
@@ -66,7 +66,6 @@ void InbandChapterTrackPrivateAVFObjC::processChapters(RetainPtr<NSArray<AVTimed
         ISOWebVTTCue cueData = ISOWebVTTCue(PAL::toMediaTime([item time]), PAL::toMediaTime([item duration]), AtomString::number(chapterNumber), [item stringValue]);
         INFO_LOG(identifier, "created cue ", cueData);
         notifyMainThreadClient([cueData = WTFMove(cueData)](TrackPrivateBaseClient& client) mutable {
-            ASSERT(is<InbandTextTrackPrivateClient>(client));
             downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(WTFMove(cueData));
         });
     });

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2951,17 +2951,17 @@ void MediaPlayerPrivateAVFoundationObjC::outputObscuredDueToInsufficientExternal
 void MediaPlayerPrivateAVFoundationObjC::cdmInstanceAttached(CDMInstance& instance)
 {
 #if HAVE(AVCONTENTKEYSESSION)
-    if (!is<CDMInstanceFairPlayStreamingAVFObjC>(instance))
+    auto* fpsInstance = dynamicDowncast<CDMInstanceFairPlayStreamingAVFObjC>(instance);
+    if (!fpsInstance)
         return;
 
-    auto& fpsInstance = downcast<CDMInstanceFairPlayStreamingAVFObjC>(instance);
-    if (&fpsInstance == m_cdmInstance)
+    if (fpsInstance == m_cdmInstance)
         return;
 
     if (m_cdmInstance)
         cdmInstanceDetached(*m_cdmInstance);
 
-    m_cdmInstance = &fpsInstance;
+    m_cdmInstance = fpsInstance;
 #else
     UNUSED_PARAM(instance);
 #endif

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -129,9 +129,9 @@ static PlatformCAAnimation::ValueFunctionType fromCAValueFunctionType(NSString* 
 
 CAMediaTimingFunction* toCAMediaTimingFunction(const TimingFunction& timingFunction, bool reverse)
 {
-    if (is<CubicBezierTimingFunction>(timingFunction)) {
+    if (auto* cubic = dynamicDowncast<CubicBezierTimingFunction>(timingFunction)) {
         RefPtr<CubicBezierTimingFunction> reversed;
-        std::reference_wrapper<const CubicBezierTimingFunction> function = downcast<CubicBezierTimingFunction>(timingFunction);
+        std::reference_wrapper<const CubicBezierTimingFunction> function = *cubic;
 
         if (reverse) {
             reversed = function.get().createReversed();
@@ -581,8 +581,8 @@ void PlatformCAAnimationCocoa::setAnimations(const Vector<RefPtr<PlatformCAAnima
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAAnimationGroup class]]);
 
     [static_cast<CAAnimationGroup *>(m_animation.get()) setAnimations:createNSArray(value, [&] (auto& animation) -> CAAnimation * {
-        if (is<PlatformCAAnimationCocoa>(animation))
-            return downcast<PlatformCAAnimationCocoa>(animation.get())->m_animation.get();
+        if (auto* platformAnimation = dynamicDowncast<PlatformCAAnimationCocoa>(animation.get()))
+            return platformAnimation->m_animation.get();
         return nil;
     }).get()];
 }

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -355,8 +355,8 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
     FilterOperation::Type type = operation->type();
     RetainPtr<id> value;
     
-    if (is<DefaultFilterOperation>(*operation)) {
-        type = downcast<DefaultFilterOperation>(*operation).representedType();
+    if (auto* defaultOperation = dynamicDowncast<DefaultFilterOperation>(*operation)) {
+        type = defaultOperation->representedType();
         operation = nullptr;
     }
     

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -138,23 +138,22 @@ RetainPtr<CMFormatDescriptionRef> createFormatDescriptionFromTrackInfo(const Tra
 {
     ASSERT(info.isVideo() || info.isAudio());
 
-    if (info.isAudio()) {
-        auto& audioInfo = downcast<const AudioInfo>(info);
-        if (!audioInfo.cookieData || !audioInfo.cookieData->size())
+    if (auto* audioInfo = dynamicDowncast<AudioInfo>(info)) {
+        if (!audioInfo->cookieData || !audioInfo->cookieData->size())
             return nullptr;
 
-        switch (audioInfo.codecName.value) {
+        switch (audioInfo->codecName.value) {
 #if ENABLE(OPUS)
         case kAudioFormatOpus:
             if (!isOpusDecoderAvailable())
                 return nullptr;
-            return createAudioFormatDescription(audioInfo);
+            return createAudioFormatDescription(*audioInfo);
 #endif
 #if ENABLE(VORBIS)
         case kAudioFormatVorbis:
             if (!isVorbisDecoderAvailable())
                 return nullptr;
-            return createAudioFormatDescription(audioInfo);
+            return createAudioFormatDescription(*audioInfo);
 #endif
         default:
             return nullptr;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1056,8 +1056,8 @@ webm::Status WebMParser::TrackData::readFrameData(webm::Reader& reader, const we
 void WebMParser::flushPendingVideoSamples()
 {
     for (auto& track : m_tracks) {
-        if (track->trackType() == TrackInfo::TrackType::Video)
-            downcast<WebMParser::VideoTrackData>(track.get()).flushPendingSamples();
+        if (auto* videoTrack = dynamicDowncast<WebMParser::VideoTrackData>(track.get()))
+            videoTrack->flushPendingSamples();
     }
 }
 

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp
@@ -542,19 +542,17 @@ void FELightingNeonParallelApplier::applyPlatformParallel(const LightingData& da
     floatArguments.colorBlue = color.blue;
     floatArguments.padding4 = 0;
 
-    if (data.lightSource->type() == LS_POINT) {
+    if (auto* pointLightSource = dynamicDowncast<PointLightSource>(*data.lightSource)) {
         neonData.flags |= FLAG_POINT_LIGHT;
-        auto& pointLightSource = downcast<PointLightSource>(*data.lightSource);
-        floatArguments.lightX = pointLightSource.position().x();
-        floatArguments.lightY = pointLightSource.position().y();
-        floatArguments.lightZ = pointLightSource.position().z();
+        floatArguments.lightX = pointLightSource->position().x();
+        floatArguments.lightY = pointLightSource->position().y();
+        floatArguments.lightZ = pointLightSource->position().z();
         floatArguments.padding2 = 0;
-    } else if (data.lightSource->type() == LS_SPOT) {
+    } else if (auto* spotLightSource = dynamicDowncast<SpotLightSource>(*data.lightSource)) {
         neonData.flags |= FLAG_SPOT_LIGHT;
-        auto& spotLightSource = downcast<SpotLightSource>(*data.lightSource);
-        floatArguments.lightX = spotLightSource.position().x();
-        floatArguments.lightY = spotLightSource.position().y();
-        floatArguments.lightZ = spotLightSource.position().z();
+        floatArguments.lightX = spotLightSource->position().x();
+        floatArguments.lightY = spotLightSource->position().y();
+        floatArguments.lightZ = spotLightSource->position().z();
         floatArguments.padding2 = 0;
 
         floatArguments.directionX = paintingData.directionVector.x();
@@ -565,8 +563,8 @@ void FELightingNeonParallelApplier::applyPlatformParallel(const LightingData& da
         floatArguments.coneCutOffLimit = paintingData.coneCutOffLimit;
         floatArguments.coneFullLight = paintingData.coneFullLight;
         floatArguments.coneCutOffRange = paintingData.coneCutOffLimit - paintingData.coneFullLight;
-        neonData.coneExponent = getPowerCoefficients(spotLightSource.specularExponent());
-        if (spotLightSource.specularExponent() == 1)
+        neonData.coneExponent = getPowerCoefficients(spotLightSource->specularExponent());
+        if (spotLightSource->specularExponent() == 1)
             neonData.flags |= FLAG_CONE_EXPONENT_IS_1;
     } else {
         ASSERT(data.lightSource->type() == LS_DISTANT);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -299,8 +299,8 @@ void Recorder::drawSystemImage(SystemImage& systemImage, const FloatRect& destin
 {
     appendStateChangeItemIfNecessary();
 #if USE(SYSTEM_PREVIEW)
-    if (is<ARKitBadgeSystemImage>(systemImage)) {
-        if (auto image = downcast<ARKitBadgeSystemImage>(systemImage).image()) {
+    if (auto* badgeSystemImage = dynamicDowncast<ARKitBadgeSystemImage>(systemImage)) {
+        if (auto image = badgeSystemImage->image()) {
             auto nativeImage = image->nativeImage();
             if (!nativeImage)
                 return;


### PR DESCRIPTION
#### 90d13e77ab2192b7efa8e763eeb8b08dbbb6d5c3
<pre>
More dynamicDowncast&lt;&gt; adoption in platform code
<a href="https://bugs.webkit.org/show_bug.cgi?id=270069">https://bugs.webkit.org/show_bug.cgi?id=270069</a>

Reviewed by Chris Dumez.

For security &amp; performance.

Part 2 of going through all downcasts in platform code and tidying them
up as needed.

* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::pushSamples):
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::createDragImageFromImage):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::toggleFullscreen):
(WebCore::PlaybackSessionModelMediaElement::togglePictureInPicture):
(WebCore::PlaybackSessionModelMediaElement::toggleInWindowFullscreen):
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
(WebCore::AudioTrackPrivate::setEnabled):
(WebCore::AudioTrackPrivate::setConfiguration):
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
(WebCore::VideoTrackPrivate::setSelected):
(WebCore::VideoTrackPrivate::setConfiguration):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm:
(WebCore::InbandChapterTrackPrivateAVFObjC::processChapters):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::cdmInstanceAttached):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::toCAMediaTimingFunction):
(WebCore::PlatformCAAnimationCocoa::setAnimations):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::filterValueForOperation):
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::createFormatDescriptionFromTrackInfo):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::flushPendingVideoSamples):
* Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp:
(WebCore::FELightingNeonParallelApplier::applyPlatformParallel const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawSystemImage):

Canonical link: <a href="https://commits.webkit.org/275322@main">https://commits.webkit.org/275322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27b5d551bfb99323158d919d3847eeb388905196

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34319 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14980 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45437 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40830 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39238 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17941 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9307 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->