### PR TITLE
Simplify use of sendWithPromisedReplyOnDispatcher

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -145,7 +145,7 @@ private:
     void ensureWeakOnDispatcher(Function<void()>&&);
     template<typename T> Ref<typename T::Promise> sendWithPromisedReply(T&& message)
     {
-        return m_gpuProcessConnection.get()->connection().sendWithPromisedReplyOnDispatcher(std::forward<T>(message), queue(), m_remoteSourceBufferIdentifier);
+        return m_gpuProcessConnection.get()->connection().sendWithPromisedReply(std::forward<T>(message), m_remoteSourceBufferIdentifier);
     }
 
     friend class MessageReceiver;

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -680,7 +680,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnDispatcher)
         dispatchAndWait(runLoop, [&] {
             ASSERT_TRUE(openB());
             for (uint64_t i = 100u; i < 160u; ++i) {
-                b()->sendWithPromisedReplyOnDispatcher(MockTestMessageWithAsyncReply1 { }, awq.queue(), i)->whenSettled(awq.queue(), [&, j = i] (auto&& result) {
+                b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, i)->whenSettled(awq.queue(), [&, j = i] (auto&& result) {
                     EXPECT_TRUE(result);
                     auto value = *result;
                     if (!value)
@@ -719,7 +719,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnMixAndMatchDispatche
         dispatchAndWait(runLoop, [&] {
             ASSERT_TRUE(openB());
             for (uint64_t i = 100u; i < 160u; ++i) {
-                b()->sendWithPromisedReplyOnDispatcher(MockTestMessageWithAsyncReply1 { }, awq.queue(), i)->whenSettled(runLoop, [&, j = i] (auto&& result) {
+                b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, i)->whenSettled(runLoop, [&, j = i] (auto&& result) {
                     EXPECT_TRUE(result);
                     auto value = *result;
                     if (!value)


### PR DESCRIPTION
#### bb615544285886057ad79e074fefe6bbf68c2292
<pre>
Simplify use of sendWithPromisedReplyOnDispatcher
<a href="https://bugs.webkit.org/show_bug.cgi?id=270320">https://bugs.webkit.org/show_bug.cgi?id=270320</a>
<a href="https://rdar.apple.com/123857833">rdar://123857833</a>

Reviewed by Kimmo Kinnunen.

We can remove Connection::sendWithPromiseReplyOnDisPatcher and have Connection::sendWithPromisedReply perform the dispatching automatically.

Using NativePromiseProducer::settleWithFunction we can set the callback that will decode the IPC&apos;s message and pass it to its listener
on the thread the listener is asking to be called on.

We can remove the RefPtr&lt;RefCountedSerialFunctionDispatcher&gt; from the AsyncReplyWithDispatcher structure and move the
dispatching logic directly into the AsyncReplyHandler&apos;s CompletionHandler which will now receive a std::unique_ptr&lt;Decoder&gt; instead of a
raw pointer.

No change in observable behaviour, covered by existing tests.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::sendMessageWithAsyncReplyWithDispatcher):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::addAsyncReplyHandlerWithDispatcher):
(IPC::Connection::cancelAsyncReplyHandlers):
(IPC::CompletionHandler&lt;void):
(IPC::Connection::takeAsyncReplyHandlerWithDispatcher): Deleted.
(IPC::Connection::takeAsyncReplyHandlerWithDispatcherWithLockHeld): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithAsyncReplyOnDispatcher):
(IPC::Connection::sendWithPromisedReply):
(IPC::Connection::makeAsyncReplyHandlerWithDispatcher):
(IPC::Connection::AsyncReplyHandlerWithDispatcher::operator bool const): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/275764@main">https://commits.webkit.org/275764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b0b3a5d1bc179cf77f9c5f339a1456fc77e4325

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35297 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37764 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/701 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46760 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42013 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19082 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40632 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9540 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->