### PR TITLE
Style cleanups after 275446@main

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -127,7 +127,7 @@ static Navigation::Result createErrorResult(Ref<DeferredPromise> committed, Ref<
     return createErrorResult(committed, finished, Exception { exceptionCode, errorMessage });
 }
 
-ExceptionOr<RefPtr<SerializedScriptValue>> Navigation::serializeState(JSC::JSValue& state)
+ExceptionOr<RefPtr<SerializedScriptValue>> Navigation::serializeState(JSC::JSValue state)
 {
     if (state.isUndefined())
         return { nullptr };
@@ -141,7 +141,7 @@ ExceptionOr<RefPtr<SerializedScriptValue>> Navigation::serializeState(JSC::JSVal
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#maybe-set-the-upcoming-non-traverse-api-method-tracker
-NavigationAPIMethodTracker Navigation::maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState)
+NavigationAPIMethodTracker Navigation::maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&& serializedState)
 {
     static uint64_t lastTrackerID;
     auto apiMethodTracker = NavigationAPIMethodTracker(lastTrackerID++, WTFMove(committed), WTFMove(finished), WTFMove(info), WTFMove(serializedState));
@@ -206,8 +206,8 @@ Navigation::Result Navigation::navigate(ScriptExecutionContext& scriptExecutionC
     // FIXME: This is not a proper Navigation API initiated traversal, just a simple load for now.
     window()->frame()->loader().load(FrameLoadRequest(*window()->frame(), newURL));
 
-    if (m_upcomingNonTraverseMethodTracker && m_upcomingNonTraverseMethodTracker.value() == apiMethodTracker) {
-        // TODO: Once the frameloader properly promotes the upcoming tracker with the navigate event `m_upcomingNonTraverseMethodTracker` should be unset or this will throw.
+    if (m_upcomingNonTraverseMethodTracker == apiMethodTracker) {
+        // FIXME: Once the frameloader properly promotes the upcoming tracker with the navigate event `m_upcomingNonTraverseMethodTracker` should be unset or this will throw.
         m_upcomingNonTraverseMethodTracker = std::nullopt;
     }
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -40,8 +40,6 @@ class SerializedScriptValue;
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker
 struct NavigationAPIMethodTracker {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-
     NavigationAPIMethodTracker(uint64_t id, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState)
         : info(info)
         , serializedState(serializedState)
@@ -136,8 +134,8 @@ private:
     bool hasEntriesAndEventsDisabled() const;
     Result performTraversal(NavigationHistoryEntry&, Ref<DeferredPromise> committed, Ref<DeferredPromise> finished);
     std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
-    ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue& state);
-    NavigationAPIMethodTracker maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&&);
+    ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
+    NavigationAPIMethodTracker maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&);
 
 
     std::optional<size_t> m_currentEntryIndex;


### PR DESCRIPTION
#### af09f4b25d115e91195b96b5e9c19a2ad01464ad
<pre>
Style cleanups after 275446@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=270299">https://bugs.webkit.org/show_bug.cgi?id=270299</a>

Reviewed by Darin Adler.

Minor cleanups brought up in review.

* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::serializeState):
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker):
(WebCore::Navigation::navigate):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/275529@main">https://commits.webkit.org/275529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc6b4d1cfce964b5928742d489fb42267d24d8f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18374 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34819 "Failure limit exceed. At least found 152 new test failures: accessibility/math-multiscript-attributes.html, animations/shadow-host-child-change.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/geometry/clipping-foreground.html, compositing/shadows/shadow-drawing.html, compositing/tiling/sticky-change-to-tiled.html, css1/box_properties/clear_float.html, css1/font_properties/font.html, css1/font_properties/font_size.html, css1/formatting_model/inline_elements.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15751 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46041 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37550 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41459 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40002 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18523 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5659 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->