### PR TITLE
AX: Incomplete object information with focus event on dynamic created div

### DIFF
--- a/LayoutTests/accessibility/focus-new-element.html
+++ b/LayoutTests/accessibility/focus-new-element.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container"></div>
+
+<script>
+var output = "This test ensures that the accessiblity tree properly handles focus for an element who has not yet attached a renderer.\n\n";
+
+var axText, axButton;
+function verifyButton() {
+    output += expect("axButton && axButton.isValid", "true");
+    axText = platformTextAlternatives(axButton);
+    output += `${axText}\n`;
+    output += expect("axText.includes('BUTTON')", "true");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // Ensure the AXObjectCache is created before issuing focus.
+    touchAccessibilityTree(accessibilityController.rootElement);
+
+    let button = document.createElement("div");
+    button.setAttribute("id", "button"),
+    button.setAttribute("role", "button"),
+    button.setAttribute("tabindex", "0");
+    button.setAttribute("aria-label", "BUTTON");
+    button.innerHTML = "TEST";
+    document.getElementById("container").appendChild(button);
+    button.focus();
+
+    setTimeout(async function() {
+        await waitFor(() => {
+            axButton = accessibilityController.focusedElement;
+            return axButton && axButton.role.toLowerCase().includes("button");
+        });
+        verifyButton();
+
+        axButton = accessibilityController.accessibleElementById("button");
+        verifyButton();
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/accessibility/focus-new-element-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/focus-new-element-expected.txt
@@ -1,0 +1,15 @@
+This test ensures that the accessiblity tree properly handles focus for an element who has not yet attached a renderer.
+
+PASS: axButton && axButton.isValid === true
+	AXTitle: BUTTON
+	AXDescription:
+PASS: axText.includes('BUTTON') === true
+PASS: axButton && axButton.isValid === true
+	AXTitle: BUTTON
+	AXDescription:
+PASS: axText.includes('BUTTON') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+TEST

--- a/LayoutTests/platform/ios-simulator-wk2/accessibility/focus-new-element-expected.txt
+++ b/LayoutTests/platform/ios-simulator-wk2/accessibility/focus-new-element-expected.txt
@@ -1,0 +1,13 @@
+This test ensures that the accessiblity tree properly handles focus for an element who has not yet attached a renderer.
+
+PASS: axButton && axButton.isValid === true
+	AXLabel: BUTTON
+PASS: axText.includes('BUTTON') === true
+PASS: axButton && axButton.isValid === true
+	AXLabel: BUTTON
+PASS: axText.includes('BUTTON') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+TEST

--- a/LayoutTests/platform/mac/accessibility/focus-new-element-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/focus-new-element-expected.txt
@@ -1,0 +1,17 @@
+This test ensures that the accessiblity tree properly handles focus for an element who has not yet attached a renderer.
+
+PASS: axButton && axButton.isValid === true
+	AXTitle: BUTTON
+	AXDescription: BUTTON
+	AXHelp:
+PASS: axText.includes('BUTTON') === true
+PASS: axButton && axButton.isValid === true
+	AXTitle: BUTTON
+	AXDescription: BUTTON
+	AXHelp:
+PASS: axText.includes('BUTTON') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+TEST

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -197,7 +197,7 @@ public:
     void childrenChanged(Node*, Node* newChild = nullptr);
     void childrenChanged(RenderObject*, RenderObject* newChild = nullptr);
     void childrenChanged(AccessibilityObject*);
-    void onFocusChange(Node* oldFocusedNode, Node* newFocusedNode);
+    void onFocusChange(Element* oldElement, Element* newElement);
     void onPopoverToggle(const HTMLElement&);
     void onScrollbarFrameRectChange(const Scrollbar&);
     void onSelectedChanged(Node*);


### PR DESCRIPTION
#### 114392b51f9c322d303c0e44142d53d89276f66b
<pre>
AX: Incomplete object information with focus event on dynamic created div
<a href="https://bugs.webkit.org/show_bug.cgi?id=270433">https://bugs.webkit.org/show_bug.cgi?id=270433</a>

Reviewed by Tyler Wilcock.

When the element is dynamically created and focused, the focus change event should be
deferred in case renderer is not available yet but document needs style recalculation.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::shouldDeferFocusChange):
(WebCore::AXObjectCache::onFocusChange):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebKitAccessibility.cpp:
(testAccessibleStateChangedFocus):
(beforeAll):
* LayoutTests/accessibility/focus-new-element.html: Added.
* LayoutTests/platform/glib/accessibility/focus-new-element-expected.txt: Added.
* LayoutTests/platform/ios-simulator-wk2/accessibility/focus-new-element-expected.txt: Added.
* LayoutTests/platform/mac/accessibility/focus-new-element-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/275980@main">https://commits.webkit.org/275980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c3a90b9d8811257a7d02b4682327073f764fbf5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35886 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16863 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38452 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1467 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42670 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41334 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9667 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->