### PR TITLE
NEW TEST[ MacOS arm64 ] media/mediacapabilities/vp9-hw.html is a constant failure

### DIFF
--- a/LayoutTests/media/mediacapabilities/vp9-hw.html
+++ b/LayoutTests/media/mediacapabilities/vp9-hw.html
@@ -20,7 +20,7 @@ promise_test(async (test) => {
     if (!result.supported)
         return;
 
-    if (window.internals && internals.isHardwareVP9DecoderExpected())
+    if (window.internals && window.testRunner && testRunner.isWebKit2 && internals.isHardwareVP9DecoderExpected())
         assert_true(result.powerEfficient);
 }, "VP9 powerEfficient for webrtc with hardware VP9 if any");
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2794,8 +2794,6 @@ webkit.org/b/270133 [ Sonoma+ ] imported/w3c/web-platform-tests/accname/name/com
 [ Sonoma+ ] imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-grayscale.html [ ImageOnlyFailure ]
 [ Sonoma+ ] imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-sepia.html [ ImageOnlyFailure ]
 
-webkit.org/b/270256 [ Monterey+ arm64 ] media/mediacapabilities/vp9-hw.html [ Failure ]
-
 webkit.org/b/270273 [ Monterey+ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-inactive-outside-range-test.html [ Skip ]
 
 webkit.org/b/270274 [ Monterey+ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-fill-outside-range-test.html [ Skip ]


### PR DESCRIPTION
#### 1866fcefba9524a5c3c8133fc0333e6de345e7b5
<pre>
NEW TEST[ MacOS arm64 ] media/mediacapabilities/vp9-hw.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=270256">https://bugs.webkit.org/show_bug.cgi?id=270256</a>
<a href="https://rdar.apple.com/123790055">rdar://123790055</a>

Reviewed by Eric Carlson.

vp9HardwareDecoderAvailable() returns false in DumpRenderTree which conflicts with Internals::isHardwareVP9DecoderExpected.
We restrict the test to WebKit2 to workaround this limitation.

* LayoutTests/media/mediacapabilities/vp9-hw.html:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/275621@main">https://commits.webkit.org/275621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30a2d8681bcf76e3b8c83233981a2a09d349e2ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44919 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38437 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35063 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15993 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46379 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41728 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17136 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14116 "Found 1 new test failure: ipc/message-listener-async-message-reply-id.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40328 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9473 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->