### PR TITLE
Check Texture::supportsBlending in addition to hasAlphaChannel

### DIFF
--- a/LayoutTests/fast/webgpu/texture-supports-blending-expected.txt
+++ b/LayoutTests/fast/webgpu/texture-supports-blending-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/texture-supports-blending.html
+++ b/LayoutTests/fast/webgpu/texture-supports-blending.html
@@ -1,0 +1,238 @@
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+onload = async () => {
+  try {
+    let adapter0 = await navigator.gpu.requestAdapter(
+    {
+    }
+    );
+    
+    let device0 = await adapter0.requestDevice(
+    {
+    requiredLimits: {
+    maxVertexAttributes: 21,
+    maxVertexBufferArrayStride: 50123,
+    maxStorageTexturesPerShaderStage: 21,
+    maxBindingsPerBindGroup: 7503,
+    },
+    }
+    );
+
+    let bindGroupLayout0 = device0.createBindGroupLayout(
+    {
+    label: 'a',
+    entries: [
+    {
+    binding: 962,
+    visibility: GPUShaderStage.FRAGMENT,
+    sampler: {
+    type: 'filtering',
+    },
+    },
+    {
+    binding: 79,
+    visibility: GPUShaderStage.VERTEX | GPUShaderStage.COMPUTE,
+    buffer: {
+    hasDynamicOffset: true,
+    },
+    }
+    ],
+    }
+    );
+    
+    let pipelineLayout0 = device0.createPipelineLayout(
+    {
+    label: 'a',
+    bindGroupLayouts: [
+    bindGroupLayout0,
+    bindGroupLayout0,
+    bindGroupLayout0,
+    bindGroupLayout0
+    ],
+    }
+    );
+    
+    let shaderModule0 = device0.createShaderModule(
+    {
+    label: 'a',
+    code: `@group(3) @binding(962)
+    var<storage, read_write> global0: array<u32>;
+    @group(3) @binding(79)
+    var<storage, read_write> global1: array<u32>;
+    @group(0) @binding(79)
+    var<storage, read_write> field0: array<u32>;
+    @group(2) @binding(79)
+    var<storage, read_write> function0: array<u32>;
+    @group(2) @binding(79)
+    var<storage, read_write> field1: array<u32>;
+    @group(2) @binding(962)
+    var<storage, read_write> __DynamicOffsets0: array<u32>;
+    @compute @workgroup_size(2, 4, 2)
+    fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+      var x: u32 = 0;
+      loop {
+        field1[x] = global_id.x;
+        x += 1;
+        function0[global_id.y-global_id.x] = field1[x];
+        if (x > 2 * arrayLength(&global1)) {
+          break;
+        }
+      }
+    }
+    @compute @workgroup_size(5, 4, 2)
+    fn compute1(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {
+      field1[global_id.x*local_id.x] = u32(function0[global_id.x*local_id.x]);
+    }
+
+    struct S {
+      @location(0) out0: vec4<f32>,
+      @location(1) out1: vec4<f32>,
+    }
+
+    struct S2 {
+      @location(0) out0: vec4<f32>,
+      out1: vec4<f32>,
+    }
+
+    struct S3 {
+      @location(0) out0: vec4<f32>,
+      out1: S4,
+    }
+
+    struct S4 {
+      @location(1) out2: vec4<f32>,
+      @location(2) out3: vec4<f32>,
+    }
+
+    @fragment
+    fn fragment0(@builtin(position) coord_in: vec4<f32>) -> @location(123) vec4<i32> {
+    return vec4<i32>();
+    }
+
+    @fragment
+    fn fragment1(@builtin(position) coord_in: vec4<f32>) -> @location(0) vec4<f32> {
+      return vec4<f32>(coord_in.x, coord_in.y, 0.0, 1.0);
+    }
+
+    @fragment
+    fn fragment2(@builtin(position) coord_in: vec4<f32>) -> S {
+    }
+
+    @fragment
+    fn fragment3(@builtin(position) coord_in: vec4<f32>) -> S {
+      return S();
+    }
+
+    @fragment
+    fn fragment4(@builtin(position) coord_in: vec4<f32>) -> S2 {
+      return S2();
+    }
+
+    @fragment
+    fn fragment5(x: S3) -> S3 {
+      return x;
+    }
+
+    @vertex
+    fn vertex0() -> @builtin(position) vec4<f32> {
+      return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+    }
+
+    @vertex
+    fn vertex1(@builtin(vertex_index) v_index: u32, @builtin(instance_index) i_index: u32,) -> @builtin(position) vec4<f32> {
+      return vec4<f32>(f32(v_index), f32(i_index), 0.0, 1.0);
+    }
+
+    @vertex
+    fn vertex2(@builtin(vertex_index) v_index: u32, @builtin(instance_index) i_index: u32,) -> S {
+    }
+
+    @vertex
+    fn vertex3(@builtin(vertex_index) v_index: u32, @builtin(instance_index) i_index: u32,) -> S {
+      return S();
+    }
+    `,
+    sourceMap: {},
+    hints: {},
+    }
+    );
+
+    let pipeline8 = await device0.createRenderPipelineAsync(
+    {
+    label: 'a',
+    layout: pipelineLayout0,
+    vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex1',
+    buffers: [
+    {
+    arrayStride: 29196,
+    stepMode: 'vertex',
+    attributes: [
+    {
+    format: 'float16x2',
+    offset: 8500,
+    shaderLocation: 6,
+    },
+    {
+    format: 'float32',
+    offset: 19580,
+    shaderLocation: 2,
+    },
+    {
+    format: 'float16x4',
+    offset: 27964,
+    shaderLocation: 9,
+    }
+    ],
+    }
+    ],
+    },
+    primitive: {
+    topology: 'triangle-strip',
+    stripIndexFormat: 'uint32',
+    frontFace: 'ccw',
+    cullMode: 'none',
+    },
+    multisample: {
+    count: 4,
+    alphaToCoverageEnabled: true,
+    },
+    fragment: {
+    module: shaderModule0,
+    entryPoint: 'fragment0',
+    constants: {},
+    targets: [
+    {
+    format: 'rgba8sint',
+    writeMask: 0,
+    }
+    ],
+    },
+    depthStencil: {
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    format: 'depth24plus-stencil8',
+    stencilFront: {
+    compare: 'greater',
+    failOp: 'keep',
+    passOp: 'decrement-clamp',
+    },
+    stencilBack: {
+    compare: 'less-equal',
+    failOp: 'replace',
+    depthFailOp: 'increment-clamp',
+    passOp: 'invert',
+    },
+    stencilReadMask: 22,
+    stencilWriteMask: 95,
+    depthBias: 41,
+    depthBiasSlopeScale: 1,
+    },
+    }
+    );
+  } catch {}
+  if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash.

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1449,7 +1449,7 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
             return returnInvalidRenderPipeline(*this, isAsync, "Can not use sampleMask with alphaToCoverage"_s);
         if (!descriptor.fragment)
             return returnInvalidRenderPipeline(*this, isAsync, "Using alphaToCoverage requires a fragment state"_s);
-        if (!descriptor.fragment->targetCount || !hasAlphaChannel(descriptor.fragment->targets[0].format))
+        if (!descriptor.fragment->targetCount || !hasAlphaChannel(descriptor.fragment->targets[0].format) || !Texture::supportsBlending(descriptor.fragment->targets[0].format, *this))
             return returnInvalidRenderPipeline(*this, isAsync, "Using alphaToCoverage requires a fragment state"_s);
         if (descriptor.multisample.count == 1)
             return returnInvalidRenderPipeline(*this, isAsync, "Using alphaToCoverage requires multisampling"_s);


### PR DESCRIPTION
#### 0ade4480b548839fd84b43494f5d1eef8ce47792
<pre>
Check Texture::supportsBlending in addition to hasAlphaChannel
<a href="https://bugs.webkit.org/show_bug.cgi?id=270484">https://bugs.webkit.org/show_bug.cgi?id=270484</a>
<a href="https://rdar.apple.com/123811134">rdar://123811134</a>

Reviewed by Mike Wyrzykowski.

This is being discussed in <a href="https://github.com/gpuweb/gpuweb/issues/4506">https://github.com/gpuweb/gpuweb/issues/4506</a>
We don&apos;t want to crash when using Metal.

* LayoutTests/fast/webgpu/texture-supports-blending-expected.txt: Added.
* LayoutTests/fast/webgpu/texture-supports-blending.html: Added.
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(WebGPU::hasAlphaChannel): Deleted.

Canonical link: <a href="https://commits.webkit.org/275662@main">https://commits.webkit.org/275662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e4f201ddb54bf3ab32aab03a46557eee5e37527

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38578 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18393 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16099 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46533 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37919 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17277 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36866 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5725 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->