### PR TITLE
Some Overlay Regions are missing for fixed elements

### DIFF
--- a/LayoutTests/overlay-region/overlay-element-expected.txt
+++ b/LayoutTests/overlay-region/overlay-element-expected.txt
@@ -1,0 +1,97 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (overlay region [x: 0 y: 0 width: 800 height: 600])
+      (layer bounds [x: 0 y: 2000 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/overlay-element-overflow-expected.txt
+++ b/LayoutTests/overlay-region/overlay-element-overflow-expected.txt
@@ -1,0 +1,155 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 0)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: <class not in allowed list of classes>]
+                                          (scrolling behavior 2)
+                                          (overlay region [x: 0 y: 0 width: 800 height: 600])
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                          (layer position [x: 400 y: 400])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 7000])
+                                              (layer anchorPoint [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                              (layer position [x: 791 y: 791])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                  (layer position [x: 6 y: 6]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 6 y: 6])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                          (layer position [x: 6 y: 6]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                          (layer position [x: 6 y: 6]))))))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+                                              (layer position [x: 400 y: 400])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                  (layer position [x: 400 y: 400]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 12])
+                                                  (layer position [x: 400 y: 400])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                      (layer position [x: 400 y: 400])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                          (layer position [x: 48 y: 48]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                          (layer position [x: 48 y: 48]))))))))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/overlay-element-overflow.html
+++ b/LayoutTests/overlay-region/overlay-element-overflow.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow: scroll;
+        }
+
+        .fixed-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div class="fixed-overlay">
+        <h1>This is a fixed overlay</h1>
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/overlay-element.html
+++ b/LayoutTests/overlay-region/overlay-element.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        .fixed-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div class="fixed-overlay">
+        <h1>This is a fixed overlay</h1>
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    await UIHelper.animationFrame();
+    window.scrollTo(0, 2000);
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
#### b6a2c84bcb5e069688d976fff1e57953741c7f47
<pre>
Some Overlay Regions are missing for fixed elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=270224">https://bugs.webkit.org/show_bug.cgi?id=270224</a>
&lt;<a href="https://rdar.apple.com/119326797">rdar://119326797</a>&gt;

Reviewed by Mike Wyrzykowski.

We can&apos;t filter Overlay Regions based on size. Instead, when
looking at regions from parent ScrollViews, only keep regions
originating from layers that draw above the selected ScrollView.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(addOverlayEventRegions):
When traversing fixed layer hierarchies, stop at ScrollView boundaries.
The issue wasn&apos;t with solid background colors layers, they don&apos;t have
Event Regions. But when a scroller is `position: fixed` we don&apos;t want to
generate Overlay Regions for all its descendants (like the scrolled
content layer, which always has an Event Region).
(configureScrollViewWithOverlayRegionsIDs):
(-[WKWebView _updateOverlayRegions:destroyedLayers:]):
Only keep regions from layers that draw above the selected ScrollView.
Remove the size check for Overlay Regions.

* LayoutTests/overlay-region/overlay-element-expected.txt: Added.
* LayoutTests/overlay-region/overlay-element-overflow-expected.txt: Added.
* LayoutTests/overlay-region/overlay-element-overflow.html: Added.
* LayoutTests/overlay-region/overlay-element.html: Added.
Add new test cases for the &quot;full page overlay&quot; scenario.

Canonical link: <a href="https://commits.webkit.org/275458@main">https://commits.webkit.org/275458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1deecb351940adc55f7e2c3fab26c55ec2d85d61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37947 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34588 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15259 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41139 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39586 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36341 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9387 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->