### PR TITLE
Changing color scheme does not update gradients with system colors or `light-dark()`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops-expected.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://www.w3.org/TR/css-color-adjust-1/#color-scheme-prop">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#css-system-colors">
+<link rel="help" href="https://www.w3.org/TR/css-color-5/#light-dark">
+<link rel="help" href="https://www.w3.org/TR/css-color-5/#color-mix">
+<title>Reference: Test changing used color-scheme updates gradient with color-scheme dependent color stops.</title>
+<style>
+
+.box {
+    color-scheme: dark;
+
+    width: 100px;
+    height: 100px;
+}
+
+#system-color {
+    background-image: linear-gradient(CanvasText, CanvasText);
+}
+
+#system-color-in-color-mix {
+    background-image: linear-gradient(color-mix(in lch, Canvas, pink), color-mix(in lch, Canvas, pink));
+}
+
+#light-dark {
+    background-image: linear-gradient(light-dark(red, green), light-dark(red, green));
+}
+
+#light-dark-in-color-mix {
+    background-image: linear-gradient(color-mix(in lch, light-dark(red, green), pink), color-mix(in lch, light-dark(red, green), pink));
+}
+
+</style>
+</head>
+<body>
+<p>Test system color</p>
+<div id="system-color" class="box"></div>
+<p>Test system color in color-mix()</p>
+<div id="system-color-in-color-mix" class="box"></div>
+<p>Test light-dark()</p>
+<div id="light-dark" class="box"></div>
+<p>Test light-dark() in color-mix()</p>
+<div id="light-dark-in-color-mix" class="box"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops-ref.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://www.w3.org/TR/css-color-adjust-1/#color-scheme-prop">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#css-system-colors">
+<link rel="help" href="https://www.w3.org/TR/css-color-5/#light-dark">
+<link rel="help" href="https://www.w3.org/TR/css-color-5/#color-mix">
+<title>Reference: Test changing used color-scheme updates gradient with color-scheme dependent color stops.</title>
+<style>
+
+.box {
+    color-scheme: dark;
+
+    width: 100px;
+    height: 100px;
+}
+
+#system-color {
+    background-image: linear-gradient(CanvasText, CanvasText);
+}
+
+#system-color-in-color-mix {
+    background-image: linear-gradient(color-mix(in lch, Canvas, pink), color-mix(in lch, Canvas, pink));
+}
+
+#light-dark {
+    background-image: linear-gradient(light-dark(red, green), light-dark(red, green));
+}
+
+#light-dark-in-color-mix {
+    background-image: linear-gradient(color-mix(in lch, light-dark(red, green), pink), color-mix(in lch, light-dark(red, green), pink));
+}
+
+</style>
+</head>
+<body>
+<p>Test system color</p>
+<div id="system-color" class="box"></div>
+<p>Test system color in color-mix()</p>
+<div id="system-color-in-color-mix" class="box"></div>
+<p>Test light-dark()</p>
+<div id="light-dark" class="box"></div>
+<p>Test light-dark() in color-mix()</p>
+<div id="light-dark-in-color-mix" class="box"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://www.w3.org/TR/css-color-adjust-1/#color-scheme-prop">
+<link rel="help" href="https://www.w3.org/TR/css-color-4/#css-system-colors">
+<link rel="help" href="https://www.w3.org/TR/css-color-5/#light-dark">
+<link rel="help" href="https://www.w3.org/TR/css-color-5/#color-mix">
+<title>Test changing used color-scheme updates gradient with color-scheme dependent color stops.</title>
+<link rel="match" href="color-scheme-dependent-color-stops-ref.html">
+<style>
+
+.dark {
+    color-scheme: dark;
+}
+
+.box {
+    width: 100px;
+    height: 100px;
+}
+
+#system-color {
+    background-image: linear-gradient(CanvasText, CanvasText);
+}
+
+#system-color-in-color-mix {
+    background-image: linear-gradient(color-mix(in lch, Canvas, pink), color-mix(in lch, Canvas, pink));
+}
+
+#light-dark {
+    background-image: linear-gradient(light-dark(red, green), light-dark(red, green));
+}
+
+#light-dark-in-color-mix {
+    background-image: linear-gradient(color-mix(in lch, light-dark(red, green), pink), color-mix(in lch, light-dark(red, green), pink));
+}
+
+</style>
+</head>
+<body>
+<p>Test system color</p>
+<div id="system-color" class="box"></div>
+<p>Test system color in color-mix()</p>
+<div id="system-color-in-color-mix" class="box"></div>
+<p>Test light-dark()</p>
+<div id="light-dark" class="box"></div>
+<p>Test light-dark() in color-mix()</p>
+<div id="light-dark-in-color-mix" class="box"></div>
+<script>
+
+setTimeout(() => {
+    document.querySelectorAll(".box").forEach((box) => {
+        box.classList.add("dark");
+    });
+
+    document.documentElement.className = '';
+}, 0);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/StyleColor.cpp
+++ b/Source/WebCore/css/StyleColor.cpp
@@ -75,7 +75,7 @@ Color StyleColor::colorFromAbsoluteKeyword(CSSValueID keyword)
     return { };
 }
 
-Color StyleColor::colorFromKeyword(CSSValueID keyword , OptionSet<StyleColorOptions> options)
+Color StyleColor::colorFromKeyword(CSSValueID keyword, OptionSet<StyleColorOptions> options)
 {
     if (isAbsoluteColorKeyword(keyword))
         return colorFromAbsoluteKeyword(keyword);
@@ -128,6 +128,17 @@ bool StyleColor::containsCurrentColor(const CSSPrimitiveValue& value)
 
     if (value.isUnresolvedColor())
         return value.unresolvedColor().containsCurrentColor();
+
+    return false;
+}
+
+bool StyleColor::containsColorSchemeDependentColor(const CSSPrimitiveValue& value)
+{
+    if (StyleColor::isSystemColorKeyword(value.valueID()))
+        return true;
+
+    if (value.isUnresolvedColor())
+        return value.unresolvedColor().containsColorSchemeDependentColor();
 
     return false;
 }

--- a/Source/WebCore/css/StyleColor.h
+++ b/Source/WebCore/css/StyleColor.h
@@ -105,6 +105,8 @@ public:
     WEBCORE_EXPORT static bool isSystemColorKeyword(CSSValueID);
     static bool isDeprecatedSystemColorKeyword(CSSValueID);
 
+    static bool containsColorSchemeDependentColor(const CSSPrimitiveValue&);
+
     enum class CSSColorType : uint8_t {
         Absolute = 1 << 0,
         Current = 1 << 1,

--- a/Source/WebCore/css/color/CSSUnresolvedColor.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.cpp
@@ -45,6 +45,18 @@ bool CSSUnresolvedColor::containsCurrentColor() const
     );
 }
 
+bool CSSUnresolvedColor::containsColorSchemeDependentColor() const
+{
+    return WTF::switchOn(m_value,
+        [] (const CSSUnresolvedColorMix& unresolved) {
+            return StyleColor::containsColorSchemeDependentColor(unresolved.mixComponents1.color) || StyleColor::containsColorSchemeDependentColor(unresolved.mixComponents2.color);
+        },
+        [] (const CSSUnresolvedLightDark&) {
+            return true;
+        }
+    );
+}
+
 void CSSUnresolvedColor::serializationForCSS(StringBuilder& builder) const
 {
     return WTF::switchOn(m_value, [&] (auto& unresolved) { WebCore::serializationForCSS(builder, unresolved); });

--- a/Source/WebCore/css/color/CSSUnresolvedColor.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.h
@@ -50,6 +50,7 @@ public:
     ~CSSUnresolvedColor();
 
     bool containsCurrentColor() const;
+    bool containsColorSchemeDependentColor() const;
 
     void serializationForCSS(StringBuilder&) const;
     String serializationForCSS() const;

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -142,15 +142,7 @@ std::optional<FilterOperations> BuilderState::createFilterOperations(const CSSVa
 
 bool BuilderState::isColorFromPrimitiveValueDerivedFromElement(const CSSPrimitiveValue& value)
 {
-    switch (value.valueID()) {
-    case CSSValueInternalDocumentTextColor:
-    case CSSValueWebkitLink:
-    case CSSValueWebkitActivelink:
-    case CSSValueCurrentcolor:
-        return true;
-    default:
-        return false;
-    }
+    return StyleColor::containsCurrentColor(value) || StyleColor::containsColorSchemeDependentColor(value);
 }
 
 StyleColor BuilderState::colorFromPrimitiveValue(const CSSPrimitiveValue& value, ForVisitedLink forVisitedLink) const


### PR DESCRIPTION
#### 5596316ca6184ec9be4d8ba87e631dfbb25d4efe
<pre>
Changing color scheme does not update gradients with system colors or `light-dark()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=267790">https://bugs.webkit.org/show_bug.cgi?id=267790</a>
<a href="https://rdar.apple.com/121285450">rdar://121285450</a>

Reviewed by Matthieu Dubet.

`CSSGradientValue`s cache their generated `StyleImage` when possible. Currently,
caching is disallowed when the gradient contains one of the following color
keywords as a color stop: &quot;-internal-document-text&quot;, &quot;-webkit-link&quot;,
&quot;-webkit-active-link&quot;, and &quot;currentcolor&quot;.

However, that denylist is not comprehensive with respect to dynamic colors.
Notably, it excludes almost all system color keywords, and `light-dark()`.
Consequently, the same cached `StyleImage` is used even when the used color
scheme of an element changes.

Fix by updating `BuilderState::isColorFromPrimitiveValueDerivedFromElement`
to account for other scenarios where colors change dynamically.

* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradient/color-scheme-dependent-color-stops.html: Added.
* Source/WebCore/css/StyleColor.cpp:
(WebCore::StyleColor::colorFromKeyword):

Drive-by style fix.

(WebCore::StyleColor::containsColorSchemeDependentColor):

System colors, `light-dark()`, and any other unresolved colors containing
either of those, are color-scheme dependent colors.

* Source/WebCore/css/StyleColor.h:
* Source/WebCore/css/color/CSSUnresolvedColor.cpp:
(WebCore::CSSUnresolvedColor::containsColorSchemeDependentColor const):
* Source/WebCore/css/color/CSSUnresolvedColor.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::isColorFromPrimitiveValueDerivedFromElement):

Update to cover colors that are color-scheme dependent.

Canonical link: <a href="https://commits.webkit.org/275645@main">https://commits.webkit.org/275645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbaae52b5b7705b8ae2b51d465a673365f22144a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35055 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15986 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46371 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41721 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40316 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36752 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9484 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->