### PR TITLE
Introduce IDBOpenRequestData and add validators

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -442,6 +442,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/indexeddb/shared/IDBIndexInfo.h
     Modules/indexeddb/shared/IDBIterateCursorData.h
     Modules/indexeddb/shared/IDBObjectStoreInfo.h
+    Modules/indexeddb/shared/IDBOpenRequestData.h
     Modules/indexeddb/shared/IDBRequestData.h
     Modules/indexeddb/shared/IDBResourceIdentifier.h
     Modules/indexeddb/shared/IDBResultData.h

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
@@ -32,6 +32,7 @@
 #include "IDBConnectionToServer.h"
 #include "IDBDatabase.h"
 #include "IDBError.h"
+#include "IDBOpenRequestData.h"
 #include "IDBRequestCompletionEvent.h"
 #include "IDBResultData.h"
 #include "IDBTransaction.h"
@@ -244,7 +245,7 @@ void IDBOpenDBRequest::setIsContextSuspended(bool isContextSuspended)
     // If this request is blocked, it means this request is being processed on the server.
     // The client needs to actively stop the request so it doesn't blocks the processing of subsequent requests.
     if (m_isBlocked) {
-        IDBRequestData requestData(connectionProxy(), *this);
+        IDBOpenRequestData requestData(connectionProxy(), *this);
         connectionProxy().openDBRequestCancelled(requestData);
         auto result = IDBResultData::error(requestData.requestIdentifier(), IDBError { ExceptionCode::UnknownError, "Blocked open request on cached page is aborted to unblock other requests"_s });
         requestCompleted(result);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -34,6 +34,7 @@
 #include "IDBIterateCursorData.h"
 #include "IDBKeyRangeData.h"
 #include "IDBOpenDBRequest.h"
+#include "IDBOpenRequestData.h"
 #include "IDBRequestData.h"
 #include "IDBResultData.h"
 #include "ScriptExecutionContext.h"
@@ -74,7 +75,7 @@ Ref<IDBOpenDBRequest> IDBConnectionProxy::openDatabase(ScriptExecutionContext& c
         m_openDBRequestMap.set(request->resourceIdentifier(), request.get());
     }
 
-    callConnectionOnMainThread(&IDBConnectionToServer::openDatabase, IDBRequestData(*this, *request));
+    callConnectionOnMainThread(&IDBConnectionToServer::openDatabase, IDBOpenRequestData(*this, *request));
 
     return request.releaseNonNull();
 }
@@ -90,7 +91,7 @@ Ref<IDBOpenDBRequest> IDBConnectionProxy::deleteDatabase(ScriptExecutionContext&
         m_openDBRequestMap.set(request->resourceIdentifier(), request.get());
     }
 
-    callConnectionOnMainThread(&IDBConnectionToServer::deleteDatabase, IDBRequestData(*this, *request));
+    callConnectionOnMainThread(&IDBConnectionToServer::deleteDatabase, IDBOpenRequestData(*this, *request));
 
     return request.releaseNonNull();
 }
@@ -315,7 +316,7 @@ void IDBConnectionProxy::notifyOpenDBRequestBlocked(const IDBResourceIdentifier&
     request->performCallbackOnOriginThread(*request, &IDBOpenDBRequest::requestBlocked, oldVersion, newVersion);
 }
 
-void IDBConnectionProxy::openDBRequestCancelled(const IDBRequestData& requestData)
+void IDBConnectionProxy::openDBRequestCancelled(const IDBOpenRequestData& requestData)
 {
     callConnectionOnMainThread(&IDBConnectionToServer::openDBRequestCancelled, requestData);
 }

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -46,6 +46,7 @@ class IDBDatabase;
 class IDBDatabaseIdentifier;
 class IDBError;
 class IDBOpenDBRequest;
+class IDBOpenRequestData;
 class IDBResultData;
 class IDBTransaction;
 class ScriptExecutionContext;
@@ -88,7 +89,7 @@ public:
     void didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IndexedDB::ConnectionClosedOnBehalfOfServer = IndexedDB::ConnectionClosedOnBehalfOfServer::No);
 
     void notifyOpenDBRequestBlocked(const IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion);
-    void openDBRequestCancelled(const IDBRequestData&);
+    void openDBRequestCancelled(const IDBOpenRequestData&);
 
     void establishTransaction(IDBTransaction&);
     void commitTransaction(IDBTransaction&, uint64_t pendingRequestCount);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -32,6 +32,7 @@
 #include "IDBGetRecordData.h"
 #include "IDBKeyRangeData.h"
 #include "IDBOpenDBRequest.h"
+#include "IDBOpenRequestData.h"
 #include "IDBRequestData.h"
 #include "IDBResultData.h"
 #include "Logging.h"
@@ -74,7 +75,7 @@ void IDBConnectionToServer::callResultFunctionWithErrorLater(ResultFunction func
     });
 }
 
-void IDBConnectionToServer::deleteDatabase(const IDBRequestData& request)
+void IDBConnectionToServer::deleteDatabase(const IDBOpenRequestData& request)
 {
     LOG(IndexedDB, "IDBConnectionToServer::deleteDatabase - %s", request.databaseIdentifier().loggingString().utf8().data());
     
@@ -90,7 +91,7 @@ void IDBConnectionToServer::didDeleteDatabase(const IDBResultData& resultData)
     m_proxy->didDeleteDatabase(resultData);
 }
 
-void IDBConnectionToServer::openDatabase(const IDBRequestData& request)
+void IDBConnectionToServer::openDatabase(const IDBOpenRequestData& request)
 {
     LOG(IndexedDB, "IDBConnectionToServer::openDatabase - %s (%s) (%" PRIu64 ")", request.databaseIdentifier().loggingString().utf8().data(), request.requestIdentifier().loggingString().utf8().data(), request.requestedVersion());
 
@@ -460,7 +461,7 @@ void IDBConnectionToServer::notifyOpenDBRequestBlocked(const IDBResourceIdentifi
     m_proxy->notifyOpenDBRequestBlocked(requestIdentifier, oldVersion, newVersion);
 }
 
-void IDBConnectionToServer::openDBRequestCancelled(const IDBRequestData& requestData)
+void IDBConnectionToServer::openDBRequestCancelled(const IDBOpenRequestData& requestData)
 {
     LOG(IndexedDB, "IDBConnectionToServer::openDBRequestCancelled");
     ASSERT(isMainThread());

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -39,6 +39,7 @@ class IDBCursorInfo;
 class IDBDatabase;
 class IDBError;
 class IDBObjectStoreInfo;
+class IDBOpenRequestData;
 class IDBResultData;
 class IDBValue;
 class SecurityOrigin;
@@ -60,10 +61,10 @@ public:
 
     IDBConnectionProxy& proxy();
 
-    void deleteDatabase(const IDBRequestData&);
+    void deleteDatabase(const IDBOpenRequestData&);
     WEBCORE_EXPORT void didDeleteDatabase(const IDBResultData&);
 
-    void openDatabase(const IDBRequestData&);
+    void openDatabase(const IDBOpenRequestData&);
     WEBCORE_EXPORT void didOpenDatabase(const IDBResultData&);
 
     void createObjectStore(const IDBRequestData&, const IDBObjectStoreInfo&);
@@ -126,7 +127,7 @@ public:
     WEBCORE_EXPORT void connectionToServerLost(const IDBError&);
 
     WEBCORE_EXPORT void notifyOpenDBRequestBlocked(const IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion);
-    void openDBRequestCancelled(const IDBRequestData&);
+    void openDBRequestCancelled(const IDBOpenRequestData&);
 
     void establishTransaction(uint64_t databaseConnectionIdentifier, const IDBTransactionInfo&);
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
@@ -35,6 +35,7 @@ class IDBCursorInfo;
 class IDBIndexInfo;
 class IDBKeyData;
 class IDBObjectStoreInfo;
+class IDBOpenRequestData;
 class IDBRequestData;
 class IDBTransactionInfo;
 class IDBValue;
@@ -59,8 +60,8 @@ public:
     virtual ~IDBConnectionToServerDelegate() = default;
 
     virtual IDBConnectionIdentifier identifier() const = 0;
-    virtual void deleteDatabase(const IDBRequestData&) = 0;
-    virtual void openDatabase(const IDBRequestData&) = 0;
+    virtual void deleteDatabase(const IDBOpenRequestData&) = 0;
+    virtual void openDatabase(const IDBOpenRequestData&) = 0;
     virtual void abortTransaction(const IDBResourceIdentifier&) = 0;
     virtual void commitTransaction(const IDBResourceIdentifier&, uint64_t pendingRequestCount) = 0;
     virtual void didFinishHandlingVersionChangeTransaction(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier&) = 0;
@@ -84,7 +85,7 @@ public:
     virtual void databaseConnectionClosed(uint64_t databaseConnectionIdentifier) = 0;
     virtual void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier) = 0;
     virtual void didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IndexedDB::ConnectionClosedOnBehalfOfServer) = 0;
-    virtual void openDBRequestCancelled(const IDBRequestData&) = 0;
+    virtual void openDBRequestCancelled(const IDBOpenRequestData&) = 0;
 
     virtual void getAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, const ClientOrigin&) = 0;
 };

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -131,7 +131,7 @@ std::unique_ptr<IDBBackingStore> IDBServer::createBackingStore(const IDBDatabase
     return makeUnique<SQLiteIDBBackingStore>(identifier, upgradedDatabaseDirectory(identifier));
 }
 
-void IDBServer::openDatabase(const IDBRequestData& requestData)
+void IDBServer::openDatabase(const IDBOpenRequestData& requestData)
 {
     LOG(IndexedDB, "IDBServer::openDatabase");
     ASSERT(!isMainThread());
@@ -149,7 +149,7 @@ void IDBServer::openDatabase(const IDBRequestData& requestData)
     uniqueIDBDatabase.openDatabaseConnection(*connection, requestData);
 }
 
-void IDBServer::deleteDatabase(const IDBRequestData& requestData)
+void IDBServer::deleteDatabase(const IDBOpenRequestData& requestData)
 {
     LOG(IndexedDB, "IDBServer::deleteDatabase - %s", requestData.databaseIdentifier().loggingString().utf8().data());
     ASSERT(!isMainThread());
@@ -189,11 +189,7 @@ void IDBServer::abortTransaction(const IDBResourceIdentifier& transactionIdentif
 
 UniqueIDBDatabaseTransaction* IDBServer::idbTransaction(const IDBRequestData& requestData) const
 {
-    auto transactionIdentifier = requestData.transactionIdentifier();
-    if (!transactionIdentifier)
-        return nullptr;
-
-    return m_transactions.get(*transactionIdentifier);
+    return m_transactions.get(requestData.transactionIdentifier());
 }
 
 void IDBServer::createObjectStore(const IDBRequestData& requestData, const IDBObjectStoreInfo& info)
@@ -486,7 +482,7 @@ void IDBServer::didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier,
         databaseConnection->didFireVersionChangeEvent(requestIdentifier, connectionClosed);
 }
 
-void IDBServer::openDBRequestCancelled(const IDBRequestData& requestData)
+void IDBServer::openDBRequestCancelled(const IDBOpenRequestData& requestData)
 {
     LOG(IndexedDB, "IDBServer::openDBRequestCancelled");
     ASSERT(!isMainThread());

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -57,8 +57,8 @@ public:
     WEBCORE_EXPORT void unregisterConnection(IDBConnectionToClient&);
 
     // Operations requested by the client.
-    WEBCORE_EXPORT void openDatabase(const IDBRequestData&);
-    WEBCORE_EXPORT void deleteDatabase(const IDBRequestData&);
+    WEBCORE_EXPORT void openDatabase(const IDBOpenRequestData&);
+    WEBCORE_EXPORT void deleteDatabase(const IDBOpenRequestData&);
     WEBCORE_EXPORT void abortTransaction(const IDBResourceIdentifier&);
     WEBCORE_EXPORT void commitTransaction(const IDBResourceIdentifier&, uint64_t pendingRequestCount);
     WEBCORE_EXPORT void didFinishHandlingVersionChangeTransaction(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier&);
@@ -82,7 +82,7 @@ public:
     WEBCORE_EXPORT void databaseConnectionClosed(uint64_t databaseConnectionIdentifier);
     WEBCORE_EXPORT void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier);
     WEBCORE_EXPORT void didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer);
-    WEBCORE_EXPORT void openDBRequestCancelled(const IDBRequestData&);
+    WEBCORE_EXPORT void openDBRequestCancelled(const IDBOpenRequestData&);
 
     WEBCORE_EXPORT void getAllDatabaseNamesAndVersions(IDBConnectionIdentifier, const IDBResourceIdentifier&, const ClientOrigin&);
 

--- a/Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.cpp
@@ -31,12 +31,12 @@
 namespace WebCore {
 namespace IDBServer {
 
-Ref<ServerOpenDBRequest> ServerOpenDBRequest::create(IDBConnectionToClient& connection, const IDBRequestData& requestData)
+Ref<ServerOpenDBRequest> ServerOpenDBRequest::create(IDBConnectionToClient& connection, const IDBOpenRequestData& requestData)
 {
     return adoptRef(*new ServerOpenDBRequest(connection, requestData));
 }
 
-ServerOpenDBRequest::ServerOpenDBRequest(IDBConnectionToClient& connection, const IDBRequestData& requestData)
+ServerOpenDBRequest::ServerOpenDBRequest(IDBConnectionToClient& connection, const IDBOpenRequestData& requestData)
     : m_connection(connection)
     , m_requestData(requestData)
 {

--- a/Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "IDBConnectionToClient.h"
-#include "IDBRequestData.h"
+#include "IDBOpenRequestData.h"
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -39,10 +39,10 @@ namespace IDBServer {
 
 class ServerOpenDBRequest : public RefCounted<ServerOpenDBRequest> {
 public:
-    static Ref<ServerOpenDBRequest> create(IDBConnectionToClient&, const IDBRequestData&);
+    static Ref<ServerOpenDBRequest> create(IDBConnectionToClient&, const IDBOpenRequestData&);
 
     IDBConnectionToClient& connection() { return m_connection; }
-    const IDBRequestData& requestData() const { return m_requestData; }
+    const IDBOpenRequestData& requestData() const { return m_requestData; }
 
     bool isOpenRequest() const;
     bool isDeleteRequest() const;
@@ -59,10 +59,10 @@ public:
 
 
 private:
-    ServerOpenDBRequest(IDBConnectionToClient&, const IDBRequestData&);
+    ServerOpenDBRequest(IDBConnectionToClient&, const IDBOpenRequestData&);
 
     Ref<IDBConnectionToClient> m_connection;
-    IDBRequestData m_requestData;
+    IDBOpenRequestData m_requestData;
 
     bool m_notifiedBlocked { false };
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -72,7 +72,7 @@ public:
     UniqueIDBDatabase(UniqueIDBDatabase&) = delete;
     WEBCORE_EXPORT ~UniqueIDBDatabase();
 
-    WEBCORE_EXPORT void openDatabaseConnection(IDBConnectionToClient&, const IDBRequestData&);
+    WEBCORE_EXPORT void openDatabaseConnection(IDBConnectionToClient&, const IDBOpenRequestData&);
 
     const IDBDatabaseInfo& info() const;
     UniqueIDBDatabaseManager* manager();
@@ -108,7 +108,7 @@ public:
 
     void enqueueTransaction(Ref<UniqueIDBDatabaseTransaction>&&);
 
-    WEBCORE_EXPORT void handleDelete(IDBConnectionToClient&, const IDBRequestData&);
+    WEBCORE_EXPORT void handleDelete(IDBConnectionToClient&, const IDBOpenRequestData&);
     WEBCORE_EXPORT void immediateClose();
 
     bool hasActiveTransactions() const;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -27,6 +27,7 @@
 #include "UniqueIDBDatabaseTransaction.h"
 
 #include "IDBIterateCursorData.h"
+#include "IDBRequestData.h"
 #include "IDBResultData.h"
 #include "Logging.h"
 #include "UniqueIDBDatabase.h"
@@ -156,7 +157,7 @@ void UniqueIDBDatabaseTransaction::createObjectStore(const IDBRequestData& reque
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::createObjectStore");
 
     ASSERT(isVersionChange());
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -182,7 +183,7 @@ void UniqueIDBDatabaseTransaction::deleteObjectStore(const IDBRequestData& reque
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteObjectStore");
 
     ASSERT(isVersionChange());
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -208,7 +209,7 @@ void UniqueIDBDatabaseTransaction::renameObjectStore(const IDBRequestData& reque
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::renameObjectStore");
 
     ASSERT(isVersionChange());
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -233,7 +234,7 @@ void UniqueIDBDatabaseTransaction::clearObjectStore(const IDBRequestData& reques
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::clearObjectStore");
 
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -259,7 +260,7 @@ void UniqueIDBDatabaseTransaction::createIndex(const IDBRequestData& requestData
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::createIndex");
 
     ASSERT(isVersionChange());
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -285,7 +286,7 @@ void UniqueIDBDatabaseTransaction::deleteIndex(const IDBRequestData& requestData
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteIndex");
 
     ASSERT(isVersionChange());
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -311,7 +312,7 @@ void UniqueIDBDatabaseTransaction::renameIndex(const IDBRequestData& requestData
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::renameIndex");
 
     ASSERT(isVersionChange());
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -338,7 +339,7 @@ void UniqueIDBDatabaseTransaction::putOrAdd(const IDBRequestData& requestData, c
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::putOrAdd");
 
     ASSERT(!isReadOnly());
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -363,7 +364,7 @@ void UniqueIDBDatabaseTransaction::getRecord(const IDBRequestData& requestData, 
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getRecord");
 
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)
@@ -388,7 +389,7 @@ void UniqueIDBDatabaseTransaction::getAllRecords(const IDBRequestData& requestDa
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getAllRecords");
 
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -413,7 +414,7 @@ void UniqueIDBDatabaseTransaction::getCount(const IDBRequestData& requestData, c
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getCount");
 
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -438,7 +439,7 @@ void UniqueIDBDatabaseTransaction::deleteRecord(const IDBRequestData& requestDat
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteRecord");
 
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -463,7 +464,7 @@ void UniqueIDBDatabaseTransaction::openCursor(const IDBRequestData& requestData,
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::openCursor");
 
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
     auto* database = this->database();
     if (!database)
@@ -488,7 +489,7 @@ void UniqueIDBDatabaseTransaction::iterateCursor(const IDBRequestData& requestDa
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::iterateCursor");
 
-    ASSERT(requestData.transactionIdentifier() && m_transactionInfo.identifier() == *requestData.transactionIdentifier());
+    ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
     auto* database = this->database();
     if (!database)

--- a/Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IDBOpenRequestData.h"
+
+#include "IDBConnectionProxy.h"
+#include "IDBDatabaseIdentifier.h"
+
+namespace WebCore {
+
+IDBOpenRequestData::IDBOpenRequestData(const IDBClient::IDBConnectionProxy& connectionProxy, const IDBOpenDBRequest& request)
+    : m_serverConnectionIdentifier(connectionProxy.serverConnectionIdentifier())
+    , m_requestIdentifier(IDBResourceIdentifier { connectionProxy, request })
+    , m_databaseIdentifier(request.databaseIdentifier())
+    , m_requestedVersion(request.version())
+    , m_requestType(request.requestType())
+{
+}
+
+IDBOpenRequestData::IDBOpenRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, IDBDatabaseIdentifier&& databaseIdentifier, uint64_t requestedVersion, IndexedDB::RequestType type)
+    : m_serverConnectionIdentifier(serverConnectionIdentifier)
+    , m_requestIdentifier(requestIdentifier)
+    , m_databaseIdentifier(databaseIdentifier)
+    , m_requestedVersion(requestedVersion)
+    , m_requestType(type)
+{
+}
+
+IDBOpenRequestData IDBOpenRequestData::isolatedCopy() const
+{
+    return IDBOpenRequestData {
+        m_serverConnectionIdentifier,
+        m_requestIdentifier,
+        m_databaseIdentifier.isolatedCopy(),
+        m_requestedVersion,
+        m_requestType
+    };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IDBDatabaseIdentifier.h"
+#include "IDBResourceIdentifier.h"
+#include "IndexedDB.h"
+#include <wtf/ArgumentCoder.h>
+
+namespace WebCore {
+
+class IDBOpenDBRequest;
+
+class IDBOpenRequestData {
+public:
+    IDBOpenRequestData(const IDBClient::IDBConnectionProxy&, const IDBOpenDBRequest&);
+    IDBOpenRequestData(const IDBOpenRequestData&) = default;
+    IDBOpenRequestData(IDBOpenRequestData&&) = default;
+    IDBOpenRequestData& operator=(IDBOpenRequestData&&) = default;
+    WEBCORE_EXPORT IDBOpenRequestData isolatedCopy() const;
+
+    IDBConnectionIdentifier serverConnectionIdentifier() const { return m_serverConnectionIdentifier; }
+    IDBResourceIdentifier requestIdentifier() const { return m_requestIdentifier; }
+    IDBDatabaseIdentifier databaseIdentifier() const { return m_databaseIdentifier; }
+    uint64_t requestedVersion() const { return m_requestedVersion; }
+    bool isOpenRequest() const { return m_requestType == IndexedDB::RequestType::Open; }
+    bool isDeleteRequest() const { return m_requestType == IndexedDB::RequestType::Delete; }
+
+private:
+    friend struct IPC::ArgumentCoder<IDBOpenRequestData, void>;
+    WEBCORE_EXPORT IDBOpenRequestData(IDBConnectionIdentifier, IDBResourceIdentifier, IDBDatabaseIdentifier&&, uint64_t requestedVersion, IndexedDB::RequestType);
+
+    IDBConnectionIdentifier m_serverConnectionIdentifier;
+    IDBResourceIdentifier m_requestIdentifier;
+    IDBDatabaseIdentifier m_databaseIdentifier;
+    uint64_t m_requestedVersion { 0 };
+    IndexedDB::RequestType m_requestType { IndexedDB::RequestType::Open };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
@@ -32,15 +32,6 @@
 
 namespace WebCore {
 
-IDBRequestData::IDBRequestData(const IDBClient::IDBConnectionProxy& connectionProxy, const IDBOpenDBRequest& request)
-    : m_serverConnectionIdentifier(connectionProxy.serverConnectionIdentifier())
-    , m_requestIdentifier(IDBResourceIdentifier { connectionProxy, request })
-    , m_databaseIdentifier(request.databaseIdentifier())
-    , m_requestedVersion(request.version())
-    , m_requestType(request.requestType())
-{
-}
-
 IDBRequestData::IDBRequestData(IDBClient::TransactionOperation& operation)
     : m_serverConnectionIdentifier(operation.transaction().database().connectionProxy().serverConnectionIdentifier())
     , m_requestIdentifier(operation.identifier())
@@ -55,15 +46,14 @@ IDBRequestData::IDBRequestData(IDBClient::TransactionOperation& operation)
         m_cursorIdentifier = *operation.cursorIdentifier();
 }
 
-IDBRequestData::IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, std::optional<IDBResourceIdentifier>&& transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType indexRecordType, std::optional<IDBDatabaseIdentifier>&& databaseIdentifier, uint64_t requestedVersion, IndexedDB::RequestType requestType)
+IDBRequestData::IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, IDBResourceIdentifier transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType indexRecordType, uint64_t requestedVersion, IndexedDB::RequestType requestType)
     : m_serverConnectionIdentifier(serverConnectionIdentifier)
     , m_requestIdentifier(requestIdentifier)
-    , m_transactionIdentifier(WTFMove(transactionIdentifier))
+    , m_transactionIdentifier(transactionIdentifier)
     , m_cursorIdentifier(WTFMove(cursorIdentifier))
     , m_objectStoreIdentifier(objectStoreIdentifier)
     , m_indexIdentifier(indexIdentifier)
     , m_indexRecordType(WTFMove(indexRecordType))
-    , m_databaseIdentifier(WTFMove(databaseIdentifier))
     , m_requestedVersion(requestedVersion)
     , m_requestType(requestType)
 {
@@ -77,7 +67,6 @@ IDBRequestData::IDBRequestData(const IDBRequestData& other)
     , m_objectStoreIdentifier(other.m_objectStoreIdentifier)
     , m_indexIdentifier(other.m_indexIdentifier)
     , m_indexRecordType(other.m_indexRecordType)
-    , m_databaseIdentifier(other.m_databaseIdentifier)
     , m_requestedVersion(other.m_requestedVersion)
     , m_requestType(other.m_requestType)
 {
@@ -105,9 +94,6 @@ void IDBRequestData::isolatedCopy(const IDBRequestData& source, IDBRequestData& 
     destination.m_indexRecordType = source.m_indexRecordType;
     destination.m_requestedVersion = source.m_requestedVersion;
     destination.m_requestType = source.m_requestType;
-
-    if (source.m_databaseIdentifier)
-        destination.m_databaseIdentifier = source.m_databaseIdentifier->isolatedCopy();
 }
 
 IDBConnectionIdentifier IDBRequestData::serverConnectionIdentifier() const
@@ -121,7 +107,7 @@ IDBResourceIdentifier IDBRequestData::requestIdentifier() const
     return m_requestIdentifier;
 }
 
-std::optional<IDBResourceIdentifier> IDBRequestData::transactionIdentifier() const
+IDBResourceIdentifier IDBRequestData::transactionIdentifier() const
 {
     return m_transactionIdentifier;
 }
@@ -148,12 +134,6 @@ IndexedDB::IndexRecordType IDBRequestData::indexRecordType() const
 {
     ASSERT(m_indexIdentifier);
     return m_indexRecordType;
-}
-
-IDBDatabaseIdentifier IDBRequestData::databaseIdentifier() const
-{
-    ASSERT(m_databaseIdentifier);
-    return m_databaseIdentifier.value_or(IDBDatabaseIdentifier { });
 }
 
 uint64_t IDBRequestData::requestedVersion() const

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
@@ -46,7 +46,6 @@ class TransactionOperation;
 
 class IDBRequestData {
 public:
-    IDBRequestData(const IDBClient::IDBConnectionProxy&, const IDBOpenDBRequest&);
     explicit IDBRequestData(IDBClient::TransactionOperation&);
     WEBCORE_EXPORT IDBRequestData(const IDBRequestData&);
     IDBRequestData(IDBRequestData&&) = default;
@@ -58,33 +57,26 @@ public:
 
     IDBConnectionIdentifier serverConnectionIdentifier() const;
     WEBCORE_EXPORT IDBResourceIdentifier requestIdentifier() const;
-    WEBCORE_EXPORT std::optional<IDBResourceIdentifier> transactionIdentifier() const;
+    WEBCORE_EXPORT IDBResourceIdentifier transactionIdentifier() const;
     uint64_t objectStoreIdentifier() const;
     uint64_t indexIdentifier() const;
     IndexedDB::IndexRecordType indexRecordType() const;
     IDBResourceIdentifier cursorIdentifier() const;
-
-    WEBCORE_EXPORT IDBDatabaseIdentifier databaseIdentifier() const;
     uint64_t requestedVersion() const;
-
-    bool isOpenRequest() const { return m_requestType == IndexedDB::RequestType::Open; }
-    bool isDeleteRequest() const { return m_requestType == IndexedDB::RequestType::Delete; }
-
     IDBRequestData isolatedCopy();
 
 private:
     friend struct IPC::ArgumentCoder<IDBRequestData, void>;
-    WEBCORE_EXPORT IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, std::optional<IDBResourceIdentifier>&& transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType, std::optional<IDBDatabaseIdentifier>&&, uint64_t requestedVersion, IndexedDB::RequestType);
+    WEBCORE_EXPORT IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, IDBResourceIdentifier transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType, uint64_t requestedVersion, IndexedDB::RequestType);
     static void isolatedCopy(const IDBRequestData& source, IDBRequestData& destination);
 
     IDBConnectionIdentifier m_serverConnectionIdentifier;
     IDBResourceIdentifier m_requestIdentifier;
-    std::optional<IDBResourceIdentifier> m_transactionIdentifier;
+    IDBResourceIdentifier m_transactionIdentifier;
     std::optional<IDBResourceIdentifier> m_cursorIdentifier;
     uint64_t m_objectStoreIdentifier { 0 };
     uint64_t m_indexIdentifier { 0 };
     IndexedDB::IndexRecordType m_indexRecordType { IndexedDB::IndexRecordType::Key };
-    std::optional<IDBDatabaseIdentifier> m_databaseIdentifier;
     uint64_t m_requestedVersion { 0 };
 
     IndexedDB::RequestType m_requestType { IndexedDB::RequestType::Other };

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
@@ -31,6 +31,7 @@
 #include "ManagedMediaSource.h"
 #include "MediaSource.h"
 #include "MediaSourceHandle.h"
+#include "MediaSourcePrivate.h"
 #include "MediaSourcePrivateClient.h"
 #include "PlatformTimeRanges.h"
 #include "TimeRanges.h"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -199,6 +199,7 @@ Modules/indexeddb/shared/IDBGetRecordData.cpp
 Modules/indexeddb/shared/IDBIndexInfo.cpp
 Modules/indexeddb/shared/IDBIterateCursorData.cpp
 Modules/indexeddb/shared/IDBObjectStoreInfo.cpp
+Modules/indexeddb/shared/IDBOpenRequestData.cpp
 Modules/indexeddb/shared/IDBRequestData.cpp
 Modules/indexeddb/shared/IDBResourceIdentifier.cpp
 Modules/indexeddb/shared/IDBResultData.cpp

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -195,8 +195,8 @@ private:
 class EmptyDatabaseProvider final : public DatabaseProvider {
     struct EmptyIDBConnectionToServerDeletegate final : public IDBClient::IDBConnectionToServerDelegate {
         IDBConnectionIdentifier identifier() const final { return { }; }
-        void deleteDatabase(const IDBRequestData&) final { }
-        void openDatabase(const IDBRequestData&) final { }
+        void deleteDatabase(const IDBOpenRequestData&) final { }
+        void openDatabase(const IDBOpenRequestData&) final { }
         void abortTransaction(const IDBResourceIdentifier&) final { }
         void commitTransaction(const IDBResourceIdentifier&, uint64_t) final { }
         void didFinishHandlingVersionChangeTransaction(uint64_t, const IDBResourceIdentifier&) final { }
@@ -219,7 +219,7 @@ class EmptyDatabaseProvider final : public DatabaseProvider {
         void databaseConnectionClosed(uint64_t) final { }
         void abortOpenAndUpgradeNeeded(uint64_t, const std::optional<IDBResourceIdentifier>&) final { }
         void didFireVersionChangeEvent(uint64_t, const IDBResourceIdentifier&, const IndexedDB::ConnectionClosedOnBehalfOfServer) final { }
-        void openDBRequestCancelled(const IDBRequestData&) final { }
+        void openDBRequestCancelled(const IDBOpenRequestData&) final { }
         void getAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, const ClientOrigin&) final { }
         ~EmptyIDBConnectionToServerDeletegate() { }
     };

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
@@ -189,13 +189,13 @@ WebCore::IDBServer::UniqueIDBDatabase& IDBStorageManager::getOrCreateUniqueIDBDa
     return *addResult.iterator->value;
 }
 
-void IDBStorageManager::openDatabase(WebCore::IDBServer::IDBConnectionToClient& connectionToClient, const WebCore::IDBRequestData& requestData)
+void IDBStorageManager::openDatabase(WebCore::IDBServer::IDBConnectionToClient& connectionToClient, const WebCore::IDBOpenRequestData& requestData)
 {
     auto& database = getOrCreateUniqueIDBDatabase(requestData.databaseIdentifier());
     database.openDatabaseConnection(connectionToClient, requestData);
 }
 
-void IDBStorageManager::deleteDatabase(WebCore::IDBServer::IDBConnectionToClient& connectionToClient, const WebCore::IDBRequestData& requestData)
+void IDBStorageManager::deleteDatabase(WebCore::IDBServer::IDBConnectionToClient& connectionToClient, const WebCore::IDBOpenRequestData& requestData)
 {
     auto& database = getOrCreateUniqueIDBDatabase(requestData.databaseIdentifier());
     database.handleDelete(connectionToClient, requestData);
@@ -232,7 +232,7 @@ Vector<WebCore::IDBDatabaseNameAndVersion> IDBStorageManager::getAllDatabaseName
     return result;
 }
 
-void IDBStorageManager::openDBRequestCancelled(const WebCore::IDBRequestData& requestData)
+void IDBStorageManager::openDBRequestCancelled(const WebCore::IDBOpenRequestData& requestData)
 {
     auto* database = m_databases.get(requestData.databaseIdentifier());
     if (!database)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
@@ -60,9 +60,9 @@ public:
     void stopDatabaseActivitiesForSuspend();
     void handleLowMemoryWarning();
 
-    void openDatabase(WebCore::IDBServer::IDBConnectionToClient&, const WebCore::IDBRequestData&);
-    void openDBRequestCancelled(const WebCore::IDBRequestData&);
-    void deleteDatabase(WebCore::IDBServer::IDBConnectionToClient&, const WebCore::IDBRequestData&);
+    void openDatabase(WebCore::IDBServer::IDBConnectionToClient&, const WebCore::IDBOpenRequestData&);
+    void openDBRequestCancelled(const WebCore::IDBOpenRequestData&);
+    void deleteDatabase(WebCore::IDBServer::IDBConnectionToClient&, const WebCore::IDBOpenRequestData&);
     Vector<WebCore::IDBDatabaseNameAndVersion> getAllDatabaseNamesAndVersions();
 
 private:

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -50,6 +50,7 @@
 #include "StorageAreaRegistry.h"
 #include "UnifiedOriginStorageLevel.h"
 #include "WebsiteDataType.h"
+#include <WebCore/IDBRequestData.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/ServiceWorkerContextData.h>
 #include <WebCore/StorageUtilities.h>
@@ -1425,18 +1426,18 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
     writeOriginToFileIfNecessary(storageArea->origin(), storageArea);
 }
 
-void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBRequestData& requestData)
+void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
     Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), requestData.requestIdentifier().connectionIdentifier());
     originStorageManager(requestData.databaseIdentifier().origin()).idbStorageManager(*m_idbStorageRegistry).openDatabase(connectionToClient, requestData);
 }
 
-void NetworkStorageManager::openDBRequestCancelled(const WebCore::IDBRequestData& requestData)
+void NetworkStorageManager::openDBRequestCancelled(const WebCore::IDBOpenRequestData& requestData)
 {
     originStorageManager(requestData.databaseIdentifier().origin()).idbStorageManager(*m_idbStorageRegistry).openDBRequestCancelled(requestData);
 }
 
-void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const WebCore::IDBRequestData& requestData)
+void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
     Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), requestData.requestIdentifier().connectionIdentifier());
     originStorageManager(requestData.databaseIdentifier().origin()).idbStorageManager(*m_idbStorageRegistry).deleteDatabase(connectionToClient, requestData);
@@ -1497,11 +1498,7 @@ void NetworkStorageManager::didFinishHandlingVersionChangeTransaction(uint64_t d
 
 WebCore::IDBServer::UniqueIDBDatabaseTransaction* NetworkStorageManager::idbTransaction(const WebCore::IDBRequestData& requestData)
 {
-    auto transactionIdentifier = requestData.transactionIdentifier();
-    if (!transactionIdentifier)
-        return nullptr;
-
-    return m_idbStorageRegistry->transaction(*transactionIdentifier);
+    return m_idbStorageRegistry->transaction(requestData.transactionIdentifier());
 }
 
 void NetworkStorageManager::createObjectStore(const WebCore::IDBRequestData& requestData, const WebCore::IDBObjectStoreInfo& objectStoreInfo)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -61,6 +61,7 @@ class IDBCursorInfo;
 class IDBKeyData;
 class IDBIndexInfo;
 class IDBObjectStoreInfo;
+class IDBOpenRequestData;
 class IDBRequestData;
 class IDBTransactionInfo;
 class IDBValue;
@@ -180,9 +181,9 @@ private:
     void clear(IPC::Connection&, StorageAreaIdentifier, StorageAreaImplIdentifier, String&& urlString, CompletionHandler<void()>&&);
 
     // Message handlers for IndexedDB.
-    void openDatabase(IPC::Connection&, const WebCore::IDBRequestData&);
-    void openDBRequestCancelled(const WebCore::IDBRequestData&);
-    void deleteDatabase(IPC::Connection&, const WebCore::IDBRequestData&);
+    void openDatabase(IPC::Connection&, const WebCore::IDBOpenRequestData&);
+    void openDBRequestCancelled(const WebCore::IDBOpenRequestData&);
+    void deleteDatabase(IPC::Connection&, const WebCore::IDBOpenRequestData&);
     void establishTransaction(uint64_t databaseConnectionIdentifier, const WebCore::IDBTransactionInfo&);
     void databaseConnectionPendingClose(uint64_t databaseConnectionIdentifier);
     void databaseConnectionClosed(uint64_t databaseConnectionIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -51,9 +51,9 @@
     RemoveItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String urlString) -> (bool hasError, HashMap<String, String> allItems)
     Clear(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String urlString) -> ()
 
-    OpenDatabase(WebCore::IDBRequestData requestData)
-    OpenDBRequestCancelled(WebCore::IDBRequestData requestData)
-    DeleteDatabase(WebCore::IDBRequestData requestData)
+    OpenDatabase(WebCore::IDBOpenRequestData requestData)
+    OpenDBRequestCancelled(WebCore::IDBOpenRequestData requestData)
+    DeleteDatabase(WebCore::IDBOpenRequestData requestData)
     EstablishTransaction(uint64_t databaseConnectionIdentifier, WebCore::IDBTransactionInfo info)
     DatabaseConnectionPendingClose(uint64_t databaseConnectionIdentifier)
     DatabaseConnectionClosed(uint64_t databaseConnectionIdentifier)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -614,15 +614,22 @@ class WebCore::IDBValue {
     Vector<String> blobFilePaths()
 };
 
+class WebCore::IDBOpenRequestData {
+    WebCore::IDBConnectionIdentifier m_serverConnectionIdentifier;
+    [Validator='!m_requestIdentifier->isEmpty()'] WebCore::IDBResourceIdentifier m_requestIdentifier;
+    [Validator='m_databaseIdentifier->isValid()'] WebCore::IDBDatabaseIdentifier m_databaseIdentifier;
+    uint64_t m_requestedVersion;
+    WebCore::IndexedDB::RequestType m_requestType;
+}
+
 class WebCore::IDBRequestData {
     WebCore::IDBConnectionIdentifier m_serverConnectionIdentifier;
-    WebCore::IDBResourceIdentifier m_requestIdentifier;
-    std::optional<WebCore::IDBResourceIdentifier> m_transactionIdentifier;
+    [Validator='!m_requestIdentifier->isEmpty()'] WebCore::IDBResourceIdentifier m_requestIdentifier;
+    [Validator='!m_transactionIdentifier->isEmpty()'] WebCore::IDBResourceIdentifier m_transactionIdentifier;
     std::optional<WebCore::IDBResourceIdentifier> m_cursorIdentifier;
     uint64_t m_objectStoreIdentifier;
     uint64_t m_indexIdentifier;
     WebCore::IndexedDB::IndexRecordType m_indexRecordType;
-    std::optional<WebCore::IDBDatabaseIdentifier> m_databaseIdentifier;
     uint64_t m_requestedVersion;
     WebCore::IndexedDB::RequestType m_requestType;
 }

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
@@ -80,12 +80,12 @@ IDBClient::IDBConnectionToServer& WebIDBConnectionToServer::coreConnectionToServ
     return m_connectionToServer;
 }
 
-void WebIDBConnectionToServer::deleteDatabase(const IDBRequestData& requestData)
+void WebIDBConnectionToServer::deleteDatabase(const IDBOpenRequestData& requestData)
 {
     send(Messages::NetworkStorageManager::DeleteDatabase(requestData));
 }
 
-void WebIDBConnectionToServer::openDatabase(const IDBRequestData& requestData)
+void WebIDBConnectionToServer::openDatabase(const IDBOpenRequestData& requestData)
 {
     send(Messages::NetworkStorageManager::OpenDatabase(requestData));
 }
@@ -200,7 +200,7 @@ void WebIDBConnectionToServer::didFireVersionChangeEvent(uint64_t databaseConnec
     send(Messages::NetworkStorageManager::DidFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed));
 }
 
-void WebIDBConnectionToServer::openDBRequestCancelled(const IDBRequestData& requestData)
+void WebIDBConnectionToServer::openDBRequestCancelled(const IDBOpenRequestData& requestData)
 {
     send(Messages::NetworkStorageManager::OpenDBRequestCancelled(requestData));
 }

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -52,8 +52,8 @@ private:
     uint64_t messageSenderDestinationID() const final { return 0; }
 
     // IDBConnectionToServerDelegate
-    void deleteDatabase(const WebCore::IDBRequestData&) final;
-    void openDatabase(const WebCore::IDBRequestData&) final;
+    void deleteDatabase(const WebCore::IDBOpenRequestData&) final;
+    void openDatabase(const WebCore::IDBOpenRequestData&) final;
     void abortTransaction(const WebCore::IDBResourceIdentifier&) final;
     void commitTransaction(const WebCore::IDBResourceIdentifier&, uint64_t pendingRequestCount) final;
     void didFinishHandlingVersionChangeTransaction(uint64_t databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier&) final;
@@ -76,7 +76,7 @@ private:
     void databaseConnectionClosed(uint64_t databaseConnectionIdentifier) final;
     void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier) final;
     void didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer) final;
-    void openDBRequestCancelled(const WebCore::IDBRequestData&) final;
+    void openDBRequestCancelled(const WebCore::IDBOpenRequestData&) final;
 
     void getAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier&, const WebCore::ClientOrigin&) final;
 

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
@@ -103,7 +103,7 @@ IDBServer::IDBConnectionToClient& InProcessIDBServer::connectionToClient() const
     return *m_connectionToClient;
 }
 
-void InProcessIDBServer::deleteDatabase(const WebCore::IDBRequestData& requestData)
+void InProcessIDBServer::deleteDatabase(const WebCore::IDBOpenRequestData& requestData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy()] {
         Locker locker { m_serverLock };
@@ -118,7 +118,7 @@ void InProcessIDBServer::didDeleteDatabase(const IDBResultData& resultData)
     });
 }
 
-void InProcessIDBServer::openDatabase(const WebCore::IDBRequestData& requestData)
+void InProcessIDBServer::openDatabase(const WebCore::IDBOpenRequestData& requestData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy()] {
         Locker locker { m_serverLock };
@@ -452,7 +452,7 @@ void InProcessIDBServer::didFireVersionChangeEvent(uint64_t databaseConnectionId
     });
 }
 
-void InProcessIDBServer::openDBRequestCancelled(const WebCore::IDBRequestData& requestData)
+void InProcessIDBServer::openDBRequestCancelled(const WebCore::IDBOpenRequestData& requestData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy()] {
         Locker locker { m_serverLock };

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -65,8 +65,8 @@ public:
     WebCore::IDBServer::IDBServer& server() { return *m_server; }
 
     // IDBConnectionToServer
-    void deleteDatabase(const WebCore::IDBRequestData&) final;
-    void openDatabase(const WebCore::IDBRequestData&) final;
+    void deleteDatabase(const WebCore::IDBOpenRequestData&) final;
+    void openDatabase(const WebCore::IDBOpenRequestData&) final;
     void abortTransaction(const WebCore::IDBResourceIdentifier&) final;
     void commitTransaction(const WebCore::IDBResourceIdentifier&, uint64_t pendingCountRequest) final;
     void didFinishHandlingVersionChangeTransaction(uint64_t databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier&) final;
@@ -89,7 +89,7 @@ public:
     void databaseConnectionClosed(uint64_t databaseConnectionIdentifier) final;
     void abortOpenAndUpgradeNeeded(uint64_t databaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier) final;
     void didFireVersionChangeEvent(uint64_t databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer) final;
-    void openDBRequestCancelled(const WebCore::IDBRequestData&) final;
+    void openDBRequestCancelled(const WebCore::IDBOpenRequestData&) final;
     void getAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier&, const WebCore::ClientOrigin&) final;
 
     // IDBConnectionToClient


### PR DESCRIPTION
#### 81d83dea0f5bec17b0ec62b7ad81b90ee95f6a42
<pre>
Introduce IDBOpenRequestData and add validators
<a href="https://bugs.webkit.org/show_bug.cgi?id=270109">https://bugs.webkit.org/show_bug.cgi?id=270109</a>
<a href="https://rdar.apple.com/123643973">rdar://123643973</a>

Reviewed by Alex Christensen.

IDBRequestData has a few optional data members because it is used to represent both open requests and transaction
requests, and different request types have different data members. For example, an open request should not have
transaction identifier. Therefore, an IDBRequestData object decoded from IPC message and has null data members will be
viewed as valid object, and message handlers need to perform additional checks on that object to ensure it&apos;s valid for
the target request type. For example, if the message is for a transaction request, then message handler needs to ensure
transaction identifier is not null. To make the code more robust by moving the checks to IPC layer, this patch
introduces a new class IDBOpenRequestData for open requests, and adds message validators to both IDBRequestData and
IDBOpenRequestData.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp:
(WebCore::IDBOpenDBRequest::setIsContextSuspended):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::IDBConnectionProxy::openDatabase):
(WebCore::IDBClient::IDBConnectionProxy::deleteDatabase):
(WebCore::IDBClient::IDBConnectionProxy::openDBRequestCancelled):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::deleteDatabase):
(WebCore::IDBClient::IDBConnectionToServer::openDatabase):
(WebCore::IDBClient::IDBConnectionToServer::openDBRequestCancelled):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h:
* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::openDatabase):
(WebCore::IDBServer::IDBServer::deleteDatabase):
(WebCore::IDBServer::IDBServer::idbTransaction const):
(WebCore::IDBServer::IDBServer::openDBRequestCancelled):
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.cpp:
(WebCore::IDBServer::ServerOpenDBRequest::create):
(WebCore::IDBServer::ServerOpenDBRequest::ServerOpenDBRequest):
* Source/WebCore/Modules/indexeddb/server/ServerOpenDBRequest.h:
(WebCore::IDBServer::ServerOpenDBRequest::requestData const):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::openDatabaseConnection):
(WebCore::IDBServer::UniqueIDBDatabase::handleDelete):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAddAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::getRecord):
(WebCore::IDBServer::UniqueIDBDatabase::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabase::getCount):
(WebCore::IDBServer::UniqueIDBDatabase::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabase::openCursor):
(WebCore::IDBServer::UniqueIDBDatabase::iterateCursor):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::clearObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getCount):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::openCursor):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::iterateCursor):
* Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.cpp: Added.
(WebCore::IDBOpenRequestData::IDBOpenRequestData):
(WebCore::m_requestType):
(WebCore::IDBOpenRequestData::isolatedCopy const):
* Source/WebCore/Modules/indexeddb/shared/IDBOpenRequestData.h: Added.
(WebCore::IDBOpenRequestData::serverConnectionIdentifier const):
(WebCore::IDBOpenRequestData::requestIdentifier const):
(WebCore::IDBOpenRequestData::databaseIdentifier const):
(WebCore::IDBOpenRequestData::requestedVersion const):
(WebCore::IDBOpenRequestData::isOpenRequest const):
(WebCore::IDBOpenRequestData::isDeleteRequest const):
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp:
(WebCore::IDBRequestData::IDBRequestData):
(WebCore::IDBRequestData::isolatedCopy):
(WebCore::IDBRequestData::transactionIdentifier const):
(WebCore::m_requestType): Deleted.
(WebCore::IDBRequestData::databaseIdentifier const): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h:
(WebCore::IDBRequestData::isOpenRequest const): Deleted.
(WebCore::IDBRequestData::isDeleteRequest const): Deleted.
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp:
(WebKit::IDBStorageManager::openDatabase):
(WebKit::IDBStorageManager::deleteDatabase):
(WebKit::IDBStorageManager::openDBRequestCancelled):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::openDatabase):
(WebKit::NetworkStorageManager::openDBRequestCancelled):
(WebKit::NetworkStorageManager::deleteDatabase):
(WebKit::NetworkStorageManager::idbTransaction):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp:
(WebKit::WebIDBConnectionToServer::deleteDatabase):
(WebKit::WebIDBConnectionToServer::openDatabase):
(WebKit::WebIDBConnectionToServer::openDBRequestCancelled):
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h:
* Source/WebKitLegacy/Storage/InProcessIDBServer.cpp:
(InProcessIDBServer::deleteDatabase):
(InProcessIDBServer::openDatabase):
(InProcessIDBServer::openDBRequestCancelled):
* Source/WebKitLegacy/Storage/InProcessIDBServer.h:

Canonical link: <a href="https://commits.webkit.org/275368@main">https://commits.webkit.org/275368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec86a26b4465004fc31698a8a98d1f984491088b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18016 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15102 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45625 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37222 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39387 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18106 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9332 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18162 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->