### PR TITLE
[WebGPU] Remove duplicate typeError when a bottom type is a member of a struct

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -436,7 +436,6 @@ void TypeChecker::visit(AST::Structure& structure)
         auto* memberType = resolve(member.type());
 
         if (UNLIKELY(std::holds_alternative<Types::Bottom>(*memberType))) {
-            typeError(InferBottom::No, member.span(), "type '", *memberType, "' cannot be used as a struct member");
             introduceType(structure.name(), m_types.bottomType());
             return;
         }


### PR DESCRIPTION
#### 56f2145d88f7f995e572dc334dbeb43a56969951
<pre>
[WebGPU] Remove duplicate typeError when a bottom type is a member of a struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=270350">https://bugs.webkit.org/show_bug.cgi?id=270350</a>
<a href="https://rdar.apple.com/123898425">rdar://123898425</a>

Reviewed by Tadeu Zagallo.

An error was already generated when the bottom type was inferred

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):

Canonical link: <a href="https://commits.webkit.org/275568@main">https://commits.webkit.org/275568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75608ef978e15a7b705edddaf77d52f5a2f8c92b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38268 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34909 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15773 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46186 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41566 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16968 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13953 "Found 1 new test failure: ipc/message-listener-async-message-reply-id.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40135 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18587 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18648 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5675 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->