### PR TITLE
Get rid of downcast<>() in Element::insertAdjacentElement()

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5291,7 +5291,7 @@ ExceptionOr<Element*> Element::insertAdjacentElement(const String& where, Elemen
     auto result = insertAdjacent(where, newChild);
     if (result.hasException())
         return result.releaseException();
-    return downcast<Element>(result.releaseReturnValue());
+    return &newChild;
 }
 
 // Step 1 of https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml.


### PR DESCRIPTION
#### 28a166a552c21ed82fdf937fbb219f381665c63c
<pre>
Get rid of downcast&lt;&gt;() in Element::insertAdjacentElement()
<a href="https://bugs.webkit.org/show_bug.cgi?id=270145">https://bugs.webkit.org/show_bug.cgi?id=270145</a>

Reviewed by NOBODY (OOPS!).

Get rid of downcast&lt;&gt;() in Element::insertAdjacentElement() for performance
reasons.

* Source/WebCore/dom/Element.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28a166a552c21ed82fdf937fbb219f381665c63c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18017 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34479 "Found 3 new test failures: fast/dynamic/insertAdjacentElement.html, imported/w3c/web-platform-tests/dom/nodes/insert-adjacent.html, media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42247 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17644 "Found 1 new test failure: fast/dynamic/insertAdjacentElement.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15150 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15337 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/nodes/insert-adjacent.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36899 "Found 2 new test failures: fast/dynamic/insertAdjacentElement.html, imported/w3c/web-platform-tests/dom/nodes/insert-adjacent.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37888 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37219 "Found 2 new test failures: fast/dynamic/insertAdjacentElement.html, imported/w3c/web-platform-tests/dom/nodes/insert-adjacent.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40967 "Found 2 new test failures: fast/dynamic/insertAdjacentElement.html, imported/w3c/web-platform-tests/dom/nodes/insert-adjacent.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16488 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13530 "Found 2 new test failures: fast/dynamic/insertAdjacentElement.html, imported/w3c/web-platform-tests/dom/nodes/insert-adjacent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39385 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18107 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->