### PR TITLE
Get rid of downcast>() in ScopedEventQueue::enqueueEvent()

### DIFF
--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -51,8 +51,10 @@ namespace WebCore {
 void EventDispatcher::dispatchScopedEvent(Node& node, Event& event)
 {
     // Need to set the target here so the scoped event queue knows which node to dispatch to.
-    event.setTarget(RefPtr { EventPath::eventTargetRespectingTargetRules(node) });
-    ScopedEventQueue::singleton().enqueueEvent(event);
+    RefPtr target = EventPath::eventTargetRespectingTargetRules(node);
+    ASSERT(target);
+    event.setTarget(target.copyRef());
+    ScopedEventQueue::singleton().enqueueEvent({ event, *target });
 }
 
 static void callDefaultEventHandlersInBubblingOrder(Event& event, const EventPath& path)

--- a/Source/WebCore/dom/ScopedEventQueue.cpp
+++ b/Source/WebCore/dom/ScopedEventQueue.cpp
@@ -43,15 +43,12 @@ ScopedEventQueue& ScopedEventQueue::singleton()
     return scopedEventQueue;
 }
 
-void ScopedEventQueue::enqueueEvent(Ref<Event>&& event)
+void ScopedEventQueue::enqueueEvent(ScopedEvent&& event)
 {
-    ASSERT(event->target());
-    auto& target = downcast<Node>(*event->target());
-    ScopedEvent scopedEvent = { WTFMove(event), target };
     if (m_scopingLevel)
-        m_queuedEvents.append(WTFMove(scopedEvent));
+        m_queuedEvents.append(WTFMove(event));
     else
-        dispatchEvent(scopedEvent);
+        dispatchEvent(event);
 }
 
 void ScopedEventQueue::dispatchEvent(const ScopedEvent& event) const

--- a/Source/WebCore/dom/ScopedEventQueue.h
+++ b/Source/WebCore/dom/ScopedEventQueue.h
@@ -45,16 +45,16 @@ class ScopedEventQueue {
     WTF_MAKE_NONCOPYABLE(ScopedEventQueue); WTF_MAKE_FAST_ALLOCATED;
 public:
     static ScopedEventQueue& singleton();
-    void enqueueEvent(Ref<Event>&&);
-
-private:
-    ScopedEventQueue() = default;
-    ~ScopedEventQueue() = delete;
 
     struct ScopedEvent {
         Ref<Event> event;
         GCReachableRef<Node> target;
     };
+    void enqueueEvent(ScopedEvent&&);
+
+private:
+    ScopedEventQueue() = default;
+    ~ScopedEventQueue() = delete;
 
     void dispatchEvent(const ScopedEvent&) const;
     void dispatchAllEvents();


### PR DESCRIPTION
#### 81d1596b36a9ff46ad8b39607e02e72deafcab4d
<pre>
Get rid of downcast&gt;() in ScopedEventQueue::enqueueEvent()
<a href="https://bugs.webkit.org/show_bug.cgi?id=270371">https://bugs.webkit.org/show_bug.cgi?id=270371</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::EventDispatcher::dispatchScopedEvent):
* Source/WebCore/dom/ScopedEventQueue.cpp:
(WebCore::ScopedEventQueue::enqueueEvent):
* Source/WebCore/dom/ScopedEventQueue.h:

Canonical link: <a href="https://commits.webkit.org/275576@main">https://commits.webkit.org/275576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c29934e12d241fbc130efbb1a8b52ebe5838d568

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44781 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18536 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34951 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15887 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46224 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40183 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18621 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18683 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5683 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->