### PR TITLE
[WebCore] Optimize Font::applyTransforms

### DIFF
--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -375,8 +375,8 @@ static void buildQuery(DDScanQueryRef scanQuery, const SimpleRange& contextRange
             continue;
         }
         // Test for white space nodes, we're coalescing them.
-        auto currentTextUpconvertedCharacters = currentText.upconvertedCharacters();
-        auto currentCharPtr = currentTextUpconvertedCharacters.get();
+        auto currentTextUpconvertedCharactersWithSize = currentText.upconvertedCharacters();
+        auto currentCharPtr = currentTextUpconvertedCharactersWithSize.get();
         
         bool containsOnlyWhiteSpace = true;
         bool hasTab = false;
@@ -415,7 +415,7 @@ static void buildQuery(DDScanQueryRef scanQuery, const SimpleRange& contextRange
             continue;
         }
         
-        RetainPtr currentTextCFString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(currentTextUpconvertedCharacters.get()), currentTextLength));
+        RetainPtr currentTextCFString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(currentTextUpconvertedCharactersWithSize.get()), currentTextLength));
 
         PAL::softLink_DataDetectorsCore_DDScanQueryAddTextFragment(scanQuery, currentTextCFString.get(), CFRangeMake(0, currentTextLength), (void *)iteratorCount, (DDTextFragmentMode)0, DDTextCoalescingTypeNone);
     }

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -136,11 +136,11 @@ public:
     {
         ASSERT(location <= size());
 
-        m_fonts.insertVector(location, Vector<const Font*>(length, font));
-        m_glyphs.insertVector(location, Vector<GlyphBufferGlyph>(length, std::numeric_limits<GlyphBufferGlyph>::max()));
-        m_advances.insertVector(location, Vector<GlyphBufferAdvance>(length, makeGlyphBufferAdvance()));
-        m_origins.insertVector(location, Vector<GlyphBufferOrigin>(length, makeGlyphBufferOrigin()));
-        m_offsetsInString.insertVector(location, Vector<GlyphBufferStringOffset>(length, 0));
+        m_fonts.insertFill(location, font, length);
+        m_glyphs.insertFill(location, std::numeric_limits<GlyphBufferGlyph>::max(), length);
+        m_advances.insertFill(location, makeGlyphBufferAdvance(), length);
+        m_origins.insertFill(location, makeGlyphBufferOrigin(), length);
+        m_offsetsInString.insertFill(location, 0, length);
     }
 
     void reverse(unsigned from, unsigned length)

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -596,8 +596,9 @@ GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned begi
     };
 
     auto substring = text.substring(beginningStringIndex);
-    auto upconvertedCharacters = substring.upconvertedCharacters();
-    auto localeString = locale.isNull() ? nullptr : LocaleCocoa::canonicalLanguageIdentifierFromString(locale).string().createCFString();
+    constexpr unsigned bufferSize = 256;
+    auto upconvertedCharacters = substring.upconvertedCharacters<bufferSize>();
+    auto localeString = locale.isNull() ? nullptr : LocaleCocoa::canonicalLanguageIdentifierFromString(locale);
     auto numberOfInputGlyphs = glyphBuffer.size() - beginningGlyphIndex;
     // FIXME: Enable kerning for single glyphs when rdar://82195405 is fixed
     CTFontShapeOptions options = kCTFontShapeWithClusterComposition

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.h
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.h
@@ -66,7 +66,7 @@ public:
     const Vector<String>& timeAMPMLabels() override;
 #endif
 
-    static AtomString canonicalLanguageIdentifierFromString(const AtomString&);
+    static RetainPtr<CFStringRef> canonicalLanguageIdentifierFromString(const AtomString&);
     static void releaseMemory();
 
 private:

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -245,26 +245,43 @@ const Vector<String>& LocaleCocoa::timeAMPMLabels()
 
 #endif
 
-using CanonicalLocaleMap = HashMap<AtomString, AtomString>;
+using CanonicalLocaleMap = HashMap<AtomString, RetainPtr<CFStringRef>>;
 
-static CanonicalLocaleMap& canonicalLocaleMap()
+struct LocaleCache {
+    AtomString m_key;
+    RetainPtr<CFStringRef> m_value;
+    CanonicalLocaleMap m_map;
+};
+
+
+static LocaleCache& localeCache()
 {
-    static NeverDestroyed<CanonicalLocaleMap> canonicalLocaleMap;
-    return canonicalLocaleMap.get();
+    static MainThreadNeverDestroyed<LocaleCache> localeCache;
+    return localeCache.get();
 }
 
-AtomString LocaleCocoa::canonicalLanguageIdentifierFromString(const AtomString& string)
+RetainPtr<CFStringRef> LocaleCocoa::canonicalLanguageIdentifierFromString(const AtomString& string)
 {
     if (string.isEmpty())
-        return string;
-    return canonicalLocaleMap().ensure(string, [&] {
-        return [NSLocale canonicalLanguageIdentifierFromString:string];
+        return CFSTR("");
+
+    auto& cache = localeCache();
+    if (cache.m_key == string)
+        return cache.m_value;
+    auto result = cache.m_map.ensure(string, [&] {
+        return (__bridge CFStringRef)[NSLocale canonicalLanguageIdentifierFromString:string];
     }).iterator->value;
+    cache.m_key = string;
+    cache.m_value = result;
+    return result;
 }
 
 void LocaleCocoa::releaseMemory()
 {
-    canonicalLocaleMap().clear();
+    auto& cache = localeCache();
+    cache.m_key = { };
+    cache.m_value = { };
+    cache.m_map.clear();
 }
 
 void LocaleCocoa::initializeLocaleData()

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -2086,4 +2086,26 @@ TEST(WTF_Vector, FlatMapInnerStruct)
     EXPECT_EQ(4, mapped[3]);
 }
 
+TEST(WTF_Vector, InsertFill)
+{
+    Vector<unsigned> vector;
+
+    for (size_t i = 0; i < 100; ++i)
+        vector.append(i);
+
+    EXPECT_EQ(vector.size(), 100U);
+
+    vector.insertFill(50, 0xffff, 100);
+    EXPECT_EQ(vector.size(), 200U);
+
+    for (size_t i = 0; i < 50; ++i)
+        EXPECT_EQ(vector[i], i);
+
+    for (size_t i = 0; i < 100; ++i)
+        EXPECT_EQ(vector[i + 50], 0xffffU);
+
+    for (size_t i = 0; i < 50; ++i)
+        EXPECT_EQ(vector[i + 150], i + 50U);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4e349ca18c0f8e55b6bdcd2786755caf68787143
<pre>
[WebCore] Optimize Font::applyTransforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=270406">https://bugs.webkit.org/show_bug.cgi?id=270406</a>
<a href="https://rdar.apple.com/123961009">rdar://123961009</a>

Reviewed by Chris Dumez.

Font::applyTransforms is very slow. While the most of time is used in CoreText, the other part is also using much time!
This patch optimizes it.

1. We add Vector::insertFill function to insert one-item-filling into Vector. GlyphBuffer is
   doing this in a very inefficient way right now: allocating filled Vector and using insertVector.
2. Add size parameter to upconvertedCharacters and use 256 for static Vector size in Font::applyTransforms,
   to avoid unnecessary allocations.
3. LocaleCocoa::canonicalLanguageIdentifierFromString should return RetainPtr&lt;CFStringRef&gt;. We found that
   we are super repeatedly creating CFString when locale is specified because canonicalLanguageIdentifierFromString
   returns AtomString and we convert it to CFString. And this is very slow. Because canonicalLanguageIdentifierFromString
   is only used in this place, we should just return RetainPtr&lt;CFStringRef&gt;. Also we optimized the caching mechanism
   in canonicalLanguageIdentifierFromString to cache the one item out of HashMap since this one-item cache can cover almost
   all cases.

* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::insertFill):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::upconvertedCharacters const):
(WTF::StringView::UpconvertedCharacters&lt;N&gt;::UpconvertedCharacters):
(WTF::StringView::UpconvertedCharacters::UpconvertedCharacters): Deleted.
* Source/WebCore/editing/TextIterator.cpp:
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::makeHole):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::applyTransforms const):
* Source/WebCore/platform/text/cocoa/LocaleCocoa.h:
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::localeCache):
(WebCore::LocaleCocoa::canonicalLanguageIdentifierFromString):
(WebCore::LocaleCocoa::releaseMemory):
(WebCore::canonicalLocaleMap): Deleted.

Canonical link: <a href="https://commits.webkit.org/275676@main">https://commits.webkit.org/275676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d04a611ea9e6226b3c4576039e2a104e67a70997

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42491 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38608 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18864 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16121 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46567 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35947 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38669 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37947 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42119 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40469 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18926 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49128 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18993 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9948 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5737 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->