### PR TITLE
Use InvalidStateError if user gesture is missing for getDisplayMedia

### DIFF
--- a/LayoutTests/fast/mediastream/screencapture-user-gesture.html
+++ b/LayoutTests/fast/mediastream/screencapture-user-gesture.html
@@ -25,6 +25,6 @@ promise_test(() => {
 
 
 promise_test((test) => {
-    return promise_rejects_dom(test, "InvalidAccessError", navigator.mediaDevices.getDisplayMedia({video : true}));
+    return promise_rejects_dom(test, "InvalidStateError", navigator.mediaDevices.getDisplayMedia({video : true}));
 }, "Deny getDisplayMedia call if no user gesture");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-iframe-audio-transfer.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-iframe-audio-transfer.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL MediaStreamTrack transfer to iframe promise_test: Unhandled rejection with value: object "InvalidAccessError: getDisplayMedia must be called from a user gesture handler."
+FAIL MediaStreamTrack transfer to iframe promise_test: Unhandled rejection with value: object "InvalidStateError: getDisplayMedia must be called from a user gesture handler."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-iframe-transfer.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-iframe-transfer.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL MediaStreamTrack transfer to iframe promise_test: Unhandled rejection with value: object "InvalidAccessError: getDisplayMedia must be called from a user gesture handler."
+FAIL MediaStreamTrack transfer to iframe promise_test: Unhandled rejection with value: object "InvalidStateError: getDisplayMedia must be called from a user gesture handler."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-transfer.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-transfer.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL MediaStreamTrack transfer to Worker promise_test: Unhandled rejection with value: object "InvalidAccessError: getDisplayMedia must be called from a user gesture handler."
+FAIL MediaStreamTrack transfer to Worker promise_test: Unhandled rejection with value: object "InvalidStateError: getDisplayMedia must be called from a user gesture handler."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/parallel-capture-requests.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/parallel-capture-requests.https-expected.txt
@@ -1,5 +1,5 @@
 User gesture
 
-FAIL getDisplayMedia() and parallel getUserMedia() promise_test: Unhandled rejection with value: object "InvalidAccessError: getDisplayMedia must be called from a user gesture handler."
-FAIL getUserMedia() and parallel getDisplayMedia() promise_test: Unhandled rejection with value: object "InvalidAccessError: getDisplayMedia must be called from a user gesture handler."
+FAIL getDisplayMedia() and parallel getUserMedia() promise_test: Unhandled rejection with value: object "InvalidStateError: getDisplayMedia must be called from a user gesture handler."
+FAIL getUserMedia() and parallel getDisplayMedia() promise_test: Unhandled rejection with value: object "InvalidStateError: getDisplayMedia must be called from a user gesture handler."
 

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -253,7 +253,7 @@ void MediaDevices::getDisplayMedia(DisplayMediaStreamConstraints&& constraints, 
 
     bool isUserGesturePriviledged = computeUserGesturePriviledge(GestureAllowedRequest::Display);
     if (!isUserGesturePriviledged) {
-        promise.reject(Exception { ExceptionCode::InvalidAccessError, "getDisplayMedia must be called from a user gesture handler."_s });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "getDisplayMedia must be called from a user gesture handler."_s });
         return;
     }
 


### PR DESCRIPTION
#### ab0993157de8494aed1b5a222f08b740e3dc00c1
<pre>
Use InvalidStateError if user gesture is missing for getDisplayMedia
<a href="https://bugs.webkit.org/show_bug.cgi?id=251906">https://bugs.webkit.org/show_bug.cgi?id=251906</a>
<a href="https://rdar.apple.com/105167105">rdar://105167105</a>

Reviewed by Jean-Yves Avenard.

* LayoutTests/fast/mediastream/screencapture-user-gesture.html:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-iframe-audio-transfer.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-iframe-transfer.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-transfer.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/parallel-capture-requests.https-expected.txt:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::getDisplayMedia):

Canonical link: <a href="https://commits.webkit.org/275685@main">https://commits.webkit.org/275685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5dfef90e2db3b99b1c9dd05d11a99b61d3e3a5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35112 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41785 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14174 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40390 "Found 1 new API test failure: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9508 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->