### PR TITLE
[GTK] Crash in WebPageProxy::getLoadDecisionForIcon

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11935,7 +11935,10 @@ void WebPageProxy::getLoadDecisionForIcon(const WebCore::LinkIcon& icon, Callbac
             return;
         }
         sendWithAsyncReply(Messages::WebPage::DidGetLoadDecisionForIcon(true, loadIdentifier), [callback = WTFMove(callback)](const IPC::SharedBufferReference& iconData) mutable {
-            callback(API::Data::create(iconData.data(), iconData.size()).ptr());
+            if (auto buffer = iconData.unsafeBuffer())
+                callback(API::Data::create(buffer->data(), buffer->size()).ptr());
+            else
+                callback(nullptr);
         });
     });
 }


### PR DESCRIPTION
#### 6a7b2d62c79487e7c4040fadf997e9238e6d9047
<pre>
[GTK] Crash in WebPageProxy::getLoadDecisionForIcon
<a href="https://bugs.webkit.org/show_bug.cgi?id=269699">https://bugs.webkit.org/show_bug.cgi?id=269699</a>

Reviewed by Michael Catanzaro.

This probably regressed in 274563@main, that changed the way a
SharedBuffer is serialized for IPC and now segments are sent, instead of
the contiguous. So, in getLoadDecisionForIcon() we need to handle the
case of data being non contiguous, by using SharedBufferReference::unsafeBuffer()

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::getLoadDecisionForIcon):

Canonical link: <a href="https://commits.webkit.org/275540@main">https://commits.webkit.org/275540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea62573addf60afd8a5c65c5ff6804e254c1022a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44575 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38101 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18335 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34792 "Failure limit exceed. At least found 162 new test failures: accessibility/math-multiscript-attributes.html, animations/additive-transform-animations.html, animations/multiple-backgrounds.html, animations/shadow-host-child-change.html, compositing/animation/keyframe-order.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/shared-backing/shared-layer-has-reflection.html, compositing/tiling/empty-to-tiled.html, css1/box_properties/clear_float.html, css1/font_properties/font_size.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15613 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46077 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41481 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13811 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40044 "Found 2 new API test failures: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18424 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18484 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5664 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->