### PR TITLE
[GTK] Make it possible to build with Skia instead of Cairo

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -70,7 +70,7 @@
 #define USE_GLIB 1
 #endif
 
-#if PLATFORM(GTK) || (PLATFORM(WPE) && !USE(SKIA))
+#if ((PLATFORM(GTK) || PLATFORM(WPE)) && !USE(SKIA))
 #define USE_FREETYPE 1
 #endif
 

--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -1,11 +1,16 @@
 include(platform/Adwaita.cmake)
-include(platform/Cairo.cmake)
-include(platform/FreeType.cmake)
 include(platform/GCrypt.cmake)
 include(platform/GStreamer.cmake)
 include(platform/ImageDecoders.cmake)
 include(platform/Soup.cmake)
 include(platform/TextureMapper.cmake)
+
+if (USE_CAIRO)
+    include(platform/Cairo.cmake)
+    include(platform/FreeType.cmake)
+elseif (USE_SKIA)
+    include(platform/Skia.cmake)
+endif ()
 
 list(APPEND WebCore_UNIFIED_SOURCE_LIST_FILES
     "SourcesGTK.txt"
@@ -119,6 +124,20 @@ if (ENABLE_SPEECH_SYNTHESIS)
     )
     list(APPEND WebCore_LIBRARIES
         ${Flite_LIBRARIES}
+    )
+endif ()
+
+if (USE_SKIA)
+    # When building with Skia we don't build Cairo sources, but since
+    # Cairo is still needed in the UI process API we need to include
+    # here the Cairo sources required.
+    list(APPEND WebCore_SOURCES
+        platform/graphics/cairo/IntRectCairo.cpp
+        platform/graphics/cairo/RefPtrCairo.cpp
+    )
+
+    list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/graphics/cairo/RefPtrCairo.h
     )
 endif ()
 

--- a/Source/WebCore/platform/DragImage.h
+++ b/Source/WebCore/platform/DragImage.h
@@ -43,6 +43,8 @@ OBJC_CLASS NSImage;
 typedef struct HBITMAP__* HBITMAP;
 #elif USE(CAIRO)
 #include "RefPtrCairo.h"
+#elif USE(SKIA)
+#include <skia/core/SkImage.h>
 #endif
 
 namespace WebCore {
@@ -61,6 +63,8 @@ typedef RetainPtr<NSImage> DragImageRef;
 typedef HBITMAP DragImageRef;
 #elif USE(CAIRO)
 typedef RefPtr<cairo_surface_t> DragImageRef;
+#elif USE(SKIA)
+typedef sk_sp<SkImage> DragImageRef;
 #else
 typedef void* DragImageRef;
 #endif

--- a/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
@@ -354,7 +354,7 @@ ScrollbarButtonPressAction ScrollbarThemeAdwaita::handleMousePressEvent(Scrollba
     return ScrollbarButtonPressAction::None;
 }
 
-#if !PLATFORM(GTK) || USE(GTK4)
+#if !PLATFORM(GTK) || USE(GTK4) || USE(SKIA)
 ScrollbarTheme& ScrollbarTheme::nativeTheme()
 {
     static ScrollbarThemeAdwaita theme;

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -50,7 +50,7 @@ typedef struct _NSRect NSRect;
 typedef struct tagRECT RECT;
 #endif
 
-#if USE(CAIRO)
+#if USE(CAIRO) || PLATFORM(GTK)
 typedef struct _cairo_rectangle_int cairo_rectangle_int_t;
 #endif
 
@@ -198,7 +198,7 @@ public:
     WEBCORE_EXPORT operator RECT() const;
 #endif
 
-#if USE(CAIRO)
+#if USE(CAIRO) || PLATFORM(GTK)
     IntRect(const cairo_rectangle_int_t&);
     operator cairo_rectangle_int_t() const;
 #endif

--- a/Source/WebCore/platform/graphics/cairo/IntRectCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/IntRectCairo.cpp
@@ -21,7 +21,7 @@
 #include "config.h"
 #include "IntRect.h"
 
-#if USE(CAIRO)
+#if USE(CAIRO) || PLATFORM(GTK)
 
 #include <cairo.h>
 
@@ -41,4 +41,4 @@ IntRect::operator cairo_rectangle_int_t() const
 
 } // namespace WebCore
 
-#endif // USE(CAIRO)
+#endif // USE(CAIRO) || PLATFORM(GTK)

--- a/Source/WebCore/platform/graphics/cairo/RefPtrCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/RefPtrCairo.cpp
@@ -19,7 +19,7 @@
 #include "config.h"
 #include "RefPtrCairo.h"
 
-#if USE(CAIRO)
+#if USE(CAIRO) || PLATFORM(GTK)
 
 #include <cairo.h>
 
@@ -105,4 +105,4 @@ void DefaultRefDerefTraits<cairo_region_t>::derefIfNotNull(cairo_region_t* ptr)
 
 } // namespace WTF
 
-#endif // USE(CAIRO)
+#endif // USE(CAIRO) || PLATFORM(GTK)

--- a/Source/WebCore/platform/graphics/cairo/RefPtrCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/RefPtrCairo.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#if USE(CAIRO)
+#if USE(CAIRO) || PLATFORM(GTK)
 
 #include <wtf/RefPtr.h>
 
@@ -70,4 +70,4 @@ struct DefaultRefDerefTraits<cairo_region_t> {
 
 } // namespace WTF
 
-#endif // USE(CAIRO)
+#endif // USE(CAIRO) || PLATFORM(GTK)

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
@@ -23,6 +23,7 @@
 #if ENABLE(VIDEO) && USE(GSTREAMER) && USE(SKIA)
 
 #include "GStreamerCommon.h"
+#include "NotImplemented.h"
 #include <gst/gst.h>
 #include <gst/video/gstvideometa.h>
 #include <skia/core/SkImage.h>

--- a/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "GdkCairoUtilities.h"
 
+#if USE(CAIRO)
+
 #include "CairoUtilities.h"
 #include "IntSize.h"
 #include <cairo.h>
@@ -60,3 +62,5 @@ GRefPtr<GdkTexture> cairoSurfaceToGdkTexture(cairo_surface_t* surface)
 #endif
 
 } // namespace WebCore
+
+#endif // #if USE(CAIRO)

--- a/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h
+++ b/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(CAIRO)
+
 #include <wtf/glib/GRefPtr.h>
 
 #if USE(GTK4)
@@ -38,3 +40,5 @@ GRefPtr<GdkPixbuf> cairoSurfaceToGdkPixbuf(cairo_surface_t*);
 GRefPtr<GdkTexture> cairoSurfaceToGdkTexture(cairo_surface_t*);
 #endif
 }
+
+#endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp
@@ -28,6 +28,7 @@
 
 #include "BitmapImage.h"
 #include "GdkCairoUtilities.h"
+#include "NotImplemented.h"
 #include "SharedBuffer.h"
 #include <cairo.h>
 #include <gdk/gdk.h>
@@ -60,8 +61,13 @@ GRefPtr<GdkPixbuf> ImageAdapter::gdkPixbuf()
     if (!nativeImage)
         return nullptr;
 
+#if USE(CAIRO)
     auto& surface = nativeImage->platformImage();
     return cairoSurfaceToGdkPixbuf(surface.get());
+#elif USE(SKIA)
+    notImplemented();
+    return nullptr;
+#endif
 }
 
 #if USE(GTK4)
@@ -71,8 +77,13 @@ GRefPtr<GdkTexture> ImageAdapter::gdkTexture()
     if (!nativeImage)
         return nullptr;
 
+#if USE(CAIRO)
     auto& surface = nativeImage->platformImage();
     return cairoSurfaceToGdkTexture(surface.get());
+#elif USE(SKIA)
+    notImplemented();
+    return nullptr;
+#endif
 }
 #endif
 

--- a/Source/WebCore/platform/gtk/CursorGtk.cpp
+++ b/Source/WebCore/platform/gtk/CursorGtk.cpp
@@ -31,6 +31,7 @@
 
 #include "Image.h"
 #include "IntPoint.h"
+#include "NotImplemented.h"
 #include <gdk/gdk.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -67,9 +68,15 @@ static GRefPtr<GdkCursor> createCustomCursor(Image* image, const IntPoint& hotSp
     if (!nativeImage)
         return nullptr;
 
+#if USE(CAIRO)
     auto& surface = nativeImage->platformImage();
     IntPoint effectiveHotSpot = determineHotSpot(image, hotSpot);
     return adoptGRef(gdk_cursor_new_from_surface(gdk_display_get_default(), surface.get(), effectiveHotSpot.x(), effectiveHotSpot.y()));
+#elif USE(SKIA)
+    UNUSED_PARAM(hotSpot);
+    notImplemented();
+    return nullptr;
+#endif
 #endif // USE(GTK4)
 }
 

--- a/Source/WebCore/platform/gtk/DragImageGtk.cpp
+++ b/Source/WebCore/platform/gtk/DragImageGtk.cpp
@@ -21,6 +21,7 @@
 
 #include "Element.h"
 #include "Image.h"
+#include "NotImplemented.h"
 #include "TextFlags.h"
 #include "TextIndicator.h"
 #include <cairo.h>
@@ -31,8 +32,13 @@ namespace WebCore {
 
 IntSize dragImageSize(DragImageRef image)
 {
+#if USE(CAIRO)
     if (image)
         return { cairo_image_surface_get_width(image.get()), cairo_image_surface_get_height(image.get()) };
+#elif USE(SKIA)
+    notImplemented();
+    UNUSED_PARAM(image);
+#endif
 
     return { 0, 0 };
 }
@@ -54,6 +60,7 @@ DragImageRef scaleDragImage(DragImageRef image, FloatSize scale)
     if (imageSize == scaledSize)
         return image;
 
+#if USE(CAIRO)
     RefPtr<cairo_surface_t> scaledSurface = adoptRef(cairo_surface_create_similar(image.get(), CAIRO_CONTENT_COLOR_ALPHA, scaledSize.width(), scaledSize.height()));
 
     RefPtr<cairo_t> context = adoptRef(cairo_create(scaledSurface.get()));
@@ -65,6 +72,10 @@ DragImageRef scaleDragImage(DragImageRef image, FloatSize scale)
     cairo_paint(context.get());
 
     return scaledSurface;
+#elif USE(SKIA)
+    notImplemented();
+    return nullptr;
+#endif
 }
 
 DragImageRef dissolveDragImageToFraction(DragImageRef image, float fraction)
@@ -77,10 +88,15 @@ DragImageRef dissolveDragImageToFraction(DragImageRef image, float fraction)
         return image;
 #endif
 
+#if USE(CAIRO)
     RefPtr<cairo_t> context = adoptRef(cairo_create(image.get()));
     cairo_set_operator(context.get(), CAIRO_OPERATOR_DEST_IN);
     cairo_set_source_rgba(context.get(), 0, 0, 0, fraction);
     cairo_paint(context.get());
+#elif USE(SKIA)
+    notImplemented();
+    UNUSED_PARAM(fraction);
+#endif
     return image;
 }
 

--- a/Source/WebCore/platform/gtk/RenderThemeGadget.cpp
+++ b/Source/WebCore/platform/gtk/RenderThemeGadget.cpp
@@ -27,7 +27,7 @@
 #include "config.h"
 #include "RenderThemeGadget.h"
 
-#if !USE(GTK4)
+#if !USE(GTK4) && USE(CAIRO)
 
 #include "FloatRect.h"
 #include "GRefPtrGtk.h"
@@ -259,4 +259,4 @@ void RenderThemeScrollbarGadget::renderStepper(cairo_t* cr, const FloatRect& pai
 
 } // namespace WebCore
 
-#endif // !USE(GTK4)
+#endif // !USE(GTK4) && USE(CAIRO)

--- a/Source/WebCore/platform/gtk/RenderThemeGadget.h
+++ b/Source/WebCore/platform/gtk/RenderThemeGadget.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if !USE(GTK4)
+#if !USE(GTK4) && USE(CAIRO)
 
 #include "Color.h"
 #include "IntSize.h"
@@ -112,4 +112,4 @@ private:
 
 } // namespace WebCore
 
-#endif // !USE(GTK4)
+#endif // !USE(GTK4) && USE(CAIRO)

--- a/Source/WebCore/platform/gtk/RenderThemeScrollbar.cpp
+++ b/Source/WebCore/platform/gtk/RenderThemeScrollbar.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "RenderThemeScrollbar.h"
 
-#if !USE(GTK4)
+#if !USE(GTK4) && USE(CAIRO)
 
 #include "GtkUtilities.h"
 #include <wtf/HashMap.h>
@@ -135,4 +135,4 @@ RenderThemeGadget* RenderThemeScrollbar::stepper(RenderThemeScrollbarGadget::Ste
 
 } // namespace WebCore
 
-#endif // !USE(GTK4)
+#endif // !USE(GTK4) && USE(CAIRO)

--- a/Source/WebCore/platform/gtk/RenderThemeScrollbar.h
+++ b/Source/WebCore/platform/gtk/RenderThemeScrollbar.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if !USE(GTK4)
+#if !USE(GTK4) && USE(CAIRO)
 
 #include "RenderThemeGadget.h"
 #include <gtk/gtk.h>
@@ -68,4 +68,4 @@ private:
 
 } // namespace WebCore
 
-#endif // !USE(GTK4)
+#endif // !USE(GTK4) && USE(CAIRO)

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
@@ -27,7 +27,7 @@
 #include "config.h"
 #include "ScrollbarThemeGtk.h"
 
-#if !USE(GTK4)
+#if !USE(GTK4) && USE(CAIRO)
 
 #include "GRefPtrGtk.h"
 #include "GraphicsContextCairo.h"
@@ -552,4 +552,4 @@ int ScrollbarThemeGtk::minimumThumbLength(Scrollbar& scrollbar)
 
 } // namespace WebCore
 
-#endif // !USE(GTK4)
+#endif // !USE(GTK4) && USE(CAIRO)

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.h
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if !USE(GTK4)
+#if !USE(GTK4) && USE(CAIRO)
 
 #include "ScrollbarThemeAdwaita.h"
 
@@ -61,4 +61,4 @@ private:
 
 } // namespace WebCore
 
-#endif // !USE(GTK4)
+#endif // !USE(GTK4) && USE(CAIRO)

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -103,6 +103,8 @@ Shared/linux/WebMemorySamplerLinux.cpp
 Shared/soup/WebCoreArgumentCodersSoup.cpp
 Shared/soup/WebErrorsSoup.cpp
 
+Shared/skia/WebCoreArgumentCodersSkia.cpp
+
 Shared/unix/AuxiliaryProcessMain.cpp
 
 UIProcess/DefaultUndoController.cpp

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
@@ -66,7 +66,7 @@ Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::copy()
     copy->m_usesWebProcessCache = this->m_usesWebProcessCache;
     copy->m_usesBackForwardCache = this->m_usesBackForwardCache;
     copy->m_usesSingleWebProcess = m_usesSingleWebProcess;
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4) && USE(CAIRO)
     copy->m_useSystemAppearanceForScrollbars = m_useSystemAppearanceForScrollbars;
 #endif
 #if PLATFORM(PLAYSTATION)

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
@@ -131,7 +131,7 @@ public:
     bool processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol() const { return m_processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol; }
     void setProcessSwapsOnNavigationWithinSameNonHTTPFamilyProtocol(bool swaps) { m_processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = swaps; }
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4) && USE(CAIRO)
     bool useSystemAppearanceForScrollbars() const { return m_useSystemAppearanceForScrollbars; }
     void setUseSystemAppearanceForScrollbars(bool useSystemAppearanceForScrollbars) { m_useSystemAppearanceForScrollbars = useSystemAppearanceForScrollbars; }
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
@@ -31,6 +31,7 @@
 #include "WebKitWebViewBasePrivate.h"
 #include <WebCore/GRefPtrGtk.h>
 #include <WebCore/GtkUtilities.h>
+#include <WebCore/NotImplemented.h>
 #include <WebCore/PasteboardCustomData.h>
 #include <gtk/gtk.h>
 
@@ -139,9 +140,14 @@ void DragSource::begin(SelectionData&& selectionData, OptionSet<DragOperation> o
 
     m_drag = gtk_drag_begin_with_coordinates(m_webView, list.get(), dragOperationToGdkDragActions(operationMask), GDK_BUTTON_PRIMARY, nullptr, -1, -1);
     if (image) {
+#if USE(CAIRO)
         RefPtr<cairo_surface_t> imageSurface(image->createCairoSurface());
         cairo_surface_set_device_offset(imageSurface.get(), -imageHotspot.x(), -imageHotspot.y());
         gtk_drag_set_icon_surface(m_drag.get(), imageSurface.get());
+#elif USE(SKIA)
+        notImplemented();
+        gtk_drag_set_icon_default(m_drag.get());
+#endif
     } else
         gtk_drag_set_icon_default(m_drag.get());
 }

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -46,7 +46,6 @@
 #include "WebKitWebViewPrivate.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
-#include <WebCore/CairoUtilities.h>
 #include <WebCore/Cursor.h>
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/EventNames.h>
@@ -64,6 +63,10 @@
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 #include "WebDateTimePickerGtk.h"
+#endif
+
+#if USE(CAIRO)
+#include <WebCore/CairoUtilities.h>
 #endif
 
 namespace WebKit {
@@ -95,7 +98,13 @@ void PageClientImpl::setViewNeedsDisplay(const WebCore::Region& region)
         return;
     }
 
+#if USE(CAIRO)
     gtk_widget_queue_draw_region(m_viewWidget, toCairoRegion(region).get());
+#else
+    // FIXME: use gtk_widget_queue_draw_region() too.
+    gtk_widget_queue_draw(m_viewWidget);
+    UNUSED_PARAM(region);
+#endif
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -63,7 +63,6 @@
 #include "WebProcessPool.h"
 #include "WebUserContentControllerProxy.h"
 #include <WebCore/ActivityState.h>
-#include <WebCore/CairoUtilities.h>
 #include <WebCore/GRefPtrGtk.h>
 #include <WebCore/GUniquePtrGtk.h>
 #include <WebCore/GtkUtilities.h>

--- a/Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
+++ b/Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WebAutomationSession.h"
 
+#if USE(CAIRO)
+
 #include "ViewSnapshotStore.h"
 #include <WebCore/RefPtrCairo.h>
 #include <cairo.h>
@@ -73,3 +75,4 @@ std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(cons
 
 } // namespace WebKit
 
+#endif // USE(CAIRO)

--- a/Source/WebKit/UIProcess/BackingStore.h
+++ b/Source/WebKit/UIProcess/BackingStore.h
@@ -25,12 +25,16 @@
 
 #pragma once
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
 
 #include <WebCore/IntSize.h>
 #include <WebCore/PlatformImage.h>
 #include <pal/HysteresisActivity.h>
 #include <wtf/Noncopyable.h>
+
+#if USE(CAIRO) || PLATFORM(GTK)
+#include <WebCore/RefPtrCairo.h>
+#endif
 
 namespace WebCore {
 class IntRect;
@@ -39,7 +43,8 @@ class IntRect;
 namespace WebKit {
 struct UpdateInfo;
 
-#if USE(CAIRO)
+#if USE(CAIRO) || PLATFORM(GTK)
+typedef struct _cairo cairo_t;
 using PlatformPaintContextPtr = cairo_t*;
 #elif USE(SKIA)
 using PlatformPaintContextPtr = void*;
@@ -63,11 +68,16 @@ private:
 
     WebCore::IntSize m_size;
     float m_deviceScaleFactor { 1 };
+#if PLATFORM(GTK)
+    RefPtr<cairo_surface_t> m_surface;
+    RefPtr<cairo_surface_t> m_scrollSurface;
+#else
     WebCore::PlatformImagePtr m_surface;
     WebCore::PlatformImagePtr m_scrollSurface;
+#endif
     PAL::HysteresisActivity m_scrolledHysteresis;
 };
 
 } // namespace WebKit
 
-#endif // USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#endif // !PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -53,11 +53,11 @@ using namespace WebCore;
 
 DrawingAreaProxyCoordinatedGraphics::DrawingAreaProxyCoordinatedGraphics(WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(DrawingAreaType::CoordinatedGraphics, webPageProxy, webProcessProxy)
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
     , m_discardBackingStoreTimer(RunLoop::current(), this, &DrawingAreaProxyCoordinatedGraphics::discardBackingStore)
 #endif
 {
-#if USE(GLIB_EVENT_LOOP) && (USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE)))
+#if USE(GLIB_EVENT_LOOP) && !PLATFORM(WPE)
     m_discardBackingStoreTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
 #endif
 }
@@ -69,7 +69,7 @@ DrawingAreaProxyCoordinatedGraphics::~DrawingAreaProxyCoordinatedGraphics()
         exitAcceleratedCompositingMode();
 }
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
 void DrawingAreaProxyCoordinatedGraphics::paint(PlatformPaintContextPtr cr, const IntRect& rect, Region& unpaintedRegion)
 {
     unpaintedRegion = rect;
@@ -162,7 +162,7 @@ void DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange()
 
 void DrawingAreaProxyCoordinatedGraphics::setBackingStoreIsDiscardable(bool isBackingStoreDiscardable)
 {
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
     if (m_isBackingStoreDiscardable == isBackingStoreDiscardable)
         return;
 
@@ -195,7 +195,7 @@ void DrawingAreaProxyCoordinatedGraphics::update(uint64_t, UpdateInfo&& updateIn
 
     // FIXME: Handle the case where the view is hidden.
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
     incorporateUpdate(WTFMove(updateInfo));
 #endif
 
@@ -211,7 +211,7 @@ void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(uint64
 void DrawingAreaProxyCoordinatedGraphics::exitAcceleratedCompositingMode(uint64_t, UpdateInfo&& updateInfo)
 {
     exitAcceleratedCompositingMode();
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
     incorporateUpdate(WTFMove(updateInfo));
 #endif
 }
@@ -229,7 +229,7 @@ bool DrawingAreaProxyCoordinatedGraphics::alwaysUseCompositing() const
 void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)
 {
     ASSERT(!isInAcceleratedCompositingMode());
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
     m_backingStore = nullptr;
 #endif
     m_layerTreeContext = layerTreeContext;
@@ -277,7 +277,7 @@ void DrawingAreaProxyCoordinatedGraphics::didUpdateGeometry()
         sendUpdateGeometry();
 }
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
 void DrawingAreaProxyCoordinatedGraphics::discardBackingStoreSoon()
 {
     if (!m_backingStore || !m_isBackingStoreDiscardable || m_discardBackingStoreTimer.isActive())

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -31,7 +31,7 @@
 #include "LayerTreeContext.h"
 #include <wtf/RunLoop.h>
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
 #include "BackingStore.h"
 #endif
 
@@ -46,7 +46,7 @@ public:
     DrawingAreaProxyCoordinatedGraphics(WebPageProxy&, WebProcessProxy&);
     virtual ~DrawingAreaProxyCoordinatedGraphics();
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
     void paint(PlatformPaintContextPtr, const WebCore::IntRect&, WebCore::Region& unpaintedRegion);
 #endif
 
@@ -86,7 +86,7 @@ private:
     void sendUpdateGeometry();
     void didUpdateGeometry();
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
     bool forceUpdateIfNeeded();
     void incorporateUpdate(UpdateInfo&&);
     void discardBackingStoreSoon();
@@ -118,7 +118,7 @@ private:
     WebCore::IntSize m_lastSentSize;
 
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if !PLATFORM(WPE)
     bool m_isBackingStoreDiscardable { true };
     bool m_inForceUpdate { false };
     std::unique_ptr<BackingStore> m_backingStore;

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -47,8 +47,6 @@
 
 #if USE(GTK4)
 #include <WebCore/GRefPtrGtk.h>
-#else
-#include <WebCore/CairoUtilities.h>
 #endif
 #endif
 

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -127,7 +127,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     parameters.gstreamerOptions = WebCore::extractGStreamerOptionsFromCommandLine();
 #endif
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4) && USE(CAIRO)
     parameters.useSystemAppearanceForScrollbars = m_configuration->useSystemAppearanceForScrollbars();
 #endif
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -36,6 +36,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/GLContext.h>
 #include <WebCore/IntRect.h>
+#include <WebCore/NotImplemented.h>
 #include <WebCore/PlatformDisplay.h>
 #include <WebCore/ShareableBitmap.h>
 #include <WebCore/SharedMemory.h>
@@ -374,8 +375,12 @@ AcceleratedBackingStoreDMABuf::BufferSHM::BufferSHM(uint64_t id, RefPtr<WebCore:
 
 void AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents()
 {
+#if USE(CAIRO)
     m_surface = m_bitmap->createCairoSurface();
     cairo_surface_set_device_scale(m_surface.get(), m_deviceScaleFactor, m_deviceScaleFactor);
+#elif USE(SKIA)
+    notImplemented();
+#endif
 }
 
 #if USE(GTK4)

--- a/Source/WebKit/UIProcess/gtk/ViewSnapshotStoreGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewSnapshotStoreGtk3.cpp
@@ -28,7 +28,7 @@
 
 #if !USE(GTK4)
 
-#include <WebCore/CairoUtilities.h>
+#include <cairo.h>
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h
@@ -26,11 +26,14 @@
 #pragma once
 
 #include "PrintInfo.h"
-#include <WebCore/RefPtrCairo.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/glib/GRefPtr.h>
+
+#if USE(CAIRO)
+#include <WebCore/RefPtrCairo.h>
+#endif
 
 typedef struct _GtkPrintSettings GtkPrintSettings;
 typedef struct _GtkPageSetup GtkPageSetup;
@@ -52,9 +55,11 @@ public:
     void startPrint(WebCore::PrintContext*, CompletionHandler<void(RefPtr<WebCore::FragmentedSharedBuffer>&&, WebCore::ResourceError&&)>&&);
 
 private:
+#if USE(CAIRO)
     void startPage(cairo_t*);
     void endPage(cairo_t*);
     void endPrint(cairo_t*);
+#endif
 
     struct PrintPagesData {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -91,7 +96,9 @@ private:
     int pageCount() const;
     bool currentPageIsFirstPageOfSheet() const;
     bool currentPageIsLastPageOfSheet() const;
+#if USE(CAIRO)
     void print(cairo_surface_t*, double xDPI, double yDPI);
+#endif
     void renderPage(int pageNumber);
     void rotatePageIfNeeded();
     void getRowsAndColumnsOfPagesPerSheet(size_t& rows, size_t& columns);
@@ -106,10 +113,13 @@ private:
     PrintInfo::PrintMode m_printMode { PrintInfo::PrintMode::Async };
     WebCore::PrintContext* m_printContext { nullptr };
     CompletionHandler<void(RefPtr<WebCore::FragmentedSharedBuffer>&&, WebCore::ResourceError&&)> m_completionHandler;
-    RefPtr<cairo_t> m_cairoContext;
     WebCore::SharedBufferBuilder m_buffer;
     double m_xDPI { 1 };
     double m_yDPI { 1 };
+
+#if USE(CAIRO)
+    RefPtr<cairo_t> m_cairoContext;
+#endif
 
     unsigned m_printPagesIdleId { 0 };
     size_t m_numberOfPagesToPrint { 0 };

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -666,7 +666,7 @@ private:
     void sendMessageToWebProcessExtension(UserMessage&&);
 #endif
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4) && USE(CAIRO)
     void setUseSystemAppearanceForScrollbars(bool);
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -186,7 +186,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
     PowerSourceDidChange(bool hasAC)
 #endif
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4) && USE(CAIRO)
     SetUseSystemAppearanceForScrollbars(bool useSystemAppearanceForScrollbars)
 #endif
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -61,7 +61,7 @@
 #include <WebCore/PlatformDisplaySurfaceless.h>
 #endif
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4) && USE(CAIRO)
 #include <WebCore/ScrollbarThemeGtk.h>
 #endif
 
@@ -173,7 +173,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     WebCore::setGStreamerOptionsFromUIProcess(WTFMove(parameters.gstreamerOptions));
 #endif
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4) && USE(CAIRO)
     setUseSystemAppearanceForScrollbars(parameters.useSystemAppearanceForScrollbars);
 #endif
 
@@ -228,7 +228,7 @@ void WebProcess::sendMessageToWebProcessExtension(UserMessage&& message)
         webkitWebProcessExtensionDidReceiveUserMessage(extension, WTFMove(message));
 }
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !USE(GTK4) && USE(CAIRO)
 void WebProcess::setUseSystemAppearanceForScrollbars(bool useSystemAppearanceForScrollbars)
 {
     static_cast<ScrollbarThemeGtk&>(ScrollbarTheme::theme()).setUseSystemAppearance(useSystemAppearanceForScrollbars);

--- a/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp
+++ b/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp
@@ -28,9 +28,13 @@
 
 #include "GtkSettingsManagerProxyMessages.h"
 #include "WebProcess.h"
-#include <WebCore/CairoUtilities.h>
+#include <WebCore/NotImplemented.h>
 #include <WebCore/Page.h>
 #include <WebCore/RenderTheme.h>
+
+#if USE(CAIRO)
+#include <WebCore/CairoUtilities.h>
+#endif
 
 namespace WebKit {
 using namespace WebCore;
@@ -114,6 +118,7 @@ void GtkSettingsManagerProxy::applySettings(GtkSettingsState&& state)
 
 void GtkSettingsManagerProxy::applyHintingSettings()
 {
+#if USE(CAIRO)
     gint hinting;
     GUniqueOutPtr<char> hintStyleString;
     
@@ -144,10 +149,14 @@ void GtkSettingsManagerProxy::applyHintingSettings()
     }
 
     setDefaultCairoHintOptions(hintMetrics, hintStyle);
+#elif USE(SKIA)
+    notImplemented();
+#endif
 }
 
 void GtkSettingsManagerProxy::applyAntialiasSettings()
 {
+#if USE(CAIRO)
     gint antialias;
     GUniqueOutPtr<char> rgbaString;
 
@@ -182,6 +191,9 @@ void GtkSettingsManagerProxy::applyAntialiasSettings()
     }
 
     setDefaultCairoAntialiasOptions(antialiasMode, subpixelOrder);
+#elif USE(SKIA)
+    notImplemented();
+#endif
 }
 
 } // namespace WebKit

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -14,8 +14,6 @@ endif ()
 set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
 
 find_package(Cairo 1.16.0 REQUIRED)
-find_package(Fontconfig 2.13.0 REQUIRED)
-find_package(Freetype 2.9.0 REQUIRED)
 find_package(LibGcrypt 1.7.0 REQUIRED)
 find_package(Libtasn1 REQUIRED)
 find_package(HarfBuzz 1.4.2 REQUIRED COMPONENTS ICU)
@@ -33,7 +31,6 @@ find_package(ATSPI 2.5.3)
 
 include(GStreamerDefinitions)
 
-SET_AND_EXPOSE_TO_BUILD(USE_CAIRO TRUE)
 SET_AND_EXPOSE_TO_BUILD(USE_GCRYPT TRUE)
 SET_AND_EXPOSE_TO_BUILD(USE_LIBEPOXY TRUE)
 SET_AND_EXPOSE_TO_BUILD(USE_THEME_ADWAITA TRUE)
@@ -262,6 +259,14 @@ endif ()
 SET_AND_EXPOSE_TO_BUILD(USE_ATSPI 1)
 SET_AND_EXPOSE_TO_BUILD(HAVE_GTK_UNIX_PRINTING ${GTK_UNIX_PRINT_FOUND})
 SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 1)
+
+if (USE_SKIA)
+    SET_AND_EXPOSE_TO_BUILD(USE_CAIRO FALSE)
+else ()
+    find_package(Fontconfig 2.13.0 REQUIRED)
+    find_package(Freetype 2.9.0 REQUIRED)
+    SET_AND_EXPOSE_TO_BUILD(USE_CAIRO TRUE)
+endif ()
 
 # https://bugs.webkit.org/show_bug.cgi?id=182247
 if (ENABLED_COMPILER_SANITIZERS)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -97,7 +97,6 @@ WEBKIT_OPTION_DEFINE(ENABLE_WPE_PLATFORM_HEADLESS "Whether to enable support for
 WEBKIT_OPTION_DEFINE(ENABLE_WPE_PLATFORM_WAYLAND "Whether to enable support for Wayland platform" PUBLIC ON)
 WEBKIT_OPTION_DEFINE(ENABLE_WPE_QT_API "Whether to enable support for the Qt5/QML plugin" PUBLIC ${ENABLE_DEVELOPER_MODE})
 WEBKIT_OPTION_DEFINE(ENABLE_WPE_1_1_API "Whether to build WPE 1.1 instead of WPE 2.0" PUBLIC OFF)
-WEBKIT_OPTION_DEFINE(USE_SKIA "Whether to use Skia instead of Cairo." PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(USE_GBM "Whether to enable usage of GBM." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_LIBBACKTRACE "Whether to enable usage of libbacktrace." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_LIBDRM "Whether to enable usage of libdrm." PUBLIC ON)

--- a/Source/cmake/WebKitFeatures.cmake
+++ b/Source/cmake/WebKitFeatures.cmake
@@ -258,6 +258,7 @@ macro(WEBKIT_OPTION_BEGIN)
     WEBKIT_OPTION_DEFINE(USE_LCMS "Toggle support for image color management using libcms2" PRIVATE ON)
     WEBKIT_OPTION_DEFINE(USE_ISO_MALLOC "Toggle IsoMalloc support" PRIVATE ON)
     WEBKIT_OPTION_DEFINE(USE_JPEGXL "Toggle support for JPEG XL images" PRIVATE ON)
+    WEBKIT_OPTION_DEFINE(USE_SKIA "Whether to use Skia instead of Cairo." PRIVATE OFF)
     WEBKIT_OPTION_DEFINE(USE_SYSTEM_MALLOC "Toggle system allocator instead of WebKit's custom allocator" PRIVATE ${USE_SYSTEM_MALLOC_DEFAULT})
     WEBKIT_OPTION_DEFINE(USE_WOFF2 "Toggle support for WOFF2 Web Fonts through libwoff2" PRIVATE ON)
 

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
@@ -27,7 +27,7 @@
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
 
-#if USE(CAIRO)
+#if USE(CAIRO) || PLATFORM(GTK)
 #include <cairo.h>
 #endif
 
@@ -298,7 +298,7 @@ public:
         g_log_set_always_fatal(static_cast<GLogLevelFlags>(fatalMask));
     }
 
-#if USE(CAIRO)
+#if USE(CAIRO) || PLATFORM(GTK)
     static bool cairoSurfacesEqual(cairo_surface_t* s1, cairo_surface_t* s2)
     {
         return (cairo_image_surface_get_format(s1) == cairo_image_surface_get_format(s2)

--- a/Tools/WebKitTestRunner/PlatformGTK.cmake
+++ b/Tools/WebKitTestRunner/PlatformGTK.cmake
@@ -11,6 +11,8 @@ list(APPEND WebKitTestRunner_SOURCES
     gtk/TestControllerGtk.cpp
     gtk/UIScriptControllerGtk.cpp
     gtk/main.cpp
+
+    skia/TestInvocationSkia.cpp
 )
 
 list(APPEND WebKitTestRunner_PRIVATE_INCLUDE_DIRECTORIES

--- a/Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp
@@ -222,6 +222,7 @@ void PlatformWebView::changeWindowScaleIfNeeded(float)
 {
 }
 
+#if USE(CAIRO)
 cairo_surface_t* PlatformWebView::windowSnapshotImage()
 {
 #if USE(GTK4)
@@ -254,6 +255,12 @@ cairo_surface_t* PlatformWebView::windowSnapshotImage()
 
     return imageSurface;
 }
+#elif USE(SKIA)
+SkImage* PlatformWebView::windowSnapshotImage()
+{
+    return nullptr;
+}
+#endif
 
 void PlatformWebView::didInitializeClients()
 {

--- a/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
@@ -161,10 +161,14 @@ TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCo
 WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()
 {
     Vector<unsigned char> output;
+#if USE(CAIRO)
     cairo_surface_write_to_png_stream(mainWebView()->windowSnapshotImage(), [](void* output, const unsigned char* data, unsigned length) -> cairo_status_t {
         reinterpret_cast<Vector<unsigned char>*>(output)->append(data, length);
         return CAIRO_STATUS_SUCCESS;
     }, &output);
+#elif USE(SKIA)
+    // FIXME: implement.
+#endif
     auto uri = makeString("data:image/png;base64,", base64Encoded(output.data(), output.size()));
     return adoptWK(WKStringCreateWithUTF8CString(uri.utf8().data()));
 }


### PR DESCRIPTION
#### 75df56fbd143a4ac7df5e554b01c22030ea0ab22
<pre>
[GTK] Make it possible to build with Skia instead of Cairo
<a href="https://bugs.webkit.org/show_bug.cgi?id=270510">https://bugs.webkit.org/show_bug.cgi?id=270510</a>

Reviewed by Don Olmstead.

Add build option to enable Skia in the GTK port. This is just an initial
patch, there are many features broken when building with Skia like
printing, non-accelerated mode, favicons, snapshots, etc. We will fix
them all in follow up patches.

* Source/WTF/wtf/PlatformUse.h:
* Source/WebCore/PlatformGTK.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/platform/DragImage.h:
* Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp:
* Source/WebCore/platform/graphics/IntRect.h:
* Source/WebCore/platform/graphics/cairo/RefPtrCairo.cpp:
* Source/WebCore/platform/graphics/cairo/RefPtrCairo.h:
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
* Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp:
* Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h:
* Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp:
(WebCore::ImageAdapter::gdkPixbuf):
(WebCore::ImageAdapter::gdkTexture):
* Source/WebCore/platform/gtk/CursorGtk.cpp:
(WebCore::createCustomCursor):
* Source/WebCore/platform/gtk/DragImageGtk.cpp:
(WebCore::dragImageSize):
(WebCore::scaleDragImage):
(WebCore::dissolveDragImageToFraction):
* Source/WebCore/platform/gtk/RenderThemeGadget.cpp:
* Source/WebCore/platform/gtk/RenderThemeGadget.h:
* Source/WebCore/platform/gtk/RenderThemeScrollbar.cpp:
* Source/WebCore/platform/gtk/RenderThemeScrollbar.h:
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp:
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.h:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp:
(API::ProcessPoolConfiguration::copy):
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkitFaviconDatabaseGetFaviconInternal):
(webkit_favicon_database_get_favicon_finish):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkitWebContextConstructed):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp:
(WebKit::DragSource::begin):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::setViewNeedsDisplay):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
* Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp:
* Source/WebKit/UIProcess/BackingStore.h:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::DrawingAreaProxyCoordinatedGraphics):
(WebKit::DrawingAreaProxyCoordinatedGraphics::setBackingStoreIsDiscardable):
(WebKit::DrawingAreaProxyCoordinatedGraphics::update):
(WebKit::DrawingAreaProxyCoordinatedGraphics::exitAcceleratedCompositingMode):
(WebKit::DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode):
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp:
(WebKit::BackingStore::incorporateUpdate):
(WebKit::BackingStore::scroll):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents):
* Source/WebKit/UIProcess/gtk/ViewSnapshotStoreGtk3.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp:
(WebKit::WebDragClient::startDrag):
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp:
(WebKit::WebPrintOperationGtk::startPrint):
(WebKit::WebPrintOperationGtk::rotatePageIfNeeded):
(WebKit::WebPrintOperationGtk::prepareContextToDraw):
(WebKit::WebPrintOperationGtk::renderPage):
(WebKit::WebPrintOperationGtk::printPagesDone):
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h:
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):
* Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp:
(WebKit::GtkSettingsManagerProxy::applyHintingSettings):
(WebKit::GtkSettingsManagerProxy::applyAntialiasSettings):
* Source/cmake/OptionsGTK.cmake:
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h:
* Tools/WebKitTestRunner/PlatformGTK.cmake:
* Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp:
(WTR::PlatformWebView::windowSnapshotImage):
* Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp:
(WTR::TestController::takeViewPortSnapshot):

Canonical link: <a href="https://commits.webkit.org/275829@main">https://commits.webkit.org/275829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f5ae0bed3a59d5322fd3c3a560daf521019ca51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19440 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19049 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1047 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/36447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47145 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42618 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14692 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42325 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19443 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40977 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19622 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49628 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5819 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19073 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10029 "Passed tests") | 
<!--EWS-Status-Bubble-End-->