### PR TITLE
Return empty port with a delay if destination extension isn't found for externally_connectable.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -118,6 +118,8 @@ NSURL *ensureDirectoryExists(NSURL *directory);
 
 NSString *escapeCharactersInString(NSString *, NSString *charactersToEscape);
 
+void callAfterRandomDelay(Function<void()>&&);
+
 NSDate *toAPI(const WallTime&);
 WallTime toImpl(NSDate *);
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -35,6 +35,7 @@
 #import "Logging.h"
 #import "WKNSData.h"
 #import <JavaScriptCore/JavaScriptCore.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/FileSystem.h>
 
 namespace WebKit {
@@ -430,6 +431,13 @@ NSString *escapeCharactersInString(NSString *string, NSString *charactersToEscap
     }
 
     return result;
+}
+
+void callAfterRandomDelay(Function<void()>&& completionHandler)
+{
+    // Random delay between 100 and 500 milliseconds.
+    auto delay = Seconds::fromMilliseconds(100) + Seconds::fromMilliseconds((static_cast<double>(arc4random()) / static_cast<double>(UINT32_MAX)) * 400);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay.nanosecondsAs<int64_t>()), dispatch_get_main_queue(), makeBlockPtr(WTFMove(completionHandler)).get());
 }
 
 NSDate *toAPI(const WallTime& time)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
@@ -83,9 +83,9 @@ void WebExtensionContext::portPostMessage(WebExtensionContentWorldType targetCon
     }
 }
 
-void WebExtensionContext::portDisconnect(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+void WebExtensionContext::portRemoved(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
 {
-    RELEASE_LOG_DEBUG(Extensions, "Port for channel %{public}llu disconnected in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(sourceContentWorldType));
+    RELEASE_LOG_DEBUG(Extensions, "Port for channel %{public}llu removed in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(sourceContentWorldType));
 
     removePort(sourceContentWorldType, channelIdentifier);
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
@@ -93,11 +93,6 @@ bool WebExtensionMessagePort::isDisconnected() const
 
 void WebExtensionMessagePort::disconnect(Error error)
 {
-    if (isDisconnected())
-        return;
-
-    m_extensionContext->portDisconnect(WebExtensionContentWorldType::Native, WebExtensionContentWorldType::Main, m_channelIdentifier);
-
     remove();
 }
 
@@ -116,6 +111,7 @@ void WebExtensionMessagePort::remove()
     if (isDisconnected())
         return;
 
+    m_extensionContext->portRemoved(WebExtensionContentWorldType::Native, WebExtensionContentWorldType::Main, m_channelIdentifier);
     m_extensionContext->removeNativePort(*this);
     m_extensionContext = nullptr;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -692,7 +692,7 @@ private:
 
     // Port APIs
     void portPostMessage(WebExtensionContentWorldType targetContentWorldType, std::optional<WebKit::WebPageProxyIdentifier>, WebExtensionPortChannelIdentifier, const String& messageJSON);
-    void portDisconnect(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier);
+    void portRemoved(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier);
     void addPorts(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, size_t totalPortObjects);
     void removePort(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier);
     void addNativePort(WebExtensionMessagePort&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -94,7 +94,7 @@ messages -> WebExtensionContext {
 
     // Port APIs
     PortPostMessage(WebKit::WebExtensionContentWorldType targetContentWorldType, std::optional<WebKit::WebPageProxyIdentifier> sendingPageProxyIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON)
-    PortDisconnect(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier)
+    PortRemoved(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier)
 
     // Runtime APIs
     RuntimeGetBackgroundPage() -> (Expected<std::optional<WebCore::PageIdentifier>, WebKit::WebExtensionError> result)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -84,6 +84,9 @@ void WebExtensionAPIEvent::addListener(WebPage& page, RefPtr<WebExtensionCallbac
     m_pageProxyIdentifier = page.webPageProxyIdentifier();
     m_listeners.append(listener);
 
+    if (!hasExtensionContext())
+        return;
+
     WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page.webPageProxyIdentifier(), m_type, contentWorldType()), extensionContext().identifier());
 }
 
@@ -97,6 +100,9 @@ void WebExtensionAPIEvent::removeListener(WebPage& page, RefPtr<WebExtensionCall
         return;
 
     ASSERT(page.webPageProxyIdentifier() == m_pageProxyIdentifier);
+
+    if (!hasExtensionContext())
+        return;
 
     WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }
@@ -113,9 +119,13 @@ void WebExtensionAPIEvent::removeAllListeners()
     if (m_listeners.isEmpty())
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), m_listeners.size()), extensionContext().identifier());
-
+    auto removedCount = m_listeners.size();
     m_listeners.clear();
+
+    if (!hasExtensionContext())
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -76,6 +76,8 @@ public:
     virtual WebExtensionAPIRuntimeBase& runtime() const { return *m_runtime; }
     WebExtensionContextProxy& extensionContext() const { return *m_extensionContext; }
 
+    bool hasExtensionContext() const { return !!m_extensionContext; }
+
 private:
     WebExtensionContentWorldType m_contentWorldType { WebExtensionContentWorldType::Main };
     RefPtr<WebExtensionAPIRuntimeBase> m_runtime;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -57,7 +57,8 @@ public:
     void postMessage(WebFrame&, NSString *, NSString **outExceptionString);
     void disconnect();
 
-    bool disconnected() const { return m_disconnected; }
+    bool isDisconnected() const { return m_disconnected; }
+    bool isQuarantined() const { return !m_channelIdentifier; }
 
     NSString *name();
     NSDictionary *sender();
@@ -79,6 +80,14 @@ public:
 
 private:
     friend class WebExtensionContextProxy;
+
+    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, const String& name)
+        : WebExtensionAPIObject(parentObject)
+        , m_targetContentWorldType(WebExtensionContentWorldType::Main)
+        , m_name(name)
+    {
+        ASSERT(isQuarantined());
+    }
 
     explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name)
         : WebExtensionAPIObject(parentObject)


### PR DESCRIPTION
#### 24d05ed6508910459be7ca081f3d4042a1174f68
<pre>
Return empty port with a delay if destination extension isn&apos;t found for externally_connectable.
<a href="https://webkit.org/b/269539">https://webkit.org/b/269539</a>
<a href="https://rdar.apple.com/123060441">rdar://123060441</a>

Reviewed by Brian Weinstein.

Enhance privacy in web-to-extension messaging by ensuring indistinguishability between scenarios
where an extension is not found or lacks permission to the page and when messaging is permitted.
This approach mitigates fingerprinting based on installed extensions.

Accomplish this by introducing a random delay for runtime.sendMessage() responses in error cases.
Also runtime.connect() now consistently returns a port, which is subsequently disconnected after
a random delay. Importantly, no errors are reported to the web page in any of these situations.

Also improved port bookkeeping by always sending the PortRemoved message (was PortDisconnect)
when the port is disconnected or garbage collected.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::callAfterRandomDelay): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::portRemoved): Added.
(WebKit::WebExtensionContext::portDisconnect): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeWebPageSendMessage): Added work behind callAfterRandomDelay().
(WebKit::WebExtensionContext::runtimeWebPageConnect): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm:
(WebKit::WebExtensionMessagePort::disconnect): Move portRemoved() call to remove().
(WebKit::WebExtensionMessagePort::remove): Add call to portRemoved().
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::addListener): Check hasExtensionContext() before using extensionContext().
This was needed since the quarantined port has no extensionContext, and events it created don&apos;t as well.
(WebKit::WebExtensionAPIEvent::removeListener): Ditto.
(WebKit::WebExtensionAPIEvent::removeAllListeners): Ditto.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::add): ASSERT !isQuarantined(), since it should not be added to the map.
(WebKit::WebExtensionAPIPort::remove): Return early for isQuarantined(). Send PortRemoved here.
(WebKit::WebExtensionAPIPort::postMessage): Use renamed isDisconnected().
(WebKit::WebExtensionAPIPort::fireMessageEventIfNeeded): Return early for isQuarantined().
(WebKit::WebExtensionAPIPort::fireDisconnectEventIfNeeded): Moved PortDisconnect message to remove().
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage): Respond after a random delay.
(WebKit::WebExtensionAPIWebPageRuntime::connect): Return a port, and disconnect after a random delay.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::hasExtensionContext const): Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
(WebKit::WebExtensionAPIPort::isDisconnected const): Added.
(WebKit::WebExtensionAPIPort::isQuarantined const): Added.
(WebKit::WebExtensionAPIPort::WebExtensionAPIPort): Added.
(WebKit::WebExtensionAPIPort::disconnected const): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithWrongIdentifier)): Added.
(TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithWrongIdentifier)): Added.

Canonical link: <a href="https://commits.webkit.org/275637@main">https://commits.webkit.org/275637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ca6c1b4a7e8c3656e87b837ebc160b087e3e59e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44876 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35031 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15962 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41694 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14080 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40284 "Found 1 new API test failure: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18775 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5710 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->