### PR TITLE
Remove privacyPreservingDescription() and always log NSErrors as %{public}@.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -112,8 +112,6 @@ NSDictionary *dictionaryWithKeys(NSDictionary *, NSArray *keys);
 NSDictionary *mergeDictionaries(NSDictionary *, NSDictionary *);
 NSDictionary *mergeDictionariesAndSetValues(NSDictionary *, NSDictionary *);
 
-NSString *privacyPreservingDescription(NSError *);
-
 NSURL *ensureDirectoryExists(NSURL *directory);
 
 NSString *escapeCharactersInString(NSString *, NSString *charactersToEscape);

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -374,26 +374,6 @@ NSDictionary *mergeDictionariesAndSetValues(NSDictionary *dictionaryA, NSDiction
     return [newDictionary copy];
 }
 
-// MARK: NSError Helpers
-
-NSString *privacyPreservingDescription(NSError *error)
-{
-    NSString *privacyPreservingDescription = objectForKey<NSString>(error.userInfo, privacyPreservingDescriptionKey);
-    if (!privacyPreservingDescription) {
-        NSString *domain = error.domain;
-        if (domain.length) {
-            id (^valueProvider)(NSError *err, NSString *userInfoKey) = [NSError userInfoValueProviderForDomain:domain];
-            if (valueProvider)
-                privacyPreservingDescription = valueProvider(error, privacyPreservingDescriptionKey);
-        }
-    }
-
-    if (privacyPreservingDescription)
-        return [NSString stringWithFormat:@"Error Domain=%@ Code=%ld \"%@\"", error.domain, (long)error.code, privacyPreservingDescription];
-
-    return [NSError errorWithDomain:error.domain ?: @"" code:error.code userInfo:nil].description;
-}
-
 NSURL *ensureDirectoryExists(NSURL *directory)
 {
     ASSERT(directory.isFileURL);

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm
@@ -106,7 +106,7 @@ using namespace WebKit;
     if (error)
         *error = errorObject;
     else
-        RELEASE_LOG_ERROR(Extensions, "Unhandled SQLite error: %{public}@", privacyPreservingDescription(errorObject));
+        RELEASE_LOG_ERROR(Extensions, "Unhandled SQLite error: %{public}@", errorObject);
 
     return NO;
 }

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -155,7 +155,7 @@ using namespace WebKit;
     // FIXME: rdar://87898825 (unlimitedStorage: Allow the SQLite database to be opened as SQLiteDatabaseAccessTypeReadOnly if the request is to calculate storage size).
     NSError *error;
     if (![_database openWithAccessType:SQLiteDatabaseAccessTypeReadWriteCreate error:&error]) {
-        RELEASE_LOG_ERROR(Extensions, "Failed to open database for extension %{private}@: %{public}@", _uniqueIdentifier, privacyPreservingDescription(error));
+        RELEASE_LOG_ERROR(Extensions, "Failed to open database for extension %{private}@: %{public}@", _uniqueIdentifier, error);
 
         if (usingDatabaseFile && deleteDatabaseFileOnError)
             return [self _deleteDatabaseFileAtURL:databaseURL reopenDatabase:YES];
@@ -168,7 +168,7 @@ using namespace WebKit;
 
     // Enable write-ahead logging to minimize the impact of SQLite's disk I/O.
     if (![_database enableWAL:&error]) {
-        RELEASE_LOG_ERROR(Extensions, "Failed to enable write-ahead logging on database for extension %{private}@: %{public}@", _uniqueIdentifier, privacyPreservingDescription(error));
+        RELEASE_LOG_ERROR(Extensions, "Failed to enable write-ahead logging on database for extension %{private}@: %{public}@", _uniqueIdentifier, error);
 
         if (usingDatabaseFile && deleteDatabaseFileOnError)
             return [self _deleteDatabaseFileAtURL:databaseURL reopenDatabase:YES];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -74,7 +74,7 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
     if (respondsToOpenOptionsPage) {
         [delegate webExtensionController:extensionController()->wrapper() openOptionsPageForExtensionContext:wrapper() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
             if (error) {
-                RELEASE_LOG_ERROR(Extensions, "Error opening options page: %{private}@", error);
+                RELEASE_LOG_ERROR(Extensions, "Error opening options page: %{public}@", error);
                 completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
                 return;
             }
@@ -98,7 +98,7 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
 
     [delegate webExtensionController:extensionController()->wrapper() openNewTabWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionTab> newTab, NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error opening options page in new tab: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error opening options page in new tab: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -98,7 +98,7 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
 
     [delegate webExtensionController:extensionController()->wrapper() openNewTabWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionTab> newTab, NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for open new tab: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for open new tab: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -103,7 +103,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
 
     [delegate webExtensionController:extensionController()->wrapper() openNewWindowWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionWindow> newWindow, NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for open new window: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for open new window: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -725,7 +725,7 @@ void WebExtensionAction::detectPopoverColorScheme()
 
     [m_popupWebView evaluateJavaScript:checkColorSchemeScript completionHandler:^(id result, NSError *error) {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error while checking popup color scheme: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error while checking popup color scheme: %{public}@", error);
             return;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -774,7 +774,7 @@ void WebExtension::recordError(NSError *error, SuppressNotification suppressNoti
     if (!m_errors)
         m_errors = [NSMutableArray array];
 
-    RELEASE_LOG_ERROR(Extensions, "Error recorded: %{private}@", error);
+    RELEASE_LOG_ERROR(Extensions, "Error recorded: %{public}@", error);
 
     [m_errors addObject:error];
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -348,7 +348,7 @@ NSMutableDictionary *WebExtensionContext::readStateFromPath(const String& stateF
     }];
 
     if (coordinatorError)
-        RELEASE_LOG_ERROR(Extensions, "Failed to coordinate reading extension state: %{private}@", coordinatorError);
+        RELEASE_LOG_ERROR(Extensions, "Failed to coordinate reading extension state: %{public}@", coordinatorError);
 
     return savedState;
 }
@@ -399,11 +399,11 @@ void WebExtensionContext::writeStateToStorage() const
     [fileCoordinator coordinateWritingItemAtURL:[NSURL fileURLWithPath:stateFilePath()] options:NSFileCoordinatorWritingForReplacing error:&coordinatorError byAccessor:^(NSURL *fileURL) {
         NSError *error;
         if (![currentState() writeToURL:fileURL error:&error])
-            RELEASE_LOG_ERROR(Extensions, "Unable to save extension state: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Unable to save extension state: %{public}@", error);
     }];
 
     if (coordinatorError)
-        RELEASE_LOG_ERROR(Extensions, "Failed to coordinate writing extension state: %{private}@", coordinatorError);
+        RELEASE_LOG_ERROR(Extensions, "Failed to coordinate writing extension state: %{public}@", coordinatorError);
 }
 
 void WebExtensionContext::moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&& completionHandler)
@@ -3714,7 +3714,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
             NSError *serializationError;
             NSData *dynamicRulesAsData = encodeJSONData(rules, JSONOptions::FragmentsAllowed, &serializationError);
             if (serializationError)
-                RELEASE_LOG_ERROR(Extensions, "Unable to serialize dynamic declarativeNetRequest rules for extension with identifier %{private}@ with error: %{public}@", (NSString *)uniqueIdentifier(), privacyPreservingDescription(serializationError));
+                RELEASE_LOG_ERROR(Extensions, "Unable to serialize dynamic declarativeNetRequest rules for extension with identifier %{private}@ with error: %{public}@", (NSString *)uniqueIdentifier(), serializationError);
             else
                 [allJSONData addObject:dynamicRulesAsData];
 
@@ -3738,7 +3738,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(
         NSError *serializationError;
         NSData *sessionRulesAsData = encodeJSONData(rules, JSONOptions::FragmentsAllowed, &serializationError);
         if (serializationError)
-            RELEASE_LOG_ERROR(Extensions, "Unable to serialize session declarativeNetRequest rules for extension with identifier %{private}@ with error: %{public}@", (NSString *)uniqueIdentifier(), privacyPreservingDescription(serializationError));
+            RELEASE_LOG_ERROR(Extensions, "Unable to serialize session declarativeNetRequest rules for extension with identifier %{private}@ with error: %{public}@", (NSString *)uniqueIdentifier(), serializationError);
         else
             [allJSONData addObject:sessionRulesAsData];
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -309,7 +309,7 @@ void WebExtensionTab::setParentTab(RefPtr<WebExtensionTab> parentTab, Completion
 
     [m_delegate setParentTab:(parentTab ? parentTab->delegate() : nil) forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for setParentTab: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for setParentTab: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -406,7 +406,7 @@ void WebExtensionTab::pin(CompletionHandler<void(Expected<void, WebExtensionErro
 
     [m_delegate pinForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for pin: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for pin: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -426,7 +426,7 @@ void WebExtensionTab::unpin(CompletionHandler<void(Expected<void, WebExtensionEr
 
     [m_delegate unpinForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for unpin: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for unpin: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -473,7 +473,7 @@ void WebExtensionTab::toggleReaderMode(CompletionHandler<void(Expected<void, Web
 
     [m_delegate toggleReaderModeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for toggleReaderMode: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for toggleReaderMode: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -509,7 +509,7 @@ void WebExtensionTab::mute(CompletionHandler<void(Expected<void, WebExtensionErr
 
     [m_delegate muteForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for mute: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for mute: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -529,7 +529,7 @@ void WebExtensionTab::unmute(CompletionHandler<void(Expected<void, WebExtensionE
 
     [m_delegate unmuteForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for unmute: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for unmute: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -582,7 +582,7 @@ void WebExtensionTab::setZoomFactor(double zoomFactor, CompletionHandler<void(Ex
 
     [m_delegate setZoomFactor:zoomFactor forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for setZoomFactor: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for setZoomFactor: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -632,7 +632,7 @@ void WebExtensionTab::detectWebpageLocale(CompletionHandler<void(Expected<NSLoca
 
     [m_delegate detectWebpageLocaleForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSLocale *locale, NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for detectWebpageLocale: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for detectWebpageLocale: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -656,7 +656,7 @@ void WebExtensionTab::captureVisibleWebpage(CompletionHandler<void(Expected<Coco
 
     auto internalCompletionHandler = makeBlockPtr([completionHandler = WTFMove(completionHandler)](CocoaImage *image, NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for captureVisibleWebpage: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for captureVisibleWebpage: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -693,7 +693,7 @@ void WebExtensionTab::loadURL(URL url, CompletionHandler<void(Expected<void, Web
 
     [m_delegate loadURL:url forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for loadURL: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for loadURL: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -714,7 +714,7 @@ void WebExtensionTab::reload(CompletionHandler<void(Expected<void, WebExtensionE
 
     [m_delegate reloadForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for reload: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for reload: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -735,7 +735,7 @@ void WebExtensionTab::reloadFromOrigin(CompletionHandler<void(Expected<void, Web
 
     [m_delegate reloadFromOriginForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for reloadFromOrigin: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for reloadFromOrigin: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -756,7 +756,7 @@ void WebExtensionTab::goBack(CompletionHandler<void(Expected<void, WebExtensionE
 
     [m_delegate goBackForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for goBack: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for goBack: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -777,7 +777,7 @@ void WebExtensionTab::goForward(CompletionHandler<void(Expected<void, WebExtensi
 
     [m_delegate goForwardForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for goForward: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for goForward: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -797,7 +797,7 @@ void WebExtensionTab::activate(CompletionHandler<void(Expected<void, WebExtensio
 
     [m_delegate activateForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for activate: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for activate: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -817,7 +817,7 @@ void WebExtensionTab::select(CompletionHandler<void(Expected<void, WebExtensionE
 
     [m_delegate selectForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for select: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for select: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -837,7 +837,7 @@ void WebExtensionTab::deselect(CompletionHandler<void(Expected<void, WebExtensio
 
     [m_delegate deselectForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for deselect: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for deselect: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -883,7 +883,7 @@ void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, Com
 
     [m_delegate duplicateForWebExtensionContext:m_extensionContext->wrapper() withOptions:duplicateOptions completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionTab> duplicatedTab, NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for duplicate: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for duplicate: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -909,7 +909,7 @@ void WebExtensionTab::close(CompletionHandler<void(Expected<void, WebExtensionEr
 
     [m_delegate closeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for tab close: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for tab close: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -292,7 +292,7 @@ void WebExtensionWindow::setState(WebExtensionWindow::State state, CompletionHan
 
     [m_delegate setWindowState:toAPI(state) forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for setWindowState: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for setWindowState: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -333,7 +333,7 @@ void WebExtensionWindow::focus(CompletionHandler<void(Expected<void, WebExtensio
 
     [m_delegate focusForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for window focus: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for window focus: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -400,7 +400,7 @@ void WebExtensionWindow::setFrame(CGRect frame, CompletionHandler<void(Expected<
 
     [m_delegate setFrame:frame forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for setFrame: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for setFrame: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }
@@ -428,7 +428,7 @@ void WebExtensionWindow::close(CompletionHandler<void(Expected<void, WebExtensio
 
     [m_delegate closeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
-            RELEASE_LOG_ERROR(Extensions, "Error for window close: %{private}@", error);
+            RELEASE_LOG_ERROR(Extensions, "Error for window close: %{public}@", error);
             completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
             return;
         }


### PR DESCRIPTION
#### 5fa14a9709f06eaacd06c462a5c522c7a01f82a3
<pre>
Remove privacyPreservingDescription() and always log NSErrors as %{public}@.
<a href="https://webkit.org/b/270234">https://webkit.org/b/270234</a>
<a href="https://rdar.apple.com/problem/123771246">rdar://problem/123771246</a>

Reviewed by NOBODY (OOPS!).

NSError and os_log already redact their description when logged as public, so we
don&apos;t need privacyPreservingDescription() and can use {public} for all NSErrors.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::privacyPreservingDescription): Deleted.
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm:
(-[_WKWebExtensionSQLiteDatabase reportErrorWithCode:query:error:]):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore _openDatabase:deleteDatabaseFileOnError:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeOpenOptionsPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::detectPopoverColorScheme):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::recordError):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::readStateFromPath):
(WebKit::WebExtensionContext::writeStateToStorage const):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::setParentTab):
(WebKit::WebExtensionTab::pin):
(WebKit::WebExtensionTab::unpin):
(WebKit::WebExtensionTab::toggleReaderMode):
(WebKit::WebExtensionTab::mute):
(WebKit::WebExtensionTab::unmute):
(WebKit::WebExtensionTab::setZoomFactor):
(WebKit::WebExtensionTab::detectWebpageLocale):
(WebKit::WebExtensionTab::captureVisibleWebpage):
(WebKit::WebExtensionTab::loadURL):
(WebKit::WebExtensionTab::reload):
(WebKit::WebExtensionTab::reloadFromOrigin):
(WebKit::WebExtensionTab::goBack):
(WebKit::WebExtensionTab::goForward):
(WebKit::WebExtensionTab::activate):
(WebKit::WebExtensionTab::select):
(WebKit::WebExtensionTab::deselect):
(WebKit::WebExtensionTab::duplicate):
(WebKit::WebExtensionTab::close):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::setState):
(WebKit::WebExtensionWindow::focus):
(WebKit::WebExtensionWindow::setFrame):
(WebKit::WebExtensionWindow::close):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fa14a9709f06eaacd06c462a5c522c7a01f82a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44462 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18225 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42454 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/17822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45860 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37408 "Failed to checkout and rebase branch from PR 25240") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16695 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->