### PR TITLE
Add a quirk to store third-party cookies in partitioned storage

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1838,4 +1838,19 @@ bool Quirks::shouldIgnorePlaysInlineRequirementQuirk() const
 #endif
 }
 
+bool Quirks::shouldUseEphemeralPartitionedStorageForDOMCookies(const URL& url) const
+{
+    if (!needsQuirks())
+        return false;
+
+    auto firstPartyDomain = RegistrableDomain(m_document->firstPartyForCookies()).string();
+    auto domain = RegistrableDomain(url).string();
+
+    // rdar://113830141
+    if (firstPartyDomain == "cagreatamerica.com"_s && domain == "queue-it.net"_s)
+        return true;
+
+    return false;
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -187,6 +187,7 @@ public:
 
     bool shouldDisableElementFullscreenQuirk() const;
     bool shouldIgnorePlaysInlineRequirementQuirk() const;
+    WEBCORE_EXPORT bool shouldUseEphemeralPartitionedStorageForDOMCookies(const URL&) const;
 
 private:
     bool needsQuirks() const;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -727,6 +727,7 @@ WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
 WebProcess/WebPage/Cocoa/DrawingAreaCocoa.mm
 WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
 WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
+WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5034,6 +5034,7 @@
 		3A18A2F22B02969800DB976C /* _WKArchiveExclusionRule.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKArchiveExclusionRule.mm; sourceTree = "<group>"; };
 		3A18A2F32B02969800DB976C /* _WKArchiveExclusionRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKArchiveExclusionRule.h; sourceTree = "<group>"; };
 		3A26F82D2B258CEF00FEB1B0 /* PlatformXR.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PlatformXR.serialization.in; sourceTree = "<group>"; };
+		3A36AFAF2B9667770098631A /* WebCookieJarCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCookieJarCocoa.mm; sourceTree = "<group>"; };
 		3A5B68962AC266D400B11868 /* WKARPresentationSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKARPresentationSession.h; sourceTree = "<group>"; };
 		3A5B68972AC266D400B11868 /* WKARPresentationSession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKARPresentationSession.mm; sourceTree = "<group>"; };
 		3A7D62D229D35D9D00D57DAC /* WebSWRegistrationStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWRegistrationStore.cpp; sourceTree = "<group>"; };
@@ -10388,6 +10389,7 @@
 				2D9CD5EB21FA503F0029ACFA /* TextCheckingControllerProxy.messages.in */,
 				2D9CD5EC21FA503F0029ACFA /* TextCheckingControllerProxy.mm */,
 				3A8997E029B25E8E00AB88B6 /* WebCookieCacheCocoa.mm */,
+				3A36AFAF2B9667770098631A /* WebCookieJarCocoa.mm */,
 				2DC4CF7A1D2DE24B00ECCC94 /* WebPageCocoa.mm */,
 				463236842314825C00A48FA7 /* WebRemoteObjectRegistry.cpp */,
 				46323683231481EF00A48FA7 /* WebRemoteObjectRegistry.h */,

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WebCookieJar.h"
+
+#if PLATFORM(COCOA)
+
+#import <WebCore/Document.h>
+#import <WebCore/Quirks.h>
+#import <WebCore/SameSiteInfo.h>
+#import <pal/spi/cf/CFNetworkSPI.h>
+#import <wtf/text/StringBuilder.h>
+#import <wtf/text/cf/StringConcatenateCF.h>
+
+namespace WebKit {
+
+static RetainPtr<NSDictionary> policyProperties(const WebCore::SameSiteInfo& sameSiteInfo, const URL& url)
+{
+    static NSURL *emptyURL = [[NSURL alloc] initWithString:@""];
+    NSURL *nsURL = url;
+    NSDictionary *policyProperties = @{
+        @"_kCFHTTPCookiePolicyPropertySiteForCookies": sameSiteInfo.isSameSite ? nsURL : emptyURL,
+        @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation": [NSNumber numberWithBool:sameSiteInfo.isTopSite],
+    };
+    return policyProperties;
+}
+
+String WebCookieJar::cookiesInPartitionedCookieStorage(const WebCore::Document& document, const URL& cookieURL, const WebCore::SameSiteInfo& sameSiteInfo) const
+{
+    if (!document.quirks().shouldUseEphemeralPartitionedStorageForDOMCookies(cookieURL))
+        return { };
+
+    if (!m_partitionedStorageForDOMCookies)
+        return { };
+
+    URL firstPartyURL = document.firstPartyForCookies();
+    String partition = WebCore::RegistrableDomain(firstPartyURL).string();
+    if (partition.isEmpty())
+        return { };
+
+    __block RetainPtr<NSArray> cookies;
+    [m_partitionedStorageForDOMCookies.get() _getCookiesForURL:cookieURL mainDocumentURL:firstPartyURL partition:partition policyProperties:policyProperties(sameSiteInfo, cookieURL).get() completionHandler:^(NSArray *result) {
+        cookies = result;
+    }];
+
+    if (!cookies || ![cookies.get() count])
+        return { };
+
+    StringBuilder cookiesBuilder;
+    for (NSHTTPCookie *cookie in cookies.get()) {
+        if (![[cookie name] length] || [cookie isHTTPOnly])
+            continue;
+
+        cookiesBuilder.append(cookiesBuilder.isEmpty() ? "" : "; ", [cookie name], "=", [cookie value]);
+    }
+
+    return cookiesBuilder.toString();
+}
+
+void WebCookieJar::setCookiesInPartitionedCookieStorage(const WebCore::Document& document, const URL& cookieURL, const WebCore::SameSiteInfo& sameSiteInfo, const String& cookieString)
+{
+    if (!document.quirks().shouldUseEphemeralPartitionedStorageForDOMCookies(cookieURL))
+        return;
+
+    if (cookieString.isEmpty())
+        return;
+
+    auto firstPartyURL = document.firstPartyForCookies();
+    String partition = WebCore::RegistrableDomain(firstPartyURL).string();
+    if (partition.isEmpty())
+        return;
+
+    NSHTTPCookie *cookie = [NSHTTPCookie _cookieForSetCookieString:cookieString forURL:cookieURL partition:partition];
+    if (!cookie || ![[cookie name] length] || [cookie isHTTPOnly])
+        return;
+
+    [ensurePartitionedCookieStorage() _setCookies:@[cookie] forURL:cookieURL mainDocumentURL:firstPartyURL policyProperties:policyProperties(sameSiteInfo, cookieURL).get()];
+}
+
+NSHTTPCookieStorage* WebCookieJar::ensurePartitionedCookieStorage()
+{
+    if (!m_partitionedStorageForDOMCookies) {
+        m_partitionedStorageForDOMCookies = adoptNS([[NSHTTPCookieStorage alloc] _initWithIdentifier:@"WebCookieJar" private:true]);
+        m_partitionedStorageForDOMCookies.get().cookieAcceptPolicy = NSHTTPCookieAcceptPolicyAlways;
+    }
+
+    return m_partitionedStorageForDOMCookies.get();
+}
+
+} // namespace WebKit
+#endif

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
@@ -34,6 +34,10 @@
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
+#if PLATFORM(COCOA)
+OBJC_CLASS NSHTTPCookieStorage;
+#endif
+
 namespace WebCore {
 struct Cookie;
 struct CookieStoreGetOptions;
@@ -76,9 +80,18 @@ private:
     bool remoteCookiesEnabledSync(WebCore::Document&) const;
     void clearCacheForHost(const String&) final;
     bool isEligibleForCache(WebFrame&, const URL& firstPartyForCookies, const URL& resourceURL) const;
+    String cookiesInPartitionedCookieStorage(const WebCore::Document&, const URL&, const WebCore::SameSiteInfo&) const;
+    void setCookiesInPartitionedCookieStorage(const WebCore::Document&, const URL&, const WebCore::SameSiteInfo&, const String& cookieString);
+#if PLATFORM(COCOA)
+    NSHTTPCookieStorage* ensurePartitionedCookieStorage();
+#endif
 
     mutable WebCookieCache m_cache;
     HashMap<String, WeakHashSet<WebCore::CookieChangeListener>> m_changeListeners;
+
+#if PLATFORM(COCOA)
+    RetainPtr<NSHTTPCookieStorage> m_partitionedStorageForDOMCookies;
+#endif
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 24260b1c915eded6dcd704ae8dd8dc05723c2d75
<pre>
Add a quirk to store third-party cookies in partitioned storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=270494">https://bugs.webkit.org/show_bug.cgi?id=270494</a>
<a href="https://rdar.apple.com/113830141">rdar://113830141</a>

Reviewed by Chris Dumez.

cagreatamerica.com does not display correctly because an iframe from queue-it.net checks to cookie storage access from
script, and third-party cookies are fully blocked when ITP is enabled. To fix that, allow queue-it.net to read and write
cookies in partitioned storage. Note the storage is partitioned by top-level domain, so quirked domain cannot perform
cross-site tracking. Also the storage currently resides in the memory of web process, so the cookies are not applied to
network tasks.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldUseEphemeralPartitionedStorageForDOMCookies const):
* Source/WebCore/page/Quirks.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm: Added.
(WebKit::policyProperties):
(WebKit::WebCookieJar::cookiesInPartitionedCookieStorage const):
(WebKit::WebCookieJar::setCookiesInPartitionedCookieStorage):
(WebKit::WebCookieJar::ensurePartitionedCookieStorage):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::cookies const):
(WebKit::WebCookieJar::setCookies):
(WebKit::WebCookieJar::cookiesInPartitionedCookieStorage const):
(WebKit::WebCookieJar::setCookiesInPartitionedCookieStorage):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:

Canonical link: <a href="https://commits.webkit.org/275763@main">https://commits.webkit.org/275763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ddf580b2672eeadc67a608f8181b580dd61988f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35373 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16331 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37846 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46857 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14473 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42098 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40727 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9541 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->