### PR TITLE
Close extension popup web views when the web content process terminates or window.close is called

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -142,7 +142,7 @@ using namespace WebKit;
     if (!_webExtensionAction)
         return;
 
-    _webExtensionAction->popupDidClose();
+    _webExtensionAction->closePopupWebView();
 }
 
 - (void)webViewDidClose:(WKWebView *)webView
@@ -150,7 +150,7 @@ using namespace WebKit;
     if (!_webExtensionAction)
         return;
 
-    _webExtensionAction->popupDidClose();
+    _webExtensionAction->closePopupWebView();
 }
 
 @end
@@ -672,8 +672,16 @@ void WebExtensionAction::popupDidClose()
 void WebExtensionAction::closePopupWebView()
 {
     [m_popupWebView _close];
+
 #if PLATFORM(IOS_FAMILY)
     [m_popupViewController dismissViewControllerAnimated:YES completion:nil];
+#endif
+
+#if PLATFORM(MAC)
+    auto *window = m_popupWebView.get().window;
+    // FIXME: Instead of checking this window type, this should be handled more like iOS.
+    if ([window isKindOfClass:NSPanel.class])
+        [window close];
 #endif
 
     popupDidClose();


### PR DESCRIPTION
#### eeef2a286027af94c7d9117260bbb72142545569
<pre>
Close extension popup web views when the web content process terminates or window.close is called
<a href="https://bugs.webkit.org/show_bug.cgi?id=270130">https://bugs.webkit.org/show_bug.cgi?id=270130</a>
<a href="https://rdar.apple.com/123468009">rdar://123468009</a>

Reviewed by Timothy Hatcher.

On iOS, this will lead to the UIViewController being closed, which leads to a better experience for the client.

On Mac, if the web view lives in an NSPanel, WebKit will close the window that the web view is in.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionWebViewDelegate webViewWebContentProcessDidTerminate:]):
(-[_WKWebExtensionActionWebViewDelegate webViewDidClose:]):

Canonical link: <a href="https://commits.webkit.org/275360@main">https://commits.webkit.org/275360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/430c4431623eb71d79ad703d89189c74710337df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44222 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17997 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17581 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45600 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37202 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/40947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18087 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9325 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->