### PR TITLE
Context menu items for Action and Tab are not filtered by tab URL.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -1037,9 +1037,14 @@ NSArray *WebExtensionAction::platformMenuItems() const
     if (!extensionContext())
         return @[ ];
 
+    RefPtr tab = m_tab;
+    if (!tab && m_window)
+        tab = m_window->activeTab();
+
     WebExtensionMenuItemContextParameters contextParameters;
     contextParameters.types = WebExtensionMenuItemContextType::Action;
-    contextParameters.tabIdentifier = m_tab ? std::optional { m_tab->identifier() } : std::nullopt;
+    contextParameters.tabIdentifier = tab ? std::optional(tab->identifier()) : std::nullopt;
+    contextParameters.frameURL = tab ? tab->url() : URL { };
 
     return WebExtensionMenuItem::matchingPlatformMenuItems(extensionContext()->mainMenuItems(), contextParameters, webExtensionActionMenuItemTopLevelLimit);
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2281,6 +2281,7 @@ NSArray *WebExtensionContext::platformMenuItems(const WebExtensionTab& tab) cons
     WebExtensionMenuItemContextParameters contextParameters;
     contextParameters.types = WebExtensionMenuItemContextType::Tab;
     contextParameters.tabIdentifier = tab.identifier();
+    contextParameters.frameURL = tab.url();
 
     if (auto *menuItem = singleMenuItemOrExtensionItemWithSubmenu(contextParameters))
         return @[ menuItem ];

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp
@@ -97,13 +97,8 @@ bool WebExtensionMenuItem::matches(const WebExtensionMenuItemContextParameters& 
         return false;
     };
 
-    if (matchesType({ ContextType::Action, ContextType::Tab })) {
-        // Additional context checks are not required for Action or Tab.
-        return true;
-    }
-
     auto matchesPattern = [&](const auto& patterns, const URL& url) {
-        if (patterns.isEmpty())
+        if (url.isNull() || patterns.isEmpty())
             return true;
 
         for (const auto& pattern : patterns) {
@@ -117,6 +112,11 @@ bool WebExtensionMenuItem::matches(const WebExtensionMenuItemContextParameters& 
     // Document patterns match for any context type.
     if (!matchesPattern(documentPatterns(), contextParameters.frameURL))
         return false;
+
+    if (matchesType({ ContextType::Action, ContextType::Tab })) {
+        // Additional context checks are not required for Action or Tab.
+        return true;
+    }
 
     if (matchesType(ContextType::Link)) {
         ASSERT(!contextParameters.linkURL.isNull());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -177,6 +177,10 @@ TEST(WKWebExtensionAPIMenus, MenuCreateWithVariousIds)
 
 TEST(WKWebExtensionAPIMenus, ActionMenus)
 {
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
     auto *backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'top-level-1',",
@@ -193,7 +197,8 @@ TEST(WKWebExtensionAPIMenus, ActionMenus)
         @"browser.menus.create({",
         @"  id: 'top-level-3',",
         @"  title: 'Top Level 3',",
-        @"  contexts: [ 'action', 'page' ]",
+        @"  contexts: [ 'action', 'page' ],",
+        @"  documentUrlPatterns: ['*://localhost/*']",
         @"})",
 
         @"browser.menus.create({",
@@ -222,6 +227,9 @@ TEST(WKWebExtensionAPIMenus, ActionMenus)
     auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [manager runForTimeInterval:1];
 
     auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
     auto *menuItems = action.menuItems;
@@ -298,7 +306,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenusWithActiveTab)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager runForTimeInterval:2];
+    [manager runForTimeInterval:1];
 
     auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
     auto *menuItems = action.menuItems;
@@ -505,6 +513,10 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenusUpdate)
 
 TEST(WKWebExtensionAPIMenus, TabMenus)
 {
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
     auto *backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'tab-item-1',",
@@ -515,7 +527,8 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
         @"browser.menus.create({",
         @"  id: 'tab-item-2',",
         @"  title: 'Tab Item 2',",
-        @"  contexts: [ 'tab' ]",
+        @"  contexts: [ 'tab' ],",
+        @"  documentUrlPatterns: ['*://localhost/*']",
         @"})",
 
         @"browser.menus.create({",
@@ -540,6 +553,9 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
     auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [manager runForTimeInterval:1];
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
     EXPECT_EQ(menuItems.count, 1lu);


### PR DESCRIPTION
#### 7a3236ba274c5374337531088e431b1ce8728a77
<pre>
Context menu items for Action and Tab are not filtered by tab URL.
<a href="https://webkit.org/b/270420">https://webkit.org/b/270420</a>
<a href="https://rdar.apple.com/123977080">rdar://123977080</a>

Reviewed by Brian Weinstein.

Allow documentUrlPatterns to apply to action and tab context for menus. This prevents
menu items from appearing that don’t apply to the current document in the tab.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::platformMenuItems const): Set frameURL.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::platformMenuItems const): Set frameURL.
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp:
(WebKit::WebExtensionMenuItem::matches const): Match frameURL before the early
return for action and tab contexts. Only match if frameURL is non-null.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TEST(WKWebExtensionAPIMenus, ActionMenus)): Added documentUrlPatterns to one item.
(TEST(WKWebExtensionAPIMenus, TabMenus)): Ditto.

Canonical link: <a href="https://commits.webkit.org/275638@main">https://commits.webkit.org/275638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e6581d08f2f833e42546c5e7066979efb44a3e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18647 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35042 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14090 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40300 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18785 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5711 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->