### PR TITLE
REGRESSION (269807@main): [ MacOS Debug x86_64 ] fast/mediastream/microphone-change-while-muted.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/mediastream/microphone-change-while-muted.html
+++ b/LayoutTests/fast/mediastream/microphone-change-while-muted.html
@@ -45,6 +45,7 @@
 
         await new Promise(resolve => video.srcObject.getAudioTracks()[0].onmute = resolve);
 
+        await new Promise(resolve => setTimeout(resolve, 500));
         testRunner.removeMockMediaDevice("usbmic");
 
         await new Promise(resolve => setTimeout(resolve, 500));

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2015,5 +2015,3 @@ webkit.org/b/270319 [ Ventura ] accessibility/datetime/input-time-label-value.ht
 # webkit.org/b/266168 Two wheel/mousewheel passive event listeners WPT test pass on macOS Sonoma and up
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Pass ]
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div.html [ Pass ]
-
-webkit.org/b/270368 [ Monterey+ Debug x86_64 ] fast/mediastream/microphone-change-while-muted.html [ Pass Failure ]


### PR DESCRIPTION
#### 53e617ff98403e641bb562b20b740136f5471e6e
<pre>
REGRESSION (269807@main): [ MacOS Debug x86_64 ] fast/mediastream/microphone-change-while-muted.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=270368">https://bugs.webkit.org/show_bug.cgi?id=270368</a>
<a href="https://rdar.apple.com/123912735">rdar://123912735</a>

Reviewed by Eric Carlson.

We were removing the device right after the unmute event.
This creates a potential race condition between the IPC message going to GPU process via UIProcess to remove the device
and the IPC message going directly to GPUProcess to stop the audio shared unit.
We are now delaying the message to remove the device to make sure the audio shared unit is stopped when the device gets removed.

* LayoutTests/fast/mediastream/microphone-change-while-muted.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/275625@main">https://commits.webkit.org/275625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2028f09586d42d01667368f2bb8a3c21c30b00ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38456 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16008 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37831 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41745 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17155 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40344 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36771 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9475 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->