### PR TITLE
TestRunner addMockCameraDevice/addMockMicrophoneDevice should have its last parameter as optional

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -401,8 +401,8 @@ interface TestRunner {
 
     undefined installFakeHelvetica(DOMString configuration);
 
-    undefined addMockCameraDevice(DOMString persistentId, DOMString label, object properties);
-    undefined addMockMicrophoneDevice(DOMString persistentId, DOMString label, object properties);
+    undefined addMockCameraDevice(DOMString persistentId, DOMString label, optional object properties);
+    undefined addMockMicrophoneDevice(DOMString persistentId, DOMString label, optional object properties);
     undefined addMockScreenDevice(DOMString persistentId, DOMString label);
     undefined clearMockMediaDevices();
     undefined removeMockMediaDevice(DOMString persistentId);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1889,6 +1889,9 @@ static WKRetainPtr<WKDictionaryRef> captureDeviceProperties(JSValueRef propertie
 {
     auto context = mainFrameJSContext();
 
+    if (JSValueGetType(context, properties) == kJSTypeUndefined)
+        return { };
+
     Vector<WKRetainPtr<WKStringRef>> strings;
     Vector<WKStringRef> keys;
     Vector<WKTypeRef> values;


### PR DESCRIPTION
#### 2d02de542a0d4770a6ce19751214dce869e0ec15
<pre>
TestRunner addMockCameraDevice/addMockMicrophoneDevice should have its last parameter as optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=270432">https://bugs.webkit.org/show_bug.cgi?id=270432</a>
<a href="https://rdar.apple.com/123999260">rdar://123999260</a>

Reviewed by Eric Carlson.

captureDeviceProperties is triggering stderr TypeError console logs.
We check whether properties is undefined and if so bail out early to not trigger these logs.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::captureDeviceProperties):

Canonical link: <a href="https://commits.webkit.org/275622@main">https://commits.webkit.org/275622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fefbcf91c24a44842c001e657e197317bd0ee310

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35065 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15995 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46382 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38525 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40327 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18758 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9474 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->