### PR TITLE
dataLogIf / dataLogLnIf should be macro

### DIFF
--- a/Source/WTF/wtf/DataLog.h
+++ b/Source/WTF/wtf/DataLog.h
@@ -52,25 +52,19 @@ void dataLogLn(const Types&... values)
     dataLog(values..., "\n");
 }
 
-template<typename... Types>
-ALWAYS_INLINE void dataLogIf(bool shouldLog, const Types&... values)
-{
-    if (UNLIKELY(shouldLog))
-        dataLog(values...);
-}
+#define dataLogIf(shouldLog, ...) do { \
+        if (UNLIKELY(shouldLog)) \
+            dataLog(__VA_ARGS__); \
+    } while (0)
 
-template<typename... Types>
-ALWAYS_INLINE void dataLogLnIf(bool shouldLog, const Types&... values)
-{
-    if (UNLIKELY(shouldLog))
-        dataLogLn(values...);
-}
+#define dataLogLnIf(shouldLog, ...) do { \
+        if (UNLIKELY(shouldLog)) \
+            dataLogLn(__VA_ARGS__); \
+    } while (0)
 
 } // namespace WTF
 
 using WTF::dataLog;
 using WTF::dataLogLn;
-using WTF::dataLogIf;
-using WTF::dataLogLnIf;
 using WTF::dataLogF;
 using WTF::dataLogFString;


### PR DESCRIPTION
#### 8bc91f004ab432c4a4c827c272a79f363f93cd29
<pre>
dataLogIf / dataLogLnIf should be macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=270309">https://bugs.webkit.org/show_bug.cgi?id=270309</a>
<a href="https://rdar.apple.com/123567317">rdar://123567317</a>

Reviewed by Mark Lam and Keith Miller.

dataLogIf and dataLogLnIf should not evaluate arguments when the first condition is not true!

* Source/WTF/wtf/DataLog.h:
(WTF::dataLogIf): Deleted.
(WTF::dataLogLnIf): Deleted.

Canonical link: <a href="https://commits.webkit.org/275521@main">https://commits.webkit.org/275521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af754b09a9b15378d5f541fbd4c94c5b427d9cc6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38167 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18401 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15775 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46071 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35511 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37573 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41683 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40038 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18490 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48692 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18550 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9896 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5652 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->