### PR TITLE
[contain-intrinsic-size] Element removed by parent should end up losing last remembered size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt
@@ -13,6 +13,8 @@ PASS Lack of cis:auto during box creation removes last remembered size
 PASS Last remembered size can be removed synchronously
 PASS Disconnected element can briefly keep last remembered size
 PASS Disconnected element ends up losing last remembered size
+PASS Disconnected element ends up losing last remembered size, parent removes all children
+PASS Disconnected element ends up losing last remembered size, the parent node is removed
 PASS Disconnected element ends up losing last remembered size even if size was 0x0
 PASS Last remembered size survives becoming inline
 PASS Last remembered size can be set to 0x0 after losing display:inline

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006.html
@@ -352,6 +352,46 @@ promise_test(async function() {
   checkSize(1, 2, "Size containment with no last remembered size");
 }, "Disconnected element ends up losing last remembered size");
 
+promise_test(async function () {
+  this.add_cleanup(cleanup);
+  target.classList.add("cis-auto");
+  contents.classList.add("size-100-50");
+  checkSize(100, 50, "Sizing normally");
+
+  await nextRendering();
+  target.classList.add("skip-contents");
+  contents.classList.remove("size-100-50");
+  contents.classList.add("size-75-25");
+  checkSize(100, 50, "Using last remembered size");
+
+  parent.innerHTML = "";
+  checkSize(0, 0, "No box");
+
+  await nextRendering();
+  parent.appendChild(target);
+  checkSize(1, 2, "Size containment with no last remembered size");
+}, "Disconnected element ends up losing last remembered size, parent removes all children");
+
+promise_test(async function () {
+  this.add_cleanup(cleanup);
+  target.classList.add("cis-auto");
+  contents.classList.add("size-100-50");
+  checkSize(100, 50, "Sizing normally");
+
+  await nextRendering();
+  target.classList.add("skip-contents");
+  contents.classList.remove("size-100-50");
+  contents.classList.add("size-75-25");
+  checkSize(100, 50, "Using last remembered size");
+
+  parent.remove();
+  checkSize(0, 0, "No box");
+
+  await nextRendering();
+  document.body.appendChild(parent);
+  checkSize(1, 2, "Size containment with no last remembered size");
+}, "Disconnected element ends up losing last remembered size, the parent node is removed");
+
 promise_test(async function() {
   this.add_cleanup(cleanup);
   target.classList.add("cis-auto");

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -727,14 +727,6 @@ ExceptionOr<void> ContainerNode::removeChild(Node& oldChild)
     rebuildSVGExtensionsElementsIfNecessary();
     dispatchSubtreeModifiedEvent();
 
-    auto* element = dynamicDowncast<Element>(oldChild);
-    if (element && (element->lastRememberedLogicalWidth() || element->lastRememberedLogicalHeight())) {
-        // The disconnected element could be unobserved because of other properties, here we need to make sure it is observed,
-        // so that deliver could be triggered and it would clear lastRememberedSize.
-        document().observeForContainIntrinsicSize(*element);
-        document().resetObservationSizeForContainIntrinsicSize(*element);
-    }
-
     return { };
 }
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2778,6 +2778,13 @@ void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldPar
 #endif
     }
 
+    if (lastRememberedLogicalWidth() || lastRememberedLogicalHeight()) {
+        // The disconnected element could be unobserved because of other properties, here we need to make sure it is observed,
+        // so that deliver could be triggered and it would clear lastRememberedSize.
+        document().observeForContainIntrinsicSize(*this);
+        document().resetObservationSizeForContainIntrinsicSize(*this);
+    }
+
     setSavedLayerScrollPosition({ });
 
     if (oldParentOfRemovedTree.isInTreeScope()) {


### PR DESCRIPTION
#### 3db230251f3c40d76cabdc09cf1e64ac3c377c2f
<pre>
[contain-intrinsic-size] Element removed by parent should end up losing last remembered size
<a href="https://bugs.webkit.org/show_bug.cgi?id=270240">https://bugs.webkit.org/show_bug.cgi?id=270240</a>

Reviewed by Ryosuke Niwa.

The code to clear last remembered size for disconnected element, it does not cover all the scenario.
This patch moves it to Element::removedFromAncestor, so that it could handle all scenarios with the element removed.

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006.html:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeChild):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::removedFromAncestor):

Canonical link: <a href="https://commits.webkit.org/275606@main">https://commits.webkit.org/275606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dab6abae3002b8b74748f6acef57eb8d9b6b03b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34965 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46191 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41571 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40208 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9461 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->