### PR TITLE
REGRESSION (275173@main): [ MacOS wk2 Debug] webrtc/h265.html is a constant timeout

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2009,5 +2009,3 @@ webkit.org/b/269996 [ Monterey+ Debug ] imported/w3c/web-platform-tests/css/css-
 [ Sonoma+ ] compositing/plugins/pdf/pdf-in-styled-embed.html [ Failure ]
 [ Sonoma+ ] compositing/plugins/pdf/pdf-scrolling-tree-dynamic.html [ Failure ]
 [ Sonoma+ ] compositing/plugins/pdf/pdf-scrolling-tree.html [ Failure ]
-
-webkit.org/b/270096 [ Monterey+ Debug ] webrtc/h265.html [ Timeout ]

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_vps_parser.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_vps_parser.h
@@ -19,12 +19,20 @@ namespace webrtc {
 // A class for parsing out video parameter set (VPS) data from an H265 NALU.
 class H265VpsParser {
  public:
+#if WEBRTC_WEBKIT_BUILD
+    static constexpr uint32_t kMaxSubLayers = 7;
+#endif
+
   // The parsed state of the VPS. Only some select values are stored.
   // Add more as they are actually needed.
   struct VpsState {
     VpsState();
 
     uint32_t id = 0;
+#if WEBRTC_WEBKIT_BUILD
+    uint32_t vps_max_sub_layers_minus1 = 0;
+    uint32_t vps_max_num_reorder_pics[kMaxSubLayers] = {};
+#endif
   };
 
   // Unpack RBSP and parse VPS state from the supplied buffer.


### PR DESCRIPTION
#### cd09e2f7f97f13339f4e61c291d60308a42990e4
<pre>
REGRESSION (275173@main): [ MacOS wk2 Debug] webrtc/h265.html is a constant timeout
<a href="https://rdar.apple.com/123637394">rdar://123637394</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270096">https://bugs.webkit.org/show_bug.cgi?id=270096</a>

Reviewed by Eric Carlson.

We were using the SPS sps_max_num_reorder_pics to compute the reorder window size.
But it appears from testing and from Chrome source code that we should instead use the VPS vps_max_num_reorder_pics.
We should probably get the VPS from PPS -&gt; SPS -&gt; VPS chain but for now, we use the first VPS available.

We add VPS parsing up to vps_max_num_reorder_pics.
We make use of it for computing the reorder window size for both HVCC and AnnexB cases.

Covered by LayoutTests/webrtc/h265.html and LayoutTests/http/tests/webcodecs/ HEVC tests.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_vps_parser.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_vps_parser.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm:
(vpsDataFromHvcc):
(ComputeH265ReorderSizeFromVPS):
(ComputeH265ReorderSizeFromHVCC):
(ComputeH265ReorderSizeFromAnnexB):
(spsDataFromHvcc): Deleted.
(ComputeH265ReorderSizeFromSPS): Deleted.

Canonical link: <a href="https://commits.webkit.org/275434@main">https://commits.webkit.org/275434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de8e2013d98a322a83b33925548d957e496ed30e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34493 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41033 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16547 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13585 "Found 1 new test failure: ipc/message-listener-async-message-reply-id.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39468 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18166 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9372 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->