### PR TITLE
Refactor MediaSessionManagerCocoa::nowPlayingEligibleSession to allow non HTMLMediaElement eligible sessions

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -434,6 +434,24 @@ void MediaSession::willPausePlayback()
     notifyPositionStateObservers();
 }
 
+void MediaSession::updateNowPlayingInfo(NowPlayingInfo& info)
+{
+    if (auto positionState = this->positionState()) {
+        info.duration = positionState->duration;
+        info.rate = positionState->playbackRate;
+    }
+    if (auto currentPosition = this->currentPosition())
+        info.currentTime = *currentPosition;
+
+    if (m_metadata && m_metadata->artworkImage()) {
+        ASSERT(m_metadata->artworkImage()->data(), "An image must always have associated data");
+        info.artwork = { { m_metadata->artworkSrc(), m_metadata->artworkImage()->mimeType(), m_metadata->artworkImage() } };
+        info.title = m_metadata->title();
+        info.artist = m_metadata->artist();
+        info.album = m_metadata->album();
+    }
+}
+
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 void MediaSession::notifyReadyStateObservers()
 {

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -49,6 +49,7 @@ class MediaSessionCoordinator;
 class MediaSessionCoordinatorPrivate;
 class Navigator;
 template<typename> class DOMPromiseDeferred;
+struct NowPlayingInfo;
 
 class MediaSession : public RefCounted<MediaSession>, public ActiveDOMObject, public CanMakeWeakPtr<MediaSession> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -119,6 +120,8 @@ public:
     void removeObserver(Observer&);
 
     RefPtr<HTMLMediaElement> activeMediaElement() const;
+
+    void updateNowPlayingInfo(NowPlayingInfo&);
 
 private:
     explicit MediaSession(Navigator&);

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -990,6 +990,9 @@ private:
     bool hasMediaStreamSource() const final;
     void processIsSuspendedChanged() final;
     bool shouldOverridePauseDuringRouteChange() const final;
+    bool isNowPlayingEligible() const final { return m_mediaSession->hasNowPlayingInfo(); }
+    std::optional<NowPlayingInfo> nowPlayingInfo() const final;
+    WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
 
     void pageMutedStateDidChange() override;
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1236,18 +1236,26 @@ void MediaElementSession::didReceiveRemoteControlCommand(RemoteControlCommandTyp
 }
 #endif
 
-std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
+bool MediaElementSession::hasNowPlayingInfo() const
 {
-    RefPtr page = m_element.document().page();
-
-#if ENABLE(MEDIA_SESSION)
-    auto* session = mediaSession();
-#endif
-
 #if ENABLE(MEDIA_SESSION) && ENABLE(MEDIA_STREAM)
+    if (!canShowControlsManager(MediaElementSession::PlaybackControlsPurpose::NowPlaying))
+        return false;
+
+    RefPtr session = mediaSession();
     if (isDocumentPlayingSeveralMediaStreamsAndCapturing(m_element.document()) && (!session || !session->hasActiveActionHandlers()))
-        return { };
+        return false;
 #endif
+
+    return true;
+}
+
+std::optional<NowPlayingInfo> MediaElementSession::computeNowPlayingInfo() const
+{
+    if (!hasNowPlayingInfo())
+        return { };
+
+    RefPtr page = m_element.document().page();
 
     bool allowsNowPlayingControlsVisibility = page && !page->isVisibleAndActive();
     bool isPlaying = state() == PlatformMediaSession::State::Playing;
@@ -1267,26 +1275,13 @@ std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
         sourceApplicationIdentifier = presentingApplicationBundleIdentifier();
 #endif
 
+    NowPlayingInfo info { m_element.mediaSessionTitle(), emptyString(), emptyString(), sourceApplicationIdentifier, duration, currentTime, rate, supportsSeeking, m_element.mediaUniqueIdentifier(), isPlaying, allowsNowPlayingControlsVisibility, { } };
 #if ENABLE(MEDIA_SESSION)
-    auto positionState = session ? session->positionState() : std::nullopt;
-    auto currentPosition = session ? session->currentPosition() : std::nullopt;
-    if (positionState) {
-        duration = positionState->duration;
-        rate = positionState->playbackRate;
-    }
-    if (currentPosition)
-        currentTime = *currentPosition;
-    if (RefPtr sessionMetadata = session ? session->metadata() : nullptr) {
-        std::optional<NowPlayingInfoArtwork> artwork;
-        if (sessionMetadata->artworkImage()) {
-            ASSERT(sessionMetadata->artworkImage()->data(), "An image must always have associated data");
-            artwork = NowPlayingInfoArtwork { sessionMetadata->artworkSrc(), sessionMetadata->artworkImage()->mimeType(), sessionMetadata->artworkImage() };
-        }
-        return NowPlayingInfo { sessionMetadata->title(), sessionMetadata->artist(), sessionMetadata->album(), sourceApplicationIdentifier, duration, currentTime, rate, supportsSeeking, m_element.mediaUniqueIdentifier(), isPlaying, allowsNowPlayingControlsVisibility, WTFMove(artwork) };
-    }
+    if (RefPtr session = mediaSession())
+        session->updateNowPlayingInfo(info);
 #endif
 
-    return NowPlayingInfo { m_element.mediaSessionTitle(), emptyString(), emptyString(), sourceApplicationIdentifier, duration, currentTime, rate, supportsSeeking, m_element.mediaUniqueIdentifier(), isPlaying, allowsNowPlayingControlsVisibility, { } };
+    return info;
 }
 
 void MediaElementSession::updateMediaUsageIfChanged()

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -145,7 +145,6 @@ public:
     bool wantsToObserveViewportVisibilityForMediaControls() const;
     bool wantsToObserveViewportVisibilityForAutoplay() const;
 
-    enum class PlaybackControlsPurpose { ControlsManager, NowPlaying, MediaSession };
     bool canShowControlsManager(PlaybackControlsPurpose) const;
     bool isLargeEnoughForMainContent(MediaSessionMainContentPurpose) const;
     bool isLongEnoughForMainContent() const final;
@@ -161,7 +160,7 @@ public:
             || type == MediaType::VideoAudio;
     }
 
-    std::optional<NowPlayingInfo> nowPlayingInfo() const final;
+    std::optional<NowPlayingInfo> computeNowPlayingInfo() const;
 
     WEBCORE_EXPORT void updateMediaUsageIfChanged() final;
     std::optional<MediaUsageInfo> mediaUsageInfo() const { return m_mediaUsageInfo; }
@@ -180,6 +179,8 @@ public:
     void actionHandlersChanged();
 
     MediaSession* mediaSession() const;
+
+    bool hasNowPlayingInfo() const;
 
 private:
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -439,7 +439,17 @@ bool PlatformMediaSession::shouldOverridePauseDuringRouteChange() const
 
 std::optional<NowPlayingInfo> PlatformMediaSession::nowPlayingInfo() const
 {
-    return { };
+    return client().nowPlayingInfo();
+}
+
+bool PlatformMediaSession::isNowPlayingEligible() const
+{
+    return client().isNowPlayingEligible();
+};
+
+WeakPtr<PlatformMediaSession> PlatformMediaSession::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>& sessions, PlaybackControlsPurpose purpose)
+{
+    return client().selectBestMediaSession(sessions, purpose);
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -452,6 +462,11 @@ WTFLogChannel& PlatformMediaSession::logChannel() const
 MediaTime PlatformMediaSessionClient::mediaSessionDuration() const
 {
     return MediaTime::invalidTime();
+}
+
+std::optional<NowPlayingInfo> PlatformMediaSessionClient::nowPlayingInfo() const
+{
+    return { };
 }
 
 }

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -126,6 +126,7 @@ public:
     void setActive(bool);
 
     using MediaType = WebCore::PlatformMediaSessionMediaType;
+    enum class PlaybackControlsPurpose { ControlsManager, NowPlaying, MediaSession };
 
     MediaType mediaType() const;
     MediaType presentationType() const;
@@ -229,7 +230,10 @@ public:
         virtual bool wantsToCaptureAudio() const = 0;
     };
 
-    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const;
+    std::optional<NowPlayingInfo> nowPlayingInfo() const;
+    bool isNowPlayingEligible() const;
+    WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlaybackControlsPurpose);
+
     virtual void updateMediaUsageIfChanged() { }
 
     virtual bool isLongEnoughForMainContent() const { return false; }
@@ -306,6 +310,10 @@ public:
     virtual void processIsSuspendedChanged() { }
 
     virtual bool shouldOverridePauseDuringRouteChange() const { return false; }
+
+    virtual bool isNowPlayingEligible() const { return false; }
+    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const;
+    virtual WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) { return nullptr; }
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -189,6 +189,8 @@ public:
 
     bool isApplicationInBackground() const { return m_isApplicationInBackground; }
 
+    WeakPtr<PlatformMediaSession> bestEligibleSessionForRemoteControls(const Function<bool(const PlatformMediaSession&)>&, PlatformMediaSession::PlaybackControlsPurpose);
+
 protected:
     friend class PlatformMediaSession;
     static std::unique_ptr<PlatformMediaSessionManager> create();

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -97,7 +97,7 @@ protected:
 
     virtual void providePresentingApplicationPIDIfNecessary() { }
 
-    PlatformMediaSession* nowPlayingEligibleSession();
+    WeakPtr<PlatformMediaSession> nowPlayingEligibleSession();
 
     void addSupportedCommand(PlatformMediaSession::RemoteControlCommandType) final;
     void removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType) final;


### PR DESCRIPTION
#### 04e0a64601921fa8f768610f715769c44d3ad712
<pre>
Refactor MediaSessionManagerCocoa::nowPlayingEligibleSession to allow non HTMLMediaElement eligible sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=270090">https://bugs.webkit.org/show_bug.cgi?id=270090</a>
<a href="https://rdar.apple.com/123632916">rdar://123632916</a>

Reviewed by Jean-Yves Avenard.

We want to allow AudioContext to be used as media playback with AudioSession API.
For that, it needs to be on par with HTMLMediaElement, and for instance trigger NowPlayingInfo updates.
This patch is refactoring code to untie a bit HTMLMediaElement and NowPlayingInfo computation.
It should not have any impact on behavior since this patch is not adding code to actually allow
AudioContext to be handled like HTMLMediaElement (for instance pay/pause from the control center).

We introduce MediaSession::updateNowPlayingInfo and NavigatorMediaSession::mediaSessionIfExists to
allow updating NowPlayingInfo according MediaSession from either HTMLMediaElement or other media producers.

We introduce getters for nowPlayingInfo and isNowPlayingEligible on PlatformMediaSession which are being forwarded to each client.
We update HTMLMediaElement/MediaElementSession implementation accordingly.

We introduce PlatformMediaSessionManager::bestEligibleSessionForRemoteControls to filter sessions according presentation types.
We then get two lists of media sessions, one of web audio and one of media (HTMLMediaElement basically).
If the HTMLMediaElement list is empty, we look at WebAudio sessions, otherwise we look at HTMLMediaElement sessions.

We introduce selectBestMediaSession so that sorting is done by each session subtype.

This allows to fix the layering violation from MediaSessionManagerCocoa::nowPlayingEligibleSession.:

* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::updateNowPlayingInfo):
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::bestMediaElementForRemoteControls):
(WebCore::HTMLMediaElement::nowPlayingInfo const):
(WebCore::HTMLMediaElement::selectBestMediaSession):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::hasNowPlayingInfo const):
(WebCore::MediaElementSession::computeNowPlayingInfo const):
(WebCore::MediaElementSession::nowPlayingInfo const): Deleted.
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::nowPlayingInfo const):
(WebCore::PlatformMediaSession::isNowPlayingEligible const):
(WebCore::PlatformMediaSession::selectBestMediaSession):
(WebCore::PlatformMediaSessionClient::nowPlayingInfo const):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WebCore::PlatformMediaSessionClient::isNowPlayingEligible const):
(WebCore::PlatformMediaSessionClient::selectBestMediaSession):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::bestEligibleSessionForRemoteControls):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::nowPlayingEligibleSession):
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo):

Canonical link: <a href="https://commits.webkit.org/275460@main">https://commits.webkit.org/275460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec873e85bb314c2cce70574a27c94d84041aefab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44259 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37780 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34449 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40993 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39418 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18121 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9390 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->