### PR TITLE
Viewport unit conversion should work in empty frame

### DIFF
--- a/LayoutTests/fast/css/viewport-unit-conversion-crash-expected.txt
+++ b/LayoutTests/fast/css/viewport-unit-conversion-crash-expected.txt
@@ -1,0 +1,2 @@
+
+This test passes if it doesn't crash

--- a/LayoutTests/fast/css/viewport-unit-conversion-crash.html
+++ b/LayoutTests/fast/css/viewport-unit-conversion-crash.html
@@ -1,0 +1,21 @@
+<style>
+div { vertical-align: 0vh; -webkit-user-modify: read-write }
+</style>
+<body>
+
+<div>
+<object id="target" style="contain: size" data="?"></object>
+</div>
+
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+(function() {
+	document.getSelection().collapse(document.getElementById("target"));
+	document.execCommand("underline");
+})();
+</script>
+
+<div>This test passes if it doesn't crash</div>
+
+</body>

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1765,18 +1765,21 @@ bool CSSPrimitiveValue::convertingToLengthHasRequiredConversionData(int lengthCo
     // return std::optional<double> instead of having this check here.
 
     bool isFixedNumberConversion = lengthConversion & (FixedIntegerConversion | FixedFloatConversion);
+    if (!isFixedNumberConversion)
+        return true;
+
     auto dependencies = computedStyleDependencies();
     if (!dependencies.rootProperties.isEmpty() && !conversionData.rootStyle())
-        return !isFixedNumberConversion;
+        return false;
 
     if (!dependencies.properties.isEmpty() && !conversionData.style())
-        return !isFixedNumberConversion;
+        return false;
 
     if (dependencies.containerDimensions && !conversionData.elementForContainerUnitResolution())
-        return !isFixedNumberConversion;
+        return false;
 
-    if (dependencies.viewportDimensions && conversionData.defaultViewportFactor().isEmpty())
-        return !isFixedNumberConversion;
+    if (dependencies.viewportDimensions && !conversionData.renderView())
+        return false;
 
     return true;
 }


### PR DESCRIPTION
#### 11d5d62ba36c7db1aab5cdf2b465dc8a8890eaf9
<pre>
Viewport unit conversion should work in empty frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=270289">https://bugs.webkit.org/show_bug.cgi?id=270289</a>
<a href="https://rdar.apple.com/116715588">rdar://116715588</a>

Reviewed by Alan Baradlay.

We hit a release assert in some cases.

* LayoutTests/fast/css/viewport-unit-conversion-crash-expected.txt: Added.
* LayoutTests/fast/css/viewport-unit-conversion-crash.html: Added.
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::convertingToLengthHasRequiredConversionData const):

An empty viewport is a valid reference for resolving viewport units. The only requirement here is that we have access to one.
Also test for non-fixed conversion first to make the code less confusing.

Canonical link: <a href="https://commits.webkit.org/275620@main">https://commits.webkit.org/275620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b1c1cfc52348e2fa8b13069f7765d69434632c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18334 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34790 "Failure limit exceed. At least found 154 new test failures: accessibility/math-multiscript-attributes.html, animations/keyframe-pseudo-shadow.html, animations/multiple-backgrounds.html, compositing/animation/keyframe-order.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/geometry/clipping-foreground.html, compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html, compositing/tiling/sticky-change-to-tiled.html, css1/font_properties/font.html, css1/font_properties/font_size.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41428 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39970 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9472 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->