### PR TITLE
[Lockdown Mode] Lockdown Mode Safe Font feature flag gets stuck, cannot be enabled in some cases

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4581,17 +4581,11 @@ static void adjustSettingsForLockdownMode(Settings& settings, const WebPreferenc
 #if ENABLE(WEB_AUDIO)
     settings.setWebAudioEnabled(false);
 #endif
-    switch (settings.downloadableBinaryFontTrustedTypes()) {
-    case DownloadableBinaryFontTrustedTypes::Any:
+    if (settings.downloadableBinaryFontTrustedTypes() != DownloadableBinaryFontTrustedTypes::None) {
         settings.setDownloadableBinaryFontTrustedTypes(
             settings.lockdownFontParserEnabled()
                 ? DownloadableBinaryFontTrustedTypes::FallbackParser
                 : DownloadableBinaryFontTrustedTypes::Restricted);
-        break;
-    case DownloadableBinaryFontTrustedTypes::FallbackParser:
-    case DownloadableBinaryFontTrustedTypes::Restricted:
-    case DownloadableBinaryFontTrustedTypes::None:
-        break;
     }
 #if ENABLE(WEB_CODECS)
     settings.setWebCodecsVideoEnabled(false);


### PR DESCRIPTION
#### 6ce61264b7ca7855ae3e0a5de0eeebe94e606b97
<pre>
[Lockdown Mode] Lockdown Mode Safe Font feature flag gets stuck, cannot be enabled in some cases

<a href="https://bugs.webkit.org/show_bug.cgi?id=270307">https://bugs.webkit.org/show_bug.cgi?id=270307</a>
<a href="https://rdar.apple.com/123848733">rdar://123848733</a>

Reviewed by Brent Fulgham.

Due to a logic error, when the Lockdown Mode Safe Font feature flag goes to
`DownloadableBinaryFontTrustedTypes::Restricted` or `...::FallbackParser`, it
gets stuck in that state and can&apos;t progress to the other. This makes the
&quot;Lockdown Mode Safe Font&quot; setting toggle ineffective.

This change addresses the issue by allowing state transitions from any
`DownloadableBinaryFontTrustedTypes` state except `...::None`.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::adjustSettingsForLockdownMode):

Canonical link: <a href="https://commits.webkit.org/275539@main">https://commits.webkit.org/275539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e3fae9fd7a51612502362880672a60c0a59f2b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38214 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34863 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15714 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41517 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40075 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18536 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9431 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->