### PR TITLE
[Win] run-bindings-tests doesn't work with a environment variable CC=clang-cl

### DIFF
--- a/Source/WebCore/bindings/scripts/preprocessor.pm
+++ b/Source/WebCore/bindings/scripts/preprocessor.pm
@@ -48,7 +48,7 @@ sub applyPreprocessor
     if (!$preprocessor) {
         if ($Config::Config{"osname"} eq "MSWin32") {
             $preprocessor = $ENV{CC} || "cl";
-            push(@args, qw(/EP));
+            push(@args, qw(/nologo /EP /TP));
         } else {
             $preprocessor = $ENV{CC} || (-x "/usr/bin/clang" ? "/usr/bin/clang" : "/usr/bin/gcc");
             push(@args, qw(-E -P -x c++));


### PR DESCRIPTION
#### 4adc8868a3aab588c005b7b6e10796f3a4e58191
<pre>
[Win] run-bindings-tests doesn&apos;t work with a environment variable CC=clang-cl
<a href="https://bugs.webkit.org/show_bug.cgi?id=270245">https://bugs.webkit.org/show_bug.cgi?id=270245</a>

Reviewed by Ross Kirsling.

preprocessor.pm didn&apos;t work as expected with CC=clang-cl. It specifies
`/EP` flag. but clang-cl doesn&apos;t work with only `/EP` flag.
WebKitCompilerFlags.cmake is specifying `/nologo /EP /TP` flags for
preprocessing on Windows.

* Source/WebCore/bindings/scripts/preprocessor.pm:
Changed the preprocessor flags on Windows.

Canonical link: <a href="https://commits.webkit.org/275477@main">https://commits.webkit.org/275477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45f3d6fbcf6e5df071f304b0b3bd5e05d2c9dbee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44537 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18297 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36124 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37482 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41378 "Build is in progress. Recent messages:") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18386 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18445 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5628 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->