### PR TITLE
[Skia] Stop using ScopedGLContextCurrent to make the Skia GL context current

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -86,9 +86,10 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
 
     if (image->isTextureBacked()) {
         auto data = SkData::MakeUninitialized(imageInfo.computeMinByteSize());
+        if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+            return false;
+
         GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
-        auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-        GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
         if (!image->readPixels(grContext, imageInfo, static_cast<uint8_t*>(data->writable_data()), bytesPerRow, 0, 0))
             return false;
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -49,7 +49,9 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
         return nullptr;
 
     auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+    if (!glContext || !glContext->makeContextCurrent())
+        return nullptr;
+
     auto* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
     RELEASE_ASSERT(grContext);
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
@@ -77,8 +79,9 @@ RefPtr<NativeImage> ImageBufferSkiaAcceleratedBackend::createNativeImageReferenc
 
 void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)
 {
-    auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+    if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+        return;
+
     auto info = m_surface->imageInfo();
     auto data = SkData::MakeUninitialized(info.computeMinByteSize());
     auto* pixels = static_cast<uint8_t*>(data->writable_data());
@@ -89,8 +92,9 @@ void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, P
 
 void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
-    auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+    if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+        return;
+
     auto info = m_surface->imageInfo();
     auto data = SkData::MakeUninitialized(info.computeMinByteSize());
     auto* pixels = static_cast<uint8_t*>(data->writable_data());

--- a/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
@@ -66,9 +66,10 @@ private:
 
 static sk_sp<SkData> encodeAcceleratedImage(SkImage* image, const String& mimeType, std::optional<double> quality)
 {
+    if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+        return nullptr;
+
     GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
-    auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
 
     if (MIMETypeRegistry::isJPEGMIMEType(mimeType)) {
         SkJpegEncoder::Options options;

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -71,9 +71,10 @@ Color NativeImage::singlePixelSolidColor() const
 
     auto platformImage = this->platformImage();
     if (platformImage->isTextureBacked()) {
+        if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+            return Color();
+
         GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
-        auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-        GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
         const auto& imageInfo = platformImage->imageInfo();
         uint32_t pixel;
         SkPixmap pixmap(imageInfo, &pixel, imageInfo.minRowBytes());

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -73,9 +73,10 @@ GLContext* PlatformDisplay::skiaGLContext()
         return m_skiaGLContext.get();
 
     m_skiaGLContext = GLContext::createOffscreen(*this);
-    GLContext::ScopedGLContextCurrent scopedCurrent(*m_skiaGLContext);
-    // FIXME: add GrContextOptions, shader cache, etc.
-    m_skiaGrContext = GrDirectContexts::MakeGL(skiaGLInterface());
+    if (m_skiaGLContext && m_skiaGLContext->makeContextCurrent()) {
+        // FIXME: add GrContextOptions, shader cache, etc.
+        m_skiaGrContext = GrDirectContexts::MakeGL(skiaGLInterface());
+    }
     return m_skiaGLContext.get();
 }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
@@ -42,8 +42,9 @@ SkiaAcceleratedBufferPool::~SkiaAcceleratedBufferPool()
     if (m_buffers.isEmpty())
         return;
 
-    auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-    GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+    if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+        return;
+
     m_buffers.clear();
 }
 
@@ -89,9 +90,7 @@ void SkiaAcceleratedBufferPool::releaseUnusedBuffersTimerFired()
     static const Seconds releaseUnusedSecondsTolerance { 3_s };
     MonotonicTime minUsedTime = MonotonicTime::now() - releaseUnusedSecondsTolerance;
 
-    {
-        auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-        GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
+    if (PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent()) {
         m_buffers.removeAllMatching([&minUsedTime](const Entry& entry) {
             return entry.canBeReleased(minUsedTime);
         });

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
@@ -70,10 +70,7 @@ Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& tileRect
 
     // Skia/GPU - accelerated rendering.
     if (auto* acceleratedBufferPool = m_coordinator->skiaAcceleratedBufferPool()) {
-        auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
-        RELEASE_ASSERT(glContext);
-        GLContext::ScopedGLContextCurrent scopedCurrent(*glContext);
-
+        PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent();
         auto buffer = acceleratedBufferPool->acquireBuffer(tileRect.size(), !contentsOpaque());
         paintBuffer(buffer.get());
         return buffer;


### PR DESCRIPTION
#### 1a34924425e4d87f83bd33db586ee4f7a9a56a95
<pre>
[Skia] Stop using ScopedGLContextCurrent to make the Skia GL context current
<a href="https://bugs.webkit.org/show_bug.cgi?id=270082">https://bugs.webkit.org/show_bug.cgi?id=270082</a>

Reviewed by Miguel Gomez.

In most of the cases we are setting anf unsetting the same context all
the time. If there&apos;s WebGL content, ANGLE graphics context will make the
ANGLE context current on every operation that requires it.

* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp:
(WebCore::encodeAcceleratedImage):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::singlePixelSolidColor const):
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::PlatformDisplay::skiaGLContext):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp:
(WebCore::SkiaAcceleratedBufferPool::~SkiaAcceleratedBufferPool):
(WebCore::SkiaAcceleratedBufferPool::releaseUnusedBuffersTimerFired):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):

Canonical link: <a href="https://commits.webkit.org/275379@main">https://commits.webkit.org/275379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ada0d9eda6a053e05b65397bc0659d2fd8cca453

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18053 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42282 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45668 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13561 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18142 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5574 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->