### PR TITLE
Further remove support for "Search with Spotlight" context menu item

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1219,9 +1219,6 @@
 /* Title of the Search button for zoomed form controls. */
 "Search" = "Search";
 
-/* Search in Spotlight context menu item */
-"Search in Spotlight" = "Search in Spotlight";
-
 /* Search the Web context menu item */
 "Search the Web" = "Search the Web";
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -125,10 +125,6 @@ class EmptyContextMenuClient final : public ContextMenuClient {
     void speak(const String&) final { }
     void stopSpeaking() final { }
 
-#if PLATFORM(COCOA)
-    void searchWithSpotlight() final { }
-#endif
-
 #if HAVE(TRANSLATION_UI_SERVICES)
     void handleTranslation(const TranslationContextMenuInfo&) final { }
 #endif

--- a/Source/WebCore/page/ContextMenuClient.h
+++ b/Source/WebCore/page/ContextMenuClient.h
@@ -66,10 +66,6 @@ public:
     virtual void handleSwapCharacters(IntRect selectionBoundsInRootView) = 0;
 #endif
 
-#if PLATFORM(COCOA)
-    virtual void searchWithSpotlight() = 0;
-#endif
-
 #if PLATFORM(GTK)
     virtual void insertEmoji(LocalFrame&) = 0;
 #endif

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -562,11 +562,6 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
     case ContextMenuItemTagTextDirectionRightToLeft:
         frame->editor().command("MakeTextWritingDirectionRightToLeft"_s).execute();
         break;
-#if PLATFORM(COCOA)
-    case ContextMenuItemTagSearchInSpotlight:
-        m_client->searchWithSpotlight();
-        break;
-#endif
     case ContextMenuItemTagShowSpellingPanel:
         frame->checkedEditor()->showSpellingGuessPanel();
         break;
@@ -952,10 +947,6 @@ void ContextMenuController::populate()
         contextMenuItemTagEnterVideoFullscreen());
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
     ContextMenuItem ToggleVideoEnhancedFullscreen(ContextMenuItemType::Action, ContextMenuItemTagToggleVideoEnhancedFullscreen, contextMenuItemTagEnterVideoEnhancedFullscreen());
-#endif
-#if PLATFORM(COCOA)
-    ContextMenuItem SearchSpotlightItem(ContextMenuItemType::Action, ContextMenuItemTagSearchInSpotlight,
-        contextMenuItemTagSearchInSpotlight());
 #endif
 
 #if ENABLE(PDFJS)
@@ -1753,7 +1744,6 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
         case ContextMenuItemTagOpenFrameInNewWindow:
         case ContextMenuItemTagSpellingGuess:
         case ContextMenuItemTagOther:
-        case ContextMenuItemTagSearchInSpotlight:
         case ContextMenuItemTagSearchWeb:
         case ContextMenuItemTagOpenWithDefaultApplication:
         case ContextMenuItemPDFActualSize:

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -188,7 +188,6 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagIgnoreSpelling:
     case ContextMenuAction::ContextMenuItemTagLearnSpelling:
     case ContextMenuAction::ContextMenuItemTagOther:
-    case ContextMenuAction::ContextMenuItemTagSearchInSpotlight:
     case ContextMenuAction::ContextMenuItemTagSearchWeb:
     case ContextMenuAction::ContextMenuItemTagLookUpInDictionary:
     case ContextMenuAction::ContextMenuItemTagOpenWithDefaultApplication:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -76,8 +76,11 @@ enum ContextMenuAction {
     ContextMenuItemTagIgnoreSpelling,
     ContextMenuItemTagLearnSpelling,
     ContextMenuItemTagOther,
-    ContextMenuItemTagSearchInSpotlight,
-    ContextMenuItemTagSearchWeb,
+#if PLATFORM(GTK)
+    ContextMenuItemTagSearchWeb = 38,
+#else
+    ContextMenuItemTagSearchWeb = 21,
+#endif
     ContextMenuItemTagLookUpInDictionary,
     ContextMenuItemTagOpenWithDefaultApplication,
     ContextMenuItemPDFActualSize,

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -125,7 +125,6 @@ namespace WebCore {
     WEBCORE_EXPORT String contextMenuItemTagLeftToRight();
     WEBCORE_EXPORT String contextMenuItemTagRightToLeft();
 #if PLATFORM(COCOA)
-    String contextMenuItemTagSearchInSpotlight();
     WEBCORE_EXPORT String contextMenuItemTagShowFonts();
     WEBCORE_EXPORT String contextMenuItemTagStyles();
     WEBCORE_EXPORT String contextMenuItemTagShowColors();

--- a/Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm
+++ b/Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm
@@ -53,11 +53,6 @@ String contextMenuItemTagAddHighlightToNewQuickNote()
 #endif
 
 #if ENABLE(CONTEXT_MENUS)
-String contextMenuItemTagSearchInSpotlight()
-{
-    return WEB_UI_STRING("Search in Spotlight", "Search in Spotlight context menu item");
-}
-
 String contextMenuItemTagSearchWeb()
 {
     auto searchProviderName = PAL::defaultSearchProviderDisplayName();

--- a/Source/WebKit/Shared/API/c/WKContextMenuItem.cpp
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItem.cpp
@@ -194,7 +194,7 @@ STATIC_ASSERT_EQUALS(16, kWKContextMenuItemTagNoGuessesFound, ContextMenuItemTag
 STATIC_ASSERT_EQUALS(17, kWKContextMenuItemTagIgnoreSpelling, ContextMenuItemTagIgnoreSpelling);
 STATIC_ASSERT_EQUALS(18, kWKContextMenuItemTagLearnSpelling, ContextMenuItemTagLearnSpelling);
 STATIC_ASSERT_EQUALS(19, kWKContextMenuItemTagOther, ContextMenuItemTagOther);
-STATIC_ASSERT_EQUALS(20, kWKContextMenuItemTagSearchInSpotlight, ContextMenuItemTagSearchInSpotlight);
+static_assert(20 == kWKContextMenuItemTagSearchInSpotlight);
 STATIC_ASSERT_EQUALS(21, kWKContextMenuItemTagSearchWeb, ContextMenuItemTagSearchWeb);
 STATIC_ASSERT_EQUALS(22, kWKContextMenuItemTagLookUpInDictionary, ContextMenuItemTagLookUpInDictionary);
 STATIC_ASSERT_EQUALS(23, kWKContextMenuItemTagOpenWithDefaultApplication, ContextMenuItemTagOpenWithDefaultApplication);

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -437,8 +437,6 @@ inline WKContextMenuItemTag toAPI(WebCore::ContextMenuAction action)
         return kWKContextMenuItemTagLearnSpelling;
     case WebCore::ContextMenuItemTagOther:
         return kWKContextMenuItemTagOther;
-    case WebCore::ContextMenuItemTagSearchInSpotlight:
-        return kWKContextMenuItemTagSearchInSpotlight;
     case WebCore::ContextMenuItemTagSearchWeb:
         return kWKContextMenuItemTagSearchWeb;
     case WebCore::ContextMenuItemTagLookUpInDictionary:
@@ -656,7 +654,7 @@ inline WebCore::ContextMenuAction toImpl(WKContextMenuItemTag tag)
     case kWKContextMenuItemTagOther:
         return WebCore::ContextMenuItemTagOther;
     case kWKContextMenuItemTagSearchInSpotlight:
-        return WebCore::ContextMenuItemTagSearchInSpotlight;
+        return WebCore::ContextMenuItemTagNoAction;
     case kWKContextMenuItemTagSearchWeb:
         return WebCore::ContextMenuItemTagSearchWeb;
     case kWKContextMenuItemTagLookUpInDictionary:

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2695,9 +2695,6 @@ private:
     void speak(const String&);
     void stopSpeaking();
 
-    // Spotlight.
-    void searchWithSpotlight(const String&);
-
     void searchTheWeb(const String&);
 
     // Dictionary.

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -332,9 +332,6 @@ messages -> WebPageProxy {
     MakeFirstResponder()
     AssistiveTechnologyMakeFirstResponder()
 
-    # Spotlight
-    SearchWithSpotlight(String string)
-
     SearchTheWeb(String string)
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -139,11 +139,6 @@ void WebPageProxy::stopSpeaking()
     notImplemented();
 }
 
-void WebPageProxy::searchWithSpotlight(const String&)
-{
-    notImplemented();
-}
-
 void WebPageProxy::searchTheWeb(const String&)
 {
     notImplemented();

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -165,11 +165,6 @@ void WebPageProxy::stopSpeaking()
     [NSApp stopSpeaking:nil];
 }
 
-void WebPageProxy::searchWithSpotlight(const String& string)
-{
-    [[NSWorkspace sharedWorkspace] showSearchResultsForQueryString:nsStringFromWebCoreString(string)];
-}
-
 void WebPageProxy::searchTheWeb(const String& string)
 {
     NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -57,10 +57,6 @@ private:
     bool supportsCopySubject() final { return true; }
 #endif
 
-#if PLATFORM(COCOA)
-    void searchWithSpotlight() override;
-#endif
-
 #if HAVE(TRANSLATION_UI_SERVICES)
     void handleTranslation(const WebCore::TranslationContextMenuInfo&) final;
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -70,36 +70,6 @@ void WebContextMenuClient::searchWithGoogle(const LocalFrame* frame)
     m_page->send(Messages::WebPageProxy::SearchTheWeb(searchString));
 }
 
-void WebContextMenuClient::searchWithSpotlight()
-{
-    // FIXME: Why do we need to search all the frames like this?
-    // Isn't there any function in WebCore that can do this?
-    // If not, can we find a place in WebCore to put this?
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->corePage()->mainFrame());
-    if (!localMainFrame)
-        return;
-
-    auto* selectionFrame = [&] () -> LocalFrame* {
-        for (Frame* selectionFrame = localMainFrame; selectionFrame; selectionFrame = selectionFrame->tree().traverseNext()) {
-            auto* localFrame = dynamicDowncast<LocalFrame>(selectionFrame);
-            if (!localFrame)
-                continue;
-            if (localFrame->selection().isRange())
-                return localFrame;
-        }
-        return nullptr;
-    }();
-    if (!selectionFrame)
-        selectionFrame = localMainFrame;
-
-    String selectedString = selectionFrame->displayStringModifiedByEncoding(selectionFrame->editor().selectedText());
-
-    if (selectedString.isEmpty())
-        return;
-
-    m_page->send(Messages::WebPageProxy::SearchWithSpotlight(selectedString));
-}
-
 #if HAVE(TRANSLATION_UI_SERVICES)
 
 void WebContextMenuClient::handleTranslation(const WebCore::TranslationContextMenuInfo& info)

--- a/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
+++ b/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
@@ -86,10 +86,6 @@
             title = UI_STRING_INTERNAL("Reload", "Reload context menu item");
             action = @selector(reload:);
             break;
-        case WebMenuItemTagSearchInSpotlight:
-            title = UI_STRING_INTERNAL("Search in Spotlight", "Search in Spotlight context menu item");
-            action = @selector(_searchWithSpotlightFromMenu:);
-            break;
         case WebMenuItemTagSearchWeb: {
             auto searchProviderName = PAL::defaultSearchProviderDisplayName();
             title = [NSString stringWithFormat:UI_STRING_INTERNAL("Search with %@", "Search with search provider context menu item with provider name inserted"), searchProviderName.get()];
@@ -143,7 +139,7 @@
     WebFrame *webFrame = [element objectForKey:WebElementFrameKey];
     
     if ([[element objectForKey:WebElementIsSelectedKey] boolValue]) {
-        // The Spotlight and Google items are implemented in WebView, and require that the
+        // The Google item is implemented in WebView, and requires that the
         // current document view conforms to WebDocumentText
         ASSERT([[[webFrame frameView] documentView] conformsToProtocol:@protocol(WebDocumentText)]);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
@@ -55,7 +55,6 @@ public:
     bool isSpeaking() const override;
     void speak(const WTF::String&) override;
     void stopSpeaking() override;
-    void searchWithSpotlight() override;
     void showContextMenu() override;
 
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -89,11 +89,6 @@ void WebContextMenuClient::downloadURL(const URL& url)
     [m_webView _downloadURL:url];
 }
 
-void WebContextMenuClient::searchWithSpotlight()
-{
-    [m_webView _searchWithSpotlightFromMenu:nil];
-}
-
 void WebContextMenuClient::searchWithGoogle(const LocalFrame*)
 {
     [m_webView _searchWithGoogleFromMenu:nil];

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -282,7 +282,7 @@ static std::optional<WebCore::ContextMenuAction> toAction(NSInteger tag)
     case WebMenuItemTagOther:
         return ContextMenuItemTagOther;
     case WebMenuItemTagSearchInSpotlight:
-        return ContextMenuItemTagSearchInSpotlight;
+        return ContextMenuItemTagNoAction;
     case WebMenuItemTagSearchWeb:
         return ContextMenuItemTagSearchWeb;
     case WebMenuItemTagLookUpInDictionary:
@@ -459,8 +459,6 @@ static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
         return WebMenuItemTagLearnSpelling;
     case ContextMenuItemTagOther:
         return WebMenuItemTagOther;
-    case ContextMenuItemTagSearchInSpotlight:
-        return WebMenuItemTagSearchInSpotlight;
     case ContextMenuItemTagSearchWeb:
         return WebMenuItemTagSearchWeb;
     case ContextMenuItemTagLookUpInDictionary:

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8598,18 +8598,6 @@ FORWARD(toggleUnderline)
     NSPerformService(@"Search With Google", pasteboard);
 }
 
-- (void)_searchWithSpotlightFromMenu:(id)sender
-{
-    id documentView = [[[self selectedFrame] frameView] documentView];
-    if (![documentView conformsToProtocol:@protocol(WebDocumentText)])
-        return;
-
-    NSString *selectedString = [(id <WebDocumentText>)documentView selectedString];
-    if (![selectedString length])
-        return;
-
-    [[NSWorkspace sharedWorkspace] showSearchResultsForQueryString:selectedString];
-}
 #endif // !PLATFORM(IOS_FAMILY)
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -246,7 +246,6 @@ WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone>);
 - (void)_writeLinkElement:(NSDictionary *)element withPasteboardTypes:(NSArray *)types toPasteboard:(NSPasteboard *)pasteboard;
 - (void)_openFrameInNewWindowFromMenu:(NSMenuItem *)sender;
 - (void)_searchWithGoogleFromMenu:(id)sender;
-- (void)_searchWithSpotlightFromMenu:(id)sender;
 #endif
 - (void)_progressCompleted:(WebFrame *)frame;
 - (void)_didCommitLoadForFrame:(WebFrame *)frame;


### PR DESCRIPTION
#### 415bdd37cb7467e4a5798e192a94cf8a6b1d3648
<pre>
Further remove support for &quot;Search with Spotlight&quot; context menu item
<a href="https://bugs.webkit.org/show_bug.cgi?id=270242">https://bugs.webkit.org/show_bug.cgi?id=270242</a>

Reviewed by Megan Gardner.

This context menu item was removed in Snow Leopard timeframe, and the functionality
behind it was broken by sandboxing later on (but still many years ago).

Remove our support, but leave the API in place.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/ContextMenuClient.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm:
(WebCore::contextMenuItemTagSearchInSpotlight): Deleted.
* Source/WebKit/Shared/API/c/WKContextMenuItem.cpp:
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::searchWithSpotlight): Deleted.
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::searchWithSpotlight): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::searchWithSpotlight): Deleted.
* Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm:
(-[WebDefaultUIDelegate menuItemWithTag:target:representedObject:]):
(-[WebDefaultUIDelegate webView:contextMenuItemsForElement:defaultMenuItems:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
(WebContextMenuClient::searchWithSpotlight): Deleted.
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(toAction):
(toTag):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _searchWithSpotlightFromMenu:]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebViewInternal.h:

Canonical link: <a href="https://commits.webkit.org/275463@main">https://commits.webkit.org/275463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd7c947054b507d7c600766489a803421078e878

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18241 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36079 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45881 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37427 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39656 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18330 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->