### PR TITLE
Clean up site isolation process selection logic, take 2

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -396,6 +396,21 @@ imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-
 # Tests that time out (or at least timed out when we initially skipped them): #
 # [ Skip ] to avoid running all these tests until verification is needed      #
 ###############################################################################
+http/tests/inspector/target/provisional-load-cancels-previous-load.html [ Skip ]
+http/tests/inspector/target/target-events-for-provisional-page.html [ Skip ]
+http/tests/media/media-stream/get-user-media-localhost.html [ Skip ]
+http/tests/privateClickMeasurement/attribution-conversion-through-fetch-keepalive.html [ Skip ]
+http/tests/privateClickMeasurement/attribution-conversion-through-image-redirect-ephemeral.html [ Skip ]
+http/tests/privateClickMeasurement/attribution-conversion-through-image-redirect-in-new-window.html [ Skip ]
+http/tests/privateClickMeasurement/attribution-conversion-through-image-redirect-with-priority.html [ Skip ]
+http/tests/privateClickMeasurement/attribution-conversion-through-image-redirect-without-priority.html [ Skip ]
+http/tests/privateClickMeasurement/clear-through-website-data-removal.html [ Skip ]
+http/tests/privateClickMeasurement/expired-ad-click-gets-removed-on-session-start.html [ Skip ]
+http/tests/privateClickMeasurement/expired-attributions-removed.html [ Skip ]
+http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-fragment-from-prevalent-resource.html [ Skip ]
+http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-and-fragment-from-prevalent-resource.html [ Skip ]
+http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-with-link-query-from-prevalent-resource.html [ Skip ]
+imported/w3c/web-platform-tests/fetch/http-cache/status.any.html [ Skip ]
 accessibility/aria-menubar-menuitems.html [ Skip ]
 accessibility/mac/spinbutton-valuedescription.html [ Skip ]
 http/tests/cache/xhr-vary-header.html [ Skip ]

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -384,6 +384,7 @@ UIProcess/DisplayLinkProcessProxyClient.cpp
 UIProcess/DrawingAreaProxy.cpp
 UIProcess/FindStringCallbackAggregator.cpp
 UIProcess/FrameLoadState.cpp
+UIProcess/FrameProcess.cpp
 UIProcess/GeolocationPermissionRequestManagerProxy.cpp
 UIProcess/GeolocationPermissionRequestProxy.cpp
 UIProcess/LegacyGlobalSettings.cpp

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -275,7 +275,7 @@ private:
     IPC::MessageReceiverMap m_messageReceiverMap;
     bool m_alwaysRunsAtBackgroundPriority { false };
     bool m_didBeginResponsivenessChecks { false };
-    WebCore::ProcessIdentifier m_processIdentifier { WebCore::ProcessIdentifier::generate() };
+    const WebCore::ProcessIdentifier m_processIdentifier { WebCore::ProcessIdentifier::generate() };
     std::optional<UseLazyStop> m_delayedResponsivenessCheck;
     MonotonicTime m_processStart;
     ProcessThrottler m_throttler;

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -26,27 +26,169 @@
 #include "config.h"
 #include "BrowsingContextGroup.h"
 
+#include "FrameProcess.h"
+#include "PageLoadState.h"
+#include "RemotePageProxy.h"
+#include "WebFrameProxy.h"
 #include "WebProcessProxy.h"
 
 namespace WebKit {
 
 BrowsingContextGroup::BrowsingContextGroup() = default;
 
-WebProcessProxy* BrowsingContextGroup::processForDomain(const WebCore::RegistrableDomain& domain)
+BrowsingContextGroup::~BrowsingContextGroup() = default;
+
+Ref<FrameProcess> BrowsingContextGroup::ensureProcessForDomain(const WebCore::RegistrableDomain& domain, WebProcessProxy& process, const WebPreferences& preferences)
+{
+    if (preferences.siteIsolationEnabled() || preferences.processSwapOnCrossSiteWindowOpenEnabled()) {
+        if (auto* existingProcess = processForDomain(domain)) {
+            ASSERT(existingProcess->process().coreProcessIdentifier() == process.coreProcessIdentifier());
+            return *existingProcess;
+        }
+    }
+    return FrameProcess::create(process, *this, domain, preferences);
+}
+
+FrameProcess* BrowsingContextGroup::processForDomain(const WebCore::RegistrableDomain& domain)
 {
     auto process = m_processMap.get(domain);
     if (!process)
         return nullptr;
-    if (process->state() == WebProcessProxy::State::Terminated)
+    if (process->process().state() == WebProcessProxy::State::Terminated)
         return nullptr;
     return process.get();
 }
 
-// FIXME: This needs a corresponding remove call when a process terminates. <rdar://116202371>
-void BrowsingContextGroup::addProcessForDomain(const WebCore::RegistrableDomain& domain, WebProcessProxy& process)
+void BrowsingContextGroup::addFrameProcess(FrameProcess& process)
 {
-    ASSERT(!m_processMap.get(domain) || m_processMap.get(domain)->state() == WebProcessProxy::State::Terminated || m_processMap.get(domain) == &process);
+    auto& domain = process.domain();
+    ASSERT(!m_processMap.get(domain) || m_processMap.get(domain)->process().state() == WebProcessProxy::State::Terminated || m_processMap.get(domain) == &process);
     m_processMap.set(domain, process);
+    for (auto& page : m_pages) {
+        if (domain == WebCore::RegistrableDomain(URL(page.currentURL())))
+            return;
+        auto& set = m_remotePages.ensure(page, [] {
+            return HashSet<std::unique_ptr<RemotePageProxy>> { };
+        }).iterator->value;
+        auto newRemotePage = makeUnique<RemotePageProxy>(page, process.process(), domain);
+        newRemotePage->injectPageIntoNewProcess();
+#if ASSERT_ENABLED
+        for (auto& existingPage : set) {
+            ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->domain() != newRemotePage->domain());
+            ASSERT(existingPage->page() == newRemotePage->page());
+        }
+#endif
+        set.add(WTFMove(newRemotePage));
+    }
+}
+
+void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
+{
+    ASSERT(process.domain().isEmpty() || m_processMap.get(process.domain()).get() == &process);
+    m_processMap.remove(process.domain());
+
+    m_remotePages.removeIf([&] (auto& pair) {
+        auto& set = pair.value;
+        set.removeIf([&] (auto& remotePage) {
+            return remotePage->process().coreProcessIdentifier() == process.process().coreProcessIdentifier();
+        });
+        return set.isEmpty();
+    });
+}
+
+void BrowsingContextGroup::addPage(WebPageProxy& page)
+{
+    ASSERT(!m_pages.contains(page));
+    m_pages.add(page);
+    auto& set = m_remotePages.ensure(page, [] {
+        return HashSet<std::unique_ptr<RemotePageProxy>> { };
+    }).iterator->value;
+    m_processMap.removeIf([&] (auto& pair) {
+        auto& domain = pair.key;
+        auto& process = pair.value;
+        if (!process) {
+            ASSERT_NOT_REACHED_WITH_MESSAGE("FrameProcess should remove itself in the destructor so we should never find a null WeakPtr");
+            return true;
+        }
+
+        if (domain == page.mainFrameOrOpenerDomain())
+            return false;
+        auto newRemotePage = makeUnique<RemotePageProxy>(page, process->process(), domain);
+        newRemotePage->injectPageIntoNewProcess();
+#if ASSERT_ENABLED
+        for (auto& existingPage : set) {
+            ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->domain() != newRemotePage->domain());
+            ASSERT(existingPage->page() == newRemotePage->page());
+        }
+#endif
+        set.add(WTFMove(newRemotePage));
+        return false;
+    });
+}
+
+void BrowsingContextGroup::removePage(WebPageProxy& page)
+{
+    ASSERT(m_pages.contains(page));
+    m_pages.remove(page);
+
+    m_remotePages.take(page);
+}
+
+void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<void(RemotePageProxy&)>&& function)
+{
+    auto it = m_remotePages.find(page);
+    if (it == m_remotePages.end())
+        return;
+    for (auto& remotePage : it->value) {
+        if (remotePage)
+            function(*remotePage);
+    }
+}
+
+RemotePageProxy* BrowsingContextGroup::remotePageInProcess(const WebPageProxy& page, const WebCore::RegistrableDomain& domain)
+{
+    if (auto frameProcess = m_processMap.get(domain))
+        return remotePageInProcess(page, frameProcess->process());
+    return nullptr;
+}
+
+RemotePageProxy* BrowsingContextGroup::remotePageInProcess(const WebPageProxy& page, const WebProcessProxy& process)
+{
+    auto it = m_remotePages.find(page);
+    if (it == m_remotePages.end())
+        return nullptr;
+    for (auto& remotePage : it->value) {
+        if (remotePage->process().coreProcessIdentifier() == process.coreProcessIdentifier())
+            return remotePage.get();
+    }
+    return nullptr;
+}
+
+std::unique_ptr<RemotePageProxy> BrowsingContextGroup::takeRemotePageInProcessForProvisionalPage(const WebPageProxy& page, const WebCore::RegistrableDomain& domain)
+{
+    auto it = m_remotePages.find(page);
+    if (it == m_remotePages.end())
+        return nullptr;
+    auto* remotePage = remotePageInProcess(page, domain);
+    if (!remotePage)
+        return nullptr;
+    return it->value.take(remotePage);
+}
+
+void BrowsingContextGroup::transitionPageToRemotePage(WebPageProxy& page, const WebCore::RegistrableDomain& openerDomain)
+{
+    auto& set = m_remotePages.ensure(page, [] {
+        return HashSet<std::unique_ptr<RemotePageProxy>> { };
+    }).iterator->value;
+
+    auto newRemotePage = makeUnique<RemotePageProxy>(page, page.process(), openerDomain, &page.messageReceiverRegistration());
+#if ASSERT_ENABLED
+    for (auto& existingPage : set) {
+        ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->domain() != newRemotePage->domain());
+        ASSERT(existingPage->page() == newRemotePage->page());
+    }
+#endif
+    set.add(WTFMove(newRemotePage));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/FrameProcess.cpp
+++ b/Source/WebKit/UIProcess/FrameProcess.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,18 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "FrameProcess.h"
 
-#include "RemotePageProxy.h"
-#include <WebCore/RegistrableDomain.h>
-#include <wtf/HashMap.h>
+#include "BrowsingContextGroup.h"
+#include "WebPageProxy.h"
+#include "WebPreferences.h"
 
 namespace WebKit {
 
-struct RemotePageProxyState {
-    HashMap<WebCore::RegistrableDomain, WeakPtr<RemotePageProxy>> domainToRemotePageProxyMap;
-    RefPtr<RemotePageProxy> remotePageProxyInOpenerProcess;
-    HashMap<WebPageProxyIdentifier, Ref<RemotePageProxy>> openedRemotePageProxies;
-};
+FrameProcess::FrameProcess(WebProcessProxy& process, BrowsingContextGroup& group, const WebCore::RegistrableDomain& domain, const WebPreferences& preferences)
+    : m_process(process)
+    , m_browsingContextGroup(group)
+    , m_domain(domain)
+{
+    if (preferences.siteIsolationEnabled() || preferences.processSwapOnCrossSiteWindowOpenEnabled())
+        group.addFrameProcess(*this);
+    else
+        m_browsingContextGroup = nullptr;
+}
+
+FrameProcess::~FrameProcess()
+{
+    if (m_browsingContextGroup)
+        m_browsingContextGroup->removeFrameProcess(*this);
+}
 
 }

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,36 +25,33 @@
 
 #pragma once
 
-#include "WebPageProxyIdentifier.h"
-#include <WebCore/LayerHostingContextIdentifier.h>
-#include <WebCore/PageIdentifier.h>
+#include <WebCore/RegistrableDomain.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
-class FrameProcess;
-class VisitedLinkStore;
-class WebFrameProxy;
+class BrowsingContextGroup;
+class WebPreferences;
 class WebProcessProxy;
 
-class ProvisionalFrameProxy : public CanMakeWeakPtr<ProvisionalFrameProxy> {
-    WTF_MAKE_FAST_ALLOCATED;
+class FrameProcess : public RefCounted<FrameProcess>, public CanMakeWeakPtr<FrameProcess> {
 public:
-    ProvisionalFrameProxy(WebFrameProxy&, Ref<FrameProcess>&&);
-    ~ProvisionalFrameProxy();
+    ~FrameProcess();
 
-    WebProcessProxy& process() const;
-    Ref<WebProcessProxy> protectedProcess() const;
-
-    WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
-
-    Ref<FrameProcess> takeFrameProcess();
+    const WebCore::RegistrableDomain& domain() const { return m_domain; }
+    const WebProcessProxy& process() const { return m_process.get(); }
+    WebProcessProxy& process() { return m_process.get(); }
 
 private:
-    WeakRef<WebFrameProxy> m_frame;
-    Ref<FrameProcess> m_frameProcess;
-    Ref<VisitedLinkStore> m_visitedLinkStore;
-    WebCore::LayerHostingContextIdentifier m_layerHostingContextIdentifier;
+    friend class BrowsingContextGroup; // FrameProcess should not be created except by BrowsingContextGroup.
+    static Ref<FrameProcess> create(WebProcessProxy& process, BrowsingContextGroup& group, const WebCore::RegistrableDomain& domain, const WebPreferences& preferences) { return adoptRef(*new FrameProcess(process, group, domain, preferences)); }
+    FrameProcess(WebProcessProxy&, BrowsingContextGroup&, const WebCore::RegistrableDomain&, const WebPreferences&);
+
+    Ref<WebProcessProxy> m_process;
+    WeakPtr<BrowsingContextGroup> m_browsingContextGroup;
+    const WebCore::RegistrableDomain m_domain;
 };
 
-} // namespace WebKit
+}

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -26,31 +26,32 @@
 #include "config.h"
 #include "ProvisionalFrameProxy.h"
 
-#include "RemotePageProxy.h"
+#include "FrameProcess.h"
 #include "VisitedLinkStore.h"
 #include "WebFrameProxy.h"
 #include "WebPageProxy.h"
 
 namespace WebKit {
 
-ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, WebProcessProxy& process, RefPtr<RemotePageProxy>&& remotePageProxy)
+ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<FrameProcess>&& frameProcess)
     : m_frame(frame)
-    , m_process(process)
-    , m_remotePageProxy(WTFMove(remotePageProxy))
+    , m_frameProcess(WTFMove(frameProcess))
     , m_visitedLinkStore(frame.page()->visitedLinkStore())
-    , m_pageID(frame.page()->webPageID())
-    , m_webPageID(frame.page()->identifier())
     , m_layerHostingContextIdentifier(WebCore::LayerHostingContextIdentifier::generate())
 {
-    ASSERT(!m_remotePageProxy || m_remotePageProxy->process().coreProcessIdentifier() == process.coreProcessIdentifier());
-    m_process->markProcessAsRecentlyUsed();
+    process().markProcessAsRecentlyUsed();
 }
 
 ProvisionalFrameProxy::~ProvisionalFrameProxy() = default;
 
-RefPtr<RemotePageProxy> ProvisionalFrameProxy::takeRemotePageProxy()
+Ref<FrameProcess> ProvisionalFrameProxy::takeFrameProcess()
 {
-    return std::exchange(m_remotePageProxy, nullptr);
+    return WTFMove(m_frameProcess);
+}
+
+WebProcessProxy& ProvisionalFrameProxy::process() const
+{
+    return m_frameProcess->process();
 }
 
 Ref<WebProcessProxy> ProvisionalFrameProxy::protectedProcess() const

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -59,19 +59,20 @@
 #include "WebProcessProxy.h"
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
 
-#define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, process().connection())
 
 namespace WebKit {
 
 using namespace WebCore;
 
-#define PROVISIONALPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i, navigationID=%" PRIu64 "] ProvisionalPageProxy::" fmt, this, m_page->identifier().toUInt64(), m_webPageID.toUInt64(), m_process->processID(), m_navigationID, ##__VA_ARGS__)
-#define PROVISIONALPAGEPROXY_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i, navigationID=%" PRIu64 "] ProvisionalPageProxy::" fmt, this, m_page->identifier().toUInt64(), m_webPageID.toUInt64(), m_process->processID(), m_navigationID, ##__VA_ARGS__)
+#define PROVISIONALPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i, navigationID=%" PRIu64 "] ProvisionalPageProxy::" fmt, this, m_page->identifier().toUInt64(), m_webPageID.toUInt64(), process().processID(), m_navigationID, ##__VA_ARGS__)
+#define PROVISIONALPAGEPROXY_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i, navigationID=%" PRIu64 "] ProvisionalPageProxy::" fmt, this, m_page->identifier().toUInt64(), m_webPageID.toUInt64(), process().processID(), m_navigationID, ##__VA_ARGS__)
 
-ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&& process, std::unique_ptr<SuspendedPageProxy> suspendedPage, API::Navigation& navigation, bool isServerRedirect, const WebCore::ResourceRequest& request, ProcessSwapRequestedByClient processSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies* websitePolicies, WebsiteDataStore* replacedDataStoreForWebArchiveLoad)
+ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>&& frameProcess, BrowsingContextGroup& group, std::unique_ptr<SuspendedPageProxy> suspendedPage, API::Navigation& navigation, bool isServerRedirect, const WebCore::ResourceRequest& request, ProcessSwapRequestedByClient processSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies* websitePolicies, WebsiteDataStore* replacedDataStoreForWebArchiveLoad)
     : m_page(page)
     , m_webPageID(suspendedPage ? suspendedPage->webPageID() : PageIdentifier::generate())
-    , m_process(WTFMove(process))
+    , m_frameProcess(WTFMove(frameProcess))
+    , m_browsingContextGroup(group)
     , m_replacedDataStoreForWebArchiveLoad(replacedDataStoreForWebArchiveLoad)
     , m_navigationID(navigation.navigationID())
     , m_isServerRedirect(isServerRedirect)
@@ -80,7 +81,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<WebProcessPro
     , m_isProcessSwappingOnNavigationResponse(isProcessSwappingOnNavigationResponse)
     , m_provisionalLoadURL(isProcessSwappingOnNavigationResponse ? request.url() : URL())
 #if USE(RUNNINGBOARD)
-    , m_provisionalLoadActivity(m_process->throttler().foregroundActivity("Provisional Load"_s))
+    , m_provisionalLoadActivity(m_frameProcess->process().throttler().foregroundActivity("Provisional Load"_s))
 #endif
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     , m_contextIDForVisibilityPropagationInWebProcess(suspendedPage ? suspendedPage->contextIDForVisibilityPropagationInWebProcess() : 0)
@@ -91,25 +92,23 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<WebProcessPro
 {
     PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "ProvisionalPageProxy: suspendedPage=%p", suspendedPage.get());
 
-    m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this);
-    m_process->addProvisionalPageProxy(*this);
-    ASSERT(navigation.processID() == m_process->coreProcessIdentifier());
+    m_messageReceiverRegistration.startReceivingMessages(process(), m_webPageID, *this);
+    process().addProvisionalPageProxy(*this);
+    ASSERT(!page.preferences().siteIsolationEnabled() || navigation.processID() == process().coreProcessIdentifier());
 
-    m_websiteDataStore = m_process->websiteDataStore();
+    m_websiteDataStore = process().websiteDataStore();
     ASSERT(m_websiteDataStore);
     if (m_websiteDataStore && m_websiteDataStore != &m_page->websiteDataStore())
-        m_process->processPool().pageBeginUsingWebsiteDataStore(protectedPage(), *m_websiteDataStore);
+        process().processPool().pageBeginUsingWebsiteDataStore(protectedPage(), *m_websiteDataStore);
 
     // If we are reattaching to a SuspendedPage, then the WebProcess' WebPage already exists and
     // WebPageProxy::didCreateMainFrame() will not be called to initialize m_mainFrame. In such
     // case, we need to initialize m_mainFrame to reflect the fact the the WebProcess' WebPage
     // already exists and already has a main frame.
     if (suspendedPage) {
-        ASSERT(&suspendedPage->process() == m_process.ptr());
+        ASSERT(&suspendedPage->process() == &process());
         suspendedPage->unsuspend();
         m_mainFrame = &suspendedPage->mainFrame();
-        m_browsingContextGroup = &suspendedPage->browsingContextGroup();
-        m_remotePageProxyState = suspendedPage->takeRemotePageProxyState();
     }
 
     initializeWebPage(websitePolicies);
@@ -125,16 +124,26 @@ ProvisionalPageProxy::~ProvisionalPageProxy()
     if (!m_wasCommitted) {
         m_page->inspectorController().willDestroyProvisionalPage(*this);
 
-        auto dataStore = m_process->websiteDataStore();
+        auto dataStore = process().websiteDataStore();
         if (dataStore && dataStore!= &m_page->websiteDataStore())
-            m_process->processPool().pageEndUsingWebsiteDataStore(Ref { m_page.get() }, *dataStore);
+            process().processPool().pageEndUsingWebsiteDataStore(Ref { m_page.get() }, *dataStore);
 
-        if (m_process->hasConnection())
+        if (process().hasConnection())
             send(Messages::WebPage::Close());
-        m_process->removeVisitedLinkStoreUser(m_page->visitedLinkStore(), m_page->identifier());
+        process().removeVisitedLinkStoreUser(m_page->visitedLinkStore(), m_page->identifier());
     }
 
-    m_process->removeProvisionalPageProxy(*this);
+    process().removeProvisionalPageProxy(*this);
+}
+
+WebProcessProxy& ProvisionalPageProxy::process()
+{
+    return m_frameProcess->process();
+}
+
+Ref<WebProcessProxy> ProvisionalPageProxy::protectedProcess()
+{
+    return process();
 }
 
 Ref<WebPageProxy> ProvisionalPageProxy::protectedPage() const
@@ -164,7 +173,7 @@ void ProvisionalPageProxy::setNavigation(API::Navigation& navigation)
         return;
 
     m_navigationID = navigation.navigationID();
-    navigation.setProcessID(m_process->coreProcessIdentifier());
+    navigation.setProcessID(process().coreProcessIdentifier());
 }
 
 void ProvisionalPageProxy::cancel()
@@ -173,7 +182,7 @@ void ProvisionalPageProxy::cancel()
     if (m_provisionalLoadURL.isEmpty() || !m_mainFrame)
         return;
 
-    ASSERT(m_process->state() == WebProcessProxy::State::Running);
+    ASSERT(process().state() == WebProcessProxy::State::Running);
 
     PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "cancel: Simulating a didFailProvisionalLoadForFrame");
     ASSERT(m_mainFrame);
@@ -195,7 +204,7 @@ void ProvisionalPageProxy::cancel()
 
 void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& websitePolicies)
 {
-    m_drawingArea = m_page->pageClient().createDrawingAreaProxy(m_process.copyRef());
+    m_drawingArea = m_page->pageClient().createDrawingAreaProxy(protectedProcess());
 
     bool sendPageCreationParameters { true };
     bool registerWithInspectorController { true };
@@ -204,19 +213,12 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
     std::optional<WebCore::FrameIdentifier> mainFrameIdentifier;
 
     if (page().preferences().processSwapOnCrossSiteWindowOpenEnabled() || page().preferences().siteIsolationEnabled()) {
-        // FIXME: <rdar://121241026> This is not elegant and not robust. It needs to be.
         RegistrableDomain navigationDomain(m_request.url());
         RefPtr openerFrame = m_page->openerFrame();
         RefPtr openerPage = openerFrame ? openerFrame->page() : nullptr;
         if (openerFrame)
             mainFrameIdentifier = m_page->mainFrame()->frameID();
-        auto existingRemotePageProxy = m_page->takeRemotePageProxyInOpenerProcessIfDomainEquals(navigationDomain);
-        if (!existingRemotePageProxy) {
-            if ((existingRemotePageProxy = m_page->takeOpenedRemotePageProxyIfDomainEquals(navigationDomain)))
-                registerWithInspectorController = false; // FIXME: <rdar://121240770> This is a hack. There seems to be a bug in our interaction with WebPageInspectorController.
-        }
-        if (existingRemotePageProxy) {
-            ASSERT(existingRemotePageProxy->process().processID() == m_process->processID());
+        if (auto existingRemotePageProxy = m_browsingContextGroup->takeRemotePageInProcessForProvisionalPage(page(), navigationDomain)) {
             m_webPageID = existingRemotePageProxy->pageID();
             m_mainFrame = existingRemotePageProxy->page()->mainFrame();
             m_messageReceiverRegistration.stopReceivingMessages();
@@ -224,23 +226,18 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
             LocalFrameCreationParameters localFrameCreationParameters {
                 std::nullopt
             };
-            m_process->send(Messages::WebPage::TransitionFrameToLocal(localFrameCreationParameters, m_page->mainFrame()->frameID()), m_webPageID);
+            protectedProcess()->send(Messages::WebPage::TransitionFrameToLocal(localFrameCreationParameters, m_page->mainFrame()->frameID()), m_webPageID);
             sendPageCreationParameters = false;
-        } else if (RefPtr existingRemotePageProxy = openerPage ? openerPage->remotePageProxyForRegistrableDomain(navigationDomain) : nullptr) {
-            ASSERT(existingRemotePageProxy->process().processID() == m_process->processID());
-            openerPage->addOpenedRemotePageProxy(m_page->identifier(), existingRemotePageProxy.releaseNonNull());
             m_needsCookieAccessAddedInNetworkProcess = true;
-        } else if (openerPage) {
-            auto remotePageProxy = RemotePageProxy::create(*openerPage, m_process, navigationDomain);
-            remotePageProxy->injectPageIntoNewProcess();
-            openerPage->addOpenedRemotePageProxy(m_page->identifier(), WTFMove(remotePageProxy));
+            registerWithInspectorController = false; // FIXME: <rdar://121240770> This is a hack. There seems to be a bug in our interaction with WebPageInspectorController.
         }
         m_needsDidStartProvisionalLoad = false;
     }
 
     if (sendPageCreationParameters) {
-        m_process->send(Messages::WebProcess::CreateWebPage(m_webPageID, m_page->creationParametersForProvisionalPage(m_process, *m_drawingArea, WTFMove(websitePolicies), WTFMove(mainFrameIdentifier))), 0);
-        m_process->addVisitedLinkStoreUser(m_page->visitedLinkStore(), m_page->identifier());
+        Ref protectedProcess = this->protectedProcess();
+        protectedProcess->send(Messages::WebProcess::CreateWebPage(m_webPageID, m_page->creationParametersForProvisionalPage(process(), *m_drawingArea, WTFMove(websitePolicies), WTFMove(mainFrameIdentifier))), 0);
+        protectedProcess->addVisitedLinkStoreUser(m_page->visitedLinkStore(), m_page->identifier());
     }
 
     if (m_page->isLayerTreeFrozenDueToSwipeAnimation())
@@ -255,7 +252,7 @@ void ProvisionalPageProxy::loadData(API::Navigation& navigation, std::span<const
     PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "loadData:");
     ASSERT(shouldTreatAsContinuingLoad != WebCore::ShouldTreatAsContinuingLoad::No);
 
-    m_page->loadDataWithNavigationShared(m_process.copyRef(), m_webPageID, navigation, data, mimeType, encoding, baseURL, userData, shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain, WTFMove(websitePolicies), navigation.lastNavigationAction().shouldOpenExternalURLsPolicy, sessionHistoryVisibility);
+    m_page->loadDataWithNavigationShared(protectedProcess(), m_webPageID, navigation, data, mimeType, encoding, baseURL, userData, shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain, WTFMove(websitePolicies), navigation.lastNavigationAction().shouldOpenExternalURLsPolicy, sessionHistoryVisibility);
 }
 
 void ProvisionalPageProxy::loadRequest(API::Navigation& navigation, WebCore::ResourceRequest&& request, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume)
@@ -267,9 +264,9 @@ void ProvisionalPageProxy::loadRequest(API::Navigation& navigation, WebCore::Res
     // we need to make sure we update fromItem's processIdentifier as we want future navigations to this BackForward item to happen in the
     // new process.
     if (navigation.fromItem() && navigation.lockBackForwardList() == WebCore::LockBackForwardList::Yes)
-        navigation.fromItem()->setLastProcessIdentifier(m_process->coreProcessIdentifier());
+        navigation.fromItem()->setLastProcessIdentifier(process().coreProcessIdentifier());
 
-    m_page->loadRequestWithNavigationShared(m_process.copyRef(), m_webPageID, navigation, WTFMove(request), navigation.lastNavigationAction().shouldOpenExternalURLsPolicy, userData, shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain, WTFMove(websitePolicies), existingNetworkResourceLoadIdentifierToResume);
+    m_page->loadRequestWithNavigationShared(protectedProcess(), m_webPageID, navigation, WTFMove(request), navigation.lastNavigationAction().shouldOpenExternalURLsPolicy, userData, shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain, WTFMove(websitePolicies), existingNetworkResourceLoadIdentifierToResume);
 }
 
 void ProvisionalPageProxy::goToBackForwardItem(API::Navigation& navigation, WebBackForwardListItem& item, RefPtr<API::WebsitePolicies>&& websitePolicies, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume)
@@ -278,7 +275,7 @@ void ProvisionalPageProxy::goToBackForwardItem(API::Navigation& navigation, WebB
 
     auto itemStates = m_page->backForwardList().filteredItemStates([this, targetItem = Ref { item }](auto& item) {
         if (auto* backForwardCacheEntry = item.backForwardCacheEntry()) {
-            if (backForwardCacheEntry->processIdentifier() == m_process->coreProcessIdentifier())
+            if (backForwardCacheEntry->processIdentifier() == process().coreProcessIdentifier())
                 return false;
         }
         return &item != targetItem.ptr();
@@ -297,15 +294,15 @@ void ProvisionalPageProxy::goToBackForwardItem(API::Navigation& navigation, WebB
 
     SandboxExtension::Handle sandboxExtensionHandle;
     URL itemURL { item.url() };
-    m_page->maybeInitializeSandboxExtensionHandle(m_process.get(), itemURL, item.resourceDirectoryURL(), sandboxExtensionHandle);
+    m_page->maybeInitializeSandboxExtensionHandle(process(), itemURL, item.resourceDirectoryURL(), sandboxExtensionHandle);
 
     GoToBackForwardItemParameters parameters { navigation.navigationID(), item.itemID(), *navigation.backForwardFrameLoadType(), shouldTreatAsContinuingLoad, WTFMove(websitePoliciesData), m_page->lastNavigationWasAppInitiated(), existingNetworkResourceLoadIdentifierToResume, topPrivatelyControlledDomain, WTFMove(sandboxExtensionHandle) };
-    if (!m_process->isLaunching() || !itemURL.protocolIsFile())
+    if (!process().isLaunching() || !itemURL.protocolIsFile())
         send(Messages::WebPage::GoToBackForwardItem(WTFMove(parameters)));
     else
         send(Messages::WebPage::GoToBackForwardItemWaitingForProcessLaunch(WTFMove(parameters), m_page->identifier()));
 
-    m_process->startResponsivenessTimer();
+    process().startResponsivenessTimer();
 }
 
 inline bool ProvisionalPageProxy::validateInput(FrameIdentifier frameID, const std::optional<uint64_t>& navigationID)
@@ -327,7 +324,7 @@ void ProvisionalPageProxy::didCreateMainFrame(FrameIdentifier frameID)
         ASSERT(m_page->mainFrame()->frameID() == frameID);
         m_mainFrame = m_page->mainFrame();
     } else
-        m_mainFrame = WebFrameProxy::create(protectedPage(), m_process, frameID);
+        m_mainFrame = WebFrameProxy::create(protectedPage(), m_frameProcess, frameID);
 
     // This navigation was destroyed so no need to notify of redirect.
     if (!m_page->navigationState().hasNavigation(m_navigationID))
@@ -349,7 +346,7 @@ void ProvisionalPageProxy::didCreateMainFrame(FrameIdentifier frameID)
             m_mainFrame->frameLoadState().didReceiveServerRedirectForProvisionalLoad(m_request.url());
         else
             m_mainFrame->frameLoadState().didStartProvisionalLoad(m_request.url());
-        m_page->didReceiveServerRedirectForProvisionalLoadForFrameShared(m_process.copyRef(), m_mainFrame->frameID(), m_navigationID, WTFMove(m_request), { });
+        m_page->didReceiveServerRedirectForProvisionalLoadForFrameShared(protectedProcess(), m_mainFrame->frameID(), m_navigationID, WTFMove(m_request), { });
     } else if (previousMainFrame && !previousMainFrame->provisionalURL().isEmpty()) {
         // In case of a process swap after response policy, the didStartProvisionalLoad already happened but the new main frame doesn't know about it
         // so we need to tell it so it can update its provisional URL.
@@ -362,7 +359,7 @@ void ProvisionalPageProxy::didPerformClientRedirect(const String& sourceURLStrin
     if (!validateInput(frameID))
         return;
 
-    m_page->didPerformClientRedirectShared(m_process.copyRef(), sourceURLString, destinationURLString, frameID);
+    m_page->didPerformClientRedirectShared(protectedProcess(), sourceURLString, destinationURLString, frameID);
 }
 
 void ProvisionalPageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, URL&& url, URL&& unreachableURL, const UserData& userData)
@@ -382,7 +379,7 @@ void ProvisionalPageProxy::didStartProvisionalLoadForFrame(FrameIdentifier frame
     if (auto* pageMainFrame = m_page->mainFrame(); pageMainFrame && m_needsDidStartProvisionalLoad)
         pageMainFrame->didStartProvisionalLoad(url);
 
-    m_page->didStartProvisionalLoadForFrameShared(m_process.copyRef(), frameID, WTFMove(frameInfo), WTFMove(request), navigationID, WTFMove(url), WTFMove(unreachableURL), userData);
+    m_page->didStartProvisionalLoadForFrameShared(protectedProcess(), frameID, WTFMove(frameInfo), WTFMove(request), navigationID, WTFMove(url), WTFMove(unreachableURL), userData);
 }
 
 void ProvisionalPageProxy::didFailProvisionalLoadForFrame(FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, const String& provisionalURL, const WebCore::ResourceError& error, WebCore::WillContinueLoading willContinueLoading, const UserData& userData, WebCore::WillInternallyHandleFailure willInternallyHandleFailure)
@@ -399,8 +396,8 @@ void ProvisionalPageProxy::didFailProvisionalLoadForFrame(FrameInfoData&& frameI
         pageMainFrame->didFailProvisionalLoad();
 
     RefPtr frame = WebFrameProxy::webFrame(frameInfo.frameID);
-    MESSAGE_CHECK(m_process, frame);
-    m_page->didFailProvisionalLoadForFrameShared(m_process.copyRef(), *frame, WTFMove(frameInfo), WTFMove(request), navigationID, provisionalURL, error, willContinueLoading, userData, willInternallyHandleFailure); // May delete |this|.
+    MESSAGE_CHECK(frame);
+    m_page->didFailProvisionalLoadForFrameShared(protectedProcess(), *frame, WTFMove(frameInfo), WTFMove(request), navigationID, provisionalURL, error, willContinueLoading, userData, willInternallyHandleFailure); // May delete |this|.
 }
 
 void ProvisionalPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType frameLoadType, const WebCore::CertificateInfo& certificateInfo, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent hasInsecureContent, WebCore::MouseEventPolicy mouseEventPolicy, const UserData& userData)
@@ -412,15 +409,13 @@ void ProvisionalPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameI
     auto page = protectedPage();
     if (page->preferences().processSwapOnCrossSiteWindowOpenEnabled() || page->preferences().siteIsolationEnabled()) {
         RefPtr openerFrame = m_page->openerFrame();
+        page->mainFrame()->setProcess(m_frameProcess);
         if (RefPtr openerPage = openerFrame ? openerFrame->page() : nullptr) {
             RegistrableDomain openerDomain(openerFrame->url());
             RegistrableDomain openedDomain(request.url());
-            if (openerDomain == openedDomain)
-                openerPage->removeOpenedRemotePageProxy(page->identifier());
-            else {
+            if (openerDomain != openedDomain) {
                 page->send(Messages::WebPage::DidCommitLoadInAnotherProcess(page->mainFrame()->frameID(), std::nullopt));
-                page->setRemotePageProxyInOpenerProcess(RemotePageProxy::create(page, openerPage->protectedProcess(), openerDomain, &page->messageReceiverRegistration()));
-                page->mainFrame()->setProcess(m_process.get());
+                m_browsingContextGroup->transitionPageToRemotePage(page, openerDomain);
             }
         }
     }
@@ -436,7 +431,7 @@ void ProvisionalPageProxy::didNavigateWithNavigationData(const WebNavigationData
     if (!validateInput(frameID))
         return;
 
-    m_page->didNavigateWithNavigationDataShared(m_process.copyRef(), store, frameID);
+    m_page->didNavigateWithNavigationDataShared(protectedProcess(), store, frameID);
 }
 
 void ProvisionalPageProxy::didChangeProvisionalURLForFrame(FrameIdentifier frameID, uint64_t navigationID, URL&& url)
@@ -444,7 +439,7 @@ void ProvisionalPageProxy::didChangeProvisionalURLForFrame(FrameIdentifier frame
     if (!validateInput(frameID, navigationID))
         return;
 
-    m_page->didChangeProvisionalURLForFrameShared(m_process.copyRef(), frameID, navigationID, WTFMove(url));
+    m_page->didChangeProvisionalURLForFrameShared(protectedProcess(), frameID, navigationID, WTFMove(url));
 }
 
 void ProvisionalPageProxy::decidePolicyForNavigationActionAsync(NavigationActionData&& data, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
@@ -452,7 +447,7 @@ void ProvisionalPageProxy::decidePolicyForNavigationActionAsync(NavigationAction
     if (!validateInput(data.frameInfo.frameID, data.navigationID))
         return completionHandler({ });
 
-    m_page->decidePolicyForNavigationActionAsyncShared(m_process.copyRef(), WTFMove(data), WTFMove(completionHandler));
+    m_page->decidePolicyForNavigationActionAsyncShared(protectedProcess(), WTFMove(data), WTFMove(completionHandler));
 }
 
 void ProvisionalPageProxy::decidePolicyForResponse(FrameInfoData&& frameInfo, uint64_t navigationID, const WebCore::ResourceResponse& response, const WebCore::ResourceRequest& request, bool canShowMIMEType, const String& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
@@ -460,7 +455,7 @@ void ProvisionalPageProxy::decidePolicyForResponse(FrameInfoData&& frameInfo, ui
     if (!validateInput(frameInfo.frameID, navigationID))
         return completionHandler({ });
 
-    m_page->decidePolicyForResponseShared(m_process.copyRef(), m_webPageID, WTFMove(frameInfo), navigationID, response, request, canShowMIMEType, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue, WTFMove(completionHandler));
+    m_page->decidePolicyForResponseShared(protectedProcess(), m_webPageID, WTFMove(frameInfo), navigationID, response, request, canShowMIMEType, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue, WTFMove(completionHandler));
 }
 
 void ProvisionalPageProxy::didPerformServerRedirect(const String& sourceURLString, const String& destinationURLString, FrameIdentifier frameID)
@@ -468,7 +463,7 @@ void ProvisionalPageProxy::didPerformServerRedirect(const String& sourceURLStrin
     if (!validateInput(frameID))
         return;
 
-    m_page->didPerformServerRedirectShared(m_process.copyRef(), sourceURLString, destinationURLString, frameID);
+    m_page->didPerformServerRedirectShared(protectedProcess(), sourceURLString, destinationURLString, frameID);
 }
 
 void ProvisionalPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame(FrameIdentifier frameID, uint64_t navigationID, WebCore::ResourceRequest&& request, const UserData& userData)
@@ -476,12 +471,12 @@ void ProvisionalPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame(Fr
     if (!validateInput(frameID, navigationID))
         return;
 
-    m_page->didReceiveServerRedirectForProvisionalLoadForFrameShared(m_process.copyRef(), frameID, navigationID, WTFMove(request), userData);
+    m_page->didReceiveServerRedirectForProvisionalLoadForFrameShared(protectedProcess(), frameID, navigationID, WTFMove(request), userData);
 }
 
 void ProvisionalPageProxy::startURLSchemeTask(URLSchemeTaskParameters&& parameters)
 {
-    m_page->startURLSchemeTaskShared(m_process.copyRef(), m_webPageID, WTFMove(parameters));
+    m_page->startURLSchemeTaskShared(protectedProcess(), m_webPageID, WTFMove(parameters));
 }
 
 void ProvisionalPageProxy::backForwardGoToItem(const WebCore::BackForwardItemIdentifier& identifier, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)
@@ -504,38 +499,38 @@ void ProvisionalPageProxy::decidePolicyForNavigationActionSync(NavigationActionD
     }
     ASSERT(m_mainFrame);
 
-    m_page->decidePolicyForNavigationActionSyncShared(m_process.copyRef(), WTFMove(data), WTFMove(reply));
+    m_page->decidePolicyForNavigationActionSyncShared(protectedProcess(), WTFMove(data), WTFMove(reply));
 }
 
 void ProvisionalPageProxy::logDiagnosticMessageFromWebProcess(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
+    MESSAGE_CHECK(message.containsOnlyASCII());
 
     m_page->logDiagnosticMessage(message, description, shouldSample);
 }
 
 void ProvisionalPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
+    MESSAGE_CHECK(message.containsOnlyASCII());
 
     m_page->logDiagnosticMessageWithEnhancedPrivacy(message, description, shouldSample);
 }
 
 void ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess(const String& message, const String& description, const WebCore::DiagnosticLoggingClient::ValueDictionary& valueDictionary, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
+    MESSAGE_CHECK(message.containsOnlyASCII());
 
     m_page->logDiagnosticMessageWithValueDictionary(message, description, valueDictionary, shouldSample);
 }
 
 void ProvisionalPageProxy::backForwardAddItem(BackForwardListItemState&& itemState)
 {
-    m_page->backForwardAddItemShared(m_process.copyRef(), WTFMove(itemState), m_replacedDataStoreForWebArchiveLoad ? LoadedWebArchive::Yes : LoadedWebArchive::No);
+    m_page->backForwardAddItemShared(protectedProcess(), WTFMove(itemState), m_replacedDataStoreForWebArchiveLoad ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
 void ProvisionalPageProxy::didDestroyNavigation(uint64_t navigationID)
 {
-    m_page->didDestroyNavigationShared(m_process.copyRef(), navigationID);
+    m_page->didDestroyNavigationShared(protectedProcess(), navigationID);
 }
 
 #if USE(QUICK_LOOK)
@@ -562,7 +557,7 @@ void ProvisionalPageProxy::bindAccessibilityTree(const String& plugID)
 #if ENABLE(CONTENT_FILTERING)
 void ProvisionalPageProxy::contentFilterDidBlockLoadForFrame(const WebCore::ContentFilterUnblockHandler& unblockHandler, FrameIdentifier frameID)
 {
-    m_page->contentFilterDidBlockLoadForFrameShared(m_process.copyRef(), unblockHandler, frameID);
+    m_page->contentFilterDidBlockLoadForFrameShared(protectedProcess(), unblockHandler, frameID);
 }
 #endif
 
@@ -758,7 +753,7 @@ bool ProvisionalPageProxy::didReceiveSyncMessage(IPC::Connection& connection, IP
 
 IPC::Connection* ProvisionalPageProxy::messageSenderConnection() const
 {
-    return m_process->connection();
+    return m_frameProcess->process().connection();
 }
 
 uint64_t ProvisionalPageProxy::messageSenderDestinationID() const
@@ -770,12 +765,12 @@ bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Option
 {
     // Send messages via the WebProcessProxy instead of the IPC::Connection since AuxiliaryProcessProxy implements queueing of messages
     // while the process is still launching.
-    return m_process->sendMessage(WTFMove(encoder), sendOptions);
+    return process().sendMessage(WTFMove(encoder), sendOptions);
 }
 
 bool ProvisionalPageProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
 {
-    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
+    return process().sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -58,8 +58,6 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
         m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this);
 
     m_process->addRemotePageProxy(*this);
-
-    page.addRemotePageProxy(domain, *this);
 }
 
 void RemotePageProxy::injectPageIntoNewProcess()
@@ -93,27 +91,17 @@ void RemotePageProxy::injectPageIntoNewProcess()
 
 void RemotePageProxy::processDidTerminate(WebCore::ProcessIdentifier processIdentifier)
 {
-    if (m_page && m_page->drawingArea())
-        m_page->drawingArea()->remotePageProcessCrashed(processIdentifier);
-    for (auto& frame : m_frames)
-        frame.remoteProcessDidTerminate();
-}
-
-void RemotePageProxy::addFrame(WebFrameProxy& frame)
-{
-    m_frames.add(frame);
-}
-
-void RemotePageProxy::removeFrame(WebFrameProxy& frame)
-{
-    m_frames.remove(frame);
+    if (!m_page)
+        return;
+    if (auto* drawingArea = m_page->drawingArea())
+        drawingArea->remotePageProcessCrashed(processIdentifier);
+    if (RefPtr mainFrame = m_page->mainFrame())
+        mainFrame->remoteProcessDidTerminate(process());
 }
 
 RemotePageProxy::~RemotePageProxy()
 {
     m_process->removeRemotePageProxy(*this);
-    if (m_page)
-        m_page->removeRemotePageProxy(m_domain);
 }
 
 void RemotePageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -33,7 +33,6 @@
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
-#include <wtf/WeakHashSet.h>
 
 namespace IPC {
 class Connection;
@@ -67,16 +66,14 @@ struct FrameInfoData;
 struct FrameTreeCreationParameters;
 struct NavigationActionData;
 
-class RemotePageProxy : public RefCounted<RemotePageProxy>, public IPC::MessageReceiver {
+class RemotePageProxy : public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemotePageProxy> create(WebPageProxy& page, WebProcessProxy& process, const WebCore::RegistrableDomain& domain, WebPageProxyMessageReceiverRegistration* registrationToTransfer = nullptr) { return adoptRef(*new RemotePageProxy(page, process, domain, registrationToTransfer)); }
+    RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::RegistrableDomain&, WebPageProxyMessageReceiverRegistration* = nullptr);
     ~RemotePageProxy();
 
     WebPageProxy* page() const;
     RefPtr<WebPageProxy> protectedPage() const;
-    void addFrame(WebFrameProxy&);
-    void removeFrame(WebFrameProxy&);
 
     template<typename M> void send(M&&);
     template<typename M> IPC::ConnectionSendSyncResult<M> sendSync(M&& message);
@@ -94,7 +91,6 @@ public:
     const WebCore::RegistrableDomain& domain() const { return m_domain; }
 
 private:
-    RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::RegistrableDomain&, WebPageProxyMessageReceiverRegistration*);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
     void decidePolicyForResponse(FrameInfoData&&, uint64_t navigationID, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, const String& downloadAttribute, bool isShowingInitialAboutBlank, WebCore::CrossOriginOpenerPolicyValue activeDocumentCOOPValue, CompletionHandler<void(PolicyDecision&&)>&&);
@@ -112,7 +108,6 @@ private:
     std::unique_ptr<RemotePageDrawingAreaProxy> m_drawingArea;
     std::unique_ptr<RemotePageVisitedLinkStoreRegistration> m_visitedLinkStoreRegistration;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
-    WeakHashSet<WebFrameProxy> m_frames;
 };
 
 template<typename M> void RemotePageProxy::send(M&& message)

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -104,7 +104,7 @@ static const MessageNameSet& messageNamesToIgnoreWhileSuspended()
 }
 #endif
 
-SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&& process, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&& browsingContextGroup, RemotePageProxyState&& remotePageProxyState, ShouldDelayClosingUntilFirstLayerFlush shouldDelayClosingUntilFirstLayerFlush)
+SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&& process, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&& browsingContextGroup, ShouldDelayClosingUntilFirstLayerFlush shouldDelayClosingUntilFirstLayerFlush)
     : m_page(page)
     , m_webPageID(page.webPageID())
     , m_process(WTFMove(process))
@@ -121,7 +121,6 @@ SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&
     , m_contextIDForVisibilityPropagationInGPUProcess(page.contextIDForVisibilityPropagationInGPUProcess())
 #endif
 #endif
-    , m_remotePageProxyState(WTFMove(remotePageProxyState))
 {
     allSuspendedPages().add(*this);
     m_process->addSuspendedPageProxy(*this);
@@ -133,7 +132,6 @@ SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&
 template<typename T>
 void SuspendedPageProxy::sendToAllProcesses(T&& message)
 {
-    // FIXME: Iterate m_remotePageProxyState.domainToRemotePageProxyMap.values() and send to each RemotePageProxy's process.
     // FIXME: Rename m_process to m_mainFrameProcess and make its use aware of site isolation.
     m_process->send(std::forward<T>(message), m_webPageID);
 }

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -27,7 +27,6 @@
 
 #include "Connection.h"
 #include "ProcessThrottler.h"
-#include "RemotePageProxyState.h"
 #include "WebBackForwardListItem.h"
 #include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebProcessProxy.h"
@@ -57,7 +56,7 @@ enum class ShouldDelayClosingUntilFirstLayerFlush : bool { No, Yes };
 class SuspendedPageProxy final: public IPC::MessageReceiver, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&&, RemotePageProxyState&&, ShouldDelayClosingUntilFirstLayerFlush);
+    SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&&, ShouldDelayClosingUntilFirstLayerFlush);
     ~SuspendedPageProxy();
 
     static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode, const API::PageConfiguration&);
@@ -67,7 +66,6 @@ public:
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
     BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
-    RemotePageProxyState takeRemotePageProxyState() { return std::exchange(m_remotePageProxyState, { }); }
 
     WebBackForwardCache& backForwardCache() const;
 
@@ -128,7 +126,6 @@ private:
     LayerHostingContextID m_contextIDForVisibilityPropagationInGPUProcess { 0 };
 #endif
 #endif
-    RemotePageProxyState m_remotePageProxyState;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -27,9 +27,11 @@
 #include "WebFrameProxy.h"
 
 #include "APINavigation.h"
+#include "BrowsingContextGroup.h"
 #include "Connection.h"
 #include "DrawingAreaMessages.h"
 #include "DrawingAreaProxy.h"
+#include "FrameProcess.h"
 #include "FrameTreeCreationParameters.h"
 #include "FrameTreeNodeData.h"
 #include "LoadedWebArchive.h"
@@ -58,7 +60,7 @@
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
-#define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, process().connection())
 
 namespace WebKit {
 using namespace WebCore;
@@ -85,9 +87,9 @@ bool WebFrameProxy::canCreateFrame(FrameIdentifier frameID)
         && !allFrames().contains(frameID);
 }
 
-WebFrameProxy::WebFrameProxy(WebPageProxy& page, WebProcessProxy& process, FrameIdentifier frameID)
+WebFrameProxy::WebFrameProxy(WebPageProxy& page, FrameProcess& process, FrameIdentifier frameID)
     : m_page(page)
-    , m_process(process)
+    , m_frameProcess(process)
     , m_frameID(frameID)
 {
     ASSERT(!allFrames().contains(frameID));
@@ -148,9 +150,14 @@ bool WebFrameProxy::isMainFrame() const
     return this == m_page->mainFrame() || (m_page->provisionalPageProxy() && this == m_page->provisionalPageProxy()->mainFrame());
 }
 
+WebProcessProxy& WebFrameProxy::process() const
+{
+    return m_frameProcess->process();
+}
+
 ProcessID WebFrameProxy::processID() const
 {
-    return m_process->processID();
+    return process().processID();
 }
 
 std::optional<PageIdentifier> WebFrameProxy::pageIdentifier() const
@@ -393,25 +400,26 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, const St
         return;
 
     RefPtr page = m_page.get();
-    MESSAGE_CHECK(m_process, page);
-    MESSAGE_CHECK(m_process, WebFrameProxy::canCreateFrame(frameID));
-    MESSAGE_CHECK(m_process, frameID.processIdentifier() == m_process->coreProcessIdentifier());
+    MESSAGE_CHECK(page);
+    MESSAGE_CHECK(WebFrameProxy::canCreateFrame(frameID));
+    MESSAGE_CHECK(frameID.processIdentifier() == process().coreProcessIdentifier());
 
-    Ref child = WebFrameProxy::create(*page, protectedProcess(), frameID);
+    Ref child = WebFrameProxy::create(*page, m_frameProcess, frameID);
     child->m_parentFrame = *this;
     child->m_frameName = frameName;
     page->createRemoteSubframesInOtherProcesses(child, frameName);
     m_childFrames.add(WTFMove(child));
 }
 
-void WebFrameProxy::prepareForProvisionalNavigationInProcess(WebProcessProxy& process, const API::Navigation& navigation, CompletionHandler<void()>&& completionHandler)
+void WebFrameProxy::prepareForProvisionalNavigationInProcess(WebProcessProxy& process, const API::Navigation& navigation, BrowsingContextGroup& group, CompletionHandler<void()>&& completionHandler)
 {
-    ASSERT(!isMainFrame());
+    if (isMainFrame())
+        return completionHandler();
 
     if (m_provisionalFrame && m_provisionalFrame->process().processID() == process.processID())
         return completionHandler();
 
-    if (process.coreProcessIdentifier() == m_process->coreProcessIdentifier()) {
+    if (process.coreProcessIdentifier() == this->process().coreProcessIdentifier()) {
         m_provisionalFrame = nullptr;
         return completionHandler();
     }
@@ -420,21 +428,13 @@ void WebFrameProxy::prepareForProvisionalNavigationInProcess(WebProcessProxy& pr
     if (!m_provisionalFrame || navigation.currentRequestIsCrossSiteRedirect()) {
         RefPtr page = m_page.get();
         // FIXME: Main resource (of main or subframe) request redirects should go straight from the network to UI process so we don't need to make the processes for each domain in a redirect chain. <rdar://116202119>
-        RefPtr remotePageProxy = page->remotePageProxyForRegistrableDomain(navigationDomain);
         RegistrableDomain mainFrameDomain(page->mainFrame()->url());
 
-        if (remotePageProxy)
-            ASSERT(remotePageProxy->process().coreProcessIdentifier() == process.coreProcessIdentifier());
-        else if (navigationDomain != mainFrameDomain) {
-            remotePageProxy = RemotePageProxy::create(*page, process, navigationDomain);
-            remotePageProxy->injectPageIntoNewProcess();
-        }
-
-        m_provisionalFrame = makeUnique<ProvisionalFrameProxy>(*this, process, WTFMove(remotePageProxy));
+        m_provisionalFrame = makeUnique<ProvisionalFrameProxy>(*this, group.ensureProcessForDomain(navigationDomain, process, page->preferences()));
         page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AddAllowedFirstPartyForCookies(process.coreProcessIdentifier(), mainFrameDomain, LoadedWebArchive::No), WTFMove(completionHandler));
     }
 
-    if (m_process->processID() != process.processID()) {
+    if (this->process().processID() != process.processID()) {
         LocalFrameCreationParameters localFrameCreationParameters {
             m_provisionalFrame->layerHostingContextIdentifier()
         };
@@ -450,13 +450,7 @@ void WebFrameProxy::commitProvisionalFrame(FrameIdentifier frameID, FrameInfoDat
     ASSERT(m_page);
     if (m_provisionalFrame) {
         protectedProcess()->send(Messages::WebPage::DidCommitLoadInAnotherProcess(frameID, m_provisionalFrame->layerHostingContextIdentifier()), m_page->webPageID());
-        m_process = m_provisionalFrame->process();
-        if (RefPtr remotePageProxy = m_remotePageProxy)
-            remotePageProxy->removeFrame(*this);
-        m_remotePageProxy = m_provisionalFrame->takeRemotePageProxy();
-        if (RefPtr remotePageProxy = m_remotePageProxy)
-            remotePageProxy->addFrame(*this);
-        m_provisionalFrame = nullptr;
+        m_frameProcess = std::exchange(m_provisionalFrame, nullptr)->takeFrameProcess();
     }
     protectedPage()->didCommitLoadForFrame(frameID, WTFMove(frameInfo), WTFMove(request), navigationID, mimeType, frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, containsPluginDocument, hasInsecureContent, mouseEventPolicy, userData);
 }
@@ -527,9 +521,10 @@ FrameTreeCreationParameters WebFrameProxy::frameTreeCreationParameters() const
     };
 }
 
-RemotePageProxy* WebFrameProxy::remotePageProxy() const
+void WebFrameProxy::setProcess(FrameProcess& process)
 {
-    return m_remotePageProxy.get();
+    ASSERT(m_frameProcess.ptr() != &process);
+    m_frameProcess = process;
 }
 
 bool WebFrameProxy::isFocused() const
@@ -538,8 +533,12 @@ bool WebFrameProxy::isFocused() const
     return webPage && webPage->focusedFrame() == this;
 }
 
-void WebFrameProxy::remoteProcessDidTerminate()
+void WebFrameProxy::remoteProcessDidTerminate(WebProcessProxy& process)
 {
+    for (Ref child : m_childFrames)
+        child->remoteProcessDidTerminate(process);
+    if (process.coreProcessIdentifier() != this->process().coreProcessIdentifier())
+        return;
     if (m_frameLoadState.state() == FrameLoadState::State::Finished)
         return;
     notifyParentOfLoadCompletion(protectedProcess());
@@ -561,8 +560,6 @@ void WebFrameProxy::notifyParentOfLoadCompletion(WebProcessProxy& childFrameProc
 
 std::optional<WebCore::PageIdentifier> WebFrameProxy::webPageIDInCurrentProcess()
 {
-    if (m_remotePageProxy)
-        return m_remotePageProxy->pageID();
     if (m_page)
         return m_page->webPageID();
     return std::nullopt;
@@ -672,7 +669,7 @@ WebFrameProxy* WebFrameProxy::previousSibling() const
 WebFrameProxy& WebFrameProxy::rootFrame()
 {
     Ref rootFrame = *this;
-    while (rootFrame->m_parentFrame && rootFrame->m_parentFrame->m_process == m_process)
+    while (rootFrame->m_parentFrame && rootFrame->m_parentFrame->process().coreProcessIdentifier() == process().coreProcessIdentifier())
         rootFrame = *rootFrame->m_parentFrame;
     return rootFrame;
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1443,7 +1443,7 @@ public:
     enum class WillContinueLoadInNewProcess : bool { No, Yes };
     void receivedPolicyDecision(WebCore::PolicyAction, API::Navigation*, RefPtr<API::WebsitePolicies>&&, Ref<API::NavigationAction>&&, WillContinueLoadInNewProcess, std::optional<SandboxExtensionHandle>, std::optional<PolicyDecisionConsoleMessage>&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void receivedNavigationResponsePolicyDecision(WebCore::PolicyAction, API::Navigation*, const WebCore::ResourceRequest&, Ref<API::NavigationResponse>&&, CompletionHandler<void(PolicyDecision&&)>&&);
-    void receivedNavigationActionPolicyDecision(WebProcessProxy&, WebProcessProxy&, WebCore::PolicyAction, API::Navigation*, Ref<API::NavigationAction>&&, ProcessSwapRequestedByClient, WebFrameProxy&, const FrameInfoData&, WasNavigationIntercepted, std::optional<PolicyDecisionConsoleMessage>&&, CompletionHandler<void(PolicyDecision&&)>&&);
+    void receivedNavigationActionPolicyDecision(WebProcessProxy&, WebCore::PolicyAction, API::Navigation*, Ref<API::NavigationAction>&&, ProcessSwapRequestedByClient, WebFrameProxy&, const FrameInfoData&, WasNavigationIntercepted, std::optional<PolicyDecisionConsoleMessage>&&, CompletionHandler<void(PolicyDecision&&)>&&);
 
     void backForwardRemovedItem(const WebCore::BackForwardItemIdentifier&);
 
@@ -2253,14 +2253,7 @@ public:
 #endif
 
     WebProcessProxy* processForRegistrableDomain(const WebCore::RegistrableDomain&);
-    RemotePageProxy* remotePageProxyForRegistrableDomain(const WebCore::RegistrableDomain&) const;
-    void addRemotePageProxy(const WebCore::RegistrableDomain&, RemotePageProxy&);
-    void removeRemotePageProxy(const WebCore::RegistrableDomain&);
-    void setRemotePageProxyInOpenerProcess(Ref<RemotePageProxy>&&);
-    RefPtr<RemotePageProxy> takeRemotePageProxyInOpenerProcessIfDomainEquals(const WebCore::RegistrableDomain&);
-    RefPtr<RemotePageProxy> takeOpenedRemotePageProxyIfDomainEquals(const WebCore::RegistrableDomain&);
-    void addOpenedRemotePageProxy(WebPageProxyIdentifier, Ref<RemotePageProxy>&&);
-    void removeOpenedRemotePageProxy(WebPageProxyIdentifier);
+    WebCore::RegistrableDomain mainFrameOrOpenerDomain() const;
 
     void createRemoteSubframesInOtherProcesses(WebFrameProxy&, const String& frameName);
     void broadcastFrameRemovalToOtherProcesses(IPC::Connection&, WebCore::FrameIdentifier);

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -32,7 +32,6 @@
 #include "LayerTreeContext.h"
 #include "PageLoadState.h"
 #include "ProcessThrottler.h"
-#include "RemotePageProxyState.h"
 #include "ScrollingAccelerationCurve.h"
 #include "VisibleWebPageCounter.h"
 #include "WebColorPicker.h"
@@ -218,8 +217,6 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     WebCore::PageIdentifier webPageID;
     WindowKind windowKind { WindowKind::Unparented };
     PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken;
-
-    RemotePageProxyState remotePageProxyState;
 
     WebPageProxyMessageReceiverRegistration messageReceiverRegistration;
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -474,7 +474,7 @@ public:
     bool hasForegroundWebProcesses() const { return m_foregroundWebProcessCounter.value(); }
     bool hasBackgroundWebProcesses() const { return m_backgroundWebProcessCounter.value(); }
 
-    void processForNavigation(WebPageProxy&, WebFrameProxy&, const API::Navigation&, Ref<WebProcessProxy>&& sourceProcess, const URL& sourceURL, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, const FrameInfoData&, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&);
+    void processForNavigation(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, const FrameInfoData&, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&);
 
     void didReachGoodTimeToPrewarm();
     bool hasPrewarmedProcess() const { return m_prewarmedProcess.get(); }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8180,7 +8180,8 @@
 		FA651BA72AA3CBB600747576 /* NetworkTransportReceiveStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportReceiveStream.h; sourceTree = "<group>"; };
 		FA651BAE2AA3E5FB00747576 /* WebTransportSendStreamSink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebTransportSendStreamSink.h; path = Network/WebTransportSendStreamSink.h; sourceTree = "<group>"; };
 		FA651BAF2AA3E5FB00747576 /* WebTransportSendStreamSink.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebTransportSendStreamSink.cpp; path = Network/WebTransportSendStreamSink.cpp; sourceTree = "<group>"; };
-		FA821D402B1FA5D500482A33 /* RemotePageProxyState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageProxyState.h; sourceTree = "<group>"; };
+		FA6757052B815C8300C1566A /* FrameProcess.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameProcess.cpp; sourceTree = "<group>"; };
+		FA6757062B815C8300C1566A /* FrameProcess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameProcess.h; sourceTree = "<group>"; };
 		FA8262722B2193EA00BB8236 /* APINumber.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = APINumber.serialization.in; sourceTree = "<group>"; };
 		FA96E4AC2AA90A1E0090C5A3 /* WebHistoryItemClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebHistoryItemClient.cpp; sourceTree = "<group>"; };
 		FA96E4AD2AA90A1E0090C5A3 /* WebHistoryItemClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebHistoryItemClient.h; sourceTree = "<group>"; };
@@ -13761,6 +13762,8 @@
 				0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */,
 				1AE00D5E1831792100087DD7 /* FrameLoadState.cpp */,
 				1AE00D5F1831792100087DD7 /* FrameLoadState.h */,
+				FA6757052B815C8300C1566A /* FrameProcess.cpp */,
+				FA6757062B815C8300C1566A /* FrameProcess.h */,
 				9EC532A22447FBAD00215216 /* GeolocationIdentifier.h */,
 				BC06F44912DBD1F5002D78DE /* GeolocationPermissionRequestManagerProxy.cpp */,
 				BC06F44812DBD1F5002D78DE /* GeolocationPermissionRequestManagerProxy.h */,
@@ -13804,7 +13807,6 @@
 				5CCB54DB2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.h */,
 				5C907E9A294D507100B3402D /* RemotePageProxy.cpp */,
 				5C907E99294D507100B3402D /* RemotePageProxy.h */,
-				FA821D402B1FA5D500482A33 /* RemotePageProxyState.h */,
 				5CEB40A22A534EE100563C91 /* RemotePageVisitedLinkStoreRegistration.h */,
 				BC111B08112F5E3C00337BAB /* ResponsivenessTimer.cpp */,
 				1A30066C1110F4F70031937C /* ResponsivenessTimer.h */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -123,9 +123,48 @@ static RetainPtr<NSSet> frameTrees(WKWebView *webView)
     return result;
 }
 
+static Vector<char> indentation(size_t count)
+{
+    Vector<char> result;
+    for (size_t i = 0; i < count; i++)
+        result.append(' ');
+    result.append(0);
+    return result;
+}
+
+static void printTree(_WKFrameTreeNode *n, size_t indent = 0)
+{
+    if (n.info._isLocalFrame)
+        WTFLogAlways("%s%@://%@ (pid %d)", indentation(indent).data(), n.info.securityOrigin.protocol, n.info.securityOrigin.host, n.info._processIdentifier);
+    else
+        WTFLogAlways("%s(remote) (pid %d)", indentation(indent).data(), n.info._processIdentifier);
+    for (_WKFrameTreeNode *c in n.childFrames)
+        printTree(c, indent + 1);
+}
+
+static void printTree(const ExpectedFrameTree& n, size_t indent = 0)
+{
+    if (auto* s = std::get_if<String>(&n.remoteOrOrigin))
+        WTFLogAlways("%s%s", indentation(indent).data(), s->utf8().data());
+    else
+        WTFLogAlways("%s(remote)", indentation(indent).data());
+    for (const auto& c : n.children)
+        printTree(c, indent + 1);
+}
+
 static void checkFrameTreesInProcesses(NSSet<_WKFrameTreeNode *> *actualTrees, Vector<ExpectedFrameTree>&& expectedFrameTrees)
 {
-    EXPECT_TRUE(frameTreesMatch(actualTrees, WTFMove(expectedFrameTrees)));
+    bool result = frameTreesMatch(actualTrees, WTFMove(expectedFrameTrees));
+    if (!result) {
+        WTFLogAlways("ACTUAL");
+        for (_WKFrameTreeNode *n in actualTrees)
+            printTree(n);
+        WTFLogAlways("EXPECTED");
+        for (const auto& e : expectedFrameTrees)
+            printTree(e);
+        WTFLogAlways("END");
+    }
+    EXPECT_TRUE(result);
 }
 
 void checkFrameTreesInProcesses(WKWebView *webView, Vector<ExpectedFrameTree>&& expectedFrameTrees)
@@ -140,7 +179,7 @@ static pid_t findFramePID(NSSet<_WKFrameTreeNode *> *set, FrameType local)
         if (node.info._isLocalFrame == (local == FrameType::Local))
             return node.info._processIdentifier;
     }
-    ASSERT_NOT_REACHED();
+    EXPECT_FALSE(true);
     return 0;
 }
 
@@ -411,9 +450,7 @@ TEST(SiteIsolation, ParentOpener)
     EXPECT_WK_STREQ([opened.uiDelegate waitForAlert], "posted message 1");
 
     [opened.webView evaluateJavaScript:@"try { top.opener.postMessage('test2', '*'); alert('posted message 2') } catch(e) { alert(e) }" inFrame:childFrame.get() inContentWorld:WKContentWorld.pageWorld completionHandler:nil];
-    // FIXME: This should say "posted message 2" like it does without site isolation on.
-    // It currently does not because when we make a new process for an iframe, we don't inject the opener remote page into it.
-    EXPECT_WK_STREQ([opened.uiDelegate waitForAlert], "TypeError: null is not an object (evaluating 'top.opener.postMessage')");
+    EXPECT_WK_STREQ([opened.uiDelegate waitForAlert], "posted message 2");
 }
 
 TEST(SiteIsolation, WindowOpenRedirect)
@@ -997,7 +1034,7 @@ TEST(SiteIsolation, ChildNavigatingToDomainLoadedOnADifferentPage)
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
-        EXPECT_NE(firstFramePID, childFramePid);
+        EXPECT_EQ(firstFramePID, childFramePid);
         EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
         EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
         done = true;


### PR DESCRIPTION
#### fd156dff97eb3b90c5ffb095d3b0b61b6efe20a1
<pre>
Clean up site isolation process selection logic, take 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=270390">https://bugs.webkit.org/show_bug.cgi?id=270390</a>
<a href="https://rdar.apple.com/123936252">rdar://123936252</a>

Reviewed by Charlie Wolfe.

This re-lands 275551@main but with two important changes:
1. I retain the preferences().siteIsolationEnabled() check when finding processNavigatingFrom
   to make it so there is no change in behavior with site isolation off.  I verified this fixes
   the three API tests that were broken by 275551@main.
2. I skip some site isolation layout tests that start timing out or asserting because the logic
   isn&apos;t quite right when opening a new page but severing the opener relationship with something
   like an anchor tag with target=_blank.  This will be fixed in a future PR.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::ensureProcessForDomain):
(WebKit::BrowsingContextGroup::processForDomain):
(WebKit::BrowsingContextGroup::addFrameProcess):
(WebKit::BrowsingContextGroup::removeFrameProcess):
(WebKit::BrowsingContextGroup::addPage):
(WebKit::BrowsingContextGroup::removePage):
(WebKit::BrowsingContextGroup::forEachRemotePage):
(WebKit::BrowsingContextGroup::remotePageInProcess):
(WebKit::BrowsingContextGroup::takeRemotePageInProcessForProvisionalPage):
(WebKit::BrowsingContextGroup::transitionPageToRemotePage):
(WebKit::BrowsingContextGroup::addProcessForDomain): Deleted.
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/FrameProcess.cpp: Renamed from Source/WebKit/UIProcess/RemotePageProxyState.h.
(WebKit::FrameProcess::FrameProcess):
(WebKit::FrameProcess::~FrameProcess):
* Source/WebKit/UIProcess/FrameProcess.h: Copied from Source/WebKit/UIProcess/BrowsingContextGroup.h.
(WebKit::FrameProcess::domain const):
(WebKit::FrameProcess::process const):
(WebKit::FrameProcess::process):
(WebKit::FrameProcess::create):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
(WebKit::ProvisionalFrameProxy::takeFrameProcess):
(WebKit::ProvisionalFrameProxy::process const):
(WebKit::ProvisionalFrameProxy::takeRemotePageProxy): Deleted.
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
(WebKit::ProvisionalFrameProxy::process const): Deleted.
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::process):
(WebKit::ProvisionalPageProxy::protectedProcess):
(WebKit::ProvisionalPageProxy::setNavigation):
(WebKit::ProvisionalPageProxy::cancel):
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::loadData):
(WebKit::ProvisionalPageProxy::loadRequest):
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
(WebKit::ProvisionalPageProxy::didCreateMainFrame):
(WebKit::ProvisionalPageProxy::didPerformClientRedirect):
(WebKit::ProvisionalPageProxy::didStartProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::didFailProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
(WebKit::ProvisionalPageProxy::didNavigateWithNavigationData):
(WebKit::ProvisionalPageProxy::didChangeProvisionalURLForFrame):
(WebKit::ProvisionalPageProxy::decidePolicyForNavigationActionAsync):
(WebKit::ProvisionalPageProxy::decidePolicyForResponse):
(WebKit::ProvisionalPageProxy::didPerformServerRedirect):
(WebKit::ProvisionalPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::startURLSchemeTask):
(WebKit::ProvisionalPageProxy::decidePolicyForNavigationActionSync):
(WebKit::ProvisionalPageProxy::logDiagnosticMessageFromWebProcess):
(WebKit::ProvisionalPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess):
(WebKit::ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess):
(WebKit::ProvisionalPageProxy::backForwardAddItem):
(WebKit::ProvisionalPageProxy::didDestroyNavigation):
(WebKit::ProvisionalPageProxy::contentFilterDidBlockLoadForFrame):
(WebKit::ProvisionalPageProxy::messageSenderConnection const):
(WebKit::ProvisionalPageProxy::sendMessage):
(WebKit::ProvisionalPageProxy::sendMessageWithAsyncReply):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
(WebKit::ProvisionalPageProxy::browsingContextGroup):
(WebKit::ProvisionalPageProxy::takeRemotePageProxyState): Deleted.
(WebKit::ProvisionalPageProxy::process): Deleted.
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):
(WebKit::RemotePageProxy::processDidTerminate):
(WebKit::RemotePageProxy::~RemotePageProxy):
(WebKit::RemotePageProxy::addFrame): Deleted.
(WebKit::RemotePageProxy::removeFrame): Deleted.
* Source/WebKit/UIProcess/RemotePageProxy.h:
(WebKit::RemotePageProxy::create): Deleted.
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
(WebKit::SuspendedPageProxy::sendToAllProcesses):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::process const):
(WebKit::WebFrameProxy::processID const):
(WebKit::WebFrameProxy::didCreateSubframe):
(WebKit::WebFrameProxy::prepareForProvisionalNavigationInProcess):
(WebKit::WebFrameProxy::commitProvisionalFrame):
(WebKit::WebFrameProxy::setProcess):
(WebKit::WebFrameProxy::remoteProcessDidTerminate):
(WebKit::WebFrameProxy::webPageIDInCurrentProcess):
(WebKit::WebFrameProxy::rootFrame):
(WebKit::WebFrameProxy::remotePageProxy const): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::create):
(WebKit::WebFrameProxy::frameProcess const):
(WebKit::WebFrameProxy::process const): Deleted.
(WebKit::WebFrameProxy::setProcess): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::commitProvisionalPage):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::getAllFrameTrees):
(WebKit::WebPageProxy::forceRepaint):
(WebKit::WebPageProxy::didCreateMainFrame):
(WebKit::WebPageProxy::updateRemoteFrameSize):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::forEachWebContentProcess):
(WebKit::WebPageProxy::createRemoteSubframesInOtherProcesses):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::callAfterNextPresentationUpdate):
(WebKit::WebPageProxy::processForRegistrableDomain):
(WebKit::WebPageProxy::mainFrameOrOpenerDomain const):
(WebKit::WebPageProxy::webPageIDInProcessForDomain const):
(WebKit::WebPageProxy::sendToWebPage):
(WebKit::WebPageProxy::addRemotePageProxy): Deleted.
(WebKit::WebPageProxy::removeRemotePageProxy): Deleted.
(WebKit::WebPageProxy::remotePageProxyForRegistrableDomain const): Deleted.
(WebKit::WebPageProxy::setRemotePageProxyInOpenerProcess): Deleted.
(WebKit::WebPageProxy::takeRemotePageProxyInOpenerProcessIfDomainEquals): Deleted.
(WebKit::WebPageProxy::removeOpenedRemotePageProxy): Deleted.
(WebKit::WebPageProxy::takeOpenedRemotePageProxyIfDomainEquals): Deleted.
(WebKit::WebPageProxy::addOpenedRemotePageProxy): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::indentation):
(TestWebKitAPI::printTree):
(TestWebKitAPI::checkFrameTreesInProcesses):
(TestWebKitAPI::findFramePID):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/275592@main">https://commits.webkit.org/275592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89d2e705a99490ddafc95bab8d21164c3db2d01d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34987 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15924 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46282 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14041 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40231 "Found 1 new API test failure: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18735 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5694 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->