### PR TITLE
Avoid flickering when showing a layer on a painted background for the first time by disabling async image decoding

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2280,8 +2280,6 @@ fast/images/jpegxl-as-image.html [ Skip ]
 fast/images/jpegxl-with-color-profile.html [ Skip ]
 fast/images/animated-jpegxl-loop-count.html [ Skip ]
 
-webkit.org/b/270330 fast/images/async-image-intersect-different-size-for-drawing.html [ Failure ]
-
 # Experimental H265 support.
 webrtc/h265.html [ Pass Failure ]
 

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -153,6 +153,7 @@ private:
         // ImageObserver API
         URL sourceUrl() const override { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).url() : URL(); }
         String mimeType() const override { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).mimeType() : emptyString(); }
+        unsigned numberOfClients() const override { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).numberOfClients() : 0; }
         long long expectedContentLength() const override { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).expectedContentLength() : 0; }
 
         void encodedDataStatusChanged(const Image&, EncodedDataStatus) final;

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -77,6 +77,7 @@ void BitmapImage::destroyDecodedData(bool destroyAll)
     } else {
         m_source->destroyDecodedData(0, frameCount());
         m_currentFrameDecodingStatus = DecodingStatus::Invalid;
+        m_lastDecodingOptions = { DecodingMode::Auto };
     }
 
     // There's no need to throw away the decoder unless we're explicitly asked
@@ -223,7 +224,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
         // it is currently being decoded. New data may have been received since the previous request was made.
         if ((!frameIsCompatible && !frameIsBeingDecoded) || m_currentFrameDecodingStatus == DecodingStatus::Invalid) {
             LOG(Images, "BitmapImage::%s - %p - url: %s [requesting large async decoding]", __FUNCTION__, this, sourceURL().string().utf8().data());
-            m_lastDecodingOptionsForTesting = { options.decodingMode(), sizeForDrawing };
+            m_lastDecodingOptions = { options.decodingMode(), sizeForDrawing };
             m_source->requestFrameAsyncDecodingAtIndex(m_currentFrame, m_currentSubsamplingLevel, sizeForDrawing);
             m_currentFrameDecodingStatus = DecodingStatus::Decoding;
         }
@@ -267,7 +268,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             }
             return ImageDrawResult::DidRequestDecoding;
         } else {
-            m_lastDecodingOptionsForTesting = { options.decodingMode(), sizeForDrawing };
+            m_lastDecodingOptions = { options.decodingMode(), sizeForDrawing };
             image = nativeImageAtIndexCacheIfNeeded(m_currentFrame, m_currentSubsamplingLevel, options.decodingMode());
             LOG(Images, "BitmapImage::%s - %p - url: %s [an image frame will be decoded synchronously]", __FUNCTION__, this, sourceURL().string().utf8().data());
         }
@@ -634,9 +635,9 @@ unsigned BitmapImage::decodeCountForTesting() const
     return m_decodeCountForTesting;
 }
 
-DecodingOptions BitmapImage::lastDecodingOptionsForTesting() const
+DecodingOptions BitmapImage::lastDecodingOptions() const
 {
-    return m_lastDecodingOptionsForTesting;
+    return m_lastDecodingOptions;
 }
 
 void BitmapImage::dump(TextStream& ts) const

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -107,7 +107,6 @@ public:
     DestinationColorSpace colorSpace() final;
 
     WEBCORE_EXPORT unsigned decodeCountForTesting() const;
-    WEBCORE_EXPORT DecodingOptions lastDecodingOptionsForTesting() const;
 
     WEBCORE_EXPORT RefPtr<NativeImage> nativeImage(const DestinationColorSpace& = DestinationColorSpace::SRGB()) override;
     RefPtr<NativeImage> nativeImageForCurrentFrame() override;
@@ -115,6 +114,7 @@ public:
 
     void imageFrameAvailableAtIndex(size_t);
     void decode(Function<void()>&&);
+    WEBCORE_EXPORT DecodingOptions lastDecodingOptions() const;
 
 private:
     WEBCORE_EXPORT BitmapImage(Ref<NativeImage>&&);
@@ -196,7 +196,7 @@ private:
 #endif
 
     unsigned m_decodeCountForTesting { 0 };
-    DecodingOptions m_lastDecodingOptionsForTesting;
+    DecodingOptions m_lastDecodingOptions { DecodingMode::Auto };
 
     RefPtr<NativeImage> m_cachedImage;
 };

--- a/Source/WebCore/platform/graphics/ImageObserver.h
+++ b/Source/WebCore/platform/graphics/ImageObserver.h
@@ -43,6 +43,7 @@ public:
 
     virtual URL sourceUrl() const = 0;
     virtual String mimeType() const = 0;
+    virtual unsigned numberOfClients() const { return 0; }
     virtual long long expectedContentLength() const = 0;
 
     virtual void encodedDataStatusChanged(const Image&, EncodedDataStatus) { };

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -327,8 +327,10 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
 
         // First tile paint.
         if (paintInfo.paintBehavior.contains(PaintBehavior::DefaultAsynchronousImageDecode)) {
-            // And the images has not been painted in this element yet.
-            if (element() && !element()->hasEverPaintedImages())
+            // No image has been painted in this element yet and it should not flicker with previous painting.
+            auto observer = bitmapImage->imageObserver();
+            bool mayOverlapOtherClients = observer && observer->numberOfClients() > 1 && bitmapImage->lastDecodingOptions().decodingMode() == DecodingMode::Asynchronous;
+            if (element() && !element()->hasEverPaintedImages() && !mayOverlapOtherClients)
                 return DecodingMode::Asynchronous;
         }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1181,7 +1181,7 @@ AtomString Internals::imageLastDecodingOptions(HTMLImageElement& element)
     if (!bitmapImage)
         return { };
 
-    auto options = bitmapImage->lastDecodingOptionsForTesting();
+    auto options = bitmapImage->lastDecodingOptions();
     StringBuilder builder;
     builder.append("{ decodingMode : ");
     builder.append(options.decodingMode() == DecodingMode::Asynchronous ? "Asynchronous" : "Synchronous");


### PR DESCRIPTION
#### 238ec677929193ee5fa48b504a09fdce55633145
<pre>
Avoid flickering when showing a layer on a painted background for the first time by disabling async image decoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=270330">https://bugs.webkit.org/show_bug.cgi?id=270330</a>
<a href="https://rdar.apple.com/117533495">rdar://117533495</a>

Reviewed by Simon Fraser;

If an image is decoded asynchronously for a sizeForDrawing different from the
current one, a flicker may happen.

To avoid this flicker, decode the image synchronously if it has more than one
RenderElement in the page and the last time it was decoded asynchronously.

* LayoutTests/TestExpectations:
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::destroyDecodedData):
(WebCore::BitmapImage::draw):
(WebCore::BitmapImage::lastDecodingOptions const):
(WebCore::BitmapImage::lastDecodingOptionsForTesting const): Deleted.
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/ImageObserver.h:
(WebCore::ImageObserver::numberOfClients const):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::imageLastDecodingOptions):

Canonical link: <a href="https://commits.webkit.org/276513@main">https://commits.webkit.org/276513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/603427581416aecb8126297b36f7b88c69e361dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21353 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21009 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17913 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39764 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2904 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49177 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16373 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21143 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9990 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->