### PR TITLE
[GPUP][MSE] RemoteSourceBufferProxy::EvictCodedFrames shouldn't be a sync call

### DIFF
--- a/LayoutTests/media/media-source/live-rewind-seek-and-evict.html
+++ b/LayoutTests/media/media-source/live-rewind-seek-and-evict.html
@@ -59,7 +59,7 @@
         testExpected('isNaN(source.duration)', true, '==');
 
         // This should allow bufering up to 177 (empirically tested).
-        internals.settings.setMaximumSourceBufferSize(3000);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 3000);
 
         exception = await appendPtsRange(120, 176);
 

--- a/LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded.html
+++ b/LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded.html
@@ -61,7 +61,7 @@
         testExpected('video.currentTime', 120, '==');
 
         // This should allow bufering up to 175 (empirically tested).
-        internals.settings.setMaximumSourceBufferSize(4000);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 4000);
 
         // Append data from 120..176. The SourceBuffer will be filled after 175, so the last iteration should throw QuotaExceededError.
         exception = await appendPtsRange(120, 176);

--- a/LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end.html
+++ b/LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end.html
@@ -77,7 +77,7 @@
         await waitFor(sourceBuffer, 'updateend');
         waitFor(sourceBuffer, 'error');
 
-        internals.settings.setMaximumSourceBufferSize(500);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 500);
 
         video.currentTime = 18;
         testExpected('video.currentTime', 18, '==');
@@ -87,7 +87,7 @@
         testExpected('bufferedRanges()', '[ 10...15 ]', '==');
 
         endTest();
-        });
+    });
     </script>
 </head>
 <body>

--- a/LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error-onstart.html
+++ b/LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error-onstart.html
@@ -39,7 +39,7 @@
         sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock");
         initSegment = makeAInit(350, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
         // Set a buffer size that is less than the init segment length.
-        internals.settings.setMaximumSourceBufferSize(30);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 30);
         exception = await appendBuffer(initSegment);
         waitFor(sourceBuffer, 'error');
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '==');

--- a/LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error.html
+++ b/LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error.html
@@ -66,7 +66,7 @@
         await waitFor(sourceBuffer, 'updateend');
         waitFor(sourceBuffer, 'error');
 
-        internals.settings.setMaximumSourceBufferSize(1000);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 1000);
 
         exception = await appendPtsRange(0, 12);
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '!=');
@@ -75,7 +75,7 @@
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '==');
 
         // To exercise eviction ahead of current time we must add over 30s of data.
-        internals.settings.setMaximumSourceBufferSize(3000);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 3000);
 
         // Ensure that small gaps that would be ignored during playback are also ignored by eviction.
         // We use a gap of 2/1000 as gaps of 1/1000th are removed and 2002/24000 is the maximum gap ignored during playback.
@@ -86,7 +86,7 @@
         // Check that appendBuffer removed all the small gaps in the data less than the threshold.
         testExpected('sourceBuffer.buffered.length', '1', '==');
 
-        internals.settings.setMaximumSourceBufferSize(1500);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 1500);
         // Ensure that if current time is close enough to the buffered data that the nearest range isn't evicted.
         sourceBuffer.remove(0, Infinity);
         await waitFor(sourceBuffer, 'updateend');
@@ -96,7 +96,7 @@
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '==');
         testExpected('sourceBuffer.buffered.length', '1', '==');
 
-        internals.settings.setMaximumSourceBufferSize(4000);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 4000);
         // Ensure that small gaps that would be ignored during playback are also ignored by eviction.
         // We use a gap of 2000/24000 which is less than the 2002/24000 gap ignored during playback.
         // Gaps are removed during append, so we remove data to create a gap <= 2000/24000.

--- a/LayoutTests/media/media-source/media-source-evict-codedframe-after-seek.html
+++ b/LayoutTests/media/media-source/media-source-evict-codedframe-after-seek.html
@@ -58,7 +58,7 @@
         await waitFor(sourceBuffer, 'updateend');
         waitFor(sourceBuffer, 'error');
 
-        internals.settings.setMaximumSourceBufferSize(3200);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 3200);
 
         exception = await appendPtsRange(0, 11);
         testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '!=');

--- a/LayoutTests/media/media-source/media-source-evict-codedframe-large-currenttime.html
+++ b/LayoutTests/media/media-source/media-source-evict-codedframe-large-currenttime.html
@@ -44,7 +44,7 @@
         var firstPts = 0 + offset;
         var lastPts = 55 + offset;
 
-        internals.settings.setMaximumSourceBufferSize(4000);
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 4000);
 
         for (var pts = firstPts; pts <= lastPts; pts++) {
             sourceBuffer.appendBuffer(makeASample(pts, pts, 1, 1, 1, SAMPLE_FLAG.SYNC, 1));

--- a/LayoutTests/media/media-source/media-source-monitor-playing-event.html
+++ b/LayoutTests/media/media-source/media-source-monitor-playing-event.html
@@ -83,7 +83,7 @@
         sample = makeASample(1, 1, 12, 1, 1, SAMPLE_FLAG.SYNC, 1);
         // This append changes the ready state to HAVE_ENOUGH_DATA and fires the playing event.
         run('sourceBuffer.appendBuffer(sample)');
-        await Promise.all([waitFor(mediaElement, 'playing'), waitFor(sourceBuffer, 'updateend')]);
+        await Promise.all([waitFor(mediaElement, 'playing'), waitFor(mediaElement, 'canplaythrough', true), waitFor(sourceBuffer, 'updateend')]);
 
         consoleWrite('video.readyState : ' + readyStateString[video.readyState]);
         endTest();

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -164,7 +164,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     Ref<MediaPromise> sourceBufferPrivateDidReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&&);
-    Ref<MediaPromise> sourceBufferPrivateBufferedChanged(Vector<PlatformTimeRanges>&&, uint64_t);
+    Ref<MediaPromise> sourceBufferPrivateBufferedChanged(Vector<PlatformTimeRanges>&&);
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);
     Ref<MediaPromise> sourceBufferPrivateDurationChanged(const MediaTime& duration);
     void sourceBufferPrivateDidDropSample();
@@ -217,6 +217,7 @@ private:
     WEBCORE_EXPORT Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID);
     WEBCORE_EXPORT MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID);
     WEBCORE_EXPORT void setMaximumQueueDepthForTrackID(TrackID, uint64_t);
+    WEBCORE_EXPORT Ref<GenericPromise> setMaximumSourceBufferSize(uint64_t);
 
     void updateBuffered();
 
@@ -263,6 +264,7 @@ private:
     bool m_appendBufferPending { false };
     uint32_t m_appendBufferOperationId { 0 };
     bool m_removeCodedFramesPending { false };
+    std::optional<uint64_t> m_maximumBufferSize;
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -43,6 +43,25 @@ class MediaDescription;
 class PlatformTimeRanges;
 class VideoTrackPrivate;
 
+struct SourceBufferEvictionData {
+    uint64_t contentSize { 0 };
+    int64_t evictableSize { 0 };
+    uint64_t maximumBufferSize { 0 };
+    size_t numMediaSamples { 0 };
+
+    bool operator!=(const SourceBufferEvictionData& other)
+    {
+        return contentSize != other.contentSize || evictableSize != other.evictableSize || maximumBufferSize != other.maximumBufferSize || numMediaSamples != other.numMediaSamples;
+    }
+
+    void clear()
+    {
+        contentSize = 0;
+        evictableSize = 0;
+        numMediaSamples = 0;
+    }
+};
+
 class SourceBufferPrivateClient : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SourceBufferPrivateClient> {
 public:
     virtual ~SourceBufferPrivateClient() = default;
@@ -70,13 +89,25 @@ public:
     };
 
     virtual Ref<MediaPromise> sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&) = 0;
-    virtual Ref<MediaPromise> sourceBufferPrivateBufferedChanged(const Vector<PlatformTimeRanges>&, uint64_t) = 0;
+    virtual Ref<MediaPromise> sourceBufferPrivateBufferedChanged(const Vector<PlatformTimeRanges>&) = 0;
     virtual Ref<MediaPromise> sourceBufferPrivateDurationChanged(const MediaTime&) = 0;
     virtual void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) = 0;
     virtual void sourceBufferPrivateDidDropSample() = 0;
     virtual void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) = 0;
+    virtual void sourceBufferPrivateEvictionDataChanged(const SourceBufferEvictionData&) { }
 };
 
 } // namespace WebCore
+
+namespace WTF {
+template<>
+struct LogArgument<WebCore::SourceBufferEvictionData> {
+    static String toString(const WebCore::SourceBufferEvictionData& evictionData)
+    {
+        return makeString("{ contentSize:", evictionData.contentSize, " evictableData:", evictionData.evictableSize, " maximumBufferSize:", evictionData.maximumBufferSize, " numSamples:", evictionData.numMediaSamples, " }");
+    }
+};
+
+} // namespace WTF
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -56,9 +56,10 @@ public:
     
     bool reenqueueMediaForTime(const MediaTime&, const MediaTime& timeFudgeFactor);
     MediaTime findSeekTimeForTargetTime(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold);
-    bool removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime);
+    int64_t removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime);
     PlatformTimeRanges removeSamples(const DecodeOrderSampleMap::MapType&, const char*);
-    
+    int64_t codedFramesIntervalSize(const MediaTime& start, const MediaTime& end);
+
     void resetTimestampOffset();
     void reset();
     void clearSamples();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4567,6 +4567,13 @@ void Internals::initializeMockMediaSource()
     platformStrategies()->mediaStrategy().enableMockMediaSource();
 }
 
+void Internals::setMaximumSourceBufferSize(SourceBuffer& buffer, uint64_t maximumSize, DOMPromiseDeferred<void>&& promise)
+{
+    buffer.setMaximumSourceBufferSize(maximumSize)->whenSettled(RunLoop::current(), [promise = WTFMove(promise)]() mutable {
+        promise.resolve();
+    });
+}
+
 void Internals::bufferedSamplesForTrackId(SourceBuffer& buffer, const AtomString& trackId, BufferedSamplesPromise&& promise)
 {
     buffer.bufferedSamplesForTrackId(parseInteger<uint64_t>(trackId).value_or(0))->whenSettled(RunLoop::current(), [promise = WTFMove(promise)](auto&& samples) mutable {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -786,6 +786,7 @@ public:
 
 #if ENABLE(MEDIA_SOURCE)
     WEBCORE_TESTSUPPORT_EXPORT void initializeMockMediaSource();
+    void setMaximumSourceBufferSize(SourceBuffer&, uint64_t, DOMPromiseDeferred<void>&&);
     using BufferedSamplesPromise = DOMPromiseDeferred<IDLSequence<IDLDOMString>>;
     void bufferedSamplesForTrackId(SourceBuffer&, const AtomString&, BufferedSamplesPromise&&);
     void enqueuedSamplesForTrackID(SourceBuffer&, const AtomString&, BufferedSamplesPromise&&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -925,6 +925,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     [Conditional=MEDIA_SOURCE] undefined initializeMockMediaSource();
     [Conditional=MEDIA_SOURCE] Promise<sequence<DOMString>> bufferedSamplesForTrackId(SourceBuffer buffer, [AtomString] DOMString trackId);
+    [Conditional=MEDIA_SOURCE] Promise<undefined> setMaximumSourceBufferSize(SourceBuffer buffer, unsigned long long maximumSize);
     [Conditional=MEDIA_SOURCE] Promise<sequence<DOMString>> enqueuedSamplesForTrackID(SourceBuffer buffer, [AtomString] DOMString trackID);
     [Conditional=MEDIA_SOURCE] undefined setShouldGenerateTimestamps(SourceBuffer buffer, boolean flag);
     [Conditional=MEDIA_SOURCE] double minimumUpcomingPresentationTimeForTrackID(SourceBuffer buffer, [AtomString] DOMString trackID);

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -68,11 +68,12 @@ private:
 
     // SourceBufferPrivateClient
     Ref<WebCore::MediaPromise> sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&) final;
-    Ref<WebCore::MediaPromise> sourceBufferPrivateBufferedChanged(const Vector<WebCore::PlatformTimeRanges>&, uint64_t) final;
+    Ref<WebCore::MediaPromise> sourceBufferPrivateBufferedChanged(const Vector<WebCore::PlatformTimeRanges>&) final;
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) final;
     Ref<WebCore::MediaPromise> sourceBufferPrivateDurationChanged(const MediaTime&) final;
     void sourceBufferPrivateDidDropSample() final;
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;
+    void sourceBufferPrivateEvictionDataChanged(const WebCore::SourceBufferEvictionData&) final;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -88,7 +89,8 @@ private:
     void setMediaSourceEnded(bool);
     void startChangingType();
     void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, CompletionHandler<void()>&&);
-    void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, CompletionHandler<void(Vector<WebCore::PlatformTimeRanges>&&, uint64_t)>&&);
+    void evictCodedFrames(uint64_t newDataSize, const MediaTime& currentTime, CompletionHandler<void(Vector<WebCore::PlatformTimeRanges>&&, WebCore::SourceBufferEvictionData&&)>&&);
+    void asyncEvictCodedFrames(uint64_t newDataSize, const MediaTime& currentTime);
     void addTrackBuffer(TrackID);
     void resetTrackBuffers();
     void clearTrackBuffers();
@@ -101,12 +103,13 @@ private:
     void setTimestampOffset(const MediaTime&);
     void setAppendWindowStart(const MediaTime&);
     void setAppendWindowEnd(const MediaTime&);
+    void setMaximumBufferSize(size_t, CompletionHandler<void()>&&);
     void computeSeekTime(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::SourceBufferPrivate::ComputeSeekPromise::Result&&)>&&);
     void seekToTime(const MediaTime&);
     void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&&);
     void bufferedSamplesForTrackId(TrackID, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&&);
     void enqueuedSamplesForTrackID(TrackID, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&&);
-    void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime);
+    void memoryPressure(const MediaTime& currentTime);
     void minimumUpcomingPresentationTimeForTrackID(TrackID, CompletionHandler<void(MediaTime)>&&);
     void setMaximumQueueDepthForTrackID(TrackID, uint64_t);
     void disconnect();

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -40,7 +40,8 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     ClearTrackBuffers()
     SetAllTrackBuffersNeedRandomAccess()
     RemoveCodedFrames(MediaTime start, MediaTime end, MediaTime currentTime) -> ()
-    EvictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, MediaTime currentTime) -> (Vector<WebCore::PlatformTimeRanges> trackBuffers, uint64_t extraMemory) Synchronous
+    EvictCodedFrames(uint64_t newDataSize, MediaTime currentTime) -> (Vector<WebCore::PlatformTimeRanges> trackBuffers, struct WebCore::SourceBufferEvictionData evictionData) Synchronous
+    AsyncEvictCodedFrames(uint64_t newDataSize, MediaTime currentTime);
     ReenqueueMediaIfNeeded(MediaTime currentMediaTime)
     SetGroupStartTimestamp(MediaTime timestamp)
     SetGroupStartTimestampToEndTimestamp()
@@ -49,12 +50,13 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     SetTimestampOffset(MediaTime timestampOffset)
     SetAppendWindowStart(MediaTime appendWindowStart)
     SetAppendWindowEnd(MediaTime appendWindowEnd)
+    SetMaximumBufferSize(size_t size) -> ()
     ComputeSeekTime(struct WebCore::SeekTarget target) -> (WebCore::SourceBufferPrivate::ComputeSeekPromise::Result seekedTime)
     SeekToTime(MediaTime time)
     UpdateTrackIds(Vector<std::pair<WebCore::TrackID , WebCore::TrackID >> identifierPairs)
     BufferedSamplesForTrackId(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     EnqueuedSamplesForTrackID(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
-    MemoryPressure(uint64_t maximumBufferSize, MediaTime currentTime)
+    MemoryPressure(MediaTime currentTime)
     SetMaximumQueueDepthForTrackID(WebCore::TrackID trackID, uint64_t depth)
     MinimumUpcomingPresentationTimeForTrackID(WebCore::TrackID trackID) -> (MediaTime time) Synchronous
 }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -898,6 +898,7 @@ def headers_for_type(type):
         'WebCore::ShouldNotifyWhenResolved': ['<WebCore/ServiceWorkerTypes.h>'],
         'WebCore::ShouldSample': ['<WebCore/DiagnosticLoggingClient.h>'],
         'WebCore::SourceBufferAppendMode': ['<WebCore/SourceBufferPrivate.h>'],
+        'WebCore::SourceBufferEvictionData': ['<WebCore/SourceBufferPrivateClient.h>'],
         'WebCore::StorageAccessPromptWasShown': ['<WebCore/DocumentStorageAccess.h>'],
         'WebCore::StorageAccessScope': ['<WebCore/DocumentStorageAccess.h>'],
         'WebCore::StorageAccessWasGranted': ['<WebCore/DocumentStorageAccess.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7351,6 +7351,14 @@ enum class WebCore::SourceBufferAppendMode : uint8_t {
     Sequence
 };
 
+header: <WebCore/SourceBufferPrivateClient.h>
+[CustomHeader] struct WebCore::SourceBufferEvictionData {
+    uint64_t contentSize;
+    int64_t evictableSize;
+    uint64_t maximumBufferSize;
+    size_t numMediaSamples;
+};
+
 #endif
 
 header: <WebCore/Font.h>

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -82,10 +82,11 @@ public:
         void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
         void takeOwnershipOfMemory(WebCore::SharedMemory::Handle&&);
         void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);
-        void sourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges>&&, uint64_t, CompletionHandler<void()>&&);
+        void sourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges>&&, CompletionHandler<void()>&&);
         void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&);
         void sourceBufferPrivateDidDropSample();
         void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode);
+        void sourceBufferPrivateEvictionDataChanged(WebCore::SourceBufferEvictionData&&);
         void sourceBufferPrivateShuttingDown(CompletionHandler<void()>&&);
         RefPtr<WebCore::SourceBufferPrivateClient> client() const;
         ThreadSafeWeakPtr<SourceBufferPrivateRemote> m_parent;
@@ -115,13 +116,16 @@ private:
     void setGroupStartTimestampToEndTimestamp() final;
     void setShouldGenerateTimestamps(bool) final;
     Ref<WebCore::MediaPromise> removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentMediaTime) final;
-    void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime) final;
+    bool evictCodedFrames(uint64_t newDataSize, const MediaTime& currentTime) final;
     void resetTimestampOffsetInTrackBuffers() final;
     void startChangingType() final;
     void setTimestampOffset(const MediaTime&) final;
     MediaTime timestampOffset() const final;
     void setAppendWindowStart(const MediaTime&) final;
     void setAppendWindowEnd(const MediaTime&) final;
+    Ref<GenericPromise> setMaximumBufferSize(size_t) final;
+    bool isBufferFullFor(uint64_t requiredSize) const final;
+    bool canAppend(uint64_t requiredSize) const final;
 
     Ref<ComputeSeekPromise> computeSeekTime(const WebCore::SeekTarget&) final;
     void seekToTime(const MediaTime&) final;
@@ -129,7 +133,7 @@ private:
     void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&&) final;
     uint64_t totalTrackBufferSizeInBytes() const final;
 
-    void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime) final;
+    void memoryPressure(const MediaTime& currentTime) final;
 
     // Internals Utility methods
     Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID) final;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
@@ -29,10 +29,11 @@ messages -> SourceBufferPrivateRemoteMessageReceiver NotRefCounted {
     SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (WebCore::MediaPromise::Result result)
     TakeOwnershipOfMemory(WebCore::SharedMemory::Handle remoteData)
     SourceBufferPrivateHighestPresentationTimestampChanged(MediaTime timestamp)
-    SourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges> trackBuffers, uint64_t extraMemory) -> ()
+    SourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges> trackBuffers) -> ()
     SourceBufferPrivateDurationChanged(MediaTime duration) -> ()
     SourceBufferPrivateDidDropSample()
     SourceBufferPrivateDidReceiveRenderingError(int64_t errorCode)
+    SourceBufferPrivateEvictionDataChanged(struct WebCore::SourceBufferEvictionData evictionData)
     SourceBufferPrivateShuttingDown() -> ()
 }
 


### PR DESCRIPTION
#### bbf768df7ba799771f882dc739c09034f7a92934
<pre>
[GPUP][MSE] RemoteSourceBufferProxy::EvictCodedFrames shouldn&apos;t be a sync call
<a href="https://bugs.webkit.org/show_bug.cgi?id=265079">https://bugs.webkit.org/show_bug.cgi?id=265079</a>
<a href="https://rdar.apple.com/118783504">rdar://118783504</a>

Reviewed by Youenn Fablet.

Sync calls should be avoided under most circumstances, however with MSE, the prepare append
algorithm is only made of synchronous steps and the synchronous call was made into a
sendSync call to the GPU process for expediency.
The only reason this call had to be synchronous was to determine if a new appendBuffer
call was going to succeed even if we were running out of space and after an eviction.

Instead, we calculate following each source buffer operation the amount of evictable data
based on the currentTime.
When the SourceBuffer needs to append a new buffer, we will then now immediately if:
1- there&apos;s enough space to accept the new buffer as-is
2- if there&apos;s not enough space and we evict content then the data would fit.
If either 1 or 2 fails, then we are to throw a QuotaExceededError.

In the case of 1) there&apos;s nothing to do, we can avoid the call to EvictCodedFrame altogher.
If 2) we can run the EvictCodedFrame algorithm asynchronously and don&apos;t need to wait for
the result of the operation: we know the next append will succeed.

For 100% spec-compliance, should we fire QuotaExceededError, we want the eviction to run and
be completed. Some browsers (Firefox in particular), do not fullfill this requirement: the SourceBuffer
will throw, and eviction will still be done asynchronously; which is arguably a better and simpler
behaviour from an implementer point of view.

While the evictable amount of data would change over time as playback progress, for our case
we don&apos;t need to update it at regular interval as we will conservatively run the eviction step
which will always then free more memory than we expected we could.

In practice, it means that the only time we will fire a sync call to the GPU process is if
the append buffer operation will fail as we have run out of space, and we will not be
able to make sufficient room.

Covered by existing tests, no change in observable behaviour.

* LayoutTests/media/media-source/live-rewind-seek-and-evict.html:
* LayoutTests/media/media-source/media-source-append-before-last-range-no-quota-exceeded.html:
* LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end.html:
* LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error-onstart.html:
* LayoutTests/media/media-source/media-source-append-buffer-full-quota-exceeded-error.html:
* LayoutTests/media/media-source/media-source-evict-codedframe-after-seek.html:
* LayoutTests/media/media-source/media-source-monitor-playing-event.html:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::m_logIdentifier):
(WebCore::SourceBuffer::appendBufferInternal):
(WebCore::SourceBuffer::maximumBufferSize const):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::setMaximumSourceBufferSize):
(WebCore::SourceBuffer::sourceBufferPrivateBufferedChanged):
(WebCore::SourceBuffer::memoryPressure):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::updateBuffered):
(WebCore::SourceBufferPrivate::computeSeekTime):
(WebCore::SourceBufferPrivate::clearTrackBuffers):
(WebCore::SourceBufferPrivate::removeCodedFrames):
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):
(WebCore::SourceBufferPrivate::setMaximumBufferSize):
(WebCore::SourceBufferPrivate::computeEvictionData):
(WebCore::SourceBufferPrivate::hasTooManySamples const):
(WebCore::SourceBufferPrivate::asyncEvictCodedFrames): Add asynchronous task that will run
evictCodedFrame after all the currently pending tasks.
(WebCore::SourceBufferPrivate::evictCodedFrames): Return a boolean to indicate if the operation
succeeded, instead of having to query isBufferFullFor.
(WebCore::SourceBufferPrivate::isBufferFullFor const):
(WebCore::SourceBufferPrivate::canAppend const):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::memoryPressure):
(WebCore::SourceBufferPrivate::evictFrames):
(WebCore::SourceBufferPrivate::isBufferFullFor): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::evictionData const):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WebCore::SourceBufferEvictionData::operator!=):
(WebCore::SourceBufferEvictionData::clear):
(WebCore::SourceBufferPrivateClient::sourceBufferPrivateEvictionDataChanged):
(WTF::LogArgument&lt;WebCore::SourceBufferEvictionData&gt;::toString):
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::removeSamples): Instead of returning a boolean to determine if the
operatiation suceeded (returned value that was unused). We return the amount of bytes we
removed from the SampleMap. It allows to incrementally update the known SourceBuffer size
without having to recalculate it all the time.
(WebCore::TrackBuffer::removeCodedFrames): Simplify code by only calculating the size removed
(for logging purposes) outside the critical loop.
(WebCore::TrackBuffer::codedFramesIntervalSize): Add method to determine approximately how
much bytes would be removed should we remove the frames. This is used for calculating the evictable
size, without actually removing the data.
* Source/WebCore/platform/graphics/TrackBuffer.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setMaximumSourceBufferSize):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl: Add a way to asynchronously set the SourceBuffer&apos;s maximumBufferSize
and wait for the operation to complete. Simply changing the settings wasn&apos;t sufficient as it provided no guarantee
that the GPU process would receive the new value in time.
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateEvictionDataChanged):
(WebKit::RemoteSourceBufferProxy::evictCodedFrames):
(WebKit::RemoteSourceBufferProxy::asyncEvictCodedFrames):
(WebKit::RemoteSourceBufferProxy::setMaximumBufferSize):
(WebKit::RemoteSourceBufferProxy::memoryPressure):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::evictCodedFrames):
(WebKit::SourceBufferPrivateRemote::clearTrackBuffers):
(WebKit::SourceBufferPrivateRemote::setMaximumBufferSize):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateEvictionDataChanged):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateBufferedChanged):
(WebKit::SourceBufferPrivateRemote::totalTrackBufferSizeInBytes const):
(WebKit::SourceBufferPrivateRemote::memoryPressure):
(WebKit::SourceBufferPrivateRemote::isBufferFullFor const):
(WebKit::SourceBufferPrivateRemote::canAppend const):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in:

Canonical link: <a href="https://commits.webkit.org/275380@main">https://commits.webkit.org/275380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2d8cd6c6a6b85a2910552e182cf5681ae537ae8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18052 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15138 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/41578 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15338 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45667 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41006 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39434 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36214 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9346 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->