### PR TITLE
imageBytesForSource should only copy the required bytes for images with more than 4 bytes per pixel

### DIFF
--- a/LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel-expected.txt
+++ b/LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel.html
+++ b/LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel.html
@@ -1,0 +1,99 @@
+<script>
+    async function makeDataUrl(width, height, color) {
+      let offscreenCanvas = new OffscreenCanvas(width, height);
+      let ctx = offscreenCanvas.getContext('2d');
+      ctx.fillStyle = color;
+      ctx.fillRect(0, 0, width, height);
+      let blob = await offscreenCanvas.convertToBlob();
+      let fileReader = new FileReader();
+      fileReader.readAsDataURL(blob);
+      return new Promise(resolve => {
+        fileReader.onload = () => {
+          resolve(fileReader.result);
+        };
+      });
+    }
+
+    async function imageWithData(width, height, color) {
+      let dataUrl = await makeDataUrl(width, height, color);
+      let img = document.createElement('img');
+      img.src = dataUrl;
+      await img.decode();
+      return img;
+    }
+
+    if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+    onload = async () => {
+        try {
+            let adapter0 = await navigator.gpu.requestAdapter(
+            {
+            }
+            );
+
+            let device0 = await adapter0.requestDevice(
+            {
+            requiredFeatures: [
+            'depth-clip-control',
+            'depth32float-stencil8',
+            'texture-compression-etc2',
+            'texture-compression-astc',
+            'shader-f16',
+            'rg11b10ufloat-renderable',
+            'bgra8unorm-storage'
+            ],
+            }
+            );
+            
+            let img0 = await imageWithData(2, 245, '#b84778');
+
+            let texture3 = device0.createTexture(
+            {
+            size: {
+            width: 5209,
+            height: 5392,
+            depthOrArrayLayers: 1,
+            },
+            mipLevelCount: 7,
+            sampleCount: 1,
+            dimension: '3d',
+            format: 'astc-10x6-unorm',
+            usage: GPUTextureUsage.COPY_SRC,
+            viewFormats: [
+            'eac-r11snorm',
+            'rg8unorm',
+            'rg32float',
+            'eac-rg11snorm',
+            'rg16sint',
+            'rg32sint',
+            'etc2-rgba8unorm'
+            ],
+            }
+            );
+            
+            device0.queue.copyExternalImageToTexture(
+            {
+            source: img0,
+            origin: [
+
+            ],
+            },
+            {
+            texture: texture3,
+            mipLevel: 6208,
+            origin: [
+            2518,
+            3374
+            ],
+            aspect: 'depth-only',
+            colorSpace: 'srgb',
+            premultipliedAlpha: true,
+            },
+            [
+
+            ]
+            );
+        } catch {}
+        if (window.testRunner) { testRunner.notifyDone() }
+    };
+</script>
+This test passes if it does not crash.


### PR DESCRIPTION
#### ed9a48d72012671cf9e92c59f443855d48ea55e1
<pre>
imageBytesForSource should only copy the required bytes for images with more than 4 bytes per pixel
<a href="https://bugs.webkit.org/show_bug.cgi?id=270493">https://bugs.webkit.org/show_bug.cgi?id=270493</a>
<a href="https://rdar.apple.com/123810952">rdar://123810952</a>

Reviewed by Mike Wyrzykowski.

Also use early returns to remove deeply nested if statements.
Also use smart pointers to retain and release images while using them.

* LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel-expected.txt: Added.
* LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel.html: Added.
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::imageBytesForSource):

Canonical link: <a href="https://commits.webkit.org/275671@main">https://commits.webkit.org/275671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6626caefe702449a634c797e67ab6bdc5f68dd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18858 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18419 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16118 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46562 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37936 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17303 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18922 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36884 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18984 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5730 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->