### PR TITLE
Assertion failure in ~CompletionHandler() via ImageBitmap::createCompletionHandler

### DIFF
--- a/LayoutTests/fast/images/create-image-bitmap-after-stopping-script-execution-context-expected.txt
+++ b/LayoutTests/fast/images/create-image-bitmap-after-stopping-script-execution-context-expected.txt
@@ -1,0 +1,4 @@
+This tests calling createImageBitmap on a window without a browsing context.
+WebKit should not crash and should show pass below.
+
+Partial PASS

--- a/LayoutTests/fast/images/create-image-bitmap-after-stopping-script-execution-context.html
+++ b/LayoutTests/fast/images/create-image-bitmap-after-stopping-script-execution-context.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests calling createImageBitmap on a window without a browsing context.<br>
+WebKit should not crash and should show pass below.</p>
+<div id="result">Running</div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => {
+        testRunner.notifyDone();
+    }, 10); // Needs to happen after promise.catch below.
+}
+
+const iframe = document.createElement('iframe');
+document.documentElement.appendChild(iframe);
+const contentWindow = iframe.contentWindow;
+iframe.remove();
+const promise = contentWindow.createImageBitmap(new Blob());
+
+result.textContent = 'Partial PASS';
+promise.catch(() => result.textContent = 'PASS');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -725,8 +725,10 @@ class PendingImageBitmap final : public RefCounted<PendingImageBitmap>, public A
 public:
     static void fetch(ScriptExecutionContext& scriptExecutionContext, RefPtr<Blob>&& blob, ImageBitmapOptions&& options, std::optional<IntRect> rect, ImageBitmap::ImageBitmapCompletionHandler&& completionHandler)
     {
-        if (scriptExecutionContext.activeDOMObjectsAreStopped())
+        if (scriptExecutionContext.activeDOMObjectsAreStopped()) {
+            completionHandler(Exception { ExceptionCode::InvalidStateError, "Cannot create ImageBitmap in a document without browsing context"_s });
             return;
+        }
         Ref pendingImageBitmap = adoptRef(*new PendingImageBitmap(scriptExecutionContext, WTFMove(blob), WTFMove(options), WTFMove(rect), WTFMove(completionHandler)));
         pendingImageBitmap->suspendIfNeeded();
         pendingImageBitmap->start(scriptExecutionContext);


### PR DESCRIPTION
#### 198cfb4f193cbb0a55f2cc4e6c4a474f19f9162f
<pre>
Assertion failure in ~CompletionHandler() via ImageBitmap::createCompletionHandler
<a href="https://bugs.webkit.org/show_bug.cgi?id=270379">https://bugs.webkit.org/show_bug.cgi?id=270379</a>

Reviewed by Wenson Hsieh.

Call the completion handler when exiting early in PendingImageBitmap::fetch.

* LayoutTests/fast/images/create-image-bitmap-after-stopping-script-execution-context-expected.txt: Added.
* LayoutTests/fast/images/create-image-bitmap-after-stopping-script-execution-context.html: Added.
* Source/WebCore/html/ImageBitmap.cpp:

Canonical link: <a href="https://commits.webkit.org/275581@main">https://commits.webkit.org/275581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6298598b322124c6a5faeddbfc02fc0ade7c8aab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18553 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34955 "Failure limit exceed. At least found 141 new test failures: accessibility/math-multiscript-attributes.html, animations/keyframe-em-unit.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/tiling/sticky-change-to-tiled.html, css1/formatting_model/inline_elements.html, css2.1/20110323/absolute-non-replaced-height-002.htm, css2.1/20110323/absolute-non-replaced-height-007.htm, css2.1/20110323/absolute-non-replaced-height-009.htm, css2.1/20110323/absolute-non-replaced-max-height-007.htm, css2.1/20110323/absolute-non-replaced-max-height-009.htm ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46245 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37710 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40192 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36652 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18700 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5687 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->