### PR TITLE
Even more dynamicDowncast<> conversion in platform code

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FilterEffect.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.h
@@ -60,9 +60,8 @@ protected:
     template<typename FilterEffectType>
     static bool areEqual(const FilterEffectType& a, const FilterEffect& b)
     {
-        if (!is<FilterEffectType>(b))
-            return false;
-        return a.operator==(downcast<FilterEffectType>(b));
+        auto* bType = dynamicDowncast<FilterEffectType>(b);
+        return bType && a.operator==(*bType);
     }
 
     virtual unsigned numberOfEffectInputs() const { return 1; }

--- a/Source/WebCore/platform/graphics/filters/LightSource.h
+++ b/Source/WebCore/platform/graphics/filters/LightSource.h
@@ -96,9 +96,8 @@ protected:
     template<typename LightSourceType>
     static bool areEqual(const LightSourceType& a, const LightSource& b)
     {
-        if (!is<LightSourceType>(b))
-            return false;
-        return a.operator==(downcast<LightSourceType>(b));
+        auto* bType = dynamicDowncast<LightSourceType>(b);
+        return bType && a.operator==(*bType);
     }
 
 private:

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
@@ -54,9 +54,8 @@ AudioTrackPrivateMediaStream::~AudioTrackPrivateMediaStream()
 #if USE(LIBWEBRTC)
 static RefPtr<LibWebRTCAudioModule> audioModuleFromSource(RealtimeMediaSource& source)
 {
-    if (!is<RealtimeIncomingAudioSource>(source))
-        return nullptr;
-    return downcast<RealtimeIncomingAudioSource>(source).audioModule();
+    auto* audioSource = dynamicDowncast<RealtimeIncomingAudioSource>(source);
+    return audioSource ? audioSource->audioModule() : nullptr;
 }
 #endif
 

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp
@@ -97,8 +97,8 @@ void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFram
                 static_cast<int>(size.width() * videoFrameScaling), static_cast<int>(size.height() * videoFrameScaling)));
             return;
         }
-        if (videoFrame.isLibWebRTC()) {
-            auto webrtcBuffer = downcast<VideoFrameLibWebRTC>(videoFrame).buffer();
+        if (auto* webrtcVideoFrame = dynamicDowncast<VideoFrameLibWebRTC>(videoFrame)) {
+            auto webrtcBuffer = webrtcVideoFrame->buffer();
             if (videoFrameScaling != 1)
                 webrtcBuffer = webrtcBuffer->Scale(webrtcBuffer->width() * videoFrameScaling, webrtcBuffer->height() * videoFrameScaling);
             sendFrame(WTFMove(webrtcBuffer));


### PR DESCRIPTION
#### 3edd02f0ef76251576ccf472966565867cacbbe7
<pre>
Even more dynamicDowncast&lt;&gt; conversion in platform code
<a href="https://bugs.webkit.org/show_bug.cgi?id=270071">https://bugs.webkit.org/show_bug.cgi?id=270071</a>

Reviewed by Chris Dumez.

For security &amp; performance. Final part of auditing all downcast calls
in platform code.

* Source/WebCore/platform/graphics/filters/FilterEffect.h:
(WebCore::FilterEffect::areEqual):
* Source/WebCore/platform/graphics/filters/LightSource.h:
(WebCore::LightSource::areEqual):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp:
(WebCore::audioModuleFromSource):
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp:
(WebCore::RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable):

Canonical link: <a href="https://commits.webkit.org/275324@main">https://commits.webkit.org/275324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc78111aac7d822aa5f45d17743c911e75db95d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17880 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15008 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37104 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13431 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17970 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9310 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->