### PR TITLE
Adopt dynamicDowncast<> in some WebGPU code

### DIFF
--- a/Source/WebGPU/WGSL/PointerRewriter.cpp
+++ b/Source/WebGPU/WGSL/PointerRewriter.cpp
@@ -153,14 +153,12 @@ void PointerRewriter::visit(AST::UnaryExpression& unary)
     AST::Expression* nested = &unary.expression();
     while (is<AST::IdentityExpression>(*nested))
         nested = &downcast<AST::IdentityExpression>(*nested).expression();
-    if (!is<AST::UnaryExpression>(*nested))
+
+    auto* nestedUnary = dynamicDowncast<AST::UnaryExpression>(*nested);
+    if (!nestedUnary || nestedUnary->operation() != AST::UnaryOperation::AddressOf)
         return;
 
-    auto& nestedUnary = downcast<AST::UnaryExpression>(*nested);
-    if (nestedUnary.operation() != AST::UnaryOperation::AddressOf)
-        return;
-
-    m_callGraph.ast().replace(unary, nestedUnary.expression());
+    m_callGraph.ast().replace(unary, nestedUnary->expression());
 }
 
 void rewritePointers(CallGraph& callGraph)

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -144,7 +144,6 @@ ConstantValue evaluate(const AST::Expression& expression, const HashMap<String, 
 {
     if (auto constantValue = expression.constantValue())
         return *constantValue;
-    ASSERT(is<const AST::IdentifierExpression>(expression));
     auto constantValue = constants.get(downcast<const AST::IdentifierExpression>(expression).identifier());
     const_cast<AST::Expression&>(expression).setConstantValue(constantValue);
     return constantValue;

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -464,10 +464,10 @@ ShaderModule::FragmentOutputs ShaderModule::parseFragmentReturnType(const WGSL::
             populateOutputState(entryPoint, *member.builtin());
 
         for (auto& attribute : member.attributes()) {
-            if (attribute.kind() != WGSL::AST::NodeKind::BuiltinAttribute)
+            auto* builtinAttribute = dynamicDowncast<WGSL::AST::BuiltinAttribute>(attribute);
+            if (!builtinAttribute)
                 continue;
-            auto& builtinAttribute = downcast<WGSL::AST::BuiltinAttribute>(attribute);
-            populateOutputState(entryPoint, builtinAttribute.builtin());
+            populateOutputState(entryPoint, builtinAttribute->builtin());
         }
 
         if (!member.location() || member.builtin())
@@ -671,37 +671,35 @@ ShaderModule::ShaderModule(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck
     if (std::holds_alternative<WGSL::SuccessfulCheck>(m_checkResult)) {
         auto& check = std::get<WGSL::SuccessfulCheck>(m_checkResult);
         for (auto& declaration : check.ast->declarations()) {
-            if (!is<WGSL::AST::Function>(declaration))
+            auto* function = dynamicDowncast<WGSL::AST::Function>(declaration);
+            if (!function || !function->stage())
                 continue;
-            auto& function = downcast<WGSL::AST::Function>(declaration);
-            if (!function.stage())
-                continue;
-            switch (*function.stage()) {
+            switch (*function->stage()) {
             case WGSL::ShaderStage::Vertex: {
-                m_stageInTypesForEntryPoint.add(function.name(), parseStageIn(function));
-                if (auto expression = function.maybeReturnType()) {
+                m_stageInTypesForEntryPoint.add(function->name(), parseStageIn(*function));
+                if (auto expression = function->maybeReturnType()) {
                     if (auto* inferredType = expression->inferredType())
-                        m_vertexReturnTypeForEntryPoint.add(function.name(), parseVertexReturnType(*inferredType));
+                        m_vertexReturnTypeForEntryPoint.add(function->name(), parseVertexReturnType(*inferredType));
                 }
                 if (!allowVertexDefault || m_defaultVertexEntryPoint.length()) {
                     allowVertexDefault = false;
                     m_defaultVertexEntryPoint = emptyString();
                     continue;
                 }
-                m_defaultVertexEntryPoint = function.name();
+                m_defaultVertexEntryPoint = function->name();
             } break;
             case WGSL::ShaderStage::Fragment: {
-                m_fragmentInputsForEntryPoint.add(function.name(), parseFragmentInputs(function));
-                if (auto expression = function.maybeReturnType()) {
+                m_fragmentInputsForEntryPoint.add(function->name(), parseFragmentInputs(*function));
+                if (auto expression = function->maybeReturnType()) {
                     if (auto* inferredType = expression->inferredType())
-                        m_fragmentReturnTypeForEntryPoint.add(function.name(), parseFragmentReturnType(*inferredType, function.name()));
+                        m_fragmentReturnTypeForEntryPoint.add(function->name(), parseFragmentReturnType(*inferredType, function->name()));
                 }
                 if (!allowFragmentDefault || m_defaultFragmentEntryPoint.length()) {
                     allowFragmentDefault = false;
                     m_defaultFragmentEntryPoint = emptyString();
                     continue;
                 }
-                m_defaultFragmentEntryPoint = function.name();
+                m_defaultFragmentEntryPoint = function->name();
             } break;
             case WGSL::ShaderStage::Compute: {
                 if (!allowComputeDefault || m_defaultComputeEntryPoint.length()) {
@@ -709,7 +707,7 @@ ShaderModule::ShaderModule(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck
                     m_defaultComputeEntryPoint = emptyString();
                     continue;
                 }
-                m_defaultComputeEntryPoint = function.name();
+                m_defaultComputeEntryPoint = function->name();
             } break;
             default:
                 ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### e827b507b48188652ffe5217598cde1ad9f27fcf
<pre>
Adopt dynamicDowncast&lt;&gt; in some WebGPU code
<a href="https://bugs.webkit.org/show_bug.cgi?id=270409">https://bugs.webkit.org/show_bug.cgi?id=270409</a>

Reviewed by Tadeu Zagallo.

For security &amp; performance.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::fragDepthIdentifierForFunction):
* Source/WebGPU/WGSL/PointerRewriter.cpp:
(WGSL::PointerRewriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::chooseOverload):
(WGSL::TypeChecker::resolve):
(WGSL::TypeChecker::texelFormat):
(WGSL::TypeChecker::accessMode):
(WGSL::TypeChecker::addressSpace):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::evaluate):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::parseFragmentReturnType):
(WebGPU::ShaderModule::ShaderModule):

Canonical link: <a href="https://commits.webkit.org/275614@main">https://commits.webkit.org/275614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/747dd7201b2048c5ef871f9495fd0d0aa6eb04fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35025 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15889 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41687 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40277 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18708 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9466 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->