### PR TITLE
[web-animations] WPT test css/CSS2/visufx/animation/visibility-interpolation.html is a unique failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/animation/visibility-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/animation/visibility-interpolation-expected.txt
@@ -91,16 +91,16 @@ PASS Web Animations: property <visibility> from [collapse] to [visible] at (0.1)
 PASS Web Animations: property <visibility> from [collapse] to [visible] at (0.9) should be [visible]
 PASS Web Animations: property <visibility> from [collapse] to [visible] at (1) should be [visible]
 PASS Web Animations: property <visibility> from [collapse] to [visible] at (1.5) should be [visible]
-FAIL CSS Transitions: property <visibility> from [collapse] to [hidden] at (-0.3) should be [hidden] assert_equals: expected "hidden " but got "collapse "
-FAIL CSS Transitions: property <visibility> from [collapse] to [hidden] at (0) should be [hidden] assert_equals: expected "hidden " but got "collapse "
-FAIL CSS Transitions: property <visibility> from [collapse] to [hidden] at (0.3) should be [hidden] assert_equals: expected "hidden " but got "collapse "
+PASS CSS Transitions: property <visibility> from [collapse] to [hidden] at (-0.3) should be [hidden]
+PASS CSS Transitions: property <visibility> from [collapse] to [hidden] at (0) should be [hidden]
+PASS CSS Transitions: property <visibility> from [collapse] to [hidden] at (0.3) should be [hidden]
 PASS CSS Transitions: property <visibility> from [collapse] to [hidden] at (0.5) should be [hidden]
 PASS CSS Transitions: property <visibility> from [collapse] to [hidden] at (0.6) should be [hidden]
 PASS CSS Transitions: property <visibility> from [collapse] to [hidden] at (1) should be [hidden]
 PASS CSS Transitions: property <visibility> from [collapse] to [hidden] at (1.5) should be [hidden]
-FAIL CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (-0.3) should be [hidden] assert_equals: expected "hidden " but got "collapse "
-FAIL CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (0) should be [hidden] assert_equals: expected "hidden " but got "collapse "
-FAIL CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (0.3) should be [hidden] assert_equals: expected "hidden " but got "collapse "
+PASS CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (-0.3) should be [hidden]
+PASS CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (0) should be [hidden]
+PASS CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (0.3) should be [hidden]
 PASS CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (0.5) should be [hidden]
 PASS CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (0.6) should be [hidden]
 PASS CSS Transitions with transition: all: property <visibility> from [collapse] to [hidden] at (1) should be [hidden]


### PR DESCRIPTION
#### c8d2cfa80287c3ba41802e0a1f55782dbf541cca
<pre>
[web-animations] WPT test css/CSS2/visufx/animation/visibility-interpolation.html is a unique failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=270434">https://bugs.webkit.org/show_bug.cgi?id=270434</a>

Reviewed by Antti Koivisto.

Interpolation of the &quot;visibility&quot; property is discrete when neither of the values for a given
animation interval is &quot;visible&quot;, per <a href="https://drafts.csswg.org/web-animations-1/#animating-visibility.">https://drafts.csswg.org/web-animations-1/#animating-visibility.</a>

This addresses the final failures in this test.

* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/visufx/animation/visibility-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):

Canonical link: <a href="https://commits.webkit.org/275636@main">https://commits.webkit.org/275636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1a1b11cf1dc88c6853071066bd282e2e4c86fbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38451 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35075 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16005 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41742 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40340 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18831 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5709 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->