### PR TITLE
Remove deferred setNeedsLayouts and call sites

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -555,8 +555,6 @@ void LocalFrameView::setContentsSize(const IntSize& size)
     if (size == contentsSize())
         return;
 
-    layoutContext().disableSetNeedsLayout();
-
     ScrollView::setContentsSize(size);
     contentsResized();
 
@@ -572,7 +570,6 @@ void LocalFrameView::setContentsSize(const IntSize& size)
         page->pageOverlayController().didChangeDocumentSize();
         BackForwardCache::singleton().markPagesForContentsSizeChanged(*page);
     }
-    layoutContext().enableSetNeedsLayout();
 }
 
 void LocalFrameView::adjustViewSize()

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -188,7 +188,6 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
     SingleThreadWeakPtr<RenderElement> layoutRoot;
     
     m_layoutTimer.stop();
-    m_setNeedsLayoutWasDeferred = false;
 
 #if !LOG_DISABLED
     if (m_firstLayout && !frame->ownerElement())
@@ -343,34 +342,16 @@ bool LocalFrameViewLayoutContext::needsLayoutInternal() const
     auto* renderView = this->renderView();
     return isLayoutPending()
         || (renderView && renderView->needsLayout())
-        || subtreeLayoutRoot()
-        || (m_disableSetNeedsLayoutCount && m_setNeedsLayoutWasDeferred);
+        || subtreeLayoutRoot();
 }
 
 void LocalFrameViewLayoutContext::setNeedsLayoutAfterViewConfigurationChange()
 {
-    if (m_disableSetNeedsLayoutCount) {
-        m_setNeedsLayoutWasDeferred = true;
-        return;
-    }
-
     if (auto* renderView = this->renderView()) {
         ASSERT(!document()->inHitTesting());
         renderView->setNeedsLayout();
         scheduleLayout();
     }
-}
-
-void LocalFrameViewLayoutContext::enableSetNeedsLayout()
-{
-    ASSERT(m_disableSetNeedsLayoutCount);
-    if (!--m_disableSetNeedsLayoutCount)
-        m_setNeedsLayoutWasDeferred = false; // FIXME: Find a way to make the deferred layout actually happen.
-}
-
-void LocalFrameViewLayoutContext::disableSetNeedsLayout()
-{
-    ++m_disableSetNeedsLayoutCount;
 }
 
 void LocalFrameViewLayoutContext::scheduleLayout()

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -77,9 +77,6 @@ public:
     void scheduleSubtreeLayout(RenderElement& layoutRoot);
     void unscheduleLayout();
 
-    void disableSetNeedsLayout();
-    void enableSetNeedsLayout();
-
     enum class LayoutPhase : uint8_t {
         OutsideLayout,
         InPreLayout,
@@ -193,13 +190,11 @@ private:
     bool m_firstLayout { true };
     bool m_needsFullRepaint { true };
     bool m_inAsynchronousTasks { false };
-    bool m_setNeedsLayoutWasDeferred { false };
     bool m_needsSkippedContentLayout { false };
     LayoutPhase m_layoutPhase { LayoutPhase::OutsideLayout };
     enum class LayoutNestedState : uint8_t  { NotInLayout, NotNested, Nested };
     LayoutNestedState m_layoutNestedState { LayoutNestedState::NotInLayout };
     unsigned m_layoutCount { 0 };
-    unsigned m_disableSetNeedsLayoutCount { 0 };
     unsigned m_paintOffsetCacheDisableCount { 0 };
     LayoutStateStack m_layoutStateStack;
     std::unique_ptr<Layout::LayoutTree> m_layoutTree;


### PR DESCRIPTION
<pre>
Remove deferred setNeedsLayouts and call sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=165781">https://bugs.webkit.org/show_bug.cgi?id=165781</a>

Reviewed by NOBODY (OOPS!).

Inspired by: <a href="https://chromium.googlesource.com/chromium/blink/+/f9b0d34b5bac00f3dedaa44b360590ba3ad55ad8">https://chromium.googlesource.com/chromium/blink/+/f9b0d34b5bac00f3dedaa44b360590ba3ad55ad8</a>

This code was added in `35072@main` in 2009 without a test coverage
for a bug with how Mail embedded WebKit1. We've long since moved past
that and it doesn't seem it should be needed anymore since 'Mail' app now
use 'WebKit2'.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(LocalFrameViewLayoutContext::needsLayout):
(LocalFrameViewLayoutContext::setNeedsLayoutAfterViewConfigurationChange):
(LocalFrameViewLayoutContext::enableSetNeedsLayout): Deleted
(LocalFrameViewLayoutContext::disableSetNeedsLayout): Deleted
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/LocalFrameView.cpp:
(LocalFrameView::setContentsSize):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e549016deea3adfa819c527f3cdf62f3c5d81534

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63325 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48235 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29060 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32904 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8676 "Found 3 new test failures: editing/selection/move-by-line-crash.html fast/flexbox/flex-hang.html fast/repaint/border-radius-repaint-2.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3339 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8870 "Found 2 new test failures: compositing/fixed-with-fixed-layout.html fast/fixed-layout/fixed-layout.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55578 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55682 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2773 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34570 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36739 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->