### PR TITLE
[ews] Load passwords.json from ews-build directory for all masters

### DIFF
--- a/Tools/CISupport/build-webkit-org/master.cfg
+++ b/Tools/CISupport/build-webkit-org/master.cfg
@@ -14,11 +14,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 loadConfig = importlib.import_module("build-webkit-org.loadConfig")
 
 
-def load_password(name, default=None):
+def load_password(name, default=None, master_prefix_path=os.path.dirname(os.path.abspath(__file__))):
     if os.getenv(name):
         return os.getenv(name)
     try:
-        passwords = json.load(open('passwords.json'))
+        passwords = json.load(open(os.path.join(master_prefix_path, 'passwords.json')))
         return passwords.get(name, default)
     except FileNotFoundError as e:
         print(f'ERROR: passwords.json missing: {e}, using default value for {name}\n')

--- a/Tools/CISupport/ews-build/utils.py
+++ b/Tools/CISupport/ews-build/utils.py
@@ -25,11 +25,11 @@ import os
 import socket
 
 
-def load_password(name, default=None):
+def load_password(name, default=None, master_prefix_path=os.path.dirname(os.path.abspath(__file__))):
     if os.getenv(name):
         return os.getenv(name)
     try:
-        passwords = json.load(open('passwords.json'))
+        passwords = json.load(open(os.path.join(master_prefix_path, 'passwords.json')))
         return passwords.get(name, default)
     except FileNotFoundError as e:
         print(f'ERROR: passwords.json missing: {e}, using default value for {name}\n')


### PR DESCRIPTION
#### 59e1c186c9fdf9ce0896b9d6a59b1d5286dccfba
<pre>
[ews] Load passwords.json from ews-build directory for all masters
<a href="https://bugs.webkit.org/show_bug.cgi?id=270232">https://bugs.webkit.org/show_bug.cgi?id=270232</a>

Reviewed by Jonathan Bedard.

Load passwords.json from ews-build directory for all masters, so that all masters
load same passwords.json without need to create a symlink.

* Tools/CISupport/ews-build/utils.py:
* Tools/CISupport/build-webkit-org/master.cfg: Similar change for build.webkit.org for future use.

Canonical link: <a href="https://commits.webkit.org/275455@main">https://commits.webkit.org/275455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47be506ade53907e1b5bcd5ff34903639256f370

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/41866 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/20881 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/44248 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/44448 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37961 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/44173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/24037 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/18211 "Build was cancelled. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/44448 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/42440 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/24037 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/44248 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/44448 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/24037 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/44248 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45845 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/24037 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/44248 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/45845 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16681 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/18211 "Build was cancelled. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45845 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41916 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/44248 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5613 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17944 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->