### PR TITLE
[Digital Identity]: navigator.identity should be implemented by a separate IdentityCredentialManager

### DIFF
--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS navigator.identity.get() default behavior checks.
+

--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>Digital Credential API: get() default behavior checks.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    promise_test(async (t) => {
+        await promise_rejects_dom(
+            t,
+            "NotSupportedError",
+            navigator.identity.get(),
+            "navigator.identity.get() with no argument."
+        );
+
+        await promise_rejects_dom(
+            t,
+            "NotSupportedError",
+            navigator.identity.get({}),
+            "navigator.identity.get() with empty dictionary."
+        );
+
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.identity.get({ digital: "wrong type" }),
+            "navigator.identity.get() with bogus digital type"
+        );
+
+        await promise_rejects_dom(
+            t,
+            "NotSupportedError",
+            navigator.identity.get({ bogus_key: "bogus" }),
+            "navigator.identity.get() with unknown key (same as passing empty dictionary)."
+        );
+
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.identity.get({ digital: { providers: [] } }),
+            "navigator.identity.get() with an empty list of providers"
+        );
+
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.identity.get({
+                digital: { providers: [{ protocol: "bogus protocol" }] },
+            }),
+            "navigator.identity.get() with a provider with unknown protocol"
+        );
+
+        const controller = new AbortController();
+        const options = { signal: controller.signal };
+
+        controller.abort();
+        await promise_rejects_dom(
+            t,
+            "AbortError",
+            navigator.identity.get(options),
+            "navigator.identity.get() with abort signal set"
+        );
+
+        assert_equals(
+            await navigator.identity.get({
+                digital: { providers: [{ protocol: "mdoc" }] },
+            }),
+            null,
+            "navigator.identity.get() with a valid provider"
+        );
+    }, "navigator.identity.get() default behavior checks.");
+</script>

--- a/LayoutTests/http/wpt/identity/identtycredentialscontainer-create-basics.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/identtycredentialscontainer-create-basics.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS create() checks.
+PASS Interaction with Web Authn API.
+

--- a/LayoutTests/http/wpt/identity/identtycredentialscontainer-create-basics.https.html
+++ b/LayoutTests/http/wpt/identity/identtycredentialscontainer-create-basics.https.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<title>Digital Credentials API: create() default behavior checks.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    promise_test(async (t) => {
+        await assert_equals(
+            await navigator.identity.create(),
+            null,
+            "No argument defaults be null."
+        );
+
+        await assert_equals(
+            await navigator.identity.create({}),
+            null,
+            "Empty dictionary defaults be null."
+        );
+
+        await assert_equals(
+            await navigator.identity.create({ identity: "bogus data" }),
+            null,
+            "The identity member is not part of CredentialCreationOptions, so defaults be null."
+        );
+
+        const controller = new AbortController();
+        controller.abort();
+        await promise_rejects_dom(
+            t,
+            "AbortError",
+            navigator.identity.create({ signal: controller.signal }),
+            "create() with abort signal set that was already aborted."
+        );
+    }, "create() checks.");
+
+    promise_test(async (t)=>{
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.identity.create({ publicKey: "bogus data" }),
+            "The Digital Credential API knows about public key."
+        );
+    }, "Interaction with Web Authn API.")
+</script>

--- a/LayoutTests/http/wpt/identity/identtycredentialscontainer-store-basics.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/identtycredentialscontainer-store-basics.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS navigator.credentials.store() basic behavior.
+

--- a/LayoutTests/http/wpt/identity/identtycredentialscontainer-store-basics.https.html
+++ b/LayoutTests/http/wpt/identity/identtycredentialscontainer-store-basics.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>Digital Credential API: store() basics.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    const testCreationMessageBase64 =
+        "AKMBZnBhY2tlZAJYxEbMf7lnnVWy25CS4cjZ5eHQK3WA8LSBLHcJYuHkj1rYQQAA" +
+        "AE74oBHzjApNFYAGFxEfntx9AEAoCK3O6P5OyXN6V/f+9nAga0NA2Cgp4V3mgSJ5" +
+        "jOHLMDrmxp/S0rbD+aihru1C0aAN3BkiM6GNy5nSlDVqOgTgpQECAyYgASFYIEFb" +
+        "he3RkNud6sgyraBGjlh1pzTlCZehQlL/b18HZ6WGIlggJgfUd/en9p5AIqMQbUni" +
+        "nEeXdFLkvW0/zV5BpEjjNxADo2NhbGcmY3NpZ1hHMEUCIQDKg+ZBmEBtf0lWq4Re" +
+        "dH4/i/LOYqOR4uR2NAj2zQmw9QIgbTXb4hvFbj4T27bv/rGrc+y+0puoYOBkBk9P" +
+        "mCewWlNjeDVjgVkCwjCCAr4wggGmoAMCAQICBHSG/cIwDQYJKoZIhvcNAQELBQAw" +
+        "LjEsMCoGA1UEAxMjWXViaWNvIFUyRiBSb290IENBIFNlcmlhbCA0NTcyMDA2MzEw" +
+        "IBcNMTQwODAxMDAwMDAwWhgPMjA1MDA5MDQwMDAwMDBaMG8xCzAJBgNVBAYTAlNF" +
+        "MRIwEAYDVQQKDAlZdWJpY28gQUIxIjAgBgNVBAsMGUF1dGhlbnRpY2F0b3IgQXR0" +
+        "ZXN0YXRpb24xKDAmBgNVBAMMH1l1YmljbyBVMkYgRUUgU2VyaWFsIDE5NTUwMDM4" +
+        "NDIwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASVXfOt9yR9MXXv/ZzE8xpOh466" +
+        "4YEJVmFQ+ziLLl9lJ79XQJqlgaUNCsUvGERcChNUihNTyKTlmnBOUjvATevto2ww" +
+        "ajAiBgkrBgEEAYLECgIEFTEuMy42LjEuNC4xLjQxNDgyLjEuMTATBgsrBgEEAYLl" +
+        "HAIBAQQEAwIFIDAhBgsrBgEEAYLlHAEBBAQSBBD4oBHzjApNFYAGFxEfntx9MAwG" +
+        "A1UdEwEB/wQCMAAwDQYJKoZIhvcNAQELBQADggEBADFcSIDmmlJ+OGaJvWn9Cqhv" +
+        "SeueToVFQVVvqtALOgCKHdwB+Wx29mg2GpHiMsgQp5xjB0ybbnpG6x212FxESJ+G" +
+        "inZD0ipchi7APwPlhIvjgH16zVX44a4e4hOsc6tLIOP71SaMsHuHgCcdH0vg5d2s" +
+        "c006WJe9TXO6fzV+ogjJnYpNKQLmCXoAXE3JBNwKGBIOCvfQDPyWmiiG5bGxYfPt" +
+        "y8Z3pnjX+1MDnM2hhr40ulMxlSNDnX/ZSnDyMGIbk8TOQmjTF02UO8auP8k3wt5D" +
+        "1rROIRU9+FCSX5WQYi68RuDrGMZB8P5+byoJqbKQdxn2LmE1oZAyohPAmLcoPO4=";
+
+    promise_test(async (t) => {
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: new Uint8Array(16),
+                    displayName: "Appleseed",
+                },
+                challenge: new Uint8Array(16),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            },
+        };
+
+        // A mock attestation object
+        internals.setMockWebAuthenticationConfiguration({
+            hid: {
+                stage: "request",
+                subStage: "msg",
+                error: "success",
+                payloadBase64: [testCreationMessageBase64],
+            },
+        });
+
+        const credential = await navigator.credentials.create(options);
+
+        await promise_rejects_dom(
+            t,
+            "NotSupportedError",
+            navigator.identity.store(credential),
+            "Trying to store a web authn credential is not supported."
+        );
+    }, "navigator.credentials.store() basic behavior.");
+</script>

--- a/LayoutTests/http/wpt/identity/idl.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/idl.https-expected.txt
@@ -1,0 +1,88 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface Navigator: original interface defined
+PASS Partial interface Navigator: member names are unique
+PASS Partial dictionary CredentialRequestOptions: original dictionary defined
+PASS Partial dictionary CredentialRequestOptions: member names are unique
+PASS Partial dictionary CredentialCreationOptions: original dictionary defined
+PASS Partial dictionary CredentialCreationOptions: member names are unique
+PASS Partial dictionary CredentialRequestOptions[2]: original dictionary defined
+PASS Partial dictionary CredentialRequestOptions[2]: member names are unique
+PASS Partial dictionary CredentialCreationOptions[2]: original dictionary defined
+PASS Partial dictionary CredentialCreationOptions[2]: member names are unique
+PASS Partial interface mixin NavigatorID: member names are unique
+PASS Partial interface Navigator[2]: original interface defined
+PASS Partial interface Navigator[2]: member names are unique
+PASS Partial dictionary CredentialRequestOptions[3]: original dictionary defined
+PASS Partial dictionary CredentialRequestOptions[3]: member names are unique
+PASS PasswordCredential includes CredentialUserData: member names are unique
+PASS FederatedCredential includes CredentialUserData: member names are unique
+PASS HTMLElement includes GlobalEventHandlers: member names are unique
+PASS HTMLElement includes DocumentAndElementEventHandlers: member names are unique
+PASS HTMLElement includes ElementContentEditable: member names are unique
+PASS HTMLElement includes HTMLOrSVGElement: member names are unique
+PASS Navigator includes NavigatorID: member names are unique
+PASS Navigator includes NavigatorLanguage: member names are unique
+PASS Navigator includes NavigatorOnLine: member names are unique
+PASS Navigator includes NavigatorContentUtils: member names are unique
+PASS Navigator includes NavigatorCookies: member names are unique
+PASS Navigator includes NavigatorPlugins: member names are unique
+PASS Navigator includes NavigatorConcurrentHardware: member names are unique
+PASS Credential interface: existence and properties of interface object
+PASS Credential interface object length
+PASS Credential interface object name
+PASS Credential interface: existence and properties of interface prototype object
+PASS Credential interface: existence and properties of interface prototype object's "constructor" property
+PASS Credential interface: existence and properties of interface prototype object's @@unscopables property
+PASS Credential interface: attribute id
+PASS Credential interface: attribute type
+PASS CredentialsContainer interface: existence and properties of interface object
+PASS CredentialsContainer interface object length
+PASS CredentialsContainer interface object name
+PASS CredentialsContainer interface: existence and properties of interface prototype object
+PASS CredentialsContainer interface: existence and properties of interface prototype object's "constructor" property
+PASS CredentialsContainer interface: existence and properties of interface prototype object's @@unscopables property
+PASS CredentialsContainer interface: operation get(optional CredentialRequestOptions)
+PASS CredentialsContainer interface: operation store(Credential)
+PASS CredentialsContainer interface: operation create(optional CredentialCreationOptions)
+PASS CredentialsContainer interface: operation preventSilentAccess()
+PASS CredentialsContainer must be primary interface of navigator.identity
+PASS Stringification of navigator.identity
+PASS CredentialsContainer interface: navigator.identity must inherit property "get(optional CredentialRequestOptions)" with the proper type
+PASS CredentialsContainer interface: calling get(optional CredentialRequestOptions) on navigator.identity with too few arguments must throw TypeError
+PASS CredentialsContainer interface: navigator.identity must inherit property "store(Credential)" with the proper type
+PASS CredentialsContainer interface: calling store(Credential) on navigator.identity with too few arguments must throw TypeError
+PASS CredentialsContainer interface: navigator.identity must inherit property "create(optional CredentialCreationOptions)" with the proper type
+PASS CredentialsContainer interface: calling create(optional CredentialCreationOptions) on navigator.identity with too few arguments must throw TypeError
+PASS CredentialsContainer interface: navigator.identity must inherit property "preventSilentAccess()" with the proper type
+FAIL PasswordCredential interface: existence and properties of interface object assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL PasswordCredential interface object length assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL PasswordCredential interface object name assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL PasswordCredential interface: existence and properties of interface prototype object assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL PasswordCredential interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL PasswordCredential interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL PasswordCredential interface: attribute password assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL PasswordCredential interface: attribute name assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL PasswordCredential interface: attribute iconURL assert_own_property: self does not have own property "PasswordCredential" expected property "PasswordCredential" missing
+FAIL FederatedCredential interface: existence and properties of interface object assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface object length assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface object name assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface: existence and properties of interface prototype object assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface: attribute provider assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface: attribute protocol assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface: attribute name assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+FAIL FederatedCredential interface: attribute iconURL assert_own_property: self does not have own property "FederatedCredential" expected property "FederatedCredential" missing
+PASS Navigator interface: attribute credentials
+PASS Navigator interface: attribute identity
+PASS DigitalCredential interface: existence and properties of interface object
+PASS DigitalCredential interface object length
+PASS DigitalCredential interface object name
+PASS DigitalCredential interface: existence and properties of interface prototype object
+PASS DigitalCredential interface: existence and properties of interface prototype object's "constructor" property
+PASS DigitalCredential interface: existence and properties of interface prototype object's @@unscopables property
+FAIL DigitalCredential interface: attribute protocol assert_true: The prototype object must have a property "protocol" expected true got false
+PASS DigitalCredential interface: attribute data
+

--- a/LayoutTests/http/wpt/identity/idl.https.html
+++ b/LayoutTests/http/wpt/identity/idl.https.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+<script type="text/plain" id="tested">
+partial interface Navigator {
+    [SecureContext, SameObject] readonly attribute CredentialsContainer identity;
+};
+
+partial dictionary CredentialRequestOptions {
+    DigitalCredentialRequestOptions digital;
+};
+
+dictionary DigitalCredentialRequestOptions {
+    sequence<IdentityRequestProvider> providers;
+};
+
+dictionary IdentityRequestProvider {
+    required DOMString protocol;
+    required DOMString request;
+};
+
+[Exposed=Window, SecureContext]
+interface DigitalCredential : Credential {
+    readonly attribute DOMString protocol;
+    readonly attribute DOMString data;
+};
+</script>
+<script>
+    "use strict";
+    idl_test(
+        ['credential-management'],
+        ['dom', 'html', 'url'],
+        idl_array => {
+            idl_array.add_idls(document.querySelector('#tested').textContent);
+            idl_array.add_untested_idls("interface Element {};");
+            idl_array.add_objects({
+                CredentialsContainer: ['navigator.identity']
+            });
+        }
+    );
+</script>

--- a/LayoutTests/http/wpt/identity/setDigitalCredentialsEnable.https.html
+++ b/LayoutTests/http/wpt/identity/setDigitalCredentialsEnable.https.html
@@ -2,36 +2,57 @@
 <html>
     <head>
         <title>
-            Check that parts of the Digital Credentials API are not exposed by
-            setting
+            Check that parts of the Digital Credentials API exposure
+            is controlled via preference.
         </title>
     </head>
     <script>
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
 
-        if (window.navigator.identity !== undefined) {
-            console.log("FAIL: identity must not be exposed by default.");
+        async function runTest() {
+            const iframe = document.querySelector("iframe");
+            try {
+                await checkWindowObject();
+
+                window.internals.settings.setDigitalCredentialsEnabled(false);
+
+                await new Promise((r) => {
+                    iframe.onload = r;
+                    iframe.src = "about:blank";
+                });
+
+                await checkIFrame(iframe);
+            } catch (err) {
+                console.log(err);
+            } finally {
+                testRunner.notifyDone();
+            }
+
+            console.log("Test finished");
         }
 
-        if (window.DigitalCredential !== undefined) {
-            console.log(
-                "FAIL: DigitalCredential interface must not be exposed by default."
-            );
-        }
+        async function checkIFrame(iframe) {
+            const iframeWindow = iframe.contentWindow;
+            if ("identity" in iframeWindow.navigator) {
+                console.log("FAIL: identity disabled by preference.");
+            }
 
-        // We check that the "digital" is not web exposed by checking if the
-        // navigator.credentials.get() method rejects with an AbortError.
-        const abortController = new AbortController();
-        abortController.abort();
-        const digitalTypeCheckPromise = navigator.credentials.get({
-            digital: "", // expects a dictionary
-            signal: abortController.signal,
-        });
+            if ("DigitalCredential" in iframeWindow) {
+                console.log(
+                    "FAIL: DigitalCredential interface disabled by preference."
+                );
+            }
 
-        window.internals.settings.setDigitalCredentialsEnabled(true);
-
-        async function checkIFrame() {
+            // We check that the "digital" is not web exposed by checking if the
+            // navigator.credentials.get() method rejects with an AbortError.
+            const abortController = new AbortController();
+            abortController.abort();
+            const digitalTypeCheckPromise =
+                iframeWindow.navigator.credentials.get({
+                    digital: "", // expects a dictionary
+                    signal: abortController.signal,
+                });
             try {
                 await digitalTypeCheckPromise;
             } catch (err) {
@@ -41,19 +62,35 @@
                     );
                 }
             }
+        }
 
-            const iframeWin = document.querySelector("iframe").contentWindow;
-
-            if (iframeWin.navigator.credentials.requestIdentity) {
+        async function checkWindowObject() {
+            if (window.navigator.credentials.requestIdentity) {
                 console.log(
                     "FAIL: navigator.credentials.requestIdentity() was removed from the spec!"
                 );
             }
 
-            const { identity } = iframeWin.navigator;
+            const { identity } = window.navigator;
             if (!identity) {
                 console.log(
                     "FAIL: navigator.identity must be exposed. Was enabled by pref."
+                );
+            }
+
+            const isInstanceOfCredentialContainer =
+                identity instanceof window.CredentialsContainer;
+            if (!isInstanceOfCredentialContainer) {
+                console.log(
+                    "FAIL: navigator.identity must be and instance of CredentialsContainer."
+                );
+            }
+
+            const isInstanceOfDigitalCredential =
+                window.DigitalCredential.prototype instanceof window.Credential;
+            if (!isInstanceOfDigitalCredential) {
+                console.log(
+                    "FAIL: DigitalCredential's prototype interface must be an instance of Credential."
                 );
             }
 
@@ -66,31 +103,9 @@
                     );
                 }
             }
-
-            const isInstanceOfCredentialContainer =
-                identity instanceof iframeWin.CredentialsContainer;
-            if (!isInstanceOfCredentialContainer) {
-                console.log(
-                    "FAIL: navigator.identity must be and instance of CredentialsContainer."
-                );
-            }
-
-            const isInstanceOfDigitalCredential =
-                iframeWin.DigitalCredential.prototype instanceof
-                iframeWin.Credential;
-            if (!isInstanceOfDigitalCredential) {
-                console.log(
-                    "FAIL: DigitalCredential's prototype interface must be an instance of Credential."
-                );
-            }
-
-            console.log("Test finished");
         }
     </script>
-    <body>
-        <iframe
-            src="about:blank"
-            onload="checkIFrame().catch(console.error).finally(() => testRunner.notifyDone())"
-        ></iframe>
+    <body onload="runTest()">
+        <iframe></iframe>
     </body>
 </html>

--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -11,6 +11,7 @@ navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
 navigator.hardwareConcurrency is OK
+navigator.identity is OK
 navigator.isLoggedIn() is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -53,6 +54,7 @@ navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
 navigator.hardwareConcurrency is OK
+navigator.identity is OK
 navigator.isLoggedIn() is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2382,7 +2382,7 @@ DiagnosticLoggingEnabled:
 
 DigitalCredentialsEnabled:
   type: bool
-  status: unstable
+  status: testable
   category: dom
   humanReadableName: "Digital Credentials API"
   humanReadableDescription: "Enable the experimental Digital Credentials API"

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
@@ -42,7 +42,7 @@ struct CredentialRequestOptions {
     MediationRequirement mediation;
     RefPtr<AbortSignal> signal;
     std::optional<PublicKeyCredentialRequestOptions> publicKey;
-    DigitalCredentialRequestOptions digital;
+    std::optional<DigitalCredentialRequestOptions> digital;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -39,31 +39,38 @@ enum class Scope;
 
 namespace WebCore {
 
-class DigitalCredential;
 class Document;
 class WeakPtrImplWithEventTargetData;
 struct CredentialCreationOptions;
 struct CredentialRequestOptions;
-struct DigitalCredentialRequestOptions;
 
 class CredentialsContainer : public RefCounted<CredentialsContainer> {
 public:
-    static Ref<CredentialsContainer> create(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document) { return adoptRef(*new CredentialsContainer(WTFMove(document))); }
+    static Ref<CredentialsContainer> create(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
+    {
+        return adoptRef(*new CredentialsContainer(WTFMove(document)));
+    }
 
-    void get(CredentialRequestOptions&&, CredentialPromise&&);
+    virtual void get(CredentialRequestOptions&&, CredentialPromise&&);
 
     void store(const BasicCredential&, CredentialPromise&&);
 
-    void isCreate(CredentialCreationOptions&&, CredentialPromise&&);
+    virtual void isCreate(CredentialCreationOptions&&, CredentialPromise&&);
 
     void preventSilentAccess(DOMPromiseDeferred<void>&&) const;
 
-private:
     CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);
 
+    virtual ~CredentialsContainer() = default;
+
+private:
     ScopeAndCrossOriginParent scopeAndCrossOriginParent() const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+
+protected:
+    template<typename Options>
+    bool performCommonChecks(const Options&, CredentialPromise&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
@@ -29,6 +29,7 @@
     EnabledBySetting=WebAuthenticationEnabled,
     Exposed=Window,
     SecureContext,
+    SkipVTableValidation,
 ] interface CredentialsContainer {
     Promise<BasicCredential?> get(optional CredentialRequestOptions options);
     Promise<BasicCredential> store(BasicCredential credential);

--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IdentityCredentialsContainer.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "CredentialCreationOptions.h"
+#include "CredentialRequestOptions.h"
+#include "DigitalCredential.h"
+#include "DigitalCredentialRequestOptions.h"
+#include "Document.h"
+#include "ExceptionOr.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSDigitalCredential.h"
+
+namespace WebCore {
+IdentityCredentialsContainer::IdentityCredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
+    : CredentialsContainer(WTFMove(document))
+{
+}
+
+void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, CredentialPromise&& promise)
+{
+    if (!performCommonChecks(std::forward<CredentialRequestOptions>(options), promise))
+        return;
+
+    if (!options.digital) {
+        promise.reject(Exception { ExceptionCode::NotSupportedError, "Only digital member is supported."_s });
+        return;
+    }
+
+    if (options.digital->providers.isEmpty()) {
+        promise.reject(Exception { ExceptionCode::TypeError, "At least one provider must be specified."_s });
+        return;
+    }
+
+    // FIXME: Implement the actual get logic.
+
+    // Default as per Cred Man spec is to resolve with null.
+    // https://www.w3.org/TR/credential-management-1/#algorithm-discover-creds
+    promise.resolve(nullptr);
+}
+
+void IdentityCredentialsContainer::isCreate(CredentialCreationOptions&& options, CredentialPromise&& promise)
+{
+    if (!performCommonChecks(std::forward<CredentialCreationOptions>(options), promise))
+        return;
+
+    // Default as per Cred Man spec is to resolve with null.
+    // https://www.w3.org/TR/credential-management-1/#algorithm-create-cred
+    promise.resolve(nullptr);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.h
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUTHN)
+
+#include "CredentialsContainer.h"
+#include "DigitalCredential.h"
+#include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class DigitalCredential;
+class Document;
+class WeakPtrImplWithEventTargetData;
+struct CredentialCreationOptions;
+struct CredentialRequestOptions;
+struct DigitalCredentialRequestOptions;
+
+class IdentityCredentialsContainer final : public CredentialsContainer {
+public:
+    static Ref<IdentityCredentialsContainer> create(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
+    {
+        return adoptRef(*new IdentityCredentialsContainer(WTFMove(document)));
+    }
+
+    void get(CredentialRequestOptions&&, CredentialPromise&&) override;
+
+    void isCreate(CredentialCreationOptions&&, CredentialPromise&&) override;
+
+private:
+    explicit IdentityCredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/identity/NavigatorIdentity.cpp
+++ b/Source/WebCore/Modules/identity/NavigatorIdentity.cpp
@@ -46,7 +46,7 @@ ASCIILiteral NavigatorIdentity::supplementName()
 CredentialsContainer* NavigatorIdentity::identity(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
 {
     if (!m_credentialsContainer)
-        m_credentialsContainer = CredentialsContainer::create(WTFMove(document));
+        m_credentialsContainer = IdentityCredentialsContainer::create(WTFMove(document));
 
     return m_credentialsContainer.get();
 }

--- a/Source/WebCore/Modules/identity/NavigatorIdentity.h
+++ b/Source/WebCore/Modules/identity/NavigatorIdentity.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "CredentialsContainer.h"
+#include "IdentityCredentialsContainer.h"
 #include "Supplementable.h"
 #include <wtf/WeakPtr.h>
 
@@ -50,7 +51,7 @@ private:
     static NavigatorIdentity* from(Navigator*);
     static ASCIILiteral supplementName();
 
-    RefPtr<CredentialsContainer> m_credentialsContainer;
+    RefPtr<IdentityCredentialsContainer> m_credentialsContainer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -147,6 +147,7 @@ Modules/highlight/AppHighlightStorage.cpp
 Modules/highlight/HighlightRegistry.cpp
 Modules/highlight/Highlight.cpp
 Modules/identity/DigitalCredential.cpp
+Modules/identity/IdentityCredentialsContainer.cpp
 Modules/identity/NavigatorIdentity.cpp
 Modules/indexeddb/IDBCursor.cpp
 Modules/indexeddb/IDBCursorWithValue.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -270,6 +270,7 @@ namespace WebCore {
     macro(IDBTransaction) \
     macro(IDBVersionChangeEvent) \
     macro(IIRFilterNode) \
+    macro(IdentityCredentialsContainer) \
     macro(ImageBitmap) \
     macro(ImageBitmapRenderingContext) \
     macro(ImageCapture) \

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -120,6 +120,7 @@ const TestFeatures& TestOptions::defaults()
             { "CSSOMViewSmoothScrollingEnabled", false },
             { "ContactPickerAPIEnabled", false },
             { "CoreMathMLEnabled", false },
+            { "DigitalCredentialsEnabled", false },
             { "GenericCueAPIEnabled", false },
             { "IsLoggedInAPIEnabled", false },
             { "LazyIframeLoadingEnabled", false },


### PR DESCRIPTION
#### 2dbfef33bb52c31bed14b8fadf209338031552a5
<pre>
[Digital Identity]: navigator.identity should be implemented by a separate IdentityCredentialManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=269165">https://bugs.webkit.org/show_bug.cgi?id=269165</a>
<a href="https://rdar.apple.com/123184696">rdar://123184696</a>

Reviewed by Andy Estes.

Implements IdentityCredentialsContainer on top of CredentialsContainer by
virtualizing some of the methods of CredentialsContainer.

For IdentityCredentialsContainer, we implement the logic for:

 * navigator.identity.get()
 * navigator.identity.create() - Default to just return null.

And we defer the logic for the following to CredentialsContainer:
 * navigator.identity.store() - which just rejects with a NotSupportedError.

Adds performCommonChecks() to CredentialsContainer to DRY up the code,
and so that we can use it in IdentityCredentialsContainer.

And the DigitalCredentialsEnable preference is now set to &quot;testable&quot;.

* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html: Added.
* LayoutTests/http/wpt/identity/identtycredentialscontainer-create-basics.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/identtycredentialscontainer-create-basics.https.html: Added.
* LayoutTests/http/wpt/identity/identtycredentialscontainer-store-basics.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/identtycredentialscontainer-store-basics.https.html: Added.
* LayoutTests/http/wpt/identity/idl.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/idl.https.html: Added.
* LayoutTests/http/wpt/identity/setDigitalCredentialsEnable.https.html:
* LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::get):
(WebCore::CredentialsContainer::isCreate):
(WebCore::CredentialsContainer::performCommonChecks):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
(WebCore::CredentialsContainer::create):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl:
* Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp: Added.
(WebCore::IdentityCredentialsContainer::IdentityCredentialsContainer):
(WebCore::IdentityCredentialsContainer::get):
(WebCore::IdentityCredentialsContainer::isCreate):
* Source/WebCore/Modules/identity/IdentityCredentialsContainer.h: Copied from Source/WebCore/Modules/identity/NavigatorIdentity.h.
* Source/WebCore/Modules/identity/NavigatorIdentity.cpp:
(WebCore::NavigatorIdentity::identity):
* Source/WebCore/Modules/identity/NavigatorIdentity.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):

Canonical link: <a href="https://commits.webkit.org/275939@main">https://commits.webkit.org/275939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/617b23372d15129e7c4112b66a36c1161b0bd207

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39340 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35736 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38308 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1269 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/36673 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47392 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42840 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42528 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41186 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9640 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19844 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49850 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19298 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10069 "Passed tests") | 
<!--EWS-Status-Bubble-End-->