### PR TITLE
Legacy EME WebKitMediaKeys createSessions unknown error

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7536,6 +7536,9 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     player->setPageIsVisible(!m_elementIsHidden, page ? page->sceneIdentifier() : ""_s);
     player->setVisibleInViewport(isVisibleInViewport());
     schedulePlaybackControlsManagerUpdate();
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)
+    updateShouldContinueAfterNeedKey();
+#endif
 
 #if ENABLE(WEB_AUDIO)
     if (m_audioSourceNode) {

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -639,6 +639,10 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
                 m_private->startVideoFrameMetadataGathering();
             if (m_processIdentity)
                 m_private->setResourceOwner(m_processIdentity);
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)
+            if (m_shouldContinueAfterKeyNeeded)
+                m_private->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
+#endif
             m_private->prepareForPlayback(m_privateBrowsing, m_preload, m_preservesPitch, m_shouldPrepareToRender);
         }
     }
@@ -764,7 +768,7 @@ void MediaPlayer::attemptToDecryptWithInstance(CDMInstance& instance)
 void MediaPlayer::setShouldContinueAfterKeyNeeded(bool should)
 {
     m_shouldContinueAfterKeyNeeded = should;
-    m_private->setShouldContinueAfterKeyNeeded(should);
+    m_private->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -98,6 +98,7 @@ public:
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RetainPtr<AVAssetResourceLoadingRequest> takeRequestForKeyURI(const String&);
+    void setShouldContinueAfterKeyNeeded(bool) final;
 #endif
 
     void playerItemStatusDidChange(int);
@@ -435,6 +436,7 @@ private:
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     WeakPtr<CDMSessionAVFoundationObjC> m_session;
+    bool m_shouldContinueAfterKeyNeeded { false };
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)


### PR DESCRIPTION
#### cac2e6433cf382126d1d9202d8e74180017df218
<pre>
Legacy EME WebKitMediaKeys createSessions unknown error
<a href="https://bugs.webkit.org/show_bug.cgi?id=262874">https://bugs.webkit.org/show_bug.cgi?id=262874</a>
<a href="https://rdar.apple.com/116689080">rdar://116689080</a>

Reviewed by Jer Noble.

If a media resource protected with the legacy EME API loads very quickly, the media player
in GPU process may try to generate a key request before the HTMLMediaElement in the web
process has signaled it is OK to continue after a key request. Have HTMLMediaElement
call player-&gt;setShouldContinueAfterKeyNeeded as soon as the media player is allocaged so
it will know before media data loading begins.

No new test added because the problem is extremely timing dependent and I was never able
to reproduce in a layout test.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::createMediaPlayer): Call updateShouldContinueAfterNeedKey.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::loadWithNextMediaEngine): Call shouldWaitForLoadingOfResource.
(WebCore::MediaPlayer::setShouldContinueAfterKeyNeeded):

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::MediaPlayerPrivateAVFoundationObjC): Add logging.
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource): Check
m_shouldContinueAfterKeyNeeded instead of calling up to the player.
(WebCore::MediaPlayerPrivateAVFoundationObjC::didCancelLoadingRequest): Add logging.
(WebCore::MediaPlayerPrivateAVFoundationObjC::didStopLoadingRequest): Ditto.
(WebCore::MediaPlayerPrivateAVFoundationObjC::setShouldContinueAfterKeyNeeded): Check
m_shouldContinueAfterKeyNeeded instead of calling up to the player.
(WebCore::MediaPlayerPrivateAVFoundationObjC::keyAdded): Add logging.

Canonical link: <a href="https://commits.webkit.org/275647@main">https://commits.webkit.org/275647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a9df075432c1f572f27c5d057663cef506c52bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44705 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18465 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34877 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15815 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15747 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unrelated-element.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html, imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-012.svg, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46166 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41547 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40116 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18553 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9483 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->