### PR TITLE
[ wk2 Debug ] loader/stateobjects/pushstate-size-iframe.html is very slow, usually times out

### DIFF
--- a/LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt
+++ b/LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt
@@ -5,40 +5,9 @@ Parent frame successfully added item: 1 times
 Parent frame successfully added item: 2 times
 Parent frame successfully added item: 3 times
 Parent frame successfully added item: 4 times
-Parent frame successfully added item: 5 times
-Parent frame successfully added item: 6 times
-Parent frame successfully added item: 7 times
-Parent frame successfully added item: 8 times
-Parent frame successfully added item: 9 times
-Parent frame successfully added item: 10 times
-
-
---------
-Frame: '<!--frame1-->'
---------
 iFrame successfully added item: 1 times
 iFrame successfully added item: 2 times
 iFrame successfully added item: 3 times
 iFrame successfully added item: 4 times
-iFrame successfully added item: 5 times
-iFrame successfully added item: 6 times
-iFrame successfully added item: 7 times
-iFrame successfully added item: 8 times
-iFrame successfully added item: 9 times
-iFrame successfully added item: 10 times
-iFrame successfully added item: 11 times
-iFrame successfully added item: 12 times
-iFrame successfully added item: 13 times
-iFrame successfully added item: 14 times
-iFrame successfully added item: 15 times
-iFrame successfully added item: 16 times
-iFrame successfully added item: 17 times
-iFrame successfully added item: 18 times
-iFrame successfully added item: 19 times
-iFrame successfully added item: 20 times
-iFrame successfully added item: 21 times
-iFrame successfully added item: 22 times
-iFrame successfully added item: 23 times
-iFrame successfully added item: 24 times
 Expected exception: QuotaExceededError: Attempt to store more data than allowed using history.pushState()
 

--- a/LayoutTests/loader/stateobjects/pushstate-size-iframe.html
+++ b/LayoutTests/loader/stateobjects/pushstate-size-iframe.html
@@ -2,8 +2,12 @@
 
 if (window.testRunner) {
     testRunner.dumpAsText();
-    testRunner.dumpChildFramesAsText();
     testRunner.waitUntilDone();
+}
+
+if (window.internals) {
+    // Decrease the state object total limit from 64MB to 4MB to speed up the test.
+    internals.setHistoryTotalStateObjectPayloadLimitOverride(4 * 1024 * 1024);
 }
 
 function log(msg) {
@@ -11,7 +15,7 @@ function log(msg) {
 }
 
 var object = "aaaaaaaaaa";
-for (var i = 0; i < 16; ++i)
+for (var i = 0; i < 14; ++i)
     object += object;
 
 function click()
@@ -42,7 +46,7 @@ function clicked()
     log("Parent frame successfully added item: " + count + " times");
     ++count;
 
-    if (count > 10) {
+    if (count > 4) {
         openFrame();
         return;
     }

--- a/LayoutTests/loader/stateobjects/resources/pushstate-iframe.html
+++ b/LayoutTests/loader/stateobjects/resources/pushstate-iframe.html
@@ -1,43 +1,27 @@
 <script>
 
-if (window.testRunner) {
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
-}
-
-function log(msg) {
-    document.getElementById("logger").innerHTML += msg + "<br>";
-}
-
-var object = "aaaaaaaaaa";
-for (var i = 0; i < 16; ++i)
-    object += object;
-
 var count = 1;
 
 function iframeClicked()
 {
     try {
-        history.pushState(object, object, "#" + object);
+        history.pushState(top.object, top.object, "#" + top.object);
     } catch (e) {
-        log("Expected exception: " + e);
+        top.log("Expected exception: " + e);
         if (window.testRunner)
             testRunner.notifyDone();    
     }
 
-    log("iFrame successfully added item: " + count + " times");
+    top.log("iFrame successfully added item: " + count + " times");
     ++count;
 
     if (count > 50) {
-        log("This has gone on for way too long");
+        top.log("This has gone on for way too long");
         if (window.testRunner)
             testRunner.notifyDone();
     }
 
-    setTimeout(window.parent.click, 0);
+    setTimeout(top.click, 0);
 }
 
 </script>
-<body>
-<div id="logger"></div>
-</body>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1978,8 +1978,6 @@ webkit.org/b/268494 [ Monterey+ Release ] media/track/media-element-enqueue-even
 
 webkit.org/b/264001 [ Debug ] imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls.html [ Pass Failure ]
 
-webkit.org/b/268836 [ Monterey+ Debug ] loader/stateobjects/pushstate-size-iframe.html [ Skip ]
-
 # webkit.org/b/269003 Umbrella bug for flaky test failures impacting EWS 
 [ Monterey+ Release X86_64 ] compositing/clipping/border-radius-async-overflow-non-stacking.html [ Pass ImageOnlyFailure ]
 [ Monterey+ Release ] imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/page/History.h
+++ b/Source/WebCore/page/History.h
@@ -51,6 +51,8 @@ public:
     ExceptionOr<ScrollRestoration> scrollRestoration() const;
     ExceptionOr<void> setScrollRestoration(ScrollRestoration);
 
+    void setTotalStateObjectPayloadLimitOverride(std::optional<uint32_t> limit) { m_totalStateObjectPayloadLimitOverride = limit; }
+
     ExceptionOr<SerializedScriptValue*> state();
     JSValueInWrappedObject& cachedState();
     JSValueInWrappedObject& cachedStateForGC() { return m_cachedState; }
@@ -78,6 +80,7 @@ private:
     URL urlForState(const String& url);
 
     SerializedScriptValue* stateInternal() const;
+    uint32_t totalStateObjectPayloadLimit() const;
 
     RefPtr<SerializedScriptValue> m_lastStateObjectRequested;
     JSValueInWrappedObject m_cachedState;
@@ -87,6 +90,7 @@ private:
 
     // For the main frame's History object to keep track of all state object usage.
     uint64_t m_totalStateObjectUsage { 0 };
+    std::optional<uint32_t> m_totalStateObjectPayloadLimitOverride;
 
     // For each individual History object to keep track of the most recent state object added.
     uint64_t m_mostRecentStateObjectUsage { 0 };

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -159,7 +159,7 @@ public:
     WEBCORE_EXPORT void setCanShowModalDialogOverride(bool);
 
     Screen& screen();
-    History& history();
+    WEBCORE_EXPORT History& history();
     Crypto& crypto() const;
     BarProp& locationbar();
     BarProp& menubar();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -108,6 +108,7 @@
 #include "HTMLTextAreaElement.h"
 #include "HTMLVideoElement.h"
 #include "HighlightRegistry.h"
+#include "History.h"
 #include "HistoryController.h"
 #include "HistoryItem.h"
 #include "HitTestResult.h"
@@ -574,6 +575,9 @@ void Internals::resetToConsistentState(Page& page)
         if (auto* backing = mainFrameView->tiledBacking())
             backing->setTileSizeUpdateDelayDisabledForTesting(false);
     }
+
+    if (RefPtr window = localMainFrame->window())
+        window->history().setTotalStateObjectPayloadLimitOverride(std::nullopt);
 
     WTF::clearDefaultPortForProtocolMapForTesting();
     overrideUserPreferredLanguages(Vector<String>());
@@ -7328,6 +7332,14 @@ bool Internals::hasScopeBreakingHasSelectors() const
 {
     contextDocument()->styleScope().flushPendingUpdate();
     return !!contextDocument()->styleScope().resolver().ruleSets().scopeBreakingHasPseudoClassInvalidationRuleSet();
+}
+
+void Internals::setHistoryTotalStateObjectPayloadLimitOverride(uint32_t limit)
+{
+    RefPtr window = contextDocument() ? contextDocument()->domWindow() : nullptr;
+    if (!window)
+        return;
+    window->history().setTotalStateObjectPayloadLimitOverride(limit);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1012,6 +1012,8 @@ public:
     double currentAudioBufferSize() const;
     bool audioSessionActive() const;
 
+    void setHistoryTotalStateObjectPayloadLimitOverride(uint32_t);
+
     void storeRegistrationsOnDisk(DOMPromiseDeferred<void>&&);
     void sendH2Ping(String url, DOMPromiseDeferred<IDLDouble>&&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1314,6 +1314,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     SelectorFilterHashCounts selectorFilterHashCounts(DOMString selector);
 
+    undefined setHistoryTotalStateObjectPayloadLimitOverride(unsigned long limit);
+
     readonly attribute boolean isVisuallyNonEmpty;
     
     boolean isUsingUISideCompositing();


### PR DESCRIPTION
#### 4e8b5c1a05ae111def3a5754f16af81ff19ae3a0
<pre>
[ wk2 Debug ] loader/stateobjects/pushstate-size-iframe.html is very slow, usually times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=268836">https://bugs.webkit.org/show_bug.cgi?id=268836</a>
<a href="https://rdar.apple.com/122401579">rdar://122401579</a>

Reviewed by Ryosuke Niwa.

This test was slow, especially in debug because it had to reach the 64MB size limit by doing
repeated history.pushState() calls. This would obviously take a while. To address the issue,
I am introducing a new window.internals API to override this limit. In the test, we now
lower this limit to 4MB, which makes the test run a lot faster.

* LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt:
* LayoutTests/loader/stateobjects/pushstate-size-iframe.html:
* LayoutTests/loader/stateobjects/resources/pushstate-iframe.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/page/History.cpp:
(WebCore::History::totalStateObjectPayloadLimit const):
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/History.h:
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::setHistoryTotalStateObjectPayloadLimitOverride):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/275452@main">https://commits.webkit.org/275452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98870facc7db1afe96ae57fef9a5f56b8d0cef0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44438 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18201 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15266 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45835 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37391 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13689 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9380 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->