### PR TITLE
Display capture Safari muting UI is broken if UseSCContentSharingPicker is false

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -193,6 +193,11 @@ void DisplayCaptureSourceCocoa::stopProducingData()
     m_capturer->stop();
 }
 
+void DisplayCaptureSourceCocoa::endProducingData()
+{
+    m_capturer->end();
+}
+
 Seconds DisplayCaptureSourceCocoa::elapsedTime()
 {
     if (m_startTime.isNaN())

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -77,6 +77,7 @@ public:
 
         virtual bool start() = 0;
         virtual void stop() = 0;
+        virtual void end() { stop(); }
         virtual DisplayFrameType generateFrame() = 0;
         virtual CaptureDevice::DeviceType deviceType() const = 0;
         virtual DisplaySurfaceType surfaceType() const = 0;
@@ -131,6 +132,7 @@ private:
     // RealtimeMediaSource
     void startProducingData() final;
     void stopProducingData() final;
+    void endProducingData() final;
     void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) final;
     bool isCaptureSource() const final { return true; }
     const RealtimeMediaSourceCapabilities& capabilities() final;

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -73,6 +73,7 @@ private:
     // DisplayCaptureSourceCocoa::Capturer
     bool start() final;
     void stop() final;
+    void end() final;
     DisplayCaptureSourceCocoa::DisplayFrameType generateFrame() final;
     CaptureDevice::DeviceType deviceType() const final;
     DisplaySurfaceType surfaceType() const final;
@@ -96,8 +97,11 @@ private:
     SCStream* contentStream() const { return m_sessionSource ? m_sessionSource->stream() : nullptr; }
     SCContentFilter* contentFilter() const { return m_sessionSource ? m_sessionSource->contentFilter() : nullptr; }
 
+    void clearSharingSession();
+
     std::optional<Content> m_content;
     RetainPtr<WebCoreScreenCaptureKitHelper> m_captureHelper;
+    RetainPtr<SCContentSharingSession> m_sharingSession;
     RetainPtr<SCContentFilter> m_contentFilter;
     RetainPtr<CMSampleBufferRef> m_currentFrame;
     RefPtr<ScreenCaptureSessionSource> m_sessionSource;

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -100,12 +100,14 @@ public:
 
     void cancelPicking();
 
-    RetainPtr<SCContentFilter> contentFilterFromCaptureDevice(const CaptureDevice&);
-    RefPtr<ScreenCaptureSessionSource> createSessionSourceForDevice(WeakPtr<ScreenCaptureSessionSource::Observer>, SCContentFilter*, SCStreamConfiguration*, SCStreamDelegate*);
+    std::pair<RetainPtr<SCContentFilter>, RetainPtr<SCContentSharingSession>> contentFilterAndSharingSessionFromCaptureDevice(const CaptureDevice&);
+    RefPtr<ScreenCaptureSessionSource> createSessionSourceForDevice(WeakPtr<ScreenCaptureSessionSource::Observer>, SCContentFilter*, SCContentSharingSession*, SCStreamConfiguration*, SCStreamDelegate*);
     void cancelPendingSessionForDevice(const CaptureDevice&);
 
     WEBCORE_EXPORT void promptForGetDisplayMedia(DisplayCapturePromptType, CompletionHandler<void(std::optional<CaptureDevice>)>&&);
     WEBCORE_EXPORT void cancelGetDisplayMediaPrompt();
+
+    void cleanupSharingSession(SCContentSharingSession*);
 
 private:
     void cleanupAllSessions();

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -535,18 +535,20 @@ void ScreenCaptureKitSharingSessionManager::cancelPendingSessionForDevice(const 
     cancelPicking();
 }
 
-RetainPtr<SCContentFilter> ScreenCaptureKitSharingSessionManager::contentFilterFromCaptureDevice(const CaptureDevice& device)
+std::pair<RetainPtr<SCContentFilter>, RetainPtr<SCContentSharingSession>> ScreenCaptureKitSharingSessionManager::contentFilterAndSharingSessionFromCaptureDevice(const CaptureDevice& device)
 {
     ASSERT(isMainThread());
 
+#if HAVE(SC_CONTENT_SHARING_PICKER)
     if (m_pendingContentFilter.get() != device) {
         RELEASE_LOG_ERROR(WebRTC, "ScreenCaptureKitSharingSessionManager::contentFilterFromCaptureDevice - unknown capture device.");
-        return nullptr;
+        return { };
     }
-    return std::exchange(m_pendingContentFilter, { });
+#endif
+    return std::make_pair(std::exchange(m_pendingContentFilter, { }), std::exchange(m_pendingSession, { }));
 }
 
-RefPtr<ScreenCaptureSessionSource> ScreenCaptureKitSharingSessionManager::createSessionSourceForDevice(WeakPtr<ScreenCaptureSessionSource::Observer> observer, SCContentFilter* contentFilter, SCStreamConfiguration* configuration, SCStreamDelegate* delegate)
+RefPtr<ScreenCaptureSessionSource> ScreenCaptureKitSharingSessionManager::createSessionSourceForDevice(WeakPtr<ScreenCaptureSessionSource::Observer> observer, SCContentFilter* contentFilter, SCContentSharingSession* sharingSession, SCStreamConfiguration* configuration, SCStreamDelegate* delegate)
 {
     ASSERT(isMainThread());
 
@@ -556,7 +558,7 @@ RefPtr<ScreenCaptureSessionSource> ScreenCaptureKitSharingSessionManager::create
         stream = adoptNS([PAL::allocSCStreamInstance() initWithFilter:contentFilter configuration:configuration delegate:(id<SCStreamDelegate> _Nullable)delegate]);
     else
 #endif
-        stream = adoptNS([PAL::allocSCStreamInstance() initWithSharingSession:m_pendingSession.get() captureOutputProperties:configuration delegate:(id<SCStreamDelegate> _Nullable)delegate]);
+        stream = adoptNS([PAL::allocSCStreamInstance() initWithSharingSession:sharingSession captureOutputProperties:configuration delegate:(id<SCStreamDelegate> _Nullable)delegate]);
 
     if (!stream) {
         RELEASE_LOG_ERROR(WebRTC, "ScreenCaptureKitSharingSessionManager::createSessionSourceForDevice - unable to create SCStream.");
@@ -570,7 +572,7 @@ RefPtr<ScreenCaptureSessionSource> ScreenCaptureKitSharingSessionManager::create
         cleanupSessionSource(source);
     };
 
-    auto newSession = ScreenCaptureSessionSource::create(WTFMove(observer), WTFMove(stream), contentFilter, WTFMove(m_pendingSession), WTFMove(cleanupFunction));
+    auto newSession = ScreenCaptureSessionSource::create(WTFMove(observer), WTFMove(stream), contentFilter, sharingSession, WTFMove(cleanupFunction));
     m_activeSources.append(newSession);
 
     return newSession;
@@ -590,11 +592,10 @@ void ScreenCaptureKitSharingSessionManager::cleanupSessionSource(ScreenCaptureSe
 
     if (!promptingInProgress())
         cancelPicking();
+}
 
-    auto sharingSession = source.sharingSession();
-    if (!sharingSession)
-        return;
-
+void ScreenCaptureKitSharingSessionManager::cleanupSharingSession(SCContentSharingSession* sharingSession)
+{
     if (m_promptHelper)
         [m_promptHelper stopObservingSession:sharingSession];
     [sharingSession end];


### PR DESCRIPTION
#### 704de66ba7cb72f0cde960ca342172fed0c1383e
<pre>
Display capture Safari muting UI is broken if UseSCContentSharingPicker is false
<a href="https://bugs.webkit.org/show_bug.cgi?id=270441">https://bugs.webkit.org/show_bug.cgi?id=270441</a>
<a href="https://rdar.apple.com/123311026">rdar://123311026</a>

Reviewed by Eric Carlson.

In case UseSCContentSharingPicker is false, we use a sharing session to start capture.
Before the patch, we would not keep the sharing session.
We update the code to store the sharing session in ScreenCaptureKitCaptureSource, so that when calling start to restart capture,
we can reuse the sharing session.

To make it work, we need the haring session to not be ended.
We end it in ScreenCaptureKitCaptureSource::end() or in ScreenCaptureKitCaptureSource destructor via ScreenCaptureKitSharingSessionManager::cleanupSharingSession.

We update ScreenCaptureKitCaptureSource::sessionFailedWithError since it is called with an error just after ScreenCaptureKitCaptureSource::stop is called.

* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::endProducingData):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::~ScreenCaptureKitCaptureSource):
(WebCore::ScreenCaptureKitCaptureSource::end):
(WebCore::ScreenCaptureKitCaptureSource::clearSharingSession):
(WebCore::ScreenCaptureKitCaptureSource::sessionFailedWithError):
(WebCore::ScreenCaptureKitCaptureSource::startContentStream):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::contentFilterAndSharingSessionFromCaptureDevice):
(WebCore::ScreenCaptureKitSharingSessionManager::createSessionSourceForDevice):
(WebCore::ScreenCaptureKitSharingSessionManager::cleanupSessionSource):
(WebCore::ScreenCaptureKitSharingSessionManager::cleanupSharingSession):
(WebCore::ScreenCaptureKitSharingSessionManager::contentFilterFromCaptureDevice): Deleted.

Canonical link: <a href="https://commits.webkit.org/275627@main">https://commits.webkit.org/275627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc184d80e69af5c4ab7350f087f691c091069d81

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44934 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44642 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/24617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35076 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16006 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15959 "layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41743 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40350 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18770 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9479 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->