### PR TITLE
When Archiving Test Results, visionOS Should be a Supported Platform

### DIFF
--- a/Tools/CISupport/test-result-archive
+++ b/Tools/CISupport/test-result-archive
@@ -59,7 +59,7 @@ def compress_spindumps(layoutTestResultsDir):
                     gzip_file(root, name)
 
 def archive_test_results(configuration, platform, layoutTestResultsDir):
-    assert platform in ('mac', 'win', 'gtk', 'wincairo', 'ios', 'watchos', 'wpe')
+    assert platform in ('mac', 'win', 'gtk', 'wincairo', 'ios', 'watchos', 'wpe', 'visionos')
 
     try:
         os.unlink(archiveFile)
@@ -76,7 +76,7 @@ def archive_test_results(configuration, platform, layoutTestResultsDir):
 
     open(os.path.join(layoutTestResultsDir, '.placeholder'), 'w').close()
 
-    if platform in ('mac', 'ios', 'watchos'):
+    if platform in ('mac', 'ios', 'watchos', 'visionos'):
         compress_spindumps(layoutTestResultsDir)
         if subprocess.call(["ditto", "-c", "-k", "--sequesterRsrc", "--zlibCompressionLevel", "2", layoutTestResultsDir, archiveFile]):
             return 1


### PR DESCRIPTION
#### 66ad17aa9e527a9d161ba093d2b706c77ba608c3
<pre>
When Archiving Test Results, visionOS Should be a Supported Platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=270464">https://bugs.webkit.org/show_bug.cgi?id=270464</a>
<a href="https://rdar.apple.com/124022341">rdar://124022341</a>

Reviewed by Ryan Haddad.

When archiving test results, visionOS should be a supported platform.

* Tools/CISupport/test-result-archive:
(archive_test_results):

Canonical link: <a href="https://commits.webkit.org/275658@main">https://commits.webkit.org/275658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0fd435dd6a1bf544437e31b8ac4235ce160f868

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45009 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38527 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18775 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16067 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46477 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41802 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40409 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18907 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5720 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->