### PR TITLE
Web Extension popup can present too soon.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -124,6 +124,7 @@ public:
 
     WKWebView *popupWebView(LoadOnFirstAccess = LoadOnFirstAccess::Yes);
     void presentPopupWhenReady();
+    void popupDidFinishDocumentLoad();
     void readyToPresentPopup();
     void popupSizeDidChange();
     void closePopup();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -579,6 +579,7 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePath)
     auto *resources = @{
         @"background.js": backgroundScript,
         @"toolbar-48.png": extraLargeToolbarIcon,
+        @"popup.html": @"Hello world!",
     };
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
@@ -612,6 +613,7 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
         @"toolbar-48.png": largeToolbarIcon,
         @"toolbar-96.png": extraLargeToolbarIcon,
         @"toolbar-128.png": superExtraLargeToolbarIcon,
+        @"popup.html": @"Hello world!",
     };
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
@@ -658,7 +660,12 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageData)
         @"browser.action.openPopup()"
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
@@ -693,7 +700,12 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)
         @"browser.action.openPopup()"
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
@@ -742,7 +754,12 @@ TEST(WKWebExtensionAPIAction, SetIconWithSVGDataURL)
         @"browser.action.openPopup()"
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
@@ -784,7 +801,12 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
         @"browser.action.openPopup();"
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {


### PR DESCRIPTION
#### d2091f38fe857c747e7eb84f0e2d7fe19aa6fd1c
<pre>
Web Extension popup can present too soon.
<a href="https://webkit.org/b/270185">https://webkit.org/b/270185</a>
<a href="https://rdar.apple.com/problem/123711867">rdar://problem/123711867</a>

Reviewed by Brian Weinstein.

Instead of starting the timer that presented the popup on the start of the load,
we should start it after the document has loaded and rendering will begin.

This prevents us from showing the popup while it might still be loading, and
causing it to resize mid-animation in most instances.

Also connect delegate methods for load fails to close the popup, so the web view
doesn&apos;t stick around indefinitely. Some API tests were failing to load because the
popup.html resource was missing.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionWebViewDelegate webView:didFailProvisionalNavigation:withError:]):
(-[_WKWebExtensionActionWebViewDelegate webView:didFailNavigation:withError:]):
(-[_WKWebExtensionActionWebViewDelegate _webView:navigationDidFinishDocumentLoad:]):
(WebKit::WebExtensionAction::presentPopupWhenReady):
(WebKit::WebExtensionAction::popupDidFinishDocumentLoad):
(WebKit::WebExtensionAction::readyToPresentPopup):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/275454@main">https://commits.webkit.org/275454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dff29456cd7afa63f287544638923de175e89dd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37960 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18210 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42439 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45844 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16680 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5612 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->