### PR TITLE
Adopt more smart pointer in CounterNode.h

### DIFF
--- a/Source/WebCore/rendering/CounterNode.h
+++ b/Source/WebCore/rendering/CounterNode.h
@@ -52,7 +52,7 @@ public:
     bool hasSetType() const { return m_type.contains(Type::Set); }
     int value() const { return m_value; }
     int countInParent() const { return m_countInParent; }
-    RenderElement& owner() const { return m_owner; }
+    RenderElement& owner() const;
     void addRenderer(RenderCounter&);
     void removeRenderer(RenderCounter&);
 
@@ -84,8 +84,8 @@ private:
     OptionSet<Type> m_type { };
     int m_value;
     int m_countInParent { 0 };
-    RenderElement& m_owner;
-    RenderCounter* m_rootRenderer { nullptr };
+    SingleThreadWeakRef<RenderElement> m_owner;
+    SingleThreadWeakPtr<RenderCounter> m_rootRenderer;
 
     SingleThreadWeakPtr<CounterNode> m_parent;
     SingleThreadWeakPtr<CounterNode> m_previousSibling;

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -54,7 +54,7 @@ private:
 
     CounterContent m_counter;
     SingleThreadWeakPtr<CounterNode> m_counterNode;
-    RenderCounter* m_nextForSameCounter { nullptr };
+    SingleThreadWeakPtr<RenderCounter> m_nextForSameCounter;
     friend class CounterNode;
 };
 


### PR DESCRIPTION
#### f55ebb2fd94051e1843712755fdcb5867fd5415e
<pre>
Adopt more smart pointer in CounterNode.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=270085">https://bugs.webkit.org/show_bug.cgi?id=270085</a>

Reviewed by Ryosuke Niwa.

Adopt more smart pointer in CounterNode.h. This tested as performance
neutral on Speedometer 2 &amp; 3.

* Source/WebCore/rendering/CounterNode.cpp:
(WebCore::CounterNode::owner const):
(WebCore::CounterNode::addRenderer):
(WebCore::CounterNode::removeRenderer):
(WebCore::CounterNode::resetRenderers):
* Source/WebCore/rendering/CounterNode.h:
(WebCore::CounterNode::owner const): Deleted.
* Source/WebCore/rendering/RenderCounter.h:

Canonical link: <a href="https://commits.webkit.org/275338@main">https://commits.webkit.org/275338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a141fb950f0bc470eff93f7cb820b4b23696c231

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34341 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15002 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45467 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40860 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39268 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17963 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18019 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5558 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->