### PR TITLE
[AVIF Downlevels] Allow pixi property to be missing in AVIF images

### DIFF
--- a/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp
@@ -37,6 +37,11 @@ AVIFImageReader::AVIFImageReader(RefPtr<AVIFImageDecoder>&& decoder)
     : m_decoder(WTFMove(decoder))
     , m_avifDecoder(avifDecoderCreate())
 {
+    // Allow the PixelInformationProperty ('pixi') to be missing in AV1 image
+    // items. libheif v1.11.0 or older does not add the 'pixi' item property to
+    // AV1 image items. (This issue has been corrected in libheif v1.12.0.).
+    // See the definition of AVIF_STRICT_PIXI_REQUIRED in avif.h.
+    m_avifDecoder->strictFlags &= ~AVIF_STRICT_PIXI_REQUIRED;
 }
 
 AVIFImageReader::~AVIFImageReader() = default;


### PR DESCRIPTION
#### 345ed1bf70a2508e18652a003f3ec26a1e272016
<pre>
[AVIF Downlevels] Allow pixi property to be missing in AVIF images
<a href="https://bugs.webkit.org/show_bug.cgi?id=270180">https://bugs.webkit.org/show_bug.cgi?id=270180</a>
<a href="https://rdar.apple.com/116808395">rdar://116808395</a>

Reviewed by Cameron McCormack.

If an image is missing the pixi property, decoding its frames will fail because
we enable AVIF_STRICT_PIXI_REQUIRED when avifDecoder is created. So we need to
remove this restriction to be compatible with newer OSs and other browsers.

* Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp:
(WebCore::AVIFImageReader::AVIFImageReader):

Canonical link: <a href="https://commits.webkit.org/275608@main">https://commits.webkit.org/275608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73563a4fab13114448115686caf7172a2f076458

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34507 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41050 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39487 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18184 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9463 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->