### PR TITLE
Handle `exitFullscreen()` when using Quick Look

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -80,9 +80,8 @@ public:
 #if PLATFORM(VISION)
     bool isVideoElement() const { return m_isVideoElement; }
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    bool isImageElement() const { return m_imageBuffer.has_value(); }
-    const String& imageMIMEType() const { return m_imageMIMEType; }
-    const std::optional<Ref<WebCore::SharedBuffer>>& imageBuffer() const { return m_imageBuffer; }
+    bool isImageElement() const { return m_imageBuffer; }
+    void prepareQuickLookImageURL(CompletionHandler<void(URL&&)>&&) const;
 #endif // QUICKLOOK_FULLSCREEN
 #endif
     void close();
@@ -135,7 +134,7 @@ private:
     bool m_isVideoElement { false };
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     String m_imageMIMEType;
-    std::optional<Ref<WebCore::SharedBuffer>> m_imageBuffer;
+    RefPtr<WebCore::SharedBuffer> m_imageBuffer;
 #endif // QUICKLOOK_FULLSCREEN
 #endif
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;

--- a/Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h
+++ b/Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class WKSPreviewWindowController;
 
 @protocol WKSPreviewWindowControllerDelegate <NSObject>
-- (void)previewWindowControllerDidClose;
+- (void)previewWindowControllerDidClose:(id)previewWindowController;
 @end
 
 @interface WKSPreviewWindowController : NSObject


### PR DESCRIPTION
#### 211b6e10b7238bbe628003074ecf6b15cf0e6b2b
<pre>
Handle `exitFullscreen()` when using Quick Look
<a href="https://bugs.webkit.org/show_bug.cgi?id=270297">https://bugs.webkit.org/show_bug.cgi?id=270297</a>
&lt;<a href="https://rdar.apple.com/120903037">rdar://120903037</a>&gt;

Reviewed by Andy Estes and Aditya Keerthi.

Use `PreviewApplication` instead or `Preview` in order to get access to
programmatic close. Wire it to the `exitFullscreen` code path.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxy::imageMIMEType const): Deleted.
(WebKit::WebFullScreenManagerProxy::imageBuffer const): Deleted.
(WebKit::WebFullScreenManagerProxy::isImageElement const):
Hold the image buffer with a `RefPtr` instead of a `std::optional&lt;Ref&gt;`.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::exitFullScreen):
(WebKit::sharedQuickLookFileQueue):
(WebKit::WebFullScreenManagerProxy::prepareQuickLookImageURL const):
Add a method to generate local URLs instead of passing NSData to the
Preview.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController exitFullScreen]):
Clean-up PreviewWindowController on exit.
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
Switch to a URL-based QLItem.
(-[WKFullScreenWindowController previewWindowControllerDidClose:]):
(-[WKFullScreenWindowController previewWindowControllerDidClose]): Deleted.
Check that the instance closing is the one we care about.
(-[WKFullScreenWindowController provideDataForItem:]): Deleted.
Remove the NSData-based delegate for QLItems.

* Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h:
Pass the WKSPreviewWindowController instance to the delegate.
* Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift:
(PreviewWindowController.item):
(PreviewWindowController.previewSession):
(PreviewWindowController.presentWindow):
(PreviewWindowController.dismissWindow):
(PreviewWindowController.previewApp): Deleted.
Switch to `PreviewApplication`.
Implement `dismissWindow`.

Canonical link: <a href="https://commits.webkit.org/275778@main">https://commits.webkit.org/275778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2250cbabcd3bb33837c94603411c480a9f5b7f30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38870 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35380 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16402 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/802 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46867 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42107 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19183 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40735 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9548 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->