### PR TITLE
 Extract a portion of NodeIteratorBase::acceptNode which checks bit flags into its own function

### DIFF
--- a/Source/WebCore/dom/TreeWalker.cpp
+++ b/Source/WebCore/dom/TreeWalker.cpp
@@ -183,6 +183,17 @@ ExceptionOr<Node*> TreeWalker::nextSibling()
 
 ExceptionOr<Node*> TreeWalker::previousNode()
 {
+    if (!filter()) {
+        if (m_current.ptr() == &root())
+            return nullptr;
+        for (RefPtr node = NodeTraversal::previous(m_current); node; node = NodeTraversal::previous(*node)) {
+            if (matchesWhatToShow(*node))
+                return setCurrent(node.releaseNonNull());
+            if (node == &root())
+                break;
+        }
+        return nullptr;
+    }
     RefPtr node = m_current.ptr();
     while (node != &root()) {
         while (RefPtr previousSibling = node->previousSibling()) {
@@ -230,6 +241,13 @@ ExceptionOr<Node*> TreeWalker::previousNode()
 
 ExceptionOr<Node*> TreeWalker::nextNode()
 {
+    if (!filter()) {
+        for (RefPtr node = NodeTraversal::next(m_current, &root()); node; node = NodeTraversal::next(*node, &root())) {
+            if (matchesWhatToShow(*node))
+                return setCurrent(node.releaseNonNull());
+        }
+        return nullptr;
+    }
     RefPtr node = m_current.ptr();
 Children:
     while (RefPtr firstChild = node->firstChild()) {


### PR DESCRIPTION
#### ff897caf5ad29704726b6551c955396a4775631e
<pre>
 Extract a portion of NodeIteratorBase::acceptNode which checks bit flags into its own function
<a href="https://bugs.webkit.org/show_bug.cgi?id=270210">https://bugs.webkit.org/show_bug.cgi?id=270210</a>
&lt;<a href="https://rdar.apple.com/problem/123733686">rdar://problem/123733686</a>&gt;

Reviewed by Chris Dumez.

Extracted matchesWhatToShow out of acceptNode and deployed in TreeWalker::nextNode and
TreeWalker::previousNode.

* Source/WebCore/dom/Traversal.cpp:
(WebCore::NodeIteratorBase::acceptNodeSlowCase):
* Source/WebCore/dom/Traversal.h:
(WebCore::NodeIteratorBase::acceptNode):
(WebCore::NodeIteratorBase::matchesWhatToShow):
* Source/WebCore/dom/TreeWalker.cpp:
(WebCore::TreeWalker::previousNode):
(WebCore::TreeWalker::nextNode):

Canonical link: <a href="https://commits.webkit.org/275468@main">https://commits.webkit.org/275468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f47d6cdcb84a534860d0ed316edb38daeb7494fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34578 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41131 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39577 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18334 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5619 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->