### PR TITLE
[results.webkit.org] Allow instance to declare default architecture

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/configuration.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/configuration.js
@@ -22,6 +22,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 import {queryToParams, escapeHTML} from '/assets/js/common.js';
+import {DEFAULT_ARCHITECTURE} from '/assets/js/constants.js'
 
 // These are flipped delibrately, it makes the fromQuery function return configurations in an
 // intuitive order.
@@ -210,7 +211,7 @@ class Configuration {
             result += ' ' + this.style.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join('-');
         } if (this.model != null)
             result += ' on ' + this.model;
-        if (this.architecture != null)
+        if (this.architecture != null && (DEFAULT_ARCHITECTURE == null || this.architecture.search(DEFAULT_ARCHITECTURE) < 0))
             result += ' with ' + this.architecture;
 
         if (this.sdk != null)

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js
@@ -24,5 +24,6 @@
 const XCODE_CLOUD_SUITES = [{% for suite in XcodeCloud %}
     '{{ suite }}',
 {% endfor %}];
+const DEFAULT_ARCHITECTURE = {{ default_architecture }};
 
-export {XCODE_CLOUD_SUITES}
+export {XCODE_CLOUD_SUITES, DEFAULT_ARCHITECTURE}

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
 import os
 import requests
 import time
@@ -43,6 +44,7 @@ class ViewRoutes(AuthedBlueprint):
         title='Results Database', auth_decorator=None,
         archive_routes=None,
         suite_types=None,
+        default_architecture=None,
     ):
         super(ViewRoutes, self).__init__('view', import_name, url_prefix=None, auth_decorator=auth_decorator)
         self._cache = {}
@@ -52,7 +54,9 @@ class ViewRoutes(AuthedBlueprint):
             loader=PackageLoader(package_name='resultsdbpy.view', package_path='templates'),
             autoescape=select_autoescape(['html', 'xml']),
         )
+
         self.suite_types = suite_types or {}
+        self.default_architecture = default_architecture
 
         # Protecting js and css with auth doesn't make sense
         self.add_url_rule('/library/<path:path>', 'library', self.library, authed=False, methods=('GET',))
@@ -169,5 +173,6 @@ class ViewRoutes(AuthedBlueprint):
         return Response(
             self.environment.get_template('constants.js').render(
                 XcodeCloud=self.suite_types.get('XcodeCloud') or [],
+                default_architecture=json.dumps(self.default_architecture) if self.default_architecture else 'null',
             ), mimetype='application/javascript',
         )

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py
@@ -146,6 +146,7 @@ class WebSiteUnittest(WebSiteTestCase):
 const XCODE_CLOUD_SUITES = [
     'Build',
 ];
+const DEFAULT_ARCHITECTURE = null;
 
-export {XCODE_CLOUD_SUITES}''',
+export {XCODE_CLOUD_SUITES, DEFAULT_ARCHITECTURE}''',
         )


### PR DESCRIPTION
#### 74450308e745435f7feebf54ea505966aa09f837
<pre>
[results.webkit.org] Allow instance to declare default architecture
<a href="https://bugs.webkit.org/show_bug.cgi?id=270442">https://bugs.webkit.org/show_bug.cgi?id=270442</a>
<a href="https://rdar.apple.com/124007556">rdar://124007556</a>

Reviewed by Dewei Zhu.

Constructed queue names on results.webkit.org are often too verbose. Architecture is a
significant cause of this length, and for many queues on many instances, architecture would
be assumed were it excluded from the UI.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/configuration.js:
(Configuration.prototype.toString): Do not include architecture in printed configuration name
if the architecture is the instance&apos;s default architecture.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js: Add default_architecture.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py:
(ViewRoutes.__init__): Add default_architecture.
(ViewRoutes.constants): Ditto.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes_unittest.py:
(WebSiteUnittest.test_constants): Update.

Canonical link: <a href="https://commits.webkit.org/275748@main">https://commits.webkit.org/275748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a822112ff5f78e444057f127c7694256e5c0e99f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45152 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38666 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35232 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16172 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/42417 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37678 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/602 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46633 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41918 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/42594 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18982 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40536 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19046 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5777 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18627 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->