### PR TITLE
[threaded-animation-resolution] explicitly obtain ref-counted properties as references when blending

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -307,15 +307,15 @@ static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& o
         break;
     }
     case AcceleratedEffectProperty::Translate:
-        if (auto toTranslate = to.translate)
+        if (auto& toTranslate = to.translate)
             output.translate = toTranslate->blend(from.translate.get(), blendingContext);
         break;
     case AcceleratedEffectProperty::Rotate:
-        if (auto toRotate = to.rotate)
+        if (auto& toRotate = to.rotate)
             output.rotate = toRotate->blend(from.rotate.get(), blendingContext);
         break;
     case AcceleratedEffectProperty::Scale:
-        if (auto toScale = to.scale)
+        if (auto& toScale = to.scale)
             output.scale = toScale->blend(from.scale.get(), blendingContext);
         break;
     case AcceleratedEffectProperty::OffsetAnchor:


### PR DESCRIPTION
#### 308a69c33af35975cea167db50a89e7c29fb06a4
<pre>
[threaded-animation-resolution] explicitly obtain ref-counted properties as references when blending
<a href="https://bugs.webkit.org/show_bug.cgi?id=270455">https://bugs.webkit.org/show_bug.cgi?id=270455</a>

Reviewed by Dean Jackson.

Several properties of `AcceleratedEffectValues` are ref-counted and we access those when blending in `AcceleratedEffect`.
We don&apos;t currently mark those as references, so we should make it explicit since we don&apos;t want to increase the ref-counting.

* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::blend):

Canonical link: <a href="https://commits.webkit.org/275704@main">https://commits.webkit.org/275704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2da69d33b8b761a1730094c67f1caa467c412c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35110 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37546 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/443 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46488 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17203 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14172 "Found 1 new test failure: ipc/message-listener-async-message-reply-id.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41806 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18822 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40414 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18884 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5751 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->