### PR TITLE
[LBSE] Fix svg/repaint/image-with-clip-path.svg

### DIFF
--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
@@ -369,7 +369,6 @@ css3/masking/reference-clip-path-change-repaint.html                            
 imported/w3c/web-platform-tests/svg/import/masking-path-07-b-manual.svg                           [ ImageOnlyFailure ]
 svg/batik/text/textProperties.svg                                                                 [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg [ ImageOnlyFailure ]
-svg/repaint/image-with-clip-path.svg                                                              [ ImageOnlyFailure ]
 
 # Masking problems
 svg/masking/mask-negative-scale.svg                       [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1341,6 +1341,17 @@ void RenderLayer::updateTransform()
     }
 }
 
+void RenderLayer::forceStackingContextIfNeeded()
+{
+    if (setIsCSSStackingContext(true)) {
+        setIsNormalFlowOnly(false);
+        if (parent()) {
+            if (!hasNotIsolatedBlendingDescendantsStatusDirty() && hasNotIsolatedBlendingDescendants())
+                parent()->dirtyAncestorChainHasBlendingDescendants();
+        }
+    }
+}
+
 TransformationMatrix RenderLayer::currentTransform(OptionSet<RenderStyle::TransformOperationOption> options) const
 {
     if (!m_transform)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -217,6 +217,8 @@ public:
     // itself, if it is a stacking container.
     RenderLayer* enclosingStackingContext() { return isStackingContext() ? this : stackingContext(); }
 
+    void forceStackingContextIfNeeded();
+
     RenderLayer* paintOrderParent() const;
 
     std::optional<LayoutRect> cachedClippedOverflowRect() const;

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -643,23 +643,32 @@ void RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange()
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
 
+    updateHasSVGTransformFlags();
+
+    // LBSE shares the text rendering code with the legacy SVG engine, largely unmodified.
+    // At present text layout depends on transformations ('screen font scaling factor' is used to
+    // determine which font to use for layout / painting). Therefore if the x/y scaling factors
+    // of the transformation matrix changes due to the transform update, we have to recompute the text metrics
+    // of all RenderSVGText descendants of the renderer in the ancestor chain, that will receive the transform
+    // update.
+    //
+    // There is no intrinsic reason for that, besides historical ones. If we decouple
+    // the 'font size screen scaling factor' from layout and only use it during painting
+    // we can optimize transformations for text, simply by avoid the need for layout.
+    auto previousTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
+    updateLayerTransform();
+
+    auto currentTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
+
+    // We have to force a stacking context if we did not have a transform before. Normally
+    // RenderLayer::styleChanged does this for us but repaintOrRelayoutAfterSVGTransformChange
+    // does not end up calling it.
+    if (previousTransform.isIdentity() && !currentTransform.isIdentity()) {
+        if (hasLayer())
+            layer()->forceStackingContextIfNeeded();
+    }
+
     auto determineIfLayerTransformChangeModifiesScale = [&]() -> bool {
-        updateHasSVGTransformFlags();
-
-        // LBSE shares the text rendering code with the legacy SVG engine, largely unmodified.
-        // At present text layout depends on transformations ('screen font scaling factor' is used to
-        // determine which font to use for layout / painting). Therefore if the x/y scaling factors
-        // of the transformation matrix changes due to the transform update, we have to recompute the text metrics
-        // of all RenderSVGText descendants of the renderer in the ancestor chain, that will receive the transform
-        // update.
-        //
-        // There is no intrinsic reason for that, besides historical ones. If we decouple
-        // the 'font size screen scaling factor' from layout and only use it during painting
-        // we can optimize transformations for text, simply by avoid the need for layout.
-        auto previousTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
-        updateLayerTransform();
-
-        auto currentTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
         if (previousTransform == currentTransform)
             return false;
 
@@ -672,9 +681,9 @@ void RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange()
             return true;
 
         return false;
-    };
+    }();
 
-    if (determineIfLayerTransformChangeModifiesScale()) {
+    if (determineIfLayerTransformChangeModifiesScale) {
         if (auto* textAffectedByTransformChange = dynamicDowncast<RenderSVGText>(this)) {
             // Mark text metrics for update, and only trigger a relayout and not an explicit repaint.
             textAffectedByTransformChange->setNeedsTextMetricsUpdate();
@@ -698,7 +707,6 @@ void RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange()
 
     // Instead of performing a full-fledged layout (issuing repaints), just recompute the layer transform, and repaint.
     // In LBSE transformations do not affect the layout (except for text, where it still does!) -- SVG follows closely the CSS/HTML route, to avoid costly layouts.
-    updateLayerTransform();
     repaintRendererOrClientsOfReferencedSVGResources();
 }
 


### PR DESCRIPTION
#### 6dc9c6a25c09a9b226ac1d692b4dcad6b29be15b
<pre>
[LBSE] Fix svg/repaint/image-with-clip-path.svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=270187">https://bugs.webkit.org/show_bug.cgi?id=270187</a>

Reviewed by Nikolas Zimmermann.

On a transform change from identity matrix to non-identity matrix
the render layer needs to become a stacking context without relying on
a style update in the case of LBSE. Add logic for this in repaintOrRelayoutAfterSVGTransformChange.

Also add a correction to only call updateLayerTransform once in
repaintOrRelayoutAfterSVGTransformChange.

* LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateTransform):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange):

Canonical link: <a href="https://commits.webkit.org/275683@main">https://commits.webkit.org/275683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5511c47bc94b3ae4fd74e06cce2e06c0802a37cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35087 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46409 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41753 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40354 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18783 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9506 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->