### PR TITLE
Adopt dynamicDowncast<> in JSC inspector code

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp
@@ -55,14 +55,12 @@ bool RemoteConnectionToTarget::setup(bool isAutomaticInspection, bool automatica
     if (!m_target || !m_target->remoteControlAllowed()) {
         RemoteInspector::singleton().setupFailed(targetIdentifier);
         m_target = nullptr;
-    } else if (is<RemoteInspectionTarget>(m_target)) {
-        auto target = downcast<RemoteInspectionTarget>(m_target);
+    } else if (auto* target = dynamicDowncast<RemoteInspectionTarget>(m_target)) {
         target->connect(*this, isAutomaticInspection, automaticallyPause);
         m_connected = true;
 
         RemoteInspector::singleton().updateTargetListing(targetIdentifier);
-    } else if (is<RemoteAutomationTarget>(m_target)) {
-        auto target = downcast<RemoteAutomationTarget>(m_target);
+    } else if (auto* target = dynamicDowncast<RemoteAutomationTarget>(m_target)) {
         target->connect(*this);
         m_connected = true;
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
@@ -216,10 +216,10 @@ void RemoteInspector::stop()
 
 TargetListing RemoteInspector::listingForTarget(const RemoteControllableTarget& target) const
 {
-    if (is<RemoteInspectionTarget>(target))
-        return listingForInspectionTarget(downcast<RemoteInspectionTarget>(target));
-    if (is<RemoteAutomationTarget>(target))
-        return listingForAutomationTarget(downcast<RemoteAutomationTarget>(target));
+    if (auto* inspectionTarget = dynamicDowncast<RemoteInspectionTarget>(target))
+        return listingForInspectionTarget(*inspectionTarget);
+    if (auto* automationTarget = dynamicDowncast<RemoteAutomationTarget>(target))
+        return listingForAutomationTarget(*automationTarget);
 
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
@@ -170,15 +170,13 @@ bool RemoteConnectionToTarget::setup(bool isAutomaticInspection, bool automatica
         if (!m_target || !m_target->remoteControlAllowed()) {
             RemoteInspector::singleton().setupFailed(targetIdentifier);
             m_target = nullptr;
-        } else if (is<RemoteInspectionTarget>(m_target)) {
-            auto castedTarget = downcast<RemoteInspectionTarget>(m_target);
-            castedTarget->connect(*this, isAutomaticInspection, automaticallyPause);
+        } else if (auto* inspectionTarget = dynamicDowncast<RemoteInspectionTarget>(m_target)) {
+            inspectionTarget->connect(*this, isAutomaticInspection, automaticallyPause);
             m_connected = true;
 
             RemoteInspector::singleton().updateTargetListing(targetIdentifier);
-        } else if (is<RemoteAutomationTarget>(m_target)) {
-            auto castedTarget = downcast<RemoteAutomationTarget>(m_target);
-            castedTarget->connect(*this);
+        } else if (auto* automationTarget = dynamicDowncast<RemoteAutomationTarget>(m_target)) {
+            automationTarget->connect(*this);
             m_connected = true;
 
             RemoteInspector::singleton().updateTargetListing(targetIdentifier);

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -720,8 +720,8 @@ void RemoteInspector::receivedIndicateMessage(NSDictionary *userInfo)
 
             target = findResult->value;
         }
-        if (is<RemoteInspectionTarget>(target))
-            downcast<RemoteInspectionTarget>(target)->setIndicating(indicateEnabled);
+        if (auto* inspectionTarget = dynamicDowncast<RemoteInspectionTarget>(target))
+            inspectionTarget->setIndicating(indicateEnabled);
     });
 }
 


### PR DESCRIPTION
#### acf3bc87ab82cf75ba7a6a9a74a468abc960a51c
<pre>
Adopt dynamicDowncast&lt;&gt; in JSC inspector code
<a href="https://bugs.webkit.org/show_bug.cgi?id=270457">https://bugs.webkit.org/show_bug.cgi?id=270457</a>

Reviewed by Devin Rousso.

For security &amp; performance.

* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp:
(Inspector::RemoteConnectionToTarget::setup):
* Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp:
(Inspector::RemoteInspector::listingForTarget const):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm:
(Inspector::RemoteConnectionToTarget::setup):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::receivedIndicateMessage):

Canonical link: <a href="https://commits.webkit.org/275679@main">https://commits.webkit.org/275679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/148fce35dac3a2af499b00caf41620690a6e4fff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38641 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18899 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16146 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46602 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35978 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37980 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41888 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42149 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18957 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49158 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9501 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19021 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/9959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->