### PR TITLE
Drop unnecessary downcast<>() calls in InputType::isValidValue()

### DIFF
--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -219,61 +219,61 @@ bool InputType::isValidValue(const String& value) const
 {
     switch (m_type) {
     case Type::Button:
-        return validateInputType(downcast<ButtonInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<ButtonInputType>(*this), value);
     case Type::Checkbox:
-        return validateInputType(downcast<CheckboxInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<CheckboxInputType>(*this), value);
 #if ENABLE(INPUT_TYPE_COLOR)
     case Type::Color:
-        return validateInputType(downcast<ColorInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<ColorInputType>(*this), value);
 #endif
 #if ENABLE(INPUT_TYPE_DATE)
     case Type::Date:
-        return validateInputType(downcast<DateInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<DateInputType>(*this), value);
 #endif
 #if ENABLE(INPUT_TYPE_DATETIMELOCAL)
     case Type::DateTimeLocal:
-        return validateInputType(downcast<DateTimeLocalInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<DateTimeLocalInputType>(*this), value);
 #endif
     case Type::Email:
-        return validateInputType(downcast<EmailInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<EmailInputType>(*this), value);
     case Type::File:
-        return validateInputType(downcast<FileInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<FileInputType>(*this), value);
     case Type::Hidden:
-        return validateInputType(downcast<HiddenInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<HiddenInputType>(*this), value);
     case Type::Image:
-        return validateInputType(downcast<ImageInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<ImageInputType>(*this), value);
 #if ENABLE(INPUT_TYPE_MONTH)
     case Type::Month:
-        return validateInputType(downcast<MonthInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<MonthInputType>(*this), value);
 #endif
     case Type::Number:
-        return validateInputType(downcast<NumberInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<NumberInputType>(*this), value);
     case Type::Password:
-        return validateInputType(downcast<PasswordInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<PasswordInputType>(*this), value);
     case Type::Radio:
-        return validateInputType(downcast<RadioInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<RadioInputType>(*this), value);
     case Type::Range:
-        return validateInputType(downcast<RangeInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<RangeInputType>(*this), value);
     case Type::Reset:
-        return validateInputType(downcast<ResetInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<ResetInputType>(*this), value);
     case Type::Search:
-        return validateInputType(downcast<SearchInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<SearchInputType>(*this), value);
     case Type::Submit:
-        return validateInputType(downcast<SubmitInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<SubmitInputType>(*this), value);
     case Type::Telephone:
-        return validateInputType(downcast<TelephoneInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<TelephoneInputType>(*this), value);
 #if ENABLE(INPUT_TYPE_TIME)
     case Type::Time:
-        return validateInputType(downcast<TimeInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<TimeInputType>(*this), value);
 #endif
     case Type::URL:
-        return validateInputType(downcast<URLInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<URLInputType>(*this), value);
 #if ENABLE(INPUT_TYPE_WEEK)
     case Type::Week:
-        return validateInputType(downcast<WeekInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<WeekInputType>(*this), value);
 #endif
     case Type::Text:
-        return validateInputType(downcast<TextInputType>(*this), value);
+        return validateInputType(uncheckedDowncast<TextInputType>(*this), value);
     default:
         break;
     }


### PR DESCRIPTION
#### 98f0251a08ba2c2bbba7e3750d2c68cfec14e975
<pre>
Drop unnecessary downcast&lt;&gt;() calls in InputType::isValidValue()
<a href="https://bugs.webkit.org/show_bug.cgi?id=270398">https://bugs.webkit.org/show_bug.cgi?id=270398</a>

Reviewed by Anne van Kesteren.

Drop unnecessary downcast&lt;&gt;() calls in InputType::isValidValue(), for performance
reasons.

* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::isValidValue const):

Canonical link: <a href="https://commits.webkit.org/275599@main">https://commits.webkit.org/275599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b856b983d77f4b5d8f4cd8f48145d95473e2023

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35001 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15936 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46298 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41666 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40249 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18749 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5698 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->