### PR TITLE
[WPE] WPE Platform: Opaque region support

### DIFF
--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -21,6 +21,7 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEVersion.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEEnumTypes.cpp
@@ -40,6 +41,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeysyms.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wpe-platform.h
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEConfig.h

--- a/Source/WebKit/WPEPlatform/wpe/WPERectangle.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPERectangle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,31 +22,34 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#include "config.h"
+#include "WPERectangle.h"
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormat.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#include <wtf/FastMalloc.h>
 
-#undef __WPE_PLATFORM_H_INSIDE__
+/**
+ * WPERectangle:
+ * @x: The X coordinate of the top-left corner of the rectangle.
+ * @y: The Y coordinate of the top-left corner of the rectangle.
+ * @width: The width of the rectangle.
+ * @height: The height of the rectangle.
+ *
+ * Boxed type representing a rectangle with integer coordinates.
+ */
 
-#endif /* __WPE_PLATFORM_H__ */
+static WPERectangle* wpe_rectangle_copy(WPERectangle* rectangle)
+{
+    g_return_val_if_fail(rectangle, nullptr);
+
+    return static_cast<WPERectangle*>(fastMemDup(rectangle, sizeof(WPERectangle)));
+}
+
+static void wpe_rectangle_free(WPERectangle* rectangle)
+{
+    g_return_if_fail(rectangle);
+
+    fastFree(rectangle);
+}
+
+G_DEFINE_BOXED_TYPE(WPERectangle, wpe_rectangle, wpe_rectangle_copy, wpe_rectangle_free)

--- a/Source/WebKit/WPEPlatform/wpe/WPERectangle.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPERectangle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,31 +22,31 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#ifndef WPERectangle_h
+#define WPERectangle_h
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormat.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEConfig.h>
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
 #include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
 
-#undef __WPE_PLATFORM_H_INSIDE__
+G_BEGIN_DECLS
 
-#endif /* __WPE_PLATFORM_H__ */
+struct _WPERectangle {
+    int x;
+    int y;
+    int width;
+    int height;
+};
+typedef struct _WPERectangle WPERectangle;
+
+#define WPE_TYPE_RECTANGLE (wpe_rectangle_get_type())
+
+WPE_API GType wpe_rectangle_get_type (void);
+
+G_END_DECLS
+
+#endif /* WPERectangle_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -835,3 +835,23 @@ GList* wpe_view_get_preferred_dma_buf_formats(WPEView* view)
 
     return wpe_display_get_preferred_dma_buf_formats(view->priv->display.get());
 }
+
+/**
+ * wpe_view_set_opaque_rectangles:
+ * @view: a #WPEView
+ * @rects: (nullable) (array length=n_rects): opaque rectangles in view-local coordinates
+ * @n_rects: the total number of elements in @rects
+ *
+ * Set the rectangles of @view that contain opaque content.
+ * This is an optimization hint that is automatically set by WebKit when the
+ * web view background color is opaque.
+ */
+void wpe_view_set_opaque_rectangles(WPEView* view, WPERectangle* rects, guint rectsCount)
+{
+    g_return_if_fail(WPE_IS_VIEW(view));
+    g_return_if_fail(!rects || rectsCount > 0);
+
+    auto* viewClass = WPE_VIEW_GET_CLASS(view);
+    if (viewClass->set_opaque_rectangles)
+        viewClass->set_opaque_rectangles(view, rects, rectsCount);
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -42,29 +42,33 @@ typedef struct _WPEBuffer WPEBuffer;
 typedef struct _WPEDisplay WPEDisplay;
 typedef struct _WPEEvent WPEEvent;
 typedef struct _WPEMonitor WPEMonitor;
+typedef struct _WPERectangle WPERectangle;
 
 struct _WPEViewClass
 {
     GObjectClass parent_class;
 
-    gboolean    (* render_buffer)                 (WPEView    *view,
-                                                   WPEBuffer  *buffer,
-                                                   GError    **error);
-    WPEMonitor *(* get_monitor)                   (WPEView    *view);
-    gboolean    (* set_fullscreen)                (WPEView    *view,
-                                                   gboolean    fullscreen);
-    gboolean    (* set_maximized)                 (WPEView    *view,
-                                                   gboolean    maximized);
-    GList      *(* get_preferred_dma_buf_formats) (WPEView    *view);
-    void        (* set_cursor_from_name)          (WPEView    *view,
-                                                   const char *name);
-    void        (* set_cursor_from_bytes)         (WPEView    *view,
-                                                   GBytes     *bytes,
-                                                   guint       width,
-                                                   guint       height,
-                                                   guint       stride,
-                                                   guint       hotspot_x,
-                                                   guint       hotspot_y);
+    gboolean    (* render_buffer)                 (WPEView      *view,
+                                                   WPEBuffer    *buffer,
+                                                   GError      **error);
+    WPEMonitor *(* get_monitor)                   (WPEView      *view);
+    gboolean    (* set_fullscreen)                (WPEView      *view,
+                                                   gboolean      fullscreen);
+    gboolean    (* set_maximized)                 (WPEView      *view,
+                                                   gboolean      maximized);
+    GList      *(* get_preferred_dma_buf_formats) (WPEView      *view);
+    void        (* set_cursor_from_name)          (WPEView      *view,
+                                                   const char   *name);
+    void        (* set_cursor_from_bytes)         (WPEView      *view,
+                                                   GBytes       *bytes,
+                                                   guint         width,
+                                                   guint         height,
+                                                   guint         stride,
+                                                   guint         hotspot_x,
+                                                   guint         hotspot_y);
+    void        (* set_opaque_rectangles)         (WPEView      *view,
+                                                   WPERectangle *rects,
+                                                   guint         n_rects);
 
     gpointer padding[32];
 };
@@ -97,52 +101,55 @@ typedef enum {
 
 WPE_API GQuark       wpe_view_error_quark                   (void);
 
-WPE_API WPEView     *wpe_view_new                           (WPEDisplay  *display);
-WPE_API WPEDisplay  *wpe_view_get_display                   (WPEView     *view);
-WPE_API int          wpe_view_get_width                     (WPEView     *view);
-WPE_API int          wpe_view_get_height                    (WPEView     *view);
-WPE_API void         wpe_view_set_width                     (WPEView     *view,
-                                                             int          width);
-WPE_API void         wpe_view_set_height                    (WPEView     *view,
-                                                             int          height);
-WPE_API void         wpe_view_resize                        (WPEView     *view,
-                                                             int          width,
-                                                             int          height);
-WPE_API gdouble      wpe_view_get_scale                     (WPEView     *view);
-WPE_API void         wpe_view_set_scale                     (WPEView     *view,
-                                                             gdouble      scale);
-WPE_API void         wpe_view_set_cursor_from_name          (WPEView     *view,
-                                                             const char  *name);
-WPE_API void         wpe_view_set_cursor_from_bytes         (WPEView     *view,
-                                                             GBytes      *bytes,
-                                                             guint        width,
-                                                             guint        height,
-                                                             guint        stride,
-                                                             guint        hotspot_x,
-                                                             guint        hotspot_y);
-WPE_API WPEViewState wpe_view_get_state                     (WPEView     *view);
-WPE_API void         wpe_view_set_state                     (WPEView     *view,
-                                                             WPEViewState state);
-WPE_API WPEMonitor  *wpe_view_get_monitor                   (WPEView     *view);
-WPE_API gboolean     wpe_view_fullscreen                    (WPEView     *view);
-WPE_API gboolean     wpe_view_unfullscreen                  (WPEView     *view);
-WPE_API gboolean     wpe_view_maximize                      (WPEView     *view);
-WPE_API gboolean     wpe_view_unmaximize                    (WPEView     *view);
-WPE_API gboolean     wpe_view_render_buffer                 (WPEView     *view,
-                                                             WPEBuffer   *buffer,
-                                                             GError     **error);
-WPE_API void         wpe_view_buffer_rendered               (WPEView     *view,
-                                                             WPEBuffer   *buffer);
-WPE_API void         wpe_view_event                         (WPEView     *view,
-                                                             WPEEvent    *event);
-WPE_API guint        wpe_view_compute_press_count           (WPEView     *view,
-                                                             gdouble      x,
-                                                             gdouble      y,
-                                                             guint        button,
-                                                             guint32      time);
-WPE_API void         wpe_view_focus_in                      (WPEView     *view);
-WPE_API void         wpe_view_focus_out                     (WPEView     *view);
-WPE_API GList       *wpe_view_get_preferred_dma_buf_formats (WPEView     *view);
+WPE_API WPEView     *wpe_view_new                           (WPEDisplay   *display);
+WPE_API WPEDisplay  *wpe_view_get_display                   (WPEView      *view);
+WPE_API int          wpe_view_get_width                     (WPEView      *view);
+WPE_API int          wpe_view_get_height                    (WPEView      *view);
+WPE_API void         wpe_view_set_width                     (WPEView      *view,
+                                                             int           width);
+WPE_API void         wpe_view_set_height                    (WPEView      *view,
+                                                             int           height);
+WPE_API void         wpe_view_resize                        (WPEView      *view,
+                                                             int           width,
+                                                             int           height);
+WPE_API gdouble      wpe_view_get_scale                     (WPEView      *view);
+WPE_API void         wpe_view_set_scale                     (WPEView      *view,
+                                                             gdouble       scale);
+WPE_API void         wpe_view_set_cursor_from_name          (WPEView      *view,
+                                                             const char   *name);
+WPE_API void         wpe_view_set_cursor_from_bytes         (WPEView      *view,
+                                                             GBytes       *bytes,
+                                                             guint         width,
+                                                             guint         height,
+                                                             guint         stride,
+                                                             guint         hotspot_x,
+                                                             guint         hotspot_y);
+WPE_API WPEViewState wpe_view_get_state                     (WPEView      *view);
+WPE_API void         wpe_view_set_state                     (WPEView      *view,
+                                                             WPEViewState  state);
+WPE_API WPEMonitor  *wpe_view_get_monitor                   (WPEView      *view);
+WPE_API gboolean     wpe_view_fullscreen                    (WPEView      *view);
+WPE_API gboolean     wpe_view_unfullscreen                  (WPEView      *view);
+WPE_API gboolean     wpe_view_maximize                      (WPEView      *view);
+WPE_API gboolean     wpe_view_unmaximize                    (WPEView      *view);
+WPE_API gboolean     wpe_view_render_buffer                 (WPEView      *view,
+                                                             WPEBuffer    *buffer,
+                                                             GError      **error);
+WPE_API void         wpe_view_buffer_rendered               (WPEView      *view,
+                                                             WPEBuffer    *buffer);
+WPE_API void         wpe_view_event                         (WPEView      *view,
+                                                             WPEEvent     *event);
+WPE_API guint        wpe_view_compute_press_count           (WPEView      *view,
+                                                             gdouble       x,
+                                                             gdouble       y,
+                                                             guint         button,
+                                                             guint32       time);
+WPE_API void         wpe_view_focus_in                      (WPEView      *view);
+WPE_API void         wpe_view_focus_out                     (WPEView      *view);
+WPE_API GList       *wpe_view_get_preferred_dma_buf_formats (WPEView      *view);
+WPE_API void         wpe_view_set_opaque_rectangles         (WPEView      *view,
+                                                             WPERectangle *rects,
+                                                             guint         n_rects);
 
 G_END_DECLS
 


### PR DESCRIPTION
#### 6b96e27c62baf1a2d8040ec73bb71c4c4e847030
<pre>
[WPE] WPE Platform: Opaque region support
<a href="https://bugs.webkit.org/show_bug.cgi?id=267705">https://bugs.webkit.org/show_bug.cgi?id=267705</a>

Reviewed by Alejandro G. Castro.

Add API to set the opaque region on a WPEView and use it from WebKit to
set the web view region as opaque when the background color is opaque.

* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
(webkit_web_view_set_background_color):
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPERectangle.cpp: Copied from Source/WebKit/WPEPlatform/wpe/wpe-platform.h.
(wpe_rectangle_copy):
(wpe_rectangle_free):
* Source/WebKit/WPEPlatform/wpe/WPERectangle.h: Copied from Source/WebKit/WPEPlatform/wpe/wpe-platform.h.
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_set_opaque_rectangles):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandConstructed):
(wpeViewWaylandSetOpaqueRectangles):
(wpe_view_wayland_class_init):
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:

Canonical link: <a href="https://commits.webkit.org/275684@main">https://commits.webkit.org/275684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57777314845ac85694237bf4e90bbfbe95784357

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18911 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18470 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16156 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46615 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38708 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19030 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5739 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->