### PR TITLE
Initialize organization storage access prompt quirks if needed

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -499,6 +499,7 @@ void DocumentLoader::finishedLoading()
         if (!frameLoader())
             return;
         frameLoader()->client().finishedLoading(this);
+        frameLoader()->client().loadStorageAccessQuirksIfNeeded();
     }
 
     m_writer.end();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2807,7 +2807,6 @@ void FrameLoader::checkLoadCompleteForThisFrame()
             if (m_frame->isMainFrame()) {
                 tracePoint(MainResourceLoadDidEnd, PAGE_ID);
                 page->didFinishLoad();
-                m_client->loadStorageAccessQuirksIfNeeded();
             }
         }
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -137,6 +137,7 @@ public:
     const Vector<WebCore::OrganizationStorageAccessPromptQuirk>& cachedQuirks() const { return m_cachedQuirks; }
     void updateQuirks(CompletionHandler<void()>&&);
     void setCachedQuirksForTesting(Vector<WebCore::OrganizationStorageAccessPromptQuirk>&&);
+    void initialize();
 
     Ref<StorageAccessPromptQuirkObserver> observeUpdates(Function<void()>&&);
 
@@ -148,6 +149,7 @@ private:
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> m_cachedQuirks;
     WeakHashSet<StorageAccessPromptQuirkObserver> m_observers;
+    bool m_wasInitialized { false };
 };
 
 class StorageAccessUserAgentStringQuirkController {
@@ -157,6 +159,7 @@ public:
     const HashMap<WebCore::RegistrableDomain, String>& cachedQuirks() const { return m_cachedQuirks; }
     void updateQuirks(CompletionHandler<void()>&&);
     void setCachedQuirksForTesting(HashMap<WebCore::RegistrableDomain, String>&&);
+    void initialize();
 
     Ref<StorageAccessUserAgentStringQuirkObserver> observeUpdates(Function<void()>&&);
 
@@ -168,6 +171,7 @@ private:
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     HashMap<WebCore::RegistrableDomain, String> m_cachedQuirks;
     WeakHashSet<StorageAccessUserAgentStringQuirkObserver> m_observers;
+    bool m_wasInitialized { false };
 };
 
 class RestrictedOpenerDomainsController {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -212,6 +212,10 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
     parameters.isParentProcessFullWebBrowserOrRunningTest = isFullWebBrowserOrRunningTest();
 #endif
 
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::shared().cachedQuirks();
+#endif
+
     WebProcessPool::platformInitializeNetworkProcess(parameters);
     sendWithAsyncReply(Messages::NetworkProcess::InitializeNetworkProcess(WTFMove(parameters)), [weakThis = WeakPtr { *this }] {
         if (weakThis)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -313,12 +313,9 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     m_storageAccessUserAgentStringQuirksDataUpdateObserver = StorageAccessUserAgentStringQuirkController::shared().observeUpdates([weakThis = WeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get()) {
-            if (StorageAccessUserAgentStringQuirkController::shared().cachedQuirks().isEmpty())
-                return;
-            // FIXME: Filter by process's site when site isolation is enabled
+        // FIXME: Filter by process's site when site isolation is enabled
+        if (RefPtr protectedThis = weakThis.get())
             protectedThis->sendToAllProcesses(Messages::WebProcess::UpdateStorageAccessUserAgentStringQuirks(StorageAccessUserAgentStringQuirkController::shared().cachedQuirks()));
-        }
     });
 
     m_storageAccessPromptQuirksDataUpdateObserver = StorageAccessPromptQuirkController::shared().observeUpdates([weakThis = WeakPtr { *this }] {
@@ -331,6 +328,10 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
             protectedThis->sendToAllProcesses(Messages::WebProcess::UpdateDomainsWithStorageAccessQuirks(domainSet));
         }
     });
+    if (StorageAccessPromptQuirkController::shared().cachedQuirks().isEmpty())
+        StorageAccessPromptQuirkController::shared().initialize();
+    if (StorageAccessUserAgentStringQuirkController::shared().cachedQuirks().isEmpty())
+        StorageAccessUserAgentStringQuirkController::shared().initialize();
 #endif
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1460,6 +1460,7 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
+
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
     __block bool done = false;
@@ -1467,6 +1468,7 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
+    done = false;
 
     [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObject:@"site2.example"] completionHandler:^{
         done = true;


### PR DESCRIPTION
#### 31d01d86c4f5bbc1dabc06aaf23fd0c0e7f1912a
<pre>
Initialize organization storage access prompt quirks if needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=270206">https://bugs.webkit.org/show_bug.cgi?id=270206</a>
<a href="https://rdar.apple.com/123728311">rdar://123728311</a>

Reviewed by Wenson Hsieh.

The API tests I added in 271821@main directly initialize the cache, but in
reality we actually need another mechanism to pull existing data from the
framework. This patch adds initialization support.

The callback is now dispatched onto the runloop because refing an APIObject in its
own constructor is not supported on some architectures.

Also this change now fetches the quirked domains to be a little earlier in the
page-load process, making the quirk behavior less racy. It also resets resource
load statistics database for some tests where stale data was causing issues.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::finishedLoading):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):

Fetch the quirk data from the network process when the main document is
finished loading.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::StorageAccessPromptQuirkController::setCachedQuirksForTesting):
(WebKit::StorageAccessPromptQuirkController::initialize):

Set and check initialized state.

(WebKit::StorageAccessPromptQuirkController::updateQuirks):

Avoid calling the completion handler synchronously. This ensures we never call
it in the WebProcessPool constructor.

(WebKit::StorageAccessUserAgentStringQuirkController::setCachedQuirksForTesting):
(WebKit::StorageAccessUserAgentStringQuirkController::initialize):
Set and check initialized state.

(WebKit::StorageAccessUserAgentStringQuirkController::updateQuirks):

Avoid calling the completion handler synchronously. This ensures we never call
it in the WebProcessPool constructor.

* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):

I missed initializing this in 271748@main.

* Source/WebKit/UIProcess/WebProcessPool.cpp:

Initialize quirk sets when creating a new web process, if necessary.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/276087@main">https://commits.webkit.org/276087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42563aa6ca844b43651600bbda8b81467f0b3710

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39639 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35977 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38549 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1566 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39756 "Found 2 new API test failures: TestWebKitAPI.WebAuthenticationPanel.NullPanelHidSuccess, TestWebKitAPI.WebAuthenticationPanel.GetAssertionInternalUV (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47689 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42761 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19963 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41433 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9722 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->