### PR TITLE
CrashTracer: com.apple.WebKit.WebContent at com.apple.WebCore: WebCore::CSSCalcOperationNode::simplifyRecursive

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed-expected.txt
@@ -8,10 +8,12 @@ PASS Property clip-path value 'xywh(0px 1% 2px 0.5em round 0)'
 PASS Property clip-path value 'xywh(0px 1% 2px 3% round 0 1px)'
 PASS Property clip-path value 'xywh(0px 1% 2px 3% round 0px 1px 2em)'
 PASS Property clip-path value 'xywh(0px 1% 2px 3% round 0px 1px 2% 3px)'
+FAIL Property clip-path value 'xywh(calc(0px) calc(1px + 1%) calc(2px + 2%) calc(3px + 3%))' assert_equals: expected "inset(calc(1% + 1px) calc(98% - 2px) calc(96% - 4px) 0px)" but got ""
 PASS Property clip-path value 'rect(auto auto auto auto)'
 PASS Property clip-path value 'rect(0 1% 2px 0.5em)'
 PASS Property clip-path value 'rect(0px 1% auto 0.5em round 0)'
 PASS Property clip-path value 'rect(0px 1% auto 3% round 0 1px)'
 PASS Property clip-path value 'rect(0px 1% auto 3% round 0px 1px 2em)'
 PASS Property clip-path value 'rect(0px 1% auto 3% round 0px 1px 2% 3px)'
+FAIL Property clip-path value 'rect(calc(0px) calc(1px + 1%) calc(2px + 2%) calc(3px + 3%))' assert_equals: expected "inset(0px calc(99% - 1px) calc(98% - 2px) calc(3% + 3px))" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed.html
@@ -32,6 +32,7 @@ test_computed_value("clip-path", "xywh(0px 1% 2px 0.5em round 0)", "inset(1% cal
 test_computed_value("clip-path", "xywh(0px 1% 2px 3% round 0 1px)", "inset(1% calc(100% - 2px) 96% 0px round 0px 1px)");
 test_computed_value("clip-path", "xywh(0px 1% 2px 3% round 0px 1px 2em)", "inset(1% calc(100% - 2px) 96% 0px round 0px 1px 80px)");
 test_computed_value("clip-path", "xywh(0px 1% 2px 3% round 0px 1px 2% 3px)", "inset(1% calc(100% - 2px) 96% 0px round 0px 1px 2% 3px)");
+test_computed_value("clip-path", "xywh(calc(0px) calc(1px + 1%) calc(2px + 2%) calc(3px + 3%))", "inset(calc(1% + 1px) calc(98% - 2px) calc(96% - 4px) 0px)");
 // Given "rect(t r b l)", the equivalent function is
 // "inset(t calc(100% - r) calc(100% - b) l)".
 test_computed_value("clip-path", "rect(auto auto auto auto)", "inset(0%)");
@@ -40,6 +41,7 @@ test_computed_value("clip-path", "rect(0px 1% auto 0.5em round 0)", "inset(0px 9
 test_computed_value("clip-path", "rect(0px 1% auto 3% round 0 1px)", "inset(0px 99% 0% 3% round 0px 1px)");
 test_computed_value("clip-path", "rect(0px 1% auto 3% round 0px 1px 2em)", "inset(0px 99% 0% 3% round 0px 1px 80px)");
 test_computed_value("clip-path", "rect(0px 1% auto 3% round 0px 1px 2% 3px)", "inset(0px 99% 0% 3% round 0px 1px 2% 3px)");
+test_computed_value("clip-path", "rect(calc(0px) calc(1px + 1%) calc(2px + 2%) calc(3px + 3%))", "inset(0px calc(99% - 1px) calc(98% - 2px) calc(3% + 3px))");
 </script>
 </body>
 </html>

--- a/Source/WebCore/css/BasicShapeFunctions.h
+++ b/Source/WebCore/css/BasicShapeFunctions.h
@@ -41,7 +41,7 @@ class RenderStyle;
 
 enum class SVGPathConversion : bool { None, ForceAbsolute };
 
-Ref<CSSValue> valueForBasicShape(const RenderStyle&, const BasicShape&, SVGPathConversion = SVGPathConversion::None);
+RefPtr<CSSValue> valueForBasicShape(const RenderStyle&, const BasicShape&, SVGPathConversion = SVGPathConversion::None);
 Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData&, const CSSValue&, float zoom = 1);
 float floatValueForCenterCoordinate(const BasicShapeCenterCoordinate&, float);
 


### PR DESCRIPTION
#### cde1c1500647995b5164beee6d5d86a4f0c4a6b7
<pre>
CrashTracer: com.apple.WebKit.WebContent at com.apple.WebCore: WebCore::CSSCalcOperationNode::simplifyRecursive
<a href="https://bugs.webkit.org/show_bug.cgi?id=270296">https://bugs.webkit.org/show_bug.cgi?id=270296</a>
<a href="https://rdar.apple.com/123508905">rdar://123508905</a>

Reviewed by NOBODY (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed.html:
* Source/WebCore/css/BasicShapeFunctions.cpp:
(WebCore::valueForBasicShape):
* Source/WebCore/css/BasicShapeFunctions.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForPathOperation):
(WebCore::shapePropertyValue):
(WebCore::valueForOffsetShorthand):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cde1c1500647995b5164beee6d5d86a4f0c4a6b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35154 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46526 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41829 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40445 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36871 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->