### PR TITLE
REGRESSION (268639@main): [ macOS wk2 ] http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html is a flaky timeout

### DIFF
--- a/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html
+++ b/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html
@@ -21,7 +21,9 @@
 
             console.log("Pressing \"z\" with access key modifiers should navigate to resources/keyboard-events-after-navigation.html.");
             window.focus();
-            eventSender.keyDown("z", internals.accessKeyModifiers());
+            setTimeout(() => {
+                eventSender.keyDown("z", internals.accessKeyModifiers());
+            }, 50)
         });
     </script>
 </body>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2016,6 +2016,4 @@ webkit.org/b/270319 [ Ventura ] accessibility/datetime/input-time-label-value.ht
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Pass ]
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div.html [ Pass ]
 
-webkit.org/b/270275 http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html [ Pass Timeout ]
-
 webkit.org/b/270368 [ Monterey+ Debug x86_64 ] fast/mediastream/microphone-change-while-muted.html [ Pass Failure ]


### PR DESCRIPTION
#### f937e7b94bf3dda61a932fb857ce59aa0642f7b5
<pre>
REGRESSION (268639@main): [ macOS wk2 ] http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=270275">https://bugs.webkit.org/show_bug.cgi?id=270275</a>
<a href="https://rdar.apple.com/123801060">rdar://123801060</a>

Reviewed by Alex Christensen.

268639@main made a change to reference the focused frame in the UI process when sending key events.

This test should make sure the UI process has up to date frame focus before sending the key event.

* LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html:

Canonical link: <a href="https://commits.webkit.org/275618@main">https://commits.webkit.org/275618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57ed5885241328ece390692e7ffa27ec0add6fc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38430 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35056 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41722 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14112 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40317 "Found 1 new API test failure: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36753 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18810 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5703 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->