### PR TITLE
Null pointer dereference in WebCore::ImageDocument::createDocumentStructure.

### DIFF
--- a/LayoutTests/fast/images/imageDocument-appendBytes-crash-expected.txt
+++ b/LayoutTests/fast/images/imageDocument-appendBytes-crash-expected.txt
@@ -1,0 +1,3 @@
+This test PASSED if it did not crash.
+
+

--- a/LayoutTests/fast/images/imageDocument-appendBytes-crash.html
+++ b/LayoutTests/fast/images/imageDocument-appendBytes-crash.html
@@ -1,0 +1,23 @@
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    function eventhandler2() {
+        try { var00010 = eventhandler5; } catch (e) { }
+        try { var00046 = htmlvar00059.contentWindow; } catch (e) { }
+        try { var00192 = var00046.window; } catch (e) { }
+        try { var00193 = var00010; } catch (e) { }
+        try { var00192.addEventListener("DOMSubtreeModified", var00193); } catch (e) { }
+    }
+    function eventhandler5() {
+        try { /* */ var00010 = document.caretRangeFromPoint(459, 251); } catch (e) { }
+        try { var00010.setStartBefore(htmlvar00032); } catch (e) { }
+        try { var00010.deleteContents(); } catch (e) { }
+    }
+</script>
+<p>This test PASSED if it did not crash.</p>
+<image src="x" onerror="eventhandler2()" nohref="nohref">
+    <map id="htmlvar00032" inputmode="email">
+        <iframe id="htmlvar00059"
+            src="data:image/gif;base64,R0lGODlhIAAgAPIBAGbMzP///wAAADOZZpn/zAAAAAAAAAAAACH5BAAAAAAALAAAAAAgACAAAAOLGLrc/k7ISau9S5DNu/8fICgaYJ5oqqbDGJRrLAMtScw468J5Xr+3nm8XFM5+PGMMWYwxcMyZ40iULQaDhSzqDGBNisGyuhUDrmNb72pWcaXhtpsM/27pVi8UX96rcQpDf3V+QD12d4NKK2+Lc4qOKI2RJ5OUNHyXSDRYnZ6foKAuLxelphMQqaoPCQA7"></iframe>
+    </map>
+</image>

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -147,6 +147,9 @@ void ImageDocument::updateDuringParsing()
     if (!m_imageElement)
         createDocumentStructure();
 
+    if (!frame())
+        return;
+
     if (RefPtr<FragmentedSharedBuffer> buffer = loader()->mainResourceData()) {
         if (auto* cachedImage = m_imageElement->cachedImage())
             cachedImage->updateBuffer(*buffer);
@@ -236,9 +239,10 @@ void ImageDocument::createDocumentStructure()
     auto head = HTMLHeadElement::create(*this);
     rootElement->appendChild(head);
 
+    RefPtr documentLoader = loader();
     auto body = HTMLBodyElement::create(*this);
     body->setAttribute(styleAttr, "margin: 0px; height: 100%"_s);
-    if (MIMETypeRegistry::isPDFMIMEType(document().loader()->responseMIMEType()))
+    if (documentLoader && MIMETypeRegistry::isPDFMIMEType(documentLoader->responseMIMEType()))
         body->setInlineStyleProperty(CSSPropertyBackgroundColor, "white"_s);
     rootElement->appendChild(body);
     
@@ -249,8 +253,8 @@ void ImageDocument::createDocumentStructure()
         imageElement->setAttribute(styleAttr, "-webkit-user-select:none; display:block; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);"_s);
     imageElement->setLoadManually(true);
     imageElement->setSrc(AtomString { url().string() });
-    if (auto* cachedImage = imageElement->cachedImage())
-        cachedImage->setResponse(loader()->response());
+    if (auto* cachedImage = imageElement->cachedImage(); documentLoader && cachedImage)
+        cachedImage->setResponse(documentLoader->response());
     body->appendChild(imageElement);
     imageElement->setLoadManually(false);
     


### PR DESCRIPTION
#### bac31e80659aa2caacbacfbba84a4053e322ed6f
<pre>
Null pointer dereference in WebCore::ImageDocument::createDocumentStructure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270283.">https://bugs.webkit.org/show_bug.cgi?id=270283.</a>
<a href="https://rdar.apple.com/122779661">rdar://122779661</a>.

Reviewed by Chris Dumez.

Adding null check to prevent the cases where local frame would be detached during createDocumentStructure.

* LayoutTests/fast/images/imageDocument-appendBytes-crash-expected.txt: Added.
* LayoutTests/fast/images/imageDocument-appendBytes-crash.html: Added.
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::updateDuringParsing):
(WebCore::ImageDocument::createDocumentStructure):

Canonical link: <a href="https://commits.webkit.org/275537@main">https://commits.webkit.org/275537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f205caaef219cb0c2219bbb790fa2072840ce598

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44704 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44424 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/24340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18464 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15807 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15727 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46137 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37625 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40081 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36568 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9429 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->