### PR TITLE
[TextureMapper] Add GLContextWrapper to handle the current GL context

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2091,6 +2091,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/cv/ImageTransferSessionVT.h
 
     platform/graphics/egl/GLContext.h
+    platform/graphics/egl/GLContextWrapper.h
 
     platform/graphics/filters/DistantLightSource.h
     platform/graphics/filters/FEBlend.h

--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -38,6 +38,7 @@ list(APPEND WebCore_SOURCES
 
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextLibWPE.cpp
+    platform/graphics/egl/GLContextWrapper.cpp
 
     platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
 

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -55,6 +55,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/angle/PlatformDisplayANGLE.cpp
 
     platform/graphics/egl/GLContext.cpp
+    platform/graphics/egl/GLContextWrapper.cpp
 
     platform/graphics/opentype/OpenTypeUtilities.cpp
 

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -60,6 +60,7 @@ platform/graphics/PlatformDisplay.cpp @no-unify
 platform/graphics/angle/PlatformDisplayANGLE.cpp @no-unify
 
 platform/graphics/egl/GLContext.cpp @no-unify
+platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -61,6 +61,7 @@ platform/graphics/wpe/SystemFontDatabaseWPE.cpp
 
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
+platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp

--- a/Source/WebCore/platform/graphics/angle/PlatformDisplayANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/PlatformDisplayANGLE.cpp
@@ -114,7 +114,7 @@ void PlatformDisplay::clearANGLESharingGLContext()
 
     ASSERT(m_angleEGLDisplay);
     ASSERT(m_sharingGLContext);
-    GLContext::ScopedGLContextCurrent scopedCurrent(*m_sharingGLContext);
+    EGL_MakeCurrent(m_angleEGLDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     EGL_DestroyContext(m_angleEGLDisplay, m_angleSharingGLContext);
     m_angleSharingGLContext = EGL_NO_CONTEXT;
 }

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #if USE(EGL)
+#include "GLContextWrapper.h"
 #include "IntSize.h"
 #include "PlatformDisplay.h"
 #include <wtf/Noncopyable.h>
@@ -43,7 +44,7 @@ typedef void* EGLSurface;
 
 namespace WebCore {
 
-class GLContext {
+class GLContext final : public GLContextWrapper {
     WTF_MAKE_NONCOPYABLE(GLContext); WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT static std::unique_ptr<GLContext> create(GLNativeWindowType, PlatformDisplay&);
@@ -85,6 +86,7 @@ public:
         ~ScopedGLContext();
     private:
         struct {
+            GLContext* glContext { nullptr };
             EGLDisplay display { nullptr };
             EGLContext context { nullptr };
             EGLSurface readSurface { nullptr };
@@ -122,6 +124,11 @@ private:
 #endif
 
     static bool getEGLConfig(PlatformDisplay&, EGLConfig*, EGLSurfaceType);
+
+    // GLContextWrapper
+    GLContextWrapper::Type type() const override { return GLContextWrapper::Type::Native; }
+    bool makeCurrentImpl() override;
+    bool unmakeCurrentImpl() override;
 
     PlatformDisplay& m_display;
     unsigned m_version { 0 };

--- a/Source/WebCore/platform/graphics/egl/GLContextWrapper.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextWrapper.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+#include "GLContextWrapper.h"
+
+#if USE(EGL)
+#include "GLContext.h"
+#include "GraphicsContextGLTextureMapperANGLE.h"
+
+namespace WebCore {
+
+static thread_local constinit GLContextWrapper* s_currentContext = nullptr;
+
+GLContextWrapper::~GLContextWrapper()
+{
+    if (s_currentContext == this)
+        s_currentContext = nullptr;
+}
+
+bool GLContextWrapper::isCurrent() const
+{
+    return s_currentContext == this;
+}
+
+GLContextWrapper* GLContextWrapper::currentContext()
+{
+    return s_currentContext;
+}
+
+void GLContextWrapper::didMakeContextCurrent()
+{
+    s_currentContext = this;
+}
+
+void GLContextWrapper::didUnmakeContextCurrent()
+{
+    s_currentContext = nullptr;
+}
+
+} // namespace WebCore
+
+#endif // USE(EGL)

--- a/Source/WebCore/platform/graphics/egl/GLContextWrapper.h
+++ b/Source/WebCore/platform/graphics/egl/GLContextWrapper.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#if USE(EGL)
+
+namespace WebCore {
+
+class GLContextWrapper {
+public:
+    GLContextWrapper() = default;
+    ~GLContextWrapper();
+
+    enum class Type : uint8_t { Native, Angle };
+    virtual Type type() const = 0;
+    virtual bool makeCurrentImpl() = 0;
+    virtual bool unmakeCurrentImpl() = 0;
+
+    bool isCurrent() const;
+    void didMakeContextCurrent();
+    void didUnmakeContextCurrent();
+
+    static GLContextWrapper* currentContext();
+};
+
+} // namespace WebCore
+
+#endif // USE(EGL)

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -95,7 +95,16 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
 
 bool GraphicsContextGLANGLE::makeContextCurrent()
 {
-    return !!EGL_MakeCurrent(m_displayObj, m_surfaceObj, m_surfaceObj, m_contextObj);
+    auto* texmapContext = static_cast<GraphicsContextGLTextureMapperANGLE*>(this);
+    if (texmapContext->isCurrent())
+        return true;
+
+    if (EGL_MakeCurrent(m_displayObj, m_surfaceObj, m_surfaceObj, m_contextObj)) {
+        texmapContext->didMakeContextCurrent();
+        return true;
+    }
+
+    return false;
 }
 
 void GraphicsContextGLANGLE::checkGPUStatus()
@@ -351,6 +360,21 @@ void GraphicsContextGLTextureMapperANGLE::prepareForDisplay()
 
     prepareTexture();
     swapCompositorTexture();
+}
+
+GLContextWrapper::Type GraphicsContextGLTextureMapperANGLE::type() const
+{
+    return GLContextWrapper::Type::Angle;
+}
+
+bool GraphicsContextGLTextureMapperANGLE::makeCurrentImpl()
+{
+    return !!EGL_MakeCurrent(m_displayObj, m_surfaceObj, m_surfaceObj, m_contextObj);
+}
+
+bool GraphicsContextGLTextureMapperANGLE::unmakeCurrentImpl()
+{
+    return !!EGL_MakeCurrent(m_displayObj, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBGL) && USE(TEXTURE_MAPPER)
 
+#include "GLContextWrapper.h"
 #include "GraphicsContextGLANGLE.h"
 
 #if USE(NICOSIA)
@@ -39,7 +40,7 @@ namespace WebCore {
 
 class TextureMapperGCGLPlatformLayer;
 
-class WEBCORE_EXPORT GraphicsContextGLTextureMapperANGLE : public GraphicsContextGLANGLE {
+class WEBCORE_EXPORT GraphicsContextGLTextureMapperANGLE : public GraphicsContextGLANGLE, public GLContextWrapper {
 public:
     static RefPtr<GraphicsContextGLTextureMapperANGLE> create(WebCore::GraphicsContextGLAttributes&&);
     virtual ~GraphicsContextGLTextureMapperANGLE();
@@ -69,6 +70,11 @@ private:
 #if USE(NICOSIA)
     GCGLuint setupCurrentTexture();
 #endif
+
+    // GLContextWrapper
+    GLContextWrapper::Type type() const override;
+    bool makeCurrentImpl() override;
+    bool unmakeCurrentImpl() override;
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
 


### PR DESCRIPTION
#### d009eb90543f0e25ee70cfb6eef3db2b0ec64d62
<pre>
[TextureMapper] Add GLContextWrapper to handle the current GL context
<a href="https://bugs.webkit.org/show_bug.cgi?id=270078">https://bugs.webkit.org/show_bug.cgi?id=270078</a>

Reviewed by Miguel Gomez.

We currently have GLContext handling the current context, but it doesn&apos;t
always work. For example, if there&apos;s WebGL content, after ANGLE context
is made current. This is not problematic with Cairo because only ANGLE
is making it context current in the main thread, but with Skia there&apos;s
another GL context that is made current in the main thread when using
the GPU renderer.
GLContextWrapper is a new class to handle the current GL context,
implemented by GLContext and GraphicsContextGLTextureMapperANGLE.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::~GLContext):
(WebCore::GLContext::makeCurrentImpl):
(WebCore::GLContext::unmakeCurrentImpl):
(WebCore::GLContext::makeContextCurrent):
(WebCore::GLContext::unmakeContextCurrent):
(WebCore::GLContext::current):
(WebCore::GLContext::ScopedGLContext::ScopedGLContext):
(WebCore::GLContext::ScopedGLContext::~ScopedGLContext):
(WebCore::GLContext::ScopedGLContextCurrent::ScopedGLContextCurrent):
(WebCore::GLContext::ScopedGLContextCurrent::~ScopedGLContextCurrent):
(): Deleted.
* Source/WebCore/platform/graphics/egl/GLContext.h:
(WebCore::GLContext::display const): Deleted.
(WebCore::GLContext::config const): Deleted.
* Source/WebCore/platform/graphics/egl/GLContextWrapper.cpp: Added.
(WebCore::GLContextWrapper::~GLContextWrapper):
(WebCore::GLContextWrapper::currentContext):
(WebCore::GLContextWrapper::makeCurrent):
(WebCore::GLContextWrapper::unmakeCurrent):
* Source/WebCore/platform/graphics/egl/GLContextWrapper.h: Added.
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::makeContextCurrent):
(WebCore::GraphicsContextGLTextureMapperANGLE::makeCurrentImpl):
(WebCore::GraphicsContextGLTextureMapperANGLE::unmakeCurrentImpl):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:

Canonical link: <a href="https://commits.webkit.org/275377@main">https://commits.webkit.org/275377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c2fa470f6ddc03d0787d03668cf1d7bfff85d69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44272 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37792 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18044 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15130 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41001 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39426 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18133 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18190 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5573 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->