### PR TITLE
[WebGPU] Forbid bottom types as struct members

### DIFF
--- a/LayoutTests/fast/webgpu/forbid-bottom-struct-member-expected.txt
+++ b/LayoutTests/fast/webgpu/forbid-bottom-struct-member-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/forbid-bottom-struct-member.html
+++ b/LayoutTests/fast/webgpu/forbid-bottom-struct-member.html
@@ -1,0 +1,22 @@
+<html>
+  <body>
+    <script>
+      const doTest = async () => {
+        try {
+            const adapter = await navigator.gpu.requestAdapter();
+            const device = await adapter.requestDevice();
+            const module = device.createShaderModule({
+              code: `
+                       struct S { x : u23 }
+                           @must_use fn foo() -> S { return S(); }
+                    `,
+            });
+        } catch (e) { }
+        if (window.testRunner) { testRunner.notifyDone() }
+      };
+      if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+      doTest();
+    </script>
+    This test passes if it does not crash.
+  </body>
+</html>

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -442,6 +442,11 @@ void TypeChecker::visit(AST::Structure& structure)
         visitAttributes(member.attributes());
         auto* memberType = resolve(member.type());
 
+        if (UNLIKELY(std::holds_alternative<Types::Bottom>(*memberType))) {
+            typeError(InferBottom::No, member.span(), "type '", *memberType, "' cannot be used as a struct member");
+            introduceType(structure.name(), m_types.bottomType());
+            return;
+        }
         if (UNLIKELY(!memberType->hasCreationFixedFootprint())) {
             if (!memberType->containsRuntimeArray()) {
                 typeError(InferBottom::No, member.span(), "type '", *memberType, "' cannot be used as a struct member because it does not have creation-fixed footprint");


### PR DESCRIPTION
#### ec01055eeeba8b823b13cd7badff17a2c3366e27
<pre>
[WebGPU] Forbid bottom types as struct members
<a href="https://bugs.webkit.org/show_bug.cgi?id=270266">https://bugs.webkit.org/show_bug.cgi?id=270266</a>
<a href="https://rdar.apple.com/123745671">rdar://123745671</a>

Reviewed by Dan Glastonbury.

* LayoutTests/fast/webgpu/forbid-bottom-struct-member-expected.txt: Added.
* LayoutTests/fast/webgpu/forbid-bottom-struct-member.html: Added.
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::zeroValue):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::convertValueImpl):

Canonical link: <a href="https://commits.webkit.org/275535@main">https://commits.webkit.org/275535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa825a4eff7b30533c3287a87737c9630e608d1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38192 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34846 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15779 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46099 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41496 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40061 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36538 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18574 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5663 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->