### PR TITLE
Consecutive calls to `-insertTextAlternatives:` should not cause dictation underlines to disappear

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3285,13 +3285,16 @@ void Editor::updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionA
 
     OptionSet<DocumentMarker::Type> markerTypesToRemove {
         DocumentMarker::Type::CorrectionIndicator,
-        DocumentMarker::Type::DictationAlternatives,
         DocumentMarker::Type::SpellCheckingExemption,
         DocumentMarker::Type::Spelling,
 #if !PLATFORM(IOS_FAMILY)
         DocumentMarker::Type::Grammar,
 #endif
     };
+
+    if (CheckedPtr client = this->client(); client && client->shouldRemoveDictationAlternativesAfterEditing())
+        markerTypesToRemove.add(DocumentMarker::Type::DictationAlternatives);
+
     adjustMarkerTypesToRemoveForWordsAffectedByEditing(markerTypesToRemove);
 
     removeMarkers(wordRange, markerTypesToRemove, RemovePartiallyOverlappingMarker::Yes);

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -81,6 +81,7 @@ public:
     virtual bool shouldChangeSelectedRange(const std::optional<SimpleRange>& fromRange, const std::optional<SimpleRange>& toRange, Affinity, bool stillSelecting) = 0;
     virtual bool shouldRevealCurrentSelectionAfterInsertion() const { return true; };
     virtual bool shouldSuppressPasswordEcho() const { return false; };
+    virtual bool shouldRemoveDictationAlternativesAfterEditing() const { return true; }
     
     virtual bool shouldApplyStyle(const StyleProperties&, const std::optional<SimpleRange>&) = 0;
     virtual void didApplyStyle() = 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -194,6 +194,7 @@ private:
     bool shouldAllowSingleClickToChangeSelection(WebCore::Node&, const WebCore::VisibleSelection&) const final;
     bool shouldRevealCurrentSelectionAfterInsertion() const final;
     bool shouldSuppressPasswordEcho() const final;
+    bool shouldRemoveDictationAlternativesAfterEditing() const final;
 #endif
 
     void willChangeSelectionForAccessibility() final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
@@ -117,6 +117,11 @@ bool WebEditorClient::shouldSuppressPasswordEcho() const
     return m_page->screenIsBeingCaptured() || m_page->hardwareKeyboardIsAttached();
 }
 
+bool WebEditorClient::shouldRemoveDictationAlternativesAfterEditing() const
+{
+    return m_page->shouldRemoveDictationAlternativesAfterEditing();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -908,6 +908,7 @@ public:
 #endif
     void willInsertFinalDictationResult();
     void didInsertFinalDictationResult();
+    bool shouldRemoveDictationAlternativesAfterEditing() const;
     void replaceDictatedText(const String& oldText, const String& newText);
     void replaceSelectedText(const String& oldText, const String& newText);
     void requestAutocorrectionData(const String& textForAutocorrection, CompletionHandler<void(WebAutocorrectionData)>&& reply);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2652,6 +2652,11 @@ void WebPage::willInsertFinalDictationResult()
     m_ignoreSelectionChangeScopeForDictation = makeUnique<IgnoreSelectionChangeForScope>(*frame);
 }
 
+bool WebPage::shouldRemoveDictationAlternativesAfterEditing() const
+{
+    return !m_ignoreSelectionChangeScopeForDictation;
+}
+
 void WebPage::didInsertFinalDictationResult()
 {
     m_ignoreSelectionChangeScopeForDictation = nullptr;

--- a/Tools/TestWebKitAPI/Tests/ios/TextAlternatives.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TextAlternatives.mm
@@ -128,6 +128,23 @@ TEST(TextAlternatives, AddTextAlternativesWithoutMatch)
     EXPECT_EQ(0U, [webView dictationAlternativesMarkerCount:@"document.body.childNodes[0]"]);
 }
 
+TEST(TextAlternatives, InsertDictationResultsAsAlternatives)
+{
+    auto webView = createWebViewForTestingTextAlternatives();
+    [webView synchronouslyLoadHTMLString:@"<body></body>"];
+    [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body)"];
+
+    [[webView textInputContentView] willInsertFinalDictationResult];
+    [webView insertText:@"I " alternatives:@[ ]];
+    [webView insertText:@"wanna" alternatives:@[ @"want to" ]];
+    [webView insertText:@" test" alternatives:@[ ]];
+    [webView insertText:@" dictation" alternatives:@[ ]];
+    [[webView textInputContentView] didInsertFinalDictationResult];
+
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ(1U, [webView dictationAlternativesMarkerCount:@"document.body.childNodes[0]"]);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -81,6 +81,7 @@ struct AutocorrectionContext {
 - (std::pair<CGRect, CGRect>)autocorrectionRectsForString:(NSString *)string;
 - (NSArray<_WKTextInputContext *> *)synchronouslyRequestTextInputContextsInRect:(CGRect)rect;
 - (void)replaceText:(NSString *)input withText:(NSString *)correction shouldUnderline:(BOOL)shouldUnderline completion:(void(^)())completion;
+- (void)insertText:(NSString *)primaryString alternatives:(NSArray<NSString *> *)alternatives;
 - (void)handleKeyEvent:(WebEvent *)event completion:(void (^)(WebEvent *theEvent, BOOL handled))completion;
 - (void)selectTextForContextMenuWithLocationInView:(CGPoint)locationInView completion:(void(^)(BOOL shouldPresent))completion;
 - (void)defineSelection;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -348,6 +348,22 @@ static NSString *overrideBundleIdentifier(id, SEL)
     }];
 }
 
+- (void)insertText:(NSString *)primaryString alternatives:(NSArray<NSString *> *)alternativeStrings
+{
+    if (!alternativeStrings.count) {
+        [self.textInputContentView insertText:primaryString];
+        return;
+    }
+
+#if USE(BROWSERENGINEKIT)
+    auto nsAlternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:primaryString alternativeStrings:alternativeStrings]);
+    auto alternatives = adoptNS([[BETextAlternatives alloc] _initWithNSTextAlternatives:nsAlternatives.get()]);
+    [self.asyncTextInput insertTextAlternatives:alternatives.get()];
+#else
+    [self.textInputContentView insertText:primaryString alternatives:alternativeStrings style:UITextAlternativeStyleNone];
+#endif
+}
+
 #if USE(BROWSERENGINEKIT)
 
 static RetainPtr<BEKeyEntry> wrap(WebEvent *webEvent)


### PR DESCRIPTION
#### ee754d7dfc571ca86d2785731e52091ccaab308b
<pre>
Consecutive calls to `-insertTextAlternatives:` should not cause dictation underlines to disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=270370">https://bugs.webkit.org/show_bug.cgi?id=270370</a>
<a href="https://rdar.apple.com/107087527">rdar://107087527</a>

Reviewed by Abrar Rahman Protyasha.

Add support for preserving dictation underlines when UIKit calls into `-insertTextAlternatives:`,
while finalizing dictation results. Currently, UIKit only calls into `-insertText:` with the best
alternative for the dictated text, which loses all information about dictation alternatives (along
with the blue dotted underlines). While there&apos;s public API on `UITextInput` to
`-insertDictationResults:` which we _could_ implement, the suggestions will eventually be shown by
UIKit when tapping on a dictation alternative range via `-alternativesForSelectedText`, which means
that we would need to convert `UIDictationPhrase` objects into `BETextAlternatives` — something
that&apos;s not possible without introducing new API surface in BrowserEngineKit.

Instead, UIKit will be inserting text alternatives in the form of `BETextAlternatives` (or
`NSTextAlternatives` in the case where BrowserEngineKit integration is disabled), which we&apos;ll honor
by adding dictation alternative document markers.

Test: TextAlternatives.InsertDictationResultsAsAlternatives

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::updateMarkersForWordsAffectedByEditing):

Prevent dictation markers from being removed as a result of inserting plain text, while finalizing
dictation results.

* Source/WebCore/page/EditorClient.h:
(WebCore::EditorClient::shouldRemoveDictationAlternativesAfterEditing const):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm:
(WebKit::WebEditorClient::shouldRemoveDictationAlternativesAfterEditing const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::shouldRemoveDictationAlternativesAfterEditing const):
* Tools/TestWebKitAPI/Tests/ios/TextAlternatives.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:

Add an API test to exercise this change.

(-[WKWebView insertText:alternatives:]):

Canonical link: <a href="https://commits.webkit.org/275579@main">https://commits.webkit.org/275579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c9abdda1200e746cde51539141abd2e072a1f51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44789 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34949 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46233 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41603 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40180 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18629 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9454 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->