### PR TITLE
REGRESSION (275244@main): Crash in MediaCapability::MediaCapability when loading 'about:blank'

### DIFF
--- a/Source/WebKit/Platform/cocoa/MediaCapability.h
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.h
@@ -30,12 +30,8 @@
 #include "ExtensionCapability.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/Ref.h>
+#include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class SecurityOrigin;
-}
 
 OBJC_CLASS BEMediaEnvironment;
 
@@ -46,7 +42,7 @@ class ExtensionCapabilityGrant;
 class MediaCapability final : public ExtensionCapability, public CanMakeWeakPtr<MediaCapability> {
     WTF_MAKE_NONCOPYABLE(MediaCapability);
 public:
-    explicit MediaCapability(Ref<WebCore::SecurityOrigin>&&);
+    explicit MediaCapability(URL&&);
     MediaCapability(MediaCapability&&) = default;
     MediaCapability& operator=(MediaCapability&&) = default;
 
@@ -61,7 +57,7 @@ public:
     void setState(State state) { m_state = state; }
     bool isActivatingOrActive() const;
 
-    const WebCore::SecurityOrigin& securityOrigin() const { return m_securityOrigin.get(); }
+    const URL& webPageURL() const { return m_webPageURL; }
 
     // ExtensionCapability
     String environmentIdentifier() const final;
@@ -70,7 +66,7 @@ public:
 
 private:
     State m_state { State::Inactive };
-    Ref<WebCore::SecurityOrigin> m_securityOrigin;
+    URL m_webPageURL;
     RetainPtr<BEMediaEnvironment> m_mediaEnvironment;
 };
 

--- a/Source/WebKit/Platform/cocoa/MediaCapability.mm
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.mm
@@ -32,13 +32,18 @@
 #import <WebCore/SecurityOrigin.h>
 #import <wtf/text/WTFString.h>
 
-#import "ExtensionKitSoftLink.h"
-
 namespace WebKit {
 
-MediaCapability::MediaCapability(Ref<WebCore::SecurityOrigin>&& securityOrigin)
-    : m_securityOrigin { WTFMove(securityOrigin) }
-    , m_mediaEnvironment { adoptNS([[BEMediaEnvironment alloc] initWithWebPageURL:m_securityOrigin->toURL()]) }
+static RetainPtr<BEMediaEnvironment> createMediaEnvironment(const URL& webPageURL)
+{
+    NSURL *protocolHostAndPortURL = URL { webPageURL.protocolHostAndPort() };
+    RELEASE_ASSERT(protocolHostAndPortURL);
+    return adoptNS([[BEMediaEnvironment alloc] initWithWebPageURL:protocolHostAndPortURL]);
+}
+
+MediaCapability::MediaCapability(URL&& webPageURL)
+    : m_webPageURL { WTFMove(webPageURL) }
+    , m_mediaEnvironment { createMediaEnvironment(m_webPageURL) }
 {
     setPlatformCapability([BEProcessCapability mediaPlaybackAndCaptureWithEnvironment:m_mediaEnvironment.get()]);
 }

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -87,7 +87,7 @@ Platform/classifier/ResourceLoadStatisticsClassifier.cpp
 
 Platform/cocoa/AssertionCapability.mm @no-unify
 Platform/cocoa/ExtensionCapabilityGrant.mm
-Platform/cocoa/MediaCapability.mm @no-unify
+Platform/cocoa/MediaCapability.mm
 Platform/cocoa/PaymentAuthorizationPresenter.mm
 Platform/cocoa/PaymentAuthorizationViewController.mm
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1043,13 +1043,13 @@ void WebPageProxy::setMediaCapability(std::optional<MediaCapability>&& capabilit
         return;
     }
 
-    WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: creating (envID=%{public}s) for host '%{sensitive}s'", internals().mediaCapability->environmentIdentifier().utf8().data(), internals().mediaCapability->securityOrigin().host().utf8().data());
+    WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: creating (envID=%{public}s) for URL '%{sensitive}s'", internals().mediaCapability->environmentIdentifier().utf8().data(), internals().mediaCapability->webPageURL().string().utf8().data());
     send(Messages::WebPage::SetMediaEnvironment(internals().mediaCapability->environmentIdentifier()));
 }
 
 void WebPageProxy::deactivateMediaCapability(MediaCapability& capability)
 {
-    WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "deactivateMediaCapability: deactivating (envID=%{public}s) for host '%{sensitive}s'", capability.environmentIdentifier().utf8().data(), capability.securityOrigin().host().utf8().data());
+    WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "deactivateMediaCapability: deactivating (envID=%{public}s) for URL '%{sensitive}s'", capability.environmentIdentifier().utf8().data(), capability.webPageURL().string().utf8().data());
     Ref processPool { protectedProcess()->protectedProcessPool() };
     processPool->extensionCapabilityGranter().setMediaCapabilityActive(capability, false);
     processPool->extensionCapabilityGranter().revoke(capability);
@@ -1067,10 +1067,8 @@ void WebPageProxy::resetMediaCapability()
         return;
     }
 
-    Ref securityOrigin = SecurityOrigin::create(currentURL);
-
-    if (!mediaCapability() || !mediaCapability()->securityOrigin().isSameOriginAs(securityOrigin.get()))
-        setMediaCapability(MediaCapability { WTFMove(securityOrigin) });
+    if (!mediaCapability() || !protocolHostAndPortAreEqual(mediaCapability()->webPageURL(), currentURL))
+        setMediaCapability(MediaCapability { WTFMove(currentURL) });
 }
 
 void WebPageProxy::updateMediaCapability()

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1901,7 +1901,6 @@
 		A13B3DA2207F39DE0090C58D /* MobileWiFiSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = A13B3DA1207F39DE0090C58D /* MobileWiFiSPI.h */; };
 		A13DC682207AA6B20066EF72 /* WKApplicationStateTrackingView.h in Headers */ = {isa = PBXBuildFile; fileRef = A13DC680207AA6B20066EF72 /* WKApplicationStateTrackingView.h */; };
 		A141DF4F2B06ED0800E80B2D /* MediaCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = A141DF4D2B06ECFB00E80B2D /* MediaCapability.h */; };
-		A141DF502B06ED0F00E80B2D /* MediaCapability.mm in Sources */ = {isa = PBXBuildFile; fileRef = A141DF4E2B06ECFB00E80B2D /* MediaCapability.mm */; };
 		A141DF522B07054900E80B2D /* ExtensionCapabilityGrant.h in Headers */ = {isa = PBXBuildFile; fileRef = A141DF512B07054900E80B2D /* ExtensionCapabilityGrant.h */; };
 		A14F9B632B686DD300AD9C56 /* WKSLinearMediaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A14F9B612B686DD200AD9C56 /* WKSLinearMediaTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A14F9B642B686DD300AD9C56 /* LinearMediaTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14F9B622B686DD200AD9C56 /* LinearMediaTypes.swift */; };
@@ -19146,7 +19145,6 @@
 				41A0EB142641714900794471 /* LibWebRTCCodecsProxy.mm in Sources */,
 				51F060E11654318500F3281C /* LibWebRTCNetworkMessageReceiver.cpp in Sources */,
 				449D90DA21FDC30B00F677C0 /* LocalAuthenticationSoftLink.mm in Sources */,
-				A141DF502B06ED0F00E80B2D /* MediaCapability.mm in Sources */,
 				07E19EFB23D401F10094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp in Sources */,
 				510C52D32B241019008EABED /* MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp in Sources */,
 				9B4790912531563200EC11AB /* MessageArgumentDescriptions.cpp in Sources */,


### PR DESCRIPTION
#### 144facca643556ff386784f2ff15735984bb049b
<pre>
REGRESSION (275244@main): Crash in MediaCapability::MediaCapability when loading &apos;about:blank&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=270318">https://bugs.webkit.org/show_bug.cgi?id=270318</a>
<a href="https://rdar.apple.com/123856265">rdar://123856265</a>

Reviewed by Jer Noble.

In 275244@main MediaCapability was changed to track a SecurityOrigin rather than a URL. Since
&apos;about:blank&apos; is considered an opaque origin, a nil NSURL is returned by SecurityOrigin::toURL()
(after implicit conversion). A crash occurs when MediaCapability attempts to instantiate a
BEMediaEnvironment with the nil URL since -initWithWebPageURL: requires a nonnull NSURL.

Fixed this by reverting MediaCapability to storing the webpage URL as a WebCore::URL, and instead
using URL::protocolHostAndPort() and protocolHostAndPortAreEqual() to ensure that the
MediaEnvironment is not reset during same-origin navigations.

* Source/WebKit/Platform/cocoa/MediaCapability.h:
* Source/WebKit/Platform/cocoa/MediaCapability.mm:
(WebKit::createMediaEnvironment):
(WebKit::MediaCapability::MediaCapability):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setMediaCapability):
(WebKit::WebPageProxy::deactivateMediaCapability):
(WebKit::WebPageProxy::resetMediaCapability):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/275533@main">https://commits.webkit.org/275533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b59c49507e36acd88dacb355f9c150f7e12f433d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38190 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18423 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36229 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15692 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37589 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40046 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18512 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9427 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->