### PR TITLE
[CSS Container Queries][Style queries] Resolve container units in style queries correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt
@@ -67,7 +67,7 @@ PASS Match registered <length> custom property with px.
 PASS Match registered <length> custom property with px via initial keyword.
 PASS Match registered <length> custom property with em in query.
 PASS Match registered <length> custom property with em in computed value.
-FAIL Match registered <length> custom property with cqi unit. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match registered <length> custom property with cqi unit.
 PASS Match registered <length> custom property with initial value.
 PASS Match registered <length> custom property with initial value via initial keyword.
 PASS Should only match exact string for numbers in non-registered custom properties

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -189,7 +189,7 @@ struct StyleFeatureSchema : public FeatureSchema {
                 context.document.get(),
                 *context.conversionData.parentStyle(),
                 context.conversionData.rootStyle(),
-                nullptr
+                context.conversionData.elementForContainerUnitResolution()
             };
 
             auto dummyStyle = RenderStyle::clone(style);


### PR DESCRIPTION
#### e1b6c5a12f892f3dee434dab3b6764a9fd7115ae
<pre>
[CSS Container Queries][Style queries] Resolve container units in style queries correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=270511">https://bugs.webkit.org/show_bug.cgi?id=270511</a>
<a href="https://rdar.apple.com/124058441">rdar://124058441</a>

Reviewed by Antoine Quint.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/custom-property-style-queries-expected.txt:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:

Provide the context element so container units can be resolved.

Canonical link: <a href="https://commits.webkit.org/275689@main">https://commits.webkit.org/275689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/196cd6778b758084a2abab8b9d3b180d8eef8c30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38646 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35204 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46611 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41895 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40506 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18962 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9510 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->