### PR TITLE
Web Inspector: Cannot see some of scope bars when scaling window to the left

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,19 +26,35 @@
 
 .content-view-container > .content-view.audit-test-group > header {
     background-color: var(--background-color-content);
+    overflow-x: hidden;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
 .content-view.audit-test-group > section > .audit-test-group > header {
     margin-top: -1px;
     border-top: 1px solid var(--border-color);
+    display: flex;
+    overflow-x: visible;
+    justify-content: end;
 }
 
 .content-view.audit-test-group > header {
     padding-inline-end: var(--audit-test-horizontal-space);
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    overflow-x: hidden;
+    justify-content: end;
 }
 
 .content-view.audit-test-group.no-matches + .audit-test-group > header {
     border-top: none;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: end;
+    overflow-x: hidden;
 }
 
 .content-view.audit-test-group > header,
@@ -73,14 +90,14 @@
 }
 
 .content-view.audit-test-group > header > nav {
-    display: inline-flex;
-    height: auto;
+    display: flex;
+    justify-content: flex-end;
     border-bottom: none;
-    overflow: visible;
 }
 
 .content-view.audit-test-group > header > nav > .scope-bar {
-    overflow: visible;
+    display: flex;
+    text-wrap: normal;
 }
 
 .content-view.audit-test-group > header > nav:empty {
@@ -88,7 +105,10 @@
 }
 
 .content-view.audit-test-group > header > nav > .scope-bar > li {
+    break-inside: avoid-column;
+    display: inline-block;
     margin: 0 3px;
+    white-space: nowrap;
 }
 
 .content-view.audit-test-group > header > nav > .scope-bar > li:not(:hover, .selected) {

--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +26,8 @@
 
 .scope-bar {
     padding: 0 3px;
+    overflow-x: visible;
+    position: relative;
 
     --scope-bar-margin-default: 2px;
     --scope-bar-padding-default: 6px;
@@ -44,6 +47,8 @@
     line-height: 11px;
     color: var(--scope-bar-text-color);
     text-align: center;
+    overflow-x: visible;
+    margin-left: 0;
 
     --scope-bar-margin: var(--scope-bar-margin-override, var(--scope-bar-margin-default));
     --scope-bar-padding: var(--scope-bar-padding-override, var(--scope-bar-padding-default));
@@ -65,6 +70,7 @@
     border: 1px solid var(--scope-bar-border-color);
     border-radius: 3px;
     opacity: var(--scope-bar-background-opacity);
+    margin-left: 0;
 }
 
 .scope-bar > li:focus {
@@ -86,7 +92,7 @@
 }
 
 .scope-bar > li.multiple {
-    position: relative;
+    position: absolute;
 }
 
 .scope-bar > li.multiple > select {

--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -128,7 +129,7 @@ body.window-inactive .tab-bar > .navigation-bar > .item.divider {
     padding: 0 8px;
 
     height: var(--tab-bar-item-height);
-    overflow: hidden;
+    overflow: visible;
 
     line-height: 15px;
     outline: none;
@@ -289,7 +290,7 @@ body.window-inactive .tab-bar > .tabs > .item > .name {
 .tab-bar > .tabs > .item > .name > .content {
     min-width: 0;
     width: 100%;
-    overflow: hidden;
+    overflow: visible;
     text-overflow: ellipsis;
     white-space: nowrap;
 }


### PR DESCRIPTION
#### 84a1cd2617f119de6db49fc33dfbc06d001e0ef0
<pre>
Web Inspector: Cannot see some of scope bars when scaling window to the left
<a href="https://bugs.webkit.org/show_bug.cgi?id=270125">https://bugs.webkit.org/show_bug.cgi?id=270125</a>

Reviewed by NOBODY (OOPS!).

The goal of the pr is to be able to see side by side the audit tab and the webpage
(especially when detached) and fix the overflow when decreasing the window size left
or right.

I added display: flex, flex-wrap: wrap, justify-content: flex-end, overflow-x: visible,
overflow-x: hidden, flex-direction: row, and break-inside: avoid-column,
to nav items inside headers for the scope bars, scope bar lists, and tab bar items.

* Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css:
(.content-view-container &gt; .content-view.audit-test-group &gt; header):
(.content-view.audit-test-group &gt; section &gt; .audit-test-group &gt; header):
(.content-view.audit-test-group &gt; header):
(.content-view.audit-test-group.no-matches + .audit-test-group &gt; header):
(.content-view.audit-test-group &gt; header &gt; nav):
(.content-view.audit-test-group &gt; header &gt; nav &gt; .scope-bar):
(.content-view.audit-test-group &gt; header &gt; nav &gt; .scope-bar &gt; li):
(@media (max-width: 700px) .content-view.audit-test-group &gt; header &gt; nav &gt; .scope-bar):
* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(.scope-bar):
(.scope-bar &gt; li):
(.scope-bar &gt; li::after):
(.scope-bar &gt; li.multiple):
* Source/WebInspectorUI/UserInterface/Views/TabBar.css:
(.tab-bar &gt; .tabs &gt; .item):
(.tab-bar &gt; .tabs &gt; .item &gt; .name &gt; .content):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84a1cd2617f119de6db49fc33dfbc06d001e0ef0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49623 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42989 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38231 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19541 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41579 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4987 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51496 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45526 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23242 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44509 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->