### PR TITLE
[WebGPU] getBindGroupLayout should return a non-null possibly-invalid layout

### DIFF
--- a/LayoutTests/fast/webgpu/bind-group-layout-invalid-expected.txt
+++ b/LayoutTests/fast/webgpu/bind-group-layout-invalid-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/bind-group-layout-invalid.html
+++ b/LayoutTests/fast/webgpu/bind-group-layout-invalid.html
@@ -1,0 +1,171 @@
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+const log = globalThis.$vm?.print ?? console.log;
+
+onload = async () => {
+  try {
+    adapter1 = await navigator.gpu.requestAdapter( { } );
+    let promise3 = adapter1.requestDevice(
+    {
+    label: 'a',
+    requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage'
+    ],
+    requiredLimits: {
+    maxVertexAttributes: 22,
+    maxVertexBufferArrayStride: 60002,
+    maxStorageTexturesPerShaderStage: 36,
+    maxBindingsPerBindGroup: 9205,
+    },
+    }
+    );
+
+
+    let device1 = await promise3;
+
+    let pipelineLayout2 = device1.createPipelineLayout(
+    {
+    label: 'a',
+    bindGroupLayouts: [
+    ],
+    }
+    );
+
+    let shaderModule4 = device1.createShaderModule(
+    {
+    label: 'a',
+    code: `@group(1) @binding(121)
+    var<storage, read_write> __dynamicOffset2: array<u32>;
+    @group(1) @binding(632)
+    var<storage, read_write> field5: array<u32>;
+    @group(0) @binding(632)
+    var<storage, read_write> __DynamicOffsets0: array<u32>;
+    @group(2) @binding(523)
+    var<storage, read_write> global4: array<u32>;
+    @group(1) @binding(351)
+    var<storage, read_write> __DynamicOffsets1: array<u32>;
+    @group(2) @binding(623)
+    var<storage, read_write> type4: array<u32>;
+    @group(0) @binding(121)
+    var<storage, read_write> __ArgumentBuffer_2: array<u32>;
+    @group(2) @binding(559)
+    var<storage, read_write> function3: array<u32>;
+    @compute @workgroup_size(7, 1, 1)
+    fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+      var x: u32 = 0;
+      loop {
+        function3[x] = global_id.x;
+        x += 1;
+        __DynamicOffsets1[global_id.y-global_id.x] = __dynamicOffset2[x];
+        if (x > 2 * arrayLength(&field5)) {
+          break;
+        }
+      }
+    }
+    @compute @workgroup_size(8, 1, 4)
+    fn compute1(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+      __dynamicOffset2[global_id.x*local_id.x] = u32(function3[global_id.x*local_id.x]);
+    }
+
+    struct S {
+      @location(0) out0: vec4<f32>,
+      @location(1) out1: vec4<f32>,
+    }
+
+    struct S2 {
+      @location(0) out0: vec4<f32>,
+      out1: vec4<f32>,
+    }
+
+    struct S3 {
+      @location(0) out0: vec4<f32>,
+      out1: S4,
+    }
+
+    struct S4 {
+      @location(1) out2: vec4<f32>,
+      @location(2) out3: vec4<f32>,
+    }
+
+    @fragment
+    fn fragment0(@builtin(position) coord_in: vec4<f32>) -> @location(123) i32 {
+    return i32();
+    }
+
+    @fragment
+    fn fragment1(@builtin(position) coord_in: vec4<f32>) -> @location(0) vec4<f32> {
+      return vec4<f32>(coord_in.x, coord_in.y, 0.0, 1.0);
+    }
+
+    @fragment
+    fn fragment2(@builtin(position) coord_in: vec4<f32>) -> S {
+    }
+
+    @fragment
+    fn fragment3(@builtin(position) coord_in: vec4<f32>) -> S {
+      return S();
+    }
+
+    @fragment
+    fn fragment4(@builtin(position) coord_in: vec4<f32>) -> S2 {
+      return S2();
+    }
+
+    @fragment
+    fn fragment5(x: S3) -> S3 {
+      return x;
+    }
+
+    @vertex
+    fn vertex0() -> @builtin(position) vec4<f32> {
+      return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+    }
+
+    @vertex
+    fn vertex1(@builtin(vertex_index) v_index: u32, @builtin(instance_index) i_index: u32,) -> @builtin(position) vec4<f32> {
+      return vec4<f32>(f32(v_index), f32(i_index), 0.0, 1.0);
+    }
+
+    @vertex
+    fn vertex2(@builtin(vertex_index) v_index: u32, @builtin(instance_index) i_index: u32,) -> S {
+    }
+
+    @vertex
+    fn vertex3(@builtin(vertex_index) v_index: u32, @builtin(instance_index) i_index: u32,) -> S {
+      return S();
+    }
+    `,
+    sourceMap: {},
+    hints: {},
+    }
+    );
+
+    let pipeline6 = device1.createComputePipeline(
+    {
+    label: 'a',
+    layout: pipelineLayout2,
+    compute: {
+    module: shaderModule4,
+    entryPoint: 'compute0',
+    constants: {},
+    },
+    }
+    );
+
+    let bindGroupLayout11 = pipeline6.getBindGroupLayout(
+    75
+    );
+
+    bindGroupLayout11.label = '\u0afc';
+  } catch { }
+  if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash.

--- a/Source/WebGPU/WebGPU/ComputePipeline.h
+++ b/Source/WebGPU/WebGPU/ComputePipeline.h
@@ -57,7 +57,7 @@ public:
 
     ~ComputePipeline();
 
-    RefPtr<BindGroupLayout> getBindGroupLayout(uint32_t groupIndex);
+    Ref<BindGroupLayout> getBindGroupLayout(uint32_t groupIndex);
     void setLabel(String&&);
 
     bool isValid() const { return m_computePipelineState; }

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -147,21 +147,21 @@ ComputePipeline::ComputePipeline(Device& device)
 
 ComputePipeline::~ComputePipeline() = default;
 
-RefPtr<BindGroupLayout> ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
+Ref<BindGroupLayout> ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
 {
     if (!isValid()) {
         m_device->generateAValidationError("getBindGroupLayout: ComputePipeline is invalid"_s);
         m_pipelineLayout->makeInvalid();
-        return nullptr;
+        return BindGroupLayout::createInvalid(m_device);
     }
 
     if (groupIndex >= m_pipelineLayout->numberOfBindGroupLayouts()) {
         m_device->generateAValidationError("getBindGroupLayout: groupIndex is out of range"_s);
         m_pipelineLayout->makeInvalid();
-        return nullptr;
+        return BindGroupLayout::createInvalid(m_device);
     }
 
-    return &m_pipelineLayout->bindGroupLayout(groupIndex);
+    return m_pipelineLayout->bindGroupLayout(groupIndex);
 }
 
 void ComputePipeline::setLabel(String&&)

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -64,7 +64,7 @@ public:
 
     ~RenderPipeline();
 
-    RefPtr<BindGroupLayout> getBindGroupLayout(uint32_t groupIndex);
+    Ref<BindGroupLayout> getBindGroupLayout(uint32_t groupIndex);
     void setLabel(String&&);
 
     bool isValid() const { return m_renderPipelineState; }

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1584,21 +1584,21 @@ RenderPipeline::RenderPipeline(Device& device)
 
 RenderPipeline::~RenderPipeline() = default;
 
-RefPtr<BindGroupLayout> RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
+Ref<BindGroupLayout> RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 {
     if (!isValid()) {
         m_device->generateAValidationError("getBindGroupLayout: RenderPipeline is invalid"_s);
         m_pipelineLayout->makeInvalid();
-        return nullptr;
+        return BindGroupLayout::createInvalid(m_device);
     }
 
     if (groupIndex >= m_pipelineLayout->numberOfBindGroupLayouts()) {
         m_device->generateAValidationError("getBindGroupLayout: groupIndex is out of range"_s);
         m_pipelineLayout->makeInvalid();
-        return nullptr;
+        return BindGroupLayout::createInvalid(m_device);
     }
 
-    return &m_pipelineLayout->bindGroupLayout(groupIndex);
+    return m_pipelineLayout->bindGroupLayout(groupIndex);
 }
 
 void RenderPipeline::setLabel(String&&)


### PR DESCRIPTION
#### 561208853674e4014dff6180ec6e96e098110514
<pre>
[WebGPU] getBindGroupLayout should return a non-null possibly-invalid layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=270469">https://bugs.webkit.org/show_bug.cgi?id=270469</a>
<a href="https://rdar.apple.com/123810931">rdar://123810931</a>

Reviewed by Mike Wyrzykowski.

* LayoutTests/fast/webgpu/bind-group-layout-invalid-expected.txt: Added.
* LayoutTests/fast/webgpu/bind-group-layout-invalid.html: Added.
* Source/WebGPU/WebGPU/ComputePipeline.h:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::ComputePipeline::getBindGroupLayout):
* Source/WebGPU/WebGPU/RenderPipeline.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):

Canonical link: <a href="https://commits.webkit.org/275664@main">https://commits.webkit.org/275664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6872b14ebe35b329a8c1ccf2d3a1933cd07d1826

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38565 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18814 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16090 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46519 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37921 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14209 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36868 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5726 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->