### PR TITLE
[JSC] Stress tests have bogus asserts due to incorrectly negating `instanceof` operator

### DIFF
--- a/JSTests/ChakraCore/test/Array/array_splice.js
+++ b/JSTests/ChakraCore/test/Array/array_splice.js
@@ -121,7 +121,7 @@ try
 }
 catch(e)
 {
- if (!e instanceof TypeError) throw(e);
+ if (!(e instanceof TypeError)) throw e;
  WScript.Echo(y);
  WScript.Echo(x);
 }
@@ -132,7 +132,7 @@ try
 }
 catch(e)
 {
- if (!e instanceof TypeError) throw(e);
+ if (!(e instanceof TypeError)) throw e;
  WScript.Echo(y);
  WScript.Echo(x);
 }
@@ -143,7 +143,7 @@ try
 }
  catch(e)
 {
- if (!e instanceof TypeError) throw(e);
+ if (!(e instanceof TypeError)) throw e;
  WScript.Echo(y);
  WScript.Echo(x);
 }

--- a/JSTests/ChakraCore/test/Array/array_splice_double.js
+++ b/JSTests/ChakraCore/test/Array/array_splice_double.js
@@ -121,7 +121,7 @@ try
 }
 catch(e)
 {
- if (!e instanceof TypeError) throw(e);
+ if (!(e instanceof TypeError)) throw e;
  WScript.Echo(y);
  WScript.Echo(x);
 }
@@ -132,7 +132,7 @@ try
 }
 catch(e)
 {
- if (!e instanceof TypeError) throw(e);
+ if (!(e instanceof TypeError)) throw e;
  WScript.Echo(y);
  WScript.Echo(x);
 }
@@ -143,7 +143,7 @@ try
 }
  catch(e)
 {
- if (!e instanceof TypeError) throw(e);
+ if (!(e instanceof TypeError)) throw e;
  WScript.Echo(y);
  WScript.Echo(x);
 }

--- a/JSTests/stress/dfg-get-private-name-by-id-generic.js
+++ b/JSTests/stress/dfg-get-private-name-by-id-generic.js
@@ -13,7 +13,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error(`Expected to throw a ${exception.name} but it threw: ${e}`);
         }
 

--- a/JSTests/stress/dfg-get-private-name-by-id-osr-bad-identifier.js
+++ b/JSTests/stress/dfg-get-private-name-by-id-osr-bad-identifier.js
@@ -13,7 +13,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error(`Expected to throw a ${exception.name} but it threw: ${e}`);
         }
 

--- a/JSTests/stress/dfg-get-private-name-by-offset-osr-bad-identifier.js
+++ b/JSTests/stress/dfg-get-private-name-by-offset-osr-bad-identifier.js
@@ -13,7 +13,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error(`Expected to throw a ${exception.name} but it threw: ${e}`);
         }
 

--- a/JSTests/stress/dfg-get-private-name-by-offset-osr-bad-structure.js
+++ b/JSTests/stress/dfg-get-private-name-by-offset-osr-bad-structure.js
@@ -13,7 +13,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error(`Expected to throw a ${exception.name} but it threw: ${e}`);
         }
 

--- a/JSTests/stress/dfg-get-private-name-by-val-generic.js
+++ b/JSTests/stress/dfg-get-private-name-by-val-generic.js
@@ -13,7 +13,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error(`Expected to throw a ${exception.name} but it threw: ${e}`);
         }
 

--- a/JSTests/stress/dfg-put-private-name-check-barrier-insertion.js
+++ b/JSTests/stress/dfg-put-private-name-check-barrier-insertion.js
@@ -12,7 +12,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/dfg-put-private-name-compiled-as-put-by-id-direct.js
+++ b/JSTests/stress/dfg-put-private-name-compiled-as-put-by-id-direct.js
@@ -8,7 +8,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/dfg-put-private-name-compiled-as-put-private-name-by-id.js
+++ b/JSTests/stress/dfg-put-private-name-compiled-as-put-private-name-by-id.js
@@ -8,7 +8,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/get-private-name-with-primitive.js
+++ b/JSTests/stress/get-private-name-with-primitive.js
@@ -6,7 +6,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/invalidate-array-iterator-prototype-next.js
+++ b/JSTests/stress/invalidate-array-iterator-prototype-next.js
@@ -7,7 +7,7 @@ try {
         throw new Error("It should never execute");
     }
 } catch(e) {
-    if (!e instanceof TypeError)
+    if (!(e instanceof TypeError))
         throw new Error("It should throw a TypeError, but it threw " + e);
 }
 

--- a/JSTests/stress/private-method-and-field-named-constructor.js
+++ b/JSTests/stress/private-method-and-field-named-constructor.js
@@ -3,7 +3,7 @@ function assertSyntaxError(code) {
         eval(code);
         throw new Error("Should throw SyntaxError, but executed code without throwing");
     } catch(e) {
-        if (!e instanceof SyntaxError)
+        if (!(e instanceof SyntaxError))
             throw new Error("Should throw SyntaxError, but threw " + e);
     }
 }

--- a/JSTests/stress/private-method-check-structure-miss.js
+++ b/JSTests/stress/private-method-check-structure-miss.js
@@ -10,7 +10,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/private-method-invalid-multiple-brand-installation.js
+++ b/JSTests/stress/private-method-invalid-multiple-brand-installation.js
@@ -10,7 +10,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/private-method-invalidate-compiled-with-constant-symbol.js
+++ b/JSTests/stress/private-method-invalidate-compiled-with-constant-symbol.js
@@ -10,7 +10,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/private-method-polymorphic-with-constant-symbol.js
+++ b/JSTests/stress/private-method-polymorphic-with-constant-symbol.js
@@ -10,7 +10,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 
@@ -45,7 +45,7 @@ for (; i < 10000; i++) {
     assert.sameValue(c.access(), 'test');
 }
 
-assert.shouldThrow(TypeError, () => {
+assert.shouldThrow(ReferenceError, () => {
     c.access.call({});
 });
 

--- a/JSTests/stress/private-method-untyped-use.js
+++ b/JSTests/stress/private-method-untyped-use.js
@@ -8,7 +8,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/put-private-name-by-id-set-do-not-add-structure-trasition.js
+++ b/JSTests/stress/put-private-name-by-id-set-do-not-add-structure-trasition.js
@@ -8,7 +8,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/put-private-name-invalid-define.js
+++ b/JSTests/stress/put-private-name-invalid-define.js
@@ -10,7 +10,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/put-private-name-invalid-store.js
+++ b/JSTests/stress/put-private-name-invalid-store.js
@@ -10,7 +10,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/put-private-name-invalidate-compiled-with-constant-symbol.js
+++ b/JSTests/stress/put-private-name-invalidate-compiled-with-constant-symbol.js
@@ -10,7 +10,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/put-private-name-untyped-use.js
+++ b/JSTests/stress/put-private-name-untyped-use.js
@@ -8,7 +8,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/put-private-name-with-primitive.js
+++ b/JSTests/stress/put-private-name-with-primitive.js
@@ -6,7 +6,7 @@ let assert = {
             threwException = false;
         } catch(e) {
             threwException = true;
-            if (!e instanceof exception)
+            if (!(e instanceof exception))
                 throw new Error("Expected to throw: " + exception.name + " but it throws: " + e.name);
         }
 

--- a/JSTests/stress/regexp-with-runtime-syntax-errors.js
+++ b/JSTests/stress/regexp-with-runtime-syntax-errors.js
@@ -5,7 +5,7 @@ function testThrowsSyntaxtError(f)
     try {
         f();
     } catch (e) {
-        if (!e instanceof SyntaxError)
+        if (!(e instanceof SyntaxError))
             throw "Expected SynteaxError, but got: " + e;
     }
 }

--- a/JSTests/stress/spread-calling.js
+++ b/JSTests/stress/spread-calling.js
@@ -75,7 +75,7 @@ for (let i = 0; i < 3000; i++) {
         testFunction(...objectThrow);
         failed = true;
     } catch (e) {
-        if (!e instanceof Error)
+        if (!(e instanceof Error))
             failed = true;
     }
     if (failed)


### PR DESCRIPTION
#### d4af38db11471f708621121528888e92ffed9443
<pre>
[JSC] Stress tests have bogus asserts due to incorrectly negating `instanceof` operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=261815">https://bugs.webkit.org/show_bug.cgi?id=261815</a>
&lt;<a href="https://rdar.apple.com/problem/116114756">rdar://problem/116114756</a>&gt;

Reviewed by Mark Lam.

Relational operators in JavaScript, including `instanceof`, have lower precedence than
logical negation, meaning `!err instanceof TypeError` evaluates as `false instanceof TypeError`
if `err` is an object.

This change fixes asserts in our tests to actually validate error constructors, which exposed
that one test had wrong expectation of `TypeError` instead of `ReferenceError`: JSC, V8, and
SpiderMonkey all throw `ReferenceError` for that code.

* JSTests/ChakraCore/test/Array/array_splice.js:
* JSTests/ChakraCore/test/Array/array_splice_double.js:
* JSTests/stress/dfg-get-private-name-by-id-generic.js:
* JSTests/stress/dfg-get-private-name-by-id-osr-bad-identifier.js:
* JSTests/stress/dfg-get-private-name-by-offset-osr-bad-identifier.js:
* JSTests/stress/dfg-get-private-name-by-offset-osr-bad-structure.js:
* JSTests/stress/dfg-get-private-name-by-val-generic.js:
* JSTests/stress/dfg-put-private-name-check-barrier-insertion.js:
* JSTests/stress/dfg-put-private-name-compiled-as-put-by-id-direct.js:
* JSTests/stress/dfg-put-private-name-compiled-as-put-private-name-by-id.js:
* JSTests/stress/get-private-name-with-primitive.js:
* JSTests/stress/invalidate-array-iterator-prototype-next.js:
* JSTests/stress/private-method-and-field-named-constructor.js:
* JSTests/stress/private-method-check-structure-miss.js:
* JSTests/stress/private-method-invalid-multiple-brand-installation.js:
* JSTests/stress/private-method-invalidate-compiled-with-constant-symbol.js:
* JSTests/stress/private-method-polymorphic-with-constant-symbol.js:
* JSTests/stress/private-method-untyped-use.js:
* JSTests/stress/put-private-name-by-id-set-do-not-add-structure-trasition.js:
* JSTests/stress/put-private-name-invalid-define.js:
* JSTests/stress/put-private-name-invalid-store.js:
* JSTests/stress/put-private-name-invalidate-compiled-with-constant-symbol.js:
* JSTests/stress/put-private-name-untyped-use.js:
* JSTests/stress/put-private-name-with-primitive.js:
* JSTests/stress/regexp-with-runtime-syntax-errors.js:
* JSTests/stress/spread-calling.js:

Canonical link: <a href="https://commits.webkit.org/275433@main">https://commits.webkit.org/275433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75f390f8936f620791b03eb08f41b31b11e84389

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34563 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15456 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45802 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35279 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41116 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41452 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39561 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18260 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48463 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18318 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9861 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5605 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->