### PR TITLE
Support moving a Web Extension tab to and from WINDOW_ID_NONE.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -700,9 +700,10 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Should be called by the app when a tab is moved to fire appropriate events with only this extension.
  @param movedTab The tab that was moved.
  @param index The old index of the tab within the window.
- @param oldWindow The window that the tab was moved from, or \c nil if the window stayed the same.
- @discussion This method informs only the specific extension that a tab has been moved. If the intention is to inform all loaded
- extensions consistently, you should use the respective method on the extension controller instead.
+ @param oldWindow The window that the tab was moved from, or \c nil if the tab is moving from no open window.
+ @discussion If the window is staying the same, the current window should be specified. This method informs only the specific extension
+ that a tab has been moved. If the intention is to inform all loaded extensions consistently, you should use the respective method on
+ the extension controller instead.
  */
 - (void)didMoveTab:(id <_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <_WKWebExtensionWindow>)oldWindow NS_SWIFT_NAME(didMoveTab(_:from:in:));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -729,7 +729,7 @@ static inline WebKit::WebExtensionContext::TabSet toImpl(NSSet<id<_WKWebExtensio
     if (oldWindow)
         NSParameterAssert([oldWindow conformsToProtocol:@protocol(_WKWebExtensionWindow)]);
 
-    _webExtensionContext->didMoveTab(toImpl(movedTab, *_webExtensionContext), index, oldWindow ? toImpl(oldWindow, *_webExtensionContext).ptr() : nullptr);
+    _webExtensionContext->didMoveTab(toImpl(movedTab, *_webExtensionContext), index != NSNotFound ? index : notFound, oldWindow ? toImpl(oldWindow, *_webExtensionContext).ptr() : nullptr);
 }
 
 - (void)didReplaceTab:(id<_WKWebExtensionTab>)oldTab withTab:(id<_WKWebExtensionTab>)newTab

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -226,9 +226,10 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Should be called by the app when a tab is moved to fire appropriate events with all loaded web extensions.
  @param movedTab The tab that was moved.
  @param index The old index of the tab within the window.
- @param oldWindow The window that the tab was moved from, or \c nil if the window stayed the same.
+ @param oldWindow The window that the tab was moved from, or \c nil if the tab is moving from no open window.
  @discussion This method informs all loaded extensions of the movement of a tab, ensuring consistent understanding across extensions.
- If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ If the window is staying the same, the current window should be specified. If the intention is to inform only a specific extension,
+ use the respective method on that extension's context instead.
  */
 - (void)didMoveTab:(id <_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <_WKWebExtensionWindow>)oldWindow NS_SWIFT_NAME(didMoveTab(_:from:in:));
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -367,7 +367,7 @@ public:
     void didActivateTab(const WebExtensionTab&, const WebExtensionTab* previousTab = nullptr);
     void didSelectOrDeselectTabs(const TabSet&);
 
-    void didMoveTab(const WebExtensionTab&, size_t oldIndex, const WebExtensionWindow* oldWindow = nullptr);
+    void didMoveTab(WebExtensionTab&, size_t oldIndex, const WebExtensionWindow* oldWindow = nullptr);
     void didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab);
     void didChangeTabProperties(WebExtensionTab&, OptionSet<WebExtensionTab::ChangedProperties> = { });
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -72,7 +72,9 @@
 
 - (instancetype)initWithWindow:(TestWebExtensionWindow *)window extensionController:(_WKWebExtensionController *)extensionController NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, weak) TestWebExtensionWindow * window;
+- (void)assignWindow:(TestWebExtensionWindow *)window;
+
+@property (nonatomic, weak) TestWebExtensionWindow *window;
 @property (nonatomic, strong) WKWebView *mainWebView;
 
 - (void)changeWebViewIfNeededForURL:(NSURL *)url forExtensionContext:(_WKWebExtensionContext *)context;
@@ -104,6 +106,9 @@
 
 - (TestWebExtensionTab *)openNewTab;
 - (TestWebExtensionTab *)openNewTabAtIndex:(NSUInteger)index;
+
+- (NSUInteger)removeTab:(TestWebExtensionTab *)tab;
+- (void)insertTab:(TestWebExtensionTab *)tab atIndex:(NSUInteger)index;
 
 - (void)closeTab:(TestWebExtensionTab *)tab;
 - (void)closeTab:(TestWebExtensionTab *)tab windowIsClosing:(BOOL)windowIsClosing;

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -339,6 +339,24 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     return self;
 }
 
+- (void)assignWindow:(TestWebExtensionWindow *)window
+{
+    _window = window;
+}
+
+- (void)setWindow:(TestWebExtensionWindow *)newWindow
+{
+    auto *oldWindow = _window;
+
+    _window = newWindow;
+
+    NSUInteger oldIndex = oldWindow ? [oldWindow removeTab:self] : NSNotFound;
+    if (newWindow)
+        [newWindow insertTab:self atIndex:newWindow.tabs.count];
+
+    [_extensionController didMoveTab:self fromIndex:oldIndex inWindow:oldWindow];
+}
+
 - (id<_WKWebExtensionWindow>)windowForWebExtensionContext:(_WKWebExtensionContext *)context
 {
     return _window;
@@ -629,6 +647,27 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         [_extensionController didActivateTab:_activeTab previousActiveTab:previousActiveTab];
 }
 
+- (NSUInteger)removeTab:(TestWebExtensionTab *)tab
+{
+    NSUInteger oldIndex = [_tabs indexOfObject:tab];
+    if (oldIndex == NSNotFound)
+        return oldIndex;
+
+    [_tabs removeObjectAtIndex:oldIndex];
+
+    if (_activeTab == tab)
+        _activeTab = _tabs.firstObject;
+
+    return oldIndex;
+}
+
+- (void)insertTab:(TestWebExtensionTab *)tab atIndex:(NSUInteger)index
+{
+    ASSERT(index <= _tabs.count);
+
+    [_tabs insertObject:tab atIndex:index];
+}
+
 - (TestWebExtensionTab *)openNewTab
 {
     return [self openNewTabAtIndex:_tabs.count];
@@ -707,7 +746,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         [oldWindow->_tabs removeObjectAtIndex:oldIndex];
         [_tabs insertObject:tab atIndex:newIndex];
 
-        tab.window = self;
+        [tab assignWindow:self];
 
         [_extensionController didMoveTab:tab fromIndex:oldIndex inWindow:oldWindow];
 
@@ -720,7 +759,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     [_tabs removeObjectAtIndex:oldIndex];
     [_tabs insertObject:tab atIndex:newIndex];
 
-    [_extensionController didMoveTab:tab fromIndex:oldIndex inWindow:nil];
+    [_extensionController didMoveTab:tab fromIndex:oldIndex inWindow:self];
 }
 
 - (NSArray<id<_WKWebExtensionTab>> *)tabsForWebExtensionContext:(_WKWebExtensionContext *)context


### PR DESCRIPTION
#### 08b9923002071e6d00a4a90607710fa07b61676d
<pre>
Support moving a Web Extension tab to and from WINDOW_ID_NONE.
<a href="https://webkit.org/b/270260">https://webkit.org/b/270260</a>
<a href="https://rdar.apple.com/123102191">rdar://123102191</a>

Reviewed by Brian Weinstein.

Safari needs to move tabs to and from WINDOW_ID_NONE when switching Tab Groups.
The existing didMoveTab:fromIndex:inWindow: method needed updated to support this,
and properly fire the tabs events.

Updated existing testing support to allow assigning nil to a tab&apos;s window.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext didMoveTab:fromIndex:inWindow:]): Handle NSNotFound.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didMoveTab): Enumerate all the possible move combos
when logging, and fire the appropriate events for for each possibility.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TEST(WKWebExtensionAPITabs, DetachAndAttachToWindowIDNone)): Added.
(TEST(WKWebExtensionAPITabs, DetachAndAttachFromWindowIDNone)): Added.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab assignWindow:]): Added.
(-[TestWebExtensionTab setWindow:]): Added. Call didMoveTab:::.
(-[TestWebExtensionWindow removeTab:]): Added.
(-[TestWebExtensionWindow insertTab:atIndex:]): Added.
(-[TestWebExtensionWindow moveTab:toIndex:]): Use assignWindow:. And pass self
when the tab is moving in the same window.

Canonical link: <a href="https://commits.webkit.org/275476@main">https://commits.webkit.org/275476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed517c7029ffc8915062365ad5d446569a14390c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38027 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18274 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36110 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37466 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39737 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18423 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5627 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->