### PR TITLE
REGRESSION (macOS 14): Native text fields are invisible in dark mode

### DIFF
--- a/LayoutTests/fast/forms/textfield-dark-color-scheme-expected-mismatch.html
+++ b/LayoutTests/fast/forms/textfield-dark-color-scheme-expected-mismatch.html
@@ -1,0 +1,8 @@
+<style>
+
+:root {
+    color-scheme: dark;
+}
+
+</style>
+<body></body>

--- a/LayoutTests/fast/forms/textfield-dark-color-scheme.html
+++ b/LayoutTests/fast/forms/textfield-dark-color-scheme.html
@@ -1,0 +1,8 @@
+<style>
+
+:root {
+    color-scheme: dark;
+}
+
+</style>
+<input>

--- a/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
@@ -151,7 +151,7 @@ static NSRect _clipBounds;
 {
     // Dark mode controls don't have borders, just a semi-transparent background of shadows.
     // In the dark mode case we can't disable borders, or we will not paint anything for the control.
-    NSAppearanceName appearance = [self.controlView.effectiveAppearance bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
+    NSAppearanceName appearance = [[NSAppearance currentDrawingAppearance] bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
     if ([appearance isEqualToString:NSAppearanceNameDarkAqua])
         return defaultOptions;
 


### PR DESCRIPTION
#### 1f547d4ed1880f4eed134ba8bf5bbcae0e58bb33
<pre>
REGRESSION (macOS 14): Native text fields are invisible in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=270134">https://bugs.webkit.org/show_bug.cgi?id=270134</a>
<a href="https://rdar.apple.com/123658326">rdar://123658326</a>

Reviewed by Richard Robinson.

201985@main added logic to ensure that text fields are displayed correctly in
dark mode, as they do not support &quot;border only&quot; painting. The detection of
dark mode was performed by checking the appearance of the cell&apos;s control view.

However, with the introduction of GPU process for DOM rendering on macOS, cells
no longer have control views. Consequently, the appearance check always fails,
and the light mode border treatment, which results in an invisible control in
dark mode, is used.

Fix by comparing against `-[NSAppearance currentDrawingAppearance]` rather than
assuming there is a control view. This is correct, as the drawing appearance is
always set (using `LocalDefaultSystemAppearance`) prior to drawing the control.

* LayoutTests/fast/forms/textfield-dark-color-scheme-expected-mismatch.html: Added.
* LayoutTests/fast/forms/textfield-dark-color-scheme.html: Added.
* Source/WebCore/platform/graphics/mac/controls/WebControlView.mm:
(-[WebControlTextFieldCell _adjustedCoreUIDrawOptionsForDrawingBordersOnly:]):

Canonical link: <a href="https://commits.webkit.org/275363@main">https://commits.webkit.org/275363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c12678ca10b1a08c47f0778bc47fb92cc56ce450

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17985 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15076 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45608 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40955 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13505 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36146 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18131 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5571 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->