### PR TITLE
Guide outside contributors to use run-minibrowser rather than run-safari

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -112,15 +112,21 @@ For building WebKit on Windows, see the [WebKit on Windows page](https://webkit.
 
 ## Running WebKit
 
-### With Safari and Other macOS Applications
+### With MiniBrowser/Safari or Other macOS Applications
 
-Run the following command to launch Safari with your local build of WebKit:
+Run the following command to launch the MiniBrowser (simple browser shell) with your local build of WebKit:
+
+```
+Tools/Scripts/run-minibrowser --debug
+```
+
+If you're building with the Apple Internal SDK, run the following to launch Safari with your local build of WebKit:
 
 ```
 Tools/Scripts/run-safari --debug
 ```
 
-The `run-safari` script sets the `DYLD_FRAMEWORK_PATH` environment variable to point to your build products, and then launches `/Applications/Safari.app`. `DYLD_FRAMEWORK_PATH` tells the system loader to prefer your build products over the frameworks installed in `/System/Library/Frameworks`.
+The `run-minibrowser` and `run-safari` scripts set the `DYLD_FRAMEWORK_PATH` environment variable to point to your build products, and then launch `WebKitBuild/Debug/MiniBrowser.app` or `/Applications/Safari.app`. `DYLD_FRAMEWORK_PATH` tells the system loader to prefer your build products over the frameworks installed in `/System/Library/Frameworks`.
 
 To run other applications with your local build of WebKit, run the following command:
 
@@ -140,13 +146,11 @@ In both cases, if you have built release builds instead, use `--release` instead
 
 ### Linux Ports
 
-If you have a development build, you can use the `run-minibrowser` script, e.g.:
+If you have a development build, run the `run-minibrowser` script with one of `--gtk`, `--jsc-only`, or `--wpe` to indicate the port to use; e.g.:
 
 ```
-run-minibrowser --debug --wpe
+Tools/Scripts/run-minibrowser --debug --wpe
 ```
-
-Pass one of `--gtk`, `--jsc-only`, or `--wpe` to indicate the port to use.
 
 ## Contribute
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2148,23 +2148,27 @@ sub relativeScriptsDir()
 
 sub launcherPath()
 {
+    return if !isGtk() && !isWPE() && !isAppleMacWebKit();
     my $relativeScriptsPath = relativeScriptsDir();
-    if (isGtk() || isWPE()) {
+    chomp(my $developerDirectory = $ENV{DEVELOPER_DIR} || `xcode-select --print-path`);
+    if (-d File::Spec->catdir("$developerDirectory", "AppleInternal")) {
+        return "$relativeScriptsPath/run-safari";
+    } else {
         if (inFlatpakSandbox()) {
             return "Tools/Scripts/run-minibrowser";
         }
         return "$relativeScriptsPath/run-minibrowser";
-    } elsif (isAppleWebKit()) {
-        return "$relativeScriptsPath/run-safari";
     }
 }
 
 sub launcherName()
 {
-    if (isGtk() || isWPE()) {
-        return "MiniBrowser";
-    } elsif (isAppleMacWebKit()) {
+    return if !isGtk() && !isWPE() && !isAppleMacWebKit();
+    chomp(my $developerDirectory = $ENV{DEVELOPER_DIR} || `xcode-select --print-path`);
+    if (-d File::Spec->catdir("$developerDirectory", "AppleInternal")) {
         return "Safari";
+    } else {
+        return "MiniBrowser";
     }
 }
 


### PR DESCRIPTION
#### 891b62f5f03e657fd5eee7a9d2b65b6d7ff4a6e2
<pre>
Guide outside contributors to use run-minibrowser rather than run-safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=270507">https://bugs.webkit.org/show_bug.cgi?id=270507</a>

Reviewed by NOBODY (OOPS!).

This change updates the build-webkit script and the repo Readme.md file to
guide all outside/non-Apple contributors — even those building on macOS —
to use the run-minibrowser script, rather than the run-safari script.

Otherwise, without this change, outside contributors on macOS are guided to
the run-safari script — and they try it but find it doesn’t work expected,
and can end up wasting a lot of time trying to find what they’ve done wrong.

* ReadMe.md:
* Tools/Scripts/webkitdirs.pm:
(launcherPath):
(launcherName):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/891b62f5f03e657fd5eee7a9d2b65b6d7ff4a6e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132723 "Failed to checkout and rebase branch from PR 25476") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44934 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140252 "Failed to checkout and rebase branch from PR 25476") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84750 "Failed to checkout and rebase branch from PR 25476") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134593 "Failed to checkout and rebase branch from PR 25476") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18921 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35215 "Failure limit exceed. At least found 148 new test failures: accessibility/math-multiscript-attributes.html, animations/keyframe-em-unit.html, animations/keyframe-pseudo-shadow.html, animations/multiple-backgrounds.html, compositing/canvas/accelerated-canvas-compositing-size-limit.html, compositing/parent-clipping-layer-on-subpixel-position.html, compositing/tiling/sticky-change-to-tiled.html, css1/font_properties/font.html, css1/formatting_model/inline_elements.html, css1/pseudo/multiple_pseudo_elements.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/84750 "Failed to checkout and rebase branch from PR 25476") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135669 "Failed to checkout and rebase branch from PR 25476") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16163 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83486 "Failed to checkout and rebase branch from PR 25476") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124793 "Failed to checkout and rebase branch from PR 25476") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37671 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142908 "Failed to checkout and rebase branch from PR 25476") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131231 "Failed to checkout and rebase branch from PR 25476") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4888 "Failed to checkout and rebase branch from PR 25476") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41907 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4970 "Failed to checkout and rebase branch from PR 25476") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40519 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58370 "Failed to checkout and rebase branch from PR 25476") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17355 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164198 "Failed to checkout and rebase branch from PR 25476") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18973 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9967 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->