### PR TITLE
[Skia] Disable antialiasing when rendering text with Ahem font

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -52,6 +52,7 @@ void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font,
     auto blob = builder.make();
     auto* canvas = graphicsContext.platformContext();
     SkPaint paint = static_cast<GraphicsContextSkia*>(&graphicsContext)->createFillPaint();
+    paint.setAntiAlias(font.allowsAntialiasing());
     paint.setImageFilter(static_cast<GraphicsContextSkia*>(&graphicsContext)->createDropShadowFilterIfNeeded(GraphicsContextSkia::ShadowStyle::Outset));
     canvas->drawTextBlob(blob, SkFloatToScalar(position.x()), SkFloatToScalar(position.y()), paint);
 }

--- a/Source/WebCore/platform/graphics/skia/FontSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontSkia.cpp
@@ -111,7 +111,10 @@ void Font::platformInit()
 
     m_syntheticBoldOffset = m_platformData.syntheticBold() ? 1.0f : 0.f;
 
-    // FIXME: Disable antialiasing for the Ahem font because many tests require this.
+    SkString familyName;
+    font.getTypeface()->getFamilyName(&familyName);
+    if (equalIgnoringASCIICase(familyName.c_str(), "Ahem"_s))
+        m_allowsAntialiasing = false;
 }
 
 void Font::platformCharWidthInit()


### PR DESCRIPTION
#### 1fb32b543a9cdd5a9f3b2b0d7888c7b0cafac8f8
<pre>
[Skia] Disable antialiasing when rendering text with Ahem font
<a href="https://bugs.webkit.org/show_bug.cgi?id=270290">https://bugs.webkit.org/show_bug.cgi?id=270290</a>

Reviewed by Alejandro G. Castro.

Ahem font is used by the test and they require the antialising to be disabled.

* Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/skia/FontSkia.cpp:
(WebCore::Font::platformInit):

Canonical link: <a href="https://commits.webkit.org/275491@main">https://commits.webkit.org/275491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6424482d36e3c6ae50d0d790887bedb75583adb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18339 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36165 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45999 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37523 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13816 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18488 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5632 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->