### PR TITLE
Atlassian Confluence blocks Epiphany's user agent

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -136,6 +136,12 @@ static bool urlRequiresMacintoshPlatform(const String& domain, const String& bas
     if (domain == "www.sspa.juntadeandalucia.es"_s)
         return true;
 
+    // Atlassian Confluence discrimates against WebKitGTK's standard user agent
+    // by completely blocking access to the application. It runs on different
+    // subdomains for each Atlassian customer so the quirk must apply broadly.
+    if (baseDomain == "atlassian.net"_s)
+        return true;
+
     return false;
 }
 #endif // ENABLE(PUBLIC_SUFFIX_LIST)

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -107,6 +107,7 @@ TEST(UserAgentTest, Quirks)
     assertUserAgentForURLHasMacPlatformQuirk("http://mail.ntu.edu.tw/");
     assertUserAgentForURLHasMacPlatformQuirk("http://exchange.tu-berlin.de/");
     assertUserAgentForURLHasMacPlatformQuirk("http://www.sspa.juntadeandalucia.es/");
+    assertUserAgentForURLHasMacPlatformQuirk("http://foobar.atlassian.net/");
 
     assertUserAgentForURLHasEmptyQuirk("http://accounts.google.com/");
     assertUserAgentForURLHasEmptyQuirk("http://docs.google.com/");


### PR DESCRIPTION
#### 1a9883acbbb02ab8671f5e31e18ea0d0b8eda162
<pre>
Atlassian Confluence blocks Epiphany&apos;s user agent
<a href="https://bugs.webkit.org/show_bug.cgi?id=270438">https://bugs.webkit.org/show_bug.cgi?id=270438</a>

Reviewed by Philippe Normand.

* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
(WebCore::urlRequiresMacintoshPlatform):
* Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/275835@main">https://commits.webkit.org/275835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36adbd21b53e2f35a099101bfc632456493bc843

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18755 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35113 "Failure limit exceed. At least found 154 new test failures: accessibility/math-multiscript-attributes.html, animations/additive-transform-animations.html, animations/keyframe-em-unit.html, animations/multiple-backgrounds.html, compositing/animation/keyframe-order.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/hidpi-compositing-layer-with-zero-sized-container.html, compositing/masks/mask-and-drop-shadow.html, compositing/tiling/empty-to-tiled.html, compositing/tiling/sticky-change-to-tiled.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16054 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37549 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17207 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14175 "Found 1 new test failure: workers/wasm-hashset-many.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41820 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18826 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40428 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9578 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->