### PR TITLE
Update trusted fonts in lockdown mode

### DIFF
--- a/Source/WebCore/loader/cache/TrustedFonts.cpp
+++ b/Source/WebCore/loader/cache/TrustedFonts.cpp
@@ -831,7 +831,30 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& trustedFontHas
         // internal build website fonts/appleicons_thin.woff
         "BeSxgqYI30lPA9+4OhNV5gZdbPSOmr1Uc3Pfh+zxgwY="_s,
         // confluence
-        "2W4TXu8CrouqU+yAxbOXQv7+cmCwBxTA8Qu4s3FiPao="_s /* adgs-icons.woff */ });
+        "2W4TXu8CrouqU+yAxbOXQv7+cmCwBxTA8Qu4s3FiPao="_s /* adgs-icons.woff */,
+        // Facebook (mobile) fonts
+        "1a96pPQvMOL3r7M4pKrELBz+gSxvFjHUUQ0unz0gzU4="_s /* 5cUXMf7SRuh.woff2 */,
+        "1bfLlCjJ0e23TraaDnSbY3f3lp3yRYxIBk93z1olQk4="_s /* SAgHdHVYZ-R.woff2 */,
+        "2WYVaxN4GYUJ1K3r2cn6EDxjs1lDDzppc4dxqIX5hbk="_s /* iYXgG2pUxVS.woff */,
+        "8HsMwJCq8uRlJrAboB720aHCK7N8pYUhDuUfnu5ZGHM="_s /* vmyyO1-mvOd.woff */,
+        "E+x+EdJlCzleQcPZFBHti7Deb2/FQ9WY4WPl0lIBoVA="_s /* UsF5W5WWG0E.woff2 */,
+        "EUi4DBFni9ElsilZOLrgzTVqYO3UCXNFcJ7B6ho3YOg="_s /* DqCNAu7Sk4G.woff */,
+        "EasQ00xIaRA1z+Mo0OytcyaLTrS854HecTIFeeglOSA="_s /* nPY4rFJtleI.woff */,
+        "HVp2n4aqJgRMuu2PXx8HIuHMA4tLh6yJ5ECN8o/weyg="_s /* Paifsle8_FW.woff */,
+        "I1qMr3fD27f3GeqSHNmjXvGYx7r1blHTV9SpOuW4VE4="_s /* UIUSNiq_0wY.woff2 */,
+        "J78l85/GfqiQJrW3Hg51GIfZhbDa7ak3lMfF2WGBhxc="_s /* TLCS-K3GTX9.woff2 */,
+        "KY+mbpM1KxujmLATIuWRn9LCwidoZ2CrJu7esqzNacc="_s /* zN72djA8Dpu.woff */,
+        "XSKMkqyLhl0oumU/pKLuo2cOQiPiHa/Z8QzOUc06FSQ="_s /* dndzIs-1lCT.woff2 */,
+        "Y16U8gcuiS/wTDlsuEH02hTU6w+cW5kBhuktTkWW/jQ="_s /* FbWLvH9Jv6h.woff2 */,
+        "Zy+VBJJuI14SZ1s/Z8xnnqyr6faavdZpl7ma2b9bbm8="_s /* P0hio8wRNYH.woff2 */,
+        "aRtGFjePuwV1JmwiKf1tQ9yD0ajb56SokVHDuMOQw7Y="_s /* tBffAN721Gl.woff */,
+        "j3/ufp5pfLyq9nNrA/4NW4qoQm6sOPeAeWr2a8EthhI="_s /* IptncetaoAc.woff2 */,
+        "lDLmI7QL8wwVsJI3hV85npRNMufchHJ2gvus+ePpUzs="_s /* mE6sRap-J3q.woff */,
+        "rgTQxpkGKLGDvfdEUqZkHsVPUA5raVtBGjitLg+eN0s="_s /* jwygLcMtndp.woff2 */,
+        "tboC32G7FHmioWbF0ScsnhgR4SnPevGgAcN9oyBxyV4="_s /* NT9VJlUQ2j5.woff */,
+        "toGCSrhxtzDo2US+GzyShOuyCBJSqfpLCfpuyuo3+Ig="_s /* F7ZcL-Lm2Os.woff */,
+        "ugyD8SdndqzkOiSODDKB0PXx5gR72goGjJ8HtpLzoBc="_s /* FqiK19_SYWS.woff */,
+        "wkSmw8cD+LK683467qvTuPjr847yjaPsRdrfsajfIgc="_s /* tL12ldcgP15.woff2 */ });
 
     return trustedFontHashes;
 }


### PR DESCRIPTION
#### 9b30f8d02ef6f1d244c7879ec60d5121f2460fdb
<pre>
Update trusted fonts in lockdown mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=270501">https://bugs.webkit.org/show_bug.cgi?id=270501</a>
<a href="https://rdar.apple.com/123658932">rdar://123658932</a>

Reviewed by Brent Fulgham.

Update list of trusted fonts with fonts requested
by mobile version of facebook.com

* Source/WebCore/loader/cache/TrustedFonts.cpp:
(WebCore::trustedFontHashesInLockdownMode):

Canonical link: <a href="https://commits.webkit.org/275705@main">https://commits.webkit.org/275705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6eca2c4a51bc92c4c42057aa5141ecb84cc19b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35187 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37641 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/559 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46603 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41886 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18939 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40496 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9520 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->