### PR TITLE
[UnifiedPDF] Selections are broken in rotated pages

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -99,19 +99,20 @@ public:
     void setShouldUpdateAutoSizeScale(ShouldUpdateAutoSizeScale autoSizeState) { m_autoSizeState = autoSizeState; }
     ShouldUpdateAutoSizeScale shouldUpdateAutoSizeScale() const { return m_autoSizeState; }
 
-private:
-    void layoutPages(float availableWidth, float maxRowWidth);
-
-    void layoutSingleColumn(float availableWidth, float maxRowWidth);
-    void layoutTwoUpColumn(float availableWidth, float maxRowWidth);
-
     struct PageGeometry {
         WebCore::FloatRect cropBox;
         WebCore::FloatRect layoutBounds;
         WebCore::IntDegrees rotation { 0 };
     };
 
+    std::optional<PageGeometry> geometryForPage(RetainPtr<PDFPage>) const;
     WebCore::AffineTransform toPageTransform(const PageGeometry&) const;
+
+private:
+    void layoutPages(float availableWidth, float maxRowWidth);
+
+    void layoutSingleColumn(float availableWidth, float maxRowWidth);
+    void layoutTwoUpColumn(float availableWidth, float maxRowWidth);
 
     RetainPtr<PDFDocument> m_pdfDocument;
     Vector<PageGeometry> m_pageGeometry;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -309,6 +309,13 @@ FloatSize PDFDocumentLayout::scaledContentsSize() const
     return m_documentBounds.size().scaled(m_scale);
 }
 
+auto PDFDocumentLayout::geometryForPage(RetainPtr<PDFPage> page) const -> std::optional<PageGeometry>
+{
+    if (auto pageIndex = indexForPage(page))
+        return m_pageGeometry[*pageIndex];
+    return { };
+}
+
 AffineTransform PDFDocumentLayout::toPageTransform(const PageGeometry& pageGeometry) const
 {
     AffineTransform matrix;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -748,8 +748,13 @@ void UnifiedPDFPlugin::paintPDFContent(GraphicsContext& context, const FloatRect
 
         // FIXME: Need to apply a rotation transform here for correct rendering in rotated pages.
 
-        if (haveSelection)
+        if (haveSelection) {
+            auto pageGeometry = m_documentLayout.geometryForPage(page);
+            auto transformForBox = m_documentLayout.toPageTransform(*pageGeometry).inverse().value_or(AffineTransform { });
+            GraphicsContextStateSaver stateSaver(context);
+            context.concatCTM(transformForBox);
             [m_currentSelection drawForPage:page.get() withBox:kCGPDFCropBox active:isVisibleAndActive inContext:context.platformContext()];
+        }
 
         if (currentPageHasAnnotation)
             paintHoveredAnnotationOnPage(pageInfo.pageIndex, context, clipRect);


### PR DESCRIPTION
#### 099c347a91fc9f6cc329b487dde7d154968dd188
<pre>
[UnifiedPDF] Selections are broken in rotated pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=270073">https://bugs.webkit.org/show_bug.cgi?id=270073</a>
<a href="https://rdar.apple.com/123621642">rdar://123621642</a>

Reviewed by Simon Fraser.

The `-[PDFPage drawWithBox:toContext:]` method accounts for page
rotation, and we took this behavior to assume that the PDFSelection
drawing API would behave similarly. Unfortunately, this is wrong, and
said method expects callers to apply the transform corresponding to
the appropriate boundary box type.

This patch amends this situation by manually applying the transform in
question to the context&apos;s CTM while we have a selection painted into
that context.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:

Expose `toPageTransform` and `geometryForPage` publicly.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::geometryForPage const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paintPDFContent):

Canonical link: <a href="https://commits.webkit.org/275351@main">https://commits.webkit.org/275351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69e524535d647f780bea1c444e203a1eb60c1dba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17947 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15055 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37164 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40917 "layout-tests (failure)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13481 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39328 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18037 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9321 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18093 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->