### PR TITLE
Crash under ScrollingStateFixedNode::reconcileLayerPositionForViewportRect

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
@@ -84,6 +84,10 @@ void ScrollingStateFixedNode::reconcileLayerPositionForViewportRect(const Layout
     FloatPoint position = m_constraints.layerPositionForViewportRect(viewportRect);
     if (layer().representsGraphicsLayer()) {
         RefPtr graphicsLayer = static_cast<GraphicsLayer*>(layer());
+        ASSERT(graphicsLayer);
+        // Crash data suggest that graphicsLayer can be null: rdar://105887621.
+        if (!graphicsLayer)
+            return;
 
         LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateFixedNode " << scrollingNodeID() <<" reconcileLayerPositionForViewportRect " << action << " position of layer " << graphicsLayer->primaryLayerID() << " to " << position);
         


### PR DESCRIPTION
#### 0c592c9b1e0c09a411af9b26f6a3e32a2c36a1fd
<pre>
Crash under ScrollingStateFixedNode::reconcileLayerPositionForViewportRect
<a href="https://bugs.webkit.org/show_bug.cgi?id=270361">https://bugs.webkit.org/show_bug.cgi?id=270361</a>
<a href="https://rdar.apple.com/105887621">rdar://105887621</a>

Reviewed by Simon Fraser.

We need a similar fix to <a href="https://github.com/WebKit/WebKit/pull/17453">https://github.com/WebKit/WebKit/pull/17453</a> as there is
the same crash signature under ScrollingStateFixedNode::reconcileLayerPositionForViewportRect
this time.

* Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp:
(WebCore::ScrollingStateFixedNode::reconcileLayerPositionForViewportRect):

Canonical link: <a href="https://commits.webkit.org/275574@main">https://commits.webkit.org/275574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04af527eabe71abf678070f772d1b21d2604f649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18521 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34930 "Found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36316 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15866 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46210 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41587 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40162 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18669 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5681 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->