### PR TITLE
[JHBuild] Dependencies are not updating after changing `Tools/gstreamer/jhbuild.modules`

### DIFF
--- a/Tools/Scripts/update-webkit-libs-jhbuild
+++ b/Tools/Scripts/update-webkit-libs-jhbuild
@@ -58,6 +58,7 @@ sub getJhbuildIncludedFilePaths
 
     foreach my $includeFile ($dom->findnodes('/moduleset/include/@href')) {
         push(@includes, $includeFile->to_literal());
+        push(@includes, getJhbuildIncludedFilePaths($includeFile->to_literal()));
     }
     return @includes;
 }

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -3,8 +3,6 @@
 <?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
 <moduleset>
 
-  <include href="../gstreamer/jhbuild.modules"/>
-
   <metamodule id="webkitgtk-minimal-dependencies">
     <dependencies>
       <dep package="wpebackend-fdo"/>


### PR DESCRIPTION
#### 63a3f022275f179c2cacab7c64576f661a439956
<pre>
[JHBuild] Dependencies are not updating after changing `Tools/gstreamer/jhbuild.modules`
<a href="https://bugs.webkit.org/show_bug.cgi?id=270228">https://bugs.webkit.org/show_bug.cgi?id=270228</a>

Reviewed by Adrian Perez de Castro.

Starting from 168884@main, `update-webkit-libs-jhbuild` updates
dependencies only when the configuration has changed.

When `WEBKIT_JHBUILD_MODULESET=minimal-plus-gstreamer` is set,
the script can detect changes in the main modules files:

* `Tools/gtk/jhbuild-minimal-plus-gstreamer.modules` for GTK
* `Tools/wpe/jhbuild-minimal-plus-gstreamer.modules` for WPE

and one level includes:

* `Tools/jhbuild/jhbuild-minimal-plus-gstreamer.modules` for both.

But it doesn&apos;t look for further includes.

This patch makes the script check all includes recursively.

Also, we don&apos;t need to include `gstreamer/jhbuild.modules` into
`jhbuild-minimal.modules` since we have a dedicated file for this -
`jhbuild-minimal-plus-gstreamer.modules` which includes both.

* Tools/Scripts/update-webkit-libs-jhbuild:
(getJhbuildIncludedFilePaths):
* Tools/jhbuild/jhbuild-minimal.modules:

Canonical link: <a href="https://commits.webkit.org/275775@main">https://commits.webkit.org/275775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc8d47fd5093b3213b4c69fe3cb06158508c1b6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45294 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38805 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35338 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16286 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16357 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37798 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46798 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42046 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19119 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40670 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19298 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5794 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->