### PR TITLE
[results.webkit.org] Add concept of suite types

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/investigate.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/investigate.js
@@ -28,6 +28,7 @@ import {queryToParams, paramsToQuery, QueryModifier, percentage, elapsedTime} fr
 import {Configuration} from '/assets/js/configuration.js'
 import {Expectations} from '/assets/js/expectations.js';
 import {Failures} from '/assets/js/failures.js';
+import {TypeForSuite} from '/assets/js/suites.js';
 
 function commitsForUuid(uuid) {
     return `Commits: ${CommitBank.commitsDuring(uuid).map((commit) => {
@@ -59,7 +60,8 @@ function testRunLink(suite, data)
 {
     if (!data.start_time)
         return '';
-    return `<a href="/urls/build?${parametersForInstance(suite, data)}" target="_blank">Test run</a> @ ${new Date(data.start_time * 1000).toLocaleString()}`;
+    const typ = TypeForSuite(suite);
+    return `<a href="/urls/build?${parametersForInstance(suite, data)}" target="_blank">${typ.runDescription}</a> @ ${new Date(data.start_time * 1000).toLocaleString()}`;
 }
 
 function archiveLink(suite, data)

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/suites.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/suites.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import {XCODE_CLOUD_SUITES} from '/assets/js/constants.js';
+
+
+class _SuiteType {
+    constructor(runTitle) {
+        this.runTitle = runTitle;
+
+        let arr = runTitle.split(' ');
+        for (let i = 1; i < arr.length; i++)
+            arr[i] = arr[i].toLowerCase();
+        this.runDescription = arr.join(' ');
+    }
+}
+
+const defaultType = new _SuiteType('Test Run');
+const xcodeCloudType = new _SuiteType('Build');
+
+
+function TypeForSuite(suite) {
+    if (XCODE_CLOUD_SUITES.includes(suite))
+        return xcodeCloudType;
+    return defaultType;
+}
+
+export {TypeForSuite}

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -27,6 +27,7 @@ import {Configuration} from '/assets/js/configuration.js';
 import {deepCompare, ErrorDisplay, escapeHTML, paramsToQuery, queryToParams, linkify, escapeEndpoint} from '/assets/js/common.js';
 import {Expectations} from '/assets/js/expectations.js';
 import {InvestigateDrawer} from '/assets/js/investigate.js';
+import {TypeForSuite} from '/assets/js/suites.js';
 import {ToolTip} from '/assets/js/tooltip.js';
 import {Timeline} from '/library/js/components/TimelineComponents.js';
 import {DOM, EventStream, REF, FP} from '/library/js/Ref.js';
@@ -873,9 +874,10 @@ class TimelineFromEndpoint {
                 if (branch)
                     buildParams['branch'] = branch;
 
+                const typ = TypeForSuite(self.suite);
                 ToolTip.set(
                     `<div class="content">
-                        ${data.start_time ? `<a href="/urls/build?${paramsToQuery(buildParams)}" target="_blank">Test run</a> @ ${new Date(data.start_time * 1000).toLocaleString()}<br>` : ''}
+                        ${data.start_time ? `<a href="/urls/build?${paramsToQuery(buildParams)}" target="_blank">${typ.runDescription}</a> @ ${new Date(data.start_time * 1000).toLocaleString()}<br>` : ''}
                         ${data.start_time && ArchiveRouter.hasArchive(self.suite, data.actual) ? `<a href="/archive/${ArchiveRouter.pathFor(self.suite, data.actual, self.test)}?${paramsToQuery(buildParams)}" target="_blank">${ArchiveRouter.labelFor(self.suite, data.actual)}</a><br>` : ''}
                         Commits: ${CommitBank.commitsDuring(data.uuid).map((commit) => {
                             let params = {

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+const XCODE_CLOUD_SUITES = [{% for suite in XcodeCloud %}
+    '{{ suite }}',
+{% endfor %}];
+
+export {XCODE_CLOUD_SUITES}

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/investigate.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/investigate.html
@@ -34,6 +34,7 @@ import {ErrorDisplay, QueryModifier, paramsToQuery, queryToParams, percentage, e
 import {Configuration} from '/assets/js/configuration.js';
 import {Expectations} from '/assets/js/expectations.js';
 import {Drawer, BranchSelector, ConfigurationSelectors} from '/assets/js/drawer.js';
+import {TypeForSuite} from '/assets/js/suites.js';
 import {Legend} from '/assets/js/timeline.js';
 import {ToolTip} from '/assets/js/tooltip.js';
 import {Failures} from '/assets/js/failures.js';
@@ -60,6 +61,7 @@ function willFilterExpected() {
 class SuiteFailuresView {
     constructor(suite) {
         this.suite = suite;
+        this.suiteType = TypeForSuite(this.suite);
         this.dataForConfig = {};
 
         this.ref = REF.createRef({
@@ -182,7 +184,7 @@ class SuiteFailuresView {
                                 </div>
                             </div>
                             ${diff.results.length === 1 ? `<div class="item">
-                                <b>Test Run</b>
+                                <b>${this.suiteType.runTitle}</b>
                                 <div>
                                     ${diff.results[0].start_time ? (() => {
                                         const branch = queryToParams(document.URL.split('?')[1]).branch;
@@ -194,7 +196,7 @@ class SuiteFailuresView {
                                         if (branch)
                                             buildParams['branch'] = branch;
                                         const query = paramsToQuery(buildParams);
-                                        let result = `<a href="/urls/build?${query}" target="_blank">Test run</a> @ ${new Date(diff.results[0].start_time * 1000).toLocaleString()}<br>`;
+                                        let result = `<a href="/urls/build?${query}" target="_blank">${this.suiteType.runDescription}</a> @ ${new Date(diff.results[0].start_time * 1000).toLocaleString()}<br>`;
                                         if (!ArchiveRouter.hasArchive(suite))
                                             return result;
                                         result += `<a href="/archive/${ArchiveRouter.pathFor(suite)}?${query}" target="_blank">${ArchiveRouter.labelFor(suite)}</a><br>`;
@@ -207,7 +209,7 @@ class SuiteFailuresView {
                         </div>
                         ${diff.results.length === 1 || !diff.failures.length ? '' : `<div class="divider mobile-control"></div>
                             <div class="col-s-6 list">
-                                <b>Test Runs</b>
+                                <b>${this.suiteType.runTitle}s</b>
                                 ${diff.failures.slice(0, 8).map(failure => {
                                     let worst = 'success';
                                     Expectations.failureTypes.forEach(type => {

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py
@@ -37,7 +37,13 @@ from webkitflaskpy.util import AssertRequest, cache_for
 
 
 class ViewRoutes(AuthedBlueprint):
-    def __init__(self, model, controller, import_name=__name__, title='Results Database', auth_decorator=None, archive_routes=None):
+    def __init__(
+        self, model, controller,
+        import_name=__name__,
+        title='Results Database', auth_decorator=None,
+        archive_routes=None,
+        suite_types=None,
+    ):
         super(ViewRoutes, self).__init__('view', import_name, url_prefix=None, auth_decorator=auth_decorator)
         self._cache = {}
 
@@ -46,10 +52,12 @@ class ViewRoutes(AuthedBlueprint):
             loader=PackageLoader(package_name='resultsdbpy.view', package_path='templates'),
             autoescape=select_autoescape(['html', 'xml']),
         )
+        self.suite_types = suite_types or {}
 
         # Protecting js and css with auth doesn't make sense
         self.add_url_rule('/library/<path:path>', 'library', self.library, authed=False, methods=('GET',))
         self.add_url_rule('/assets/<path:path>', 'assets', self.assets, authed=False, methods=('GET',))
+        self.add_url_rule('/assets/js/constants.js', 'constants', self.constants, authed=False, methods=('GET',))
 
         self.site_menu = SiteMenu(title=self.title)
 
@@ -156,3 +164,10 @@ class ViewRoutes(AuthedBlueprint):
         return self.environment.get_template('documentation.html').render(
             title=f'{self.title}: Documentation',
             **kwargs)
+
+    def constants(self):
+        return Response(
+            self.environment.get_template('constants.js').render(
+                XcodeCloud=self.suite_types.get('XcodeCloud') or [],
+            ), mimetype='application/javascript',
+        )

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py
@@ -66,7 +66,10 @@ class WebSiteTestCase(FlaskTestCase, WaitForDockerTestCase):
                 ],
             )
             api_routes = APIRoutes(model=model, import_name=__name__)
-            view_routes = ViewRoutes(model=model, controller=api_routes, import_name=__name__)
+            view_routes = ViewRoutes(
+                model=model, controller=api_routes, import_name=__name__,
+                suite_types=dict(XcodeCloud=['Build']),
+            )
 
             app.register_blueprint(api_routes)
             app.register_blueprint(view_routes)
@@ -109,3 +112,40 @@ class WebSiteUnittest(WebSiteTestCase):
         commit_link.click()
         time.sleep(.1)
         self.assertEqual(driver.title, 'Results Database: Commits')
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
+    def test_constants(self, client, **kwargs):
+        response = client.get(f'{self.URL}/assets/js/constants.js')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.text,
+            '''// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+const XCODE_CLOUD_SUITES = [
+    'Build',
+];
+
+export {XCODE_CLOUD_SUITES}''',
+        )


### PR DESCRIPTION
#### e7c50346bf9a377ca4736d355426d3d09c96ce72
<pre>
[results.webkit.org] Add concept of suite types
<a href="https://bugs.webkit.org/show_bug.cgi?id=270294">https://bugs.webkit.org/show_bug.cgi?id=270294</a>
<a href="https://rdar.apple.com/123834321">rdar://123834321</a>

Reviewed by Dewei Zhu.

To support reporting alternate suite types to results.webkit.org, ViewRoutes
need to be able to define a type for a specific suite.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/investigate.js:
(testRunLink): Use description from suite type.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/suites.js: Added.
(_SuiteType): Class to hold various suite-specific customizations.
(TypeForSuite): Return a SuiteType object for a given suite name.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
(TimelineFromEndpoint.prototype.render.onDotEnterFactory): Use description from suite type.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js: Added.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/investigate.html:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py:
(ViewRoutes.__init__): Add suite_types parameter, constants.js endpoint.
(ViewRoutes.constants): Parameterize the constants.js file based on arguments to ViewRoutes.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py:
(WebSiteTestCase.setup_webserver): Add suite_types parameter.
(WebSiteUnittest.test_constants):

Canonical link: <a href="https://commits.webkit.org/275522@main">https://commits.webkit.org/275522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/915a83f88d8d236cde9b6764dcd1a9cc289a50ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44605 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/38130 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18364 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34807 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36180 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/15740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/41889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15635 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46029 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38207 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37538 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41450 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16834 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/13834 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/39993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/42066 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18453 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18513 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5653 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18098 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->