### PR TITLE
Add a fast path for EventContext::handleLocalEvents

### DIFF
--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -39,7 +39,7 @@
 
 namespace WebCore {
 
-void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
+void EventContext::invokeSlowCase(Event& event, EventInvokePhase phase) const
 {
     event.setTarget(m_target.copyRef());
     event.setCurrentTarget(m_currentTarget.copyRef(), m_currentTargetIsInShadowTree);
@@ -84,9 +84,6 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
             return;
         }
     }
-
-    if (!m_node->hasEventTargetData())
-        return;
 
     if (event.isTrusted() && is<MouseEvent>(event) && !event.isWheelEvent() && !m_node->document().settings().sendMouseEventsToDisabledFormControlsEnabled()) {
         auto* element = dynamicDowncast<Element>(m_node.get());

--- a/Source/WebCore/dom/EventContext.h
+++ b/Source/WebCore/dom/EventContext.h
@@ -56,7 +56,13 @@ public:
     EventTarget* target() const { return m_target.get(); }
     int closedShadowDepth() const { return m_closedShadowDepth; }
 
-    void handleLocalEvents(Event&, EventInvokePhase) const;
+    // https://dom.spec.whatwg.org/#concept-event-listener-invoke
+    void invoke(Event& event, EventInvokePhase phase) const
+    {
+        bool hasEventTargetData = m_node && m_type != Type::Window ? m_node->hasEventTargetData() : m_currentTarget->hasEventTargetData();
+        if (hasEventTargetData)
+          invokeSlowCase(event, phase);
+    }
 
     bool isMouseOrFocusEventContext() const { return m_type == Type::MouseOrFocus; }
     bool isTouchEventContext() const { return m_type == Type::Touch; }
@@ -72,6 +78,8 @@ public:
 
 private:
     inline EventContext(Type, Node* currentNode, RefPtr<EventTarget>&& currentTarget, EventTarget* origin, int closedShadowDepth, bool currentTargetIsInShadowTree = false);
+
+    void invokeSlowCase(Event&, EventInvokePhase) const;
 
 #if ENABLE(TOUCH_EVENTS)
     void initializeTouchLists();

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -93,7 +93,7 @@ static void dispatchEventInDOM(Event& event, const EventPath& path)
             event.setEventPhase(Event::AT_TARGET);
         else
             event.setEventPhase(Event::CAPTURING_PHASE);
-        eventContext.handleLocalEvents(event, EventTarget::EventInvokePhase::Capturing);
+        eventContext.invoke(event, EventTarget::EventInvokePhase::Capturing);
         if (event.propagationStopped())
             return;
     }
@@ -108,7 +108,7 @@ static void dispatchEventInDOM(Event& event, const EventPath& path)
             event.setEventPhase(Event::BUBBLING_PHASE);
         else
             continue;
-        eventContext.handleLocalEvents(event, EventTarget::EventInvokePhase::Bubbling);
+        eventContext.invoke(event, EventTarget::EventInvokePhase::Bubbling);
         if (event.propagationStopped())
             return;
     }


### PR DESCRIPTION
#### 57d996861260d11b8420ddb740634763d042b3ba
<pre>
Add a fast path for EventContext::handleLocalEvents
<a href="https://bugs.webkit.org/show_bug.cgi?id=270286">https://bugs.webkit.org/show_bug.cgi?id=270286</a>

Reviewed by NOBODY (OOPS!).

This PR adds a fast path for handleLocalEvents which is a no-op when hasEventTargetData returns false.
It also renames it to EventContext::invoke to match the spec concept of the same name:
<a href="https://dom.spec.whatwg.org/#concept-event-listener-invoke">https://dom.spec.whatwg.org/#concept-event-listener-invoke</a>

* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::invokeSlowCase const):
(WebCore::EventContext::handleLocalEvents const): Deleted.
* Source/WebCore/dom/EventContext.h:
(WebCore::EventContext::invoke const):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::dispatchEventInDOM):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57d996861260d11b8420ddb740634763d042b3ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42236 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34986 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15853 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37416 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38432 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37745 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41647 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17052 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14038 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/mouse-pointer-boundary-events-for-shadowdom.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40229 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18733 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->