### PR TITLE
Ensure TrackingPreventionEnabled flag is correctly set before using WebsiteDataStore

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -102,7 +102,6 @@ struct NetworkSessionCreationParameters {
     bool shouldRunServiceWorkersOnMainThreadForTesting { false };
     std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue;
     bool preventsSystemHTTPProxyAuthentication { false };
-    bool appHasRequestedCrossWebsiteTrackingPermission { false };
     std::optional<bool> useNetworkLoader { std::nullopt };
     bool allowsHSTSWithUntrustedRootCertificate { false };
     String pcmMachServiceName;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -69,7 +69,6 @@
     bool shouldRunServiceWorkersOnMainThreadForTesting;
     std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue;
     bool preventsSystemHTTPProxyAuthentication;
-    bool appHasRequestedCrossWebsiteTrackingPermission;
     std::optional<bool> useNetworkLoader;
     bool allowsHSTSWithUntrustedRootCertificate;
     String pcmMachServiceName;

--- a/Source/WebKit/Shared/ResourceLoadStatisticsParameters.h
+++ b/Source/WebKit/Shared/ResourceLoadStatisticsParameters.h
@@ -36,7 +36,6 @@ struct ResourceLoadStatisticsParameters {
     String directory;
     SandboxExtension::Handle directoryExtensionHandle;
     bool enabled { false };
-    bool isTrackingPreventionStateExplicitlySet { false };
     bool enableLogTestingEvent { false };
     bool shouldIncludeLocalhost { true };
     bool enableDebugMode { false };

--- a/Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in
+++ b/Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in
@@ -24,7 +24,6 @@
     String directory;
     WebKit::SandboxExtension::Handle directoryExtensionHandle;
     bool enabled;
-    bool isTrackingPreventionStateExplicitlySet;
     bool enableLogTestingEvent;
     bool shouldIncludeLocalhost;
     bool enableDebugMode;

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -112,9 +112,7 @@ void WKWebsiteDataStoreResetServiceWorkerFetchTimeoutForTesting(WKWebsiteDataSto
 
 void WKWebsiteDataStoreSetResourceLoadStatisticsEnabled(WKWebsiteDataStoreRef dataStoreRef, bool enable)
 {
-    auto* websiteDataStore = WebKit::toImpl(dataStoreRef);
-    websiteDataStore->useExplicitTrackingPreventionState();
-    websiteDataStore->setTrackingPreventionEnabled(enable);
+    WebKit::toImpl(dataStoreRef)->setTrackingPreventionEnabled(enable);
 }
 
 void WKWebsiteDataStoreIsStatisticsEphemeral(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreStatisticsEphemeralFunction completionHandler)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -608,7 +608,6 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 
 - (void)_setResourceLoadStatisticsEnabled:(BOOL)enabled
 {
-    _websiteDataStore->useExplicitTrackingPreventionState();
     _websiteDataStore->setTrackingPreventionEnabled(enabled);
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -254,8 +254,6 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
         WebCore::NetworkStorageSession::permitProcessToUseCookieAPI(true);
         Process::setIdentifier(WebCore::ProcessIdentifier::generate());
 #if PLATFORM(COCOA)
-        determineTrackingPreventionState();
-
         // This can be removed once Safari calls _setLinkedOnOrAfterEverything everywhere that WebKit deploys.
 #if PLATFORM(IOS_FAMILY)
         bool isSafari = WebCore::IOSApplication::isMobileSafari();
@@ -762,12 +760,6 @@ void WebProcessPool::resolvePathsForSandboxExtensions()
 
 Ref<WebProcessProxy> WebProcessPool::createNewWebProcess(WebsiteDataStore* websiteDataStore, WebProcessProxy::LockdownMode lockdownMode, WebProcessProxy::IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode)
 {
-#if PLATFORM(COCOA)
-    m_tccPreferenceEnabled = doesAppHaveTrackingPreventionEnabled();
-    if (websiteDataStore && !websiteDataStore->isTrackingPreventionStateExplicitlySet())
-        websiteDataStore->setTrackingPreventionEnabled(m_tccPreferenceEnabled);
-#endif
-
     auto processProxy = WebProcessProxy::create(*this, websiteDataStore, lockdownMode, isPrewarmed, crossOriginMode);
     initializeNewWebProcess(processProxy, websiteDataStore, isPrewarmed);
     m_processes.append(processProxy.copyRef());

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -762,7 +762,6 @@ private:
     bool m_alwaysRunsAtBackgroundPriority;
     bool m_shouldTakeUIBackgroundAssertion;
     bool m_shouldMakeNextWebProcessLaunchFailForTesting { false };
-    bool m_tccPreferenceEnabled { false };
 
     UserObservablePageCounter m_userObservablePageCounter;
     ProcessSuppressionDisabledCounter m_processSuppressionDisabledForPageCounter;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -160,6 +160,9 @@ WebsiteDataStore::WebsiteDataStore(Ref<WebsiteDataStoreConfiguration>&& configur
 {
     RELEASE_LOG(Storage, "%p - WebsiteDataStore::WebsiteDataStore sessionID=%" PRIu64, this, m_sessionID.toUInt64());
 
+#if PLATFORM(COCOA)
+    determineTrackingPreventionState();
+#endif
     WTF::setProcessPrivileges(allPrivileges());
     registerWithSessionIDMap();
     platformInitialize();
@@ -1294,8 +1297,6 @@ void WebsiteDataStore::grantStorageAccessForTesting(String&& topFrameDomain, Vec
 
 void WebsiteDataStore::setIsRunningResourceLoadStatisticsTest(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    useExplicitTrackingPreventionState();
-
     protectedNetworkProcess()->setIsRunningResourceLoadStatisticsTest(m_sessionID, value, WTFMove(completionHandler));
 }
 
@@ -1662,9 +1663,21 @@ void WebsiteDataStore::sendNetworkProcessDidResume()
     protectedNetworkProcess()->sendProcessDidResume(AuxiliaryProcessProxy::ResumeReason::ForegroundActivity);
 }
 
+bool WebsiteDataStore::defaultTrackingPreventionEnabled() const
+{
+#if PLATFORM(COCOA)
+    return doesAppHaveTrackingPreventionEnabled();
+#else
+    return false;
+#endif
+}
+
 bool WebsiteDataStore::trackingPreventionEnabled() const
 {
-    return m_trackingPreventionEnabled;
+    if (m_trackingPreventionEnabled == TrackingPreventionEnabled::Default)
+        return defaultTrackingPreventionEnabled();
+
+    return m_trackingPreventionEnabled == TrackingPreventionEnabled::Yes;
 }
 
 bool WebsiteDataStore::resourceLoadStatisticsDebugMode() const
@@ -1674,18 +1687,22 @@ bool WebsiteDataStore::resourceLoadStatisticsDebugMode() const
 
 void WebsiteDataStore::setTrackingPreventionEnabled(bool enabled)
 {
-    if (enabled == trackingPreventionEnabled())
+    auto targetTrackingPreventionEnabled = enabled ? TrackingPreventionEnabled::Yes : TrackingPreventionEnabled::No;
+    if (m_trackingPreventionEnabled == targetTrackingPreventionEnabled)
         return;
 
-    RELEASE_LOG(Storage, "%p - WebsiteDataStore::setTrackingPreventionEnabled sessionID=%" PRIu64 ", enabled=%d", this, m_sessionID.toUInt64(), enabled);
+    bool valueChanged = trackingPreventionEnabled() != enabled;
+    m_trackingPreventionEnabled = targetTrackingPreventionEnabled;
+    if (!valueChanged)
+        return;
 
-    m_trackingPreventionEnabled = enabled;
+    RELEASE_LOG(Storage, "%p - WebsiteDataStore::setTrackingPreventionEnabled: sessionID=%" PRIu64 ", enabled=%d", this, m_sessionID.toUInt64(), enabled);
 
     if (RefPtr networkProcessProxy = m_networkProcess)
-        networkProcessProxy->send(Messages::NetworkProcess::SetTrackingPreventionEnabled(m_sessionID, m_trackingPreventionEnabled), 0);
+        networkProcessProxy->send(Messages::NetworkProcess::SetTrackingPreventionEnabled(m_sessionID, enabled), 0);
 
     for (RefPtr processPool : processPools())
-        processPool->sendToAllProcessesForSession(Messages::WebProcess::SetTrackingPreventionEnabled(m_trackingPreventionEnabled), m_sessionID);
+        processPool->sendToAllProcessesForSession(Messages::WebProcess::SetTrackingPreventionEnabled(enabled), m_sessionID);
 }
 
 void WebsiteDataStore::setStatisticsTestingCallback(Function<void(const String&)>&& callback)
@@ -1856,7 +1873,6 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
         WTFMove(resourceLoadStatisticsDirectory),
         WTFMove(resourceLoadStatisticsDirectoryHandle),
         trackingPreventionEnabled(),
-        isTrackingPreventionStateExplicitlySet(),
         hasStatisticsTestingCallback(),
         shouldIncludeLocalhostInResourceLoadStatistics,
         resourceLoadStatisticsDebugMode(),
@@ -1926,10 +1942,9 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 #endif
 
     parameters.networkSessionParameters = WTFMove(networkSessionParameters);
-    parameters.networkSessionParameters.resourceLoadStatisticsParameters.enabled = m_trackingPreventionEnabled;
+    parameters.networkSessionParameters.resourceLoadStatisticsParameters.enabled = trackingPreventionEnabled();
     platformSetNetworkParameters(parameters);
 #if PLATFORM(COCOA)
-    parameters.networkSessionParameters.appHasRequestedCrossWebsiteTrackingPermission = hasRequestedCrossWebsiteTrackingPermission();
     parameters.networkSessionParameters.useNetworkLoader = useNetworkLoader();
 #endif
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -268,8 +268,6 @@ public:
     void setResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting(const URL& firstPartyURL, const URL& cnameURL, CompletionHandler<void()>&&);
     void setResourceLoadStatisticsThirdPartyCNAMEDomainForTesting(const URL&, CompletionHandler<void()>&&);
     WebCore::ThirdPartyCookieBlockingMode thirdPartyCookieBlockingMode() const;
-    bool isTrackingPreventionStateExplicitlySet() const { return m_isTrackingPreventionStateExplicitlySet; }
-    void useExplicitTrackingPreventionState() { m_isTrackingPreventionStateExplicitlySet = true; }
     void closeDatabases(CompletionHandler<void()>&&);
     void syncLocalStorage(CompletionHandler<void()>&&);
     void storeServiceWorkerRegistrations(CompletionHandler<void()>&&);
@@ -524,6 +522,7 @@ private:
 
     void registerWithSessionIDMap();
     bool hasActivePages();
+    bool defaultTrackingPreventionEnabled() const;
 
 #if ENABLE(APP_BOUND_DOMAINS)
     static std::optional<HashSet<WebCore::RegistrableDomain>> appBoundDomainsIfInitialized();
@@ -559,7 +558,8 @@ private:
 #endif
 
     bool m_trackingPreventionDebugMode { false };
-    bool m_trackingPreventionEnabled { false };
+    enum class TrackingPreventionEnabled : uint8_t { Default, No, Yes };
+    TrackingPreventionEnabled m_trackingPreventionEnabled { TrackingPreventionEnabled::Default };
     Function<void(const String&)> m_statisticsTestingCallback;
 
     Ref<WorkQueue> m_queue;
@@ -584,8 +584,6 @@ private:
 
     WeakHashSet<WebProcessProxy> m_processes;
     WeakHashSet<WebPageProxy> m_pages;
-
-    bool m_isTrackingPreventionStateExplicitlySet { false };
 
 #if HAVE(SEC_KEY_PROXY)
     Vector<Ref<SecKeyProxyStore>> m_secKeyProxyStores;


### PR DESCRIPTION
#### 64fda2fa68e045b76c91af8864e0cde1d8ffe896
<pre>
Ensure TrackingPreventionEnabled flag is correctly set before using WebsiteDataStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=270382">https://bugs.webkit.org/show_bug.cgi?id=270382</a>
<a href="https://rdar.apple.com/123922825">rdar://123922825</a>

Reviewed by Chris Dumez.

We currently set TrackingPreventionEnabled on WebsiteDataStore in WebProcessPool::createNewWebProcess. This has caused
problem that TrackingPreventionEnabled is incorrectly set when WebsiteDataStore (or its corresponding NetworkSession)
is in use. One case is when process is created for prewarm, it does not have a attached WebsiteDataStore (it will be
assigned a WebsiteDataStore later), so we don&apos;t set TrackingPreventionEnabled flag, and we don&apos;t set it when the
prewarmed process is used for loading (WebsiteDataStore is assigned to it). Another case is when WebsiteDataStore is
used without web process for website data retrieval. Failing to set the flag will cause ITP data not to be fetched or
removed.

To fix this issue, this patch moves TrackingPreventionEnabled setting to WebsiteDataStore: WebsiteDataStore will get
the right value when it needs to send its parameters to network process and web process (i.e. it&apos;s going to be used).
To simply the setting logic, this patch also makes the following changes:
1. WebsiteDataStore::m_trackingPreventionEnabled now has 3 states: yes, no and default, where default means we will fall
back to TCC permission state to decide the value. This enables us to remove m_isTrackingPreventionStateExplicitlySet.
2. Drop appHasRequestedCrossWebsiteTrackingPermission and TrackingPreventionStateExplicitlySet parameters since network
process does not need to re-compute the TrackingPreventionEnabled value and know about how it is computed. We previously
used it for logging and debugging purpose, and we probably don&apos;t need it any more (as TCC check is not free). This patch
replaces it with normal logging in NetworkSession::setTrackingPreventionEnabled.

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::setTrackingPreventionEnabled):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::activateSessionCleanup): Deleted.
* Source/WebKit/Shared/ResourceLoadStatisticsParameters.h:
* Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in:
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreSetResourceLoadStatisticsEnabled):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _setResourceLoadStatisticsEnabled:]):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createNewWebProcess):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::WebsiteDataStore):
(WebKit::WebsiteDataStore::setIsRunningResourceLoadStatisticsTest):
(WebKit::WebsiteDataStore::defaultTrackingPreventionEnabled const):
(WebKit::WebsiteDataStore::trackingPreventionEnabled const):
(WebKit::WebsiteDataStore::setTrackingPreventionEnabled):
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::isTrackingPreventionStateExplicitlySet const): Deleted.
(WebKit::WebsiteDataStore::useExplicitTrackingPreventionState): Deleted.

Canonical link: <a href="https://commits.webkit.org/275635@main">https://commits.webkit.org/275635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e39d7816173100f39910fba2ff5707b082b5210

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44972 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38490 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18736 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18326 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16038 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46437 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37861 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14162 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18808 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9480 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->