### PR TITLE
Resolve directories on WorkQueue in UI process

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -580,6 +580,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 
     auto sessionID = configuration.isPersistent ? PAL::SessionID::generatePersistentSessionID() : PAL::SessionID::generateEphemeralSessionID();
     API::Object::constructInWrapper<WebKit::WebsiteDataStore>(self, configuration->_configuration->copy(), sessionID);
+    _websiteDataStore->resolveDirectoriesAsynchronously();
 
     return self;
 }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -644,7 +644,8 @@ static inline GPUProcessSessionParameters gpuProcessSessionParameters(const Webs
 {
     GPUProcessSessionParameters parameters;
 
-    parameters.mediaCacheDirectory = store.resolvedMediaCacheDirectory();
+    auto& resolvedDirectories = const_cast<WebsiteDataStore&>(store).resolvedDirectories();
+    parameters.mediaCacheDirectory = resolvedDirectories.mediaCacheDirectory;
     SandboxExtension::Handle mediaCacheDirectoryExtensionHandle;
     if (!parameters.mediaCacheDirectory.isEmpty()) {
         if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(parameters.mediaCacheDirectory, SandboxExtension::Type::ReadWrite))
@@ -652,7 +653,7 @@ static inline GPUProcessSessionParameters gpuProcessSessionParameters(const Webs
     }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    parameters.mediaKeysStorageDirectory = store.resolvedMediaKeysDirectory();
+    parameters.mediaKeysStorageDirectory = resolvedDirectories.mediaKeysStorageDirectory;
     SandboxExtension::Handle mediaKeysStorageDirectorySandboxExtensionHandle;
     if (!parameters.mediaKeysStorageDirectory.isEmpty()) {
         if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(parameters.mediaKeysStorageDirectory, SandboxExtension::Type::ReadWrite))

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -818,9 +818,10 @@ void WebProcessPool::registerHighDynamicRangeChangeCallback()
 
 WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebProcessProxy& process, WebsiteDataStore& websiteDataStore)
 {
-    websiteDataStore.resolveDirectoriesIfNecessary();
+    websiteDataStore.waitForDirectoriesToResolveIfNecessary();
 
-    String mediaCacheDirectory = websiteDataStore.resolvedMediaCacheDirectory();
+    auto& resolvedDirectories = websiteDataStore.resolvedDirectories();
+    String mediaCacheDirectory = resolvedDirectories.mediaCacheDirectory;
 #if !ENABLE(GPU_PROCESS)
     SandboxExtension::Handle mediaCacheDirectoryExtensionHandle;
     if (!mediaCacheDirectory.isEmpty()) {
@@ -829,7 +830,7 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
     }
 #endif
 
-    String mediaKeyStorageDirectory = websiteDataStore.resolvedMediaKeysDirectory();
+    String mediaKeyStorageDirectory = resolvedDirectories.mediaKeysStorageDirectory;
     SandboxExtension::Handle mediaKeyStorageDirectoryExtensionHandle;
     if (!mediaKeyStorageDirectory.isEmpty()) {
         if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(mediaKeyStorageDirectory, SandboxExtension::Type::ReadWrite))
@@ -841,7 +842,7 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
     if (!m_javaScriptConfigurationDirectory.isEmpty())
         javaScriptConfigurationDirectory = resolvePathForSandboxExtension(m_javaScriptConfigurationDirectory);
     else if (javaScriptConfigurationFileEnabled())
-        javaScriptConfigurationDirectory = websiteDataStore.resolvedJavaScriptConfigurationDirectory();
+        javaScriptConfigurationDirectory = resolvedDirectories.javaScriptConfigurationDirectory;
 
     SandboxExtension::Handle javaScriptConfigurationDirectoryExtensionHandle;
     if (!javaScriptConfigurationDirectory.isEmpty()) {
@@ -850,7 +851,7 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
     }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-    auto modelElementCacheDirectory = websiteDataStore.resolvedModelElementCacheDirectory();
+    auto modelElementCacheDirectory = resolvedDirectories.modelElementCacheDirectory;
     SandboxExtension::Handle modelElementCacheDirectoryExtensionHandle;
     if (!modelElementCacheDirectory.isEmpty()) {
         if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(modelElementCacheDirectory, SandboxExtension::Type::ReadWrite))

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -179,9 +179,10 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
     if (!httpsProxy.isValid() && (isSafari || isMiniBrowser))
         httpsProxy = URL { [defaults stringForKey:(NSString *)WebKit2HTTPSProxyDefaultsKey] };
 
+    auto& directories = resolvedDirectories();
 #if HAVE(ALTERNATIVE_SERVICE)
     SandboxExtension::Handle alternativeServiceStorageDirectoryExtensionHandle;
-    String alternativeServiceStorageDirectory = resolvedAlternativeServicesStorageDirectory();
+    String alternativeServiceStorageDirectory = directories.alternativeServicesDirectory;
     createHandleFromResolvedPathIfPossible(alternativeServiceStorageDirectory, alternativeServiceStorageDirectoryExtensionHandle);
 #endif
 
@@ -203,7 +204,7 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.standaloneApplicationDomain = WebCore::RegistrableDomain { m_configuration->standaloneApplicationURL() };
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.manualPrevalentResource = WTFMove(resourceLoadStatisticsManualPrevalentResource);
 
-    auto cookieFile = resolvedCookieStorageFile();
+    auto cookieFile = directories.cookieStorageFile;
     createHandleFromResolvedPathIfPossible(FileSystem::parentPath(cookieFile), parameters.cookieStoragePathExtensionHandle);
 
     if (m_uiProcessCookieStorageIdentifier.isEmpty()) {
@@ -946,14 +947,14 @@ void WebsiteDataStore::setBackupExclusionPeriodForTesting(Seconds period, Comple
 
 void WebsiteDataStore::saveRecentSearches(const String& name, const Vector<WebCore::RecentSearch>& searchItems)
 {
-    m_queue->dispatch([name = name.isolatedCopy(), searchItems = crossThreadCopy(searchItems), directory = resolvedSearchFieldHistoryDirectory().isolatedCopy()] {
+    m_queue->dispatch([name = name.isolatedCopy(), searchItems = crossThreadCopy(searchItems), directory = resolvedDirectories().searchFieldHistoryDirectory.isolatedCopy()] {
         WebCore::saveRecentSearchesToFile(name, searchItems, directory);
     });
 }
 
 void WebsiteDataStore::loadRecentSearches(const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
 {
-    m_queue->dispatch([name = name.isolatedCopy(), completionHandler = WTFMove(completionHandler), directory = resolvedSearchFieldHistoryDirectory().isolatedCopy()]() mutable {
+    m_queue->dispatch([name = name.isolatedCopy(), completionHandler = WTFMove(completionHandler), directory = resolvedDirectories().searchFieldHistoryDirectory.isolatedCopy()]() mutable {
         auto result = WebCore::loadRecentSearchesFromFile(name, directory);
         RunLoop::main().dispatch([completionHandler = WTFMove(completionHandler), result = crossThreadCopy(result)]() mutable {
             completionHandler(WTFMove(result));
@@ -963,7 +964,7 @@ void WebsiteDataStore::loadRecentSearches(const String& name, CompletionHandler<
 
 void WebsiteDataStore::removeRecentSearches(WallTime oldestTimeToRemove, CompletionHandler<void()>&& completionHandler)
 {
-    m_queue->dispatch([time = oldestTimeToRemove.isolatedCopy(), directory = resolvedSearchFieldHistoryDirectory().isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
+    m_queue->dispatch([time = oldestTimeToRemove.isolatedCopy(), directory = resolvedDirectories().searchFieldHistoryDirectory.isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
         WebCore::removeRecentlyModifiedRecentSearchesFromFile(time, directory);
         RunLoop::main().dispatch(WTFMove(completionHandler));
     });

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -137,20 +137,23 @@ void WebsiteDataStore::forEachWebsiteDataStore(Function<void(WebsiteDataStore&)>
 
 Ref<WebsiteDataStore> WebsiteDataStore::createNonPersistent()
 {
-    return adoptRef(*new WebsiteDataStore(WebsiteDataStoreConfiguration::create(IsPersistent::No), PAL::SessionID::generateEphemeralSessionID()));
+    Ref result = adoptRef(*new WebsiteDataStore(WebsiteDataStoreConfiguration::create(IsPersistent::No), PAL::SessionID::generateEphemeralSessionID()));
+    result->resolveDirectoriesAsynchronously();
+    return result;
 }
 
 Ref<WebsiteDataStore> WebsiteDataStore::create(Ref<WebsiteDataStoreConfiguration>&& configuration, PAL::SessionID sessionID)
 {
-    return adoptRef(*new WebsiteDataStore(WTFMove(configuration), sessionID));
+    Ref result = adoptRef(*new WebsiteDataStore(WTFMove(configuration), sessionID));
+    result->resolveDirectoriesAsynchronously();
+    return result;
 }
 
 WebsiteDataStore::WebsiteDataStore(Ref<WebsiteDataStoreConfiguration>&& configuration, PAL::SessionID sessionID)
     : m_sessionID(sessionID)
-    , m_resolvedConfiguration(WTFMove(configuration))
-    , m_configuration(m_resolvedConfiguration->copy())
+    , m_configuration(WTFMove(configuration))
     , m_deviceIdHashSaltStorage(DeviceIdHashSaltStorage::create(isPersistent() ? m_configuration->deviceIdHashSaltsStorageDirectory() : String()))
-    , m_trackingPreventionDebugMode(m_resolvedConfiguration->resourceLoadStatisticsDebugModeEnabled())
+    , m_trackingPreventionDebugMode(m_configuration->resourceLoadStatisticsDebugModeEnabled())
     , m_queue(WorkQueue::create("com.apple.WebKit.WebsiteDataStore"))
 #if ENABLE(WEB_AUTHN)
     , m_authenticatorManager(makeUniqueRef<AuthenticatorManager>())
@@ -236,12 +239,11 @@ Ref<WebsiteDataStore> WebsiteDataStore::defaultDataStore()
         return Ref { *globalDatasStore };
 
     auto isPersistent = defaultDataStoreIsPersistent();
-    auto newDataStore = adoptRef(new WebsiteDataStore(WebsiteDataStoreConfiguration::create(isPersistent),
-        isPersistent == IsPersistent::Yes ? PAL::SessionID::defaultSessionID() : PAL::SessionID::generateEphemeralSessionID()));
-    globalDatasStore = newDataStore.get();
-    protectedDefaultDataStore() = newDataStore.get();
+    Ref newDataStore = WebsiteDataStore::create(WebsiteDataStoreConfiguration::create(isPersistent), isPersistent == IsPersistent::Yes ? PAL::SessionID::defaultSessionID() : PAL::SessionID::generateEphemeralSessionID());
+    globalDatasStore = newDataStore.ptr();
+    protectedDefaultDataStore() = newDataStore.ptr();
 
-    return *newDataStore;
+    return newDataStore;
 }
 
 void WebsiteDataStore::deleteDefaultDataStoreForTesting()
@@ -359,15 +361,15 @@ void WebsiteDataStore::unregisterProcess(WebProcessProxy& process)
     m_processes.remove(process);
 }
 
-String WebsiteDataStore::migrateMediaKeysStorageIfNecessary(const String& directory)
+static std::pair<String, FileSystem::Salt> migrateMediaKeysStorageIfNecessary(const String& directory)
 {
     if (directory.isEmpty())
-        return emptyString();
+        return { emptyString(), { } };
 
     static constexpr ASCIILiteral versionName = "v1"_s;
     auto versionDirectory = FileSystem::pathByAppendingComponent(directory, versionName);
     auto saltPath = FileSystem::pathByAppendingComponent(versionDirectory, "salt"_s);
-    m_mediaKeysStorageSalt = valueOrDefault(FileSystem::readOrMakeSalt(saltPath));
+    auto mediaKeysStorageSalt = valueOrDefault(FileSystem::readOrMakeSalt(saltPath));
 
     auto originDirectoryNames = FileSystem::listDirectory(directory);
     // Migrate existing data to new version directory.
@@ -386,91 +388,135 @@ String WebsiteDataStore::migrateMediaKeysStorageIfNecessary(const String& direct
             continue;
         }
 
-        auto newOriginDirectoryName = WebCore::StorageUtilities::encodeSecurityOriginForFileName(m_mediaKeysStorageSalt, *originData);
+        auto newOriginDirectoryName = WebCore::StorageUtilities::encodeSecurityOriginForFileName(mediaKeysStorageSalt, *originData);
         auto newOriginDirectory = FileSystem::pathByAppendingComponent(versionDirectory, newOriginDirectoryName);
         if (FileSystem::moveFile(originDirectory, newOriginDirectory))
             WebCore::StorageUtilities::writeOriginToFile(FileSystem::pathByAppendingComponent(newOriginDirectory, "origin"_s), WebCore::ClientOrigin { *originData, *originData });
     }
 
-    return versionDirectory;
+    return { versionDirectory, mediaKeysStorageSalt };
 }
 
-void WebsiteDataStore::resolveDirectoriesIfNecessary()
+static void resolveDirectories(WebsiteDataStoreConfiguration::Directories& directories, FileSystem::Salt& mediaKeysStorageSalt)
 {
-    if (m_hasResolvedDirectories)
-        return;
-    m_hasResolvedDirectories = true;
+    if (!directories.mediaCacheDirectory.isEmpty())
+        directories.mediaCacheDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.mediaCacheDirectory);
 
-    // Resolve directory paths.
-    Ref configuration = m_configuration;
-    Ref resolvedConfiguration = m_resolvedConfiguration;
-    if (!configuration->mediaCacheDirectory().isEmpty())
-        resolvedConfiguration->setMediaCacheDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->mediaCacheDirectory()));
-    if (!configuration->mediaKeysStorageDirectory().isEmpty()) {
-        auto mediaKeysStorageDirectory = migrateMediaKeysStorageIfNecessary(configuration->mediaKeysStorageDirectory());
-        resolvedConfiguration->setMediaKeysStorageDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(mediaKeysStorageDirectory));
+    if (!directories.mediaKeysStorageDirectory.isEmpty()) {
+        auto [mediaKeysStorageDirectory, salt] = migrateMediaKeysStorageIfNecessary(directories.mediaKeysStorageDirectory);
+        mediaKeysStorageSalt = salt;
+        directories.mediaKeysStorageDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(mediaKeysStorageDirectory);
     }
-    if (!configuration->indexedDBDatabaseDirectory().isEmpty())
-        resolvedConfiguration->setIndexedDBDatabaseDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->indexedDBDatabaseDirectory()));
-    if (!configuration->alternativeServicesDirectory().isEmpty())
-        resolvedConfiguration->setAlternativeServicesDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->alternativeServicesDirectory()));
-    if (!configuration->localStorageDirectory().isEmpty())
-        resolvedConfiguration->setLocalStorageDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->localStorageDirectory()));
-    if (!configuration->deviceIdHashSaltsStorageDirectory().isEmpty())
-        resolvedConfiguration->setDeviceIdHashSaltsStorageDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->deviceIdHashSaltsStorageDirectory()));
-    if (!configuration->networkCacheDirectory().isEmpty())
-        resolvedConfiguration->setNetworkCacheDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->networkCacheDirectory()));
-    if (!configuration->resourceLoadStatisticsDirectory().isEmpty())
-        resolvedConfiguration->setResourceLoadStatisticsDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->resourceLoadStatisticsDirectory()));
-    if (!configuration->serviceWorkerRegistrationDirectory().isEmpty())
-        resolvedConfiguration->setServiceWorkerRegistrationDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->serviceWorkerRegistrationDirectory()));
-    if (!configuration->javaScriptConfigurationDirectory().isEmpty())
-        resolvedConfiguration->setJavaScriptConfigurationDirectory(resolvePathForSandboxExtension(configuration->javaScriptConfigurationDirectory()));
-    if (!configuration->cacheStorageDirectory().isEmpty())
-        resolvedConfiguration->setCacheStorageDirectory(resolvePathForSandboxExtension(configuration->cacheStorageDirectory()));
-    if (!configuration->hstsStorageDirectory().isEmpty())
-        resolvedConfiguration->setHSTSStorageDirectory(resolvePathForSandboxExtension(configuration->hstsStorageDirectory()));
-    if (!configuration->generalStorageDirectory().isEmpty())
-        resolvedConfiguration->setGeneralStorageDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->generalStorageDirectory()));
+
+    if (!directories.indexedDBDatabaseDirectory.isEmpty())
+        directories.indexedDBDatabaseDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.indexedDBDatabaseDirectory);
+
+    if (!directories.alternativeServicesDirectory.isEmpty())
+        directories.alternativeServicesDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.alternativeServicesDirectory);
+
+    if (!directories.localStorageDirectory.isEmpty())
+        directories.localStorageDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.localStorageDirectory);
+
+    if (!directories.deviceIdHashSaltsStorageDirectory.isEmpty())
+        directories.deviceIdHashSaltsStorageDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.deviceIdHashSaltsStorageDirectory);
+
+    if (!directories.networkCacheDirectory.isEmpty())
+        directories.networkCacheDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.networkCacheDirectory);
+
+    if (!directories.resourceLoadStatisticsDirectory.isEmpty())
+        directories.resourceLoadStatisticsDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.resourceLoadStatisticsDirectory);
+
+    if (!directories.serviceWorkerRegistrationDirectory.isEmpty())
+        directories.serviceWorkerRegistrationDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.serviceWorkerRegistrationDirectory);
+
+    if (!directories.javaScriptConfigurationDirectory.isEmpty())
+        directories.javaScriptConfigurationDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.javaScriptConfigurationDirectory);
+
+    if (!directories.cacheStorageDirectory.isEmpty())
+        directories.cacheStorageDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.cacheStorageDirectory);
+
+    if (!directories.hstsStorageDirectory.isEmpty())
+        directories.hstsStorageDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.hstsStorageDirectory);
+
+    if (!directories.generalStorageDirectory.isEmpty())
+        directories.generalStorageDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.generalStorageDirectory);
+
+    if (!directories.searchFieldHistoryDirectory.isEmpty())
+        directories.searchFieldHistoryDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.searchFieldHistoryDirectory);
+
+    if (!directories.generalStorageDirectory.isEmpty())
+        directories.generalStorageDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.generalStorageDirectory);
+
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-    if (!configuration->modelElementCacheDirectory().isEmpty())
-        resolvedConfiguration->setModelElementCacheDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->modelElementCacheDirectory()));
+    if (!directories.modelElementCacheDirectory.isEmpty())
+        directories.modelElementCacheDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(directories.modelElementCacheDirectory);
 #endif
-    if (!configuration->searchFieldHistoryDirectory().isEmpty())
-        resolvedConfiguration->setSearchFieldHistoryDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(configuration->searchFieldHistoryDirectory()));
 
-    // Resolve file paths.
-    if (!configuration->cookieStorageFile().isEmpty()) {
-        auto resolvedCookieDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(FileSystem::parentPath(configuration->cookieStorageFile()));
-        resolvedConfiguration->setCookieStorageFile(FileSystem::pathByAppendingComponent(resolvedCookieDirectory, FileSystem::pathFileName(configuration->cookieStorageFile())));
+    if (!directories.cookieStorageFile.isEmpty()) {
+        auto resolvedCookieDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(FileSystem::parentPath(directories.cookieStorageFile));
+        directories.cookieStorageFile = FileSystem::pathByAppendingComponent(resolvedCookieDirectory, FileSystem::pathFileName(directories.cookieStorageFile));
     }
+}
 
-    // Default paths of WebsiteDataStore created with identifier are not under caches or tmp directory,
-    // so we need to explicitly exclude them from backup.
-    if (configuration->identifier()) {
-        Vector<String> allCacheDirectories = {
-            resolvedMediaCacheDirectory()
-            , resolvedNetworkCacheDirectory()
+const WebsiteDataStoreConfiguration::Directories& WebsiteDataStore::resolvedDirectories() const
+{
+    Locker resolveLocker { m_resolveDirectoriesLock };
+    return *m_resolvedDirectories;
+}
+
+FileSystem::Salt WebsiteDataStore::mediaKeysStorageSalt() const
+{
+    Locker resolveLocker { m_resolveDirectoriesLock };
+    RELEASE_ASSERT(m_resolvedDirectories);
+
+    return m_mediaKeysStorageSalt;
+}
+
+void WebsiteDataStore::resolveDirectoriesAsynchronously()
+{
+    ASSERT(RunLoop::isMain());
+
+    RELEASE_ASSERT(!m_hasDispatchedResolveDirectories);
+    m_hasDispatchedResolveDirectories = true;
+
+    Ref resolveDirectoriesQueue = WorkQueue::create("com.apple.WebKit.WebsiteDataStore.resolveDirectories", WorkQueue::QOS::UserInteractive);
+    resolveDirectoriesQueue->dispatch([this, protectedThis = Ref { *this }, directories = crossThreadCopy(m_configuration->directories()), shouldExcludeCacheDirectories = !!m_configuration->identifier()]() mutable {
+        FileSystem::Salt mediaKeysStorageSalt;
+        resolveDirectories(directories, mediaKeysStorageSalt);
+        // Default paths of WebsiteDataStore created with identifier are not under caches or tmp directory,
+        // so we need to explicitly exclude them from backup.
+        handleResolvedDirectoriesAsynchronously(directories, shouldExcludeCacheDirectories);
+        {
+            Locker resolveLocker { m_resolveDirectoriesLock };
+            m_resolvedDirectories = crossThreadCopy(WTFMove(directories));
+            m_mediaKeysStorageSalt = WTFMove(mediaKeysStorageSalt);
+            m_resolveDirectoriesCondition.notifyOne();
+        }
+        RunLoop::main().dispatch([protectedThis = WTFMove(protectedThis)] { });
+    });
+}
+
+void WebsiteDataStore::handleResolvedDirectoriesAsynchronously(const WebsiteDataStoreConfiguration::Directories& directories, bool shouldExcludeCacheDirectories)
+{
+    Vector<String> allCacheDirectories;
+    if (shouldExcludeCacheDirectories) {
+        allCacheDirectories = {
+            directories.mediaCacheDirectory.isolatedCopy()
+            , directories.networkCacheDirectory.isolatedCopy()
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-            , resolvedModelElementCacheDirectory()
+            , directories.modelElementCacheDirectory.isolatedCopy()
 #endif
         };
-        protectedQueue()->dispatch([directories = crossThreadCopy(WTFMove(allCacheDirectories))]() {
-            for (auto& directory : directories)
-                FileSystem::setExcludedFromBackup(directory, true);
-        });
     }
 
-    // Clear data of deprecated types asynchronously.
-    if (auto webSQLDirectory = configuration->webSQLDatabaseDirectory(); !webSQLDirectory.isEmpty()) {
-        protectedQueue()->dispatch([webSQLDirectory = webSQLDirectory.isolatedCopy()]() {
+    // Clear data of deprecated types.
+    protectedQueue()->dispatch([webSQLDirectory = crossThreadCopy(directories.webSQLDatabaseDirectory), applicationCacheDirectory = crossThreadCopy(directories.applicationCacheDirectory), applicationCacheFlatFileSubdirectoryName = crossThreadCopy(directories.applicationCacheFlatFileSubdirectoryName), directoriesToExclude = WTFMove(allCacheDirectories)]() {
+        if (!webSQLDirectory.isEmpty()) {
             WebCore::DatabaseTracker::trackerWithDatabasePath(webSQLDirectory)->deleteAllDatabasesImmediately();
             FileSystem::deleteEmptyDirectory(webSQLDirectory);
-        });
-    }
+        }
 
-    if (auto applicationCacheDirectory = m_configuration->applicationCacheDirectory(); !applicationCacheDirectory.isEmpty()) {
-        protectedQueue()->dispatch([applicationCacheDirectory = applicationCacheDirectory.isolatedCopy(), applicationCacheFlatFileSubdirectoryName = m_configuration->applicationCacheFlatFileSubdirectoryName().isolatedCopy()]() {
+        if (!applicationCacheDirectory.isEmpty()) {
             {
                 auto storage = WebCore::ApplicationCacheStorage::create(applicationCacheDirectory, applicationCacheFlatFileSubdirectoryName);
                 storage->deleteAllCaches();
@@ -482,8 +528,26 @@ void WebsiteDataStore::resolveDirectoriesIfNecessary()
             auto applicationCacheDatabasePath = FileSystem::pathByAppendingComponent(applicationCacheDirectory, "ApplicationCache.db"_s);
             WebCore::SQLiteFileSystem::deleteDatabaseFile(applicationCacheDatabasePath);
             FileSystem::deleteEmptyDirectory(applicationCacheDirectory);
-        });
-    }
+        }
+
+        for (auto& directory : directoriesToExclude)
+            FileSystem::setExcludedFromBackup(directory, true);
+    });
+}
+
+void WebsiteDataStore::waitForDirectoriesToResolveIfNecessary()
+{
+    ASSERT(RunLoop::isMain());
+
+    Locker resolveLocker { m_resolveDirectoriesLock };
+    if (m_resolvedDirectories)
+        return;
+
+    // Ensure task is dispatched before wait.
+    RELEASE_ASSERT(m_hasDispatchedResolveDirectories);
+
+    while (!m_resolvedDirectories)
+        m_resolveDirectoriesCondition.wait(m_resolveDirectoriesLock);
 }
 
 Ref<WorkQueue> WebsiteDataStore::protectedQueue() const
@@ -682,8 +746,9 @@ private:
     }
 
     if (dataTypes.contains(WebsiteDataType::MediaKeys) && isPersistent()) {
-        auto mediaKeysStorageDirectory = migrateMediaKeysStorageIfNecessary(m_configuration->mediaKeysStorageDirectory());
-        protectedQueue()->dispatch([mediaKeysStorageDirectory = mediaKeysStorageDirectory.isolatedCopy(), callbackAggregator] {
+        waitForDirectoriesToResolveIfNecessary();
+        auto mediaKeysStorageDirectory = resolvedDirectories().mediaKeysStorageDirectory;
+        protectedQueue()->dispatch([mediaKeysStorageDirectory = crossThreadCopy(WTFMove(mediaKeysStorageDirectory)), callbackAggregator] {
             WebsiteData websiteData;
             websiteData.entries = mediaKeysStorageOrigins(mediaKeysStorageDirectory).map([](auto& origin) {
                 return WebsiteData::Entry { origin, WebsiteDataType::MediaKeys, 0 };
@@ -793,8 +858,9 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, WallTime
         m_deviceIdHashSaltStorage->deleteDeviceIdHashSaltOriginsModifiedSince(modifiedSince, [callbackAggregator] { });
 
     if (dataTypes.contains(WebsiteDataType::MediaKeys) && isPersistent()) {
-        auto mediaKeysStorageDirectory = migrateMediaKeysStorageIfNecessary(m_configuration->mediaKeysStorageDirectory());
-        protectedQueue()->dispatch([mediaKeysStorageDirectory = mediaKeysStorageDirectory.isolatedCopy(), callbackAggregator, modifiedSince] {
+        waitForDirectoriesToResolveIfNecessary();
+        auto mediaKeysStorageDirectory = resolvedDirectories().mediaKeysStorageDirectory;
+        protectedQueue()->dispatch([mediaKeysStorageDirectory = crossThreadCopy(WTFMove(mediaKeysStorageDirectory)), callbackAggregator, modifiedSince] {
             removeMediaKeysStorage(mediaKeysStorageDirectory, modifiedSince);
         });
     }
@@ -891,8 +957,9 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Ve
                 origins.add(crossThreadCopy(origin));
         }
 
-        auto mediaKeysStorageDirectory = migrateMediaKeysStorageIfNecessary(m_configuration->mediaKeysStorageDirectory());
-        protectedQueue()->dispatch([mediaKeysStorageDirectory = mediaKeysStorageDirectory.isolatedCopy(), salt = m_mediaKeysStorageSalt, callbackAggregator, origins = WTFMove(origins)] {
+        waitForDirectoriesToResolveIfNecessary();
+        auto mediaKeysStorageDirectory = resolvedDirectories().mediaKeysStorageDirectory;
+        protectedQueue()->dispatch([mediaKeysStorageDirectory = crossThreadCopy(WTFMove(mediaKeysStorageDirectory)), salt = mediaKeysStorageSalt(), callbackAggregator, origins = WTFMove(origins)] {
             removeMediaKeysStorage(mediaKeysStorageDirectory, origins, salt);
         });
     }
@@ -1843,17 +1910,18 @@ void WebsiteDataStore::createHandleFromResolvedPathIfPossible(const String& reso
 WebsiteDataStoreParameters WebsiteDataStore::parameters()
 {
     WebsiteDataStoreParameters parameters;
-    resolveDirectoriesIfNecessary();
+    waitForDirectoriesToResolveIfNecessary();
 
-    auto resourceLoadStatisticsDirectory = resolvedResourceLoadStatisticsDirectory();
+    auto& directories = resolvedDirectories();
+    auto resourceLoadStatisticsDirectory = directories.resourceLoadStatisticsDirectory;
     SandboxExtension::Handle resourceLoadStatisticsDirectoryHandle;
     createHandleFromResolvedPathIfPossible(resourceLoadStatisticsDirectory, resourceLoadStatisticsDirectoryHandle);
 
-    auto networkCacheDirectory = resolvedNetworkCacheDirectory();
+    auto networkCacheDirectory = directories.networkCacheDirectory;
     SandboxExtension::Handle networkCacheDirectoryExtensionHandle;
     createHandleFromResolvedPathIfPossible(networkCacheDirectory, networkCacheDirectoryExtensionHandle);
 
-    auto hstsStorageDirectory = resolvedHSTSStorageDirectory();
+    auto hstsStorageDirectory = directories.hstsStorageDirectory;
     SandboxExtension::Handle hstsStorageDirectoryExtensionHandle;
     createHandleFromResolvedPathIfPossible(hstsStorageDirectory, hstsStorageDirectoryExtensionHandle);
 
@@ -1924,16 +1992,16 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.totalQuotaRatio = m_configuration->totalQuotaRatio();
     networkSessionParameters.standardVolumeCapacity = m_configuration->standardVolumeCapacity();
     networkSessionParameters.volumeCapacityOverride = m_configuration->volumeCapacityOverride();
-    networkSessionParameters.localStorageDirectory = resolvedLocalStorageDirectory();
+    networkSessionParameters.localStorageDirectory = directories.localStorageDirectory;
     createHandleFromResolvedPathIfPossible(networkSessionParameters.localStorageDirectory, networkSessionParameters.localStorageDirectoryExtensionHandle);
-    networkSessionParameters.indexedDBDirectory = resolvedIndexedDBDatabaseDirectory();
+    networkSessionParameters.indexedDBDirectory = directories.indexedDBDatabaseDirectory;
     createHandleFromResolvedPathIfPossible(networkSessionParameters.indexedDBDirectory, networkSessionParameters.indexedDBDirectoryExtensionHandle);
-    networkSessionParameters.generalStorageDirectory = resolvedGeneralStorageDirectory();
+    networkSessionParameters.generalStorageDirectory = directories.generalStorageDirectory;
     createHandleFromResolvedPathIfPossible(networkSessionParameters.generalStorageDirectory, networkSessionParameters.generalStorageDirectoryHandle);
-    networkSessionParameters.cacheStorageDirectory = resolvedCacheStorageDirectory();
+    networkSessionParameters.cacheStorageDirectory = directories.cacheStorageDirectory;
     createHandleFromResolvedPathIfPossible(networkSessionParameters.cacheStorageDirectory, networkSessionParameters.cacheStorageDirectoryExtensionHandle);
 
-    networkSessionParameters.serviceWorkerRegistrationDirectory = resolvedServiceWorkerRegistrationDirectory();
+    networkSessionParameters.serviceWorkerRegistrationDirectory = directories.serviceWorkerRegistrationDirectory;
     createHandleFromResolvedPathIfPossible(networkSessionParameters.serviceWorkerRegistrationDirectory, networkSessionParameters.serviceWorkerRegistrationDirectoryExtensionHandle);
     networkSessionParameters.serviceWorkerProcessTerminationDelayEnabled = m_configuration->serviceWorkerProcessTerminationDelayEnabled();
     networkSessionParameters.inspectionForServiceWorkersAllowed = m_inspectionForServiceWorkersAllowed;
@@ -2431,13 +2499,6 @@ void WebsiteDataStore::setProxyConfigData(Vector<std::pair<Vector<uint8_t>, WTF:
     m_proxyConfigData = WTFMove(data);
 }
 #endif // HAVE(NW_PROXY_CONFIG)
-
-FileSystem::Salt WebsiteDataStore::mediaKeysStorageSalt() const
-{
-    RELEASE_ASSERT(m_hasResolvedDirectories);
-
-    return m_mediaKeysStorageSalt;
-}
 
 void WebsiteDataStore::setCompletionHandlerForRemovalFromNetworkProcess(CompletionHandler<void(String&&)>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -175,8 +175,8 @@ public:
     void setPrivateClickMeasurementDebugMode(bool);
     void storePrivateClickMeasurement(const WebCore::PrivateClickMeasurement&);
 
-    uint64_t perOriginStorageQuota() const { return m_resolvedConfiguration->perOriginStorageQuota(); }
-    std::optional<double> originQuotaRatio() { return m_resolvedConfiguration->originQuotaRatio(); }
+    uint64_t perOriginStorageQuota() const { return m_configuration->perOriginStorageQuota(); }
+    std::optional<double> originQuotaRatio() { return m_configuration->originQuotaRatio(); }
 
     void didAllowPrivateTokenUsageByThirdPartyForTesting(bool wasAllowed, URL&& resourceURL);
 
@@ -273,24 +273,8 @@ public:
     void storeServiceWorkerRegistrations(CompletionHandler<void()>&&);
     void setCacheMaxAgeCapForPrevalentResources(Seconds, CompletionHandler<void()>&&);
     void resetCacheMaxAgeCapForPrevalentResources(CompletionHandler<void()>&&);
-    void resolveDirectoriesIfNecessary();
-    const String& resolvedCacheStorageDirectory() const { return m_resolvedConfiguration->cacheStorageDirectory(); }
-    const String& resolvedLocalStorageDirectory() const { return m_resolvedConfiguration->localStorageDirectory(); }
-    const String& resolvedNetworkCacheDirectory() const { return m_resolvedConfiguration->networkCacheDirectory(); }
-    const String& resolvedAlternativeServicesStorageDirectory() const { return m_resolvedConfiguration->alternativeServicesDirectory(); }
-    const String& resolvedMediaCacheDirectory() const { return m_resolvedConfiguration->mediaCacheDirectory(); }
-    const String& resolvedMediaKeysDirectory() const { return m_resolvedConfiguration->mediaKeysStorageDirectory(); }
-    const String& resolvedJavaScriptConfigurationDirectory() const { return m_resolvedConfiguration->javaScriptConfigurationDirectory(); }
-    const String& resolvedCookieStorageFile() const { return m_resolvedConfiguration->cookieStorageFile(); }
-    const String& resolvedIndexedDBDatabaseDirectory() const { return m_resolvedConfiguration->indexedDBDatabaseDirectory(); }
-    const String& resolvedServiceWorkerRegistrationDirectory() const { return m_resolvedConfiguration->serviceWorkerRegistrationDirectory(); }
-    const String& resolvedResourceLoadStatisticsDirectory() const { return m_resolvedConfiguration->resourceLoadStatisticsDirectory(); }
-    const String& resolvedHSTSStorageDirectory() const { return m_resolvedConfiguration->hstsStorageDirectory(); }
-    const String& resolvedGeneralStorageDirectory() const { return m_resolvedConfiguration->generalStorageDirectory(); }
-    const String& resolvedSearchFieldHistoryDirectory() const { return m_resolvedConfiguration->searchFieldHistoryDirectory(); }
-#if ENABLE(ARKIT_INLINE_PREVIEW)
-    const String& resolvedModelElementCacheDirectory() const { return m_resolvedConfiguration->modelElementCacheDirectory(); }
-#endif
+    void waitForDirectoriesToResolveIfNecessary();
+    const WebsiteDataStoreConfiguration::Directories& resolvedDirectories() const;
     FileSystem::Salt mediaKeysStorageSalt() const;
 
     static void setCachedProcessSuspensionDelayForTesting(Seconds);
@@ -484,6 +468,7 @@ public:
     void setRestrictedOpenerTypeForDomainForTesting(const WebCore::RegistrableDomain&, RestrictedOpenerType);
 
     bool operator==(const WebsiteDataStore& other) const { return (m_sessionID == other.sessionID()); }
+    void resolveDirectoriesAsynchronously();
 
 private:
     enum class ForceReinitialization : bool { No, Yes };
@@ -541,14 +526,16 @@ private:
     String resolvedContainerCachesNetworkingDirectory();
     String parentBundleDirectory() const;
 #endif
-
-    String migrateMediaKeysStorageIfNecessary(const String& directory);
+    void handleResolvedDirectoriesAsynchronously(const WebsiteDataStoreConfiguration::Directories&, bool);
 
     const PAL::SessionID m_sessionID;
 
-    Ref<WebsiteDataStoreConfiguration> m_resolvedConfiguration;
+    mutable Lock m_resolveDirectoriesLock;
+    Condition m_resolveDirectoriesCondition;
+    bool m_hasDispatchedResolveDirectories { false };
+    std::optional<WebsiteDataStoreConfiguration::Directories> m_resolvedDirectories WTF_GUARDED_BY_LOCK(m_resolveDirectoriesLock);
+    FileSystem::Salt m_mediaKeysStorageSalt WTF_GUARDED_BY_LOCK(m_resolveDirectoriesLock);
     Ref<const WebsiteDataStoreConfiguration> m_configuration;
-    bool m_hasResolvedDirectories { false };
     const Ref<DeviceIdHashSaltStorage> m_deviceIdHashSaltStorage;
 #if PLATFORM(IOS_FAMILY)
     String m_resolvedContainerCachesWebContentDirectory;
@@ -612,8 +599,6 @@ private:
     CompletionHandler<void(String&&)> m_completionHandlerForRemovalFromNetworkProcess;
 
     bool m_inspectionForServiceWorkersAllowed { true };
-    FileSystem::Salt m_mediaKeysStorageSalt;
-
     bool m_isBlobRegistryPartitioningEnabled { false };
 
     HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> m_restrictedOpenerTypesForTesting;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -127,34 +127,17 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
 
     copy->m_baseCacheDirectory = this->m_baseCacheDirectory;
     copy->m_baseDataDirectory = this->m_baseDataDirectory;
+    copy->m_directories = this->m_directories;
     copy->m_serviceWorkerProcessTerminationDelayEnabled = this->m_serviceWorkerProcessTerminationDelayEnabled;
     copy->m_fastServerTrustEvaluationEnabled = this->m_fastServerTrustEvaluationEnabled;
     copy->m_networkCacheSpeculativeValidationEnabled = this->m_networkCacheSpeculativeValidationEnabled;
     copy->m_staleWhileRevalidateEnabled = this->m_staleWhileRevalidateEnabled;
-    copy->m_cacheStorageDirectory = this->m_cacheStorageDirectory;
-    copy->m_generalStorageDirectory = this->m_generalStorageDirectory;
     copy->m_unifiedOriginStorageLevel = this->m_unifiedOriginStorageLevel;
     copy->m_perOriginStorageQuota = this->m_perOriginStorageQuota;
     copy->m_originQuotaRatio = this->m_originQuotaRatio;
     copy->m_totalQuotaRatio = this->m_totalQuotaRatio;
     copy->m_standardVolumeCapacity = this->m_standardVolumeCapacity;
     copy->m_volumeCapacityOverride = this->m_volumeCapacityOverride;
-    copy->m_networkCacheDirectory = this->m_networkCacheDirectory;
-    copy->m_applicationCacheDirectory = this->m_applicationCacheDirectory;
-    copy->m_applicationCacheFlatFileSubdirectoryName = this->m_applicationCacheFlatFileSubdirectoryName;
-    copy->m_mediaCacheDirectory = this->m_mediaCacheDirectory;
-    copy->m_indexedDBDatabaseDirectory = this->m_indexedDBDatabaseDirectory;
-    copy->m_serviceWorkerRegistrationDirectory = this->m_serviceWorkerRegistrationDirectory;
-    copy->m_webSQLDatabaseDirectory = this->m_webSQLDatabaseDirectory;
-    copy->m_hstsStorageDirectory = this->m_hstsStorageDirectory;
-    copy->m_localStorageDirectory = this->m_localStorageDirectory;
-    copy->m_mediaKeysStorageDirectory = this->m_mediaKeysStorageDirectory;
-    copy->m_alternativeServicesDirectory = this->m_alternativeServicesDirectory;
-    copy->m_deviceIdHashSaltsStorageDirectory = this->m_deviceIdHashSaltsStorageDirectory;
-    copy->m_resourceLoadStatisticsDirectory = this->m_resourceLoadStatisticsDirectory;
-    copy->m_javaScriptConfigurationDirectory = this->m_javaScriptConfigurationDirectory;
-    copy->m_searchFieldHistoryDirectory = this->m_searchFieldHistoryDirectory;
-    copy->m_cookieStorageFile = this->m_cookieStorageFile;
     copy->m_sourceApplicationBundleIdentifier = this->m_sourceApplicationBundleIdentifier;
     copy->m_sourceApplicationSecondaryIdentifier = this->m_sourceApplicationSecondaryIdentifier;
     copy->m_httpProxy = this->m_httpProxy;
@@ -186,9 +169,6 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     if (m_proxyConfiguration)
         copy->m_proxyConfiguration = adoptCF(CFDictionaryCreateCopy(nullptr, this->m_proxyConfiguration.get()));
 #endif
-#if ENABLE(ARKIT_INLINE_PREVIEW)
-    copy->m_modelElementCacheDirectory = this->m_modelElementCacheDirectory;
-#endif
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     copy->m_isDeclarativeWebPushEnabled = this->m_isDeclarativeWebPushEnabled;
 #endif
@@ -199,6 +179,60 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
 WebPushD::WebPushDaemonConnectionConfiguration WebsiteDataStoreConfiguration::webPushDaemonConnectionConfiguration() const
 {
     return { m_webPushDaemonUsesMockBundlesForTesting, { }, m_webPushPartitionString, m_identifier };
+}
+
+WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Directories::isolatedCopy() const &
+{
+    return {
+        crossThreadCopy(applicationCacheFlatFileSubdirectoryName),
+        crossThreadCopy(applicationCacheDirectory),
+        crossThreadCopy(alternativeServicesDirectory),
+        crossThreadCopy(cacheStorageDirectory),
+        crossThreadCopy(cookieStorageFile),
+        crossThreadCopy(deviceIdHashSaltsStorageDirectory),
+        crossThreadCopy(generalStorageDirectory),
+        crossThreadCopy(hstsStorageDirectory),
+        crossThreadCopy(indexedDBDatabaseDirectory),
+        crossThreadCopy(javaScriptConfigurationDirectory),
+        crossThreadCopy(localStorageDirectory),
+        crossThreadCopy(mediaCacheDirectory),
+        crossThreadCopy(mediaKeysStorageDirectory),
+        crossThreadCopy(networkCacheDirectory),
+        crossThreadCopy(resourceLoadStatisticsDirectory),
+        crossThreadCopy(searchFieldHistoryDirectory),
+        crossThreadCopy(serviceWorkerRegistrationDirectory),
+        crossThreadCopy(webSQLDatabaseDirectory),
+#if ENABLE(ARKIT_INLINE_PREVIEW)
+        crossThreadCopy(modelElementCacheDirectory),
+#endif
+    };
+}
+
+WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Directories::isolatedCopy() &&
+{
+    return {
+        crossThreadCopy(WTFMove(applicationCacheFlatFileSubdirectoryName)),
+        crossThreadCopy(WTFMove(applicationCacheDirectory)),
+        crossThreadCopy(WTFMove(alternativeServicesDirectory)),
+        crossThreadCopy(WTFMove(cacheStorageDirectory)),
+        crossThreadCopy(WTFMove(cookieStorageFile)),
+        crossThreadCopy(WTFMove(deviceIdHashSaltsStorageDirectory)),
+        crossThreadCopy(WTFMove(generalStorageDirectory)),
+        crossThreadCopy(WTFMove(hstsStorageDirectory)),
+        crossThreadCopy(WTFMove(indexedDBDatabaseDirectory)),
+        crossThreadCopy(WTFMove(javaScriptConfigurationDirectory)),
+        crossThreadCopy(WTFMove(localStorageDirectory)),
+        crossThreadCopy(WTFMove(mediaCacheDirectory)),
+        crossThreadCopy(WTFMove(mediaKeysStorageDirectory)),
+        crossThreadCopy(WTFMove(networkCacheDirectory)),
+        crossThreadCopy(WTFMove(resourceLoadStatisticsDirectory)),
+        crossThreadCopy(WTFMove(searchFieldHistoryDirectory)),
+        crossThreadCopy(WTFMove(serviceWorkerRegistrationDirectory)),
+        crossThreadCopy(WTFMove(webSQLDatabaseDirectory)),
+#if ENABLE(ARKIT_INLINE_PREVIEW)
+        crossThreadCopy(WTFMove(modelElementCacheDirectory)),
+#endif
+    };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -83,43 +83,43 @@ public:
     void setIsDeclarativeWebPushEnabled(bool enabled) { m_isDeclarativeWebPushEnabled = enabled; }
 #endif
 
-    const String& applicationCacheDirectory() const { return m_applicationCacheDirectory; }
-    void setApplicationCacheDirectory(String&& directory) { m_applicationCacheDirectory = WTFMove(directory); }
+    const String& applicationCacheDirectory() const { return m_directories.applicationCacheDirectory; }
+    void setApplicationCacheDirectory(String&& directory) { m_directories.applicationCacheDirectory = WTFMove(directory); }
     
-    const String& mediaCacheDirectory() const { return m_mediaCacheDirectory; }
-    void setMediaCacheDirectory(String&& directory) { m_mediaCacheDirectory = WTFMove(directory); }
+    const String& mediaCacheDirectory() const { return m_directories.mediaCacheDirectory; }
+    void setMediaCacheDirectory(String&& directory) { m_directories.mediaCacheDirectory = WTFMove(directory); }
     
-    const String& mediaKeysStorageDirectory() const { return m_mediaKeysStorageDirectory; }
-    void setMediaKeysStorageDirectory(String&& directory) { m_mediaKeysStorageDirectory = WTFMove(directory); }
+    const String& mediaKeysStorageDirectory() const { return m_directories.mediaKeysStorageDirectory; }
+    void setMediaKeysStorageDirectory(String&& directory) { m_directories.mediaKeysStorageDirectory = WTFMove(directory); }
     
-    const String& alternativeServicesDirectory() const { return m_alternativeServicesDirectory; }
-    void setAlternativeServicesDirectory(String&& directory) { m_alternativeServicesDirectory = WTFMove(directory); }
+    const String& alternativeServicesDirectory() const { return m_directories.alternativeServicesDirectory; }
+    void setAlternativeServicesDirectory(String&& directory) { m_directories.alternativeServicesDirectory = WTFMove(directory); }
 
-    const String& javaScriptConfigurationDirectory() const { return m_javaScriptConfigurationDirectory; }
-    void setJavaScriptConfigurationDirectory(String&& directory) { m_javaScriptConfigurationDirectory = WTFMove(directory); }
+    const String& javaScriptConfigurationDirectory() const { return m_directories.javaScriptConfigurationDirectory; }
+    void setJavaScriptConfigurationDirectory(String&& directory) { m_directories.javaScriptConfigurationDirectory = WTFMove(directory); }
 
-    const String& searchFieldHistoryDirectory() const { return m_searchFieldHistoryDirectory; }
-    void setSearchFieldHistoryDirectory(String&& directory) { m_searchFieldHistoryDirectory = WTFMove(directory); }
+    const String& searchFieldHistoryDirectory() const { return m_directories.searchFieldHistoryDirectory; }
+    void setSearchFieldHistoryDirectory(String&& directory) { m_directories.searchFieldHistoryDirectory = WTFMove(directory); }
 
     // indexedDBDatabaseDirectory is sort of deprecated. Data is migrated from here to
     // generalStoragePath unless useCustomStoragePaths is true.
-    const String& indexedDBDatabaseDirectory() const { return m_indexedDBDatabaseDirectory; }
-    void setIndexedDBDatabaseDirectory(String&& directory) { m_indexedDBDatabaseDirectory = WTFMove(directory); }
+    const String& indexedDBDatabaseDirectory() const { return m_directories.indexedDBDatabaseDirectory; }
+    void setIndexedDBDatabaseDirectory(String&& directory) { m_directories.indexedDBDatabaseDirectory = WTFMove(directory); }
 
-    const String& webSQLDatabaseDirectory() const { return m_webSQLDatabaseDirectory; }
-    void setWebSQLDatabaseDirectory(String&& directory) { m_webSQLDatabaseDirectory = WTFMove(directory); }
+    const String& webSQLDatabaseDirectory() const { return m_directories.webSQLDatabaseDirectory; }
+    void setWebSQLDatabaseDirectory(String&& directory) { m_directories.webSQLDatabaseDirectory = WTFMove(directory); }
 
-    const String& hstsStorageDirectory() const { return m_hstsStorageDirectory; }
-    void setHSTSStorageDirectory(String&& directory) { m_hstsStorageDirectory = WTFMove(directory); }
+    const String& hstsStorageDirectory() const { return m_directories.hstsStorageDirectory; }
+    void setHSTSStorageDirectory(String&& directory) { m_directories.hstsStorageDirectory = WTFMove(directory); }
 
     // localStorageDirectory is sort of deprecated. Data is migrated from here to
     // generalStoragePath unless useCustomStoragePaths is true.
-    const String& localStorageDirectory() const { return m_localStorageDirectory; }
-    void setLocalStorageDirectory(String&& directory) { m_localStorageDirectory = WTFMove(directory); }
+    const String& localStorageDirectory() const { return m_directories.localStorageDirectory; }
+    void setLocalStorageDirectory(String&& directory) { m_directories.localStorageDirectory = WTFMove(directory); }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-    const String& modelElementCacheDirectory() const { return m_modelElementCacheDirectory; }
-    void setModelElementCacheDirectory(String&& directory) { m_modelElementCacheDirectory = WTFMove(directory); }
+    const String& modelElementCacheDirectory() const { return m_directories.modelElementCacheDirectory; }
+    void setModelElementCacheDirectory(String&& directory) { m_directories.modelElementCacheDirectory = WTFMove(directory); }
 #endif
 
     const String& boundInterfaceIdentifier() const { return m_boundInterfaceIdentifier; }
@@ -157,23 +157,23 @@ public:
     void setProxyConfiguration(CFDictionaryRef configuration) { m_proxyConfiguration = configuration; }
 #endif
     
-    const String& deviceIdHashSaltsStorageDirectory() const { return m_deviceIdHashSaltsStorageDirectory; }
-    void setDeviceIdHashSaltsStorageDirectory(String&& directory) { m_deviceIdHashSaltsStorageDirectory = WTFMove(directory); }
+    const String& deviceIdHashSaltsStorageDirectory() const { return m_directories.deviceIdHashSaltsStorageDirectory; }
+    void setDeviceIdHashSaltsStorageDirectory(String&& directory) { m_directories.deviceIdHashSaltsStorageDirectory = WTFMove(directory); }
 
-    const String& cookieStorageFile() const { return m_cookieStorageFile; }
-    void setCookieStorageFile(String&& directory) { m_cookieStorageFile = WTFMove(directory); }
+    const String& cookieStorageFile() const { return m_directories.cookieStorageFile; }
+    void setCookieStorageFile(String&& directory) { m_directories.cookieStorageFile = WTFMove(directory); }
     
-    const String& resourceLoadStatisticsDirectory() const { return m_resourceLoadStatisticsDirectory; }
-    void setResourceLoadStatisticsDirectory(String&& directory) { m_resourceLoadStatisticsDirectory = WTFMove(directory); }
+    const String& resourceLoadStatisticsDirectory() const { return m_directories.resourceLoadStatisticsDirectory; }
+    void setResourceLoadStatisticsDirectory(String&& directory) { m_directories.resourceLoadStatisticsDirectory = WTFMove(directory); }
 
-    const String& networkCacheDirectory() const { return m_networkCacheDirectory; }
-    void setNetworkCacheDirectory(String&& directory) { m_networkCacheDirectory = WTFMove(directory); }
+    const String& networkCacheDirectory() const { return m_directories.networkCacheDirectory; }
+    void setNetworkCacheDirectory(String&& directory) { m_directories.networkCacheDirectory = WTFMove(directory); }
     
-    const String& cacheStorageDirectory() const { return m_cacheStorageDirectory; }
-    void setCacheStorageDirectory(String&& directory) { m_cacheStorageDirectory = WTFMove(directory); }
+    const String& cacheStorageDirectory() const { return m_directories.cacheStorageDirectory; }
+    void setCacheStorageDirectory(String&& directory) { m_directories.cacheStorageDirectory = WTFMove(directory); }
 
-    const String& generalStorageDirectory() const { return m_generalStorageDirectory; }
-    void setGeneralStorageDirectory(String&& directory) { m_generalStorageDirectory = WTFMove(directory); }
+    const String& generalStorageDirectory() const { return m_directories.generalStorageDirectory; }
+    void setGeneralStorageDirectory(String&& directory) { m_directories.generalStorageDirectory = WTFMove(directory); }
 
     UnifiedOriginStorageLevel unifiedOriginStorageLevel() const { return m_unifiedOriginStorageLevel; }
     void setUnifiedOriginStorageLevel(UnifiedOriginStorageLevel level) { m_unifiedOriginStorageLevel = level; }
@@ -181,11 +181,11 @@ public:
     const String& webPushPartitionString() const { return m_webPushPartitionString; }
     void setWebPushPartitionString(String&& string) { m_webPushPartitionString = WTFMove(string); }
 
-    const String& applicationCacheFlatFileSubdirectoryName() const { return m_applicationCacheFlatFileSubdirectoryName; }
-    void setApplicationCacheFlatFileSubdirectoryName(String&& directory) { m_applicationCacheFlatFileSubdirectoryName = WTFMove(directory); }
+    const String& applicationCacheFlatFileSubdirectoryName() const { return m_directories.applicationCacheFlatFileSubdirectoryName; }
+    void setApplicationCacheFlatFileSubdirectoryName(String&& directory) { m_directories.applicationCacheFlatFileSubdirectoryName = WTFMove(directory); }
     
-    const String& serviceWorkerRegistrationDirectory() const { return m_serviceWorkerRegistrationDirectory; }
-    void setServiceWorkerRegistrationDirectory(String&& directory) { m_serviceWorkerRegistrationDirectory = WTFMove(directory); }
+    const String& serviceWorkerRegistrationDirectory() const { return m_directories.serviceWorkerRegistrationDirectory; }
+    void setServiceWorkerRegistrationDirectory(String&& directory) { m_directories.serviceWorkerRegistrationDirectory = WTFMove(directory); }
     
     bool serviceWorkerProcessTerminationDelayEnabled() const { return m_serviceWorkerProcessTerminationDelayEnabled; }
     void setServiceWorkerProcessTerminationDelayEnabled(bool enabled) { m_serviceWorkerProcessTerminationDelayEnabled = enabled; }
@@ -250,6 +250,33 @@ public:
     void setMemoryFootprintNotificationThresholds(Vector<size_t>&& thresholds) { m_memoryFootprintNotificationThresholds = WTFMove(thresholds); }
     const Vector<size_t>& memoryFootprintNotificationThresholds() { return m_memoryFootprintNotificationThresholds; }
 
+    struct Directories {
+        String applicationCacheFlatFileSubdirectoryName { "Files"_s };
+        String applicationCacheDirectory;
+        String alternativeServicesDirectory;
+        String cacheStorageDirectory;
+        String cookieStorageFile;
+        String deviceIdHashSaltsStorageDirectory;
+        String generalStorageDirectory;
+        String hstsStorageDirectory;
+        String indexedDBDatabaseDirectory;
+        String javaScriptConfigurationDirectory;
+        String localStorageDirectory;
+        String mediaCacheDirectory;
+        String mediaKeysStorageDirectory;
+        String networkCacheDirectory;
+        String resourceLoadStatisticsDirectory;
+        String searchFieldHistoryDirectory;
+        String serviceWorkerRegistrationDirectory;
+        String webSQLDatabaseDirectory;
+#if ENABLE(ARKIT_INLINE_PREVIEW)
+        String modelElementCacheDirectory;
+#endif
+        Directories isolatedCopy() const&;
+        Directories isolatedCopy() &&;
+    };
+    const Directories& directories() const { return m_directories; }
+
 private:
     WebsiteDataStoreConfiguration(const String& baseCacheDirectory, const String& baseDataDirectory);
     static Ref<WebsiteDataStoreConfiguration> create(IsPersistent isPersistent, ShouldInitializePaths shouldInitializePaths) { return adoptRef(*new WebsiteDataStoreConfiguration(isPersistent, shouldInitializePaths)); }
@@ -262,38 +289,18 @@ private:
     Markable<WTF::UUID> m_identifier;
     String m_baseCacheDirectory;
     String m_baseDataDirectory;
-    String m_cacheStorageDirectory;
-    String m_generalStorageDirectory;
+    Directories m_directories;
     uint64_t m_perOriginStorageQuota;
     std::optional<double> m_originQuotaRatio;
     std::optional<double> m_totalQuotaRatio;
     std::optional<uint64_t> m_standardVolumeCapacity;
     std::optional<uint64_t> m_volumeCapacityOverride;
-    String m_networkCacheDirectory;
-    String m_applicationCacheDirectory;
-    String m_applicationCacheFlatFileSubdirectoryName { "Files"_s };
-    String m_mediaCacheDirectory;
-    String m_indexedDBDatabaseDirectory;
-    String m_serviceWorkerRegistrationDirectory;
-    String m_webSQLDatabaseDirectory;
-    String m_hstsStorageDirectory;
-#if ENABLE(ARKIT_INLINE_PREVIEW)
-    String m_modelElementCacheDirectory;
-#endif
 #if USE(GLIB)
     bool m_networkCacheSpeculativeValidationEnabled { true };
 #else
     bool m_networkCacheSpeculativeValidationEnabled { false };
 #endif
     bool m_staleWhileRevalidateEnabled { true };
-    String m_localStorageDirectory;
-    String m_mediaKeysStorageDirectory;
-    String m_alternativeServicesDirectory;
-    String m_deviceIdHashSaltsStorageDirectory;
-    String m_resourceLoadStatisticsDirectory;
-    String m_javaScriptConfigurationDirectory;
-    String m_searchFieldHistoryDirectory;
-    String m_cookieStorageFile;
     String m_sourceApplicationBundleIdentifier;
     String m_sourceApplicationSecondaryIdentifier;
     String m_boundInterfaceIdentifier;

--- a/Source/WebKit/UIProcess/WebsiteData/curl/WebsiteDataStoreCurl.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/curl/WebsiteDataStoreCurl.cpp
@@ -35,13 +35,14 @@ namespace WebKit {
 
 void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& parameters)
 {
-    auto alternativeServiceStorageDirectory = resolvedAlternativeServicesStorageDirectory();
+    auto& directories = resolvedDirectories();
+    auto alternativeServiceStorageDirectory = directories.alternativeServicesDirectory;
     SandboxExtension::Handle alternativeServiceStorageDirectoryExtensionHandle;
     createHandleFromResolvedPathIfPossible(alternativeServiceStorageDirectory, alternativeServiceStorageDirectoryExtensionHandle);
 
     parameters.networkSessionParameters.alternativeServiceDirectory = WTFMove(alternativeServiceStorageDirectory);
     parameters.networkSessionParameters.alternativeServiceDirectoryExtensionHandle = WTFMove(alternativeServiceStorageDirectoryExtensionHandle);
-    parameters.networkSessionParameters.cookiePersistentStorageFile = resolvedCookieStorageFile();
+    parameters.networkSessionParameters.cookiePersistentStorageFile = directories.cookieStorageFile;
     parameters.networkSessionParameters.proxySettings = m_proxySettings;
 }
 

--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -47,8 +47,8 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
         WebsiteDataStore* dataStore = isPrewarmed() ? WebsiteDataStore::defaultDataStore().ptr() : websiteDataStore();
 
         ASSERT(dataStore);
-        dataStore->resolveDirectoriesIfNecessary();
-        launchOptions.extraInitializationData.set("mediaKeysDirectory"_s, dataStore->resolvedMediaKeysDirectory());
+        dataStore->waitForDirectoriesToResolveIfNecessary();
+        launchOptions.extraInitializationData.set("mediaKeysDirectory"_s, dataStore->resolvedDirectories().mediaKeysStorageDirectory);
 
         launchOptions.extraSandboxPaths = m_processPool->sandboxPaths();
     }


### PR DESCRIPTION
#### 3d45c70fab6dbc2f2f3810af811b32bdbc19be05
<pre>
Resolve directories on WorkQueue in UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=270300">https://bugs.webkit.org/show_bug.cgi?id=270300</a>
<a href="https://rdar.apple.com/123841003">rdar://123841003</a>

Reviewed by Chris Dumez.

Move resolving directoreis off main thread in UI process to avoid slowing down main thread. Main thread still needs to
wait directories to be resolved before using them, but now we dipsatch the task when WebsiteDataStore is created, so
there is chance that the directories are already resolved before the use. Also, the queue has the same priority as main
thread, so in the worst case where client uses WebsiteDataStore immediately after creating it, the performance will be
the same as current implementation.

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _initWithConfiguration:]):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::gpuProcessSessionParameters):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::webProcessDataStoreParameters):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
(WebKit::WebsiteDataStore::saveRecentSearches):
(WebKit::WebsiteDataStore::loadRecentSearches):
(WebKit::WebsiteDataStore::removeRecentSearches):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::createNonPersistent):
(WebKit::WebsiteDataStore::create):
(WebKit::WebsiteDataStore::WebsiteDataStore):
(WebKit::WebsiteDataStore::defaultDataStore):
(WebKit::migrateMediaKeysStorageIfNecessary):
(WebKit::resolveDirectories):
(WebKit::WebsiteDataStore::resolvedDirectories const):
(WebKit::WebsiteDataStore::mediaKeysStorageSalt const):
(WebKit::WebsiteDataStore::resolveDirectoriesAsynchronously):
(WebKit::WebsiteDataStore::handleResolvedDirectoriesAsynchronously):
(WebKit::WebsiteDataStore::waitForDirectoriesToResolveIfNecessary):
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::migrateMediaKeysStorageIfNecessary): Deleted.
(WebKit::WebsiteDataStore::resolveDirectoriesIfNecessary): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::perOriginStorageQuota const):
(WebKit::WebsiteDataStore::originQuotaRatio):
(WebKit::WebsiteDataStore::resolvedCacheStorageDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedLocalStorageDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedNetworkCacheDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedAlternativeServicesStorageDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedMediaCacheDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedMediaKeysDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedJavaScriptConfigurationDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedCookieStorageFile const): Deleted.
(WebKit::WebsiteDataStore::resolvedIndexedDBDatabaseDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedServiceWorkerRegistrationDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedResourceLoadStatisticsDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedHSTSStorageDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedGeneralStorageDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedSearchFieldHistoryDirectory const): Deleted.
(WebKit::WebsiteDataStore::resolvedModelElementCacheDirectory const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy const):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::applicationCacheDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setApplicationCacheDirectory):
(WebKit::WebsiteDataStoreConfiguration::mediaCacheDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setMediaCacheDirectory):
(WebKit::WebsiteDataStoreConfiguration::mediaKeysStorageDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setMediaKeysStorageDirectory):
(WebKit::WebsiteDataStoreConfiguration::alternativeServicesDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setAlternativeServicesDirectory):
(WebKit::WebsiteDataStoreConfiguration::javaScriptConfigurationDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setJavaScriptConfigurationDirectory):
(WebKit::WebsiteDataStoreConfiguration::searchFieldHistoryDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setSearchFieldHistoryDirectory):
(WebKit::WebsiteDataStoreConfiguration::indexedDBDatabaseDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setIndexedDBDatabaseDirectory):
(WebKit::WebsiteDataStoreConfiguration::webSQLDatabaseDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setWebSQLDatabaseDirectory):
(WebKit::WebsiteDataStoreConfiguration::hstsStorageDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setHSTSStorageDirectory):
(WebKit::WebsiteDataStoreConfiguration::localStorageDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setLocalStorageDirectory):
(WebKit::WebsiteDataStoreConfiguration::modelElementCacheDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setModelElementCacheDirectory):
(WebKit::WebsiteDataStoreConfiguration::deviceIdHashSaltsStorageDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setDeviceIdHashSaltsStorageDirectory):
(WebKit::WebsiteDataStoreConfiguration::cookieStorageFile const):
(WebKit::WebsiteDataStoreConfiguration::setCookieStorageFile):
(WebKit::WebsiteDataStoreConfiguration::resourceLoadStatisticsDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setResourceLoadStatisticsDirectory):
(WebKit::WebsiteDataStoreConfiguration::networkCacheDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setNetworkCacheDirectory):
(WebKit::WebsiteDataStoreConfiguration::cacheStorageDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setCacheStorageDirectory):
(WebKit::WebsiteDataStoreConfiguration::generalStorageDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setGeneralStorageDirectory):
(WebKit::WebsiteDataStoreConfiguration::applicationCacheFlatFileSubdirectoryName const):
(WebKit::WebsiteDataStoreConfiguration::setApplicationCacheFlatFileSubdirectoryName):
(WebKit::WebsiteDataStoreConfiguration::serviceWorkerRegistrationDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setServiceWorkerRegistrationDirectory):
(WebKit::WebsiteDataStoreConfiguration::directories const):
* Source/WebKit/UIProcess/WebsiteData/curl/WebsiteDataStoreCurl.cpp:
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
* Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp:
(WebKit::WebProcessProxy::platformGetLaunchOptions):

Canonical link: <a href="https://commits.webkit.org/275959@main">https://commits.webkit.org/275959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab3603eddafa97df06299f230e4fd12a3502150c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43373 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39499 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35850 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16829 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47552 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42634 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19824 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41294 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9652 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->