### PR TITLE
Implement getAttributeType and getPropertyType functions on TrustedTypePolicyFactory

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace-expected.txt
@@ -1,23 +1,23 @@
 
-FAIL 0: getAttributeType with full namespace info. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 0: getAttributeType with element namespace and empty attribute namespace assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 0: getAttributeType without namespaces. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 0: getAttributeType with undefined and empty namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 0: getAttributeType with empty and undefined namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 0: getAttributeType with empty namespaces. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 0: getAttributeType with element namespace and empty attribute namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 1: getAttributeType with full namespace info. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 1: getAttributeType with element namespace and empty attribute namespace assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 1: getAttributeType without namespaces. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 1: getAttributeType with undefined and empty namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 1: getAttributeType with empty and undefined namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 1: getAttributeType with empty namespaces. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 1: getAttributeType with element namespace and empty attribute namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 2: getAttributeType with full namespace info. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 2: getAttributeType with element namespace and empty attribute namespace assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 2: getAttributeType without namespaces. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 2: getAttributeType with undefined and empty namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 2: getAttributeType with empty and undefined namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 2: getAttributeType with empty namespaces. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL 2: getAttributeType with element namespace and empty attribute namespace. assert_equals: expected (string) "TrustedScriptURL" but got (object) null
+PASS 0: getAttributeType with full namespace info.
+PASS 0: getAttributeType with element namespace and empty attribute namespace
+PASS 0: getAttributeType without namespaces.
+PASS 0: getAttributeType with undefined and empty namespace.
+PASS 0: getAttributeType with empty and undefined namespace.
+PASS 0: getAttributeType with empty namespaces.
+PASS 0: getAttributeType with element namespace and empty attribute namespace.
+PASS 1: getAttributeType with full namespace info.
+PASS 1: getAttributeType with element namespace and empty attribute namespace
+PASS 1: getAttributeType without namespaces.
+PASS 1: getAttributeType with undefined and empty namespace.
+PASS 1: getAttributeType with empty and undefined namespace.
+PASS 1: getAttributeType with empty namespaces.
+PASS 1: getAttributeType with element namespace and empty attribute namespace.
+PASS 2: getAttributeType with full namespace info.
+PASS 2: getAttributeType with element namespace and empty attribute namespace
+PASS 2: getAttributeType without namespaces.
+PASS 2: getAttributeType with undefined and empty namespace.
+PASS 2: getAttributeType with empty and undefined namespace.
+PASS 2: getAttributeType with empty namespaces.
+PASS 2: getAttributeType with element namespace and empty attribute namespace.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-svg-expected.txt
@@ -1,0 +1,6 @@
+
+PASS trustedTypes.getAttributeType html script[href]
+PASS trustedTypes.getAttributeType svg script[href]
+PASS trustedTypes.getAttributeType svg script[href] xlink href
+PASS trustedTypes.getAttributeType svg script[href] other href
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-svg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-svg.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js" ></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.sub.js"></script>
+
+<body>
+<div id="target"></div>
+<script>
+  test(t => {
+    assert_equals(trustedTypes.getAttributeType("script", "href"), null);
+  }, "trustedTypes.getAttributeType html script[href]");
+  test(t => {
+    assert_equals(trustedTypes.getAttributeType("script", "href", "http://www.w3.org/2000/svg"), "TrustedScriptURL");
+  }, "trustedTypes.getAttributeType svg script[href]");
+  test(t => {
+    assert_equals(trustedTypes.getAttributeType("script", "href", "http://www.w3.org/2000/svg", "http://www.w3.org/1999/xlink"), "TrustedScriptURL");
+  }, "trustedTypes.getAttributeType svg script[href] xlink href");
+  test(t => {
+    assert_equals(trustedTypes.getAttributeType("script", "href", "http://www.w3.org/2000/svg", "http://www.w3.org/other"), null);
+  }, "trustedTypes.getAttributeType svg script[href] other href");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt
@@ -1,26 +1,26 @@
 
-FAIL sanity check trustedTypes.getPropertyType for the HTML script element. assert_equals: expected (string) "TrustedScript" but got (object) null
-FAIL sanity check trustedTypes.getAttributeType. assert_equals: expected (string) "TrustedScript" but got (object) null
+PASS sanity check trustedTypes.getPropertyType for the HTML script element.
+PASS sanity check trustedTypes.getAttributeType.
 FAIL sanity check trustedTypes.getTypeMapping trustedTypes.getTypeMapping is not a function. (In 'trustedTypes.getTypeMapping()', 'trustedTypes.getTypeMapping' is undefined)
-FAIL getPropertyType tests adapted from w3c/trusted-types polyfill assert_equals: expected (string) "TrustedScriptURL" but got (object) null
-FAIL getAttributeType tests adapted from w3c/trusted-types polyfill assert_equals: expected (string) "TrustedScriptURL" but got (object) null
+PASS getPropertyType tests adapted from w3c/trusted-types polyfill
+PASS getAttributeType tests adapted from w3c/trusted-types polyfill
 FAIL getTypeMapping tests adapted from w3c/trusted-types polyfill trustedTypes.getTypeMapping is not a function. (In 'trustedTypes.getTypeMapping()', 'trustedTypes.getTypeMapping' is undefined)
-FAIL object[codeBase] is defined assert_true: expected true got false
-FAIL object.codeBase is maybe defined assert_equals: expected true but got false
-FAIL OBJECT[codeBase] is defined assert_true: expected true got false
-FAIL OBJECT.codeBase is maybe defined assert_equals: expected true but got false
-FAIL oBjEcT[codeBase] is defined assert_true: expected true got false
-FAIL oBjEcT.codeBase is maybe defined assert_equals: expected true but got false
-FAIL object[CODEBASE] is defined assert_true: expected true got false
+PASS object[codeBase] is defined
+PASS object.codeBase is maybe defined
+PASS OBJECT[codeBase] is defined
+PASS OBJECT.codeBase is maybe defined
+PASS oBjEcT[codeBase] is defined
+PASS oBjEcT.codeBase is maybe defined
+PASS object[CODEBASE] is defined
 PASS object.CODEBASE is maybe defined
-FAIL OBJECT[CODEBASE] is defined assert_true: expected true got false
+PASS OBJECT[CODEBASE] is defined
 PASS OBJECT.CODEBASE is maybe defined
-FAIL oBjEcT[CODEBASE] is defined assert_true: expected true got false
+PASS oBjEcT[CODEBASE] is defined
 PASS oBjEcT.CODEBASE is maybe defined
-FAIL object[codebase] is defined assert_true: expected true got false
+PASS object[codebase] is defined
 PASS object.codebase is maybe defined
-FAIL OBJECT[codebase] is defined assert_true: expected true got false
+PASS OBJECT[codebase] is defined
 PASS OBJECT.codebase is maybe defined
-FAIL oBjEcT[codebase] is defined assert_true: expected true got false
+PASS oBjEcT[codebase] is defined
 PASS oBjEcT.codebase is maybe defined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt
@@ -16,22 +16,22 @@ PASS Test assignment of TrustedScript on madeup.id
 PASS Test assignment of TrustedScript on madeup.setAttribute(id,..)
 PASS Test assignment of TrustedScriptURL on madeup.id
 PASS Test assignment of TrustedScriptURL on madeup.setAttribute(id,..)
-PASS Test assignment of string on madeup.onerror
-PASS Test assignment of string on madeup.setAttribute(onerror,..)
-PASS Test assignment of TrustedHTML on madeup.onerror
-PASS Test assignment of TrustedHTML on madeup.setAttribute(onerror,..)
+FAIL Test assignment of string on madeup.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of string on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+FAIL Test assignment of TrustedHTML on madeup.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of TrustedHTML on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of TrustedScript on madeup.onerror
 PASS Test assignment of TrustedScript on madeup.setAttribute(onerror,..)
-PASS Test assignment of TrustedScriptURL on madeup.onerror
-PASS Test assignment of TrustedScriptURL on madeup.setAttribute(onerror,..)
-PASS Test assignment of string on madeup.onclick
-PASS Test assignment of string on madeup.setAttribute(onclick,..)
-PASS Test assignment of TrustedHTML on madeup.onclick
-PASS Test assignment of TrustedHTML on madeup.setAttribute(onclick,..)
+FAIL Test assignment of TrustedScriptURL on madeup.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of TrustedScriptURL on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+FAIL Test assignment of string on madeup.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of string on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+FAIL Test assignment of TrustedHTML on madeup.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of TrustedHTML on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of TrustedScript on madeup.onclick
 PASS Test assignment of TrustedScript on madeup.setAttribute(onclick,..)
-PASS Test assignment of TrustedScriptURL on madeup.onclick
-PASS Test assignment of TrustedScriptURL on madeup.setAttribute(onclick,..)
+FAIL Test assignment of TrustedScriptURL on madeup.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of TrustedScriptURL on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of string on b.madeup
 PASS Test assignment of string on b.setAttribute(madeup,..)
 PASS Test assignment of TrustedHTML on b.madeup
@@ -48,20 +48,20 @@ PASS Test assignment of TrustedScript on b.id
 PASS Test assignment of TrustedScript on b.setAttribute(id,..)
 PASS Test assignment of TrustedScriptURL on b.id
 PASS Test assignment of TrustedScriptURL on b.setAttribute(id,..)
-PASS Test assignment of string on b.onerror
-PASS Test assignment of string on b.setAttribute(onerror,..)
-PASS Test assignment of TrustedHTML on b.onerror
-PASS Test assignment of TrustedHTML on b.setAttribute(onerror,..)
+FAIL Test assignment of string on b.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of string on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+FAIL Test assignment of TrustedHTML on b.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of TrustedHTML on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of TrustedScript on b.onerror
 PASS Test assignment of TrustedScript on b.setAttribute(onerror,..)
-PASS Test assignment of TrustedScriptURL on b.onerror
-PASS Test assignment of TrustedScriptURL on b.setAttribute(onerror,..)
-PASS Test assignment of string on b.onclick
-PASS Test assignment of string on b.setAttribute(onclick,..)
-PASS Test assignment of TrustedHTML on b.onclick
-PASS Test assignment of TrustedHTML on b.setAttribute(onclick,..)
+FAIL Test assignment of TrustedScriptURL on b.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of TrustedScriptURL on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+FAIL Test assignment of string on b.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of string on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
+FAIL Test assignment of TrustedHTML on b.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of TrustedHTML on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of TrustedScript on b.onclick
 PASS Test assignment of TrustedScript on b.setAttribute(onclick,..)
-PASS Test assignment of TrustedScriptURL on b.onclick
-PASS Test assignment of TrustedScriptURL on b.setAttribute(onclick,..)
+FAIL Test assignment of TrustedScriptURL on b.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+FAIL Test assignment of TrustedScriptURL on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
@@ -1,5 +1,3 @@
-Blocked access to external URL https://example.test/
-Blocked access to external URL https://example.test/
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
@@ -14,8 +12,6 @@ CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the followin
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-Blocked access to external URL https://example.test/
-Blocked access to external URL https://example.test/
 
 hello
 hello

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
@@ -1,5 +1,7 @@
 Blocked access to external URL https://example.test/
 Blocked access to external URL https://example.test/
+Blocked access to external URL https://example.test/
+Blocked access to external URL https://example.test/
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
@@ -14,8 +16,6 @@ CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the followin
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-Blocked access to external URL https://example.test/
-Blocked access to external URL https://example.test/
 
 hello
 hello

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
@@ -1,5 +1,3 @@
-Blocked access to external URL https://example.test/
-Blocked access to external URL https://example.test/
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
@@ -14,8 +12,6 @@ CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the followin
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-Blocked access to external URL https://example.test/
-Blocked access to external URL https://example.test/
 
 hello
 hello

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.h
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.h
@@ -52,7 +52,7 @@ public:
     Ref<TrustedHTML> emptyHTML() const;
     Ref<TrustedScript> emptyScript() const;
 
-    String getAttributeType(const String& tagName, const String& attribute, const String& elementNamespace, const String& attrNamespace) const;
+    String getAttributeType(const String& tagName, const String& attribute, const String& elementNamespace, const String& attributeNamespace) const;
     String getPropertyType(const String& tagName, const String& property, const String& elementNamespace) const;
 
     RefPtr<TrustedTypePolicy> defaultPolicy() const { return m_defaultPolicy; }

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.idl
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.idl
@@ -35,9 +35,9 @@ interface TrustedTypePolicyFactory {
     readonly attribute TrustedHTML emptyHTML;
     readonly attribute TrustedScript emptyScript;
 
-    DOMString? getAttributeType(DOMString tagName, DOMString attribute, optional DOMString elementNamespace = "", optional DOMString attrNamespace = "");
+    DOMString? getAttributeType(DOMString tagName, DOMString attribute, optional DOMString? elementNamespace = "", optional DOMString? attrNamespace = "");
 
-    DOMString? getPropertyType(DOMString tagName, DOMString property, optional DOMString elementNamespace = "");
+    DOMString? getPropertyType(DOMString tagName, DOMString property, optional DOMString? elementNamespace = "");
 
     readonly attribute TrustedTypePolicy? defaultPolicy;
 };


### PR DESCRIPTION
#### 6b79732d9cb95141673959f934689029a8cf6801
<pre>
Implement getAttributeType and getPropertyType functions on TrustedTypePolicyFactory
<a href="https://bugs.webkit.org/show_bug.cgi?id=270080">https://bugs.webkit.org/show_bug.cgi?id=270080</a>

Reviewed by Ryosuke Niwa and Darin Adler.

Implements getAttributeType and getPropertyType metadata functions.
Also adds missing test coverage for SVGScript href attribute handling.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-svg-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-svg.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt: Added.
* Source/WebCore/dom/TrustedTypePolicyFactory.cpp:
(WebCore::TrustedTypePolicyFactory::getAttributeType const):
(WebCore::TrustedTypePolicyFactory::getPropertyType const):
* Source/WebCore/dom/TrustedTypePolicyFactory.idl:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/276310@main">https://commits.webkit.org/276310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25ea46a23ddd6b3b8f95683f5344691acc905d79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36277 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17295 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38975 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2040 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37352 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48236 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43137 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38157 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41857 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9849 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20578 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50623 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19996 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10212 "Passed tests") | 
<!--EWS-Status-Bubble-End-->