### PR TITLE
WebCodecs remote video encoders get timestamps in microseconds and not nanoseconds

### DIFF
--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -440,7 +440,7 @@ void LibWebRTCCodecsProxy::encodeFrame(VideoEncoderIdentifier identifier, Shared
 
 #if !PLATFORM(MACCATALYST)
     encoder->encodingCallbacks.append(WTFMove(callback));
-    webrtc::encodeLocalEncoderFrame(encoder->webrtcEncoder, pixelBuffer.get(), sharedVideoFrame.time.toTimeScale(1000000).timeValue(), timeStamp, duration, toWebRTCVideoRotation(sharedVideoFrame.rotation), shouldEncodeAsKeyFrame);
+    webrtc::encodeLocalEncoderFrame(encoder->webrtcEncoder, pixelBuffer.get(), Seconds(sharedVideoFrame.time.toDouble()).nanoseconds(), timeStamp, duration, toWebRTCVideoRotation(sharedVideoFrame.rotation), shouldEncodeAsKeyFrame);
 #else
     callback(false);
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -693,7 +693,7 @@ template<typename Frame> int32_t LibWebRTCCodecs::encodeFrameInternal(Encoder& e
 
 int32_t LibWebRTCCodecs::encodeFrame(Encoder& encoder, const webrtc::VideoFrame& frame, bool shouldEncodeAsKeyFrame)
 {
-    return encodeFrameInternal(encoder, frame, shouldEncodeAsKeyFrame, toVideoRotation(frame.rotation()), MediaTime(frame.timestamp_us() * 1000, 1000000), frame.timestamp(), { }, [](auto) { });
+    return encodeFrameInternal(encoder, frame, shouldEncodeAsKeyFrame, toVideoRotation(frame.rotation()), MediaTime::createWithDouble(Seconds::fromMicroseconds(frame.timestamp_us()).value()), frame.timestamp(), { }, [](auto) { });
 }
 
 int32_t LibWebRTCCodecs::encodeFrame(Encoder& encoder, const WebCore::VideoFrame& frame, int64_t timestamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame, Function<void(bool)>&& callback)


### PR DESCRIPTION
#### aef6a763596ad4bd9e007a52b373eb1b423e1f84
<pre>
WebCodecs remote video encoders get timestamps in microseconds and not nanoseconds
<a href="https://rdar.apple.com/123684436">rdar://123684436</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270159">https://bugs.webkit.org/show_bug.cgi?id=270159</a>

Reviewed by Eric Carlson.

In WebRTC code path, we are getting a microsecond timestamp.
We were converting it to a MediaTime in LibWebRTCCodecs which was then converted back to
a nanosecond timestamp in LibWebRTCCodecsProxy.
A factor of 1000 was applied in LibWebRTCCodecs and handled correctly on LibWebRTCCodecsProxy.

The WebCodecs path is getting a MediaTime directly but without the 1000 factor.
This was causing the timestamps given to WebCodecs encoder to be in microseconds and not nanoseconds.
This can have an impact on encoders in some circumstances.

We fix this by using Seconds/MediaTime routines on WebProcess WebRTC side (this removes the 1000 factor),
and we update LibWebRTCCodecsProxy to do the same.

* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::encodeFrame):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::encodeFrame):

Canonical link: <a href="https://commits.webkit.org/275392@main">https://commits.webkit.org/275392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48769e9462392039410e992a3ebf9c08112359f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44279 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34470 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42279 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17662 "Found 2 new test failures: fast/forms/datalist/datalist-option-labels.html, fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15354 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45694 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37254 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39464 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18139 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9352 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17783 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->