### PR TITLE
TypeChecker::visit should set zeroValue for arrays without arguments

### DIFF
--- a/LayoutTests/fast/webgpu/type-checker-array-without-argument-expected.txt
+++ b/LayoutTests/fast/webgpu/type-checker-array-without-argument-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/type-checker-array-without-argument.html
+++ b/LayoutTests/fast/webgpu/type-checker-array-without-argument.html
@@ -1,0 +1,47 @@
+<html>
+  <body>
+    <script>
+      const doTest = async () => {
+        try {
+          const adapter = await navigator.gpu.requestAdapter();
+          const device = await adapter.requestDevice();
+          const module = device.createShaderModule({
+            code: `
+              fn tesch() {
+                let x1 = array<i32, 5>();
+              _32611&=
+               array<i32, 2>()[-0];
+              ;
+              _32611&=
+              array<i32, 9>();
+                let x1 = array<i32, 120>();
+                let x2 = array<i32,9>();//
+              l=array<i32,1>();//consents:han 0z
+                let x1 = array<i32, 39>();
+                let x1 = array<i32,10>();
+              ;
+              _32611&=
+               array<i32, 2>();
+              ;
+              _32611&=
+               array<i32, 2>();
+                let x1 = array<i32, 39>();
+                let x2 = array<i32,9>();//
+              l=array<i32,1>();//conster than 0z
+                let x1 = array<i32, 120>();
+                let x1 = array<i32, 71h>()[-0];
+              ;
+              _32611&=
+               array<i32, 2>();
+              }
+            `,
+          });
+        } catch (e) { }
+        if (window.testRunner) { testRunner.notifyDone() }
+      };
+      if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+      doTest();
+    </script>
+    This test passes if it does not crash.
+  </body>
+</html>

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1272,7 +1272,6 @@ void TypeChecker::visit(AST::CallExpression& call)
                         isConstant = false;
                     }
                     if (isConstant) {
-
                         if (numberOfArguments)
                             setConstantValue(call, targetBinding->type, ConstantStruct { WTFMove(constantFields) });
                         else
@@ -1493,9 +1492,12 @@ void TypeChecker::visit(AST::CallExpression& call)
             else
                 arguments[i] = *value;
         }
-        if (isConstant)
-            setConstantValue(call, result, ConstantArray(WTFMove(arguments)));
-
+        if (isConstant) {
+            if (argumentCount)
+                setConstantValue(call, result, ConstantArray(WTFMove(arguments)));
+            else
+                setConstantValue(call, result, zeroValue(result));
+        }
         return;
     }
 


### PR DESCRIPTION
#### 4098a18a57d8b50fa8970688171dba7bd6ef71d7
<pre>
TypeChecker::visit should set zeroValue for arrays without arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=270230">https://bugs.webkit.org/show_bug.cgi?id=270230</a>
<a href="https://rdar.apple.com/123745652">rdar://123745652</a>

Reviewed by Tadeu Zagallo.

This matches what we do with ConstantStruct.

* LayoutTests/fast/webgpu/type-checker-array-bounds-expected.txt: Added.
* LayoutTests/fast/webgpu/type-checker-array-bounds.html: Added.
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):

Canonical link: <a href="https://commits.webkit.org/275534@main">https://commits.webkit.org/275534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0f0553b51dc5670da2e2b6774d5ac15250b3a51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38219 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18452 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15797 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46126 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37620 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40072 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36563 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18601 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5662 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->