### PR TITLE
VideoSourceIdentifier should contain std::optional<WebCore::MediaPlayerIdentifier>

### DIFF
--- a/LayoutTests/fast/webgpu/optional-media-identifier-expected.txt
+++ b/LayoutTests/fast/webgpu/optional-media-identifier-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/optional-media-identifier.html
+++ b/LayoutTests/fast/webgpu/optional-media-identifier.html
@@ -1,0 +1,43 @@
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+
+function videoWithData() {
+  const data = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = data;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+onload = async () => {
+  try {
+    let video = await videoWithData();
+    let videoFrame = new VideoFrame(video, {timestamp: 0});
+    try { videoFrame.close() } catch {}
+    let video6 = document.createElement('video');
+    let adapter4 = await navigator.gpu.requestAdapter({ });
+    let device3 = await adapter4.requestDevice({
+      label: 'a',
+      requiredFeatures: [
+        'depth32float-stencil8',
+        'texture-compression-etc2',
+        'texture-compression-astc',
+        'shader-f16',
+        'rg11b10ufloat-renderable'
+      ],
+      requiredLimits: {
+      maxVertexAttributes: 22,
+      maxVertexBufferArrayStride: 51879,
+      maxStorageTexturesPerShaderStage: 25,
+      maxBindingsPerBindGroup: 1319,
+      },
+    });
+    let externalTexture15 = device3.importExternalTexture({ label: 'a', source: video6, colorSpace: 'srgb', });
+  } catch {}
+  globalThis.testRunner?.notifyDone();
+};
+</script>
+This test passes if it does not crash.

--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
@@ -50,13 +50,13 @@ struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
     {
 #if ENABLE(WEB_CODECS)
         return WTF::switchOn(videoSource, [&](const RefPtr<HTMLVideoElement> videoElement) -> WebGPU::VideoSourceIdentifier {
-            return videoElement->playerIdentifier().value_or(MediaPlayerIdentifier(0));
+            return videoElement->playerIdentifier();
         }
         , [&](const RefPtr<WebCodecsVideoFrame> videoFrame) -> WebGPU::VideoSourceIdentifier {
             return videoFrame->internalFrame();
         });
 #else
-        return videoSource->playerIdentifier().value_or(MediaPlayerIdentifier(0));
+        return videoSource->playerIdentifier();
 #endif
     }
 #endif

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h
@@ -38,11 +38,11 @@ typedef struct __CVBuffer* CVPixelBufferRef;
 namespace WebCore::WebGPU {
 
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
-using VideoSourceIdentifier = std::variant<WebCore::MediaPlayerIdentifier, RefPtr<WebCore::VideoFrame>, RetainPtr<CVPixelBufferRef>>;
+using VideoSourceIdentifier = std::variant<std::optional<WebCore::MediaPlayerIdentifier>, RefPtr<WebCore::VideoFrame>, RetainPtr<CVPixelBufferRef>>;
 #elif ENABLE(VIDEO)
-using VideoSourceIdentifier = std::variant<WebCore::MediaPlayerIdentifier, RefPtr<WebCore::VideoFrame>, void*>;
+using VideoSourceIdentifier = std::variant<std::optional<WebCore::MediaPlayerIdentifier>, RefPtr<WebCore::VideoFrame>, void*>;
 #else
-using VideoSourceIdentifier = std::variant<WebCore::MediaPlayerIdentifier, void*>;
+using VideoSourceIdentifier = std::variant<std::optional<WebCore::MediaPlayerIdentifier>, void*>;
 #endif
 
 struct ExternalTextureDescriptor : public ObjectDescriptorBase {

--- a/Source/WebCore/platform/VideoPixelFormat.cpp
+++ b/Source/WebCore/platform/VideoPixelFormat.cpp
@@ -46,7 +46,6 @@ VideoPixelFormat convertVideoFramePixelFormat(uint32_t format, bool shouldDiscar
         return shouldDiscardAlpha ? VideoPixelFormat::BGRX : VideoPixelFormat::BGRA;
     if (format == kCVPixelFormatType_32ARGB)
         return shouldDiscardAlpha ? VideoPixelFormat::RGBX : VideoPixelFormat::RGBA;
-    ASSERT_NOT_REACHED();
 #elif USE(GSTREAMER)
     switch (format) {
     case GST_VIDEO_FORMAT_I420:

--- a/Source/WebKit/Shared/WebGPU/WebGPUExternalTextureDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUExternalTextureDescriptor.cpp
@@ -41,7 +41,7 @@ std::optional<ExternalTextureDescriptor> ConvertToBackingContext::convertToBacki
         return std::nullopt;
 
     std::optional<WebCore::MediaPlayerIdentifier> optionalMediaIdentifier { std::nullopt };
-    if (auto* mediaIdentifier = std::get_if<WebCore::MediaPlayerIdentifier>(&externalTextureDescriptor.videoBacking))
+    if (auto* mediaIdentifier = std::get_if<std::optional<WebCore::MediaPlayerIdentifier>>(&externalTextureDescriptor.videoBacking))
         optionalMediaIdentifier = *mediaIdentifier;
     return { { WTFMove(*base), optionalMediaIdentifier, externalTextureDescriptor.colorSpace
 #if PLATFORM(COCOA) && ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -53,13 +53,13 @@ void RemoteAdapterProxy::requestDevice(const WebCore::WebGPU::DeviceDescriptor& 
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
     ASSERT(convertedDescriptor);
     if (!convertedDescriptor)
-        return;
+        return callback(nullptr);
 
     auto identifier = WebGPUIdentifier::generate();
     auto queueIdentifier = WebGPUIdentifier::generate();
     auto sendResult = sendSync(Messages::RemoteAdapter::RequestDevice(*convertedDescriptor, identifier, queueIdentifier));
     if (!sendResult.succeeded())
-        return;
+        return callback(nullptr);
 
     auto [supportedFeatures, supportedLimits] = sendResult.takeReply();
     if (!supportedLimits.maxTextureDimension2D) {


### PR DESCRIPTION
#### da4ede4b4b39958909e39b0e8bc6b34be16a7178
<pre>
VideoSourceIdentifier should contain std::optional&lt;WebCore::MediaPlayerIdentifier&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=270397">https://bugs.webkit.org/show_bug.cgi?id=270397</a>
<a href="https://rdar.apple.com/123810898">rdar://123810898</a>

Reviewed by Mike Wyrzykowski.

Otherwise in RemoteDeviceProxy::importExternalTexture we send a non-nullopt identifier with a value of 0
when what we wanted was to send nullopt.  Identifiers with a value of 0 fail to decode on the receiving
side.  Also fix a few small issues: removed an invalid debug assertion, and call some completion handlers
in error cases.

* LayoutTests/fast/webgpu/optional-media-identifier-expected.txt: Added.
* LayoutTests/fast/webgpu/optional-media-identifier.html: Added.
* Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h:
(WebCore::GPUExternalTextureDescriptor::mediaIdentifierForSource):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTextureDescriptor.h:
* Source/WebCore/platform/VideoPixelFormat.cpp:
(WebCore::convertVideoFramePixelFormat):
* Source/WebKit/Shared/WebGPU/WebGPUExternalTextureDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
(WebKit::WebGPU::RemoteAdapterProxy::requestDevice):

Canonical link: <a href="https://commits.webkit.org/275594@main">https://commits.webkit.org/275594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f4715ad630277fd0407d09dc2f320a780b2df61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34999 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41661 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40247 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36697 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18747 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5696 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->