### PR TITLE
Add NSPopover to _WKWebExtensionAction.

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -73,6 +73,10 @@ typedef NS_OPTIONS(NSUInteger, NSWindowShadowOptions) {
 
 #endif
 
+@interface NSPopover (IPI)
+@property (readonly) NSView *positioningView;
+@end
+
 @interface NSWorkspace (NSWorkspaceAccessibilityDisplayInternal_IPI)
 + (void)_invalidateAccessibilityDisplayValues;
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
@@ -38,6 +38,7 @@
 #else
 @class NSImage;
 @class NSMenuItem;
+@class NSPopover;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -45,14 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @abstract This notification is sent whenever a @link WKWebExtensionAction has changed properties. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionActionPropertiesDidChangeNotification NS_SWIFT_NAME(_WKWebExtensionAction.propertiesDidChangeNotification);
-
-/*! @abstract This notification is sent when the `intrinsicContentSize` of the popup web view associated with a @link WKWebExtensionAction changes. */
-WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
-WK_EXTERN NSNotificationName const _WKWebExtensionActionPopupWebViewContentSizeDidChangeNotification NS_SWIFT_NAME(_WKWebExtensionAction.popupWebViewContentSizeDidChangeNotification);
-
-/*! @abstract This notification is sent when the popup web view associated with a @link WKWebExtensionAction is closed. */
-WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
-WK_EXTERN NSNotificationName const _WKWebExtensionActionPopupWebViewDidCloseNotification NS_SWIFT_NAME(_WKWebExtensionAction.popupWebViewDidCloseNotification);
 
 /*!
  @abstract A `WKWebExtensionAction` object encapsulates the properties for an individual web extension action.
@@ -122,8 +115,7 @@ NS_SWIFT_NAME(_WKWebExtension.Action)
 
 /*!
  @abstract A Boolean value indicating whether the action has a popup.
- @discussion Use this property to check if the action has a popup before attempting to access the `popupWebView` property.
- @seealso popupWebView
+ @discussion Use this property to check if the action has a popup before attempting to show any popup views.
  */
 @property (nonatomic, readonly) BOOL presentsPopup;
 
@@ -132,26 +124,39 @@ NS_SWIFT_NAME(_WKWebExtension.Action)
  @abstract A view controller that presents a web view loaded with the popup page for this action, or `nil` if no popup is specified.
  @discussion The view controller adaptively adjusts its presentation style based on where it is presented from, preferring popover.
  It contains a web view preloaded with the popup page and automatically adjusts tis `preferredContentSize` to fit the web view's
- content size. The `presentsPopup` property should be checked to determine the availability of a popup before accessing this property.
- Dismissing the view controller will close the web view.
+ content size. The `presentsPopup` property should be checked to determine the availability of a popup before using this property.
+ Dismissing the view controller will close the popup and unload the web view.
  @seealso presentsPopup
  */
 @property (nonatomic, readonly, nullable) UIViewController *popupViewController;
 #endif
 
+#if TARGET_OS_OSX
+/*!
+ @abstract A popover that presents a web view loaded with the popup page for this action, or `nil` if no popup is specified.
+ @discussion This popover contains a view controller with a web view preloaded with the popup page. It automatically adjusts its size to fit
+ the web view's content size. The `presentsPopup` property should be checked to determine the availability of a popup before using this
+ property.  Dismissing the popover will close the popup and unload the web view.
+ @seealso presentsPopup
+ */
+@property (nonatomic, readonly, nullable) NSPopover *popupPopover;
+#endif
+
 /*!
  @abstract A web view loaded with the popup page for this action, or `nil` if no popup is specified.
- @discussion The web view will be preloaded with the popup page upon first access or after it has been closed. Use the `presentsPopup`
- property to determine whether a popup should be displayed before accessing this property.
+ @discussion The web view will be preloaded with the popup page upon first access or after it has been unloaded. Use the `presentsPopup`
+ property to determine whether a popup should be displayed before using this property.
  @seealso presentsPopup
  */
 @property (nonatomic, readonly, nullable) WKWebView *popupWebView;
 
 /*!
- @abstract Should be called by the app to close the popup's web view.
- @discussion This method should be called when the popup web view is no longer presented to the user, indicating that it can safely be closed.
+ @abstract Triggers the dismissal process of the popup.
+ @discussion Invoke this method to manage the popup's lifecycle, ensuring the web view is unloaded and resources are released once the
+ popup closes. This method is automatically called upon the dismissal of the action's `UIViewController` or `NSPopover`.  For custom
+ scenarios where the popup's lifecycle is manually managed, it must be explicitly invoked to ensure proper closure.
  */
-- (void)closePopupWebView;
+- (void)closePopup;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
@@ -38,8 +38,6 @@
 #import <wtf/CompletionHandler.h>
 
 NSNotificationName const _WKWebExtensionActionPropertiesDidChangeNotification = @"_WKWebExtensionActionPropertiesDidChange";
-NSNotificationName const _WKWebExtensionActionPopupWebViewContentSizeDidChangeNotification = @"_WKWebExtensionActionPopupWebViewContentSizeDidChange";
-NSNotificationName const _WKWebExtensionActionPopupWebViewDidCloseNotification = @"_WKWebExtensionActionPopupWebViewDidClose";
 
 #if USE(APPKIT)
 using CocoaMenuItem = NSMenuItem;
@@ -126,14 +124,21 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionAction, WebExtensionAction,
 }
 #endif
 
+#if PLATFORM(MAC)
+- (NSPopover *)popupPopover
+{
+    return _webExtensionAction->popupPopover();
+}
+#endif
+
 - (WKWebView *)popupWebView
 {
     return _webExtensionAction->popupWebView();
 }
 
-- (void)closePopupWebView
+- (void)closePopup
 {
-    _webExtensionAction->closePopupWebView();
+    _webExtensionAction->closePopup();
 }
 
 #pragma mark WKObject protocol implementation
@@ -206,12 +211,19 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionAction, WebExtensionAction,
 }
 #endif
 
+#if PLATFORM(MAC)
+- (NSPopover *)popupPopover
+{
+    return nil;
+}
+#endif
+
 - (WKWebView *)popupWebView
 {
     return nil;
 }
 
-- (void)closePopupWebView
+- (void)closePopup
 {
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -45,6 +45,11 @@ OBJC_CLASS UIViewController;
 OBJC_CLASS _WKWebExtensionActionViewController;
 #endif
 
+#if PLATFORM(MAC)
+OBJC_CLASS NSPopover;
+OBJC_CLASS _WKWebExtensionActionPopover;
+#endif
+
 namespace WebKit {
 
 class WebExtensionContext;
@@ -67,6 +72,10 @@ public:
 
     enum class LoadOnFirstAccess { No, Yes };
     enum class FallbackWhenEmpty { No, Yes };
+
+#if PLATFORM(MAC)
+    enum class Appearance : uint8_t { Default, Light, Dark, Both };
+#endif
 
     bool operator==(const WebExtensionAction&) const;
 
@@ -106,12 +115,18 @@ public:
     UIViewController *popupViewController();
 #endif
 
+#if PLATFORM(MAC)
+    NSPopover *popupPopover();
+
+    Appearance popupPopoverAppearance() const { return m_popoverAppearance; }
+    void setPopupPopoverAppearance(Appearance);
+#endif
+
     WKWebView *popupWebView(LoadOnFirstAccess = LoadOnFirstAccess::Yes);
     void presentPopupWhenReady();
     void readyToPresentPopup();
     void popupSizeDidChange();
-    void popupDidClose();
-    void closePopupWebView();
+    void closePopup();
 
     NSArray *platformMenuItems() const;
 
@@ -122,12 +137,21 @@ public:
 private:
     WebExtensionAction* fallbackAction() const;
 
+#if PLATFORM(MAC)
+    void detectPopoverColorScheme();
+#endif
+
     WeakPtr<WebExtensionContext> m_extensionContext;
     RefPtr<WebExtensionTab> m_tab;
     RefPtr<WebExtensionWindow> m_window;
 
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<_WKWebExtensionActionViewController> m_popupViewController;
+#endif
+
+#if PLATFORM(MAC)
+    RetainPtr<_WKWebExtensionActionPopover> m_popupPopover;
+    Appearance m_popoverAppearance { Appearance::Default };
 #endif
 
     RetainPtr<_WKWebExtensionActionWebView> m_popupWebView;

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -4206,6 +4206,7 @@ def check_identifier_name_in_declaration(filename, line_number, line, file_state
                 and not modified_identifier == "WTF_GUARDED_BY_LOCK"
                 and not modified_identifier == "WTF_GUARDED_BY_CAPABILITY"
                 and not modified_identifier.startswith("_AX")
+                and not modified_identifier.startswith("_WK")
                 and not modified_identifier.find('chrono_literals') >= 0):
                 error(line_number, 'readability/naming/underscores', 4, identifier + " is incorrectly named. Don't use underscores in your identifier names.")
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -171,6 +171,10 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
         EXPECT_NOT_NULL(action.popupViewController);
 #endif
 
+#if PLATFORM(MAC)
+        EXPECT_NOT_NULL(action.popupPopover);
+#endif
+
         EXPECT_NOT_NULL(action.popupWebView);
         EXPECT_FALSE(action.popupWebView.loading);
 
@@ -178,7 +182,7 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
         EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
         EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
 
-        [action closePopupWebView];
+        [action closePopup];
 
         [manager done];
     };
@@ -343,7 +347,7 @@ TEST(WKWebExtensionAPIAction, SetDefaultActionProperties)
         EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
         EXPECT_NS_EQUAL(webViewURL.path, @"/alt-popup.html");
 
-        [action closePopupWebView];
+        [action closePopup];
 
         [manager done];
     };
@@ -457,9 +461,9 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
         EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
         EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
 
-        [secondTabAction closePopupWebView];
-        [secondWindowAction closePopupWebView];
-        [action closePopupWebView];
+        [secondTabAction closePopup];
+        [secondWindowAction closePopup];
+        [action closePopup];
 
         [manager done];
     };
@@ -551,8 +555,8 @@ TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
         EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
         EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
 
-        [secondWindowAction closePopupWebView];
-        [action closePopupWebView];
+        [secondWindowAction closePopup];
+        [action closePopup];
 
         [manager done];
     };
@@ -877,6 +881,10 @@ TEST(WKWebExtensionAPIAction, BrowserAction)
         EXPECT_NOT_NULL(action.popupViewController);
 #endif
 
+#if PLATFORM(MAC)
+        EXPECT_NOT_NULL(action.popupPopover);
+#endif
+
         EXPECT_NOT_NULL(action.popupWebView);
         EXPECT_FALSE(action.popupWebView.loading);
 
@@ -884,7 +892,7 @@ TEST(WKWebExtensionAPIAction, BrowserAction)
         EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
         EXPECT_NS_EQUAL(webViewURL.path, @"/alt-popup.html");
 
-        [action closePopupWebView];
+        [action closePopup];
 
         [manager done];
     };
@@ -967,6 +975,10 @@ TEST(WKWebExtensionAPIAction, PageAction)
         EXPECT_NOT_NULL(action.popupViewController);
 #endif
 
+#if PLATFORM(MAC)
+        EXPECT_NOT_NULL(action.popupPopover);
+#endif
+
         EXPECT_NOT_NULL(action.popupWebView);
         EXPECT_FALSE(action.popupWebView.loading);
 
@@ -974,7 +986,7 @@ TEST(WKWebExtensionAPIAction, PageAction)
         EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
         EXPECT_NS_EQUAL(webViewURL.path, @"/alt-popup.html");
 
-        [action closePopupWebView];
+        [action closePopup];
 
         [manager done];
     };


### PR DESCRIPTION
#### 75b646bd8fd82fcc3457d7c99efb23206a3617ca
<pre>
Add NSPopover to _WKWebExtensionAction.
<a href="https://webkit.org/b/270126">https://webkit.org/b/270126</a>
<a href="https://rdar.apple.com/problem/123655122">rdar://problem/123655122</a>

Reviewed by Jeff Miller.

Also remove the ContentSizeDidChange and DidClose notifications, since those things
and handled internally now with the UIViewController and NSPopover paths.

Rename closePopupWebView to closePopup to also better align with the new approach.

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm:
(-[_WKWebExtensionAction popupPopover]):
(-[_WKWebExtensionAction closePopup]):
(-[_WKWebExtensionAction closePopupWebView]): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionWebViewDelegate webViewWebContentProcessDidTerminate:]):
(-[_WKWebExtensionActionWebViewDelegate webViewDidClose:]):
(-[_WKWebExtensionActionViewController _viewControllerDismissalTransitionDidEnd:]):
(-[_WKWebExtensionActionPopover initWithWebExtensionAction:]):
(-[_WKWebExtensionActionPopover dealloc]):
(-[_WKWebExtensionActionPopover popoverWillClose:]):
(-[_WKWebExtensionActionPopover popoverDidClose:]):
(-[_WKWebExtensionActionPopover _otherPopoverWillShow:]):
(WebKit::WebExtensionAction::clearCustomizations):
(WebKit::WebExtensionAction::setPopupPath):
(WebKit::WebExtensionAction::popupPopover):
(WebKit::WebExtensionAction::setPopupPopoverAppearance):
(WebKit::WebExtensionAction::detectPopoverColorScheme):
(WebKit::WebExtensionAction::popupWebView):
(WebKit::WebExtensionAction::readyToPresentPopup):
(WebKit::WebExtensionAction::popupSizeDidChange):
(WebKit::WebExtensionAction::closePopup):
(WebKit::WebExtensionAction::popupDidClose): Deleted.
(WebKit::WebExtensionAction::closePopupWebView): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
(WebKit::WebExtensionAction::popupPopoverAppearance const):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_identifier_name_in_declaration): Make an exception for _WK prefixed classes.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/275391@main">https://commits.webkit.org/275391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99cae319720446567af3d9d68c372783caa82d2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37829 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44043 "Failed to checkout and rebase branch from PR 25155") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18081 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42310 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/41607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45701 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5582 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->