### PR TITLE
Inert attribute should make text not findable by find-in-page

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-and-find-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-and-find-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Basic test for inert and find assert_unreached: Error: assert_equals: Should be not findable: Basic use case, text: me, iter: 1 expected false but got true Reached unreachable code
+PASS Basic test for inert and find
 

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-003-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Inner nodes with 'inert' attribute become inert anyways assert_false: expected false got true
-FAIL If the modal dialog has the 'inert' attribute, everything becomes inert assert_false: expected false got true
-FAIL If an ancestor of the dialog has the 'inert' attribute, the dialog escapes inertness assert_false: expected false got true
+PASS Inner nodes with 'inert' attribute become inert anyways
+PASS If the modal dialog has the 'inert' attribute, everything becomes inert
+PASS If an ancestor of the dialog has the 'inert' attribute, the dialog escapes inertness
 find wrapper

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -524,6 +524,8 @@ void TextIterator::advance()
             if (!isRendererAccessible(renderer.get(), m_behaviors)) {
                 m_handledNode = true;
                 m_handledChildren = !hasDisplayContents(*m_currentNode) && !renderer;
+            } else if (m_behaviors.contains(TextIteratorBehavior::IgnoresInertNodes) && renderer->style().effectiveInert()) {
+                m_handledNode = true;
             } else {
                 if (isConsideredSkippedContent(dynamicDowncast<RenderBox>(renderer.get()), m_behaviors))
                     m_handledChildren = true;

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -322,7 +322,8 @@ constexpr TextIteratorBehaviors findIteratorOptions(FindOptions options = { })
         TextIteratorBehavior::EntersTextControls,
         TextIteratorBehavior::ClipsToFrameAncestors,
         TextIteratorBehavior::EntersImageOverlays,
-        TextIteratorBehavior::EntersSkippedContentRelevantToUser
+        TextIteratorBehavior::EntersSkippedContentRelevantToUser,
+        TextIteratorBehavior::IgnoresInertNodes
     };
     if (!options.contains(FindOption::DoNotTraverseFlatTree))
         iteratorOptions.add(TextIteratorBehavior::TraversesFlatTree);

--- a/Source/WebCore/editing/TextIteratorBehavior.h
+++ b/Source/WebCore/editing/TextIteratorBehavior.h
@@ -80,7 +80,9 @@ enum class TextIteratorBehavior : uint32_t {
     // elements: <p> gets unconditional blank lines (not margin-dependent),
     // <h1>-<h6> do not get extra blank lines, and trailing block newlines are
     // stripped. Without this flag, the original margin-based heuristic is used.
-    EmitsNewlinesPerInnerTextSpec = 1 << 16
+    EmitsNewlinesPerInnerTextSpec = 1 << 16,
+
+    IgnoresInertNodes = 1 << 17,
 };
 
 using TextIteratorBehaviors = OptionSet<TextIteratorBehavior>;


### PR DESCRIPTION
#### 4ade1283453851f148bae117c4ee4a7d08c24bb2
<pre>
Inert attribute should make text not findable by find-in-page
<a href="https://bugs.webkit.org/show_bug.cgi?id=269909">https://bugs.webkit.org/show_bug.cgi?id=269909</a>

Reviewed by NOBODY (OOPS!).

This change makes WebKit conform to the HTML spec requirement at
<a href="https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees">https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees</a>,
which states that if a node is inert, “the user agent should ignore the
node for the purposes of find-in-page&quot;, and gets WebKit passing the WPT
test at <a href="https://wpt.fyi/results/inert/inert-and-find.html">https://wpt.fyi/results/inert/inert-and-find.html</a>

Otherwise, without this change, WebKit doesn’t conform to the “ignore
inert nodes for the purposes of find-in-page” spec requirement, and
doesn’t pass the WPT test which checks conformance to that requirement.

* LayoutTests/imported/w3c/web-platform-tests/inert/inert-and-find-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/inert/inert-and-find.html: Added.
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::advance):
* Source/WebCore/editing/TextIterator.h:
* Source/WebCore/editing/TextIteratorBehavior.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ade1283453851f148bae117c4ee4a7d08c24bb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126967 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89501 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28288 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26916 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174923 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135276 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135256 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146483 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99423 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23334 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36128 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109245 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 32423 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35625 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1355 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35773 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->