### PR TITLE
[GStreamer][WebRTC] Incoming track handling fixes

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -888,7 +888,7 @@ void GStreamerMediaEndpoint::initiate(bool isInitiator, GstStructure* rawOptions
 void GStreamerMediaEndpoint::getStats(GstPad* pad, const GstStructure* additionalStats, Ref<DeferredPromise>&& promise)
 {
     GUniquePtr<GstStructure> aggregatedStats(additionalStats ? gst_structure_copy(additionalStats) : gst_structure_new_empty("stats"));
-    for (auto& processor : m_trackProcessors) {
+    for (auto& processor : m_trackProcessors.values()) {
         if (pad && pad != processor->pad())
             continue;
 
@@ -933,7 +933,7 @@ void GStreamerMediaEndpoint::getStats(RTCRtpReceiver& receiver, Ref<DeferredProm
         // The incoming source bin is not linked yet, so look for a matching upstream track processor.
         GstPad* pad = nullptr;
         const auto& trackId = receiver.track().id();
-        for (auto& processor : m_trackProcessors) {
+        for (auto& processor : m_trackProcessors.values()) {
             if (processor->trackId() != trackId)
                 continue;
             pad = processor->pad();
@@ -1017,13 +1017,12 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
     auto& mediaStream = mediaStreamFromRTCStream(data.mediaStreamId);
     mediaStream.addTrackFromPlatform(track);
 
-    for (auto& processor : m_trackProcessors) {
+    for (auto& processor : m_trackProcessors.values()) {
         if (!processor->isReady())
             return;
     }
 
     GST_DEBUG_OBJECT(m_pipeline.get(), "Incoming streams gathered, now dispatching track events");
-    m_pendingIncomingStreams = 0;
     m_peerConnectionBackend.dispatchPendingTrackEvents(mediaStream);
     gst_element_set_state(m_pipeline.get(), GST_STATE_PLAYING);
 
@@ -1035,9 +1034,12 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
 
 void GStreamerMediaEndpoint::connectPad(GstPad* pad)
 {
-    m_pendingIncomingStreams++;
+    GRefPtr<GstWebRTCRTPTransceiver> transceiver;
+    g_object_get(pad, "transceiver", &transceiver.outPtr(), nullptr);
 
-    auto trackProcessor = GStreamerIncomingTrackProcessor::create(ThreadSafeWeakPtr { *this }, GRefPtr<GstPad>(pad));
+    auto trackProcessor = m_trackProcessors.get(transceiver);
+    trackProcessor->configure(ThreadSafeWeakPtr { *this }, GRefPtr<GstPad>(pad));
+
     auto bin = trackProcessor->bin();
     gst_bin_add(GST_BIN_CAST(m_pipeline.get()), bin);
 
@@ -1045,7 +1047,6 @@ void GStreamerMediaEndpoint::connectPad(GstPad* pad)
     gst_pad_link(pad, sinkPad.get());
     gst_element_sync_state_with_parent(bin);
 
-    m_trackProcessors.append(WTFMove(trackProcessor));
 #ifndef GST_DISABLE_GST_DEBUG
     auto dotFileName = makeString(GST_OBJECT_NAME(m_pipeline.get()), ".pending-"_s, GST_OBJECT_NAME(pad));
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
@@ -1585,6 +1586,9 @@ void GStreamerMediaEndpoint::collectTransceivers()
 
     for (unsigned i = 0; i < transceivers->len; i++) {
         auto current = adoptGRef(g_array_index(transceivers, GstWebRTCRTPTransceiver*, i));
+        m_trackProcessors.ensure(GRefPtr(current), [] {
+            return GStreamerIncomingTrackProcessor::create();
+        });
         auto* existingTransceiver = m_peerConnectionBackend.existingTransceiver([&](auto& transceiverBackend) {
             return current == transceiverBackend.rtcTransceiver();
         });

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -187,7 +187,6 @@ private:
 
     Ref<GStreamerStatsCollector> m_statsCollector;
 
-    unsigned m_pendingIncomingStreams { 0 };
     uint32_t m_negotiationNeededEventId { 0 };
 
 #if !RELEASE_LOG_DISABLED
@@ -204,7 +203,7 @@ private:
 
     RefPtr<UniqueSSRCGenerator> m_ssrcGenerator;
 
-    Vector<RefPtr<GStreamerIncomingTrackProcessor>> m_trackProcessors;
+    HashMap<GRefPtr<GstWebRTCRTPTransceiver>, RefPtr<GStreamerIncomingTrackProcessor>> m_trackProcessors;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -195,7 +195,6 @@ void GStreamerPeerConnectionBackend::close()
 void GStreamerPeerConnectionBackend::doStop()
 {
     m_endpoint->stop();
-    m_pendingReceivers.clear();
 }
 
 void GStreamerPeerConnectionBackend::doAddIceCandidate(RTCIceCandidate& candidate, AddIceCandidateCallback&& callback)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -120,8 +120,6 @@ private:
     bool m_isLocalDescriptionSet { false };
     bool m_isRemoteDescriptionSet { false };
 
-    Vector<std::unique_ptr<GStreamerIceCandidate>> m_pendingCandidates;
-    Vector<Ref<RTCRtpReceiver>> m_pendingReceivers;
     Vector<PendingTrackEvent> m_pendingTrackEvents;
 
     bool m_isReconfiguring { false };

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -29,15 +29,18 @@ GST_DEBUG_CATEGORY(webkit_webrtc_incoming_track_processor_debug);
 
 namespace WebCore {
 
-GStreamerIncomingTrackProcessor::GStreamerIncomingTrackProcessor(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&& endPoint, GRefPtr<GstPad>&& pad)
-    : m_endPoint(WTFMove(endPoint))
-    , m_pad(WTFMove(pad))
+GStreamerIncomingTrackProcessor::GStreamerIncomingTrackProcessor()
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_webrtc_incoming_track_processor_debug, "webkitwebrtcincomingtrackprocessor", 0, "WebKit WebRTC Incoming Track Processor");
     });
+}
 
+void GStreamerIncomingTrackProcessor::configure(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&& endPoint, GRefPtr<GstPad>&& pad)
+{
+    m_endPoint = WTFMove(endPoint);
+    m_pad = WTFMove(pad);
     m_data.mediaStreamBinName = makeString(GST_OBJECT_NAME(m_pad.get()));
     m_bin = gst_bin_new(m_data.mediaStreamBinName.ascii().data());
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
@@ -30,14 +30,16 @@ class GStreamerIncomingTrackProcessor : public RefCounted<GStreamerIncomingTrack
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    static Ref<GStreamerIncomingTrackProcessor> create(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&& endPoint, GRefPtr<GstPad>&& pad)
+    static Ref<GStreamerIncomingTrackProcessor> create()
     {
-        return adoptRef(*new GStreamerIncomingTrackProcessor(WTFMove(endPoint), WTFMove(pad)));
+        return adoptRef(*new GStreamerIncomingTrackProcessor());
     }
     ~GStreamerIncomingTrackProcessor() = default;
 
-    GstElement* bin() const { return m_bin.get(); }
+    void configure(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&&, GRefPtr<GstPad>&&);
     GstPad* pad() const { return m_pad.get(); }
+
+    GstElement* bin() const { return m_bin.get(); }
 
     const GstStructure* stats();
 
@@ -46,7 +48,7 @@ public:
     const String& trackId() const { return m_data.trackId; }
 
 private:
-    GStreamerIncomingTrackProcessor(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&&, GRefPtr<GstPad>&&);
+    GStreamerIncomingTrackProcessor();
 
     void retrieveMediaStreamAndTrackIdFromSDP();
     String mediaStreamIdFromPad();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -241,7 +241,6 @@ public:
             if (GST_IS_QUERY(info->data)) {
                 switch (GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info))) {
                 case GST_QUERY_CAPS:
-                case GST_QUERY_LATENCY:
                     return GST_PAD_PROBE_OK;
                 default:
                     break;


### PR DESCRIPTION
#### 0dc9f7d98abd0412a0c01e62c5de0119ec1720b3
<pre>
[GStreamer][WebRTC] Incoming track handling fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=270225">https://bugs.webkit.org/show_bug.cgi?id=270225</a>

Reviewed by Xabier Rodriguez-Calvar.

The IncomingTrackProcessors are now created upfront, based on the transceivers. Creating them within
the pad-added signal handler was too late, potentially leading to issues where  the track events
might be emitted too early, for an incoming MediaStream containing a video and audio track, when the
audio RTP stream is slightly delayed the video track event would be fired too early, leading to
unexpected behaviour on JS side.

We also now relay latency queries from the webkitmediastreamsrc to the WebRTC pipeline, fixing audio
loss issues in case the audio track is delayed compared to the video track.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::getStats):
(WebCore::GStreamerMediaEndpoint::connectIncomingTrack):
(WebCore::GStreamerMediaEndpoint::connectPad):
(WebCore::GStreamerMediaEndpoint::collectTransceivers):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::doStop):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::GStreamerIncomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::configure):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h:
(WebCore::GStreamerIncomingTrackProcessor::create):
(WebCore::GStreamerIncomingTrackProcessor::bin const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:

Canonical link: <a href="https://commits.webkit.org/275483@main">https://commits.webkit.org/275483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/618fd22efed275eaf60777b9aa03ee2fa905f615

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37956 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34600 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45840 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39602 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18295 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9400 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->