### PR TITLE
`BackgroundPainter::paintFillLayers` should check box-shadow when finding an opaque layer

### DIFF
--- a/LayoutTests/fast/box-shadow/normal-box-shadow-with-background-image-expected-mismatch.html
+++ b/LayoutTests/fast/box-shadow/normal-box-shadow-with-background-image-expected-mismatch.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+<style>
+#theDiv {
+  height: 48px;
+  background-color: lightgrey;
+  width: 200px;
+  background-image: linear-gradient(red, lime), linear-gradient(blue, cyan);
+}
+</style>
+</head>
+<body>
+  <div id="theDiv"></div>
+</body>
+</html>

--- a/LayoutTests/fast/box-shadow/normal-box-shadow-with-background-image.html
+++ b/LayoutTests/fast/box-shadow/normal-box-shadow-with-background-image.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+<style>
+#theDiv {
+  height: 48px;
+  background-color: lightgrey;
+  box-shadow: black 0px 2px 4px;
+  width: 200px;
+  background-image: linear-gradient(red, green), linear-gradient(blue, cyan);
+}
+</style>
+</head>
+<body>
+  <div id="theDiv"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -4,7 +4,7 @@
  *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
  *           (C) 2005, 2006 Samuel Weinig (sam.weinig@gmail.com)
  * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2010-2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -131,7 +131,7 @@ void BackgroundPainter::paintFillLayers(const Color& color, const FillLayer& fil
         // and pass it down.
 
         // The clipOccludesNextLayers condition must be evaluated first to avoid short-circuiting.
-        if (layer->clipOccludesNextLayers(layer == &fillLayer) && layer->hasOpaqueImage(m_renderer) && layer->image()->canRender(&m_renderer, m_renderer.style().effectiveZoom()) && layer->hasRepeatXY() && layer->blendMode() == BlendMode::Normal)
+        if (layer->clipOccludesNextLayers(layer == &fillLayer) && layer->hasOpaqueImage(m_renderer) && layer->image()->canRender(&m_renderer, m_renderer.style().effectiveZoom()) && layer->hasRepeatXY() && layer->blendMode() == BlendMode::Normal && !boxShadowShouldBeAppliedToBackground(m_renderer, rect.location(), bleedAvoidance, { }))
             break;
     }
 


### PR DESCRIPTION
#### b6231f750f4e26e71cdf3c0f1d2fbb81879c665b
<pre>
`BackgroundPainter::paintFillLayers` should check box-shadow when finding an opaque layer

<a href="https://bugs.webkit.org/show_bug.cgi?id=250882">https://bugs.webkit.org/show_bug.cgi?id=250882</a>
<a href="https://rdar.apple.com/problem/104722307">rdar://problem/104722307</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/a48f4540763c24adff42b9b77d719597f51482f6">https://chromium.googlesource.com/chromium/blink/+/a48f4540763c24adff42b9b77d719597f51482f6</a>

BackgroundPainter::paintFillLayers has a fast path when a layer has an opaque background image.
If a layer has an opaque background image, basically the layer&apos;s background layers will be
hidden by the background image. So we can skip rendering the background layers.
However, if box-shadow is also specified, the box-shadow will be rendered in a skipped background layer.

This causes &quot;box-shadow disappears&quot;. We cannot use the fast path if box-shadow is specified.

* Source/WebCore/rendering/BackgroundPainter.cpp:
(BackgroundPainter::paintFillLayers):
* LayoutTests/fast/box-shadow/normal-box-shadow-with-background-image.html: Add Test Case
* LayoutTests/fast/box-shadow/normal-box-shadow-with-background-image-expected-mismatch.html: Add Test Case Expectation Mismatch

Canonical link: <a href="https://commits.webkit.org/275735@main">https://commits.webkit.org/275735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f2c8071402dd1d5db8b0244feafead40de5add3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35123 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16065 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37555 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46474 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41800 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9534 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18904 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->