### PR TITLE
Non-unified build fixes, late February 2024 edition

### DIFF
--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(ASSEMBLER) && (OS(LINUX) || OS(DARWIN))
 
+#include "Options.h"
 #include <array>
 #include <fcntl.h>
 #include <mutex>
@@ -41,6 +42,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/PageBlock.h>
 #include <wtf/ProcessID.h>
+#include <wtf/StringPrintStream.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
@@ -30,6 +30,8 @@
 
 #include "ManagedMediaSource.h"
 #include "MediaSource.h"
+#include "SourceBufferList.h"
+#include "TimeRanges.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+class MediaSource;
+
 class MediaSourceInterfaceMainThread : public MediaSourceInterfaceProxy {
 public:
     static Ref<MediaSourceInterfaceMainThread> create(Ref<MediaSource>&& mediaSource) { return adoptRef(*new MediaSourceInterfaceMainThread(WTFMove(mediaSource))); }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -73,9 +73,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(SourceBuffer);
 
-static const double ExponentialMovingAverageCoefficient = 0.2;
-
-
 class SourceBufferClientImpl final : public SourceBufferPrivateClient {
 public:
     static Ref<SourceBufferClientImpl> create(SourceBuffer& parent) { return adoptRef(*new SourceBufferClientImpl(parent)); }

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
@@ -33,6 +33,7 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Event.h"
 #include "EventNames.h"
 #include "SourceBuffer.h"

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -27,9 +27,11 @@
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSWebCodecsVideoFrame.h"
 #include "Logging.h"
 #include "ReadableStream.h"
+#include <wtf/IsoMallocInlines.h>
 #include <wtf/Seconds.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "RTCDTMFSenderBackend.h"
 #include "RTCDTMFToneChangeEvent.h"
 #include "RTCRtpSender.h"

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "CryptoKeyRaw.h"
 #include "JSDOMConvertBufferSource.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -33,6 +33,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "Logging.h"
 #include "RTCDTMFSender.h"

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
@@ -26,12 +26,12 @@
 #include "config.h"
 #include "SpeechSynthesisUtterance.h"
 
+#if ENABLE(SPEECH_SYNTHESIS)
+
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "SpeechSynthesisErrorEvent.h"
 #include "SpeechSynthesisEvent.h"
-
-#if ENABLE(SPEECH_SYNTHESIS)
-
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
 #include "Event.h"
 #include "EventNames.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(WEB_CODECS)
 
 #include "AacEncoderConfig.h"
+#include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
 #include "Event.h"
 #include "EventNames.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
 #include "Event.h"
 #include "EventNames.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
 #include "Event.h"
 #include "EventNames.h"

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleOriginatedAnimationEvent.h"
 
+#include "Node.h"
 #include "WebAnimationUtilities.h"
 
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -37,8 +37,13 @@ namespace WebCore {
 enum class PseudoId : uint32_t;
 
 class AnimationEventBase;
+class Document;
 class Element;
 class WebAnimation;
+
+namespace Style {
+struct PseudoElementIdentifier;
+}
 
 inline double secondsToWebAnimationsAPITime(const Seconds time)
 {

--- a/Source/WebCore/bindings/js/GCController.h
+++ b/Source/WebCore/bindings/js/GCController.h
@@ -30,6 +30,10 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 
+namespace JSC {
+class VM;
+}
+
 namespace WebCore {
 
 class GCController {

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -34,6 +34,7 @@
 #include "CSSParserIdioms.h"
 #include "CSSSelector.h"
 #include "CSSSelectorInlines.h"
+#include "CSSTokenizer.h"
 #include "CommonAtomStrings.h"
 #include "Document.h"
 #include "MutableCSSSelector.h"

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "FragmentDirectiveGenerator.h"
 
+#include "Document.h"
 #include "HTMLParserIdioms.h"
 #include "Logging.h"
 #include "Range.h"

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.h
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class Range;
+struct SimpleRange;
 
 struct TextDirective {
     String textStart;

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -29,7 +29,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "Editing.h"
-#include "Element.h"
+#include "ElementInlines.h"
 #include "HTMLInputElement.h"
 #include "Settings.h"
 #include "ShadowRoot.h"

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -44,6 +44,7 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "MediaUsageInfo.h"
+#include "Navigator.h"
 #include "NowPlayingInfo.h"
 #include "Page.h"
 #include "PlatformMediaSessionManager.h"

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -40,6 +40,7 @@
 #include "MIMETypeRegistry.h"
 #include "MemoryCache.h"
 #include "OriginAccessPatterns.h"
+#include "Quirks.h"
 #include "SecurityPolicy.h"
 #include "ServiceWorkerRegistrationData.h"
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/page/PointerLockController.cpp
+++ b/Source/WebCore/page/PointerLockController.cpp
@@ -29,6 +29,7 @@
 
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "DocumentInlines.h"
 #include "Element.h"
 #include "Event.h"
 #include "EventNames.h"

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -39,6 +39,7 @@ class EventTypeInfo;
 class HTMLElement;
 class HTMLVideoElement;
 class LayoutUnit;
+class LocalFrame;
 class PlatformMouseEvent;
 class RegistrableDomain;
 class SecurityOriginData;

--- a/Source/WebCore/platform/MediaDescription.h
+++ b/Source/WebCore/platform/MediaDescription.h
@@ -26,8 +26,8 @@
 #ifndef MediaDescription_h
 #define MediaDescription_h
 
-#include <wtf/Forward.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -26,7 +26,11 @@
 #include "config.h"
 #include "RenderViewTransitionCapture.h"
 
+#include "ImageOverlayController.h"
+#include "ImageQualityController.h"
+#include "PaintInfo.h"
 #include "RenderBoxModelObjectInlines.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -31,6 +31,7 @@
 #include "LegacyRenderSVGRoot.h"
 #include "RenderAncestorIterator.h"
 #include "RenderBlock.h"
+#include "RenderObjectInlines.h"
 #include "RenderSVGText.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGInlineTextBoxInlines.h"

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -48,6 +48,7 @@
 #include "RenderListItem.h"
 #include "RenderListMarker.h"
 #include "RenderStyleInlines.h"
+#include "RenderView.h"
 #include "StyleCustomPropertyData.h"
 #include "StyleOriginatedAnimation.h"
 #include "StylePropertyShorthand.h"

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebCookieManager.h"
 
+#include "Logging.h"
 #include "MessageSenderInlines.h"
 #include "NetworkProcess.h"
 #include "NetworkProcessProxyMessages.h"

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -137,7 +137,7 @@ Data Data::adoptMap(FileSystem::MappedFileData&& mappedFile, FileSystem::Platfor
     return { adoptGRef(g_bytes_new_with_free_func(map, size, reinterpret_cast<GDestroyNotify>(deleteMapWrapper), wrapper)), fd };
 }
 
-RefPtr<SharedMemory> Data::tryCreateSharedMemory() const
+RefPtr<WebCore::SharedMemory> Data::tryCreateSharedMemory() const
 {
     if (isNull() || !isMap())
         return nullptr;
@@ -145,7 +145,7 @@ RefPtr<SharedMemory> Data::tryCreateSharedMemory() const
     int fd = FileSystem::posixFileDescriptor(m_fileDescriptor);
     gsize length;
     const auto* data = g_bytes_get_data(m_buffer.get(), &length);
-    return SharedMemory::wrapMap(const_cast<void*>(data), length, fd);
+    return WebCore::SharedMemory::wrapMap(const_cast<void*>(data), length, fd);
 }
 
 } // namespace NetworkCache

--- a/Source/WebKit/Shared/WebCompiledContentRuleListData.cpp
+++ b/Source/WebKit/Shared/WebCompiledContentRuleListData.cpp
@@ -37,14 +37,14 @@ static size_t ruleListDataSize(size_t topURLFiltersBytecodeOffset, size_t topURL
     return topURLFiltersBytecodeOffset + topURLFiltersBytecodeSize;
 }
 
-std::optional<SharedMemoryHandle> WebCompiledContentRuleListData::createDataHandle(SharedMemory::Protection protection) const
+std::optional<WebCore::SharedMemoryHandle> WebCompiledContentRuleListData::createDataHandle(WebCore::SharedMemory::Protection protection) const
 {
     return data->createHandle(protection);
 }
 
 WebCompiledContentRuleListData::WebCompiledContentRuleListData(String&& identifier, std::optional<WebCore::SharedMemoryHandle>&& dataHandle, size_t actionsOffset, size_t actionsSize, size_t urlFiltersBytecodeOffset, size_t urlFiltersBytecodeSize, size_t topURLFiltersBytecodeOffset, size_t topURLFiltersBytecodeSize, size_t frameURLFiltersBytecodeOffset, size_t frameURLFiltersBytecodeSize)
     : identifier(WTFMove(identifier))
-    , data(dataHandle ? SharedMemory::map(WTFMove(*dataHandle), SharedMemory::Protection::ReadOnly) : nullptr)
+    , data(dataHandle ? WebCore::SharedMemory::map(WTFMove(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr)
     , actionsOffset(actionsOffset)
     , actionsSize(actionsSize)
     , urlFiltersBytecodeOffset(urlFiltersBytecodeOffset)

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -42,11 +42,6 @@ namespace WebKit {
 
 using namespace WebCore;
 
-#if GTK_CHECK_VERSION(4, 7, 0)
-// Keep in sync with https://gitlab.gnome.org/GNOME/gtk/-/blob/493660a296af3b8a140714988ddece4199818a04/gtk/gtkscrolledwindow.c#L204
-static const double gtkScrollDeltaMultiplier = 2.5;
-#endif
-
 static inline bool isGdkKeyCodeFromKeyPad(unsigned keyval)
 {
     return keyval >= GDK_KEY_KP_Space && keyval <= GDK_KEY_KP_9;

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -27,6 +27,7 @@
 #include "WebProcessProxy.h"
 
 #include "APIFrameHandle.h"
+#include "APIPageConfiguration.h"
 #include "APIPageHandle.h"
 #include "APIUIClient.h"
 #include "AuthenticatorManager.h"
@@ -94,6 +95,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
+#include <wtf/Scope.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakListHashSet.h>

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -56,7 +56,6 @@ static const double swipeCancelArea = 0.5;
 static const double swipeCancelVelocityThreshold = 0.4;
 
 #if USE(GTK4)
-static const float swipeOverlayShadowOpacity = 0.06;
 static const float swipeOverlayBorderOpacity = 0.05;
 static const float swipeOverlayOutlineOpacity = 0.05;
 static const float swipeOverlayDimmingOpacity = 0.12;


### PR DESCRIPTION
#### 3f4bd57a7ba1532a3e48df585f56e6e998acdb2e
<pre>
Non-unified build fixes, late February 2024 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=270156">https://bugs.webkit.org/show_bug.cgi?id=270156</a>

Unreviewed non-unified build fixes.

* Source/JavaScriptCore/assembler/PerfLog.cpp: Add missing inclusions of
Options.h and wtf/StringPrintStream.h.
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp:
Add missing inclusions of SourceBufferList.h and TimeRanges.h.
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h:
Add missing forward declaration for the WebCore::MediaSource type.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp: Remove unused
ExponentialMovingAverageCoefficient constant.
* Source/WebCore/Modules/mediasource/SourceBufferList.cpp: Add missing
ContextDestructionObserverInlines.h header.
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
Ditto, plus wtf/IsoMallocInlines.h.
* Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp: Add missing
ContextDestructionObserverInlines.h.
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp: Ditto
* Source/WebCore/Modules/mediastream/RTCRtpSender.cpp: Ditto.
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp: Ditto,
plus move all inclusions into ENABLE(SPEECH_SYNTHESIS).
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp: Add
missing ContextDestructionObserverInlines.h inclusion.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp: Ditto.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp: Ditto.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp: Ditto.
* Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp: Add
missing Node.h inclusion.
* Source/WebCore/animation/WebAnimationUtilities.h: Add missing forward
declarations for WebCore::Document and WebCore::Style::PseudoElementIdentifier.
* Source/WebCore/bindings/js/GCController.h: Add missing forward
declaration for the JSC::VM type.
* Source/WebCore/css/parser/CSSSelectorParser.cpp: Add missing
CSSTokenizer.h inclusion.
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp: Add missing
Document.h inclusion.
* Source/WebCore/dom/FragmentDirectiveGenerator.h: Add missing wtf/URL.h
inclusion, add missing WebCore::SimpleRange forward declaration, and
remove the unneeded WebCore::Range one.
* Source/WebCore/editing/VisibleSelection.cpp: Replace Element.h
inclusion with ElementInlines.h.
* Source/WebCore/html/MediaElementSession.cpp: Add missing Navigator.h
inclusion.
* Source/WebCore/loader/cache/CachedResourceRequest.cpp: Add missing
Quirks.h inclusion.
* Source/WebCore/page/PointerLockController.cpp: Add missing
DocumentInlines.h inclusion.
* Source/WebCore/page/Quirks.h: Add missing WebCore::LocalFrame forward
declaration.
* Source/WebCore/platform/MediaDescription.h: Add missing
wtf/text/WTFString.h inclusion, remove the unneeded wtf/Forward.h one.
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp: Add missing
inclusions for ImageOverlayController.h, ImageQualityController.h,
PaintInfo.h, and wtf/IsoMallocInlines.h.
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp: Add missing
inclusion of RenderObjectInlines.h.
* Source/WebCore/style/Styleable.cpp: Add missing RenderView.h
inclusion.
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp: Add missing
Logging.h inclusion.
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp: Add
missing WebCore:: namespace prefixes to uses of the
WebCore::SharedMemory type.
(WebKit::NetworkCache::Data::tryCreateSharedMemory const):
* Source/WebKit/Shared/WebCompiledContentRuleListData.cpp: Ditto.
(WebKit::WebCompiledContentRuleListData::createDataHandle const):
(WebKit::WebCompiledContentRuleListData::WebCompiledContentRuleListData):
* Source/WebKit/Shared/gtk/WebEventFactory.cpp: Remove unused.
gtkScrollDeltaMultiplier constant.
* Source/WebKit/UIProcess/WebProcessProxy.cpp: Add missing inclusions
for APIPageConfiguration.h and wtf/Scope.h.
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp: Remove
unused swipeOverlayShadowOpacity constant.

Canonical link: <a href="https://commits.webkit.org/275381@main">https://commits.webkit.org/275381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e9fc8b7959b358ad85f2fc94f32f81a85233c71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18055 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15142 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45671 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35163 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37262 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16525 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13563 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39440 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18144 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48347 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18201 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9849 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5576 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->