### PR TITLE
[Skia] Do not set synthetic bold offset

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontSkia.cpp
@@ -38,7 +38,6 @@ Path Font::platformPathForGlyph(Glyph glyph) const
     auto path = PathSkia::create();
     const auto& font = m_platformData.skFont();
     font.getPath(glyph, path->platformPath());
-    // FIXME: syntetic bold offset.
     return { path };
 }
 
@@ -108,8 +107,6 @@ void Font::platformInit()
         m_avgCharWidth = SkScalarToFloat(metrics.fAvgCharWidth);
 
     m_fontMetrics.setUnitsPerEm(font.getTypeface()->getUnitsPerEm());
-
-    m_syntheticBoldOffset = m_platformData.syntheticBold() ? 1.0f : 0.f;
 
     SkString familyName;
     font.getTypeface()->getFamilyName(&familyName);


### PR DESCRIPTION
#### c7ee831c38599255e3ae78a2b28b71968615107f
<pre>
[Skia] Do not set synthetic bold offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=270291">https://bugs.webkit.org/show_bug.cgi?id=270291</a>

Reviewed by Don Olmstead.

It&apos;s handled internally by Skia.

* Source/WebCore/platform/graphics/skia/FontSkia.cpp:
(WebCore::Font::platformPathForGlyph const):
(WebCore::Font::platformInit):

Canonical link: <a href="https://commits.webkit.org/275541@main">https://commits.webkit.org/275541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/518b99510936a592e0c003b7fd0bbd4614d18fb1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34801 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15734 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46012 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41443 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39986 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18497 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5665 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->