### PR TITLE
PDFPlugin hangs in deallocation when data load contends with waiting for thread completion

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not timeout.
+
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html
@@ -1,0 +1,17 @@
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  onload = async () => {
+    let iframe0 = document.createElement('iframe');
+    iframe0.src = 'data:application/pdf,x';
+    document.body.append(iframe0);
+
+    await caches.has('a');
+    await caches.has('a');
+
+    $vm.print('before');
+    iframe0.remove();
+    $vm.print('after');
+  };
+</script>
+<p>This test passes if it does not timeout.</p>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -29,8 +29,10 @@
 
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Threading.h>
+#include <wtf/threads/BinarySemaphore.h>
 
 OBJC_CLASS PDFDocument;
 
@@ -114,6 +116,27 @@ private:
     void logStreamLoader(WTF::TextStream&, WebCore::NetscapePlugInStreamLoader&);
 #endif
 
+    class SemaphoreWrapper : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SemaphoreWrapper> {
+    public:
+        static Ref<SemaphoreWrapper> create() { return adoptRef(*new SemaphoreWrapper); }
+
+        void wait() { m_semaphore.wait(); }
+        void signal()
+        {
+            m_wasSignaled = true;
+            m_semaphore.signal();
+        }
+        bool wasSignaled() const { return m_wasSignaled; }
+
+    private:
+        SemaphoreWrapper() = default;
+
+        BinarySemaphore m_semaphore;
+        std::atomic<bool> m_wasSignaled { false };
+    };
+
+    RefPtr<SemaphoreWrapper> createDataSemaphore();
+
     ThreadSafeWeakPtr<PDFPluginBase> m_plugin;
 
     RetainPtr<PDFDocument> m_backgroundThreadDocument;
@@ -123,6 +146,11 @@ private:
 
     struct RequestData;
     std::unique_ptr<RequestData> m_requestData;
+
+    ThreadSafeWeakHashSet<SemaphoreWrapper> m_dataSemaphores WTF_GUARDED_BY_LOCK(m_wasPDFThreadTerminationRequestedLock);
+
+    Lock m_wasPDFThreadTerminationRequestedLock;
+    bool m_wasPDFThreadTerminationRequested WTF_GUARDED_BY_LOCK(m_wasPDFThreadTerminationRequestedLock) { false };
 
 #if !LOG_DISABLED
     std::atomic<size_t> m_threadsWaitingOnCallback { 0 };


### PR DESCRIPTION
#### e604d7c70127a9d0abd95421c65a2ca594df690e
<pre>
PDFPlugin hangs in deallocation when data load contends with waiting for thread completion
<a href="https://bugs.webkit.org/show_bug.cgi?id=246454">https://bugs.webkit.org/show_bug.cgi?id=246454</a>
<a href="https://rdar.apple.com/101147811">rdar://101147811</a>

Reviewed by Tim Horton.

When `PDFPlugin::teardown()` would get called (on the main thread), it would
wait for the PDF thread to complete. However, if loading is still going on,
the PDF thread might be blocked on `dataSemaphore.wait()` in
PDFIncrementalLoader::dataProviderGetBytesAtPosition(). The `dataSemaphore`
is supposed to get signaled on a task dispatched to the main thread but this
task won&apos;t run if the main thread is blocked on waiting for the thread to
exit.

To address the issue, PDFIncrementalLoader::clear() now signals the
pending dataSemaphores before waiting for the thread to exit and sets a
flag indicating we want the thread to exit. This flag is then checked
on the PDF thread to make sure we don&apos;t queue additional work / semaphores.

* LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt: Added.
* LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html: Added.
I took the test from Erica Li&apos;s earlier PR that got reverted.

* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
(WebKit::PDFIncrementalLoader::SemaphoreWrapper::create):
(WebKit::PDFIncrementalLoader::SemaphoreWrapper::wait):
(WebKit::PDFIncrementalLoader::SemaphoreWrapper::signal):
(WebKit::PDFIncrementalLoader::WTF_GUARDED_BY_LOCK):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::clear):
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):
(WebKit::PDFIncrementalLoader::dataProviderGetByteRanges):
(WebKit::PDFIncrementalLoader::threadEntry):

Canonical link: <a href="https://commits.webkit.org/275707@main">https://commits.webkit.org/275707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ffcd92c4b1d4bf79bbbf4e472a95018312833d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38633 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35190 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37644 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46594 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41878 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36912 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40486 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9522 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->