### PR TITLE
[JSC] ProxyObject's "apply" and "construct" traps use incorrect global object

### DIFF
--- a/JSTests/microbenchmarks/proxy-apply-miss-handler.js
+++ b/JSTests/microbenchmarks/proxy-apply-miss-handler.js
@@ -1,0 +1,6 @@
+(function() {
+    var proxy = new Proxy(function() {}, {});
+
+    for (var i = 0; i < 1e6; ++i)
+        proxy();
+})();

--- a/JSTests/microbenchmarks/proxy-apply.js
+++ b/JSTests/microbenchmarks/proxy-apply.js
@@ -1,0 +1,8 @@
+(function() {
+    var proxy = new Proxy(function() {}, {
+        apply() {},
+    });
+
+    for (var i = 0; i < 1e6; ++i)
+        proxy();
+})();

--- a/JSTests/stress/proxy-call-cross-realm.js
+++ b/JSTests/stress/proxy-call-cross-realm.js
@@ -1,0 +1,43 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion");
+}
+
+var proxyThatReturnsArgs = new Proxy(function() {}, {
+    apply(_, __, args) { return args; }
+});
+
+(function() {
+    var other = createGlobalObject();
+    var func = new other.Function("proxy", "return proxy()");
+
+    for (var i = 0; i < 1e6; i++)
+        assert(func(proxyThatReturnsArgs) instanceof other.Array);
+})();
+
+(function() {
+    var other = createGlobalObject();
+    other.proxyThatReturnsArgs = proxyThatReturnsArgs;
+
+    for (var i = 0; i < 1e6; i++)
+        assert(other.eval("proxyThatReturnsArgs()") instanceof other.Array);
+})();
+
+(function() {
+    var other = createGlobalObject();
+
+    for (var i = 0; i < 1e6; i++) {
+        var mapped = other.Array.prototype.map.call([1], proxyThatReturnsArgs);
+        assert(mapped[0] instanceof other.Array);
+    }
+})();
+
+(function() {
+    var other = createGlobalObject();
+    other.proxyThatReturnsArgs = proxyThatReturnsArgs;
+
+    for (var i = 0; i < 1e6; i++) {
+        var mapped = other.eval("[1].map(proxyThatReturnsArgs)");
+        assert(mapped[0] instanceof other.Array);
+    }
+})();

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -22,42 +22,6 @@ test/built-ins/Object/entries/order-after-define-property-with-function.js:
 test/built-ins/Object/keys/order-after-define-property-with-function.js:
   default: 'Test262Error: Expected [a, length] and [length, a] to have the same contents. '
   strict mode: 'Test262Error: Expected [a, length] and [length, a] to have the same contents. '
-test/built-ins/Proxy/apply/arguments-realm.js:
-  default: 'Test262Error: Expected SameValue(«function Array() {'
-  strict mode: 'Test262Error: Expected SameValue(«function Array() {'
-test/built-ins/Proxy/apply/null-handler-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/apply/trap-is-not-callable-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/arguments-realm.js:
-  default: 'Test262Error: Expected SameValue(«function Array() {'
-  strict mode: 'Test262Error: Expected SameValue(«function Array() {'
-test/built-ins/Proxy/construct/null-handler-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-boolean-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-null-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-number-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-string-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-symbol-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-undefined-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
 test/built-ins/RegExp/prototype/Symbol.match/builtin-infer-unicode.js:
   default: 'Test262Error: Expected SameValue(«�», «null») to be true'
   strict mode: 'Test262Error: Expected SameValue(«�», «null») to be true'

--- a/Source/JavaScriptCore/interpreter/StackVisitor.h
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.h
@@ -206,4 +206,25 @@ private:
     mutable CallFrame* m_callerFrame;
 };
 
+class CallerExecutionContextFunctor {
+public:
+    CallerExecutionContextFunctor(JSObject* startFrameCallee)
+        : m_startFrameCallee(startFrameCallee)
+    {
+    }
+
+    IterationStatus operator()(StackVisitor&) const;
+
+    JSCell* resultCallee() const { return m_resultCallee; }
+    JSGlobalObject* resultGlobalObject(VM&) const;
+
+private:
+    JSObject* m_startFrameCallee;
+    mutable bool m_hasFoundStartFrame { false };
+    mutable bool m_hasSkippedFirstFrame { false };
+    mutable JSCell* m_resultCallee { nullptr };
+    mutable CallFrame* m_resultCallFrame { nullptr };
+    mutable CodeBlock* m_resultCodeBlock { nullptr };
+};
+
 } // namespace JSC


### PR DESCRIPTION
#### 1c5838b52914dd5eceb063fd2c10bfee7ea69dac
<pre>
[JSC] ProxyObject&apos;s &quot;apply&quot; and &quot;construct&quot; traps use incorrect global object
<a href="https://bugs.webkit.org/show_bug.cgi?id=270015">https://bugs.webkit.org/show_bug.cgi?id=270015</a>
&lt;<a href="https://rdar.apple.com/problem/123530886">rdar://problem/123530886</a>&gt;

Reviewed by NOBODY (OOPS!).

Per spec, calling a ProxyObject or bound function doesn&apos;t push a new execution context onto the stack,
unlike calling an ordinary [1] or built-in [2] functions does.

With this in mind, whenever the spec references TypeError or any other intrinsic [3], the one associated
with the running execution context [4] should be used, which includes ProxyObject&apos;s [[Call]] and
[[Construct]] methods. They don&apos;t override the resolution of intrinsics.

To match the spec and other runtimes, this change replaces the global object, used by ProxyObject methods,
with the one obtained by traversing the call stack. This patch leverages existing Function.prototype.caller
implementation [5], which already implements resolution of current execution context, after tweaking it
to return correct global object even in case of DFG call frame inlining.

Call stack traversal is so fast that it doesn&apos;t regress even added microbenchmarks:

                                     ToT                      patch

proxy-apply                    81.6943+-0.1479     ?     82.2021+-0.4902        ?
proxy-apply-miss-handler       62.8556+-0.0727     ?     62.8685+-0.0845        ?

&lt;geometric&gt;                    71.6580+-0.0774     ?     71.8841+-0.2086        ? might be 1.0032x slower

[1]: <a href="https://tc39.es/ecma262/#sec-prepareforordinarycall">https://tc39.es/ecma262/#sec-prepareforordinarycall</a> (step 12)
[2]: <a href="https://tc39.es/ecma262/#sec-builtincallorconstruct">https://tc39.es/ecma262/#sec-builtincallorconstruct</a> (step 9)
[3]: <a href="https://tc39.es/ecma262/#sec-well-known-intrinsic-objects">https://tc39.es/ecma262/#sec-well-known-intrinsic-objects</a>
[4]: <a href="https://tc39.es/ecma262/#current-realm">https://tc39.es/ecma262/#current-realm</a>
[5]: <a href="https://github.com/claudepache/es-legacy-function-reflection/blob/master/spec.md#get-functionprototypecaller">https://github.com/claudepache/es-legacy-function-reflection/blob/master/spec.md#get-functionprototypecaller</a> (step 3)

* JSTests/microbenchmarks/proxy-apply-miss-handler.js: Added.
* JSTests/microbenchmarks/proxy-apply.js: Added.
* JSTests/stress/proxy-call-cross-realm.js: Added.
* JSTests/test262/expectations.yaml: Mark 24 tests as passing.
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::CallerExecutionContextFunctor::operator() const):
(JSC::CallerExecutionContextFunctor::resultGlobalObject const):
* Source/JavaScriptCore/interpreter/StackVisitor.h:
(JSC::CallerExecutionContextFunctor::CallerExecutionContextFunctor):
(JSC::CallerExecutionContextFunctor::resultCallee const):
* Source/JavaScriptCore/runtime/FunctionPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
(JSC::RetrieveCallerFunctionFunctor::RetrieveCallerFunctionFunctor): Deleted.
(JSC::RetrieveCallerFunctionFunctor::result const): Deleted.
(JSC::RetrieveCallerFunctionFunctor::operator() const): Deleted.
(JSC::retrieveCallerFunction): Deleted.
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::retrieveCallerGlobalObjectWithFallback):
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c5838b52914dd5eceb063fd2c10bfee7ea69dac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37658 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17910 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34374 "Found 3 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html, imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html, imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15221 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36813 "Found 3 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html, imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html, imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45506 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35019 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37753 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37134 "Found 3 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html, imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html, imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40898 "Found 3 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html, imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html, imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41192 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16381 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13455 "Found 3 new test failures: imported/w3c/web-platform-tests/dom/events/EventListener-handleEvent-cross-realm.html, imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm.html, imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39314 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18000 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48203 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18056 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9835 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->