### PR TITLE
[WGSL] shader,validation,parse,semicolon:* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/semicolon-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/semicolon-expected.txt
@@ -1,1 +1,43 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :module_scope_single:
+PASS :module_scope_multiple:
+PASS :after_enable:
+PASS :after_requires:
+PASS :after_diagnostic:
+PASS :after_struct_decl:
+PASS :after_member:
+PASS :after_func_decl:
+PASS :after_type_alias_decl:
+PASS :after_return:
+PASS :after_call:
+PASS :after_module_const_decl:
+PASS :after_fn_const_decl:
+PASS :after_module_var_decl:
+PASS :after_fn_var_decl:
+PASS :after_let_decl:
+PASS :after_discard:
+PASS :after_assignment:
+PASS :after_fn_const_assert:
+PASS :function_body_single:
+PASS :function_body_multiple:
+PASS :compound_statement_single:
+PASS :compound_statement_multiple:
+PASS :after_compound_statement:
+PASS :after_if:
+PASS :after_if_else:
+PASS :after_switch:
+PASS :after_case:
+PASS :after_case_break:
+PASS :after_default_case:
+PASS :after_default_case_break:
+PASS :after_for:
+PASS :after_for_break:
+PASS :after_loop:
+PASS :after_loop_break:
+PASS :after_loop_break_if:
+PASS :after_loop_continue:
+PASS :after_continuing:
+PASS :after_while:
+PASS :after_while_break:
+PASS :after_while_continue:
+

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -373,6 +373,7 @@ Result<void> Parser<Lexer>::parseShader()
         case TokenType::KeywordDiagnostic: {
             consume();
             PARSE(diagnostic, Diagnostic);
+            CONSUME_TYPE(Semicolon);
             auto& directive = MAKE_ARENA_NODE(DiagnosticDirective, WTFMove(diagnostic));
             m_shaderModule.directives().append(directive);
             break;


### PR DESCRIPTION
#### edb02386f41a913296d04bedf0f811bd10bd4644
<pre>
[WGSL] shader,validation,parse,semicolon:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=270237">https://bugs.webkit.org/show_bug.cgi?id=270237</a>
<a href="https://rdar.apple.com/123773267">rdar://123773267</a>

Reviewed by Mike Wyrzykowski.

We were missing a semicolon after diagnostic declarations, after that all semicolon
tests pass.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/semicolon-expected.txt:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseShader):

Canonical link: <a href="https://commits.webkit.org/275488@main">https://commits.webkit.org/275488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944c0002f67d1a1813912deee942e82bdffb53a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37982 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18232 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36073 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15516 "Found 1 new test failure: imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/fetch.https.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37420 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13718 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18321 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9405 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->