### PR TITLE
[threaded-animation-resolution] remove WEBCORE_EXPORT for some blend() methods

### DIFF
--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -238,7 +238,7 @@ public:
     const LengthPoint& position() const { return m_position; }
 
     WEBCORE_EXPORT bool canBlend(const PathOperation&) const final;
-    WEBCORE_EXPORT RefPtr<PathOperation> blend(const PathOperation*, const BlendingContext&) const final;
+    RefPtr<PathOperation> blend(const PathOperation*, const BlendingContext&) const final;
 
     double lengthForPath() const;
     double lengthForContainPath(const FloatRect& elementRect, double computedPathLength) const;

--- a/Source/WebCore/rendering/style/OffsetRotation.h
+++ b/Source/WebCore/rendering/style/OffsetRotation.h
@@ -39,7 +39,7 @@ public:
     float angle() const { return m_angle; }
 
     bool canBlend(const OffsetRotation&) const;
-    WEBCORE_EXPORT OffsetRotation blend(const OffsetRotation&, const BlendingContext&) const;
+    OffsetRotation blend(const OffsetRotation&, const BlendingContext&) const;
 
     friend bool operator==(const OffsetRotation&, const OffsetRotation&) = default;
 


### PR DESCRIPTION
#### e6c8b884f6bfd98006e6bb209b5e171afeda29fc
<pre>
[threaded-animation-resolution] remove WEBCORE_EXPORT for some blend() methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=270443">https://bugs.webkit.org/show_bug.cgi?id=270443</a>
<a href="https://rdar.apple.com/124007704">rdar://124007704</a>

Reviewed by Anne van Kesteren.

Since blending is actually performed in WebCore, we don&apos;t need WEBCORE_EXPORT for
blending `PathOperation` and `OffsetRotation` values.

* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/rendering/style/OffsetRotation.h:

Canonical link: <a href="https://commits.webkit.org/275634@main">https://commits.webkit.org/275634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3527f6da1dde1098fd0603ec51328e252ebf80e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38457 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35084 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16014 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46401 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41747 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40346 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18837 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5708 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->