### PR TITLE
[MSE] Remove unnecessary main runloop hop when performing source buffer IPC connection

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -111,7 +111,7 @@ Ref<MediaPromise> SourceBufferPrivateRemote::append(Ref<SharedBuffer>&& data)
         if (!gpuProcessConnection || !isGPURunning())
             return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return gpuProcessConnection->connection().sendWithPromisedReply(Messages::RemoteSourceBufferProxy::Append(IPC::SharedBufferReference { WTFMove(data) }), m_remoteSourceBufferIdentifier)->whenSettled(m_dispatcher, [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::Append(IPC::SharedBufferReference { WTFMove(data) }))->whenSettled(m_dispatcher, [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
             if (!result)
                 return MediaPromise::createAndReject(PlatformMediaError::IPCError);
             if (RefPtr protectedThis = weakThis.get()) {
@@ -214,8 +214,7 @@ Ref<MediaPromise> SourceBufferPrivateRemote::removeCodedFrames(const MediaTime& 
         if (!gpuProcessConnection || !isGPURunning())
             return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return gpuProcessConnection->connection().sendWithPromisedReply(
-            Messages::RemoteSourceBufferProxy::RemoveCodedFrames(start, end, currentMediaTime), m_remoteSourceBufferIdentifier)->whenSettled(m_dispatcher, [] (auto&& result) mutable {
+        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::RemoveCodedFrames(start, end, currentMediaTime))->whenSettled(m_dispatcher, [] (auto&& result) mutable {
                 if (!result)
                     return MediaPromise::createAndReject(PlatformMediaError::IPCError);
                 return MediaPromise::createAndResolve();
@@ -383,7 +382,7 @@ Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivateRemote::computeS
         if (!gpuProcessConnection || !isGPURunning())
             return ComputeSeekPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return gpuProcessConnection->connection().sendWithPromisedReply(Messages::RemoteSourceBufferProxy::ComputeSeekTime(target), m_remoteSourceBufferIdentifier)->whenSettled(m_dispatcher, [](auto&& result) {
+        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::ComputeSeekTime(target))->whenSettled(m_dispatcher, [](auto&& result) {
             return result ? ComputeSeekPromise::createAndSettle(*result) : ComputeSeekPromise::createAndReject(PlatformMediaError::IPCError);
         });
     });
@@ -410,7 +409,7 @@ Ref<SourceBufferPrivate::SamplesPromise> SourceBufferPrivateRemote::bufferedSamp
         if (!gpuProcessConnection || !isGPURunning())
             return SamplesPromise::createAndResolve(Vector<String> { });
 
-        return gpuProcessConnection->connection().sendWithPromisedReply(Messages::RemoteSourceBufferProxy::BufferedSamplesForTrackId(trackID), m_remoteSourceBufferIdentifier)->whenSettled(m_dispatcher, [](auto&& result) {
+        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::BufferedSamplesForTrackId(trackID))->whenSettled(m_dispatcher, [](auto&& result) {
             if (!result)
                 return SamplesPromise::createAndResolve(Vector<String> { });
             return SamplesPromise::createAndSettle(WTFMove(*result));
@@ -425,7 +424,7 @@ Ref<SourceBufferPrivate::SamplesPromise> SourceBufferPrivateRemote::enqueuedSamp
         if (!gpuProcessConnection || !isGPURunning())
             return SamplesPromise::createAndResolve(Vector<String> { });
 
-        return gpuProcessConnection->connection().sendWithPromisedReply(Messages::RemoteSourceBufferProxy::EnqueuedSamplesForTrackID(trackID), m_remoteSourceBufferIdentifier)->whenSettled(m_dispatcher, [](auto&& result) {
+        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::EnqueuedSamplesForTrackID(trackID))->whenSettled(m_dispatcher, [](auto&& result) {
             if (!result)
                 return SamplesPromise::createAndResolve(Vector<String> { });
             return SamplesPromise::createAndSettle(WTFMove(*result));

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -143,6 +143,10 @@ private:
 
     void ensureOnDispatcherSync(Function<void()>&&);
     void ensureWeakOnDispatcher(Function<void()>&&);
+    template<typename T> Ref<typename T::Promise> sendWithPromisedReply(T&& message)
+    {
+        return m_gpuProcessConnection.get()->connection().sendWithPromisedReplyOnDispatcher(std::forward<T>(message), queue(), m_remoteSourceBufferIdentifier);
+    }
 
     friend class MessageReceiver;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;


### PR DESCRIPTION
#### 4f68b41033d3bdac7a1080faea0cd1af93e0fa12
<pre>
[MSE] Remove unnecessary main runloop hop when performing source buffer IPC connection
<a href="https://bugs.webkit.org/show_bug.cgi?id=270277">https://bugs.webkit.org/show_bug.cgi?id=270277</a>
<a href="https://rdar.apple.com/123805564">rdar://123805564</a>

Reviewed by Kimmo Kinnunen.

Make use of the new sendWithPromisedReplyOnDispatcher to avoid main runloop hop.

No change in JS observable behaviour (other than it&apos;s now very fast under most circumstances)

* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::append):
(WebKit::SourceBufferPrivateRemote::removeCodedFrames):
(WebKit::SourceBufferPrivateRemote::computeSeekTime):
(WebKit::SourceBufferPrivateRemote::bufferedSamplesForTrackId):
(WebKit::SourceBufferPrivateRemote::enqueuedSamplesForTrackID):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/275498@main">https://commits.webkit.org/275498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd6c00da792ecc60827ed1cfd1f7f8998c2851e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38129 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18363 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17961 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15633 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46028 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38205 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16833 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18452 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9409 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->