### PR TITLE
Some media modules files are missing headers

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 
+#include "Document.h"
 #include "EventNames.h"
 #include "JSDOMException.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp
@@ -31,6 +31,7 @@
 #include "MediaSource.h"
 #include "MediaSourcePrivate.h"
 #include "MediaSourcePrivateClient.h"
+#include <wtf/IsoMallocInlines.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 

--- a/Source/WebCore/Modules/mediasource/MediaSourceHandle.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceHandle.h
@@ -28,6 +28,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/IsoMalloc.h>
 #include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
 


### PR DESCRIPTION
#### 094154ff04b2e1135a07f8f250b0f520ed23258d
<pre>
Some media modules files are missing headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=270430">https://bugs.webkit.org/show_bug.cgi?id=270430</a>
<a href="https://rdar.apple.com/123988923">rdar://123988923</a>

Reviewed by Jean-Yves Avenard.

Imported missing header files for media related things.

* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp:
* Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp:
* Source/WebCore/Modules/mediasource/MediaSourceHandle.h:

Canonical link: <a href="https://commits.webkit.org/275613@main">https://commits.webkit.org/275613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04f9de2698ca7c0e02a0f83eb22170e4f0fe27dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35054 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15985 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46370 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41720 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40315 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18746 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9465 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->