### PR TITLE
JSMessageListener needs to protect its API values

### DIFF
--- a/Source/JavaScriptCore/API/JSBase.cpp
+++ b/Source/JavaScriptCore/API/JSBase.cpp
@@ -27,6 +27,7 @@
 #include "JSBase.h"
 #include "JSBaseInternal.h"
 #include "JSBasePrivate.h"
+#include "JSValueRef.h"
 
 #include "APICast.h"
 #include "Completion.h"

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -349,8 +349,8 @@ private:
 
     WeakPtr<JSIPC> m_jsIPC;
     Type m_type;
-    JSContextRef m_context;
-    JSObjectRef m_callback;
+    Ref<std::remove_ptr_t<JSContextRef>> m_context;
+    Ref<std::remove_ptr_t<JSObjectRef>> m_callback;
 };
 
 class JSIPC : public RefCounted<JSIPC>, public CanMakeWeakPtr<JSIPC> {
@@ -2851,8 +2851,8 @@ JSValueRef JSIPC::processTargets(JSContextRef context, JSObjectRef thisObject, J
 JSMessageListener::JSMessageListener(JSIPC& jsIPC, Type type, JSContextRef context, JSObjectRef callback)
     : m_jsIPC(jsIPC)
     , m_type(type)
-    , m_context(context)
-    , m_callback(callback)
+    , m_context(*context)
+    , m_callback(*callback)
 {
     auto* globalObject = toJS(context);
     auto& vm = globalObject->vm();


### PR DESCRIPTION
#### d3a3479dd63b9cfd8bc5ae9f21ad372a3de9f8ea
<pre>
JSMessageListener needs to protect its API values
<a href="https://bugs.webkit.org/show_bug.cgi?id=270422">https://bugs.webkit.org/show_bug.cgi?id=270422</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/API/APICast.h:
(WTF::DefaultRefDerefTraits&lt;std::remove_pointer_t&lt;JSValueRef&gt;&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;std::remove_pointer_t&lt;JSValueRef&gt;&gt;::ref):
(WTF::DefaultRefDerefTraits&lt;std::remove_pointer_t&lt;JSValueRef&gt;&gt;::derefIfNotNull):
(WTF::DefaultRefDerefTraits&lt;std::remove_pointer_t&lt;JSContextRef&gt;&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;std::remove_pointer_t&lt;JSContextRef&gt;&gt;::ref):
(WTF::DefaultRefDerefTraits&lt;std::remove_pointer_t&lt;JSContextRef&gt;&gt;::derefIfNotNull):
* Source/JavaScriptCore/API/JSBase.cpp:
* Source/JavaScriptCore/API/tests/testapi.cpp:
(TestAPI::foo):
(TestAPI::evaluateScript):
(TestAPI::interestingObjects):
(TestAPI::interestingKeys):
(TestAPI::symbolsGetPropertyForKey):
(TestAPI::symbolsSetPropertyForKey):
(TestAPI::symbolsHasPropertyForKey):
(TestAPI::symbolsDeletePropertyForKey):
(APIVector::APIVector): Deleted.
(APIVector::~APIVector): Deleted.
(APIVector::append): Deleted.
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSMessageListener::JSMessageListener):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3a3479dd63b9cfd8bc5ae9f21ad372a3de9f8ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42293 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21311 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44687 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44891 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38410 "Hash d3a3479d for PR 25395 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24525 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18653 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/44891 "Hash d3a3479d for PR 25395 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42867 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/24525 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/44687 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/44891 "Hash d3a3479d for PR 25395 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/24525 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/44687 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46350 "Hash d3a3479d for PR 25395 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35749 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/24525 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/44687 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/46350 "Hash d3a3479d for PR 25395 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41921 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17109 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/18653 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/46350 "Hash d3a3479d for PR 25395 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18728 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/44687 "Hash d3a3479d for PR 25395 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/48930 "Hash d3a3479d for PR 25395 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18790 "Hash d3a3479d for PR 25395 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/48930 "Hash d3a3479d for PR 25395 does not build (failure)") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18373 "Hash d3a3479d for PR 25395 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->