### PR TITLE
REGRESSION(274689@main): [GTK][Debug] Triggers assert on WOFF2 tests

### DIFF
--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -170,7 +170,7 @@ RefPtr<FontCustomPlatformData> CachedFont::createCustomFontData(SharedBuffer& by
 {
     RefPtr buffer = { &bytes };
     wrapping = !convertWOFFToSfntIfNecessary(buffer);
-    return FontCustomPlatformData::create(*buffer, itemInCollection);
+    return buffer ? FontCustomPlatformData::create(*buffer, itemInCollection) : nullptr;
 }
 
 RefPtr<FontCustomPlatformData> CachedFont::createCustomFontDataExperimentalParser(SharedBuffer& bytes, const String& itemInCollection, bool& wrapping)


### PR DESCRIPTION
#### 81bff4c4360f4a33ae558e9d02878947af20c011
<pre>
REGRESSION(274689@main): [GTK][Debug] Triggers assert on WOFF2 tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=270414">https://bugs.webkit.org/show_bug.cgi?id=270414</a>

Reviewed by Michael Catanzaro.

The convertWOFFToSfntIfNecessary() function can set the buffer to nullptr, specially if the
woff2::ConvertWOFF2ToTTF() call in convertWOFFToSfnt() fails. This patch re-introduces the buffer
check that was removed in 274689@main.

* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::createCustomFontData):

Canonical link: <a href="https://commits.webkit.org/275617@main">https://commits.webkit.org/275617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64123e3fb636ff3059a60fbd5b20886ef75eec4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35032 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15963 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15917 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unrelated-element.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html, imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html, imported/w3c/web-platform-tests/payment-request/constructor_convert_method_data.https.html, imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-012.svg, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46335 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38497 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41695 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14082 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40285 "Found 1 new API test failure: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18715 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->