### PR TITLE
Replies from GPUConnection::Connection::sendWithAsyncReply will always be called on the main thread

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -632,6 +632,26 @@ Error Connection::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncR
     return error;
 }
 
+Error Connection::sendMessageWithAsyncReplyWithDispatcher(UniqueRef<Encoder>&& encoder, AsyncReplyHandlerWithDispatcher&& replyHandler, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
+{
+    ASSERT(replyHandler.replyID);
+    ASSERT(replyHandler.completionHandler);
+    ASSERT(replyHandler.dispatcher);
+    auto replyID = replyHandler.replyID;
+    encoder.get() << replyID;
+    addAsyncReplyHandlerWithDispatcher(WTFMove(replyHandler));
+    auto error = sendMessage(WTFMove(encoder), sendOptions, qos);
+    if (error == Error::NoError)
+        return Error::NoError;
+
+    if (auto replyHandlerToCancel = takeAsyncReplyHandlerWithDispatcher(replyID)) {
+        replyHandlerToCancel.dispatcher->dispatch([completionHandler = WTFMove(replyHandlerToCancel.completionHandler)]() mutable {
+            completionHandler(nullptr);
+        });
+    }
+    return error;
+}
+
 Error Connection::sendSyncReply(UniqueRef<Encoder>&& encoder)
 {
     return sendMessage(WTFMove(encoder), { });
@@ -905,6 +925,16 @@ void Connection::processIncomingMessage(UniqueRef<Decoder> message)
     Locker incomingMessagesLocker { m_incomingMessagesLock };
     if (!m_syncState)
         return;
+
+    if (message->messageReceiverName() == ReceiverName::AsyncReply) {
+        if (auto replyHandlerWithDispatcher = takeAsyncReplyHandlerWithDispatcherWithLockHeld(AtomicObjectIdentifier<AsyncReplyIDType>(message->destinationID()))) {
+            replyHandlerWithDispatcher.dispatcher->dispatch([handler = WTFMove(replyHandlerWithDispatcher.completionHandler), message = WTFMove(message)]() mutable {
+                handler(message.ptr());
+            });
+            return;
+        }
+        // Fallback to default case, error handling will be performed in sendMessage().
+    }
 
     if (auto* receiveQueue = m_receiveQueues.get(message.get())) {
         receiveQueue->enqueueMessage(*this, WTFMove(message));
@@ -1420,17 +1450,34 @@ void Connection::addAsyncReplyHandler(AsyncReplyHandler&& handler)
     ASSERT_UNUSED(result, result.isNewEntry);
 }
 
+void Connection::addAsyncReplyHandlerWithDispatcher(AsyncReplyHandlerWithDispatcher&& handler)
+{
+    Locker locker { m_incomingMessagesLock };
+    auto result = m_asyncReplyHandlerWithDispatchers.add(handler.replyID, WTFMove(handler));
+    ASSERT_UNUSED(result, result.isNewEntry);
+}
+
 void Connection::cancelAsyncReplyHandlers()
 {
     AsyncReplyHandlerMap map;
+    AsyncReplyHandlerWithDispatcherMap mapDispatcher;
     {
         Locker locker { m_incomingMessagesLock };
         map.swap(m_asyncReplyHandlers);
+        mapDispatcher.swap(m_asyncReplyHandlerWithDispatchers);
     }
 
     for (auto& handler : map.values()) {
         if (handler)
             handler(nullptr);
+    }
+
+    for (auto& handlerWithDispatcher : mapDispatcher.values()) {
+        if (handlerWithDispatcher) {
+            handlerWithDispatcher.dispatcher->dispatch([handler = WTFMove(handlerWithDispatcher.completionHandler)]() mutable {
+                handler(nullptr);
+            });
+        }
     }
 }
 
@@ -1440,6 +1487,24 @@ CompletionHandler<void(Decoder*)> Connection::takeAsyncReplyHandler(AsyncReplyID
     if (!m_asyncReplyHandlers.isValidKey(replyID))
         return nullptr;
     return m_asyncReplyHandlers.take(replyID);
+}
+
+bool Connection::isAsyncReplyHandlerWithDispatcher(AsyncReplyID replyID)
+{
+    Locker locker { m_incomingMessagesLock };
+    return m_asyncReplyHandlerWithDispatchers.isValidKey(replyID);
+}
+
+Connection::AsyncReplyHandlerWithDispatcher Connection::takeAsyncReplyHandlerWithDispatcher(AsyncReplyID replyID)
+{
+    Locker locker { m_incomingMessagesLock };
+    return takeAsyncReplyHandlerWithDispatcherWithLockHeld(replyID);
+}
+
+Connection::AsyncReplyHandlerWithDispatcher Connection::takeAsyncReplyHandlerWithDispatcherWithLockHeld(AsyncReplyID replyID)
+{
+    assertIsHeld(m_incomingMessagesLock);
+    return m_asyncReplyHandlerWithDispatchers.take(replyID);
 }
 
 void Connection::wakeUpRunLoop()

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -542,6 +542,87 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsync)
     localReferenceBarrier();
 }
 
+class AutoWorkQueue {
+public:
+    class WorkQueueWithShutdown : public WorkQueue {
+    public:
+        static Ref<WorkQueueWithShutdown> create(const char* name) { return adoptRef(*new WorkQueueWithShutdown(name)); }
+        void beginShutdown()
+        {
+            dispatch([this, strong = Ref { *this }] {
+                m_shutdown = true;
+                m_semaphore.signal();
+            });
+        }
+        void waitUntilShutdown()
+        {
+            while (!m_shutdown)
+                m_semaphore.wait();
+        }
+
+    private:
+        WorkQueueWithShutdown(const char* name)
+            : WorkQueue(name, QOS::Default)
+        {
+        }
+        std::atomic<bool> m_shutdown { false };
+        BinarySemaphore m_semaphore;
+    };
+
+    AutoWorkQueue()
+        : m_workQueue(WorkQueueWithShutdown::create("com.apple.WebKit.Test.simple"))
+    {
+    }
+
+    Ref<WorkQueueWithShutdown> queue() { return m_workQueue; }
+
+    ~AutoWorkQueue()
+    {
+        m_workQueue->waitUntilShutdown();
+    }
+
+private:
+    Ref<WorkQueueWithShutdown> m_workQueue;
+};
+
+TEST_P(ConnectionRunLoopTest, RunLoopSendAsyncOnTarget)
+{
+    HashSet<uint64_t> replies;
+    {
+        AutoWorkQueue awq;
+
+        ASSERT_TRUE(openA());
+        aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+            auto listenerID = decoder.decode<uint64_t>();
+            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+            encoder.get() << decoder.destinationID();
+            a()->sendSyncReply(WTFMove(encoder));
+            return true;
+        });
+
+        auto runLoop = createRunLoop(RUN_LOOP_NAME);
+        dispatchAndWait(runLoop, [&] {
+            ASSERT_TRUE(openB());
+            for (uint64_t i = 100u; i < 160u; ++i) {
+                b()->sendWithAsyncReplyOnDispatcher(MockTestMessageWithAsyncReply1 { }, awq.queue(), [&, j = i, queue = awq.queue()] (uint64_t value) {
+                    assertIsCurrent(queue);
+                    if (!value)
+                        WTFLogAlways("GOT: %llu", j);
+                    EXPECT_GE(value, 100u);
+                    replies.add(value);
+                }, i);
+            }
+            while (replies.size() < 60u)
+                RunLoop::current().cycle();
+            b()->invalidate();
+        });
+        awq.queue()->beginShutdown();
+    }
+    for (uint64_t i = 100u; i < 160u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    localReferenceBarrier();
+}
+
 TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReply)
 {
     ASSERT_TRUE(openA());
@@ -577,6 +658,141 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReply)
 
     for (uint64_t i = 100u; i < 160u; ++i)
         EXPECT_TRUE(replies.contains(i));
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnDispatcher)
+{
+    HashSet<uint64_t> replies;
+
+    {
+        AutoWorkQueue awq;
+        ASSERT_TRUE(openA());
+        aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+            auto listenerID = decoder.decode<uint64_t>();
+            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+            encoder.get() << decoder.destinationID();
+            a()->sendSyncReply(WTFMove(encoder));
+            return true;
+        });
+
+        auto runLoop = createRunLoop(RUN_LOOP_NAME);
+        dispatchAndWait(runLoop, [&] {
+            ASSERT_TRUE(openB());
+            for (uint64_t i = 100u; i < 160u; ++i) {
+                b()->sendWithPromisedReplyOnDispatcher(MockTestMessageWithAsyncReply1 { }, awq.queue(), i)->whenSettled(awq.queue(), [&, j = i] (auto&& result) {
+                    EXPECT_TRUE(result);
+                    auto value = *result;
+                    if (!value)
+                        WTFLogAlways("GOT: %llu", j);
+                    EXPECT_GE(value, 100u);
+                    replies.add(value);
+                });
+            }
+            while (replies.size() < 60u)
+                RunLoop::current().cycle();
+            b()->invalidate();
+        });
+        awq.queue()->beginShutdown();
+    }
+    for (uint64_t i = 100u; i < 160u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnMixAndMatchDispatcher)
+{
+    HashSet<uint64_t> replies;
+
+    {
+        AutoWorkQueue awq;
+        ASSERT_TRUE(openA());
+        aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+            auto listenerID = decoder.decode<uint64_t>();
+            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+            encoder.get() << decoder.destinationID();
+            a()->sendSyncReply(WTFMove(encoder));
+            return true;
+        });
+
+        auto runLoop = createRunLoop(RUN_LOOP_NAME);
+        dispatchAndWait(runLoop, [&] {
+            ASSERT_TRUE(openB());
+            for (uint64_t i = 100u; i < 160u; ++i) {
+                b()->sendWithPromisedReplyOnDispatcher(MockTestMessageWithAsyncReply1 { }, awq.queue(), i)->whenSettled(runLoop, [&, j = i] (auto&& result) {
+                    EXPECT_TRUE(result);
+                    auto value = *result;
+                    if (!value)
+                        WTFLogAlways("GOT: %llu", j);
+                    EXPECT_GE(value, 100u);
+                    replies.add(value);
+                });
+            }
+            while (replies.size() < 60u)
+                RunLoop::current().cycle();
+            b()->invalidate();
+        });
+        awq.queue()->beginShutdown();
+    }
+    for (uint64_t i = 100u; i < 160u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    localReferenceBarrier();
+}
+
+// Tests that all sent messages with async replies are received, even if sender invalidates
+// without synchronizing with the receiver. The async reply callbacks are always run, either
+// with the reply or the cancel value and always on the provided dispatcher
+TEST_P(ConnectionRunLoopTest, SendAsyncAndInvalidateOnDispatcher)
+{
+    HashSet<uint64_t> messages;
+    HashSet<uint64_t> replies;
+    constexpr uint64_t messageCount = 1536u;
+
+    {
+        AutoWorkQueue awq;
+
+        ASSERT_TRUE(openA());
+        auto runLoop = createRunLoop(RUN_LOOP_NAME);
+        BinarySemaphore semaphore;
+        runLoop->dispatch([&] {
+            bClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+                auto listenerID = decoder.decode<uint64_t>();
+                auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+                encoder.get() << decoder.destinationID();
+                b()->sendSyncReply(WTFMove(encoder));
+                messages.add(decoder.destinationID());
+                return true;
+            });
+            ASSERT_TRUE(openB());
+            while (messages.size() < messageCount - 1)
+                RunLoop::current().cycle();
+            semaphore.signal();
+        });
+        for (uint64_t i = 1u; i < messageCount; ++i) {
+            a()->sendWithAsyncReplyOnDispatcher(MockTestMessageWithAsyncReply1 { }, awq.queue(), [&, j = i] (uint64_t) {
+                assertIsCurrent(awq.queue());
+                // The reply value might be the reply value (destinationID) or zero in case the
+                // reply was resolved as invalid. Either of these are expected valid results.
+                // Use the `j` to prove that reply callback was run as expected.
+                replies.add(j);
+            }, i);
+        }
+        auto flushResult = a()->flushSentMessages(kDefaultWaitForTimeout);
+        EXPECT_EQ(flushResult, IPC::Error::NoError);
+        a()->invalidate();
+        semaphore.wait();
+
+        // Sending a message on an invalidated Connection should still deliver the message on the dispatcher.
+        a()->sendWithAsyncReplyOnDispatcher(MockTestMessageWithAsyncReply1 { }, awq.queue(), [queue = awq.queue()] (uint64_t) {
+            assertIsCurrent(queue);
+            queue->beginShutdown();
+        }, 0);
+    }
+
+    for (uint64_t i = 1u; i < messageCount; ++i) {
+        EXPECT_TRUE(replies.contains(i)) << i;
+        EXPECT_TRUE(messages.contains(i)) << i;
+    }
     localReferenceBarrier();
 }
 


### PR DESCRIPTION
#### cae00d824a496148f16e28b0bb56bd39cb61e00a
<pre>
Replies from GPUConnection::Connection::sendWithAsyncReply will always be called on the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=270118">https://bugs.webkit.org/show_bug.cgi?id=270118</a>
<a href="https://rdar.apple.com/123650202">rdar://123650202</a>

Reviewed by Kimmo Kinnunen.

A Connection::sendWithAsyncReply was only ever designed to call the AsyncReplyHandler
used to return the reply on the Connection&apos;s dispatcher. Which in the case
of the GPUConnection&apos;s Connection is the main thread/runloop.
While the Connection&apos;s itself uses a dedicated WorkQueue to send and receive
IPC messages, and that a WorkQueueMessageReceiver let you decide on which
WorkQueue the messages should be dispatched on; there was no ability to
specify on which dispatcher (or WorkQueueMessageReceiver) the sendWithAsyncReply&apos;s
replies will be delivered on.

While Connection::sendWithPromisedReply returned a thread-safe NativePromise
which allow to define on which dispatcher&apos;s the callback should be run on,
it also used sendWithAsyncReply and used the AsyncReplyHandler to wrap
a NativePromiseProducer which would then be resolved or rejected on the
Connection&apos;s dispatcher.

This became problematic in situation where a WorkQueueMessageReceiver was
used for performance reasons; the bottleneck would still be on the main
thread&apos;s usage state. It made the current MSE in a Worker implementation&apos;s
moot.

We add two new methods: sendWithAsyncReplyOnDispatcher and sendWithPromisedReplyOnDispatcher
Which let you defines the RefCountedSerialFunctionDispatcher on which the AsyncReply
will be delivered on.

The semantics for sendWithPromisedReplyOnDispatcher is rather cumbersome as you
need to set the dispatcher twice, but at this stage there’s no possibility
to retrieve the WorkQueue set with whenSettled/then as at the time the NativePromiseProducer
Has been settled, no listener may have been attached yet. This will be fixed in a follow
up change.

Rather than expanding the existing ConnectionAsyncReplyHandler object with a dispatcher member
and using a single HashMap of AsyncReplyHandler which would have allowed less duplication
in the code, we create a new
Connection::AsyncReplyHandlerWithDispatcher and have a separate map. The reasons are two fold:
1- We don’t have to handle cases where a dispatcher would have been set for a AsyncReplyHandler
that should be run in the Connection’s dispatcher, or vice-versa: a dispatcher wasn’t set
when it should have been.
2- The vast majority of the usage is using the older sendWithAsyncReply so we don’t have to
Search in an overall larget HashMap twice.

So we favour code readability over size.

Added API tests to check several scenarios including:
- That replies are delivered on the correct dispatcher and in the right order
- The replies of messages sent to an invalidated Connection are properly delivered on
the dispatcher.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::sendMessageWithAsyncReplyWithDispatcher):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::addAsyncReplyHandlerWithDispatcher):
(IPC::Connection::cancelAsyncReplyHandlers):
(IPC::Connection::isAsyncReplyHandlerWithDispatcher):
(IPC::Connection::takeAsyncReplyHandlerWithDispatcher):
(IPC::Connection::takeAsyncReplyHandlerWithDispatcherWithLockHeld):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::sendWithAsyncReplyOnDispatcher):
(IPC::Connection::sendWithPromisedReplyOnDispatcher):
(IPC::Connection::AsyncReplyHandlerWithDispatcher::operator bool const):
(IPC::Connection::sendWithPromisedReply):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
(IPC::CompletionHandler&lt;void):
(IPC::Connection::makeAsyncReplyHandler):
(IPC::Connection::makeAsyncReplyHandlerWithDispatcher):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::AutoWorkQueue::WorkQueueWithShutdown::create):
(TestWebKitAPI::AutoWorkQueue::WorkQueueWithShutdown::beginShutdown):
(TestWebKitAPI::AutoWorkQueue::WorkQueueWithShutdown::waitUntilShutdown):
(TestWebKitAPI::AutoWorkQueue::WorkQueueWithShutdown::WorkQueueWithShutdown):
(TestWebKitAPI::AutoWorkQueue::AutoWorkQueue):
(TestWebKitAPI::AutoWorkQueue::queue):
(TestWebKitAPI::AutoWorkQueue::~AutoWorkQueue):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/275494@main">https://commits.webkit.org/275494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26f10d253e3662c53a139afe5d292a3c01982507

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41958 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18304 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36136 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45955 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37494 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39843 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18393 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9408 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->