### PR TITLE
results.webkit.org does not indicate unexpected passing tests

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
@@ -58,16 +58,18 @@ class Expectations
     {
         const unexpectedSet = new Set(results.split('.'));
         const expectedSet = new Set(expectations.split(' '));
+        let result = 'WARNING';
 
         if (expectedSet.has('FAIL'))
             expectedSet.add('TEXT').add('AUDIO').add('IMAGE');
 
         for (const result of unexpectedSet) {
-            if (expectedSet.has(result))
+            if (expectedSet.has(result)) {
+                result = 'PASS';
                 unexpectedSet.delete(result);
+            }
         }
 
-        let result = 'PASS';
         for (const candidate of unexpectedSet) {
             if (Expectations.stringToStateId(candidate) < Expectations.stringToStateId(result))
                 result = candidate;


### PR DESCRIPTION
#### 8fac0d1f0dc0ee63a85b3f43cdb2b8fa6efd3602
<pre>
results.webkit.org does not indicate unexpected passing tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=270407">https://bugs.webkit.org/show_bug.cgi?id=270407</a>
<a href="https://rdar.apple.com/124008210">rdar://124008210</a>

Reviewed by NOBODY (OOPS!).

When filtering by expected results, we should annotate tests which are passing,
but not matching any of the expected results.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js:
(Expectations.unexpectedResults): If an actual result is not part of the list of
expected results, report that as a &apos;WARNING&apos;.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c2faf75568d4536a6bae93811e89e41d68d3d6c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18758 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35115 "Failure limit exceed. At least found 145 new test failures: accessibility/math-multiscript-attributes.html, animations/shadow-host-child-change.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/contents-scale/hidpi-tests/rasterization-scale.html, compositing/hidpi-non-simple-compositing-layer-with-fractional-size-and-background.html, compositing/tiling/sticky-change-to-tiled.html, css1/box_properties/clear_float.html, css1/font_properties/font.html, css1/font_properties/font_size.html, css1/pseudo/multiple_pseudo_elements.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16056 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/42265 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37551 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46460 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41788 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/42442 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18829 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40396 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->