### PR TITLE
Adopt dynamicDowncast<> in even more accessibility code

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1629,10 +1629,8 @@ template<typename T, typename F>
 T* findChild(T& object, F&& matches)
 {
     for (auto child : object.children()) {
-        if (matches(child)) {
-            RELEASE_ASSERT(is<T>(child.get()));
-            return downcast<T>(child.get());
-        }
+        if (matches(child))
+            return checkedDowncast<T>(child.get());
     }
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1316,7 +1316,7 @@ void AXObjectCache::handleChildrenChanged(AccessibilityObject& object)
         if (children.isEmpty())
             return;
 
-        ASSERT(children.size() == 1 && is<AccessibilityObject>(*children[0]));
+        ASSERT(children.size() == 1);
         handleChildrenChanged(downcast<AccessibilityObject>(*children[0]));
     } else if (auto* menuListPopup = dynamicDowncast<AccessibilityMenuListPopup>(object)) {
         menuListPopup->handleChildrenChanged();

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -147,13 +147,9 @@ RenderElement* AccessibilityImageMapLink::imageMapLinkRenderer() const
     if (!m_mapElement || !m_areaElement)
         return nullptr;
 
-    RenderElement* renderer = nullptr;
-    if (is<AccessibilityRenderObject>(m_parent))
-        renderer = downcast<RenderElement>(downcast<AccessibilityRenderObject>(*m_parent).renderer());
-    else
-        renderer = m_mapElement->renderer();
-    
-    return renderer;
+    if (auto* parent = dynamicDowncast<AccessibilityRenderObject>(m_parent.get()))
+        return downcast<RenderElement>(parent->renderer());
+    return m_mapElement->renderer();
 }
 
 void AccessibilityImageMapLink::detachFromParent()

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.h
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.h
@@ -76,7 +76,11 @@ private:
     
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilityImageMapLink) \
-    static bool isType(const WebCore::AXCoreObject& object) { return object.isAccessibilityObject() && downcast<WebCore::AccessibilityObject>(object).isImageMapLink(); } \
-    static bool isType(const WebCore::AccessibilityObject& object) { return object.isImageMapLink(); } \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilityImageMapLink)
+    static bool isType(const WebCore::AXCoreObject& object)
+    {
+        auto* accessibilityObject = dynamicDowncast<WebCore::AccessibilityObject>(object);
+        return accessibilityObject && accessibilityObject->isImageMapLink();
+    }
+    static bool isType(const WebCore::AccessibilityObject& object) { return object.isImageMapLink(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -152,18 +152,14 @@ bool AccessibilityMathMLElement::isAnonymousMathOperator() const
 
 bool AccessibilityMathMLElement::isMathFenceOperator() const
 {
-    if (!is<RenderMathMLOperator>(renderer()))
-        return false;
-
-    return downcast<RenderMathMLOperator>(*m_renderer).hasOperatorFlag(MathMLOperatorDictionary::Fence);
+    auto* mathMLOperator = dynamicDowncast<RenderMathMLOperator>(renderer());
+    return mathMLOperator && mathMLOperator->hasOperatorFlag(MathMLOperatorDictionary::Fence);
 }
 
 bool AccessibilityMathMLElement::isMathSeparatorOperator() const
 {
-    if (!is<RenderMathMLOperator>(renderer()))
-        return false;
-
-    return downcast<RenderMathMLOperator>(*m_renderer).hasOperatorFlag(MathMLOperatorDictionary::Separator);
+    auto* mathMLOperator = dynamicDowncast<RenderMathMLOperator>(renderer());
+    return mathMLOperator && mathMLOperator->hasOperatorFlag(MathMLOperatorDictionary::Separator);
 }
 
 bool AccessibilityMathMLElement::isMathText() const
@@ -443,10 +439,11 @@ void AccessibilityMathMLElement::mathPostscripts(AccessibilityMathMultiscriptPai
 
 int AccessibilityMathMLElement::mathLineThickness() const
 {
-    if (!is<RenderMathMLFraction>(renderer()))
+    auto* fraction = dynamicDowncast<RenderMathMLFraction>(renderer());
+    if (!fraction)
         return -1;
 
-    return downcast<RenderMathMLFraction>(*m_renderer).relativeLineThickness();
+    return fraction->relativeLineThickness();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
@@ -63,7 +63,11 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilityMenuListPopup) \
-    static bool isType(const WebCore::AccessibilityObject& object) { return object.isMenuListPopup(); } \
-    static bool isType(const WebCore::AXCoreObject& object) { return object.isAccessibilityObject() && downcast<WebCore::AccessibilityObject>(object).isMenuListPopup(); } \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilityMenuListPopup)
+    static bool isType(const WebCore::AccessibilityObject& object) { return object.isMenuListPopup(); }
+    static bool isType(const WebCore::AXCoreObject& object)
+    {
+        auto* accessibilityObject = dynamicDowncast<WebCore::AccessibilityObject>(object);
+        return accessibilityObject && accessibilityObject->isMenuListPopup();
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/accessibility/AccessibilitySVGElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGElement.cpp
@@ -61,15 +61,15 @@ Ref<AccessibilitySVGElement> AccessibilitySVGElement::create(RenderObject* rende
 
 AccessibilityObject* AccessibilitySVGElement::targetForUseElement() const
 {
-    if (!is<SVGUseElement>(element()))
+    auto* use = dynamicDowncast<SVGUseElement>(element());
+    if (!use)
         return nullptr;
 
-    SVGUseElement& use = downcast<SVGUseElement>(*element());
-    String href = use.href();
+    auto href = use->href();
     if (href.isEmpty())
         href = getAttribute(HTMLNames::hrefAttr);
 
-    auto target = SVGURIReference::targetElementFromIRIString(href, use.treeScopeForSVGReferences());
+    auto target = SVGURIReference::targetElementFromIRIString(href, use->treeScopeForSVGReferences());
     if (!target.element)
         return nullptr;
 

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.cpp
@@ -79,17 +79,14 @@ bool AccessibilitySVGRoot::hasAccessibleContent() const
     if (!rootElement)
         return false;
 
-    auto isAccessibleSVGElement = [] (const Element& element) -> bool {
-        if (!is<SVGElement>(element))
-            return false;
-
+    auto isAccessibleSVGElement = [] (const SVGElement& element) -> bool {
         // The presence of an SVGTitle or SVGDesc element is enough to deem the SVG hierarchy as accessible.
         if (is<SVGTitleElement>(element)
             || is<SVGDescElement>(element))
             return true;
 
         // Text content is accessible.
-        if (downcast<SVGElement>(element).isTextContent())
+        if (element.isTextContent())
             return true;
 
         // If the role or aria-label attributes are specified, this is accessible.
@@ -100,7 +97,8 @@ bool AccessibilitySVGRoot::hasAccessibleContent() const
         return false;
     };
 
-    if (isAccessibleSVGElement(*rootElement))
+    auto* svgRootElement = dynamicDowncast<SVGElement>(*rootElement);
+    if (svgRootElement && isAccessibleSVGElement(*svgRootElement))
         return true;
 
     // This SVG hierarchy is accessible if any of its descendants is accessible.

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -175,10 +175,10 @@ LayoutRect AccessibilitySliderThumb::elementRect() const
     if (!m_parent)
         return LayoutRect();
     
-    RenderObject* sliderRenderer = m_parent->renderer();
-    if (!sliderRenderer || !sliderRenderer->isRenderSlider())
+    auto* sliderRenderer = dynamicDowncast<RenderSlider>(m_parent->renderer());
+    if (!sliderRenderer)
         return LayoutRect();
-    if (auto* thumbRenderer = downcast<RenderSlider>(*sliderRenderer).element().sliderThumbElement()->renderer())
+    if (auto* thumbRenderer = sliderRenderer->element().sliderThumbElement()->renderer())
         return thumbRenderer->absoluteBoundingBoxRect();
     return LayoutRect();
 }

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -138,15 +138,15 @@ LayoutRect AccessibilitySpinButtonPart::elementRect() const
 
 bool AccessibilitySpinButtonPart::press()
 {
-    if (!is<AccessibilitySpinButton>(m_parent))
+    auto* spinButton = dynamicDowncast<AccessibilitySpinButton>(m_parent.get());
+    if (!spinButton)
         return false;
-    
-    auto& spinButton = downcast<AccessibilitySpinButton>(*m_parent);
+
     if (m_isIncrementor)
-        spinButton.step(1);
+        spinButton->step(1);
     else
-        spinButton.step(-1);
-    
+        spinButton->step(-1);
+
     return true;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -66,14 +66,11 @@ void AccessibilityTableHeaderContainer::addChildren()
     ASSERT(!m_childrenInitialized); 
     
     m_childrenInitialized = true;
-    if (!is<AccessibilityTable>(m_parent))
+    auto* parentTable = dynamicDowncast<AccessibilityTable>(m_parent.get());
+    if (!parentTable || !parentTable->isExposable())
         return;
 
-    auto& parentTable = downcast<AccessibilityTable>(*m_parent);
-    if (!parentTable.isExposable())
-        return;
-
-    for (auto& columnHeader : parentTable.columnHeaders())
+    for (auto& columnHeader : parentTable->columnHeaders())
         addChild(columnHeader.get());
 
     for (const auto& child : m_children)

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -98,13 +98,13 @@ int AccessibilityObject::accessibilitySecureFieldLength()
 {
     if (!isSecureField())
         return 0;
-    RenderObject* renderObject = downcast<AccessibilityRenderObject>(*this).renderer();
-    
-    if (!renderObject || !is<HTMLInputElement>(renderObject->node()))
-        return false;
-    
-    HTMLInputElement& inputElement = downcast<HTMLInputElement>(*renderObject->node());
-    return inputElement.value().length();
+
+    auto* renderObject = downcast<AccessibilityRenderObject>(*this).renderer();
+    if (!renderObject)
+        return 0;
+
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(renderObject->node());
+    return inputElement ? inputElement->value().length() : 0;
 }
 
 bool AccessibilityObject::accessibilityIgnoreAttachment() const

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -747,62 +747,54 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     if (![self _prepareAccessibilityCall])
         return NO;
 
-    if (self.axBackingObject->roleValue() != AccessibilityRole::Video || !is<AccessibilityMediaObject>(self.axBackingObject))
+    if (self.axBackingObject->roleValue() != AccessibilityRole::Video)
         return NO;
 
     // Convey the video object as interactive if auto-play is not enabled.
-    return !downcast<AccessibilityMediaObject>(*self.axBackingObject).isAutoplayEnabled();
+    auto* mediaObject = dynamicDowncast<AccessibilityMediaObject>(self.axBackingObject);
+    return mediaObject && !mediaObject->isAutoplayEnabled();
 }
 
 - (NSString *)interactiveVideoDescription
 {
-    if (!is<AccessibilityMediaObject>(self.axBackingObject))
-        return nil;
-    return downcast<AccessibilityMediaObject>(self.axBackingObject)->interactiveVideoDuration();
+    auto* mediaObject = dynamicDowncast<AccessibilityMediaObject>(self.axBackingObject);
+    return mediaObject ? mediaObject->interactiveVideoDuration() : nullString();
 }
 
 - (BOOL)accessibilityIsMediaPlaying
 {
     if (![self _prepareAccessibilityCall])
         return NO;
-    
-    if (!is<AccessibilityMediaObject>(self.axBackingObject))
-        return NO;
-    
-    return downcast<AccessibilityMediaObject>(self.axBackingObject)->isPlaying();
+
+    auto* mediaObject = dynamicDowncast<AccessibilityMediaObject>(self.axBackingObject);
+    return mediaObject && mediaObject->isPlaying();
 }
 
 - (BOOL)accessibilityIsMediaMuted
 {
     if (![self _prepareAccessibilityCall])
         return NO;
-    
-    if (!is<AccessibilityMediaObject>(self.axBackingObject))
-        return NO;
-    
-    return downcast<AccessibilityMediaObject>(self.axBackingObject)->isMuted();
+
+    auto* mediaObject = dynamicDowncast<AccessibilityMediaObject>(self.axBackingObject);
+    return mediaObject && mediaObject->isMuted();
 }
 
 - (void)accessibilityToggleMuteForMedia
 {
     if (![self _prepareAccessibilityCall])
         return;
-    
-    if (!is<AccessibilityMediaObject>(self.axBackingObject))
-        return;
 
-    downcast<AccessibilityMediaObject>(self.axBackingObject)->toggleMute();
+    if (auto* mediaObject = dynamicDowncast<AccessibilityMediaObject>(self.axBackingObject))
+        mediaObject->toggleMute();
 }
 
 - (void)accessibilityVideoEnterFullscreen
 {
     if (![self _prepareAccessibilityCall])
         return;
-    
-    if (!is<AccessibilityMediaObject>(self.axBackingObject))
-        return;
-    
-    downcast<AccessibilityMediaObject>(self.axBackingObject)->enterFullscreen();
+
+    if (auto* mediaObject = dynamicDowncast<AccessibilityMediaObject>(self.axBackingObject))
+        mediaObject->enterFullscreen();
 }
 
 - (uint64_t)_accessibilityTextEntryTraits
@@ -1574,7 +1566,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return [NSString stringWithFormat:@"%.2f", backingObject->valueForRange()];
     }
 
-    if (is<AccessibilityAttachment>(backingObject.get()) && downcast<AccessibilityAttachment>(backingObject.get()).hasProgress())
+    if (auto* attachment = dynamicDowncast<AccessibilityAttachment>(backingObject.get()); attachment && attachment->hasProgress())
         return [NSString stringWithFormat:@"%.2f", backingObject->valueForRange()];
 
     return nil;

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -86,7 +86,8 @@ RemoteAXObjectRef AXIsolatedObject::remoteParentObject() const
     auto* scrollView = Accessibility::findAncestor<AXCoreObject>(*this, true, [] (const AXCoreObject& object) {
         return object.isScrollView();
     });
-    return is<AXIsolatedObject>(scrollView) ? downcast<AXIsolatedObject>(scrollView)->m_remoteParent.get() : nil;
+    auto* isolatedObject = dynamicDowncast<AXIsolatedObject>(scrollView);
+    return isolatedObject ? isolatedObject->m_remoteParent.get() : nil;
 }
 
 FloatRect AXIsolatedObject::primaryScreenRect() const


### PR DESCRIPTION
#### c792c0e220b690ac5f6852e9c66af91ca62b99fe
<pre>
Adopt dynamicDowncast&lt;&gt; in even more accessibility code
<a href="https://bugs.webkit.org/show_bug.cgi?id=270512">https://bugs.webkit.org/show_bug.cgi?id=270512</a>

Reviewed by Chris Dumez and Tyler Wilcock.

For security &amp; performance.

This also takes care of some minor cleanup as well as removing asserts
that are now redundant with downcast&lt;&gt; or checkedDowncast&lt;&gt;.

* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::findChild):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleChildrenChanged):
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
(WebCore::AccessibilityImageMapLink::imageMapLinkRenderer const):
* Source/WebCore/accessibility/AccessibilityImageMapLink.h:
(isType):
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::isMathFenceOperator const):
(WebCore::AccessibilityMathMLElement::isMathSeparatorOperator const):
(WebCore::AccessibilityMathMLElement::mathLineThickness const):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.h:
(isType):
* Source/WebCore/accessibility/AccessibilitySVGElement.cpp:
(WebCore::AccessibilitySVGElement::targetForUseElement const):
* Source/WebCore/accessibility/AccessibilitySVGRoot.cpp:
(WebCore::AccessibilitySVGRoot::hasAccessibleContent const):
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySliderThumb::elementRect const):
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
(WebCore::AccessibilitySpinButtonPart::press):
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::addChildren):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AccessibilityObject::accessibilitySecureFieldLength):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityIsWebInteractiveVideo]):
(-[WebAccessibilityObjectWrapper interactiveVideoDescription]):
(-[WebAccessibilityObjectWrapper accessibilityIsMediaPlaying]):
(-[WebAccessibilityObjectWrapper accessibilityIsMediaMuted]):
(-[WebAccessibilityObjectWrapper accessibilityToggleMuteForMedia]):
(-[WebAccessibilityObjectWrapper accessibilityVideoEnterFullscreen]):
(-[WebAccessibilityObjectWrapper accessibilityValue]):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::remoteParentObject const):

Canonical link: <a href="https://commits.webkit.org/275697@main">https://commits.webkit.org/275697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd4b47bcf9c8c8686e221bf778d87f302a229748

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45161 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18938 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16176 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37683 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/611 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46644 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14316 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/42602 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18991 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9515 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->