### PR TITLE
Safari unable to play YouTube content fast enough. Content window spins and plays only after 25-30 seconds

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h
@@ -48,7 +48,7 @@ public:
         static std::once_flag onceKey;
         static LazyNeverDestroyed<Ref<WorkQueue>> messageQueue;
         std::call_once(onceKey, [] {
-            messageQueue.construct(WorkQueue::create("PlatformMediaResourceLoader", WorkQueue::QOS::Background));
+            messageQueue.construct(WorkQueue::create("PlatformMediaResourceLoader"));
         });
         return messageQueue.get();
     }

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -55,7 +55,7 @@ WorkQueue& MediaSourcePrivateRemote::queue()
     static std::once_flag onceKey;
     static LazyNeverDestroyed<Ref<WorkQueue>> workQueue;
     std::call_once(onceKey, [] {
-        workQueue.construct(WorkQueue::create("MediaSourceRemote", WorkQueue::QOS::Background));
+        workQueue.construct(WorkQueue::create("MediaSourceRemote"));
     });
     return workQueue.get();
 }


### PR DESCRIPTION
#### dc7bb79ca72bfc056244eb5d31e0d5844f8faa61
<pre>
Safari unable to play YouTube content fast enough. Content window spins and plays only after 25-30 seconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=270205">https://bugs.webkit.org/show_bug.cgi?id=270205</a>
<a href="https://rdar.apple.com/123528095">rdar://123528095</a>

Reviewed by Eric Carlson.

Both MSE and MediaSourceRemote and RemoteMediaResourceLoader WorkQueue were created using QOS::Background priority.
Trace shows that when a task is being run on those WorkQueues, they are either being pre-empted or yielded and sometimes
it takes over 10s for a task to even complete.

We change the priority to the default, the same as what the IPC&apos;s WorkQueue is using.

* Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::queue):

Canonical link: <a href="https://commits.webkit.org/275443@main">https://commits.webkit.org/275443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5efad0ed5f4885dd9137d358765e82284ee4e452

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37890 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34542 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15450 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41098 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18231 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9378 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->