### PR TITLE
[iOS] Avoid transcoding images on file inputs unless the set of image types is explicitly restricted

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5270,6 +5270,18 @@ PermissionsAPIEnabled:
     WebCore:
       default: false
 
+PhotoPickerPrefersOriginalImageFormat:
+  type: bool
+  status: internal
+  humanReadableName: "Photo Picker Prefers Original Image Format"
+  humanReadableDescription: "Prefer the original image format when selecting photos for file upload"
+  webcoreBinding: none
+  condition: HAVE(PHOTOS_UI)
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKit:
+      default: true
+
 PictographFontFamily:
   type: String
   status: embedder

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9023,6 +9023,14 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
         && [uiDelegate _webView:webView.get() fileUploadPanelContentIsManagedWithInitiatingFrame:wrapper(API::FrameInfo::create(WTFMove(_frameInfoForFileUploadPanel), _page.get())).get()];
 }
 
+#if HAVE(PHOTOS_UI)
+- (BOOL)fileUploadPanelPhotoPickerPrefersOriginalImageFormat:(WKFileUploadPanel *)fileUploadPanel
+{
+    ASSERT(_fileUploadPanel.get() == fileUploadPanel);
+    return _page->preferences().photoPickerPrefersOriginalImageFormat();
+}
+#endif
+
 - (void)_showShareSheet:(const WebCore::ShareDataWithParsedURL&)data inRect:(std::optional<WebCore::FloatRect>)rect completionHandler:(CompletionHandler<void(bool)>&&)completionHandler
 {
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h
@@ -56,6 +56,9 @@ class WebOpenPanelResultListenerProxy;
 @optional
 - (void)fileUploadPanelDidDismiss:(WKFileUploadPanel *)fileUploadPanel;
 - (BOOL)fileUploadPanelDestinationIsManaged:(WKFileUploadPanel *)fileUploadPanel;
+#if HAVE(PHOTOS_UI)
+- (BOOL)fileUploadPanelPhotoPickerPrefersOriginalImageFormat:(WKFileUploadPanel *)fileUploadPanel;
+#endif
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 0f76043f78527099a8af73cff7e76c489fd79568
<pre>
[iOS] Avoid transcoding images on file inputs unless the set of image types is explicitly restricted
<a href="https://bugs.webkit.org/show_bug.cgi?id=267277">https://bugs.webkit.org/show_bug.cgi?id=267277</a>
<a href="https://rdar.apple.com/106763672">rdar://106763672</a>

Reviewed by Abrar Rahman Protyasha.

On iOS, when using an `&lt;input type=file&gt;` that supports images or videos, the
user has the option to select content from their photo library. Historically,
in WebKit, selected content has always been transcoded to JPEG (for images)
and H.264 (for video).

However, this can be undesirable for users that want to provide the image in
its original form. In particular, this is important for photo editing applications.
Furthermore, macOS does not have this general transcoding behavior.

This patch changes the behavior on iOS so that transcoding to the compatible
format for images is only performed if the `accept` attribute restricts the set
of image types. Videos remain exempted from this behavior change due to known
compatibility issues.

Note that this change does have non-zero compatibility risk. However, it is more
correct, and resolves known issues on image editing applications. Sites that
want a compatibile representation are expected to use the `accept` attribute to
indicate their need.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Introduce a setting so the new behavior can easily be toggled off for testing.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView fileUploadPanelPhotoPickerPrefersOriginalImageFormat:]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.h:
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadPanel _preferredAssetRepresentationMode]):

Disable transcoding by the picker if the set of restricted types is empty,
or contains all image types.

(-[WKFileUploadPanel _showPhotoPicker]):
(-[WKFileUploadPanel picker:didFinishPicking:]):

Continue to transcode video, when the picker does not perform transcoding, for
compatibility.

Canonical link: <a href="https://commits.webkit.org/275726@main">https://commits.webkit.org/275726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcc43578675dc2c9580047ad4e8de6265db09a3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38540 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18789 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35131 "Failure limit exceed. At least found 151 new test failures: accessibility/math-multiscript-attributes.html, animations/keyframe-em-unit.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/masks/become-tiled-mask.html, compositing/tiling/empty-to-tiled.html, css1/font_properties/font.html, css1/font_properties/font_size.html, css1/formatting_model/inline_elements.html, css1/pseudo/multiple_pseudo_elements.html, css2.1/20110323/absolute-non-replaced-height-002.htm ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37570 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/479 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35879 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46491 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42051 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41808 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18858 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40416 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18920 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49060 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5764 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18503 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9938 "Passed tests") | 
<!--EWS-Status-Bubble-End-->