### PR TITLE
REGRESSION(275377@main): [Win] GLContext::makeContextCurrent calls purecall for WebGL tests

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -40,7 +40,7 @@ namespace WebCore {
 
 class TextureMapperGCGLPlatformLayer;
 
-class WEBCORE_EXPORT GraphicsContextGLTextureMapperANGLE : public GraphicsContextGLANGLE, public GLContextWrapper {
+class WEBCORE_EXPORT GraphicsContextGLTextureMapperANGLE : public GLContextWrapper, public GraphicsContextGLANGLE {
 public:
     static RefPtr<GraphicsContextGLTextureMapperANGLE> create(WebCore::GraphicsContextGLAttributes&&);
     virtual ~GraphicsContextGLTextureMapperANGLE();


### PR DESCRIPTION
#### cc42f3bc02dcbb775285515187d926faf241c2f7
<pre>
REGRESSION(275377@main): [Win] GLContext::makeContextCurrent calls purecall for WebGL tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=270186">https://bugs.webkit.org/show_bug.cgi?id=270186</a>

Unreviewed crash fix.

275377@main introduced GLContextWrapper class to track the current GL
context. ~GLContextWrapper unsets the current context if it is `this`
context.

GraphicsContextGLTextureMapperANGLE class inherits both
GraphicsContextGLANGLE and GLContextWrapper classes in the following
order.

&gt; class GraphicsContextGLTextureMapperANGLE : public GraphicsContextGLANGLE, public GLContextWrapper {

Thus, destructors are called in the following order

1. ~GraphicsContextGLTextureMapperANGLE
2. ~GLContextWrapper
3. ~GraphicsContextGLANGLE

~GLContextWrapper unsets the current context, but
~GraphicsContextGLANGLE makes `this` context current again.
GLContextWrapper base class should be before GraphicsContextGLANGLE.

* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:

Canonical link: <a href="https://commits.webkit.org/275402@main">https://commits.webkit.org/275402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2321db48f4babfa982d89463e958379e26b1c801

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41761 "Failed to checkout and rebase branch from PR 25188") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37854 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44068 "Failed to checkout and rebase branch from PR 25188") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18106 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17703 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/35963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/36987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45731 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37947 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16576 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18252 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5587 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->