### PR TITLE
Web Inspector: expanded sections of Storage should not collapse

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FolderTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FolderTreeElement.js
@@ -25,11 +25,37 @@
 
 WI.FolderTreeElement = class FolderTreeElement extends WI.GeneralTreeElement
 {
-    constructor(title, representedObject)
+    constructor(title, representedObject, options = {})
     {
         const classNames = [WI.FolderTreeElement.FolderIconStyleClassName];
         const subtitle = null;
         super(classNames, title, subtitle, representedObject, {hasChildren: true});
+
+        if (options.id) {
+            let settingName = `folder-tree-element-${options.id}-expanded`;
+            this._expandedSetting = new WI.Setting(settingName, false);
+
+            if (this._expandedSetting.value)
+                this.expand();
+        }
+    }
+
+    // Public
+
+    collapse()
+    {
+        super.collapse();
+
+        if (this._expandedSetting)
+            this._expandedSetting.value = this.expanded;
+    }
+
+    expand()
+    {
+        super.expand();
+
+        if (this._expandedSetting)
+            this._expandedSetting.value = this.expanded;
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/StorageSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/StorageSidebarPanel.js
@@ -216,9 +216,9 @@ WI.StorageSidebarPanel = class StorageSidebarPanel extends WI.NavigationSidebarP
         var storageElement = new WI.DOMStorageTreeElement(domStorage);
 
         if (domStorage.isLocalStorage())
-            this._localStorageRootTreeElement = this._addStorageChild(storageElement, this._localStorageRootTreeElement, WI.UIString("Local Storage"));
+            this._localStorageRootTreeElement = this._addStorageChild(storageElement, this._localStorageRootTreeElement, WI.UIString("Local Storage"), "local-storage");
         else
-            this._sessionStorageRootTreeElement = this._addStorageChild(storageElement, this._sessionStorageRootTreeElement, WI.UIString("Session Storage"));
+            this._sessionStorageRootTreeElement = this._addStorageChild(storageElement, this._sessionStorageRootTreeElement, WI.UIString("Session Storage"), "session-storage");
     }
 
     _domStorageObjectWasInspected(event)
@@ -241,7 +241,7 @@ WI.StorageSidebarPanel = class StorageSidebarPanel extends WI.NavigationSidebarP
         if (!databaseHostElement) {
             databaseHostElement = new WI.DatabaseHostTreeElement(database.host);
             this._databaseHostTreeElementMap.set(database.host, databaseHostElement);
-            this._databaseRootTreeElement = this._addStorageChild(databaseHostElement, this._databaseRootTreeElement, WI.UIString("Databases"));
+            this._databaseRootTreeElement = this._addStorageChild(databaseHostElement, this._databaseRootTreeElement, WI.UIString("Databases"), "databases");
         }
 
         let databaseElement = new WI.DatabaseTreeElement(database);
@@ -268,7 +268,7 @@ WI.StorageSidebarPanel = class StorageSidebarPanel extends WI.NavigationSidebarP
         if (!indexedDatabaseHostElement) {
             indexedDatabaseHostElement = new WI.IndexedDatabaseHostTreeElement(indexedDatabase.host);
             this._indexedDatabaseHostTreeElementMap.set(indexedDatabase.host, indexedDatabaseHostElement);
-            this._indexedDatabaseRootTreeElement = this._addStorageChild(indexedDatabaseHostElement, this._indexedDatabaseRootTreeElement, WI.UIString("Indexed Databases"));
+            this._indexedDatabaseRootTreeElement = this._addStorageChild(indexedDatabaseHostElement, this._indexedDatabaseRootTreeElement, WI.UIString("Indexed Databases"), "indexed-databases");
         }
 
         let indexedDatabaseElement = new WI.IndexedDatabaseTreeElement(indexedDatabase);
@@ -285,7 +285,7 @@ WI.StorageSidebarPanel = class StorageSidebarPanel extends WI.NavigationSidebarP
         console.assert(cookieStorage instanceof WI.CookieStorageObject);
 
         var cookieElement = new WI.CookieStorageTreeElement(cookieStorage);
-        this._cookieStorageRootTreeElement = this._addStorageChild(cookieElement, this._cookieStorageRootTreeElement, WI.UIString("Cookies"));
+        this._cookieStorageRootTreeElement = this._addStorageChild(cookieElement, this._cookieStorageRootTreeElement, WI.UIString("Cookies"), "cookies");
     }
 
     _frameManifestAdded(event)
@@ -303,7 +303,7 @@ WI.StorageSidebarPanel = class StorageSidebarPanel extends WI.NavigationSidebarP
         if (!applicationCacheManifestElement) {
             applicationCacheManifestElement = new WI.ApplicationCacheManifestTreeElement(manifest);
             this._applicationCacheURLTreeElementMap.set(manifestURL, applicationCacheManifestElement);
-            this._applicationCacheRootTreeElement = this._addStorageChild(applicationCacheManifestElement, this._applicationCacheRootTreeElement, WI.UIString("Application Cache"));
+            this._applicationCacheRootTreeElement = this._addStorageChild(applicationCacheManifestElement, this._applicationCacheRootTreeElement, WI.UIString("Application Cache"), "application-cache");
         }
 
         let frameCacheElement = new WI.ApplicationCacheFrameTreeElement(frameManifest);
@@ -323,7 +323,7 @@ WI.StorageSidebarPanel = class StorageSidebarPanel extends WI.NavigationSidebarP
         return (a.mainTitle || "").extendedLocaleCompare(b.mainTitle || "");
     }
 
-    _addStorageChild(childElement, parentElement, folderName)
+    _addStorageChild(childElement, parentElement, folderName, folderId)
     {
         if (!parentElement) {
             childElement.flattened = true;
@@ -336,11 +336,12 @@ WI.StorageSidebarPanel = class StorageSidebarPanel extends WI.NavigationSidebarP
         if (parentElement instanceof WI.StorageTreeElement) {
             console.assert(parentElement.flattened);
 
-            var previousOnlyChild = parentElement;
+            let previousOnlyChild = parentElement;
             previousOnlyChild.flattened = false;
             this.contentTreeOutline.removeChild(previousOnlyChild);
 
-            var folderElement = new WI.FolderTreeElement(folderName);
+            const representedObject = null;
+            let folderElement = new WI.FolderTreeElement(folderName, representedObject, {id: folderId});
             this.contentTreeOutline.insertChild(folderElement, insertionIndexForObjectInListSortedByFunction(folderElement, this.contentTreeOutline.children, this._compareTreeElements));
 
             folderElement.appendChild(previousOnlyChild);


### PR DESCRIPTION
#### e03b5777dbef981543833275d15e5bd4b3eaddd4
<pre>
Web Inspector: expanded sections of Storage should not collapse
<a href="https://rdar.apple.com/107687975">rdar://107687975</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=255071">https://bugs.webkit.org/show_bug.cgi?id=255071</a>

Reviewed by Devin Rousso.

Use WI.Setting to remember the expanded state of each FolderTreeElement
in the StorageSidebarPanel.

* Source/WebInspectorUI/UserInterface/Views/FolderTreeElement.js:
(WI.FolderTreeElement):
  - Optionally create and load a WI.Setting item for this element.

(WI.FolderTreeElement.prototype.collapse):
(WI.FolderTreeElement.prototype.expand):
  - Update the WI.Setting item on change.

* Source/WebInspectorUI/UserInterface/Views/StorageSidebarPanel.js:
(WI.StorageSidebarPanel.prototype._addDOMStorageObject):
(WI.StorageSidebarPanel.prototype._addDatabase):
(WI.StorageSidebarPanel.prototype._addIndexedDatabase):
(WI.StorageSidebarPanel.prototype._addCookieStorageObject):
(WI.StorageSidebarPanel.prototype._addFrameManifest):
(WI.StorageSidebarPanel.prototype._addStorageChild):
  - Give each of these folder elements an ID so that they create
    and use WI.Setting items.

Canonical link: <a href="https://commits.webkit.org/275783@main">https://commits.webkit.org/275783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd99a975af96b4daa9ea8544736949896b2d31cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38687 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16187 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16311 "Found 9 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-007.html, imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html, imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unrelated-element.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html, imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-disconnected-group-owner.html, imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-012.svg, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37698 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/622 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38820 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46656 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14330 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41933 "Found 1 new test failure: webrtc/captureCanvas-webrtc-software-h264-high.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19003 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40546 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9551 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->