### PR TITLE
[LBSE] Only clipPath should be an opportunistic stacking context

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
@@ -45,15 +45,6 @@ void RenderSVGHiddenContainer::layout()
     clearNeedsLayout();    
 }
 
-void RenderSVGHiddenContainer::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
-{
-    RenderSVGContainer::styleDidChange(diff, oldStyle);
-
-    // Ensure that descendants with layers are rooted within our layer.
-    if (hasLayer())
-        layer()->setIsOpportunisticStackingContext(true);
-}
-
 }
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
@@ -37,8 +37,6 @@ public:
 protected:
     void layout() override;
 
-    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
-
 private:
     ASCIILiteral renderName() const override { return "RenderSVGHiddenContainer"_s; }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -250,6 +250,15 @@ bool RenderSVGResourceClipper::needsHasSVGTransformFlags() const
     return protectedClipPathElement()->hasTransformRelatedAttributes();
 }
 
+void RenderSVGResourceClipper::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
+{
+    RenderSVGHiddenContainer::styleDidChange(diff, oldStyle);
+
+    // Ensure that descendants with layers are rooted within our layer.
+    if (hasLayer())
+        layer()->setIsOpportunisticStackingContext(true);
+}
+
 }
 
 #endif // ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -60,6 +60,8 @@ private:
     void updateFromStyle() final;
 
     ASCIILiteral renderName() const final { return "RenderSVGResourceClipper"_s; }
+
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
 };
 
 }


### PR DESCRIPTION
#### 1ad9a7beb555644c0b5f949b8f635e305018ab4a
<pre>
[LBSE] Only clipPath should be an opportunistic stacking context
<a href="https://bugs.webkit.org/show_bug.cgi?id=270338">https://bugs.webkit.org/show_bug.cgi?id=270338</a>

Reviewed by Nikolas Zimmermann.

Only clipPath should be an opportunistic stacking context, other
SVG resources are stacking contexts according to CSS or do not
need to be one (for example gradients).

* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp:
(WebCore::RenderSVGHiddenContainer::styleDidChange): Deleted.
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:

Canonical link: <a href="https://commits.webkit.org/276449@main">https://commits.webkit.org/276449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7f6acc0cda53349076aa93b50ecdf48591edde2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47242 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21059 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36687 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 133 flakes 179 failures 1 missing results; Uploaded test results (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17736 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18199 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results (exception)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39527 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2633 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48873 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43604 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20875 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42361 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9961 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->