### PR TITLE
Log attachment editing operations

### DIFF
--- a/Source/WTF/wtf/StackTrace.h
+++ b/Source/WTF/wtf/StackTrace.h
@@ -68,6 +68,8 @@ public:
     }
 
     void dump(PrintStream&) const;
+    template<typename Functor> // void Functor(int frameNumber, void* stackFrame, const char* name)
+    void forEachFrame(Functor) const;
     WTF_EXPORT_PRIVATE String toString() const;
 
 private:
@@ -182,6 +184,12 @@ private:
 inline void StackTrace::dump(PrintStream& out) const
 {
     StackTracePrinter { *this }.dump(out);
+}
+
+template<typename Functor>
+void StackTrace::forEachFrame(Functor functor) const
+{
+    StackTraceSymbolResolver { *this }.forEach(functor);
 }
 
 } // namespace WTF


### PR DESCRIPTION
#### f069b9d3124d91b6e537be45ea349b79388895f5
<pre>
Log attachment editing operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=270152">https://bugs.webkit.org/show_bug.cgi?id=270152</a>
<a href="https://rdar.apple.com/121088022">rdar://121088022</a>

Reviewed by Wenson Hsieh and Aditya Keerthi.

This is for Mail to know when and why an attachment was quickly inserted, removed,
then another attachment was inserted, all soon after the document creation; this
seems to correlate with unexpected behavior where an attachment cannot be inserted
in an email reply.

When this quick sequence happens, compact stacks are logged for each event, in the
&quot;Editing&quot; category. Example:
```
HTMLAttachmentElement - quick insert(A)-remove(A)-insert(B) within 0.074342s of the first document[0x116122400] load, stacks below:
HTMLAttachmentElement[0x117006530 uuid=47a8d676-657f-4510-a8f3-5cb9723b0947] - 1st insertion 108.248833ms ago: [stack]
HTMLAttachmentElement[0x117006530 uuid=47a8d676-657f-4510-a8f3-5cb9723b0947] - removal 4.043792ms ago: [stack]
HTMLAttachmentElement[0x11700ba30 uuid=47a8d676-657f-4510-a8f3-5cb9723b0947] - 2nd insertion: [stack]
```

* Source/WTF/wtf/StackTrace.h:
(WTF::StackTrace::forEachFrame const):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::compactStackTrace):
(WebCore::AttachmentEvent::attachment const):
(WebCore::AttachmentEvent::document const):
(WebCore::AttachmentEvent::uniqueIdentifier const):
(WebCore::AttachmentEvent::time const):
(WebCore::AttachmentEvent::stackTrace const):
(WebCore::AttachmentEvent::capture):
(WebCore::AttachmentEvent::reset):
(WebCore::AttachmentEvent::operator bool const):
(WebCore::lastInsertionInDocument):
(WebCore::lastRemovalFromDocument):
(WebCore::shouldMonitorDocumentTraffic):
(WebCore::HTMLAttachmentElement::insertedIntoAncestor):
(WebCore::HTMLAttachmentElement::removedFromAncestor):

Canonical link: <a href="https://commits.webkit.org/278245@main">https://commits.webkit.org/278245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3128dfc7ad14f98291114b94a61b768e419c08b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/517 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40663 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51938 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26703 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 15 new passes 9 flakes 2 failures; Uploaded test results; 16 new passes 7 flakes 3 failures; Running compile-webkit-without-change") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42891 "Found 64 new API test failures: TestWebKitAPI.WebKit.InterruptionBetweenGetDisplayMediaAndGetUserMedia, TestWebKitAPI.WebKit2.MultipleGetUserMediaSynchronously, TestWebKitAPI.FullscreenVideoTextRecognition.DoNotAnalyzeVideoAfterExitingFullscreen, TestWebKitAPI.WebKit.AutoplayOnVisibilityChange, TestWebKitAPI.WebKit.GeolocationPermissionInIFrame, TestWebKitAPI.PDFHUD.NestedIFrames, TestWebKitAPI.PictureInPicture.WKUIDelegate, TestWebKitAPI.Fullscreen.Focus, TestWebKitAPI.WebKit.GetUserMediaFocus, TestWebKitAPI.PDFHUD.MultipleIFrames ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21788 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24136 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/78 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8210 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43162 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46156 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54664 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49334 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/83 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48050 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47081 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10957 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27052 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56818 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25919 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11674 "Passed tests") | 
<!--EWS-Status-Bubble-End-->