### PR TITLE
Simplify compiler flags checking in Source/ThirdParty/skia/CMakeLists.txt

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -1002,59 +1002,21 @@ set(Skia_SkCMS_SKX_FLAGS
 if (WTF_CPU_X86 OR WTF_CPU_X86_64)
     target_compile_definitions(Skia PRIVATE SK_ENABLE_AVX512_OPTS)
 
-    set(Skia_SkCMS_HSW_OPTS TRUE)
-    foreach (_flag ${Skia_SkCMS_HSW_FLAGS})
-        if (NOT DEFINED CXX_COMPILER_SUPPORTS_${_flag})
-            check_cxx_compiler_flag("${_flag}" CXX_COMPILER_SUPPORTS_${_flag})
-        endif ()
-        if (NOT CXX_COMPILER_SUPPORTS_${_flag})
-            set(Skia_SkCMS_HSW_OPTS FALSE)
-            break ()
-        endif ()
-    endforeach ()
+    WEBKIT_CHECK_COMPILER_FLAGS(CXX Skia_SkCMS_HSW_OPTS ${Skia_SkCMS_HSW_FLAGS})
+    WEBKIT_CHECK_COMPILER_FLAGS(CXX Skia_SkCMS_SKX_OPTS ${Skia_SkCMS_SKX_FLAGS})
 
-    set(Skia_SkCMS_SKX_OPTS TRUE)
-    foreach (_flag ${Skia_SkCMS_SKX_FLAGS})
-        if (NOT DEFINED CXX_COMPILER_SUPPORTS_${_flag})
-            check_cxx_compiler_flag("${_flag}" CXX_COMPILER_SUPPORTS_${_flag})
-        endif ()
-        if (NOT CXX_COMPILER_SUPPORTS_${_flag})
-            set(Skia_SkCMS_SKX_OPTS FALSE)
-            break ()
-        endif ()
-    endforeach ()
-
-    if (NOT DEFINED CXX_COMPILER_SUPPORTS_-march=haswell)
-        check_cxx_compiler_flag(-march=haswell CXX_COMPILER_SUPPORTS_-march=haswell)
-    endif ()
-    if (CXX_COMPILER_SUPPORTS_-march=haswell)
-        set_property(
-            SOURCE src/opts/SkOpts_hsw.cpp
-            APPEND PROPERTY COMPILE_OPTIONS -march=haswell
-        )
-    endif ()
-
-    if (NOT DEFINED CXX_COMPILER_SUPPORTS_-march=skylake-avx512)
-        check_cxx_compiler_flag(-march=skylake-avx512 CXX_COMPILER_SUPPORTS_-march=skylake-avx512)
-    endif ()
-    if (CXX_COMPILER_SUPPORTS_-march=skylake-avx512)
-        set_property(
-            SOURCE src/opts/SkOpts_skx.cpp
-            APPEND PROPERTY COMPILE_OPTIONS -march=skylake-avx512
-        )
-    endif ()
+    WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE src/opts/SkOpts_hsw.cpp "-march=haswell")
+    WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE src/opts/SkOpts_skx.cpp "-march=skylake-avx512")
 endif ()
 
 if (Skia_SkCMS_HSW_OPTS)
-    set_property(SOURCE modules/skcms/src/skcms_TransformHsw.cc
-        APPEND PROPERTY COMPILE_OPTIONS ${Skia_SkCMS_HSW_FLAGS})
+    WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE modules/skcms/src/skcms_TransformHsw.cc ${Skia_SkCMS_HSW_FLAGS})
 else ()
     target_compile_definitions(Skia PRIVATE SKCMS_DISABLE_HSW)
 endif ()
 
 if (Skia_SkCMS_SKX_OPTS)
-    set_property(SOURCE modules/skcms/src/skcms_TransformSkx.cc
-        APPEND PROPERTY COMPILE_OPTIONS ${Skia_SkCMS_SKX_FLAGS})
+    WEBKIT_ADD_COMPILER_FLAGS(CXX SOURCE modules/skcms/src/skcms_TransformSkx.cc ${Skia_SkCMS_SKX_FLAGS})
 else ()
     target_compile_definitions(Skia PRIVATE SKCMS_DISABLE_SKX)
 endif ()

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -60,17 +60,51 @@ macro(WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS)
     WEBKIT_APPEND_GLOBAL_CXX_FLAGS(${ARGN})
 endmacro()
 
+# Checks whether all the given compiler flags are supported by the compiler.
+# The _compiler may be either "C" or "CXX", and the result from the check
+# will be stored in the variable named by _result.
+function(WEBKIT_CHECK_COMPILER_FLAGS _compiler _result)
+    string(TOUPPER "${_compiler}" _compiler)
+    set(${_result} FALSE PARENT_SCOPE)
+    foreach (_flag IN LISTS ARGN)
+        # If an equals (=) character is present in a variable name, it will
+        # not be cached correctly, and the check will be retried ad nauseam.
+        string(REPLACE "=" "__" _cachevar "${_compiler}_COMPILER_SUPPORTS_${_flag}")
+        if (${_compiler} STREQUAL CXX)
+            check_cxx_compiler_flag("${_flag}" "${_cachevar}")
+        elseif (${_compiler} STREQUAL C)
+            check_c_compiler_flag("${_flag}" "${_cachevar}")
+        else ()
+            set(${_cachevar} FALSE CACHE INTERNAL "" FORCE)
+            message(WARNING "WEBKIT_CHECK_COMPILER_FLAGS: unknown compiler '${_compiler}'")
+            return()
+        endif ()
+        if (NOT ${_cachevar})
+            return()
+        endif ()
+    endforeach ()
+    set(${_result} TRUE PARENT_SCOPE)
+endfunction()
+
+# Appends flags to COMPILE_OPTIONS of _subject if supported by the C
+# or CXX _compiler. The _subject argument depends on its _kind, it may be
+# a target name (with TARGET as _kind), or a path (with SOURCE or DIRECTORY
+# as _kind).
+function(WEBKIT_ADD_COMPILER_FLAGS _compiler _kind _subject)
+    foreach (_flag IN LISTS ARGN)
+        WEBKIT_CHECK_COMPILER_FLAGS(${_compiler} flag_supported "${_flag}")
+        if (flag_supported)
+            set_property(${_kind} ${_subject} APPEND PROPERTY COMPILE_OPTIONS "${_flag}")
+        endif ()
+    endforeach ()
+endfunction()
+
 # Appends flags to COMPILE_FLAGS of _target if supported by the C compiler.
 # Note that it is simply not possible to pass different C and C++ flags, unless
 # we drop support for the Visual Studio backend and use the COMPILE_LANGUAGE
 # generator expression. This is a very serious limitation.
 macro(WEBKIT_ADD_TARGET_C_FLAGS _target)
-    foreach (_flag ${ARGN})
-        check_c_compiler_flag("${_flag}" C_COMPILER_SUPPORTS_${_flag})
-        if (C_COMPILER_SUPPORTS_${_flag})
-            target_compile_options(${_target} PRIVATE ${_flag})
-        endif ()
-    endforeach ()
+    WEBKIT_ADD_COMPILER_FLAGS(C TARGET ${_target} ${ARGN})
 endmacro()
 
 # Appends flags to COMPILE_FLAGS of _target if supported by the C++ compiler.
@@ -78,12 +112,7 @@ endmacro()
 # we drop support for the Visual Studio backend and use the COMPILE_LANGUAGE
 # generator expression. This is a very serious limitation.
 macro(WEBKIT_ADD_TARGET_CXX_FLAGS _target)
-    foreach (_flag ${ARGN})
-        check_cxx_compiler_flag("${_flag}" CXX_COMPILER_SUPPORTS_${_flag})
-        if (CXX_COMPILER_SUPPORTS_${_flag})
-            target_compile_options(${_target} PRIVATE ${_flag})
-        endif ()
-    endforeach ()
+    WEBKIT_ADD_COMPILER_FLAGS(CXX TARGET ${_target} ${ARGN})
 endmacro()
 
 


### PR DESCRIPTION
#### e739d6576a590c7211f9438c5fa9d54fd4cb1ee6
<pre>
Simplify compiler flags checking in Source/ThirdParty/skia/CMakeLists.txt
<a href="https://bugs.webkit.org/show_bug.cgi?id=270162">https://bugs.webkit.org/show_bug.cgi?id=270162</a>

Reviewed by Michael Catanzaro.

Add new WEBKIT_CHECK_COMPILER_FLAGS and WEBKIT_ADD_COMPILER_FLAGS
functions, which split the existing functionality of the existing
WEBKIT_ADD_TARGET_{C,CXX}_FLAGS macros, making them more generic.
The old macros are kept for now, but implemented in terms of the
new functions.

While at it, the WEBKIT_ADD_COMPILER_FLAGS function was augmented to
support applying flags to SOURCE files and DIRECTORY paths, and a
tweak added to ensure results of checks for flags containing equals
characters (=) are properly cached by CMake to save some time in CMake
re-runs.

* Source/ThirdParty/skia/CMakeLists.txt: Make use of the new
  WEBKIT_CHECK_COMPILER_FLAGS and WEBKIT_ADD_COMPILER_FLAGS functions.
* Source/cmake/WebKitCompilerFlags.cmake: Split and improve
  functionality from the WEBKIT_ADD_TARGET_{C,CXX}_FLAGS macros into
  a new function to check flags and another generic function to apply
  flags to targets, sources, or directories.

Canonical link: <a href="https://commits.webkit.org/275430@main">https://commits.webkit.org/275430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a6c84d7dcdbf3aca511a56682de43b0b3ae0167

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37809 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34473 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45685 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35169 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41024 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41342 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39456 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18150 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48353 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18207 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9850 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5602 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->