### PR TITLE
Bump the QoS of the IPC receive queue in the UIProcess

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -290,9 +290,9 @@ struct Connection::PendingSyncReply {
     }
 };
 
-Ref<Connection> Connection::createServerConnection(Identifier identifier)
+Ref<Connection> Connection::createServerConnection(Identifier identifier, Thread::QOS receiveQueueQOS)
 {
-    return adoptRef(*new Connection(identifier, true));
+    return adoptRef(*new Connection(identifier, true, receiveQueueQOS));
 }
 
 Ref<Connection> Connection::createClientConnection(Identifier identifier)
@@ -306,10 +306,10 @@ HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>& Connection::c
     return map;
 }
 
-Connection::Connection(Identifier identifier, bool isServer)
+Connection::Connection(Identifier identifier, bool isServer, Thread::QOS receiveQueueQOS)
     : m_uniqueID(UniqueID::generate())
     , m_isServer(isServer)
-    , m_connectionQueue(WorkQueue::create("com.apple.IPC.ReceiveQueue"))
+    , m_connectionQueue(WorkQueue::create("com.apple.IPC.ReceiveQueue", receiveQueueQOS))
 {
     {
         Locker locker { s_connectionMapLock };

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -255,7 +255,7 @@ public:
     pid_t remoteProcessID() const;
 #endif
 
-    static Ref<Connection> createServerConnection(Identifier);
+    static Ref<Connection> createServerConnection(Identifier, Thread::QOS = Thread::QOS::Default);
     static Ref<Connection> createClientConnection(Identifier);
 
     struct ConnectionIdentifierPair {
@@ -423,7 +423,7 @@ public:
     template<typename T, typename C> static void cancelReply(C&& completionHandler);
 
 private:
-    Connection(Identifier, bool isServer);
+    Connection(Identifier, bool isServer, Thread::QOS = Thread::QOS::Default);
     void platformInitialize(Identifier);
     bool platformPrepareForOpen();
     void platformOpen();

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -328,7 +328,7 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::C
     m_boostedJetsamAssertion = ProcessAssertion::create(*this, "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
 #endif
 
-    RefPtr connection = IPC::Connection::createServerConnection(connectionIdentifier);
+    RefPtr connection = IPC::Connection::createServerConnection(connectionIdentifier, Thread::QOS::UserInteractive);
     m_connection = connection.copyRef();
 
     connectionWillOpen(*connection);


### PR DESCRIPTION
#### a1ec0afd089816638d36426a46298c019ae12246
<pre>
Bump the QoS of the IPC receive queue in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=270178">https://bugs.webkit.org/show_bug.cgi?id=270178</a>
<a href="https://rdar.apple.com/120745771">rdar://120745771</a>

Reviewed by Geoffrey Garen and Sihui Liu.

Bump the QoS of the IPC receive queue in the UIProcess. The IPC receive queue was
running at a much lower QoS than the main thread, potentially causing delay in
some performance-sensitive tasks. We&apos;ve seen examples (see radar) of the main
thread hanging, waiting on the IPC receive queue to release a lock for e.g.

This tested as performance-neutral on most benchmarks. However, this tested as
a ~0.7% progression on PLT5 on Apple Silicon.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::createServerConnection):
(IPC::Connection::Connection):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):

Canonical link: <a href="https://commits.webkit.org/275462@main">https://commits.webkit.org/275462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9869a94b67203666c8ea5668a61a29adc2e08565

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37836 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34503 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15173 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15376 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41046 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39483 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18234 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5617 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->