### PR TITLE
WebCore::AutoscrollType should be an enum class

### DIFF
--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -39,13 +39,13 @@ class PlatformMouseEvent;
 class RenderBox;
 class RenderObject;
 
-enum AutoscrollType {
-    NoAutoscroll,
-    AutoscrollForDragAndDrop,
-    AutoscrollForSelection,
+enum class AutoscrollType : uint8_t {
+    None,
+    DragAndDrop,
+    Selection,
 #if ENABLE(PAN_SCROLLING)
-    AutoscrollForPanCanStop,
-    AutoscrollForPan,
+    PanCanStop,
+    Pan,
 #endif
 };
 
@@ -78,7 +78,7 @@ private:
 
     Timer m_autoscrollTimer;
     SingleThreadWeakPtr<RenderBox> m_autoscrollRenderer;
-    AutoscrollType m_autoscrollType { NoAutoscroll };
+    AutoscrollType m_autoscrollType { AutoscrollType::None };
     IntPoint m_dragAndDropAutoscrollReferencePosition;
     WallTime m_dragAndDropAutoscrollStartTime;
 #if ENABLE(PAN_SCROLLING)


### PR DESCRIPTION
#### c26d0af2b563850ca7d0cc8138c19a95a0b258b9
<pre>
WebCore::AutoscrollType should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=270337">https://bugs.webkit.org/show_bug.cgi?id=270337</a>
<a href="https://rdar.apple.com/123890042">rdar://123890042</a>

Reviewed by Aditya Keerthi.

This is a mechanical patch converting WebCore::AutoscrollType to an enum
class. We also take the liberty to rename individual cases now that they
will always be prefixed with AutoscrollType::.

* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::autoscrollInProgress const):
(WebCore::AutoscrollController::startAutoscrollForSelection):
(WebCore::AutoscrollController::stopAutoscrollTimer):
(WebCore::AutoscrollController::updateDragAndDrop):
(WebCore::AutoscrollController::didPanScrollStart):
(WebCore::AutoscrollController::didPanScrollStop):
(WebCore::AutoscrollController::handleMouseReleaseEvent):
(WebCore::AutoscrollController::panScrollInProgress const):
(WebCore::AutoscrollController::startPanScrolling):
(WebCore::AutoscrollController::autoscrollTimerFired):
(WebCore::AutoscrollController::updatePanScrollState):
* Source/WebCore/page/AutoscrollController.h:

Canonical link: <a href="https://commits.webkit.org/275566@main">https://commits.webkit.org/275566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c4780d7ae89edc6e18294ddb0ab0abd72a2ded0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38257 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34895 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41550 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40114 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18576 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9448 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->