### PR TITLE
[iOS] http/tests/IndexedDB/collect-IDB-objects.https.html is flaky

### DIFF
--- a/LayoutTests/http/tests/IndexedDB/collect-IDB-objects.https.html
+++ b/LayoutTests/http/tests/IndexedDB/collect-IDB-objects.https.html
@@ -39,8 +39,7 @@ var promise = new Promise((resolve, reject) => {
                 nukeArray(frames);
                 frames = null;
                 return frameIdentifiers;
-            }
-        );
+            }, { gcCount:100, documentCount:50 });
         resolve(promise);
     };
 });


### PR DESCRIPTION
#### f98f5f2c1804c13633a127c3b9ca191d3754ed3d
<pre>
[iOS] http/tests/IndexedDB/collect-IDB-objects.https.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=270143">https://bugs.webkit.org/show_bug.cgi?id=270143</a>
<a href="https://rdar.apple.com/116426402">rdar://116426402</a>

Reviewed by Youenn Fablet.

The test flakily fails on bots with guard malloc enabled, so this patch adds more frames and invokes gc more times in
the test in order to increase the chance of frame being garbage collected, according to 224541@main.

* LayoutTests/http/tests/IndexedDB/collect-IDB-objects.https.html:

Canonical link: <a href="https://commits.webkit.org/275449@main">https://commits.webkit.org/275449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e7d249500c6cfb9be33e3797153cac8ea89599

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37765 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34431 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45623 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37218 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40965 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39383 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36178 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9384 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->