### PR TITLE
Sync `media-element-enqueue-event-crash.html` from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/media/track/media-element-enqueue-event-crash-expected.txt
+++ b/LayoutTests/media/track/media-element-enqueue-event-crash-expected.txt
@@ -1,4 +1,3 @@
-Tests that appending events for dispatching doesn't crash
 
-** No crash. Pass **
+PASS Tests that appending events for dispatching doesn't crash.
 

--- a/LayoutTests/media/track/media-element-enqueue-event-crash.html
+++ b/LayoutTests/media/track/media-element-enqueue-event-crash.html
@@ -1,60 +1,42 @@
 <!DOCTYPE  html>
-<html>
-    <head>
-        <script src=../video-test.js></script>
-        <script src=../../resources/gc.js></script>
+<title>Tests that appending events for dispatching doesn't crash.</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/gc.js"></script>
+<video autoplay>
+    <track src="captions-webvtt/captions-fast.vtt" default>
+</video>
+<script>
+async_test(function(t) {
+    if (localStorage.testRuns)
+        localStorage.testRuns = Number(localStorage.testRuns) + 1;
+    else {
+        localStorage.testRuns = 1;
+        localStorage.totalRuns = 5;
+    }
 
-        <script>
-        if (window.testRunner)
-        {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
+    document.querySelector("track").track.mode = "showing";
+    setTimeout(t.step_func(CFcrash), 100);
 
-        function startTest()
-        {
-            if (localStorage.testRuns)
-                localStorage.testRuns = Number(localStorage.testRuns) + 1;
-            else {
-                localStorage.testRuns = 1;
-                localStorage.totalRuns = 2;
-            }
+    function CFcrash() {
+        var video = document.querySelector("video");
+        video.src = "content/test.mp4";
+        var document1 = document.implementation.createDocument("", null);
+        document1.appendChild(video);
+        delete document1;
 
-            document.getElementsByTagName('track')[0].track.mode = 'showing';
-            setTimeout(CFcrash, 100);
-        }
+        setTimeout(t.step_func(forceGC), 0);
+    }
 
-        function forceGC() {
-            gc();
+    function forceGC() {
+        gc();
 
-            // End the test only if it ran at least totalRuns.
-            if (window.testRunner && localStorage.testRuns == localStorage.totalRuns) {
-                consoleWrite("** No crash. Pass **");
-                testRunner.notifyDone();
-            } else
-                window.location.reload();
-        }
+        // End the test only if it ran totalRuns.
+        if (localStorage.testRuns == localStorage.totalRuns)
+            t.done();
+        else
+            location.reload();
+    }
 
-        function CFcrash()
-        {
-            document1 = document.implementation.createDocument("", null);
-            document1.appendChild(videoElement);
-            delete document1;
-
-            setTimeout(forceGC, 0);
-        }
-
-        document.addEventListener("DOMContentLoaded", startTest, false);
-        setCaptionDisplayMode('Automatic');
-        </script>
-    </head>
-
-    <body>
-        <p>Tests that appending events for dispatching doesn't crash</p>
-        <video autoplay id="videoElement">
-            <source src="../content/test.ogv">
-            <source src="../content/test.mp4">
-            <track src="captions-webvtt/captions-fast.vtt" default>
-        </video>
-    </body>
-</html>
+});
+</script>


### PR DESCRIPTION
#### e651241992db825459849c26dbd8d85a7e1c6988
<pre>
Sync `media-element-enqueue-event-crash.html` from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=270410">https://bugs.webkit.org/show_bug.cgi?id=270410</a>

Reviewed by Jean-Yves Avenard.

This patch is to sync `media-element-enqueue-event-crash.html` from
Blink / Chromium upstream as per below latest commit:

Only change is to use `mp4` rather than `ogv`.

Partial Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/2e0d99c0e86f5dc6624817f27ba76884f5cbbf83">https://source.chromium.org/chromium/chromium/src/+/2e0d99c0e86f5dc6624817f27ba76884f5cbbf83</a>

* LayoutTests/media/track/media-element-enqueue-event-crash.html: Updated
* LayoutTests/media/track/media-element-enqueue-event-crash-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/275654@main">https://commits.webkit.org/275654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87f739a3d5cec6f57ff88823310539aeeb1d381e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44953 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38471 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35088 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46416 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41756 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40358 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36782 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9493 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->