### PR TITLE
Use WeakPtr for members of GPUDeviceVideoFrameRequestCallback

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -292,31 +292,35 @@ class GPUDeviceVideoFrameRequestCallback final : public VideoFrameRequestCallbac
 public:
     CallbackResult<void> handleEvent(double, const VideoFrameMetadata&) override
     {
-        auto it = m_weakMap.find(m_videoElement);
-        if (it != m_weakMap.end() && m_externalTexture.ptr() == it->value.get())
+        if (!m_videoElement)
+            return { };
+        if (!m_gpuDevice)
+            return { };
+        auto texture = m_gpuDevice->takeExternalTextureForVideoElement(*m_videoElement);
+        if (!texture)
+            return { };
+        if (texture.get() == m_externalTexture.ptr())
             m_externalTexture->destroy();
-
-        m_weakMap.remove(m_videoElement);
-        return CallbackResult<void>();
+        return { };
     }
-    static Ref<GPUDeviceVideoFrameRequestCallback> create(GPUExternalTexture& externalTexture, HTMLVideoElement& videoElement, WeakHashMap<HTMLVideoElement, WeakPtr<GPUExternalTexture>>& weakMap, ScriptExecutionContext* scriptExecutionContext)
+    static Ref<GPUDeviceVideoFrameRequestCallback> create(GPUExternalTexture& externalTexture, HTMLVideoElement& videoElement, GPUDevice& gpuDevice, ScriptExecutionContext* scriptExecutionContext)
     {
-        return adoptRef(*new GPUDeviceVideoFrameRequestCallback(externalTexture, videoElement, weakMap, scriptExecutionContext));
+        return adoptRef(*new GPUDeviceVideoFrameRequestCallback(externalTexture, videoElement, gpuDevice, scriptExecutionContext));
     }
 
     ~GPUDeviceVideoFrameRequestCallback() final { }
 private:
-    GPUDeviceVideoFrameRequestCallback(GPUExternalTexture& externalTexture, HTMLVideoElement& videoElement, WeakHashMap<HTMLVideoElement, WeakPtr<GPUExternalTexture>>& weakMap, ScriptExecutionContext* scriptExecutionContext)
+    GPUDeviceVideoFrameRequestCallback(GPUExternalTexture& externalTexture, HTMLVideoElement& videoElement, GPUDevice& gpuDevice, ScriptExecutionContext* scriptExecutionContext)
         : VideoFrameRequestCallback(scriptExecutionContext)
         , m_externalTexture(externalTexture)
         , m_videoElement(videoElement)
-        , m_weakMap(weakMap)
+        , m_gpuDevice(gpuDevice)
     {
     }
 
     Ref<GPUExternalTexture> m_externalTexture;
-    HTMLVideoElement& m_videoElement;
-    WeakHashMap<HTMLVideoElement, WeakPtr<GPUExternalTexture>> &m_weakMap;
+    WeakPtr<HTMLVideoElement> m_videoElement;
+    WeakPtr<GPUDevice, WeakPtrImplWithEventTargetData> m_gpuDevice;
 };
 
 Ref<GPUExternalTexture> GPUDevice::importExternalTexture(const GPUExternalTextureDescriptor& externalTextureDescriptor)
@@ -340,7 +344,7 @@ Ref<GPUExternalTexture> GPUDevice::importExternalTexture(const GPUExternalTextur
 #endif
         HTMLVideoElement* videoElementPtr = videoElement->get();
         m_videoElementToExternalTextureMap.set(*videoElementPtr, externalTexture.get());
-        videoElementPtr->requestVideoFrameCallback(GPUDeviceVideoFrameRequestCallback::create(externalTexture.get(), *videoElementPtr, m_videoElementToExternalTextureMap, scriptExecutionContext()));
+        videoElementPtr->requestVideoFrameCallback(GPUDeviceVideoFrameRequestCallback::create(externalTexture.get(), *videoElementPtr, *this, scriptExecutionContext()));
         queueTaskKeepingObjectAlive(*this, TaskSource::WebGPU, [protecedThis = Ref { *this }, videoElementPtr, externalTextureRef = externalTexture]() {
             auto it = protecedThis->m_videoElementToExternalTextureMap.find(*videoElementPtr);
             if (it == protecedThis->m_videoElementToExternalTextureMap.end() || externalTextureRef.ptr() != it->value.get())
@@ -530,6 +534,11 @@ bool GPUDevice::addEventListener(const AtomString& eventType, Ref<EventListener>
     }
 #endif
     return result;
+}
+
+WeakPtr<GPUExternalTexture> GPUDevice::takeExternalTextureForVideoElement(const HTMLVideoElement& element)
+{
+    return m_videoElementToExternalTextureMap.take(element);
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -139,6 +139,8 @@ public:
     using RefCounted::ref;
     using RefCounted::deref;
 
+    WeakPtr<GPUExternalTexture> takeExternalTextureForVideoElement(const HTMLVideoElement&);
+
 private:
     GPUDevice(ScriptExecutionContext*, Ref<WebGPU::Device>&&);
 


### PR DESCRIPTION
#### 4f76c56c5655b26ed84f9f1b1d03a59c87e74885
<pre>
Use WeakPtr for members of GPUDeviceVideoFrameRequestCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=270362">https://bugs.webkit.org/show_bug.cgi?id=270362</a>
<a href="https://rdar.apple.com/123908079">rdar://123908079</a>

Reviewed by Mike Wyrzykowski.

This makes it more robust against lifetime issues.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
* Source/WebCore/Modules/WebGPU/GPUDevice.h:

Canonical link: <a href="https://commits.webkit.org/275567@main">https://commits.webkit.org/275567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afc4f5b73114d9a5423386e457f55fcecdb768dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44765 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38287 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34933 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41589 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40164 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18606 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18668 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5676 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->