### PR TITLE
[resultsdb] rewrite JS unexpectedResults for clarity

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
@@ -56,23 +56,22 @@ class Expectations
 
     static unexpectedResults(results, expectations)
     {
-        let r = results.split('.');
-        expectations.split(' ').forEach(expectation => {
-            const i = r.indexOf(expectation);
-            if (i > -1)
-                r.splice(i, 1);
-            if (expectation === 'FAIL')
-                ['TEXT', 'AUDIO', 'IMAGE'].forEach(expectation => {
-                    const i = r.indexOf(expectation);
-                    if (i > -1)
-                        r.splice(i, 1);
-                });
-        });
+        const unexpectedSet = new Set(results.split('.'));
+        const expectedSet = new Set(expectations.split(' '));
+
+        if (expectedSet.has('FAIL'))
+            expectedSet.add('TEXT').add('AUDIO').add('IMAGE');
+
+        for (const result of unexpectedSet) {
+            if (expectedSet.has(result))
+                unexpectedSet.delete(result);
+        }
+
         let result = 'PASS';
-        r.forEach(candidate => {
+        for (const candidate of unexpectedSet) {
             if (Expectations.stringToStateId(candidate) < Expectations.stringToStateId(result))
                 result = candidate;
-        });
+        }
         return result;
     }
 }


### PR DESCRIPTION
#### aff41c9edc609f47758d711bd341eccbbd052f33
<pre>
[resultsdb] rewrite JS unexpectedResults for clarity
<a href="https://bugs.webkit.org/show_bug.cgi?id=270448">https://bugs.webkit.org/show_bug.cgi?id=270448</a>
<a href="https://rdar.apple.com/problem/124013364">rdar://problem/124013364</a>

Reviewed by Jonathan Bedard.

Based on profiling in both Safari and Chrome, this doesn&apos;t meaningfully
change the performance of the hot code. In either browser,
unexpectedResults scarcely manages to get sampled.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js:
(Expectations.unexpectedResults):

Canonical link: <a href="https://commits.webkit.org/275628@main">https://commits.webkit.org/275628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ec3135dadb3cc526f486c679e3f2b4c71afefa8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44970 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/38488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18734 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42945 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/42242 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/15979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46435 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37857 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17187 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/42419 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5705 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->