### PR TITLE
Add UIViewController to _WKWebExtensionAction.

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -414,6 +414,7 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 @class FBSDisplayConfiguration;
 @interface UIScreen ()
 @property (nonatomic, readonly, retain) FBSDisplayConfiguration *displayConfiguration;
+@property (nonatomic, readonly) CGRect _referenceBounds;
 @end
 
 @interface UIScrollView ()
@@ -544,6 +545,13 @@ typedef enum {
 - (pid_t)_hostProcessIdentifier;
 @property (readonly) NSString *_hostApplicationBundleIdentifier;
 @end
+
+@interface UIViewController (Private)
+- (/* nullable */ UIPresentationController *)_existingPresentationControllerImmediate:(BOOL)immediate effective:(BOOL)effective;
+@end
+
+extern NSString * const UIPresentationControllerDismissalTransitionDidEndNotification;
+extern NSString * const UIPresentationControllerDismissalTransitionDidEndCompletedKey;
 
 @interface _UIViewControllerTransitionContext : NSObject <UIViewControllerContextTransitioning>
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
@@ -34,6 +34,7 @@
 #if TARGET_OS_IPHONE
 @class UIImage;
 @class UIMenuElement;
+@class UIViewController;
 #else
 @class NSImage;
 @class NSMenuItem;
@@ -126,11 +127,23 @@ NS_SWIFT_NAME(_WKWebExtension.Action)
  */
 @property (nonatomic, readonly) BOOL presentsPopup;
 
+#if TARGET_OS_IPHONE
+/*!
+ @abstract A view controller that presents a web view loaded with the popup page for this action, or `nil` if no popup is specified.
+ @discussion The view controller adaptively adjusts its presentation style based on where it is presented from, preferring popover.
+ It contains a web view preloaded with the popup page and automatically adjusts tis `preferredContentSize` to fit the web view's
+ content size. The `presentsPopup` property should be checked to determine the availability of a popup before accessing this property.
+ Dismissing the view controller will close the web view.
+ @seealso presentsPopup
+ */
+@property (nonatomic, readonly, nullable) UIViewController *popupViewController;
+#endif
+
 /*!
  @abstract A web view loaded with the popup page for this action, or `nil` if no popup is specified.
- @discussion The web view will be preloaded with the popup page upon first access or after it has been closed. Use the `hasPopup`
+ @discussion The web view will be preloaded with the popup page upon first access or after it has been closed. Use the `presentsPopup`
  property to determine whether a popup should be displayed before accessing this property.
- @seealso hasPopup
+ @seealso presentsPopup
  */
 @property (nonatomic, readonly, nullable) WKWebView *popupWebView;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
@@ -119,6 +119,13 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionAction, WebExtensionAction,
     return _webExtensionAction->presentsPopup();
 }
 
+#if PLATFORM(IOS_FAMILY)
+- (UIViewController *)popupViewController
+{
+    return _webExtensionAction->popupViewController();
+}
+#endif
+
 - (WKWebView *)popupWebView
 {
     return _webExtensionAction->popupWebView();
@@ -191,6 +198,13 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionAction, WebExtensionAction,
 {
     return NO;
 }
+
+#if PLATFORM(IOS_FAMILY)
+- (UIViewController *)popupViewController
+{
+    return nil;
+}
+#endif
 
 - (WKWebView *)popupWebView
 {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -40,6 +40,11 @@ OBJC_CLASS _WKWebExtensionAction;
 OBJC_CLASS _WKWebExtensionActionWebView;
 OBJC_CLASS _WKWebExtensionActionWebViewDelegate;
 
+#if PLATFORM(IOS_FAMILY)
+OBJC_CLASS UIViewController;
+OBJC_CLASS _WKWebExtensionActionViewController;
+#endif
+
 namespace WebKit {
 
 class WebExtensionContext;
@@ -97,6 +102,10 @@ public:
     String popupPath() const;
     void setPopupPath(String);
 
+#if PLATFORM(IOS_FAMILY)
+    UIViewController *popupViewController();
+#endif
+
     WKWebView *popupWebView(LoadOnFirstAccess = LoadOnFirstAccess::Yes);
     void presentPopupWhenReady();
     void readyToPresentPopup();
@@ -116,6 +125,10 @@ private:
     WeakPtr<WebExtensionContext> m_extensionContext;
     RefPtr<WebExtensionTab> m_tab;
     RefPtr<WebExtensionWindow> m_window;
+
+#if PLATFORM(IOS_FAMILY)
+    RetainPtr<_WKWebExtensionActionViewController> m_popupViewController;
+#endif
 
     RetainPtr<_WKWebExtensionActionWebView> m_popupWebView;
     RetainPtr<_WKWebExtensionActionWebViewDelegate> m_popupWebViewDelegate;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -167,6 +167,10 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
         EXPECT_NOT_NULL(largeIcon);
         EXPECT_TRUE(CGSizeEqualToSize(largeIcon.size, CGSizeMake(32, 32)));
 
+#if PLATFORM(IOS_FAMILY)
+        EXPECT_NOT_NULL(action.popupViewController);
+#endif
+
         EXPECT_NOT_NULL(action.popupWebView);
         EXPECT_FALSE(action.popupWebView.loading);
 
@@ -869,6 +873,10 @@ TEST(WKWebExtensionAPIAction, BrowserAction)
         EXPECT_TRUE(action.presentsPopup);
         EXPECT_FALSE(action.isEnabled);
 
+#if PLATFORM(IOS_FAMILY)
+        EXPECT_NOT_NULL(action.popupViewController);
+#endif
+
         EXPECT_NOT_NULL(action.popupWebView);
         EXPECT_FALSE(action.popupWebView.loading);
 
@@ -954,6 +962,10 @@ TEST(WKWebExtensionAPIAction, PageAction)
 
         EXPECT_TRUE(action.presentsPopup);
         EXPECT_FALSE(action.isEnabled);
+
+#if PLATFORM(IOS_FAMILY)
+        EXPECT_NOT_NULL(action.popupViewController);
+#endif
 
         EXPECT_NOT_NULL(action.popupWebView);
         EXPECT_FALSE(action.popupWebView.loading);


### PR DESCRIPTION
#### eb5c280e046344fc93ee454dce60690da5d75e7a
<pre>
Add UIViewController to _WKWebExtensionAction.
<a href="https://webkit.org/b/270099">https://webkit.org/b/270099</a>
<a href="https://rdar.apple.com/121461105">rdar://121461105</a>

Reviewed by Brian Weinstein.

The logic for popups is complex on iOS, we should vend a UIViewController instead of just the WKWebView.
This also overrides the viewport to accommodate desktop extenions better on mobile.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm:
(-[_WKWebExtensionAction popupViewController]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionWebViewDelegate initWithWebExtensionAction:]):
(-[_WKWebExtensionActionWebViewDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(-[_WKWebExtensionActionWebView initWithFrame:configuration:webExtensionAction:]):
(-[_WKWebExtensionActionWebView dealloc]):
(-[_WKWebExtensionActionWebView invalidateIntrinsicContentSize]):
(-[_WKWebExtensionActionWebView observeValueForKeyPath:ofObject:change:context:]):
(-[_WKWebExtensionActionWebView _contentSize]):
(-[_WKWebExtensionActionWebView _contentSizeDidChange]):
(-[_WKWebExtensionActionWebView _checkIfContentSizeStabilizedAndPresentPopup]):
(-[_WKWebExtensionActionViewController initWithWebExtensionAction:]):
(-[_WKWebExtensionActionViewController viewIsAppearing:]):
(-[_WKWebExtensionActionViewController adaptivePresentationStyleForPresentationController:traitCollection:]):
(-[_WKWebExtensionActionViewController presentationController:prepareAdaptivePresentationController:]):
(-[_WKWebExtensionActionViewController presentationController:viewControllerForAdaptivePresentationStyle:]):
(-[_WKWebExtensionActionViewController _viewControllerDismissalTransitionDidEnd:]):
(-[_WKWebExtensionActionViewController _updatePopoverContentSize]):
(-[_WKWebExtensionActionViewController _updateDetentForSheetPresentationController:]):
(-[_WKWebExtensionActionViewController _dismissPopup]):
(WebKit::WebExtensionAction::popupViewController):
(WebKit::WebExtensionAction::popupWebView):
(WebKit::WebExtensionAction::readyToPresentPopup):
(WebKit::WebExtensionAction::popupSizeDidChange):
(WebKit::WebExtensionAction::popupDidClose):
(WebKit::WebExtensionAction::closePopupWebView):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST): Check that popupViewController is non-null.

Canonical link: <a href="https://commits.webkit.org/275337@main">https://commits.webkit.org/275337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/818c6368482ef9767a57529f689a5e9a75644606

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41572 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44141 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17916 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42146 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37755 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5557 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->