### PR TITLE
Address minor nit in CSSSelectorParser::consumePseudo()

### DIFF
--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -750,10 +750,9 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumePseudo(CSSParserTo
         return selector;
     }
 
+    ASSERT(token.type() == FunctionToken);
     CSSParserTokenRange block = range.consumeBlock();
     block.consumeWhitespace();
-    if (token.type() != FunctionToken)
-        return nullptr;
 
     if (selector->match() == CSSSelector::Match::PseudoClass) {
         switch (selector->pseudoClass()) {


### PR DESCRIPTION
#### b59882be39166bf8b4def711497dd0025bc74f47
<pre>
Address minor nit in CSSSelectorParser::consumePseudo()
<a href="https://bugs.webkit.org/show_bug.cgi?id=270081">https://bugs.webkit.org/show_bug.cgi?id=270081</a>

Reviewed by Antti Koivisto.

As it&apos;s already been verified that token is either an IdentToken or
FunctionToken, and IdentToken has been dealt with at this point, it can
only be a FunctionToken.

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumePseudo):

Canonical link: <a href="https://commits.webkit.org/275323@main">https://commits.webkit.org/275323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d155e5614568b4291592ff0fc8b94d5cc5ce81a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44089 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37613 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17865 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34334 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14995 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40854 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39262 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17955 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9306 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->