### PR TITLE
WKWebExtensionTab and WKWebExtensionWindow tests are failing after 275651@main.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionTab.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionTab.mm
@@ -100,23 +100,23 @@ TEST(WKWebExtensionTab, OpenTabs)
 
     [testController unloadExtensionContext:testContextOne.get() error:nullptr];
 
-    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, [NSSet set]);
     EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
 
     testWindowOne.get().tabs = @[ testTabOne.get() ];
     [testController didOpenTab:testTabOne.get()];
 
-    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, [NSSet set]);
     EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
 
     [testController didCloseWindow:testWindowOne.get()];
 
-    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, [NSSet set]);
     EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
 
     [testController didCloseWindow:testWindowTwo.get()];
 
-    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, [NSSet set]);
     EXPECT_NS_EQUAL(testContextTwo.get().openTabs, [NSSet set]);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionWindow.mm
@@ -93,22 +93,22 @@ TEST(WKWebExtensionWindow, OpenWindows)
 
     [testController unloadExtensionContext:testContextOne.get() error:nullptr];
 
-    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, @[ ]);
     EXPECT_NS_EQUAL(testContextTwo.get().openWindows, openWindows);
 
     [testController didFocusWindow:testWindowTwo.get()];
 
-    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, @[ ]);
     EXPECT_NS_EQUAL(testContextTwo.get().openWindows, reversedOpenWindows);
 
     [testController didCloseWindow:testWindowTwo.get()];
 
-    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, @[ ]);
     EXPECT_NS_EQUAL(testContextTwo.get().openWindows, @[ testWindowOne.get() ]);
 
     [testController didOpenWindow:testWindowTwo.get()];
 
-    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, @[ ]);
     EXPECT_NS_EQUAL(testContextTwo.get().openWindows, reversedOpenWindows);
 }
 
@@ -166,17 +166,17 @@ TEST(WKWebExtensionWindow, FocusedWindow)
 
     [testController unloadExtensionContext:testContextOne.get() error:nullptr];
 
-    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowOne.get());
+    EXPECT_NULL(testContextOne.get().focusedWindow);
     EXPECT_NS_EQUAL(testContextTwo.get().focusedWindow, testWindowOne.get());
 
     [testController didFocusWindow:testWindowTwo.get()];
 
-    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowOne.get());
+    EXPECT_NULL(testContextOne.get().focusedWindow);
     EXPECT_NS_EQUAL(testContextTwo.get().focusedWindow, testWindowTwo.get());
 
     [testController didCloseWindow:testWindowTwo.get()];
 
-    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowOne.get());
+    EXPECT_NULL(testContextOne.get().focusedWindow);
     EXPECT_NULL(testContextTwo.get().focusedWindow);
 }
 


### PR DESCRIPTION
#### e1d3b912b733e4145aaaabad85c8b21cc816fd0f
<pre>
WKWebExtensionTab and WKWebExtensionWindow tests are failing after 275651@main.
<a href="https://webkit.org/b/270502">https://webkit.org/b/270502</a>
<a href="https://rdar.apple.com/problem/124049994">rdar://problem/124049994</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionTab.mm:
(TestWebKitAPI::TEST): Updated expected results.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionWindow.mm:
(TestWebKitAPI::TEST): Updated expected results.

Canonical link: <a href="https://commits.webkit.org/275672@main">https://commits.webkit.org/275672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b1c1d617d618d09bc7b989f25ed32b11b4deb74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44902 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/38625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18882 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/45109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43079 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46585 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/37971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/5734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->