### PR TITLE
[JSC] B3 Eliminate Common Subexpressions shouldn't remove reads status for the processed blocks

### DIFF
--- a/JSTests/stress/ecs-store-with-loop.js
+++ b/JSTests/stress/ecs-store-with-loop.js
@@ -1,0 +1,24 @@
+//@ runDefault("--jitPolicyScale=0")
+let var1 = 0x80000000;
+
+function foo() {
+    for (let i = 0; i < 7; i++) {
+        var1 = var1 << i;
+        var1 = var1 - 1;
+    }
+    var1 >>= 8;
+    return var1;
+}
+noInline(foo);
+
+function main() {
+    let ret = undefined;
+    foo();
+    let expected = foo();
+    for (let i = 0; i < 1e3; i++) {
+        ret = foo();
+        if (expected != ret)
+            throw new Error();
+    }
+}
+main();

--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -278,6 +278,8 @@ private:
         
         if (memory)
             processMemoryAfterClobber(memory);
+
+        m_data.reads.add(m_value->effects().reads);
     }
 
     // Return true if we got rid of the operation. If you changed IR in this function, you have to

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1203,6 +1203,8 @@ void addTupleTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
 
 bool shouldRun(const TestConfig*, const char* testName);
 
+void testCSEStoreWithLoop();
+
 void testLoadPreIndex32();
 void testLoadPreIndex64();
 void testLoadPostIndex32();


### PR DESCRIPTION
#### 72406ce3b7cd65b2eb32b7a6e358e0942d7ec7c7
<pre>
[JSC] B3 Eliminate Common Subexpressions shouldn&apos;t remove reads status for the processed blocks
<a href="https://bugs.webkit.org/show_bug.cgi?id=270450">https://bugs.webkit.org/show_bug.cgi?id=270450</a>
<a href="https://rdar.apple.com/118832222">rdar://118832222</a>

Reviewed by NOBODY (OOPS!).

Eliminate common subexpressions in B3 is used to remove redundant Load and Store nodes.
Current algorithm removes block reads info after processing each block. This is wrong
since some Store nodes may be deleted erroneously due to the missing reads info from
the processed blocks. Consider this B3 graph:

    BB#0:
        ...
    Successors: #1

    BB#1:
    Predecessors: #0, #2
        ...
        @a = Load(addr, Reads:Top)
        ...
    Successors: #2

    BB#2:
    Predecessors: #1
        ...
        @b = Store(..., addr, Writes:Top)
        ...
        ...= &lt;Node&gt;(..., Reads:Top)
        ...
        @c = Store(..., addr, Writes:Top)
        ...
    Successors: Then:#1, Else:#3

    BB#3:
    Predecessors: #2
        ...
        @d = Store(..., addr, Writes:Top)
        ...

Before processing ECS, these blocks should have reads, writes, and storesAtHead status:

    #0: {reads = , writes = , storesAtHead = {}, ...}
    #1: {reads = Top, writes = , storesAtHead = {}, ...}
    #2: {reads = Top, writes = Top, storesAtHead = {addr=&gt;@b}, ...}
    #3: {reads = , writes = Top, storesAtHead = {addr=&gt;@d}, ...}

When processing @c at #2, the reads info of #1 is deleted since it&apos;s processed before.
In the next findStoreAfterClobber(@c), it will traverse all paths after @c to find
matching candidate nodes to prove that the node is redundant. A Store node should not
be deleted if any path may interfere with the data stored at the Store node&apos;s target
address (any read or write heap range overlaps the range where the data is stored).

In this case, two candidates @d and @b are found for paths #2 -&gt; #3 and #2 -&gt; #1 -&gt; #2
respectively for @c, where @b is not correct since the stored data of @c may dependent
on @a. And the root cause is that the reads info were for #1 was deleted after processing.
To fix this issue, we should update block reads info after processing each nodes.

* JSTests/stress/ecs-store-with-loop.js: Added.
(foo):
(main):
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testCSEStoreWithLoop):
(addShrTests):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72406ce3b7cd65b2eb32b7a6e358e0942d7ec7c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44979 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24623 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/18785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35104 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16043 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46445 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35836 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41775 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42008 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17196 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14168 "Exiting early after 60 failures. 24595 tests run. 60 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40378 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18815 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49017 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18877 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9935 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->