### PR TITLE
[WebAuthn] Add logging for authenticators

### DIFF
--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -200,6 +200,35 @@ Vector<uint8_t> encodeRawPublicKey(const Vector<uint8_t>& x, const Vector<uint8_
     return rawKey;
 }
 
+String toString(AuthenticatorTransport transport)
+{
+    switch (transport) {
+    case AuthenticatorTransport::Usb:
+        return authenticatorTransportUsb;
+        break;
+    case AuthenticatorTransport::Nfc:
+        return authenticatorTransportNfc;
+        break;
+    case AuthenticatorTransport::Ble:
+        return authenticatorTransportBle;
+        break;
+    case AuthenticatorTransport::Internal:
+        return authenticatorTransportInternal;
+        break;
+    case AuthenticatorTransport::Cable:
+        return authenticatorTransportCable;
+    case AuthenticatorTransport::Hybrid:
+        return authenticatorTransportHybrid;
+    case AuthenticatorTransport::SmartCard:
+        return authenticatorTransportSmartCard;
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return nullString();
+}
+
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "AttestationConveyancePreference.h"
+#include "AuthenticatorTransport.h"
 #include "BufferSource.h"
 #include "CBORValue.h"
 #include "SecurityOrigin.h"
@@ -64,6 +65,9 @@ WEBCORE_EXPORT cbor::CBORValue::MapValue buildUserEntityMap(const Vector<uint8_t
 
 // encodeRawPublicKey takes X & Y and returns them as a 0x04 || X || Y byte array.
 WEBCORE_EXPORT Vector<uint8_t> encodeRawPublicKey(const Vector<uint8_t>& X, const Vector<uint8_t>& Y);
+
+WEBCORE_EXPORT String toString(AuthenticatorTransport);
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -35,6 +35,7 @@
 #include "CBORValue.h"
 #include "CBORWriter.h"
 #include "WebAuthenticationConstants.h"
+#include "WebAuthenticationUtils.h"
 
 namespace fido {
 
@@ -89,34 +90,6 @@ AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setRemainingDiscover
     return *this;
 }
 
-static String toString(WebCore::AuthenticatorTransport transport)
-{
-    switch (transport) {
-    case WebCore::AuthenticatorTransport::Usb:
-        return WebCore::authenticatorTransportUsb;
-        break;
-    case WebCore::AuthenticatorTransport::Nfc:
-        return WebCore::authenticatorTransportNfc;
-        break;
-    case WebCore::AuthenticatorTransport::Ble:
-        return WebCore::authenticatorTransportBle;
-        break;
-    case WebCore::AuthenticatorTransport::Internal:
-        return WebCore::authenticatorTransportInternal;
-        break;
-    case WebCore::AuthenticatorTransport::Cable:
-        return WebCore::authenticatorTransportCable;
-    case WebCore::AuthenticatorTransport::Hybrid:
-        return WebCore::authenticatorTransportHybrid;
-    case WebCore::AuthenticatorTransport::SmartCard:
-        return WebCore::authenticatorTransportSmartCard;
-    default:
-        break;
-    }
-    ASSERT_NOT_REACHED();
-    return nullString();
-}
-
 Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
 {
     using namespace cbor;
@@ -142,7 +115,7 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
     
     if (response.transports()) {
         auto transports = *response.transports();
-        deviceInfoMap.emplace(CBORValue(7), toArrayValue(transports.map(toString)));
+        deviceInfoMap.emplace(CBORValue(7), toArrayValue(transports.map(WebCore::toString)));
     }
 
     if (response.remainingDiscoverableCredentials())

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -42,9 +42,13 @@
 #include <WebCore/ExceptionData.h>
 #include <WebCore/Pin.h>
 #include <WebCore/U2fCommandConstructor.h>
+#include <WebCore/WebAuthenticationUtils.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/RunLoop.h>
+#include <wtf/text/Base64.h>
 #include <wtf/text/StringConcatenateNumbers.h>
+
+#define CTAP_RELEASE_LOG(fmt, ...) RELEASE_LOG(WebAuthn, "%p [aaguid=%s, transport=%s] - CtapAuthenticator::" fmt, this, aaguidForDebugging().utf8().data(), transportForDebugging().utf8().data(), ##__VA_ARGS__)
 
 namespace WebKit {
 using namespace WebCore;
@@ -93,6 +97,7 @@ CtapAuthenticator::CtapAuthenticator(std::unique_ptr<CtapDriver>&& driver, Authe
 
 void CtapAuthenticator::makeCredential()
 {
+    CTAP_RELEASE_LOG("makeCredential");
     ASSERT(!m_isDowngraded);
     Vector<uint8_t> cborCmd;
     auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
@@ -113,6 +118,7 @@ void CtapAuthenticator::makeCredential()
         cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth });
     else
         cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions);
+    CTAP_RELEASE_LOG("makeCredential: Sending %s", base64EncodeToString(cborCmd).utf8().data());
     driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
@@ -123,10 +129,11 @@ void CtapAuthenticator::makeCredential()
 
 void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&& data)
 {
+    auto error = getResponseCode(data);
+    CTAP_RELEASE_LOG("continueMakeCredentialAfterResponseReceived: Got error code: %hhu from authenticator.", error);
     auto response = readCTAPMakeCredentialResponse(data, AuthenticatorAttachment::CrossPlatform, transports(), std::get<PublicKeyCredentialCreationOptions>(requestData().options).attestation);
     if (!response) {
-        auto error = getResponseCode(data);
-        RELEASE_LOG_DEBUG(WebAuthn, "Got error code: %hhu from authenticator.", enumToUnderlyingType(error));
+        CTAP_RELEASE_LOG("makeCredential: Failed to parse response %s", base64EncodeToString(data).utf8().data());
 
         if (error == CtapDeviceResponseCode::kCtap2ErrActionTimeout) {
             makeCredential();
@@ -184,6 +191,7 @@ void CtapAuthenticator::getAssertion()
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth });
     else
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions);
+    CTAP_RELEASE_LOG("getAssertion: Sending %s", base64EncodeToString(cborCmd).utf8().data());
     driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
@@ -195,9 +203,10 @@ void CtapAuthenticator::getAssertion()
 void CtapAuthenticator::continueGetAssertionAfterResponseReceived(Vector<uint8_t>&& data)
 {
     auto response = readCTAPGetAssertionResponse(data, AuthenticatorAttachment::CrossPlatform);
+    auto error = getResponseCode(data);
+    CTAP_RELEASE_LOG("continueGetAssertionAfterResponseReceived: errorcode: %hhu", error);
     if (!response) {
-        auto error = getResponseCode(data);
-
+        CTAP_RELEASE_LOG("continueGetAssertionAfterResponseReceived: Failed to parse response %s", base64EncodeToString(data).utf8().data());
         if (error == CtapDeviceResponseCode::kCtap2ErrActionTimeout) {
             getAssertion();
             return;
@@ -216,9 +225,11 @@ void CtapAuthenticator::continueGetAssertionAfterResponseReceived(Vector<uint8_t
         if (error == CtapDeviceResponseCode::kCtap2ErrNoCredentials && observer())
             observer()->authenticatorStatusUpdated(WebAuthenticationStatus::NoCredentialsFound);
 
+        CTAP_RELEASE_LOG("continueGetAssertionAfterResponseReceived: No credentials found.");
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, makeString("Unknown internal error. Error code: ", static_cast<uint8_t>(error)) });
         return;
     }
+    CTAP_RELEASE_LOG("continueGetAssertionAfterResponseReceived: Get %lu credentials back.", response->numberOfCredentials());
 
     if (response->numberOfCredentials() <= 1) {
         receiveRespond(response.releaseNonNull());
@@ -228,7 +239,9 @@ void CtapAuthenticator::continueGetAssertionAfterResponseReceived(Vector<uint8_t
     m_remainingAssertionResponses = response->numberOfCredentials() - 1;
     m_assertionResponses.reserveInitialCapacity(response->numberOfCredentials());
     m_assertionResponses.append(response.releaseNonNull());
-    driver().transact(encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorGetNextAssertion), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    auto cborCmd = encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorGetNextAssertion);
+    CTAP_RELEASE_LOG("continueGetAssertionAfterResponseReceived: Sending %s", base64EncodeToString(cborCmd).utf8().data());
+    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
@@ -238,14 +251,17 @@ void CtapAuthenticator::continueGetAssertionAfterResponseReceived(Vector<uint8_t
 
 void CtapAuthenticator::continueGetNextAssertionAfterResponseReceived(Vector<uint8_t>&& data)
 {
+    auto error = getResponseCode(data);
+    CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived: errorcode: %hhu", error);
     auto response = readCTAPGetAssertionResponse(data, AuthenticatorAttachment::CrossPlatform);
     if (!response) {
-        auto error = getResponseCode(data);
+        CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived: Unable to parse response: %s", base64EncodeToString(data).utf8().data());
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, makeString("Unknown internal error. Error code: ", static_cast<uint8_t>(error)) });
         return;
     }
     m_remainingAssertionResponses--;
     m_assertionResponses.append(response.releaseNonNull());
+    CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived: Remaining responses: %lu", m_remainingAssertionResponses);
 
     if (!m_remainingAssertionResponses) {
         if (auto* observer = this->observer()) {
@@ -264,7 +280,9 @@ void CtapAuthenticator::continueGetNextAssertionAfterResponseReceived(Vector<uin
         return;
     }
 
-    driver().transact(encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorGetNextAssertion), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    auto cborCmd = encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorGetNextAssertion);
+    CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived: Sending %s", base64EncodeToString(cborCmd).utf8().data());
+    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
@@ -275,16 +293,19 @@ void CtapAuthenticator::continueGetNextAssertionAfterResponseReceived(Vector<uin
 void CtapAuthenticator::getRetries()
 {
     auto cborCmd = encodeAsCBOR(pin::RetriesRequest { });
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    CTAP_RELEASE_LOG("getRetries: Sending %s", base64EncodeToString(cborCmd).utf8().data());
+    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, this](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
+        CTAP_RELEASE_LOG("getRetries: Response %s", base64EncodeToString(data).utf8().data());
         weakThis->continueGetKeyAgreementAfterGetRetries(WTFMove(data));
     });
 }
 
 void CtapAuthenticator::continueGetKeyAgreementAfterGetRetries(Vector<uint8_t>&& data)
 {
+    CTAP_RELEASE_LOG("continueGetKeyAgreementAfterGetRetries");
     auto retries = pin::RetriesResponse::parse(data);
     if (!retries) {
         auto error = getResponseCode(data);
@@ -293,16 +314,19 @@ void CtapAuthenticator::continueGetKeyAgreementAfterGetRetries(Vector<uint8_t>&&
     }
 
     auto cborCmd = encodeAsCBOR(pin::KeyAgreementRequest { });
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, retries = retries->retries] (Vector<uint8_t>&& data) {
+    CTAP_RELEASE_LOG("continueGetKeyAgreementAfterGetRetries: Sending %s", base64EncodeToString(cborCmd).utf8().data());
+    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, this, retries = retries->retries] (Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
+        CTAP_RELEASE_LOG("continueGetKeyAgreementAfterGetRetries: Response %s", base64EncodeToString(data).utf8().data());
         weakThis->continueRequestPinAfterGetKeyAgreement(WTFMove(data), retries);
     });
 }
 
 void CtapAuthenticator::continueRequestPinAfterGetKeyAgreement(Vector<uint8_t>&& data, uint64_t retries)
 {
+    CTAP_RELEASE_LOG("continueRequestPinAfterGetKeyAgreement");
     auto keyAgreement = pin::KeyAgreementResponse::parse(data);
     if (!keyAgreement) {
         auto error = getResponseCode(data);
@@ -311,10 +335,12 @@ void CtapAuthenticator::continueRequestPinAfterGetKeyAgreement(Vector<uint8_t>&&
     }
 
     if (auto* observer = this->observer()) {
-        observer->requestPin(retries, [weakThis = WeakPtr { *this }, keyAgreement = WTFMove(*keyAgreement)] (const String& pin) {
+        CTAP_RELEASE_LOG("continueRequestPinAfterGetKeyAgreement: Requesting pin from observer.");
+        observer->requestPin(retries, [weakThis = WeakPtr { *this }, this, keyAgreement = WTFMove(*keyAgreement)] (const String& pin) {
             RELEASE_ASSERT(RunLoop::isMain());
             if (!weakThis)
                 return;
+            CTAP_RELEASE_LOG("continueRequestPinAfterGetKeyAgreement: Got pin from observer.");
             weakThis->continueGetPinTokenAfterRequestPin(pin, keyAgreement.peerKey);
         });
     }
@@ -322,6 +348,7 @@ void CtapAuthenticator::continueRequestPinAfterGetKeyAgreement(Vector<uint8_t>&&
 
 void CtapAuthenticator::continueGetPinTokenAfterRequestPin(const String& pin, const CryptoKeyEC& peerKey)
 {
+    CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived");
     if (pin.isNull()) {
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, "Pin is null."_s });
         return;
@@ -342,16 +369,19 @@ void CtapAuthenticator::continueGetPinTokenAfterRequestPin(const String& pin, co
     }
 
     auto cborCmd = encodeAsCBOR(*tokenRequest);
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, tokenRequest = WTFMove(*tokenRequest)] (Vector<uint8_t>&& data) {
+    CTAP_RELEASE_LOG("continueGetPinTokenAfterRequestPin: Sending %s", base64EncodeToString(cborCmd).utf8().data());
+    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, this, tokenRequest = WTFMove(*tokenRequest)] (Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
+        CTAP_RELEASE_LOG("continueGetPinTokenAfterRequestPin: Response %s", base64EncodeToString(data).utf8().data());
         weakThis->continueRequestAfterGetPinToken(WTFMove(data), tokenRequest);
     });
 }
 
 void CtapAuthenticator::continueRequestAfterGetPinToken(Vector<uint8_t>&& data, const fido::pin::TokenRequest& tokenRequest)
 {
+    CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived");
     auto token = pin::TokenResponse::parse(tokenRequest.sharedKey(), data);
     if (!token) {
         auto error = getResponseCode(data);
@@ -377,6 +407,7 @@ void CtapAuthenticator::continueRequestAfterGetPinToken(Vector<uint8_t>&& data, 
 
 bool CtapAuthenticator::tryRestartPin(const CtapDeviceResponseCode& error)
 {
+    CTAP_RELEASE_LOG("tryRestartPin: Error code: %hhu", error);
     switch (error) {
     case CtapDeviceResponseCode::kCtap2ErrPinAuthInvalid:
     case CtapDeviceResponseCode::kCtap2ErrPinInvalid:
@@ -390,6 +421,7 @@ bool CtapAuthenticator::tryRestartPin(const CtapDeviceResponseCode& error)
 
 bool CtapAuthenticator::tryDowngrade()
 {
+    CTAP_RELEASE_LOG("tryDowngrade");
     if (m_info.versions().find(ProtocolVersion::kU2f) == m_info.versions().end())
         return false;
     if (!observer())
@@ -404,6 +436,7 @@ bool CtapAuthenticator::tryDowngrade()
     if (!isConvertible)
         return false;
 
+    CTAP_RELEASE_LOG("tryDowngrade: Downgrading to U2F.");
     m_isDowngraded = true;
     driver().setProtocol(ProtocolVersion::kU2f);
     observer()->downgrade(this, U2fAuthenticator::create(releaseDriver()));
@@ -416,6 +449,11 @@ Vector<AuthenticatorTransport> CtapAuthenticator::transports() const
     if (auto& infoTransports = m_info.transports())
         return *infoTransports;
     return Vector { driver().transport() };
+}
+
+String CtapAuthenticator::aaguidForDebugging() const
+{
+    return WTF::UUID { std::span<const uint8_t, 16> { m_info.aaguid() } }.toString();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -71,6 +71,8 @@ private:
 
     Vector<WebCore::AuthenticatorTransport> transports() const;
 
+    String aaguidForDebugging() const;
+
     fido::AuthenticatorGetInfoResponse m_info;
     bool m_isDowngraded { false };
     bool m_isKeyStoreFull { false };

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "FidoAuthenticator.h"
+#include <WebCore/WebAuthenticationUtils.h>
 
 #if ENABLE(WEB_AUTHN)
 
@@ -54,6 +55,11 @@ std::unique_ptr<CtapDriver> FidoAuthenticator::releaseDriver()
 {
     ASSERT(m_driver);
     return WTFMove(m_driver);
+}
+
+String FidoAuthenticator::transportForDebugging() const
+{
+    return WebCore::toString(driver().transport());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
@@ -43,6 +43,8 @@ protected:
     CtapDriver& driver() const;
     std::unique_ptr<CtapDriver> releaseDriver();
 
+    String transportForDebugging() const;
+
 private:
     std::unique_ptr<CtapDriver> m_driver;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -36,6 +36,8 @@
 #include <WebCore/U2fResponseConverter.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
+#define U2F_RELEASE_LOG(fmt, ...) RELEASE_LOG(WebAuthn, "%p [transport=%s] - U2fAuthenticator::" fmt, this, transportForDebugging().utf8().data(), ##__VA_ARGS__)
+
 namespace WebKit {
 using namespace WebCore;
 using namespace apdu;
@@ -53,6 +55,7 @@ U2fAuthenticator::U2fAuthenticator(std::unique_ptr<CtapDriver>&& driver)
 
 void U2fAuthenticator::makeCredential()
 {
+    U2F_RELEASE_LOG("makeCredential");
     auto& creationOptions = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
     if (!isConvertibleToU2fRegisterCommand(creationOptions))
         return;
@@ -66,6 +69,7 @@ void U2fAuthenticator::makeCredential()
 
 void U2fAuthenticator::checkExcludeList(size_t index)
 {
+    U2F_RELEASE_LOG("checkExcludeList");
     auto& creationOptions = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
     if (index >= creationOptions.excludeCredentials.size()) {
         issueRegisterCommand();
@@ -79,14 +83,18 @@ void U2fAuthenticator::checkExcludeList(size_t index)
 void U2fAuthenticator::issueRegisterCommand()
 {
     auto u2fCmd = convertToU2fRegisterCommand(requestData().hash, std::get<PublicKeyCredentialCreationOptions>(requestData().options));
+    U2F_RELEASE_LOG("issueRegisterCommand: Sending %s", base64EncodeToString(*u2fCmd).utf8().data());
     ASSERT(u2fCmd);
     issueNewCommand(WTFMove(*u2fCmd), CommandType::RegisterCommand);
 }
 
 void U2fAuthenticator::getAssertion()
 {
-    if (!isConvertibleToU2fSignCommand(std::get<PublicKeyCredentialRequestOptions>(requestData().options)))
+    U2F_RELEASE_LOG("getAssertion: Sending bogus sign.");
+    if (!isConvertibleToU2fSignCommand(std::get<PublicKeyCredentialRequestOptions>(requestData().options))) {
+        U2F_RELEASE_LOG("getAssertion: command not convertible.");
         return;
+    }
     ASSERT(!m_nextListIndex);
     issueSignCommand(m_nextListIndex++);
 }
@@ -95,16 +103,19 @@ void U2fAuthenticator::issueSignCommand(size_t index)
 {
     auto& requestOptions = std::get<PublicKeyCredentialRequestOptions>(requestData().options);
     if (index >= requestOptions.allowCredentials.size()) {
+        U2F_RELEASE_LOG("issueSignCommand: Sending bogus sign.");
         issueNewCommand(constructBogusU2fRegistrationCommand(), CommandType::BogusCommandNoCredentials);
         return;
     }
     auto u2fCmd = convertToU2fSignCommand(requestData().hash, requestOptions, requestOptions.allowCredentials[index].id, m_isAppId);
+    U2F_RELEASE_LOG("issueSignCommand: index: %lu Sending %s", index, base64EncodeToString(*u2fCmd).utf8().data());
     ASSERT(u2fCmd);
     issueNewCommand(WTFMove(*u2fCmd), CommandType::SignCommand);
 }
 
 void U2fAuthenticator::issueNewCommand(Vector<uint8_t>&& command, CommandType type)
 {
+    U2F_RELEASE_LOG("issueNewCommand");
     m_lastCommand = WTFMove(command);
     m_lastCommandType = type;
     issueCommand(m_lastCommand, m_lastCommandType);
@@ -112,6 +123,7 @@ void U2fAuthenticator::issueNewCommand(Vector<uint8_t>&& command, CommandType ty
 
 void U2fAuthenticator::issueCommand(const Vector<uint8_t>& command, CommandType type)
 {
+    U2F_RELEASE_LOG("issueCommand: Sending %s", base64EncodeToString(command).utf8().data());
     driver().transact(Vector<uint8_t>(command), [weakThis = WeakPtr { *this }, type](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
@@ -124,9 +136,11 @@ void U2fAuthenticator::responseReceived(Vector<uint8_t>&& response, CommandType 
 {
     auto apduResponse = ApduResponse::createFromMessage(response);
     if (!apduResponse) {
+        U2F_RELEASE_LOG("responseReceived: Failed to parse response: %s", base64EncodeToString(response).utf8().data());
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, "Couldn't parse the APDU response."_s });
         return;
     }
+    U2F_RELEASE_LOG("responseReceived: Got response for command type: %hhu", type);
 
     switch (type) {
     case CommandType::RegisterCommand:
@@ -150,6 +164,7 @@ void U2fAuthenticator::responseReceived(Vector<uint8_t>&& response, CommandType 
 
 void U2fAuthenticator::continueRegisterCommandAfterResponseReceived(ApduResponse&& apduResponse)
 {
+    U2F_RELEASE_LOG("continueRegisterCommandAfterResponseReceived: Status %hu", apduResponse.status());
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR: {
         auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
@@ -173,6 +188,7 @@ void U2fAuthenticator::continueRegisterCommandAfterResponseReceived(ApduResponse
 
 void U2fAuthenticator::continueCheckOnlyCommandAfterResponseReceived(ApduResponse&& apduResponse)
 {
+    U2F_RELEASE_LOG("continueCheckOnlyCommandAfterResponseReceived: Status %hu", apduResponse.status());
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR:
     case ApduResponse::Status::SW_CONDITIONS_NOT_SATISFIED:
@@ -185,6 +201,7 @@ void U2fAuthenticator::continueCheckOnlyCommandAfterResponseReceived(ApduRespons
 
 void U2fAuthenticator::continueBogusCommandExcludeCredentialsMatchAfterResponseReceived(ApduResponse&& apduResponse)
 {
+    U2F_RELEASE_LOG("continueBogusCommandExcludeCredentialsMatchAfterResponseReceived: Status %hu", apduResponse.status());
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR:
         receiveRespond(ExceptionData { ExceptionCode::InvalidStateError, "At least one credential matches an entry of the excludeCredentials list in the authenticator."_s });
@@ -200,6 +217,7 @@ void U2fAuthenticator::continueBogusCommandExcludeCredentialsMatchAfterResponseR
 
 void U2fAuthenticator::continueBogusCommandNoCredentialsAfterResponseReceived(ApduResponse&& apduResponse)
 {
+    U2F_RELEASE_LOG("continueBogusCommandNoCredentialsAfterResponseReceived: Status %hu", apduResponse.status());
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR:
         if (auto* observer = this->observer())
@@ -217,6 +235,7 @@ void U2fAuthenticator::continueBogusCommandNoCredentialsAfterResponseReceived(Ap
 
 void U2fAuthenticator::continueSignCommandAfterResponseReceived(ApduResponse&& apduResponse)
 {
+    U2F_RELEASE_LOG("continueSignCommandAfterResponseReceived: Status %hu", apduResponse.status());
     auto& requestOptions = std::get<PublicKeyCredentialRequestOptions>(requestData().options);
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR: {


### PR DESCRIPTION
#### 7db187aff8f92fa64a130fecf7d69471eb95aa1e
<pre>
[WebAuthn] Add logging for authenticators
<a href="https://bugs.webkit.org/show_bug.cgi?id=270463">https://bugs.webkit.org/show_bug.cgi?id=270463</a>
<a href="https://rdar.apple.com/123704181">rdar://123704181</a>

Reviewed by Charlie Wolfe.

This patch adds detailed logging to understand the flows through the CTAP
and U2F authenticator code. Sometimes we hit flaky or hard to reproduce
error conditions with security keys. This change will aid in debugging
these cases.

Although challenges are short-lived. We don&apos;t log the responses of successful
makeCredential and getAssertion calls containing signatures, instead logging only
if there was an issue with the response.

* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::toString):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h:
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::encodeAsCBOR):
(fido::toString): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
(WebKit::CtapAuthenticator::getAssertion):
(WebKit::CtapAuthenticator::continueGetAssertionAfterResponseReceived):
(WebKit::CtapAuthenticator::continueGetNextAssertionAfterResponseReceived):
(WebKit::CtapAuthenticator::getRetries):
(WebKit::CtapAuthenticator::continueGetKeyAgreementAfterGetRetries):
(WebKit::CtapAuthenticator::continueRequestPinAfterGetKeyAgreement):
(WebKit::CtapAuthenticator::continueGetPinTokenAfterRequestPin):
(WebKit::CtapAuthenticator::continueRequestAfterGetPinToken):
(WebKit::CtapAuthenticator::tryRestartPin):
(WebKit::CtapAuthenticator::tryDowngrade):
(WebKit::CtapAuthenticator::aaguidForDebugging const):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp:
(WebKit::FidoAuthenticator::transportForDebugging const):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::makeCredential):
(WebKit::U2fAuthenticator::checkExcludeList):
(WebKit::U2fAuthenticator::issueRegisterCommand):
(WebKit::U2fAuthenticator::getAssertion):
(WebKit::U2fAuthenticator::issueSignCommand):
(WebKit::U2fAuthenticator::issueNewCommand):
(WebKit::U2fAuthenticator::issueCommand):
(WebKit::U2fAuthenticator::continueRegisterCommandAfterResponseReceived):
(WebKit::U2fAuthenticator::continueCheckOnlyCommandAfterResponseReceived):
(WebKit::U2fAuthenticator::continueBogusCommandExcludeCredentialsMatchAfterResponseReceived):
(WebKit::U2fAuthenticator::continueBogusCommandNoCredentialsAfterResponseReceived):
(WebKit::U2fAuthenticator::continueSignCommandAfterResponseReceived):

Canonical link: <a href="https://commits.webkit.org/275657@main">https://commits.webkit.org/275657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca739cbfa47e1a9fde0836fb22f429e97820f38d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45052 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/38569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18819 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43026 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46524 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17268 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9494 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->