### PR TITLE
[TextureMapper] Add GLContextWrapper to handle the current GL context

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2090,6 +2090,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/cv/ImageTransferSessionVT.h
 
     platform/graphics/egl/GLContext.h
+    platform/graphics/egl/GLContextWrapper.h
 
     platform/graphics/filters/DistantLightSource.h
     platform/graphics/filters/FEBlend.h

--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -38,6 +38,7 @@ list(APPEND WebCore_SOURCES
 
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextLibWPE.cpp
+    platform/graphics/egl/GLContextWrapper.cpp
 
     platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
 

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -55,6 +55,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/angle/PlatformDisplayANGLE.cpp
 
     platform/graphics/egl/GLContext.cpp
+    platform/graphics/egl/GLContextWrapper.cpp
 
     platform/graphics/opentype/OpenTypeUtilities.cpp
 

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -60,6 +60,7 @@ platform/graphics/PlatformDisplay.cpp @no-unify
 platform/graphics/angle/PlatformDisplayANGLE.cpp @no-unify
 
 platform/graphics/egl/GLContext.cpp @no-unify
+platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -61,6 +61,7 @@ platform/graphics/wpe/SystemFontDatabaseWPE.cpp
 
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
+platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -22,7 +22,6 @@
 #if USE(EGL)
 #include "GraphicsContextGL.h"
 #include "Logging.h"
-#include <wtf/ThreadSpecific.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -37,16 +36,6 @@
 #endif
 
 namespace WebCore {
-
-static ThreadSpecific<GLContext*>& currentContext()
-{
-    static ThreadSpecific<GLContext*>* context;
-    static std::once_flag flag;
-    std::call_once(flag, [] {
-        context = new ThreadSpecific<GLContext*>();
-    });
-    return *context;
-}
 
 const char* GLContext::errorString(int statusCode)
 {
@@ -409,9 +398,6 @@ GLContext::~GLContext()
 #if USE(WPE_RENDERER)
     destroyWPETarget();
 #endif
-
-    if (this == *currentContext())
-        *currentContext() = nullptr;
 }
 
 EGLContext GLContext::createContextForEGLVersion(PlatformDisplay& platformDisplay, EGLConfig config, EGLContext sharingContext)
@@ -430,31 +416,33 @@ EGLContext GLContext::createContextForEGLVersion(PlatformDisplay& platformDispla
     return eglCreateContext(platformDisplay.eglDisplay(), config, sharingContext, contextAttributes);
 }
 
-bool GLContext::makeContextCurrent()
+bool GLContext::makeCurrentImpl()
 {
     ASSERT(m_context);
-
-    *currentContext() = this;
-    if (eglGetCurrentContext() == m_context)
-        return true;
-
     return eglMakeCurrent(m_display.eglDisplay(), m_surface, m_surface, m_context);
+}
+
+bool GLContext::unmakeCurrentImpl()
+{
+    return eglMakeCurrent(m_display.eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+}
+
+bool GLContext::makeContextCurrent()
+{
+    return makeCurrent();
 }
 
 bool GLContext::unmakeContextCurrent()
 {
-    if (this != *currentContext())
-        return false;
-
-    eglMakeCurrent(m_display.eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-    *currentContext() = nullptr;
-
-    return true;
+    return unmakeCurrent();
 }
 
 GLContext* GLContext::current()
 {
-    return *currentContext();
+    auto* context = currentContext();
+    if (context && context->type() == GLContextWrapper::Type::Native)
+        return static_cast<GLContext*>(context);
+    return nullptr;
 }
 
 void GLContext::swapBuffers()
@@ -527,11 +515,15 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
 GLContext::ScopedGLContext::ScopedGLContext(std::unique_ptr<GLContext>&& context)
     : m_context(WTFMove(context))
 {
-    m_previous.context = eglGetCurrentContext();
-    if (m_previous.context) {
-        m_previous.display = eglGetCurrentDisplay();
-        m_previous.readSurface = eglGetCurrentSurface(EGL_READ);
-        m_previous.drawSurface = eglGetCurrentSurface(EGL_DRAW);
+    auto eglContext = eglGetCurrentContext();
+    m_previous.glContext = GLContext::current();
+    if (!m_previous.glContext || m_previous.glContext->platformContext() != eglContext) {
+        m_previous.context = eglContext;
+        if (m_previous.context != EGL_NO_CONTEXT) {
+            m_previous.display = eglGetCurrentDisplay();
+            m_previous.readSurface = eglGetCurrentSurface(EGL_READ);
+            m_previous.drawSurface = eglGetCurrentSurface(EGL_DRAW);
+        }
     }
     m_context->makeContextCurrent();
 }
@@ -539,20 +531,25 @@ GLContext::ScopedGLContext::ScopedGLContext(std::unique_ptr<GLContext>&& context
 GLContext::ScopedGLContext::~ScopedGLContext()
 {
     m_context = nullptr;
-    if (m_previous.context)
+
+    if (m_previous.context != EGL_NO_CONTEXT)
         eglMakeCurrent(m_previous.display, m_previous.drawSurface, m_previous.readSurface, m_previous.context);
+    else if (m_previous.glContext)
+        m_previous.glContext->makeContextCurrent();
 }
 
 GLContext::ScopedGLContextCurrent::ScopedGLContextCurrent(GLContext& context)
     : m_context(context)
 {
     auto eglContext = eglGetCurrentContext();
-    m_previous.glContext = *currentContext();
+    m_previous.glContext = GLContext::current();
     if (!m_previous.glContext || m_previous.glContext->platformContext() != eglContext) {
         m_previous.context = eglContext;
-        m_previous.display = eglGetCurrentDisplay();
-        m_previous.readSurface = eglGetCurrentSurface(EGL_READ);
-        m_previous.drawSurface = eglGetCurrentSurface(EGL_DRAW);
+        if (m_previous.context != EGL_NO_CONTEXT) {
+            m_previous.display = eglGetCurrentDisplay();
+            m_previous.readSurface = eglGetCurrentSurface(EGL_READ);
+            m_previous.drawSurface = eglGetCurrentSurface(EGL_DRAW);
+        }
     }
     m_context.makeContextCurrent();
 }
@@ -564,12 +561,10 @@ GLContext::ScopedGLContextCurrent::~ScopedGLContextCurrent()
         return;
     }
 
+    m_context.unmakeContextCurrent();
+
     if (m_previous.context)
         eglMakeCurrent(m_previous.display, m_previous.drawSurface, m_previous.readSurface, m_previous.context);
-    else
-        m_context.unmakeContextCurrent();
-
-    *currentContext() = m_previous.glContext;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #if USE(EGL)
+#include "GLContextWrapper.h"
 #include "IntSize.h"
 #include "PlatformDisplay.h"
 #include <wtf/Noncopyable.h>
@@ -43,7 +44,7 @@ typedef void* EGLSurface;
 
 namespace WebCore {
 
-class GLContext {
+class GLContext final : public GLContextWrapper {
     WTF_MAKE_NONCOPYABLE(GLContext); WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT static std::unique_ptr<GLContext> create(GLNativeWindowType, PlatformDisplay&);
@@ -85,6 +86,7 @@ public:
         ~ScopedGLContext();
     private:
         struct {
+            GLContext* glContext { nullptr };
             EGLDisplay display { nullptr };
             EGLContext context { nullptr };
             EGLSurface readSurface { nullptr };
@@ -122,6 +124,11 @@ private:
 #endif
 
     static bool getEGLConfig(PlatformDisplay&, EGLConfig*, EGLSurfaceType);
+
+    // GLContextWrapper
+    GLContextWrapper::Type type() const override { return GLContextWrapper::Type::Native; }
+    bool makeCurrentImpl() override;
+    bool unmakeCurrentImpl() override;
 
     PlatformDisplay& m_display;
     unsigned m_version { 0 };

--- a/Source/WebCore/platform/graphics/egl/GLContextWrapper.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextWrapper.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+#include "GLContextWrapper.h"
+
+#if USE(EGL)
+namespace WebCore {
+
+static thread_local constinit GLContextWrapper* s_currentContext = nullptr;
+
+GLContextWrapper::~GLContextWrapper()
+{
+    if (s_currentContext == this)
+        s_currentContext = nullptr;
+}
+
+GLContextWrapper* GLContextWrapper::currentContext()
+{
+    return s_currentContext;
+}
+
+bool GLContextWrapper::makeCurrent()
+{
+    if (s_currentContext == this)
+        return true;
+
+    if (makeCurrentImpl()) {
+        s_currentContext = this;
+        return true;
+    }
+
+    return false;
+}
+
+bool GLContextWrapper::unmakeCurrent()
+{
+    if (s_currentContext != this)
+        return false;
+
+    if (unmakeCurrentImpl()) {
+        s_currentContext = nullptr;
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace WebCore
+
+#endif // USE(EGL)

--- a/Source/WebCore/platform/graphics/egl/GLContextWrapper.h
+++ b/Source/WebCore/platform/graphics/egl/GLContextWrapper.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#if USE(EGL)
+
+namespace WebCore {
+
+class GLContextWrapper {
+public:
+    GLContextWrapper() = default;
+    ~GLContextWrapper();
+
+    enum class Type : uint8_t { Native, Angle };
+    virtual Type type() const = 0;
+
+    bool makeCurrent();
+    bool unmakeCurrent();
+
+protected:
+    virtual bool makeCurrentImpl() = 0;
+    virtual bool unmakeCurrentImpl() = 0;
+
+    static GLContextWrapper* currentContext();
+};
+
+} // namespace WebCore
+
+#endif // USE(EGL)

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -95,7 +95,7 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
 
 bool GraphicsContextGLANGLE::makeContextCurrent()
 {
-    return !!EGL_MakeCurrent(m_displayObj, m_surfaceObj, m_surfaceObj, m_contextObj);
+    return static_cast<GraphicsContextGLTextureMapperANGLE*>(this)->makeCurrent();
 }
 
 void GraphicsContextGLANGLE::checkGPUStatus()
@@ -351,6 +351,21 @@ void GraphicsContextGLTextureMapperANGLE::prepareForDisplay()
 
     prepareTexture();
     swapCompositorTexture();
+}
+
+GLContextWrapper::Type GraphicsContextGLTextureMapperANGLE::type() const
+{
+    return GLContextWrapper::Type::Angle;
+}
+
+bool GraphicsContextGLTextureMapperANGLE::makeCurrentImpl()
+{
+    return !!EGL_MakeCurrent(m_displayObj, m_surfaceObj, m_surfaceObj, m_contextObj);
+}
+
+bool GraphicsContextGLTextureMapperANGLE::unmakeCurrentImpl()
+{
+    return !!EGL_MakeCurrent(m_displayObj, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBGL) && USE(TEXTURE_MAPPER)
 
+#include "GLContextWrapper.h"
 #include "GraphicsContextGLANGLE.h"
 
 #if USE(NICOSIA)
@@ -39,7 +40,7 @@ namespace WebCore {
 
 class TextureMapperGCGLPlatformLayer;
 
-class WEBCORE_EXPORT GraphicsContextGLTextureMapperANGLE : public GraphicsContextGLANGLE {
+class WEBCORE_EXPORT GraphicsContextGLTextureMapperANGLE : public GraphicsContextGLANGLE, public GLContextWrapper {
 public:
     static RefPtr<GraphicsContextGLTextureMapperANGLE> create(WebCore::GraphicsContextGLAttributes&&);
     virtual ~GraphicsContextGLTextureMapperANGLE();
@@ -69,6 +70,11 @@ private:
 #if USE(NICOSIA)
     GCGLuint setupCurrentTexture();
 #endif
+
+    // GLContextWrapper
+    GLContextWrapper::Type type() const override;
+    bool makeCurrentImpl() override;
+    bool unmakeCurrentImpl() override;
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
 


### PR DESCRIPTION
#### 6c2fa470f6ddc03d0787d03668cf1d7bfff85d69
<pre>
[TextureMapper] Add GLContextWrapper to handle the current GL context
<a href="https://bugs.webkit.org/show_bug.cgi?id=270078">https://bugs.webkit.org/show_bug.cgi?id=270078</a>

Reviewed by Miguel Gomez.

We currently have GLContext handling the current context, but it doesn&apos;t
always work. For example, if there&apos;s WebGL content, after ANGLE context
is made current. This is not problematic with Cairo because only ANGLE
is making it context current in the main thread, but with Skia there&apos;s
another GL context that is made current in the main thread when using
the GPU renderer.
GLContextWrapper is a new class to handle the current GL context,
implemented by GLContext and GraphicsContextGLTextureMapperANGLE.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::~GLContext):
(WebCore::GLContext::makeCurrentImpl):
(WebCore::GLContext::unmakeCurrentImpl):
(WebCore::GLContext::makeContextCurrent):
(WebCore::GLContext::unmakeContextCurrent):
(WebCore::GLContext::current):
(WebCore::GLContext::ScopedGLContext::ScopedGLContext):
(WebCore::GLContext::ScopedGLContext::~ScopedGLContext):
(WebCore::GLContext::ScopedGLContextCurrent::ScopedGLContextCurrent):
(WebCore::GLContext::ScopedGLContextCurrent::~ScopedGLContextCurrent):
(): Deleted.
* Source/WebCore/platform/graphics/egl/GLContext.h:
(WebCore::GLContext::display const): Deleted.
(WebCore::GLContext::config const): Deleted.
* Source/WebCore/platform/graphics/egl/GLContextWrapper.cpp: Added.
(WebCore::GLContextWrapper::~GLContextWrapper):
(WebCore::GLContextWrapper::currentContext):
(WebCore::GLContextWrapper::makeCurrent):
(WebCore::GLContextWrapper::unmakeCurrent):
* Source/WebCore/platform/graphics/egl/GLContextWrapper.h: Added.
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::makeContextCurrent):
(WebCore::GraphicsContextGLTextureMapperANGLE::makeCurrentImpl):
(WebCore::GraphicsContextGLTextureMapperANGLE::unmakeCurrentImpl):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:

Canonical link: https://commits.webkit.org/275316@main
</pre>