### PR TITLE
[WPE] WPE Platform: add API to get/set the primary display

### DIFF
--- a/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
@@ -41,8 +41,7 @@ PlatformDisplayID ScreenManager::generatePlatformDisplayID(WPEMonitor* monitor)
 
 ScreenManager::ScreenManager()
 {
-    // FIXME: default might not be the right display.
-    auto* display = wpe_display_get_default();
+    auto* display = wpe_display_get_primary();
     auto monitorsCount = wpe_display_get_n_monitors(display);
     for (unsigned i = 0; i < monitorsCount; ++i) {
         if (auto* monitor = wpe_display_get_monitor(display, i))
@@ -64,8 +63,7 @@ ScreenManager::ScreenManager()
 void ScreenManager::updatePrimaryDisplayID()
 {
     // Assume the first monitor is the primary one.
-    // FIXME: default might not be the right display.
-    auto* display = wpe_display_get_default();
+    auto* display = wpe_display_get_primary();
     auto monitorsCount = wpe_display_get_n_monitors(display);
     auto* monitor = monitorsCount ? wpe_display_get_monitor(display, 0) : nullptr;
     m_primaryDisplayID = monitor ? displayID(monitor) : 0;

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -78,6 +78,8 @@ typedef enum {
 
 WPE_API GQuark       wpe_display_error_quark                   (void);
 WPE_API WPEDisplay  *wpe_display_get_default                   (void);
+WPE_API WPEDisplay  *wpe_display_get_primary                   (void);
+WPE_API void         wpe_display_set_primary                   (WPEDisplay *display);
 WPE_API gboolean     wpe_display_connect                       (WPEDisplay *display,
                                                                 GError    **error);
 WPE_API gpointer     wpe_display_get_egl_display               (WPEDisplay *display,


### PR DESCRIPTION
#### a997251a7158008b2d0d9698567f77912e114948
<pre>
[WPE] WPE Platform: add API to get/set the primary display
<a href="https://bugs.webkit.org/show_bug.cgi?id=270336">https://bugs.webkit.org/show_bug.cgi?id=270336</a>

Reviewed by Alejandro G. Castro.

We are currently using the default display for the screen manager, which
is wrong for apps not using the default display and explicitly creating
one. In most of the cases there&apos;s only one display, and in most of the
cases where there&apos;s more than one, the first one created is the primary
one. So, we can add API to get the primary display that is set
automatically for the first created display, but still allow to set any
other display as primary.

* Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp:
(WebKit::ScreenManager::ScreenManager):
(WebKit::ScreenManager::updatePrimaryDisplayID):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpe_display_class_init):
(wpe_display_get_primary):
(wpe_display_set_primary):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:

Canonical link: <a href="https://commits.webkit.org/275544@main">https://commits.webkit.org/275544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4cf382705c05cac6fa1abf1237617d9a4b1c274

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44729 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18489 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15831 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46168 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41549 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13942 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40115 "Found 1 new API test failure: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18636 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5668 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->