### PR TITLE
[WGSL] Validate maximum array size

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/array.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/array.wgsl
@@ -7,11 +7,20 @@ fn testArrayLengthMismatch() {
   // CHECK-L: array count must be greater than 0
   let x1 = array<i32, 0>();
 
+  // CHECK-L: array count must be greater than 0
+  let x2 = array<i32, -1>();
+
   // CHECK-L: array constructor has too few elements: expected 2, found 1
-  let x2 = array<i32, 2>(0);
+  let x3 = array<i32, 2>(0);
 
   // CHECK-L: array constructor has too many elements: expected 1, found 2
-  let x3 = array<i32, 1>(0, 0);
+  let x4 = array<i32, 1>(0, 0);
+
+  // CHECK-L: array count (65536) must be less than 65536
+  let x5 = array<i32, 65536>();
+
+  // CHECK-NOT-L: array count (65535) must be less than 65536
+  let x6 = array<i32, 65535>();
 
 }
 


### PR DESCRIPTION
#### 8c7b8419c6ff3be3a4ae2f5246c6327a962c8698
<pre>
[WGSL] Validate maximum array size
<a href="https://bugs.webkit.org/show_bug.cgi?id=270313">https://bugs.webkit.org/show_bug.cgi?id=270313</a>
<a href="https://rdar.apple.com/123852286">rdar://123852286</a>

Reviewed by Mike Wyrzykowski and Alex Christensen.

Fix 2 issues with array sizes:
- the size was being treated as unsigned and only checking for 0, but according
  to the spec the size can also be signed, and we should return an error for
  negative values
- we also need to limit the maximum size of an array. the spec[1] says the minimum
  size we must support is 65535 bytes, but for now we just check for 65535 elements.

[1]: <a href="https://www.w3.org/TR/WGSL/#limits">https://www.w3.org/TR/WGSL/#limits</a>

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/array.wgsl:

Canonical link: <a href="https://commits.webkit.org/275557@main">https://commits.webkit.org/275557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73b6fb409df7366f68d5d456d3a08dd0fa4a9d7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38269 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34911 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15847 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15774 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41567 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40136 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18588 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9441 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->