### PR TITLE
WebKit.GPU using an average of 57% CPU (2.0W estimated impact) for 2.1 hrs [+7%/hr]

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -758,6 +758,8 @@ void SourceBufferPrivateAVFObjC::flushIfNeeded()
     if (!requiresFlush())
         return;
 
+    ALWAYS_LOG(LOGIDENTIFIER);
+
 #if PLATFORM(IOS_FAMILY)
     m_displayLayerWasInterrupted = false;
 #endif
@@ -1193,6 +1195,9 @@ void SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples(TrackID trackID)
 
 void SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples(TrackID trackID)
 {
+    if (requiresFlush())
+        return;
+
     if (isEnabledVideoTrackID(trackID)) {
         if (m_decompressionSession) {
             m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, trackID] {


### PR DESCRIPTION
#### 7be7a65a49c17c990afe62c11528e99ef6ccfaf4
<pre>
WebKit.GPU using an average of 57% CPU (2.0W estimated impact) for 2.1 hrs [+7%/hr]
<a href="https://bugs.webkit.org/show_bug.cgi?id=270154">https://bugs.webkit.org/show_bug.cgi?id=270154</a>
<a href="https://rdar.apple.com/122916282">rdar://122916282</a>

Reviewed by Eric Carlson.

When the AVSampleBufferDisplaLayer notified the SourceBufferPrivateAVObjC that is was
ready for more data, we checked via SourceBufferPrivate::isReadyForMoreSamples().

If we had previously been interrupted with a layerRequiresFlushToResumeDecodingChanged
error, and until we flushed the renderer, isReadyForMoreSamples() would have returned false
and iwe would then immediately request the layer to notify us when ready again.
Prior 268283@main, requesting the AVSBDL to notify us if it was ready for more sample
was the right thing to do.
However, now that there&apos;s a flush pending, what it would do is make the AVSBDL call
us immediately. This caused the code to run in an unlimited loop.

We add a check if flushing is required and abort early if so.

The ability to reproduce the case and to simulate is not possible with the current
infrastructure. Problem was found through log analysis and code review only.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::flushIfNeeded): Add logging for when we are actually
flushing the SourceBuffer. Not having logging made the investigation difficult as we had log
that the AVSBDL required flushing, but no information about if we had log flushed or not
(which can happen in two cases: page became visible again, or play() was called)
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):

Canonical link: <a href="https://commits.webkit.org/275415@main">https://commits.webkit.org/275415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/157f33f51799e3cee2bf07b908616cc49f61f430

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18124 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15198 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45750 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/37971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37322 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39519 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18213 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9363 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->