### PR TITLE
[WGSL] shader,validation,expression,unary,address_of_and_indirection:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -52,10 +52,6 @@ operator :'&', {
     must_use: true,
     const: 'constantBitwiseAnd',
 
-    # unary
-    # FIXME: move this out of here
-    [AS, T, AM].(ref[AS, T, AM]) => ptr[AS, T, AM],
-
     # binary
     [].(bool, bool) => bool,
     [N].(vec[N][bool], vec[N][bool]) => vec[N][bool],
@@ -97,10 +93,6 @@ operator :+, {
 operator :*, {
     must_use: true,
     const: "constantMultiply",
-
-    # unary
-    # FIXME: move this out of here
-    [AS, T, AM].(ptr[AS, T, AM]) => ref[AS, T, AM],
 
     # binary
     [T < Number].(T, T) => T,

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -87,8 +87,9 @@ struct ReferenceKey {
     const Type* elementType;
     AddressSpace addressSpace;
     AccessMode accessMode;
+    bool isVectorComponent;
 
-    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Reference, WTF::enumToUnderlyingType(addressSpace), WTF::enumToUnderlyingType(accessMode), 0, bitwise_cast<uintptr_t>(elementType)); }
+    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Reference, WTF::enumToUnderlyingType(addressSpace), WTF::enumToUnderlyingType(accessMode), isVectorComponent, bitwise_cast<uintptr_t>(elementType)); }
 };
 
 struct PointerKey {
@@ -217,13 +218,13 @@ const Type* TypeStore::functionType(WTF::Vector<const Type*>&& parameters, const
     return allocateType<Function>(WTFMove(parameters), result, mustUse);
 }
 
-const Type* TypeStore::referenceType(AddressSpace addressSpace, const Type* element, AccessMode accessMode)
+const Type* TypeStore::referenceType(AddressSpace addressSpace, const Type* element, AccessMode accessMode, bool isVectorComponent)
 {
-    ReferenceKey key { element, addressSpace, accessMode };
+    ReferenceKey key { element, addressSpace, accessMode, isVectorComponent };
     const Type* type = m_cache.find(key);
     if (type)
         return type;
-    type = allocateType<Reference>(addressSpace, accessMode, element);
+    type = allocateType<Reference>(addressSpace, accessMode, element, isVectorComponent);
     m_cache.insert(key, type);
     return type;
 }

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -99,7 +99,7 @@ public:
     const Type* textureType(Types::Texture::Kind, const Type*);
     const Type* textureStorageType(Types::TextureStorage::Kind, TexelFormat, AccessMode);
     const Type* functionType(Vector<const Type*>&&, const Type*, bool mustUse);
-    const Type* referenceType(AddressSpace, const Type*, AccessMode);
+    const Type* referenceType(AddressSpace, const Type*, AccessMode, bool isVectorComponent = false);
     const Type* pointerType(AddressSpace, const Type*, AccessMode);
     const Type* atomicType(const Type*);
     const Type* typeConstructorType(ASCIILiteral, std::function<const Type*(AST::ElaboratedTypeExpression&)>&&);

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -220,6 +220,7 @@ struct Reference {
     AddressSpace addressSpace;
     AccessMode accessMode;
     const Type* element;
+    bool isVectorComponent;
 };
 
 struct Pointer {


### PR DESCRIPTION
#### 8529f0139b931464e17a5441db507b544d6a9926
<pre>
[WGSL] shader,validation,expression,unary,address_of_and_indirection:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=270095">https://bugs.webkit.org/show_bug.cgi?id=270095</a>
<a href="https://rdar.apple.com/123636841">rdar://123636841</a>

Reviewed by Mike Wyrzykowski.

Move the logic for address of and indirection from a type declaration into the
type checker in order to separate it from the arithmetic operators, and implement
the additional validation:
- don&apos;t allow taking the address of a vector component
- don&apos;t allow taking the address of textures and samplers

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::ReferenceKey::encode const):
(WGSL::TypeStore::referenceType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/275373@main">https://commits.webkit.org/275373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1566e8fa5350287de9bd455f70f494a991e6e425

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37640 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34358 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15018 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15208 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45488 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39285 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17982 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9337 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->