### PR TITLE
REGRESSION(IFC multicol): Satisfying `widows` can cause a floating image to overlap text

### DIFF
--- a/LayoutTests/fast/multicol/multicol-intrusive-float-orphan-expected.html
+++ b/LayoutTests/fast/multicol/multicol-intrusive-float-orphan-expected.html
@@ -1,0 +1,22 @@
+<style>
+.columns {
+  width: 250px;
+  column-width: 250px;
+  height: 160px;
+  font-size: 22px;
+}
+img {
+  float: left;
+  background-color: red;
+  width: 100px;
+  height: 100px;
+}
+.widower {
+  orphans: 1;
+  widows: 2;
+}
+</style>
+<div class="columns">
+  <div class="first">first<br>second<br>third<br>fourth<br></div>
+  <div class=widower>PASS if this text does not overlap <img>the red box on the second column.</div>
+</div>

--- a/LayoutTests/fast/multicol/multicol-intrusive-float-orphan.html
+++ b/LayoutTests/fast/multicol/multicol-intrusive-float-orphan.html
@@ -1,0 +1,22 @@
+<style>
+.columns {
+  width: 250px;
+  column-width: 250px;
+  height: 160px;
+  font-size: 22px;
+}
+img {
+  float: left;
+  background-color: red;
+  width: 100px;
+  height: 100px;
+}
+.widower {
+  orphans: 1;
+  widows: 2;
+}
+</style>
+<div class="columns">
+  <div class="first">first<br>second<br>third<br>fourth<br><img></div>
+  <div class=widower>PASS if this text does not overlap the red box on the second column.</div>
+</div>

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineDamage.h
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineDamage.h
@@ -61,13 +61,15 @@ public:
         Append        = 1 << 0,
         Insert        = 1 << 1,
         Remove        = 1 << 2,
-        ContentChange = 1 << 3
+        ContentChange = 1 << 3,
+        Pagination    = 1 << 4
     };
     OptionSet<Reason> reasons() const { return m_damageReasons; }
     // FIXME: Add support for damage range with multiple, different damage types.
     struct Position {
         size_t lineIndex { 0 };
         InlineItemPosition inlineItemPosition { };
+        LayoutUnit partialContentTop;
     };
     std::optional<Position> start() const { return m_startPosition; }
     using TrailingDisplayBoxList = Vector<InlineDisplay::Box>;

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h
@@ -54,9 +54,11 @@ public:
 
     void horizontalConstraintChanged();
 
+    void restartForPagination(size_t lineIndex, LayoutUnit pageTopAdjustment);
+
 private:
     enum class ShouldApplyRangeLayout : bool { No, Yes };
-    void updateInlineDamage(InlineDamage::Type, std::optional<InlineDamage::Reason>, std::optional<InvalidatedLine>, ShouldApplyRangeLayout = ShouldApplyRangeLayout::No);
+    void updateInlineDamage(InlineDamage::Type, std::optional<InlineDamage::Reason>, std::optional<InvalidatedLine>, ShouldApplyRangeLayout = ShouldApplyRangeLayout::No, LayoutUnit restartPaginationAdjustment = 0_lu);
     bool applyFullDamageIfNeeded(const Box&);
     const InlineDisplay::Boxes& displayBoxes() const { return m_displayContent.boxes; }
     const InlineDisplay::Lines& displayLines() const { return m_displayContent.lines; }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -139,7 +139,7 @@ public:
 private:
     void preparePlacedFloats();
     FloatRect constructContent(const Layout::InlineLayoutState&, Layout::InlineLayoutResult&&);
-    Vector<LineAdjustment> adjustContent(const Layout::BlockLayoutState&);
+    Vector<LineAdjustment> adjustContentForPagination(const Layout::BlockLayoutState&, bool isPartialLayout);
     void updateRenderTreePositions(const Vector<LineAdjustment>&);
 
     InlineContent& ensureInlineContent();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
@@ -53,7 +53,7 @@ static LayoutUnit computeFirstLineSnapAdjustment(const InlineDisplay::Line& line
     return lineGrid.paginationOrigin.value_or(LayoutSize { }).height() + firstBaselinePosition - baseline;
 }
 
-Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent& inlineContent, const Layout::PlacedFloats& placedFloats, const Layout::BlockLayoutState& blockLayoutState, RenderBlockFlow& flow)
+std::pair<Vector<LineAdjustment>, std::optional<size_t>> computeAdjustmentsForPagination(const InlineContent& inlineContent, const Layout::PlacedFloats& placedFloats, bool allowLayoutRestart, const Layout::BlockLayoutState& blockLayoutState, RenderBlockFlow& flow)
 {
     auto lineCount = inlineContent.displayContent().lines.size();
     Vector<LineAdjustment> adjustments { lineCount };
@@ -92,6 +92,7 @@ Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent& inli
     }
 
     std::optional<size_t> previousPageBreakIndex;
+    std::optional<size_t> layoutRestartLineIndex;
 
     size_t widows = flow.style().hasAutoWidows() ? 0 : flow.style().widows();
     size_t orphans = flow.style().orphans();
@@ -110,7 +111,7 @@ Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent& inli
                 remainingLines--;
 
             // See if there are enough lines left to meet the widow requirement.
-            if (remainingLines < widows && !flow.didBreakAtLineToAvoidWidow()) {
+            if (remainingLines < widows && allowLayoutRestart && !layoutRestartLineIndex) {
                 auto previousPageLineCount = lineIndex - previousPageBreakIndex.value_or(0);
                 auto neededLines = widows - remainingLines;
                 auto availableLines = previousPageLineCount > orphans ? previousPageLineCount - orphans : 0;
@@ -120,6 +121,8 @@ Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent& inli
                     // Set the widow break and recompute the adjustments starting from that line.
                     flow.setBreakAtLineToAvoidWidow(breakIndex + 1);
                     lineIndex = breakIndex;
+                    // We need to redo the layout starting from the break for things like intrusive floats.
+                    layoutRestartLineIndex = breakIndex;
                     continue;
                 }
             }
@@ -147,7 +150,7 @@ Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent& inli
     if (!previousPageBreakIndex)
         return { };
 
-    return adjustments;
+    return { adjustments, layoutRestartLineIndex };
 }
 
 void adjustLinePositionsForPagination(InlineContent& inlineContent, const Vector<LineAdjustment>& adjustments)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h
@@ -43,7 +43,7 @@ struct LineAdjustment {
     bool isFirstAfterPageBreak { false };
 };
 
-Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent&, const Layout::PlacedFloats&, const Layout::BlockLayoutState&, RenderBlockFlow&);
+std::pair<Vector<LineAdjustment>, std::optional<size_t>> computeAdjustmentsForPagination(const InlineContent&, const Layout::PlacedFloats&, bool allowLayoutRestart, const Layout::BlockLayoutState&, RenderBlockFlow&);
 void adjustLinePositionsForPagination(InlineContent&, const Vector<LineAdjustment>&);
 
 }


### PR DESCRIPTION
#### 65ee365616b160ff51540fd6611625d89eda3b64
<pre>
REGRESSION(IFC multicol): Satisfying `widows` can cause a floating image to overlap text
<a href="https://bugs.webkit.org/show_bug.cgi?id=269818">https://bugs.webkit.org/show_bug.cgi?id=269818</a>
<a href="https://rdar.apple.com/123343009">rdar://123343009</a>

Reviewed by Alan Baradlay.

Combination of a widow break and intruding floats requires another layout pass.
Legacy line layout did this as well using a bit different approach.

* LayoutTests/fast/multicol/multicol-intrusive-float-orphan-expected.html: Added.
* LayoutTests/fast/multicol/multicol-intrusive-float-orphan.html: Added.
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineDamage.h:
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp:
(WebCore::Layout::InlineInvalidation::updateInlineDamage):

Include the vertical restart position to InlineDamage,

(WebCore::Layout::InlineInvalidation::restartForPagination):

Add a new invlaidation type for pagination relayout. It restarts from the top of the page to be relayouted.

* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::layout):

Perform another layout if we have damage after pagination adjustments.

(WebCore::LayoutIntegration::LineLayout::adjustContentForPagination):

Damage the content if needed.

(WebCore::LayoutIntegration::LineLayout::adjustContent): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):

In case we need a layout restart return the restart position.
This is needed when we have a widow break.

* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h:

Canonical link: <a href="https://commits.webkit.org/275629@main">https://commits.webkit.org/275629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59d3faccb8dc0b19bb1eeb259581067199fd8f85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38474 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18720 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18311 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16021 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41757 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14149 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36785 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9476 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->