### PR TITLE
Adopt dynamicDowncast<> in WebKit/Shared

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
@@ -54,9 +54,10 @@ std::optional<WebCore::DynamicContentScalingDisplayList> DynamicContentScalingBi
     if (!m_dynamicContentScalingBackend)
         return std::nullopt;
     auto* sharing = static_cast<WebCore::ImageBufferBackend&>(*m_dynamicContentScalingBackend).toBackendSharing();
-    if (!is<ImageBufferBackendHandleSharing>(sharing))
+    auto* imageSharing = dynamicDowncast<ImageBufferBackendHandleSharing>(sharing);
+    if (!imageSharing)
         return std::nullopt;
-    auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).takeBackendHandle();
+    auto handle = imageSharing->takeBackendHandle();
     if (!handle || !std::holds_alternative<WebCore::DynamicContentScalingDisplayList>(*handle))
         return std::nullopt;
     auto& displayList = std::get<WebCore::DynamicContentScalingDisplayList>(*handle);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -326,15 +326,13 @@ bool RemoteLayerBackingStoreCollection::markAllBackingStoreVolatile(OptionSet<Vo
     auto now = MonotonicTime::now();
 
     for (auto& backingStore : m_liveBackingStore) {
-        if (is<RemoteLayerWithRemoteRenderingBackingStore>(backingStore))
-            continue;
-        successfullyMadeBackingStoreVolatile &= markInProcessBackingStoreVolatile(downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore), liveBackingStoreMarkingBehavior, now);
+        if (auto* inProcessBackingStore = dynamicDowncast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore))
+            successfullyMadeBackingStoreVolatile &= markInProcessBackingStoreVolatile(*inProcessBackingStore, liveBackingStoreMarkingBehavior, now);
     }
 
     for (auto& backingStore : m_unparentedBackingStore) {
-        if (is<RemoteLayerWithRemoteRenderingBackingStore>(backingStore))
-            continue;
-        successfullyMadeBackingStoreVolatile &= markInProcessBackingStoreVolatile(downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore), unparentedBackingStoreMarkingBehavior, now);
+        if (auto* inProcessBackingStore = dynamicDowncast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore))
+            successfullyMadeBackingStoreVolatile &= markInProcessBackingStoreVolatile(*inProcessBackingStore, unparentedBackingStoreMarkingBehavior, now);
     }
 
     return successfullyMadeBackingStoreVolatile;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -72,11 +72,8 @@ void RemoteLayerWithInProcessRenderingBackingStore::clearBackingStore()
 
 static std::optional<ImageBufferBackendHandle> handleFromBuffer(ImageBuffer& buffer)
 {
-    auto* sharing = buffer.toBackendSharing();
-    if (is<ImageBufferBackendHandleSharing>(sharing))
-        return downcast<ImageBufferBackendHandleSharing>(*sharing).takeBackendHandle(SharedMemory::Protection::ReadOnly);
-
-    return std::nullopt;
+    auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(buffer.toBackendSharing());
+    return sharing ? sharing->takeBackendHandle(SharedMemory::Protection::ReadOnly) : std::nullopt;
 }
 
 std::optional<ImageBufferBackendHandle> RemoteLayerWithInProcessRenderingBackingStore::frontBufferHandle() const

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/Node.h>
 #include <WebCore/RenderImage.h>
 #include <WebCore/SharedBuffer.h>
+#include <WebCore/Text.h>
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
@@ -96,7 +97,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
     , elementBoundingBox(elementBoundingBoxInWindowCoordinates(hitTestResult))
     , isScrollbar(IsScrollbar::No)
     , isSelected(hitTestResult.isSelected())
-    , isTextNode(hitTestResult.innerNode() && hitTestResult.innerNode()->isTextNode())
+    , isTextNode(is<Text>(hitTestResult.innerNode()))
     , isOverTextInsideFormControlElement(hitTestResult.isOverTextInsideFormControlElement())
     , isDownloadableMedia(hitTestResult.isDownloadableMedia())
     , mediaIsInFullscreen(hitTestResult.mediaIsInFullscreen())
@@ -126,7 +127,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, b
     , elementBoundingBox(elementBoundingBoxInWindowCoordinates(hitTestResult))
     , isScrollbar(IsScrollbar::No)
     , isSelected(hitTestResult.isSelected())
-    , isTextNode(hitTestResult.innerNode() && hitTestResult.innerNode()->isTextNode())
+    , isTextNode(is<Text>(hitTestResult.innerNode()))
     , isOverTextInsideFormControlElement(hitTestResult.isOverTextInsideFormControlElement())
     , isDownloadableMedia(hitTestResult.isDownloadableMedia())
     , mediaIsInFullscreen(hitTestResult.mediaIsInFullscreen())
@@ -151,9 +152,9 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, b
             imageSharedMemory = WebCore::SharedMemory::copyBuffer(*buffer);
     }
 
-    if (auto target = RefPtr { hitTestResult.innerNonSharedNode() }) {
+    if (RefPtr target = hitTestResult.innerNonSharedNode()) {
         if (auto renderer = dynamicDowncast<RenderImage>(target->renderer())) {
-            imageBitmap = createShareableBitmap(*downcast<RenderImage>(target->renderer()));
+            imageBitmap = createShareableBitmap(*renderer);
             if (auto* cachedImage = renderer->cachedImage()) {
                 if (auto* image = cachedImage->image())
                     sourceImageMIMEType = image->mimeType();

--- a/Source/WebKit/Shared/WebImage.cpp
+++ b/Source/WebKit/Shared/WebImage.cpp
@@ -137,11 +137,8 @@ RefPtr<ShareableBitmap> WebImage::bitmap() const
         return nullptr;
     const_cast<ImageBuffer&>(*m_buffer).flushDrawingContext();
 
-    auto* sharing = m_buffer->toBackendSharing();
-    if (!is<ImageBufferBackendHandleSharing>(sharing))
-        return nullptr;
-
-    return downcast<ImageBufferBackendHandleSharing>(*sharing).bitmap();
+    auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(m_buffer->toBackendSharing());
+    return sharing ? sharing->bitmap() : nullptr;
 }
 
 #if USE(CAIRO)
@@ -156,16 +153,16 @@ RefPtr<cairo_surface_t> WebImage::createCairoSurface()
 std::optional<ShareableBitmap::Handle> WebImage::createHandle(SharedMemory::Protection protection) const
 {
     if (!m_buffer)
-        return std::nullopt;
+        return { };
     const_cast<ImageBuffer&>(*m_buffer).flushDrawingContext();
 
-    auto* sharing = m_buffer->toBackendSharing();
-    if (!is<ImageBufferBackendHandleSharing>(sharing))
-        return std::nullopt;
+    auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(m_buffer->toBackendSharing());
+    if (!sharing)
+        return { };
 
-    auto backendHandle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle(protection);
+    auto backendHandle = sharing->createBackendHandle(protection);
     if (!backendHandle)
-        return std::nullopt;
+        return { };
 
     return std::get<ShareableBitmap::Handle>(WTFMove(*backendHandle));
 }

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.cpp
@@ -77,8 +77,8 @@ size_t MediaSampleByteRange::sizeInBytes() const
 
 WebCore::FloatSize MediaSampleByteRange::presentationSize() const
 {
-    if (m_block.isVideo())
-        return downcast<const VideoInfo>(m_block.info())->displaySize;
+    if (auto* videoInfo = dynamicDowncast<VideoInfo>(m_block.info()))
+        return videoInfo->displaySize;
     return { };
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -953,7 +953,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FloatPoint locati
     }
 
     // FIXME: Avoid scanning if we will just throw away the result (e.g. we're over a link).
-    if (!pageOverlayDidOverrideDataDetectors && hitTestResult.innerNode() && (hitTestResult.innerNode()->isTextNode() || hitTestResult.isOverTextInsideFormControlElement())) {
+    if (!pageOverlayDidOverrideDataDetectors && (is<Text>(hitTestResult.innerNode()) || hitTestResult.isOverTextInsideFormControlElement())) {
         if (auto result = DataDetection::detectItemAroundHitTestResult(hitTestResult)) {
             if (auto detectedContext = WTFMove(result->actionContext))
                 immediateActionResult.platformData.detectedDataActionContext = { { WTFMove(detectedContext) } };


### PR DESCRIPTION
#### fd792cf72092af5479252d3203ffcf11fa1855ae
<pre>
Adopt dynamicDowncast&lt;&gt; in WebKit/Shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=270216">https://bugs.webkit.org/show_bug.cgi?id=270216</a>

Reviewed by Chris Dumez.

For security &amp; performance.

* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm:
(WebKit::DynamicContentScalingBifurcatedImageBuffer::dynamicContentScalingDisplayList):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::markAllBackingStoreVolatile):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::handleFromBuffer):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):

Includes a drive-by fix to adopt is&lt;Text&gt;.

* Source/WebKit/Shared/WebImage.cpp:
(WebKit::WebImage::bitmap const):
(WebKit::WebImage::createHandle const):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleByteRange.cpp:
(WebKit::MediaSampleByteRange::presentationSize const):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):

This is a drive-by fix to adopt is&lt;Text&gt;. As
isOverTextInsideFormControlElement() already does its own null check on
innerNode() there&apos;s no need to do that twice.

Canonical link: <a href="https://commits.webkit.org/275447@main">https://commits.webkit.org/275447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9df78858a6c276da24231e01d2609f8b51f17aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44413 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37928 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34572 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15462 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45811 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41125 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39571 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18267 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9382 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->