### PR TITLE
[ews-build] Reduce duration to keep buildbot logs to 30 days

### DIFF
--- a/Tools/CISupport/ews-build/master.cfg
+++ b/Tools/CISupport/ews-build/master.cfg
@@ -70,7 +70,7 @@ else:
     # See https://docs.buildbot.net/1.7.0/manual/configuration/global.html#database-specification
     c['db_url'] = 'postgresql://{}:{}@{}/{}'.format(db_username, db_password, db_url, db_name)
     # configure a janitor to delete old logs
-    c['configurators'] = [util.JanitorConfigurator(logHorizon=timedelta(weeks=52), hour='1', dayOfWeek='*')]
+    c['configurators'] = [util.JanitorConfigurator(logHorizon=timedelta(days=30), hour='1', dayOfWeek='*')]
 
 c['logCompressionMethod'] = 'lz4'
 c['buildbotNetUsageData'] = None


### PR DESCRIPTION
#### 9f6fe8dd5f940a6c609a80b8a00779f3c1f178bc
<pre>
[ews-build] Reduce duration to keep buildbot logs to 30 days
<a href="https://bugs.webkit.org/show_bug.cgi?id=270255">https://bugs.webkit.org/show_bug.cgi?id=270255</a>

Reviewed by Jonathan Bedard.

old buildbot logs on EWS aren&apos;t much usable. Most of the PRs are already landed and even
if they aren&apos;t, people should rebase on ToT and re-run EWS for latest results.

Note that this does not affect GitHub status-bubbles or bugzilla status-bubbles. The builds
will still be there, links will still work from GitHub status-bubbles, just that the detailed
logs wouldn&apos;t be available for older builds.

* Tools/CISupport/ews-build/master.cfg:

Canonical link: <a href="https://commits.webkit.org/275472@main">https://commits.webkit.org/275472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f68feb24d8e3c812b194a440791166c133901649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41923 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/20938 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/44306 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/44506 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/38018 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44230 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/24096 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/18268 "Build was cancelled. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/44506 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/42497 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/24096 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/44306 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/44506 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/24096 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/44306 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45909 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/24096 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/44306 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/45909 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16738 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/18268 "Build was cancelled. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45909 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/41971 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/44306 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5623 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18001 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->