### PR TITLE
1Password fails to load popup after focusing a form field on a page.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -145,6 +145,11 @@ void WebExtensionContext::runtimeSendMessage(const String& extensionID, const St
 
     for (auto& process : mainWorldProcesses) {
         process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeMessageEvent(targetContentWorldType, messageJSON, std::nullopt, completeSenderParameters), [callbackAggregator](String&& replyJSON) {
+            // A null reply means no listeners replied. Don't call the callbackAggregator
+            // to give other listeners in a different process a chance to reply.
+            if (replyJSON.isNull())
+                return;
+
             callbackAggregator.get()(WTFMove(replyJSON));
         }, identifier());
     }
@@ -294,6 +299,11 @@ void WebExtensionContext::runtimeWebPageSendMessage(const String& extensionID, c
 
     for (auto& process : mainWorldProcesses) {
         process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeMessageEvent(WebExtensionContentWorldType::Main, messageJSON, std::nullopt, completeSenderParameters), [callbackAggregator](String&& replyJSON) {
+            // A null reply means no listeners replied. Don't call the callbackAggregator
+            // to give other listeners in a different process a chance to reply.
+            if (replyJSON.isNull())
+                return;
+
             callbackAggregator.get()(WTFMove(replyJSON));
         }, identifier());
     }


### PR DESCRIPTION
#### 53b1e6b7f02bbbc8a252792659963244ee04620f
<pre>
1Password fails to load popup after focusing a form field on a page.
<a href="https://webkit.org/b/270233">https://webkit.org/b/270233</a>
<a href="https://rdar.apple.com/123423266">rdar://123423266</a>

Reviewed by Jeff Miller and Brian Weinstein.

Once the input field is focused, 1Password creates an iframe with an extension document in the
tab. This causes two processes to have listeners for the runtime.onMessage event. That then
causes a race when sending messages, and the tab frame wins since the background replies async
after doing some work.

This was happening because the reply aggregator in the web process was sending a default null
reply, since the completion handler is always called, which was indistinguishable from a real
reply. Now we always send either null for default or at minimum an empty string for the JSON
reply, and the UI process skips the replies that are null strings. The aggregator on the UI
process side will then get the real reply or default to null later once it goes out of scope.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeSendMessage): Don&apos;t call callbackAggregator for null string.
(WebKit::WebExtensionContext::runtimeWebPageSendMessage): Ditto.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent): Ensure a real reply is
never null, so the completionHandler can make the distinction. Send default replies as null.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TEST(WKWebExtensionAPIRuntime, SendMessageWithTabFrameAndAsyncReply)): Added.
(TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)): Added.

Canonical link: <a href="https://commits.webkit.org/275461@main">https://commits.webkit.org/275461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bedde6b7363311ada72c6cb775244a8a95df577

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18230 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17826 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45865 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37419 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39634 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18319 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18378 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5616 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->