### PR TITLE
Use smart pointers in Modules/WebGPU

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.h
@@ -46,7 +46,7 @@ struct GPUBindGroupDescriptor : public GPUObjectDescriptorBase {
         };
     }
 
-    GPUBindGroupLayout* layout { nullptr };
+    WeakPtr<GPUBindGroupLayout> layout;
     Vector<GPUBindGroupEntry> entries;
 };
 

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.h
@@ -28,11 +28,12 @@
 #include "WebGPUBindGroupLayout.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class GPUBindGroupLayout : public RefCounted<GPUBindGroupLayout> {
+class GPUBindGroupLayout : public RefCounted<GPUBindGroupLayout>, public CanMakeWeakPtr<GPUBindGroupLayout> {
 public:
     static Ref<GPUBindGroupLayout> create(Ref<WebGPU::BindGroupLayout>&& backing)
     {

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -102,7 +102,8 @@ static auto makeArrayBuffer(auto source, auto byteLength, auto& cachedArrayBuffe
     auto arrayBuffer = ArrayBuffer::create(source, byteLength);
     cachedArrayBuffer = arrayBuffer.ptr();
     cachedArrayBuffer->pin();
-    device.addBufferToUnmap(buffer);
+    if (device)
+        device->addBufferToUnmap(buffer);
     return arrayBuffer;
 }
 
@@ -185,7 +186,8 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> GPUBuffer::getMappedRange(std::optional<GPUSi
 void GPUBuffer::unmap(ScriptExecutionContext& scriptExecutionContext)
 {
     internalUnmap(scriptExecutionContext);
-    m_device.removeBufferToUnmap(*this);
+    if (m_device)
+        m_device->removeBufferToUnmap(*this);
 }
 
 void GPUBuffer::internalUnmap(ScriptExecutionContext& scriptExecutionContext)

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -79,14 +79,14 @@ private:
 
     Ref<WebGPU::Buffer> m_backing;
     WebGPU::Buffer::MappedRange m_mappedRange;
-    JSC::ArrayBuffer* m_arrayBuffer { nullptr };
+    RefPtr<JSC::ArrayBuffer> m_arrayBuffer;
     size_t m_bufferSize { 0 };
     size_t m_mappedRangeOffset { 0 };
     size_t m_mappedRangeSize { 0 };
     const GPUBufferUsageFlags m_usage { 0 };
     GPUBufferMapState m_mapState { GPUBufferMapState::Unmapped };
     std::optional<MapAsyncPromise> m_pendingMapPromise;
-    GPUDevice& m_device;
+    WeakPtr<GPUDevice, WeakPtrImplWithEventTargetData> m_device;
     using MappedRanges = WTF::RangeSet<WTF::Range<size_t>>;
     MappedRanges m_mappedRanges;
     HashSet<size_t, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>> m_mappedPoints;

--- a/Source/WebCore/Modules/WebGPU/GPUBufferBinding.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferBinding.h
@@ -44,7 +44,7 @@ struct GPUBufferBinding {
         };
     }
 
-    GPUBuffer* buffer { nullptr };
+    WeakPtr<GPUBuffer> buffer;
     GPUSize64 offset { 0 };
     std::optional<GPUSize64> size;
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h
@@ -51,7 +51,7 @@ struct GPUCanvasConfiguration {
         };
     }
 
-    GPUDevice* device { nullptr };
+    WeakPtr<GPUDevice, WeakPtrImplWithEventTargetData> device;
     GPUTextureFormat format { GPUTextureFormat::R8unorm };
     GPUTextureUsageFlags usage { GPUTextureUsage::RENDER_ATTACHMENT };
     Vector<GPUTextureFormat> viewFormats;

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h
@@ -43,7 +43,7 @@ struct GPUComputePassTimestampWrites {
         };
     }
 
-    GPUQuerySet* querySet { nullptr };
+    WeakPtr<GPUQuerySet> querySet;
     GPUSize32 beginningOfPassWriteIndex { UINT32_MAX };
     GPUSize32 endOfPassWriteIndex { UINT32_MAX };
 };

--- a/Source/WebCore/Modules/WebGPU/GPUImageCopyBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUImageCopyBuffer.h
@@ -46,7 +46,7 @@ struct GPUImageCopyBuffer : public GPUImageDataLayout {
         };
     }
 
-    GPUBuffer* buffer { nullptr };
+    WeakPtr<GPUBuffer> buffer;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUImageCopyTexture.h
+++ b/Source/WebCore/Modules/WebGPU/GPUImageCopyTexture.h
@@ -47,7 +47,7 @@ struct GPUImageCopyTexture {
         };
     }
 
-    GPUTexture* texture { nullptr };
+    WeakPtr<GPUTexture> texture;
     GPUIntegerCoordinate mipLevel { 0 };
     std::optional<GPUOrigin3D> origin;
     GPUTextureAspect aspect { GPUTextureAspect::All };

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 void GPUPresentationContext::configure(const GPUCanvasConfiguration& canvasConfiguration, GPUIntegerCoordinate width, GPUIntegerCoordinate height)
 {
-    m_device = canvasConfiguration.device;
+    m_device = canvasConfiguration.device.get();
     m_backing->configure(canvasConfiguration.convertToBacking());
     m_textureDescriptor = GPUTextureDescriptor {
         { "canvas backing"_s },

--- a/Source/WebCore/Modules/WebGPU/GPUProgrammableStage.h
+++ b/Source/WebCore/Modules/WebGPU/GPUProgrammableStage.h
@@ -30,6 +30,7 @@
 #include <wtf/KeyValuePair.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -46,7 +47,7 @@ struct GPUProgrammableStage {
         };
     }
 
-    GPUShaderModule* module { nullptr };
+    WeakPtr<GPUShaderModule> module;
     std::optional<String> entryPoint;
     Vector<KeyValuePair<String, GPUPipelineConstantValue>> constants;
 };

--- a/Source/WebCore/Modules/WebGPU/GPUQuerySet.h
+++ b/Source/WebCore/Modules/WebGPU/GPUQuerySet.h
@@ -30,11 +30,12 @@
 #include "WebGPUQuerySet.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class GPUQuerySet : public RefCounted<GPUQuerySet> {
+class GPUQuerySet : public RefCounted<GPUQuerySet>, public CanMakeWeakPtr<GPUQuerySet> {
 public:
     static Ref<GPUQuerySet> create(Ref<WebGPU::QuerySet>&& backing, const GPUQuerySetDescriptor& descriptor)
     {

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h
@@ -51,9 +51,9 @@ struct GPURenderPassColorAttachment {
         };
     }
 
-    GPUTextureView* view { nullptr };
+    WeakPtr<GPUTextureView> view;
     std::optional<GPUIntegerCoordinate> depthSlice;
-    GPUTextureView* resolveTarget { nullptr };
+    WeakPtr<GPUTextureView> resolveTarget;
 
     std::optional<GPUColor> clearValue;
     GPULoadOp loadOp { GPULoadOp::Load };

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.h
@@ -52,7 +52,7 @@ struct GPURenderPassDepthStencilAttachment {
         };
     }
 
-    GPUTextureView* view { nullptr };
+    WeakPtr<GPUTextureView> view;
 
     std::optional<float> depthClearValue;
     std::optional<GPULoadOp> depthLoadOp;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.h
@@ -56,7 +56,7 @@ struct GPURenderPassDescriptor : public GPUObjectDescriptorBase {
 
     Vector<std::optional<GPURenderPassColorAttachment>> colorAttachments;
     std::optional<GPURenderPassDepthStencilAttachment> depthStencilAttachment;
-    GPUQuerySet* occlusionQuerySet { nullptr };
+    WeakPtr<GPUQuerySet> occlusionQuerySet;
     GPURenderPassTimestampWrites timestampWrites;
     std::optional<GPUSize64> maxDrawCount;
 };

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h
@@ -43,7 +43,7 @@ struct GPURenderPassTimestampWrites {
         };
     }
 
-    GPUQuerySet* querySet { nullptr };
+    WeakPtr<GPUQuerySet> querySet;
     GPUSize32 beginningOfPassWriteIndex { UINT32_MAX };
     GPUSize32 endOfPassWriteIndex { UINT32_MAX };
 };

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModule.h
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModule.h
@@ -31,13 +31,14 @@
 #include "WebGPUShaderModule.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class DeferredPromise;
 
-class GPUShaderModule : public RefCounted<GPUShaderModule> {
+class GPUShaderModule : public RefCounted<GPUShaderModule>, public CanMakeWeakPtr<GPUShaderModule> {
 public:
     static Ref<GPUShaderModule> create(Ref<WebGPU::ShaderModule>&& backing)
     {

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.h
@@ -33,6 +33,7 @@
 #include <optional>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ class GPUTextureView;
 struct GPUTextureDescriptor;
 struct GPUTextureViewDescriptor;
 
-class GPUTexture : public RefCounted<GPUTexture> {
+class GPUTexture : public RefCounted<GPUTexture>, public CanMakeWeakPtr<GPUTexture> {
 public:
     static Ref<GPUTexture> create(Ref<WebGPU::Texture>&& backing, const GPUTextureDescriptor& descriptor, const GPUDevice& device)
     {

--- a/Source/WebCore/Modules/WebGPU/GPUTextureView.h
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureView.h
@@ -28,11 +28,12 @@
 #include "WebGPUTextureView.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class GPUTextureView : public RefCounted<GPUTextureView> {
+class GPUTextureView : public RefCounted<GPUTextureView>, public CanMakeWeakPtr<GPUTextureView> {
 public:
     static Ref<GPUTextureView> create(Ref<WebGPU::TextureView>&& backing)
     {

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupDescriptor.h
@@ -28,13 +28,14 @@
 #include "WebGPUBindGroupEntry.h"
 #include "WebGPUObjectDescriptorBase.h"
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 
 class BindGroupLayout;
 
 struct BindGroupDescriptor : public ObjectDescriptorBase {
-    BindGroupLayout& layout;
+    WeakRef<BindGroupLayout> layout;
     Vector<BindGroupEntry> entries;
 };
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupLayout.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupLayout.h
@@ -28,11 +28,12 @@
 #include <wtf/DebugHeap.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
 
-class BindGroupLayout : public RefCounted<BindGroupLayout> {
+class BindGroupLayout : public RefCounted<BindGroupLayout>, public CanMakeWeakPtr<BindGroupLayout> {
 public:
     virtual ~BindGroupLayout() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -32,11 +32,12 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
 
-class Buffer : public RefCounted<Buffer> {
+class Buffer : public RefCounted<Buffer>, public CanMakeWeakPtr<Buffer> {
 public:
     virtual ~Buffer() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBinding.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBinding.h
@@ -28,13 +28,14 @@
 #include "WebGPUIntegralTypes.h"
 #include <optional>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 
 class Buffer;
 
 struct BufferBinding {
-    Buffer& buffer;
+    WeakRef<Buffer> buffer;
     Size64 offset { 0 };
     std::optional<Size64> size;
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasConfiguration.h
@@ -30,13 +30,14 @@
 #include "WebGPUTextureFormat.h"
 #include "WebGPUTextureUsage.h"
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 
 class Device;
 
 struct CanvasConfiguration {
-    Device& device;
+    WeakRef<Device> device;
     TextureFormat format { TextureFormat::R8unorm };
     TextureUsageFlags usage { TextureUsage::RenderAttachment };
     Vector<TextureFormat> viewFormats;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h
@@ -28,13 +28,14 @@
 #include "WebGPUIntegralTypes.h"
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore::WebGPU {
 
 class QuerySet;
 
 struct ComputePassTimestampWrites {
-    QuerySet* querySet { nullptr };
+    WeakPtr<QuerySet> querySet;
     Size32 beginningOfPassWriteIndex { 0 };
     Size32 endOfPassWriteIndex { 0 };
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
@@ -36,6 +36,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 #if HAVE(IOSURFACE)
@@ -76,7 +77,7 @@ class Surface;
 class Texture;
 struct TextureDescriptor;
 
-class Device : public RefCounted<Device> {
+class Device : public RefCounted<Device>, public CanMakeWeakPtr<Device> {
 public:
     virtual ~Device() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyBuffer.h
@@ -27,13 +27,14 @@
 
 #include "WebGPUImageDataLayout.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 
 class Buffer;
 
 struct ImageCopyBuffer : public ImageDataLayout {
-    Buffer& buffer;
+    WeakRef<Buffer> buffer;
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUImageCopyTexture.h
@@ -30,13 +30,14 @@
 #include "WebGPUTextureAspect.h"
 #include <optional>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 
 class Texture;
 
 struct ImageCopyTexture {
-    Texture& texture;
+    WeakRef<Texture> texture;
     IntegerCoordinate mipLevel { 0 };
     std::optional<Origin3D> origin;
     TextureAspect aspect { TextureAspect::All };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "WebGPUObjectDescriptorBase.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore::WebGPU {
 
 class PipelineLayout;
 
 struct PipelineDescriptorBase : public ObjectDescriptorBase {
-    PipelineLayout* layout { nullptr };
+    WeakPtr<PipelineLayout> layout;
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h
@@ -27,11 +27,12 @@
 
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
 
-class PipelineLayout : public RefCounted<PipelineLayout> {
+class PipelineLayout : public RefCounted<PipelineLayout>, public CanMakeWeakPtr<PipelineLayout> {
 public:
     virtual ~PipelineLayout() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUProgrammableStage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUProgrammableStage.h
@@ -28,6 +28,7 @@
 #include <wtf/KeyValuePair.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,7 +37,7 @@ class ShaderModule;
 using PipelineConstantValue = double; // May represent WGSL’s bool, f32, i32, u32.
 
 struct ProgrammableStage {
-    ShaderModule& module;
+    WeakRef<ShaderModule> module;
     std::optional<String> entryPoint;
     Vector<KeyValuePair<String, PipelineConstantValue>> constants;
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h
@@ -27,11 +27,12 @@
 
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
 
-class QuerySet : public RefCounted<QuerySet> {
+class QuerySet : public RefCounted<QuerySet>, public CanMakeWeakPtr<QuerySet> {
 public:
     virtual ~QuerySet() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
@@ -32,15 +32,16 @@
 #include <variant>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 
 class TextureView;
 
 struct RenderPassColorAttachment {
-    TextureView& view;
+    WeakRef<TextureView> view;
     std::optional<IntegerCoordinate> depthSlice;
-    TextureView* resolveTarget { nullptr };
+    WeakPtr<TextureView> resolveTarget;
 
     std::optional<Color> clearValue;
     LoadOp loadOp { LoadOp::Load };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
@@ -30,13 +30,14 @@
 #include "WebGPUStoreOp.h"
 #include <variant>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 
 class TextureView;
 
 struct RenderPassDepthStencilAttachment {
-    TextureView& view;
+    WeakRef<TextureView> view;
 
     float depthClearValue { 0 };
     std::optional<LoadOp> depthLoadOp;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h
@@ -32,13 +32,14 @@
 #include "WebGPURenderPassTimestampWrites.h"
 #include <optional>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore::WebGPU {
 
 struct RenderPassDescriptor : public ObjectDescriptorBase {
     Vector<std::optional<RenderPassColorAttachment>> colorAttachments;
     std::optional<RenderPassDepthStencilAttachment> depthStencilAttachment;
-    QuerySet* occlusionQuerySet { nullptr };
+    WeakPtr<QuerySet> occlusionQuerySet;
     std::optional<RenderPassTimestampWrites> timestampWrites;
     std::optional<uint64_t> maxDrawCount;
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h
@@ -28,13 +28,14 @@
 #include "WebGPUIntegralTypes.h"
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore::WebGPU {
 
 class QuerySet;
 
 struct RenderPassTimestampWrites {
-    QuerySet* querySet { nullptr };
+    WeakPtr<QuerySet> querySet;
     Size32 beginningOfPassWriteIndex { 0 };
     Size32 endOfPassWriteIndex { 0 };
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModule.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModule.h
@@ -29,13 +29,14 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
 
 class CompilationInfo;
 
-class ShaderModule : public RefCounted<ShaderModule> {
+class ShaderModule : public RefCounted<ShaderModule>, public CanMakeWeakPtr<ShaderModule> {
 public:
     virtual ~ShaderModule() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
@@ -28,6 +28,7 @@
 #include <optional>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -35,7 +36,7 @@ namespace WebCore::WebGPU {
 class TextureView;
 struct TextureViewDescriptor;
 
-class Texture : public RefCounted<Texture> {
+class Texture : public RefCounted<Texture>, public CanMakeWeakPtr<Texture> {
 public:
     virtual ~Texture() = default;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h
@@ -27,11 +27,12 @@
 
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
 
-class TextureView : public RefCounted<TextureView> {
+class TextureView : public RefCounted<TextureView>, public CanMakeWeakPtr<TextureView> {
 public:
     virtual ~TextureView() = default;
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
@@ -31,6 +31,7 @@
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/WebGPUBindGroupDescriptor.h>
+#include <WebCore/WebGPUBindGroupLayout.h>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUBufferBinding.cpp
@@ -30,6 +30,7 @@
 
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <WebCore/WebGPUBuffer.h>
 #include <WebCore/WebGPUBufferBinding.h>
 
 namespace WebKit::WebGPU {

--- a/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
@@ -31,6 +31,7 @@
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/WebGPUCanvasConfiguration.h>
+#include <WebCore/WebGPUDevice.h>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUComputePassTimestampWrites.cpp
@@ -31,6 +31,8 @@
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/WebGPUComputePassTimestampWrites.h>
+#include <WebCore/WebGPUDevice.h>
+#include <WebCore/WebGPUQuerySet.h>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyBuffer.cpp
@@ -30,6 +30,7 @@
 
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <WebCore/WebGPUBuffer.h>
 #include <WebCore/WebGPUImageCopyBuffer.h>
 
 namespace WebKit::WebGPU {

--- a/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUImageCopyTexture.cpp
@@ -31,6 +31,7 @@
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/WebGPUImageCopyTexture.h>
+#include <WebCore/WebGPUTexture.h>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineDescriptorBase.cpp
@@ -31,6 +31,7 @@
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/WebGPUPipelineDescriptorBase.h>
+#include <WebCore/WebGPUPipelineLayout.h>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp
@@ -31,6 +31,7 @@
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/WebGPUProgrammableStage.h>
+#include <WebCore/WebGPUShaderModule.h>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
@@ -31,6 +31,7 @@
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/WebGPURenderPassColorAttachment.h>
+#include <WebCore/WebGPUTextureView.h>
 
 namespace WebKit::WebGPU {
 

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassTimestampWrites.cpp
@@ -30,6 +30,7 @@
 
 #include "WebGPUConvertFromBackingContext.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <WebCore/WebGPUQuerySet.h>
 #include <WebCore/WebGPURenderPassTimestampWrites.h>
 
 namespace WebKit::WebGPU {


### PR DESCRIPTION
#### 067f08a43f10286e6d769a0b31847652244fbead
<pre>
Use smart pointers in Modules/WebGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=270378">https://bugs.webkit.org/show_bug.cgi?id=270378</a>
<a href="https://rdar.apple.com/123810573">rdar://123810573</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.h:
(): Deleted.
* Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.h:
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::makeArrayBuffer):
(WebCore::GPUBuffer::unmap):
* Source/WebCore/Modules/WebGPU/GPUBuffer.h:
* Source/WebCore/Modules/WebGPU/GPUBufferBinding.h:
* Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h:
* Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/GPUImageCopyBuffer.h:
(): Deleted.
* Source/WebCore/Modules/WebGPU/GPUImageCopyTexture.h:
* Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp:
(WebCore::GPUPresentationContext::configure):
* Source/WebCore/Modules/WebGPU/GPUProgrammableStage.h:
(): Deleted.
* Source/WebCore/Modules/WebGPU/GPUQuerySet.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.h:
(): Deleted.
* Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/GPUShaderModule.h:
* Source/WebCore/Modules/WebGPU/GPUTexture.h:
* Source/WebCore/Modules/WebGPU/GPUTextureView.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineDescriptorBase.h:
(): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDescriptor.h:
(): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampWrites.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h:

Canonical link: <a href="https://commits.webkit.org/275584@main">https://commits.webkit.org/275584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32866efd061f1398655f020cadb0f1a66ef357a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44811 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18566 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/34968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18168 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15904 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37722 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17032 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18713 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5690 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->