### PR TITLE
Add optimization in `handleStyleSpans()` to restrict 'for-loop' to iterate only over InsteredNodes

### DIFF
--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2009-2022 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -963,7 +963,8 @@ void ReplaceSelectionCommand::handleStyleSpans(InsertedNodes& insertedNodes)
     // The style span that contains the source document's default style should be at
     // the top of the fragment, but Mail sometimes adds a wrapper (for Paste As Quotation),
     // so search for the top level style span instead of assuming it's at the top.
-    for (RefPtr node = insertedNodes.firstNodeInserted(); node; node = NodeTraversal::next(*node)) {
+    RefPtr pastEndNode = insertedNodes.pastLastLeaf();
+    for (RefPtr node = insertedNodes.firstNodeInserted(); node && node != pastEndNode; node = NodeTraversal::next(*node)) {
         if (isLegacyAppleStyleSpan(node.get())) {
             wrappingStyleSpan = static_pointer_cast<HTMLElement>(WTFMove(node));
             break;


### PR DESCRIPTION
<pre>
Add optimization in `handleStyleSpans()` to restrict 'for-loop' to iterate only over InsteredNodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=270325">https://bugs.webkit.org/show_bug.cgi?id=270325</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/9cb6b76486b616e567c0a3dc2dac6a800b353912">https://chromium.googlesource.com/chromium/blink/+/9cb6b76486b616e567c0a3dc2dac6a800b353912</a>

This patch adds similar optimization present in `removeRedundantStylesAndKeepStyleSpanInline`
to `handleStyleSpans()`, where the 'for-loop' is restricted to only iterate over newly inserted nodes.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(ReplaceSelectionCommand::handleStyleSpans):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42c5fd3b14b1064b8ea834f3da8dec715cbd18c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6620 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6814 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45416 "Found 1 new test failure: fast/editing/replace-selection-command-crash.html (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4595 "Found 2 new test failures: editing/inserting/inset-html-textarea-without-renderer.html fast/editing/replace-selection-command-crash.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58213 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33400 "Found 3 new test failures: editing/inserting/inset-html-textarea-without-renderer.html editing/pasteboard/5761530-2.html fast/editing/replace-selection-command-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30180 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5798 "Found 3 new test failures: editing/inserting/inset-html-textarea-without-renderer.html editing/pasteboard/5761530-2.html fast/editing/replace-selection-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5624 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52178 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6070 "Found 3 new test failures: editing/inserting/inset-html-textarea-without-renderer.html editing/pasteboard/5761530-2.html fast/editing/replace-selection-command-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/92 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6194 "Found 4 new test failures: editing/inserting/inset-html-textarea-without-renderer.html editing/pasteboard/5761530-2.html fast/editing/replace-selection-command-crash.html media/video-replaces-poster.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52743 "Found 3 new test failures: editing/inserting/inset-html-textarea-without-renderer.html editing/pasteboard/5761530-2.html fast/editing/replace-selection-command-crash.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/92 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48535 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52569 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/81 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31337 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32423 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->