### PR TITLE
Reduce use of downcast<>() in WebCore/

### DIFF
--- a/Source/WebCore/dom/ComposedTreeIterator.cpp
+++ b/Source/WebCore/dom/ComposedTreeIterator.cpp
@@ -180,7 +180,7 @@ void ComposedTreeIterator::traverseNextLeavingContext()
 {
     while (context().iterator == context().end && m_contextStack.size() > 1) {
         m_contextStack.removeLast();
-        if (is<HTMLSlotElement>(current()) && advanceInSlot(1))
+        if (auto* slot = dynamicDowncast<HTMLSlotElement>(current()); slot && advanceInSlot(1, *slot))
             return;
         if (context().iterator == context().end)
             return;
@@ -188,11 +188,11 @@ void ComposedTreeIterator::traverseNextLeavingContext()
     }
 }
 
-bool ComposedTreeIterator::advanceInSlot(int direction)
+bool ComposedTreeIterator::advanceInSlot(int direction, const HTMLSlotElement& slot)
 {
     ASSERT(context().slotNodeIndex != notFound);
 
-    auto& assignedNodes = *downcast<HTMLSlotElement>(current()).assignedNodes();
+    auto& assignedNodes = *slot.assignedNodes();
     // It is fine to underflow this.
     context().slotNodeIndex += direction;
     if (context().slotNodeIndex >= assignedNodes.size())
@@ -212,7 +212,7 @@ void ComposedTreeIterator::traverseSiblingInSlot(int direction)
 
     m_contextStack.removeLast();
 
-    if (!advanceInSlot(direction))
+    if (!advanceInSlot(direction, downcast<HTMLSlotElement>(current())))
         *this = { };
 }
 

--- a/Source/WebCore/dom/ComposedTreeIterator.h
+++ b/Source/WebCore/dom/ComposedTreeIterator.h
@@ -62,7 +62,7 @@ private:
     void traverseNextInShadowTree();
     void traverseNextLeavingContext();
     void traverseShadowRoot(ShadowRoot&);
-    bool advanceInSlot(int direction);
+    bool advanceInSlot(int direction, const HTMLSlotElement&);
     void traverseSiblingInSlot(int direction);
 
     struct Context {

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1961,7 +1961,7 @@ void DocumentLoader::stopLoadingSubresources()
     ASSERT(m_subresourceLoaders.isEmpty());
 }
 
-void DocumentLoader::addSubresourceLoader(ResourceLoader& loader)
+void DocumentLoader::addSubresourceLoader(SubresourceLoader& loader)
 {
     // The main resource's underlying ResourceLoader will ask to be added here.
     // It is much simpler to handle special casing of main resource loads if we don't
@@ -1985,7 +1985,7 @@ void DocumentLoader::addSubresourceLoader(ResourceLoader& loader)
             break;
         case Document::AboutToEnterBackForwardCache: {
             // A page about to enter the BackForwardCache should only be able to start ping loads.
-            auto* cachedResource = downcast<SubresourceLoader>(loader).cachedResource();
+            auto* cachedResource = loader.cachedResource();
             ASSERT(cachedResource && (CachedResource::shouldUsePingLoad(cachedResource->type()) || cachedResource->options().keepAlive));
             break;
         }
@@ -2000,15 +2000,15 @@ void DocumentLoader::addSubresourceLoader(ResourceLoader& loader)
     m_subresourceLoaders.add(loader.identifier(), &loader);
 }
 
-void DocumentLoader::removeSubresourceLoader(LoadCompletionType type, ResourceLoader* loader)
+void DocumentLoader::removeSubresourceLoader(LoadCompletionType type, SubresourceLoader& loader)
 {
-    ASSERT(loader->identifier());
+    ASSERT(loader.identifier());
 
-    if (!m_subresourceLoaders.remove(loader->identifier()))
+    if (!m_subresourceLoaders.remove(loader.identifier()))
         return;
     checkLoadComplete();
-    if (m_frame)
-        m_frame->loader().subresourceLoadDone(type);
+    if (RefPtr frame = m_frame.get())
+        frame->checkedLoader()->subresourceLoadDone(type);
 }
 
 void DocumentLoader::addPlugInStreamLoader(ResourceLoader& loader)

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -379,8 +379,8 @@ public:
     WEBCORE_EXPORT ColorSchemePreference colorSchemePreference() const;
     void setColorSchemePreference(ColorSchemePreference preference) { m_colorSchemePreference = preference; }
 
-    void addSubresourceLoader(ResourceLoader&);
-    void removeSubresourceLoader(LoadCompletionType, ResourceLoader*);
+    void addSubresourceLoader(SubresourceLoader&);
+    void removeSubresourceLoader(LoadCompletionType, SubresourceLoader&);
     void addPlugInStreamLoader(ResourceLoader&);
     void removePlugInStreamLoader(ResourceLoader&);
 

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -895,7 +895,7 @@ void SubresourceLoader::notifyDone(LoadCompletionType type)
     if (reachedTerminalState())
         return;
     if (RefPtr documentLoader = this->documentLoader())
-        documentLoader->removeSubresourceLoader(type, this);
+        documentLoader->removeSubresourceLoader(type, *this);
     else
         SUBRESOURCELOADER_RELEASE_LOG_ERROR("notifyDone: document loader is null. Could not call removeSubresourceLoader()");
 }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2726,11 +2726,15 @@ void EventHandler::updateMouseEventTargetNode(const AtomString& eventType, Node*
     // If we're capturing, we always go right to that element.
     if (m_capturingMouseEventsElement)
         targetElement = m_capturingMouseEventsElement.get();
-    else if (targetNode) {
+    else {
         // If the target node is a non-element, dispatch on the parent. <rdar://problem/4196646>
-        while (targetNode && !is<Element>(*targetNode))
+        while (targetNode) {
+            if (auto* asElement = dynamicDowncast<Element>(*targetNode)) {
+                targetElement = asElement;
+                break;
+            }
             targetNode = targetNode->parentInComposedTree();
-        targetElement = downcast<Element>(targetNode);
+        }
     }
 
     m_elementUnderMouse = targetElement;

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -330,10 +330,8 @@ Element* FocusNavigationScope::owner() const
     ASSERT(m_treeScopeRootNode);
     if (RefPtr shadowRoot = dynamicDowncast<ShadowRoot>(*m_treeScopeRootNode))
         return shadowRoot->host();
-    if (isOpenPopoverWithInvoker(m_treeScopeRootNode.get())) {
-        RELEASE_ASSERT(is<HTMLElement>(m_treeScopeRootNode.get()));
-        return downcast<HTMLElement>(*m_treeScopeRootNode).popoverData()->invoker();
-    }
+    if (isOpenPopoverWithInvoker(m_treeScopeRootNode.get()))
+        return checkedDowncast<HTMLElement>(*m_treeScopeRootNode).popoverData()->invoker();
     if (auto* frame = m_treeScopeRootNode->document().frame())
         return frame->ownerElement();
     return nullptr;

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -111,14 +111,11 @@ RenderWidget* Frame::ownerRenderer() const
     RefPtr ownerElement = this->ownerElement();
     if (!ownerElement)
         return nullptr;
-    auto* object = ownerElement->renderer();
     // FIXME: If <object> is ever fixed to disassociate itself from frames
     // that it has started but canceled, then this can turn into an ASSERT
     // since ownerElement would be nullptr when the load is canceled.
     // https://bugs.webkit.org/show_bug.cgi?id=18585
-    if (!is<RenderWidget>(object))
-        return nullptr;
-    return downcast<RenderWidget>(object);
+    return dynamicDowncast<RenderWidget>(ownerElement->renderer());
 }
 
 RefPtr<FrameView> Frame::protectedVirtualView() const

--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -184,8 +184,8 @@ Color estimatedBackgroundColorForRange(const SimpleRange& range, const LocalFram
     RenderElement* renderer = nullptr;
     auto commonAncestor = commonInclusiveAncestor<ComposedTree>(range);
     while (commonAncestor) {
-        if (is<RenderElement>(commonAncestor->renderer())) {
-            renderer = downcast<RenderElement>(commonAncestor->renderer());
+        if (auto* renderElement = dynamicDowncast<RenderElement>(commonAncestor->renderer())) {
+            renderer = renderElement;
             break;
         }
         commonAncestor = commonAncestor->parentOrShadowHostElement();

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -224,9 +224,8 @@ IntPoint FrameView::convertFromContainingViewToRenderer(const RenderElement* ren
 
 IntRect FrameView::convertToContainingView(const IntRect& localRect) const
 {
-    if (const ScrollView* parentScrollView = parent()) {
-        if (is<FrameView>(*parentScrollView)) {
-            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
             RenderWidget* renderer = frame().ownerRenderer();
             if (!renderer)
@@ -234,7 +233,7 @@ IntRect FrameView::convertToContainingView(const IntRect& localRect) const
 
             auto rect = localRect;
             rect.moveBy(roundedIntPoint(renderer->contentBoxLocation()));
-            return parentView.convertFromRendererToContainingView(renderer, rect);
+            return parentView->convertFromRendererToContainingView(renderer, rect);
         }
         return Widget::convertToContainingView(localRect);
     }
@@ -243,16 +242,14 @@ IntRect FrameView::convertToContainingView(const IntRect& localRect) const
 
 IntRect FrameView::convertFromContainingView(const IntRect& parentRect) const
 {
-    if (const ScrollView* parentScrollView = parent()) {
-        if (is<FrameView>(*parentScrollView)) {
-            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
-
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
             RenderWidget* renderer = frame().ownerRenderer();
             if (!renderer)
                 return parentRect;
 
-            auto rect = parentView.convertFromContainingViewToRenderer(renderer, parentRect);
+            auto rect = parentView->convertFromContainingViewToRenderer(renderer, parentRect);
             rect.moveBy(-roundedIntPoint(renderer->contentBoxLocation()));
             return rect;
         }
@@ -263,16 +260,14 @@ IntRect FrameView::convertFromContainingView(const IntRect& parentRect) const
 
 FloatRect FrameView::convertFromContainingView(const FloatRect& parentRect) const
 {
-    if (const ScrollView* parentScrollView = parent()) {
-        if (is<FrameView>(*parentScrollView)) {
-            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
-
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
             RenderWidget* renderer = frame().ownerRenderer();
             if (!renderer)
                 return parentRect;
 
-            auto rect = parentView.convertFromContainingViewToRenderer(renderer, parentRect);
+            auto rect = parentView->convertFromContainingViewToRenderer(renderer, parentRect);
             rect.moveBy(-renderer->contentBoxLocation());
             return rect;
         }
@@ -283,10 +278,8 @@ FloatRect FrameView::convertFromContainingView(const FloatRect& parentRect) cons
 
 IntPoint FrameView::convertToContainingView(const IntPoint& localPoint) const
 {
-    if (const ScrollView* parentScrollView = parent()) {
-        if (is<FrameView>(*parentScrollView)) {
-            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
-
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
             RenderWidget* renderer = frame().ownerRenderer();
             if (!renderer)
@@ -294,7 +287,7 @@ IntPoint FrameView::convertToContainingView(const IntPoint& localPoint) const
 
             auto point = localPoint;
             point.moveBy(roundedIntPoint(renderer->contentBoxLocation()));
-            return parentView.convertFromRendererToContainingView(renderer, point);
+            return parentView->convertFromRendererToContainingView(renderer, point);
         }
         return Widget::convertToContainingView(localPoint);
     }
@@ -303,10 +296,8 @@ IntPoint FrameView::convertToContainingView(const IntPoint& localPoint) const
 
 FloatPoint FrameView::convertToContainingView(const FloatPoint& localPoint) const
 {
-    if (const ScrollView* parentScrollView = parent()) {
-        if (is<FrameView>(*parentScrollView)) {
-            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
-
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
             RenderWidget* renderer = frame().ownerRenderer();
             if (!renderer)
@@ -314,7 +305,7 @@ FloatPoint FrameView::convertToContainingView(const FloatPoint& localPoint) cons
 
             auto point = localPoint;
             point.moveBy(renderer->contentBoxLocation());
-            return parentView.convertFromRendererToContainingView(renderer, point);
+            return parentView->convertFromRendererToContainingView(renderer, point);
         }
         return Widget::convertToContainingView(localPoint);
     }
@@ -323,16 +314,14 @@ FloatPoint FrameView::convertToContainingView(const FloatPoint& localPoint) cons
 
 IntPoint FrameView::convertFromContainingView(const IntPoint& parentPoint) const
 {
-    if (const ScrollView* parentScrollView = parent()) {
-        if (is<FrameView>(*parentScrollView)) {
-            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
-
+    if (auto* parentScrollView = parent()) {
+        if (auto* parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
             RenderWidget* renderer = frame().ownerRenderer();
             if (!renderer)
                 return parentPoint;
 
-            auto point = parentView.convertFromContainingViewToRenderer(renderer, parentPoint);
+            auto point = parentView->convertFromContainingViewToRenderer(renderer, parentPoint);
             point.moveBy(-roundedIntPoint(renderer->contentBoxLocation()));
             return point;
         }

--- a/Source/WebCore/page/ImageAnalysisQueue.cpp
+++ b/Source/WebCore/page/ImageAnalysisQueue.cpp
@@ -58,15 +58,15 @@ ImageAnalysisQueue::~ImageAnalysisQueue() = default;
 
 void ImageAnalysisQueue::enqueueIfNeeded(HTMLImageElement& element)
 {
-    if (!is<RenderImage>(element.renderer()))
+    CheckedPtr renderer = downcast<RenderImage>(element.renderer());
+    if (!renderer)
         return;
 
-    auto& renderer = downcast<RenderImage>(*element.renderer());
-    auto* cachedImage = renderer.cachedImage();
+    CachedResourceHandle cachedImage = renderer->cachedImage();
     if (!cachedImage || cachedImage->errorOccurred())
         return;
 
-    auto* image = cachedImage->image();
+    RefPtr image = cachedImage->image();
     if (!image || image->width() < minimumWidthForAnalysis || image->height() < minimumHeightForAnalysis)
         return;
 
@@ -94,10 +94,10 @@ void ImageAnalysisQueue::enqueueIfNeeded(HTMLImageElement& element)
     if (!shouldAddToQueue)
         return;
 
-    Ref view = renderer.view().frameView();
+    Ref view = renderer->view().frameView();
     m_queue.enqueue({
         element,
-        renderer.isVisibleInDocumentRect(view->windowToContents(view->windowClipRect())) ? Priority::High : Priority::Low,
+        renderer->isVisibleInDocumentRect(view->windowToContents(view->windowClipRect())) ? Priority::High : Priority::Low,
         nextTaskNumber()
     });
     resumeProcessingSoon();

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -205,15 +205,15 @@ void EventHandler::focusDocumentView()
 bool EventHandler::passWidgetMouseDownEventToWidget(const MouseEventWithHitTestResults& event)
 {
     // Figure out which view to send the event to.
-    auto* target = event.targetNode() ? event.targetNode()->renderer() : nullptr;
-    if (!is<RenderWidget>(target))
+    auto* target = event.targetNode() ? dynamicDowncast<RenderWidget>(event.targetNode()->renderer()) : nullptr;
+    if (!target)
         return false;
 
     // Double-click events don't exist in Cocoa. Since passWidgetMouseDownEventToWidget() will
     // just pass currentEvent down to the widget, we don't want to call it for events that
     // don't correspond to Cocoa events. The mousedown/ups will have already been passed on as
     // part of the pressed/released handling.
-    return passMouseDownEventToWidget(downcast<RenderWidget>(*target).widget());
+    return passMouseDownEventToWidget(target->widget());
 }
 
 bool EventHandler::passWidgetMouseDownEventToWidget(RenderWidget* renderWidget)
@@ -399,13 +399,13 @@ bool EventHandler::passSubframeEventToSubframe(MouseEventWithHitTestResults& eve
         auto* node = event.targetNode();
         if (!node)
             return false;
-        auto* renderer = node->renderer();
-        if (!is<RenderWidget>(renderer))
+        auto* renderer = dynamicDowncast<RenderWidget>(node->renderer());
+        if (!renderer)
             return false;
-        auto* widget = downcast<RenderWidget>(*renderer).widget();
+        auto* widget = renderer->widget();
         if (!widget || !widget->isLocalFrameView())
             return false;
-        if (!passWidgetMouseDownEventToWidget(downcast<RenderWidget>(renderer)))
+        if (!passWidgetMouseDownEventToWidget(renderer))
             return false;
         m_mouseDownWasInSubframe = true;
         return true;

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -208,26 +208,25 @@ void ImageOverlayController::elementUnderMouseDidChange(LocalFrame& frame, Eleme
         return;
     }
 
-    auto shadowHost = elementUnderMouse->shadowHost();
-    if (!is<HTMLElement>(shadowHost)) {
+    RefPtr imageOverlayHost = dynamicDowncast<HTMLElement>(elementUnderMouse->shadowHost());
+    if (!imageOverlayHost) {
         ASSERT_NOT_REACHED();
         m_hostElementForDataDetectors = nullptr;
         uninstallPageOverlayIfNeeded();
         return;
     }
 
-    Ref imageOverlayHost = downcast<HTMLElement>(*shadowHost);
-    if (!ImageOverlay::hasOverlay(imageOverlayHost.get())) {
+    if (!ImageOverlay::hasOverlay(*imageOverlayHost)) {
         ASSERT_NOT_REACHED();
         m_hostElementForDataDetectors = nullptr;
         uninstallPageOverlayIfNeeded();
         return;
     }
 
-    if (m_hostElementForDataDetectors == imageOverlayHost.ptr())
+    if (m_hostElementForDataDetectors == imageOverlayHost.get())
         return;
 
-    updateDataDetectorHighlights(imageOverlayHost.get());
+    updateDataDetectorHighlights(*imageOverlayHost);
 
     if (m_dataDetectorContainersAndHighlights.isEmpty()) {
         m_hostElementForDataDetectors = nullptr;
@@ -235,7 +234,7 @@ void ImageOverlayController::elementUnderMouseDidChange(LocalFrame& frame, Eleme
         return;
     }
 
-    m_hostElementForDataDetectors = imageOverlayHost;
+    m_hostElementForDataDetectors = imageOverlayHost.releaseNonNull();
     installPageOverlayIfNeeded();
 }
 


### PR DESCRIPTION
#### 4669b7a5345f90b57f5219e92c8ff15f854e911c
<pre>
Reduce use of downcast&lt;&gt;() in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=270402">https://bugs.webkit.org/show_bug.cgi?id=270402</a>

Reviewed by Darin Adler.

Reduce use of downcast&lt;&gt;() in WebCore/, for performance reasons.

* Source/WebCore/dom/ComposedTreeIterator.cpp:
(WebCore::ComposedTreeIterator::traverseNextLeavingContext):
(WebCore::ComposedTreeIterator::advanceInSlot):
(WebCore::ComposedTreeIterator::traverseSiblingInSlot):
* Source/WebCore/dom/ComposedTreeIterator.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::addSubresourceLoader):
(WebCore::DocumentLoader::removeSubresourceLoader):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::notifyDone):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateMouseEventTargetNode):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusNavigationScope::owner const):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::ownerRenderer const):
* Source/WebCore/page/FrameSnapshotting.cpp:
(WebCore::estimatedBackgroundColorForRange):
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::convertToContainingView const):
(WebCore::FrameView::convertFromContainingView const):
* Source/WebCore/page/ImageAnalysisQueue.cpp:
(WebCore::ImageAnalysisQueue::enqueueIfNeeded):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::passWidgetMouseDownEventToWidget):
(WebCore::EventHandler::passSubframeEventToSubframe):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passWidgetMouseDownEventToWidget):
(WebCore::EventHandler::passSubframeEventToSubframe):
(WebCore::scrollableAreaForBox):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::elementUnderMouseDidChange):

Canonical link: <a href="https://commits.webkit.org/275597@main">https://commits.webkit.org/275597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ecaba238cd81b2ee24646291b73b723340d28ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38384 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18623 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35018 "Failure limit exceed. At least found 176 new test failures: accessibility/math-multiscript-attributes.html, animations/multiple-backgrounds.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/masks/become-tiled-mask.html, compositing/tiling/empty-to-tiled.html, compositing/tiling/sticky-change-to-tiled.html, css1/basic/inheritance.html, css1/font_properties/font.html, css1/font_properties/font_size.html, css1/formatting_model/inline_elements.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15950 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41681 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40269 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18702 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9460 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->