### PR TITLE
[B3] Build fix

### DIFF
--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -125,7 +125,7 @@ public:
     JS_EXPORT_PRIVATE const Vector<Type>& tupleForType(Type tuple) const;
 
     unsigned resultCount(Type type) const { return type.isTuple() ? tupleForType(type).size() : type.isNumeric(); }
-    Type typeAtOffset(Type type, unsigned index) const { ASSERT(index < resultCount(type)); return type.isTuple() ? extractFromTuple(type, index) : type; }
+    virtual Type typeAtOffset(Type type, unsigned index) const { ASSERT(index < resultCount(type)); return type.isTuple() ? extractFromTuple(type, index) : type; }
 
     template<typename ValueType, typename... Arguments>
     ValueType* add(Arguments...);


### PR DESCRIPTION
In B3Procedure.h typeAtOffset() calls extractFromTuple() which is only implemented by sub classes.

* Source/JavaScriptCore/b3/B3Procedure.h: making typeAtOffset() virtual.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a5cdb89996ea1afedc07bf9cb64fbf1f7eea766

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42360 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21378 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44754 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44959 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/38477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24602 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18723 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42934 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/24602 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/44754 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/24602 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/44754 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/46422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35816 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/24602 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/44754 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/46422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/41988 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/18723 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/46422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/44754 "Hash 0a5cdb89 for PR 25416 does not build (failure)") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/48997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/48997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->