### PR TITLE
[JSC] Destroy LinkBuffer in compiler thread

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -551,13 +551,6 @@ void LinkBuffer::performFinalization()
     MacroAssembler::cacheFlush(code(), m_size);
 }
 
-void LinkBuffer::runMainThreadFinalizationTasks()
-{
-    for (auto& task : m_mainThreadFinalizationTasks)
-        task->run();
-    m_mainThreadFinalizationTasks.clear();
-}
-
 #if DUMP_LINK_STATISTICS
 void LinkBuffer::dumpLinkStatistics(void* code, size_t initializeSize, size_t finalSize)
 {

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -135,8 +135,6 @@ public:
     {
     }
 
-    void runMainThreadFinalizationTasks();
-    
     bool didFailToAllocate() const
     {
         return !m_didAllocate;
@@ -323,12 +321,6 @@ ALLOW_NONLITERAL_FORMAT_END
     JS_EXPORT_PRIVATE static void clearProfileStatistics();
     JS_EXPORT_PRIVATE static void dumpProfileStatistics(std::optional<PrintStream*> = std::nullopt);
 
-    template<typename Functor>
-    void addMainThreadFinalizationTask(const Functor& functor)
-    {
-        m_mainThreadFinalizationTasks.append(createSharedTask<void()>(functor));
-    }
-
     void setIsThunk() { m_isThunk = true; }
 
 private:
@@ -416,7 +408,6 @@ private:
     CodePtr<LinkBufferPtrTag> m_code;
     Vector<RefPtr<SharedTask<void(LinkBuffer&)>>> m_linkTasks;
     Vector<RefPtr<SharedTask<void(LinkBuffer&)>>> m_lateLinkTasks;
-    Vector<RefPtr<SharedTask<void()>>> m_mainThreadFinalizationTasks;
 
     static size_t s_profileCummulativeLinkedSizes[numberOfProfiles];
     static size_t s_profileCummulativeLinkedCounts[numberOfProfiles];

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
@@ -39,10 +39,9 @@ namespace JSC { namespace DFG {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITFinalizer);
 
-JITFinalizer::JITFinalizer(Plan& plan, Ref<DFG::JITCode>&& jitCode, std::unique_ptr<LinkBuffer> linkBuffer, CodePtr<JSEntryPtrTag> withArityCheck)
+JITFinalizer::JITFinalizer(Plan& plan, Ref<DFG::JITCode>&& jitCode, CodePtr<JSEntryPtrTag> withArityCheck)
     : Finalizer(plan)
     , m_jitCode(WTFMove(jitCode))
-    , m_linkBuffer(WTFMove(linkBuffer))
     , m_withArityCheck(withArityCheck)
 {
 }
@@ -53,7 +52,7 @@ JITFinalizer::~JITFinalizer()
 
 size_t JITFinalizer::codeSize()
 {
-    return m_linkBuffer->size();
+    return m_jitCode->size();
 }
 
 bool JITFinalizer::finalize()
@@ -62,7 +61,7 @@ bool JITFinalizer::finalize()
 
     WTF::crossModifyingCodeFence();
 
-    m_linkBuffer->runMainThreadFinalizationTasks();
+    m_plan.runMainThreadFinalizationTasks();
 
     CodeBlock* codeBlock = m_plan.codeBlock();
 

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
@@ -29,7 +29,6 @@
 
 #include "DFGFinalizer.h"
 #include "DFGJITCode.h"
-#include "LinkBuffer.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
@@ -37,7 +36,7 @@ namespace JSC { namespace DFG {
 class JITFinalizer final : public Finalizer {
     WTF_MAKE_TZONE_ALLOCATED(JITFinalizer);
 public:
-    JITFinalizer(Plan&, Ref<DFG::JITCode>&&, std::unique_ptr<LinkBuffer>, CodePtr<JSEntryPtrTag> withArityCheck = CodePtr<JSEntryPtrTag>(CodePtr<JSEntryPtrTag>::EmptyValue));
+    JITFinalizer(Plan&, Ref<DFG::JITCode>&&, CodePtr<JSEntryPtrTag> withArityCheck = CodePtr<JSEntryPtrTag>(CodePtr<JSEntryPtrTag>::EmptyValue));
     ~JITFinalizer() final;
     
     size_t codeSize() final;
@@ -47,7 +46,6 @@ public:
 private:
     
     Ref<DFG::JITCode> m_jitCode;
-    std::unique_ptr<LinkBuffer> m_linkBuffer;
     CodePtr<JSEntryPtrTag> m_withArityCheck;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
@@ -238,7 +238,7 @@ uintptr_t LazyJSValue::switchLookupValue(SwitchKind kind) const
     return 0;
 }
 
-void LazyJSValue::emit(CCallHelpers& jit, JSValueRegs result) const
+void LazyJSValue::emit(CCallHelpers& jit, JSValueRegs result, Plan& planRef) const
 {
     if (m_kind == KnownValue) {
         jit.moveValue(value()->value(), result);
@@ -263,14 +263,15 @@ void LazyJSValue::emit(CCallHelpers& jit, JSValueRegs result) const
 
     CodeBlock* codeBlock = jit.codeBlock();
     
+    auto* plan = &planRef;
     jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
         auto patchLocation = linkBuffer.locationOf<JITCompilationPtrTag>(label);
-        linkBuffer.addMainThreadFinalizationTask([=] {
+        plan->addMainThreadFinalizationTask([=] {
             JSValue realValue = thisValue.getValue(codeBlock->vm());
             RELEASE_ASSERT(realValue.isCell());
 
             codeBlock->addConstant(ConcurrentJSLocker(codeBlock->m_lock), realValue);
-            
+
             if (thisValue.m_kind == NewStringImpl)
                 thisValue.u.stringImpl->deref();
 

--- a/Source/JavaScriptCore/dfg/DFGLazyJSValue.h
+++ b/Source/JavaScriptCore/dfg/DFGLazyJSValue.h
@@ -39,6 +39,7 @@ class CCallHelpers;
 namespace DFG {
 
 class Graph;
+class Plan;
 
 // Represents either a JSValue, or for JSValues that require allocation in the heap,
 // it tells you everything you'd need to know in order to allocate it.
@@ -112,7 +113,7 @@ public:
     
     uintptr_t switchLookupValue(SwitchKind) const;
 
-    void emit(CCallHelpers&, JSValueRegs) const;
+    void emit(CCallHelpers&, JSValueRegs, Plan&) const;
     
     void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
@@ -50,15 +50,7 @@ JITFinalizer::~JITFinalizer()
 
 size_t JITFinalizer::codeSize()
 {
-    size_t result = 0;
-
-    if (b3CodeLinkBuffer)
-        result += b3CodeLinkBuffer->size();
-    
-    if (entrypointLinkBuffer)
-        result += entrypointLinkBuffer->size();
-    
-    return result;
+    return m_codeSize;
 }
 
 bool JITFinalizer::finalize()
@@ -66,7 +58,7 @@ bool JITFinalizer::finalize()
     VM& vm = *m_plan.vm();
     WTF::crossModifyingCodeFence();
 
-    b3CodeLinkBuffer->runMainThreadFinalizationTasks();
+    m_plan.runMainThreadFinalizationTasks();
 
     CodeBlock* codeBlock = m_plan.codeBlock();
 

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
@@ -36,18 +36,6 @@
 
 namespace JSC { namespace FTL {
 
-class OutOfLineCodeInfo {
-public:
-    OutOfLineCodeInfo(std::unique_ptr<LinkBuffer> linkBuffer, const char* codeDescription)
-        : m_linkBuffer(WTFMove(linkBuffer))
-        , m_codeDescription(codeDescription)
-    {
-    }
-
-    std::unique_ptr<LinkBuffer> m_linkBuffer;
-    const char* m_codeDescription;
-};
-
 class JITFinalizer final : public DFG::Finalizer {
     WTF_MAKE_TZONE_ALLOCATED(JITFinalizer);
 public:
@@ -57,15 +45,11 @@ public:
     size_t codeSize() final;
     bool finalize() final;
     bool isFailed() final { return false; };
-    
-    std::unique_ptr<LinkBuffer> b3CodeLinkBuffer;
 
-    // Eventually, we can get rid of this with B3.
-    std::unique_ptr<LinkBuffer> entrypointLinkBuffer;
-    
     Vector<CCallHelpers::Jump> lazySlowPathGeneratorJumps;
     GeneratedFunction function;
     RefPtr<FTL::JITCode> jitCode;
+    size_t m_codeSize { 0 };
 };
 
 } } // namespace JSC::FTL

--- a/Source/JavaScriptCore/ftl/FTLLink.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLink.cpp
@@ -141,7 +141,7 @@ void link(State& state)
         bool dumpDisassembly = shouldDumpDisassembly() || Options::asyncDisassembly();
 
         MacroAssemblerCodeRef<JSEntryPtrTag> b3CodeRef =
-            FINALIZE_CODE_IF(dumpDisassembly, *state.finalizer->b3CodeLinkBuffer, JSEntryPtrTag, nullptr,
+            FINALIZE_CODE_IF(dumpDisassembly, *state.b3CodeLinkBuffer, JSEntryPtrTag, nullptr,
                 "FTL B3 code for %s", toCString(CodeBlockWithJITType(codeBlock, JITType::FTLJIT)).data());
 
         MacroAssemblerCodeRef<JSEntryPtrTag> arityCheckCodeRef = linkBuffer
@@ -154,7 +154,7 @@ void link(State& state)
         state.jitCode->common.m_jumpReplacements = WTFMove(state.jumpReplacements);
     }
 
-    state.finalizer->entrypointLinkBuffer = WTFMove(linkBuffer);
+    state.finalizer->m_codeSize = state.b3CodeLinkBuffer->size() + (linkBuffer ? linkBuffer->size() : 0);
     state.finalizer->function = state.generatedFunction;
     state.finalizer->jitCode = state.jitCode;
 }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1943,9 +1943,10 @@ private:
     {
         PatchpointValue* patchpoint = m_out.patchpoint(Int64);
         LazyJSValue value = m_node->lazyJSValue();
+        State* state = &m_ftlState;
         patchpoint->setGenerator(
             [=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-                value.emit(jit, JSValueRegs(params[0].gpr()));
+                value.emit(jit, JSValueRegs(params[0].gpr()), state->graph.m_plan);
             });
         patchpoint->effects = Effects::none();
         setJSValue(patchpoint);

--- a/Source/JavaScriptCore/ftl/FTLPatchpointExceptionHandle.cpp
+++ b/Source/JavaScriptCore/ftl/FTLPatchpointExceptionHandle.cpp
@@ -83,15 +83,16 @@ void PatchpointExceptionHandle::scheduleExitCreationForUnwind(
     handle->m_jitCode->m_osrExit[handle->m_index].m_exceptionHandlerCallSiteIndex = callSiteIndex;
 
     HandlerInfo handler = m_handler;
+    auto* plan = &m_state.graph.m_plan;
     params.addLatePath(
-        [handle, handler, callSiteIndex] (CCallHelpers& jit) {
+        [handle, handler, callSiteIndex, plan] (CCallHelpers& jit) {
             CodeBlock* codeBlock = jit.codeBlock();
             jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
                 HandlerInfo newHandler = handler;
                 newHandler.start = callSiteIndex.bits();
                 newHandler.end = callSiteIndex.bits() + 1;
                 newHandler.nativeCode = linkBuffer.locationOf<ExceptionHandlerPtrTag>(handle->label);
-                linkBuffer.addMainThreadFinalizationTask([=] {
+                plan->addMainThreadFinalizationTask([=] {
                     codeBlock->appendExceptionHandler(newHandler);
                 });
             });

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -80,13 +80,12 @@ State::State(Graph& graph)
     proc->setFrontendData(&graph);
 }
 
-void State::dumpDisassembly(PrintStream& out, const ScopedLambda<void(DFG::Node*)>& perDFGNodeCallback)
+void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const ScopedLambda<void(DFG::Node*)>& perDFGNodeCallback)
 {
     B3::Air::Disassembler* disassembler = proc->code().disassembler();
 
     out.print("Generated ", graph.m_plan.mode(), " code for ", CodeBlockWithJITType(graph.m_codeBlock, JITType::FTLJIT), ", instructions size = ", graph.m_codeBlock->instructionsSize(), ":\n");
 
-    LinkBuffer& linkBuffer = *finalizer->b3CodeLinkBuffer;
     B3::Value* currentB3Value = nullptr;
     Node* currentDFGNode = nullptr;
 

--- a/Source/JavaScriptCore/ftl/FTLState.h
+++ b/Source/JavaScriptCore/ftl/FTLState.h
@@ -70,7 +70,7 @@ public:
 
     VM& vm() { return graph.m_vm; }
 
-    void dumpDisassembly(PrintStream&, const ScopedLambda<void(DFG::Node*)>& perDFGNodeCallback = scopedLambda<void(DFG::Node*)>([] (DFG::Node*) { }));
+    void dumpDisassembly(PrintStream&, LinkBuffer&, const ScopedLambda<void(DFG::Node*)>& perDFGNodeCallback = scopedLambda<void(DFG::Node*)>([] (DFG::Node*) { }));
 
     StructureStubInfo* addStructureStubInfo();
     OptimizingCallLinkInfo* addCallLinkInfo(CodeOrigin);
@@ -83,6 +83,7 @@ public:
     RefPtr<FTL::JITCode> jitCode;
     GeneratedFunction generatedFunction;
     JITFinalizer* finalizer;
+    std::unique_ptr<LinkBuffer> b3CodeLinkBuffer;
     // Top-level exception handler. Jump here if you know that you have to genericUnwind() and there
     // are no applicable catch blocks anywhere in the Graph.
     RefPtr<PatchpointExceptionHandle> defaultExceptionHandle;

--- a/Source/JavaScriptCore/jit/BaselineJITPlan.h
+++ b/Source/JavaScriptCore/jit/BaselineJITPlan.h
@@ -45,9 +45,13 @@ public:
     size_t codeSize() const final;
     CompilationResult finalize() override;
 
+    CompilationPath compileSync(JITCompilationEffort);
+
 private:
+    CompilationPath compileInThreadImpl(JITCompilationEffort);
+
+
     BytecodeIndex m_loopOSREntryBytecodeIndex;
-    std::unique_ptr<LinkBuffer> m_linkBuffer;
     RefPtr<BaselineJITCode> m_jitCode;
 };
 

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -29,6 +29,7 @@
 
 #include "JIT.h"
 
+#include "BaselineJITPlan.h"
 #include "BytecodeGraph.h"
 #include "CodeBlock.h"
 #include "CodeBlockWithJITType.h"
@@ -65,8 +66,9 @@ Seconds totalFTLCompileTime;
 Seconds totalFTLDFGCompileTime;
 Seconds totalFTLB3CompileTime;
 
-JIT::JIT(VM& vm, CodeBlock* codeBlock, BytecodeIndex loopOSREntryBytecodeIndex)
+JIT::JIT(VM& vm, BaselineJITPlan& plan, CodeBlock* codeBlock, BytecodeIndex loopOSREntryBytecodeIndex)
     : JSInterfaceJIT(&vm, nullptr)
+    , m_plan(plan)
     , m_labels(codeBlock ? codeBlock->instructions().size() : 0)
     , m_pcToCodeOriginMapBuilder(vm)
     , m_canBeOptimized(false)
@@ -465,7 +467,7 @@ void JIT::privateCompileMainPass()
         }
 
         if (UNLIKELY(sizeMarker))
-            m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this);
+            m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, m_plan);
 
         if (JITInternal::verbose)
             dataLog("At ", bytecodeOffset, ": ", m_slowCases.size(), "\n");
@@ -632,7 +634,7 @@ void JIT::privateCompileSlowCases()
 
         if (UNLIKELY(sizeMarker)) {
             m_bytecodeIndex = BytecodeIndex(m_bytecodeIndex.offset() + currentInstruction->size());
-            m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this);
+            m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, m_plan);
         }
     }
 
@@ -725,7 +727,7 @@ void JIT::emitConsistencyCheck()
 }
 #endif
 
-std::tuple<std::unique_ptr<LinkBuffer>, RefPtr<BaselineJITCode>> JIT::compileAndLinkWithoutFinalizing(JITCompilationEffort effort)
+RefPtr<BaselineJITCode> JIT::compileAndLinkWithoutFinalizing(JITCompilationEffort effort)
 {
     DFG::CapabilityLevel level = m_profiledCodeBlock->capabilityLevel();
     switch (level) {
@@ -819,7 +821,7 @@ std::tuple<std::unique_ptr<LinkBuffer>, RefPtr<BaselineJITCode>> JIT::compileAnd
     RELEASE_ASSERT(!JITCode::isJIT(m_profiledCodeBlock->jitType()));
 
     if (UNLIKELY(sizeMarker))
-        m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this);
+        m_vm->jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, m_plan);
 
     privateCompileMainPass();
     privateCompileLinkPass();
@@ -877,9 +879,8 @@ std::tuple<std::unique_ptr<LinkBuffer>, RefPtr<BaselineJITCode>> JIT::compileAnd
         m_disassembler->setEndOfCode(label());
     m_pcToCodeOriginMapBuilder.appendItem(label(), PCToCodeOriginMapBuilder::defaultCodeOrigin());
 
-    auto linkBuffer = makeUnique<LinkBuffer>(*this, m_profiledCodeBlock, LinkBuffer::Profile::Baseline, effort);
-    auto jitCode = link(*linkBuffer);
-    return std::tuple { WTFMove(linkBuffer), WTFMove(jitCode) };
+    LinkBuffer linkBuffer(*this, m_profiledCodeBlock, LinkBuffer::Profile::Baseline, effort);
+    return link(linkBuffer);
 }
 
 RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
@@ -1008,14 +1009,14 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
     return jitCode;
 }
 
-CompilationResult JIT::finalizeOnMainThread(CodeBlock* codeBlock, LinkBuffer& linkBuffer, RefPtr<BaselineJITCode> jitCode)
+CompilationResult JIT::finalizeOnMainThread(CodeBlock* codeBlock, BaselineJITPlan& plan, RefPtr<BaselineJITCode> jitCode)
 {
     RELEASE_ASSERT(!isCompilationThread());
 
     if (!jitCode)
         return CompilationFailed;
 
-    linkBuffer.runMainThreadFinalizationTasks();
+    plan.runMainThreadFinalizationTasks();
 
     codeBlock->vm().machineCodeBytesPerBytecodeWordForBaselineJIT->add(
         static_cast<double>(jitCode->size()) /
@@ -1026,11 +1027,11 @@ CompilationResult JIT::finalizeOnMainThread(CodeBlock* codeBlock, LinkBuffer& li
     return CompilationSuccessful;
 }
 
-CompilationResult JIT::privateCompile(CodeBlock* codeBlock, JITCompilationEffort effort)
+CompilationResult JIT::compileSync(VM&, CodeBlock* codeBlock, JITCompilationEffort effort)
 {
-    doMainThreadPreparationBeforeCompile(vm());
-    auto [ linkBuffer, jitCode ] = compileAndLinkWithoutFinalizing(effort);
-    return JIT::finalizeOnMainThread(codeBlock, *linkBuffer, WTFMove(jitCode));
+    auto plan = adoptRef(*new BaselineJITPlan(codeBlock, BytecodeIndex(0)));
+    plan->compileSync(effort);
+    return plan->finalize();
 }
 
 void JIT::doMainThreadPreparationBeforeCompile(VM& vm)

--- a/Source/JavaScriptCore/jit/JITCode.cpp
+++ b/Source/JavaScriptCore/jit/JITCode.cpp
@@ -197,8 +197,9 @@ unsigned JITCodeWithCodeRef::offsetOf(void* pointerIntoCode)
 
 size_t JITCodeWithCodeRef::size()
 {
-    RELEASE_ASSERT(m_executableMemory);
-    return m_executableMemory->sizeInBytes();
+    if (RefPtr memory = m_executableMemory)
+        return memory->sizeInBytes();
+    return 0;
 }
 
 bool JITCodeWithCodeRef::contains(void* address)

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -254,6 +254,13 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
     }
 }
 
+void JITPlan::runMainThreadFinalizationTasks()
+{
+    auto tasks = std::exchange(m_mainThreadFinalizationTasks, { });
+    for (auto& task : tasks)
+        task->run();
+}
+
 } // namespace JSC
 
 #endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -96,6 +96,14 @@ public:
     virtual bool iterateCodeBlocksForGC(AbstractSlotVisitor&, const Function<void(CodeBlock*)>&);
     virtual bool checkLivenessAndVisitChildren(AbstractSlotVisitor&);
 
+    template<typename Functor>
+    void addMainThreadFinalizationTask(const Functor& functor)
+    {
+        m_mainThreadFinalizationTasks.append(createSharedTask<void()>(functor));
+    }
+
+    void runMainThreadFinalizationTasks();
+
 protected:
     bool computeCompileTimes() const;
     bool reportCompileTimes() const;
@@ -109,6 +117,7 @@ protected:
     VM* m_vm;
     CodeBlock* m_codeBlock;
     JITWorklistThread* m_thread { nullptr };
+    Vector<RefPtr<SharedTask<void()>>> m_mainThreadFinalizationTasks;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JITSizeStatistics.cpp
+++ b/Source/JavaScriptCore/jit/JITSizeStatistics.cpp
@@ -45,12 +45,13 @@ JITSizeStatistics::Marker JITSizeStatistics::markStart(String identifier, CCallH
     return marker;
 }
 
-void JITSizeStatistics::markEnd(Marker marker, CCallHelpers& jit)
+void JITSizeStatistics::markEnd(Marker marker, CCallHelpers& jit, JITPlan& planRef)
 {
     CCallHelpers::Label end = jit.labelIgnoringWatchpoints();
+    auto* plan = &planRef;
     jit.addLinkTask([=, this] (LinkBuffer& linkBuffer) {
         size_t size = linkBuffer.locationOf<NoPtrTag>(end).untaggedPtr<char*>() - linkBuffer.locationOf<NoPtrTag>(marker.start).untaggedPtr<char*>();
-        linkBuffer.addMainThreadFinalizationTask([=, this] {
+        plan->addMainThreadFinalizationTask([=, this] {
             auto& entry = m_data.add(marker.identifier, Entry { }).iterator->value;
             ++entry.count;
             entry.totalBytes += size;

--- a/Source/JavaScriptCore/jit/JITSizeStatistics.h
+++ b/Source/JavaScriptCore/jit/JITSizeStatistics.h
@@ -36,6 +36,8 @@
 
 namespace JSC {
 
+class JITPlan;
+
 class JITSizeStatistics {
     WTF_MAKE_TZONE_ALLOCATED(JITSizeStatistics);
 public:
@@ -45,7 +47,7 @@ public:
     };
 
     Marker markStart(String identifier, CCallHelpers&);
-    void markEnd(Marker, CCallHelpers&);
+    void markEnd(Marker, CCallHelpers&, JITPlan&);
 
     JS_EXPORT_PRIVATE void dump(PrintStream&) const;
 

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
@@ -377,7 +377,7 @@ static void setupLLInt(CodeBlock* codeBlock)
 static void setupJIT(VM& vm, CodeBlock* codeBlock)
 {
 #if ENABLE(JIT)
-    CompilationResult result = JIT::compile(vm, codeBlock, JITCompilationMustSucceed);
+    CompilationResult result = JIT::compileSync(vm, codeBlock, JITCompilationMustSucceed);
     RELEASE_ASSERT(result == CompilationSuccessful);
 #else
     UNUSED_PARAM(vm);


### PR DESCRIPTION
#### 15aaecdc0805096996f25abacbb59c509a1a6986
<pre>
[JSC] Destroy LinkBuffer in compiler thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=270503">https://bugs.webkit.org/show_bug.cgi?id=270503</a>
<a href="https://rdar.apple.com/124050058">rdar://124050058</a>

Reviewed by Keith Miller.

We are keeping LinkBuffer only because m_mainThreadFinalizationTasks exists. That&apos;s not great since LinkBuffer
destruction is relatively costly operation. So we should do it in the compiler thread instead of the main thread.
This patch moves m_mainThreadFinalizationTasks to JITPlan and run it appropriately in JITPlan so that we can destroy
LinkBuffer in the compiler thread.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::runMainThreadFinalizationTasks): Deleted.
* Source/JavaScriptCore/assembler/LinkBuffer.h:
(JSC::LinkBuffer::addMainThreadFinalizationTask): Deleted.
* Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp:
(JSC::DFG::JITFinalizer::JITFinalizer):
(JSC::DFG::JITFinalizer::codeSize):
(JSC::DFG::JITFinalizer::finalize):
* Source/JavaScriptCore/dfg/DFGJITFinalizer.h:
* Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp:
(JSC::DFG::LazyJSValue::emit const):
* Source/JavaScriptCore/dfg/DFGLazyJSValue.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileFunction):
(JSC::DFG::SpeculativeJIT::runSlowPathGenerators):
(JSC::DFG::SpeculativeJIT::compileCurrentBlock):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):
* Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp:
(JSC::FTL::JITFinalizer::codeSize):
(JSC::FTL::JITFinalizer::finalize):
* Source/JavaScriptCore/ftl/FTLJITFinalizer.h:
(JSC::FTL::OutOfLineCodeInfo::OutOfLineCodeInfo): Deleted.
* Source/JavaScriptCore/ftl/FTLLink.cpp:
(JSC::FTL::link):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileLazyJSConstant):
* Source/JavaScriptCore/ftl/FTLPatchpointExceptionHandle.cpp:
(JSC::FTL::PatchpointExceptionHandle::scheduleExitCreationForUnwind):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::dumpDisassembly):
* Source/JavaScriptCore/ftl/FTLState.h:
(JSC::FTL::State::dumpDisassembly):
* Source/JavaScriptCore/jit/BaselineJITPlan.cpp:
(JSC::BaselineJITPlan::compileInThreadImpl):
(JSC::BaselineJITPlan::compileSync):
(JSC::BaselineJITPlan::codeSize const):
(JSC::BaselineJITPlan::finalize):
* Source/JavaScriptCore/jit/BaselineJITPlan.h:
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::JIT):
(JSC::JIT::privateCompileMainPass):
(JSC::JIT::privateCompileSlowCases):
(JSC::JIT::compileAndLinkWithoutFinalizing):
(JSC::JIT::finalizeOnMainThread):
(JSC::JIT::compileSync):
(JSC::JIT::privateCompile): Deleted.
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITCode.cpp:
(JSC::JITCodeWithCodeRef::size):
* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::runMainThreadFinalizationTasks):
* Source/JavaScriptCore/jit/JITPlan.h:
(JSC::JITPlan::addMainThreadFinalizationTask):
* Source/JavaScriptCore/jit/JITSizeStatistics.cpp:
(JSC::JITSizeStatistics::markEnd):
* Source/JavaScriptCore/jit/JITSizeStatistics.h:
* Source/JavaScriptCore/runtime/ScriptExecutable.cpp:
(JSC::setupJIT):

Canonical link: <a href="https://commits.webkit.org/275696@main">https://commits.webkit.org/275696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c09ead669d410202d3eaa3d5dae4a79d66e00708

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38627 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35192 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16138 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37642 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/563 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/35964 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38712 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46588 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42135 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41879 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18943 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40487 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19007 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49144 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5744 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18588 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9953 "Passed tests") | 
<!--EWS-Status-Bubble-End-->