### PR TITLE
[WebGPU] Fix bounds check with offset in Queue::writeTexture

### DIFF
--- a/LayoutTests/fast/webgpu/queue-write-texture-offset-expected.txt
+++ b/LayoutTests/fast/webgpu/queue-write-texture-offset-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/fast/webgpu/queue-write-texture-offset.html
+++ b/LayoutTests/fast/webgpu/queue-write-texture-offset.html
@@ -1,0 +1,196 @@
+<script>
+if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone() }
+onload = async () => {
+  try {
+    let adapter1 = await navigator.gpu.requestAdapter();
+
+    let adapter2 = await navigator.gpu.requestAdapter(
+    {
+    }
+    );
+
+    let adapter0 = await navigator.gpu.requestAdapter(
+    {
+    powerPreference: 'high-performance',
+    }
+    );
+
+    let device1 = await adapter1.requestDevice(
+    {
+    label: 'a',
+    requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage'
+    ],
+    requiredLimits: {
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 11955,
+    maxStorageTexturesPerShaderStage: 36,
+    maxBindingsPerBindGroup: 5823,
+    },
+    }
+    );
+    
+    let device0 = await adapter0.requestDevice(
+    {
+    label: 'a',
+    requiredFeatures: [
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage'
+    ],
+    requiredLimits: {
+    maxVertexAttributes: 27,
+    maxVertexBufferArrayStride: 56492,
+    maxStorageTexturesPerShaderStage: 20,
+    maxBindingsPerBindGroup: 1044,
+    },
+    }
+    );
+
+    
+    let buffer2 = device0.createBuffer(
+    {
+    label: 'a',
+    size: 416592,
+    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    mappedAtCreation: true,
+    }
+    );
+
+    let texture6 = device1.createTexture(
+    {
+    label: 'a',
+    size: {
+    width: 7082,
+    height: 2090,
+    depthOrArrayLayers: 1,
+    },
+    mipLevelCount: 11,
+    format: 'rgb9e5ufloat',
+    usage: GPUTextureUsage.COPY_DST,
+    }
+    );
+
+    let arrayBuffer0 = (() => {
+      try {
+        return buffer2.getMappedRange();
+      } catch (e) {
+        if (e instanceof DOMException && e.name === 'OperationError') {
+          if (
+            e.message === 'getMappedRangeFailed because offset + size > mappedRangeSize + mappedRangeOffset'
+            || e.message === 'validation failed offset < m_mappedRangeOffset'
+            || e.message === 'validation failed - containsRange'
+            || e.message === 'not mapped or destroyed'
+          ) {
+            return new ArrayBuffer(711904);
+          }
+        }
+        throw e;
+      }
+    })();
+
+    let arrayBuffer1 = (() => {
+      try {
+        return buffer2.getMappedRange(
+    176,
+    5664
+    );
+      } catch (e) {
+        if (e instanceof DOMException && e.name === 'OperationError') {
+          if (
+            e.message === 'getMappedRangeFailed because offset + size > mappedRangeSize + mappedRangeOffset'
+            || e.message === 'validation failed offset < m_mappedRangeOffset'
+            || e.message === 'validation failed - containsRange'
+            || e.message === 'not mapped or destroyed'
+          ) {
+            return new ArrayBuffer(7470392);
+          }
+        }
+        throw e;
+      }
+    })();
+
+    let texture0 = device0.createTexture(
+    {
+    size: {
+    width: 521,
+    depthOrArrayLayers: 1,
+    },
+    mipLevelCount: 14,
+    dimension: '3d',
+    format: 'astc-10x10-unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+    viewFormats: [
+    'stencil8',
+    'astc-6x5-unorm'
+    ],
+    }
+    );
+
+    device0.queue.writeTexture(
+    {
+    texture: texture0,
+    mipLevel: 8007,
+    origin: {
+    x: 3805,
+    z: 8083,
+    },
+    aspect: 'depth-only',
+    },
+    arrayBuffer0,
+    {
+    offset: 2178360,
+    bytesPerRow: 7878048,
+    rowsPerImage: 2412496,
+    },
+    {
+    width: 9007,
+    height: 5238,
+    depthOrArrayLayers: 1213,
+    }
+    );
+    
+    device1.queue.writeTexture(
+    {
+    texture: texture6,
+    },
+    arrayBuffer1,
+    {
+    offset: 1356656,
+    bytesPerRow: 3996080,
+    rowsPerImage: 2422968,
+    },
+    {
+    width: 1693,
+    depthOrArrayLayers: 1,
+    }
+    );
+
+    let device2 = await adapter2.requestDevice(
+    {
+    label: 'a',
+    requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable'
+    ],
+    }
+    );
+  } catch {}
+  if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -465,7 +465,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
         return;
     }
 
-    if (!data || !dataByteSize || dataByteSize == dataLayout.offset)
+    if (!data || !dataByteSize || dataByteSize <= dataLayout.offset)
         return;
 
     uint32_t blockSize = Texture::texelBlockSize(textureFormat);
@@ -690,7 +690,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
     ensureBlitCommandEncoder();
     // FIXME(PERFORMANCE): Suballocate, so the common case doesn't need to hit the kernel.
     // FIXME(PERFORMANCE): Should this temporary buffer really be shared?
-    auto newBufferSize = static_cast<NSUInteger>(dataByteSize);
+    NSUInteger newBufferSize = dataByteSize - dataLayout.offset;
     bool noCopy = newBufferSize >= largeBufferSize;
     id<MTLBuffer> temporaryBuffer = noCopy ? [device->device() newBufferWithBytesNoCopy:static_cast<char*>(data) + dataLayout.offset length:newBufferSize options:MTLResourceStorageModeShared deallocator:nil] : [device->device() newBufferWithBytes:static_cast<char*>(data) + dataLayout.offset length:newBufferSize options:MTLResourceStorageModeShared];
     if (!temporaryBuffer)


### PR DESCRIPTION
#### 6dae676c4f80b3c0fab306f0a7aed956dbd57d6a
<pre>
[WebGPU] Fix bounds check with offset in Queue::writeTexture
<a href="https://bugs.webkit.org/show_bug.cgi?id=270400">https://bugs.webkit.org/show_bug.cgi?id=270400</a>
<a href="https://rdar.apple.com/123810754">rdar://123810754</a>

Reviewed by Mike Wyrzykowski.

* LayoutTests/fast/webgpu/queue-write-texture-offset-expected.txt: Added.
* LayoutTests/fast/webgpu/queue-write-texture-offset.html: Added.
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):

Canonical link: <a href="https://commits.webkit.org/275593@main">https://commits.webkit.org/275593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a71b6dcc9deea80fec52ee4c1b8a5c457dc3a360

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46303 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41667 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14058 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40252 "Found 1 new API test failure: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36704 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18754 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5695 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->