### PR TITLE
import-w3c-tests should rewrite reference file names in meta fuzzy annotations.

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -393,6 +393,8 @@ class TestImporter(object):
                     total_tests += 1
                     test_basename = self.filesystem.basename(test_info['test'])
 
+                    ref_files = []
+
                     # Add the ref file, following WebKit style.
                     # FIXME: Ideally we'd support reading the metadata
                     # directly rather than relying  on a naming convention.
@@ -402,13 +404,15 @@ class TestImporter(object):
                         ref_file = self.filesystem.splitext(test_basename)[0] + '-expected'
                         ref_file += self.filesystem.splitext(test_info['match_reference'])[1]
                         copy_list.append({'src': test_info['match_reference'], 'dest': ref_file, 'reference_support_info': test_info['match_reference_support_info']})
+                        ref_files.append({'src': self.filesystem.split(test_info['match_reference'])[1], 'dest': self.filesystem.split(ref_file)[1]})
 
                     if 'mismatch_reference' in test_info.keys():
                         ref_file = self.filesystem.splitext(test_basename)[0] + '-expected-mismatch'
                         ref_file += self.filesystem.splitext(test_info['mismatch_reference'])[1]
                         copy_list.append({'src': test_info['mismatch_reference'], 'dest': ref_file, 'reference_support_info': test_info['mismatch_reference_support_info']})
+                        ref_files.append({'src': self.filesystem.split(test_info['mismatch_reference'])[1], 'dest': self.filesystem.split(ref_file)[1]})
 
-                    copy_list.append({'src': test_info['test'], 'dest': filename})
+                    copy_list.append({'src': test_info['test'], 'dest': filename, 'reference_file_renames': ref_files})
 
                 elif 'jstest' in test_info.keys():
                     jstests += 1
@@ -566,6 +570,11 @@ class TestImporter(object):
                 else:
                     reference_support_info = None
 
+                if 'reference_file_renames' in file_to_copy.keys() and file_to_copy['reference_file_renames'] != {}:
+                    reference_file_renames = file_to_copy['reference_file_renames']
+                else:
+                    reference_file_renames = []
+
                 if not(self.filesystem.exists(self.filesystem.dirname(new_filepath))):
                     self.filesystem.maybe_make_directory(self.filesystem.dirname(new_filepath))
 
@@ -585,7 +594,7 @@ class TestImporter(object):
                                         and ('html' in str(mimetype[0]) or 'xml' in str(mimetype[0])  or 'css' in str(mimetype[0]) or 'javascript' in str(mimetype[0])):
                     _log.info("Rewriting: %s" % new_filepath)
                     try:
-                        converted_file = convert_for_webkit(new_path, filename=orig_filepath, reference_support_info=reference_support_info, host=self.host, webkit_test_runner_options=self._webkit_test_runner_options(new_filepath))
+                        converted_file = convert_for_webkit(new_path, filename=orig_filepath, reference_support_info=reference_support_info, reference_file_renames=reference_file_renames, host=self.host, webkit_test_runner_options=self._webkit_test_runner_options(new_filepath))
                     except:
                         _log.warn('Failed converting %s', orig_filepath)
                         failed_conversion_files.append(orig_filepath)


### PR DESCRIPTION
#### 525f853875c0dcaebc7df8ba2317ce8ab0734156
<pre>
import-w3c-tests should rewrite reference file names in meta fuzzy annotations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270426">https://bugs.webkit.org/show_bug.cgi?id=270426</a>
&lt;<a href="https://rdar.apple.com/124034791">rdar://124034791</a>&gt;

Reviewed by Jonathan Bedard.

* Tools/Scripts/webkitpy/w3c/test_converter.py:
(convert_for_webkit):
(_W3CTestConverter.__init__):
(_W3CTestConverter.convert_attributes_if_needed):
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.find_importable_tests):
(TestImporter.import_tests):

Canonical link: <a href="https://commits.webkit.org/275750@main">https://commits.webkit.org/275750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94c89857ed03bee477de4caed48af748c1ba99a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35314 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16270 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/42540 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37783 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/726 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46781 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42027 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19107 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40653 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19286 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5778 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->