### PR TITLE
[view-transitions] Address post-landing comments from 275156@main

### DIFF
--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -453,13 +453,11 @@ void DocumentTimeline::enqueueAnimationEvent(AnimationEventBase& event)
         scheduleAnimationResolution();
 }
 
-bool DocumentTimeline::hasPendingAnimationEventForAnimation(WebAnimation& animation) const
+bool DocumentTimeline::hasPendingAnimationEventForAnimation(const WebAnimation& animation) const
 {
-    for (auto& event : m_pendingAnimationEvents) {
-        if (event->animation() == &animation)
-            return true;
-    }
-    return false;
+    return m_pendingAnimationEvents.containsIf([&](auto& event) {
+        return event->animation() == &animation;
+    });
 }
 
 AnimationEvents DocumentTimeline::prepareForPendingAnimationEventsDispatch()

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -66,7 +66,7 @@ public:
     void detachFromDocument();
 
     void enqueueAnimationEvent(AnimationEventBase&);
-    bool hasPendingAnimationEventForAnimation(WebAnimation&) const;
+    bool hasPendingAnimationEventForAnimation(const WebAnimation&) const;
     
     enum class ShouldUpdateAnimationsAndSendEvents : bool { No, Yes };
     ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents();

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -509,12 +509,13 @@ void ViewTransition::handleTransitionFrame()
     if (!documentElement)
         return;
 
-    auto checkForActiveAnimations = [&](const Style::PseudoElementIdentifier& pseudoElementIdentifier) -> bool {
+    auto checkForActiveAnimations = [&](const Style::PseudoElementIdentifier& pseudoElementIdentifier) {
         if (!documentElement->animations(pseudoElementIdentifier))
             return false;
 
         for (auto& animation : *documentElement->animations(pseudoElementIdentifier)) {
-            if (animation->playState() == WebAnimation::PlayState::Paused || animation->playState() == WebAnimation::PlayState::Running)
+            auto playState = animation->playState();
+            if (playState == WebAnimation::PlayState::Paused || playState == WebAnimation::PlayState::Running)
                 return true;
             if (m_document->timeline().hasPendingAnimationEventForAnimation(animation))
                 return true;


### PR DESCRIPTION
#### c443a870227a0afdd57c689e9912238c07092f60
<pre>
[view-transitions] Address post-landing comments from 275156@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=270466">https://bugs.webkit.org/show_bug.cgi?id=270466</a>

Reviewed by Aditya Keerthi.

* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::hasPendingAnimationEventForAnimation const):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::handleTransitionFrame):

Canonical link: <a href="https://commits.webkit.org/275652@main">https://commits.webkit.org/275652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7594d496e8d45263e75f5518f77a8be8edd6ebe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45019 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18784 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16072 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38605 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17235 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9489 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->