### PR TITLE
[git-webkit revert] Default should not upload a PR

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -59,7 +59,7 @@ class Revert(Command):
         )
         parser.add_argument(
             '--pr', '--no-pr',
-            default=True,
+            default=None,
             action=arguments.NoAction,
             help='Create a pull request (or do not) after reverting'
         )
@@ -291,7 +291,15 @@ class Revert(Command):
         if cls.relate_issues(args, repository, issue, commit_issues, revert_reason):
             return 1
 
-        if args.safe is not None and args.pr:
+        if args.safe is not None:
+            if args.pr is False:
+                response = Terminal.choose(
+                    '--no-pr is set. Do you want to create a PR and land the revert?', options=('Yes', 'No'), default='No',
+                )
+                if response == 'No':
+                    return 0
+                if response == 'Yes':
+                    log.info('Creating PR...')
             return Land.main(args, repository, identifier_template=None, canonical_svn=False, hooks=None)
 
         if args.pr:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -274,7 +274,7 @@ index 05e8751..0bf3c85 100644
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-v', '--pr'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -339,7 +339,7 @@ index 05e8751..0bf3c85 100644
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--pr'),
                 path=self.path,
             )
             self.assertEqual(0, result)


### PR DESCRIPTION
#### 1decf3d3beafe159c5cfcaa6e0005bcd36bf8ece
<pre>
[git-webkit revert] Default should not upload a PR
<a href="https://bugs.webkit.org/show_bug.cgi?id=270129">https://bugs.webkit.org/show_bug.cgi?id=270129</a>
<a href="https://rdar.apple.com/problem/123655661">rdar://problem/123655661</a>

Reviewed by Jonathan Bedard.

Sets PR argument default to False.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.parser):
(Revert.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(test_update):
(test_pr):

Canonical link: <a href="https://commits.webkit.org/275397@main">https://commits.webkit.org/275397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9083a5b7710b8b2231200496e91b19dce351d933

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35956 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/41626 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45722 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37301 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39493 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41802 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18246 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5586 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->