### PR TITLE
Web Inspector: Links to inline style sheets don't work

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -142,9 +142,10 @@
                 { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Stylesheet origin."},
                 { "name": "title", "type": "string", "description": "Stylesheet title."},
                 { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."},
-                { "name": "isInline", "type": "boolean", "description": "Whether this stylesheet is a <style> tag created by the parser. This is not set for document.written <style> tags." },
-                { "name": "startLine", "type": "number", "description": "Line offset of the stylesheet within the resource (zero based)." },
-                { "name": "startColumn", "type": "number", "description": "Column offset of the stylesheet within the resource (zero based)." }
+                { "name": "isInline", "type": "boolean", "description": "Whether this stylesheet lives inside a <style> element." },
+                { "name": "ownerNodeId", "$ref": "DOM.NodeId", "optional": true, "description": "Id of the <style> element that the stylesheet lives in. Only included if the stylesheet is inline." },
+                { "name": "startLine", "type": "number", "optional": true, "description": "Line offset of the stylesheet within the resource (zero based). If not included, this stylesheet is created dynamically by JavaScript within sourceURL (e.g. with document.write)." },
+                { "name": "startColumn", "type": "number", "optional": true, "description": "Column offset of the stylesheet within the resource (zero based). If not included, this stylesheet is created dynamically by JavaScript within sourceURL (e.g. with document.write)." }
             ]
         },
         {

--- a/Source/WebCore/dom/InlineStyleSheetOwner.cpp
+++ b/Source/WebCore/dom/InlineStyleSheetOwner.cpp
@@ -64,10 +64,11 @@ static std::optional<Style::StyleSheetContentsCache::Key> makeStyleSheetContents
 InlineStyleSheetOwner::InlineStyleSheetOwner(Document& document, bool createdByParser)
     : m_isParsingChildren(createdByParser)
     , m_loading(false)
-    , m_startTextPosition()
 {
     if (createdByParser && document.scriptableDocumentParser() && !document.isInDocumentWrite())
         m_startTextPosition = document.scriptableDocumentParser()->textPosition();
+    else
+        m_startTextPosition = TextPosition::belowRangePosition();
 }
 
 InlineStyleSheetOwner::~InlineStyleSheetOwner()

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -511,7 +511,7 @@ WI.CSSManager = class CSSManager extends WI.Object
 
             const url = null;
             let styleSheet = WI.cssManager.styleSheetForIdentifier(styleSheetId);
-            styleSheet.updateInfo(url, frame, styleSheet.origin, styleSheet.isInlineStyleTag(), styleSheet.startLineNumber, styleSheet.startColumnNumber);
+            styleSheet.updateInfo(url, frame, styleSheet.origin, styleSheet.isInlineStyleTag(), styleSheet.startLineNumber, styleSheet.startColumnNumber, styleSheet.ownerNodeId);
             styleSheet[WI.CSSManager.PreferredInspectorStyleSheetSymbol] = true;
             callback(styleSheet);
         });
@@ -614,7 +614,7 @@ WI.CSSManager = class CSSManager extends WI.Object
         let styleSheet = this.styleSheetForIdentifier(styleSheetInfo.styleSheetId);
         let parentFrame = WI.networkManager.frameForIdentifier(styleSheetInfo.frameId);
         let origin = WI.CSSManager.protocolStyleSheetOriginToEnum(styleSheetInfo.origin);
-        styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn);
+        styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn, styleSheetInfo.ownerNodeId);
 
         this.dispatchEventToListeners(WI.CSSManager.Event.StyleSheetAdded, {styleSheet});
     }
@@ -758,7 +758,7 @@ WI.CSSManager = class CSSManager extends WI.Object
                 let origin = WI.CSSManager.protocolStyleSheetOriginToEnum(styleSheetInfo.origin);
 
                 let styleSheet = this.styleSheetForIdentifier(styleSheetInfo.styleSheetId);
-                styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn);
+                styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn, styleSheetInfo.ownerNodeId);
 
                 let key = this._frameURLMapKey(parentFrame, styleSheetInfo.sourceURL);
                 this._styleSheetFrameURLMap.set(key, styleSheet);

--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js
@@ -34,9 +34,9 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
         this._id = id || null;
         this._parentFrame = null;
         this._origin = null;
-        this._startLineNumber = 0;
-        this._startColumnNumber = 0;
-
+        this._startLineNumber = NaN;
+        this._startColumnNumber = NaN;
+        this._ownerNodeId = NaN;
         this._inlineStyleAttribute = false;
         this._inlineStyleTag = false;
 
@@ -107,6 +107,10 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
         return this._startColumnNumber;
     }
 
+    get ownerNodeId() {
+        return this._ownerNodeId;
+    }
+
     hasInfo()
     {
         return this._hasInfo;
@@ -148,7 +152,7 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
 
     // Protected
 
-    updateInfo(url, parentFrame, origin, inlineStyle, startLineNumber, startColumnNumber)
+    updateInfo(url, parentFrame, origin, inlineStyle, startLineNumber, startColumnNumber, ownerNodeId)
     {
         this._hasInfo = true;
 
@@ -161,6 +165,7 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
         this._inlineStyleTag = inlineStyle;
         this._startLineNumber = startLineNumber;
         this._startColumnNumber = startColumnNumber;
+        this._ownerNodeId = ownerNodeId;
     }
 
     get revisionForRequestedContent()

--- a/Source/WebInspectorUI/UserInterface/Views/StyleOriginView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/StyleOriginView.js
@@ -41,8 +41,17 @@ WI.StyleOriginView = class StyleOriginView
         switch (style.type) {
         case WI.CSSStyleDeclaration.Type.Rule:
             console.assert(style.ownerRule);
+            console.assert(style.ownerStyleSheet);
 
-            if (style.ownerRule.sourceCodeLocation) {
+            if (style.ownerRule.type === WI.CSSStyleSheet.Type.Author && isNaN(style.ownerStyleSheet.startLineNumber)) {
+                let styleTagLink = document.createElement("a");
+                styleTagLink.style.textDecoration = "underline";
+                styleTagLink.style.cursor = "pointer";
+                let ownerNodeId = style.ownerStyleSheet.ownerNodeId;
+                styleTagLink.textContent = `<style> (node ${ownerNodeId})`;
+                styleTagLink.addEventListener("click", () => WI.domManager.inspectElement(ownerNodeId));
+                this.element.appendChild(styleTagLink);
+            } else if (style.ownerRule.sourceCodeLocation) {
                 let options = {
                     dontFloat: true,
                     ignoreNetworkTab: true,


### PR DESCRIPTION
#### aeee567cb1d9676b74b4bd18d792ef1622c6c935
<pre>
Web Inspector: Links to inline style sheets don&apos;t work
<a href="https://rdar.apple.com/122866054">rdar://122866054</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268818">https://bugs.webkit.org/show_bug.cgi?id=268818</a>

Reviewed by NOBODY (OOPS!).

Add a feature to the inspector&apos;s frontend that, if an inline/internal
CSS rule (one that lives within an HTML &lt;style&gt; element) is created
dynamically with JavaScript, the style details panel should link
that rule to its owner &lt;style&gt; element in the DOM tree in the Elements
tab.

The backend now includes the relevant data for a CSS header that links
a style sheet to its owner &lt;style&gt; element if one exists.

The frontend now takes this data and renders a link to that &lt;style&gt;
element as a CSS rule&apos;s source URL when appropriate.

NOTE:
- This new feature currently does not always work as it suffers from
  <a href="https://webkit.org/b/213499">https://webkit.org/b/213499</a>, where during the construction of a
  CSSStyleSheetHeader protocol object and trying to retrieve the node ID
  of the style sheet&apos;s owner node, the document element might not have
  been instrumented to have a bound ID. (See <a href="https://github.com/WebKit/WebKit/blob/e9235eeac4b213cb15e87a5c1b2a97bd27826195/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp#L596)">https://github.com/WebKit/WebKit/blob/e9235eeac4b213cb15e87a5c1b2a97bd27826195/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp#L596)</a>
- In order to successfully use this feature, the user must open the web
  inspector and then do a hard-refresh (Option-Command-R). I have yet
  figured out what side effect hard-refresh had that made this
  work.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
  - Add the ownerNodeId field to help link the style sheet to its owner
    HTML &lt;style&gt; element.
  - The isInline field&apos;s value did not match what its name suggested,
    and the frontend did not make use of this special meaning either.
    This commit fixes that so isInline always reflect whether the style
    sheet is inline/internal.
  - The startLine and startColumn fields had values of 0 if the style
    sheet was created dynamically, but 0 could be a meaningful value
    (indicating that the source was indeed at line 0). This commit makes
    them optional fields, so a missing value from these fields can
    inform that the style sheet was created dynamically.

* Source/WebCore/dom/InlineStyleSheetOwner.cpp:
(WebCore::InlineStyleSheetOwner::InlineStyleSheetOwner):
  - Use `TextPosition::belowRangePosition` to indicate that the style
    sheet is created dynamically, as the default value `TextPosition()`
    has a legit meaning (line 0, column 0).

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::buildObjectForStyleSheetInfo):
  - Adapt to the new protocol for CSSStyleSheetHeader.

* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.prototype.preferredInspectorStyleSheetForFrame):
(WI.CSSManager.prototype.styleSheetAdded):
(WI.CSSManager.prototype._fetchInfoForAllStyleSheets):
  - Adapt to the new protocol for CSSStyleSheetHeader.

* Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js:
(WI.CSSStyleSheet):
(WI.CSSStyleSheet.prototype.get ownerNodeId):
  - Initialize the new field ownerNodeId to record the style sheet&apos;s
    owner HTML &lt;style&gt; element, if one exists from an update with
    `updateInfo()`.
  - Change the default values of startLineNumber and startColumn to NaN,
    which indicate the style sheet was created dynamically.

(WI.CSSStyleSheet.prototype.updateInfo):
  - Add support for the new field ownerNodeId.

* Source/WebInspectorUI/UserInterface/Views/StyleOriginView.js:
(WI.StyleOriginView.prototype.update):
(WI.StyleOriginView):
  - If a style sheet is created dynamically, render the URL link that
    links to the owner HTML &lt;style&gt; element within the DOM tree instead.
  - (The `(node ?)` text is there as a placeholder for now, which helps
    with debugging and demonstrating the issue described above in the
    NOTE section.)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aeee567cb1d9676b74b4bd18d792ef1622c6c935

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38311 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34950 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15811 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37369 "Found 2 new test failures: inspector/css/getMatchedStylesForNodeLayerGrouping.html, inspector/css/stylesheet-events-imports.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46244 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35651 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38388 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37697 "Found 2 new test failures: inspector/css/getMatchedStylesForNodeLayerGrouping.html, inspector/css/stylesheet-events-imports.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41615 "Found 3 new test failures: inspector/css/getAllStyleSheets.html, inspector/css/getMatchedStylesForNodeLayerGrouping.html, inspector/css/stylesheet-events-imports.html (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41823 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17011 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13999 "Found 2 new test failures: inspector/css/getMatchedStylesForNodeLayerGrouping.html, inspector/css/stylesheet-events-imports.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40193 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18630 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48832 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18692 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9916 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->