### PR TITLE
Align criteria for isAlignedForUnder.

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-underline-position/text-underline-position-auto-computed-underline-offset-crash-expected.txt
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-underline-position/text-underline-position-auto-computed-underline-offset-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash or assert.

--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-underline-position/text-underline-position-auto-computed-underline-offset-crash.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-underline-position/text-underline-position-auto-computed-underline-offset-crash.html
@@ -1,0 +1,13 @@
+<style>
+    html {
+        writing-mode: vertical-lr;
+    }
+</style>
+<span id=under>PASS</span> if no crash or assert.
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    document.body.offsetHeight;
+    under.style.textDecoration = "underline";
+    under.style.textUnderlinePosition = "auto";
+</script>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -717,10 +717,7 @@ inline bool RenderStyle::changeAffectsVisualOverflow(const RenderStyle& other) c
         || m_rareInheritedData->textUnderlinePosition != other.m_rareInheritedData->textUnderlinePosition) {
         // Underlines are always drawn outside of their textbox bounds when text-underline-position: under;
         // is specified. We can take an early out here.
-        auto isVertialWritingMode = isVerticalWritingMode() || other.isVerticalWritingMode();
-        auto isAlignedForUnder = textUnderlinePosition() == TextUnderlinePosition::Under || other.textUnderlinePosition() == TextUnderlinePosition::Under
-            || (isVertialWritingMode && (textUnderlinePosition() == TextUnderlinePosition::Right || other.textUnderlinePosition() == TextUnderlinePosition::Right || textUnderlinePosition() == TextUnderlinePosition::Left || other.textUnderlinePosition() == TextUnderlinePosition::Left));
-        if (isAlignedForUnder)
+        if (isAlignedForUnder(*this) || isAlignedForUnder(other))
             return true;
         return visualOverflowForDecorations(*this) != visualOverflowForDecorations(other);
     }

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -42,21 +42,6 @@ struct UnderlineOffsetArguments {
     std::optional<TextUnderlinePositionUnder> textUnderlinePositionUnder { };
 };
 
-static bool isAlignedForUnder(const RenderStyle& decoratingBoxStyle)
-{
-    auto underlinePosition = decoratingBoxStyle.textUnderlinePosition();
-    if (underlinePosition == TextUnderlinePosition::Under)
-        return true;
-    if (decoratingBoxStyle.isHorizontalWritingMode())
-        return false;
-    if (underlinePosition == TextUnderlinePosition::Left || underlinePosition == TextUnderlinePosition::Right) {
-        // In vertical typographic modes, the underline is aligned as for under for 'left' and 'right'.
-        return true;
-    }
-    // When left/right support is not enabled.
-    return underlinePosition == TextUnderlinePosition::Auto && decoratingBoxStyle.textUnderlineOffset().isAuto();
-}
-
 static bool isAncestorAndWithinBlock(const RenderInline& ancestor, const RenderObject* child)
 {
     const RenderObject* object = child;
@@ -277,6 +262,21 @@ static GlyphOverflow computedVisualOverflowForDecorations(const RenderStyle& lin
         overflowResult.extendBottom(rect.maxY() - height);
     }
     return overflowResult;
+}
+
+bool isAlignedForUnder(const RenderStyle& decoratingBoxStyle)
+{
+    auto underlinePosition = decoratingBoxStyle.textUnderlinePosition();
+    if (underlinePosition == TextUnderlinePosition::Under)
+        return true;
+    if (decoratingBoxStyle.isHorizontalWritingMode())
+        return false;
+    if (underlinePosition == TextUnderlinePosition::Left || underlinePosition == TextUnderlinePosition::Right) {
+        // In vertical typographic modes, the underline is aligned as for under for 'left' and 'right'.
+        return true;
+    }
+    // When left/right support is not enabled.
+    return underlinePosition == TextUnderlinePosition::Auto && decoratingBoxStyle.textUnderlineOffset().isAuto();
 }
 
 GlyphOverflow visualOverflowForDecorations(const InlineIterator::LineBoxIterator& lineBox, const RenderText& renderer, float textBoxLogicalTop, float textBoxLogicalBottom)

--- a/Source/WebCore/style/InlineTextBoxStyle.h
+++ b/Source/WebCore/style/InlineTextBoxStyle.h
@@ -60,6 +60,7 @@ struct TextUnderlinePositionUnder {
 GlyphOverflow visualOverflowForDecorations(const RenderStyle&);
 GlyphOverflow visualOverflowForDecorations(const RenderStyle&, TextUnderlinePositionUnder);
 GlyphOverflow visualOverflowForDecorations(const InlineIterator::LineBoxIterator&, const RenderText&, float textBoxLogicalTop, float textBoxLogicalBottom);
+bool isAlignedForUnder(const RenderStyle& decoratingBoxStyle);
 
 float underlineOffsetForTextBoxPainting(const InlineIterator::InlineBox&, const RenderStyle&);
 float overlineOffsetForTextBoxPainting(const InlineIterator::InlineBox&, const RenderStyle&);


### PR DESCRIPTION
#### e644c808ec390094ac7cc6701b45156ad6ef38e5
<pre>
Align criteria for isAlignedForUnder.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270431">https://bugs.webkit.org/show_bug.cgi?id=270431</a>

Reviewed by Alan Baradlay.

The criteria of isAlignedForUnder is not aligned between RenderStyle::changeAffectsVisualOverflow from and isAlignedForUnder in InlineTextBoxStyle.

* LayoutTests/fast/css3-text/css3-text-decoration/text-underline-position/text-underline-position-auto-computed-underline-offset-crash-expected.txt: Added.
* LayoutTests/fast/css3-text/css3-text-decoration/text-underline-position/text-underline-position-auto-computed-underline-offset-crash.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeAffectsVisualOverflow const):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::isAlignedForUnder):
* Source/WebCore/style/InlineTextBoxStyle.h:

Canonical link: <a href="https://commits.webkit.org/275771@main">https://commits.webkit.org/275771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9dc9d7ac3d30f3e21ea0cc95ef8d18e32670d07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35294 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16244 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37761 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46745 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41996 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40615 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9546 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->