### PR TITLE
DigitalCredentialRequestOptions doesn't need an abort signal

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "AbortSignal.h"
 #include "IdentityRequestProvider.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -36,7 +35,6 @@ namespace WebCore {
 struct IdentityRequestProvider;
 
 struct DigitalCredentialRequestOptions {
-    RefPtr<AbortSignal> signal;
     Vector<IdentityRequestProvider> providers;
 };
 

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
@@ -24,6 +24,5 @@
  */
 
 dictionary DigitalCredentialRequestOptions {
-    AbortSignal signal;
     required sequence<IdentityRequestProvider> providers;
 };


### PR DESCRIPTION
#### 71de231b1df27e6a4fff8905938ad0f8a8ed767f
<pre>
DigitalCredentialRequestOptions doesn&apos;t need an abort signal
<a href="https://bugs.webkit.org/show_bug.cgi?id=270212">https://bugs.webkit.org/show_bug.cgi?id=270212</a>
<a href="https://rdar.apple.com/123735008">rdar://123735008</a>

Reviewed by Anne van Kesteren.

Removed signal member as per latest Digital Credentials spec.

* Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.h:
* Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl:

Canonical link: <a href="https://commits.webkit.org/275437@main">https://commits.webkit.org/275437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2e0179a9e5cbef2c0bd1d0b48de9fc9ca87b578

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41838 "Failed to checkout and rebase branch from PR 25211") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44420 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37933 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44145 "Failed to checkout and rebase branch from PR 25211") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18183 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42412 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/45816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16653 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18331 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5606 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->