### PR TITLE
Initialize organization storage access prompt quirks if needed

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -499,6 +499,7 @@ void DocumentLoader::finishedLoading()
         if (!frameLoader())
             return;
         frameLoader()->client().finishedLoading(this);
+        frameLoader()->client().loadStorageAccessQuirksIfNeeded();
     }
 
     m_writer.end();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2800,7 +2800,6 @@ void FrameLoader::checkLoadCompleteForThisFrame()
             if (m_frame->isMainFrame()) {
                 tracePoint(MainResourceLoadDidEnd, PAGE_ID);
                 page->didFinishLoad();
-                m_client->loadStorageAccessQuirksIfNeeded();
             }
         }
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -137,6 +137,7 @@ public:
     const Vector<WebCore::OrganizationStorageAccessPromptQuirk>& cachedQuirks() const { return m_cachedQuirks; }
     void updateQuirks(CompletionHandler<void()>&&);
     void setCachedQuirksForTesting(Vector<WebCore::OrganizationStorageAccessPromptQuirk>&&);
+    void initialize();
 
     Ref<StorageAccessPromptQuirkObserver> observeUpdates(Function<void()>&&);
 
@@ -148,6 +149,7 @@ private:
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> m_cachedQuirks;
     WeakHashSet<StorageAccessPromptQuirkObserver> m_observers;
+    bool m_wasInitialized { false };
 };
 
 class StorageAccessUserAgentStringQuirkController {
@@ -157,6 +159,7 @@ public:
     const HashMap<WebCore::RegistrableDomain, String>& cachedQuirks() const { return m_cachedQuirks; }
     void updateQuirks(CompletionHandler<void()>&&);
     void setCachedQuirksForTesting(HashMap<WebCore::RegistrableDomain, String>&&);
+    void initialize();
 
     Ref<StorageAccessUserAgentStringQuirkObserver> observeUpdates(Function<void()>&&);
 
@@ -168,6 +171,7 @@ private:
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     HashMap<WebCore::RegistrableDomain, String> m_cachedQuirks;
     WeakHashSet<StorageAccessUserAgentStringQuirkObserver> m_observers;
+    bool m_wasInitialized { false };
 };
 
 class RestrictedOpenerDomainsController {

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -147,7 +147,7 @@ private:
     void setCachedQuirks(Vector<WebCore::OrganizationStorageAccessPromptQuirk>&&);
 
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
-    Vector<WebCore::OrganizationStorageAccessPromptQuirk> m_cachedQuirks;
+    Vector<WebCore::OrganizationStorageAccessPromptQuirk> m_cachedQuirks { };
     WeakHashSet<StorageAccessPromptQuirkObserver> m_observers;
     bool m_wasInitialized { false };
 };
@@ -169,7 +169,7 @@ private:
     void setCachedQuirks(HashMap<WebCore::RegistrableDomain, String>&&);
 
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
-    HashMap<WebCore::RegistrableDomain, String> m_cachedQuirks;
+    HashMap<WebCore::RegistrableDomain, String> m_cachedQuirks { };
     WeakHashSet<StorageAccessUserAgentStringQuirkObserver> m_observers;
     bool m_wasInitialized { false };
 };

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -306,6 +306,7 @@ void StorageAccessPromptQuirkController::setCachedQuirks(Vector<WebCore::Organiz
 
 void StorageAccessPromptQuirkController::setCachedQuirksForTesting(Vector<WebCore::OrganizationStorageAccessPromptQuirk>&& quirks)
 {
+    m_wasInitialized = true;
     setCachedQuirks(WTFMove(quirks));
     m_observers.forEach([](auto& observer) {
         observer.invokeCallback();
@@ -323,6 +324,19 @@ static HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>> d
         map.add(WebCore::RegistrableDomain::fromRawString(String { topDomain }), WTFMove(subFrameDomains));
     }
     return map;
+}
+
+void StorageAccessPromptQuirkController::initialize()
+{
+    if (m_wasInitialized)
+        return;
+
+    updateQuirks([this] {
+        m_observers.forEach([](auto& observer) {
+            observer.invokeCallback();
+        });
+    });
+    m_wasInitialized = true;
 }
 
 void StorageAccessPromptQuirkController::updateQuirks(CompletionHandler<void()>&& completionHandler)
@@ -392,6 +406,20 @@ void StorageAccessUserAgentStringQuirkController::setCachedQuirksForTesting(Hash
     m_observers.forEach([](auto& observer) {
         observer.invokeCallback();
     });
+    m_wasInitialized = true;
+}
+
+void StorageAccessUserAgentStringQuirkController::initialize()
+{
+    if (m_wasInitialized)
+        return;
+
+    updateQuirks([this] {
+        m_observers.forEach([](auto& observer) {
+            observer.invokeCallback();
+        });
+    });
+    m_wasInitialized = true;
 }
 
 void StorageAccessUserAgentStringQuirkController::updateQuirks(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -99,6 +99,7 @@ void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationPa
 void AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName)
 {
     auto errorMessage = makeString("Received invalid message: '", description(messageName), "' (", messageName, ')');
+    WTFLogAlways("AuxiliaryProcess::didReceiveInvalidMessage: %s", errorMessage.utf8().data());
     logAndSetCrashLogMessage(errorMessage.utf8().data());
     CRASH_WITH_INFO(WTF::enumToUnderlyingType(messageName));
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -212,6 +212,10 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
     parameters.isParentProcessFullWebBrowserOrRunningTest = isFullWebBrowserOrRunningTest();
 #endif
 
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::shared().cachedQuirks();
+#endif
+
     WebProcessPool::platformInitializeNetworkProcess(parameters);
     sendWithAsyncReply(Messages::NetworkProcess::InitializeNetworkProcess(WTFMove(parameters)), [weakThis = WeakPtr { *this }] {
         if (weakThis)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -331,8 +331,8 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
             protectedThis->sendToAllProcesses(Messages::WebProcess::UpdateDomainsWithStorageAccessQuirks(domainSet));
         }
     });
-    //if (StorageAccessPromptQuirkController::shared().cachedQuirks().isEmpty())
-    //    StorageAccessPromptQuirkController::shared().initialize();
+    if (StorageAccessPromptQuirkController::shared().cachedQuirks().isEmpty())
+        StorageAccessPromptQuirkController::shared().initialize();
     if (StorageAccessUserAgentStringQuirkController::shared().cachedQuirks().isEmpty())
         StorageAccessUserAgentStringQuirkController::shared().initialize();
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -331,6 +331,10 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
             protectedThis->sendToAllProcesses(Messages::WebProcess::UpdateDomainsWithStorageAccessQuirks(domainSet));
         }
     });
+    if (StorageAccessPromptQuirkController::shared().cachedQuirks().isEmpty())
+        StorageAccessPromptQuirkController::shared().initialize();
+    if (StorageAccessUserAgentStringQuirkController::shared().cachedQuirks().isEmpty())
+        StorageAccessUserAgentStringQuirkController::shared().initialize();
 #endif
 
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -331,8 +331,8 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
             protectedThis->sendToAllProcesses(Messages::WebProcess::UpdateDomainsWithStorageAccessQuirks(domainSet));
         }
     });
-    if (StorageAccessPromptQuirkController::shared().cachedQuirks().isEmpty())
-        StorageAccessPromptQuirkController::shared().initialize();
+    //if (StorageAccessPromptQuirkController::shared().cachedQuirks().isEmpty())
+    //    StorageAccessPromptQuirkController::shared().initialize();
     if (StorageAccessUserAgentStringQuirkController::shared().cachedQuirks().isEmpty())
         StorageAccessUserAgentStringQuirkController::shared().initialize();
 #endif


### PR DESCRIPTION
#### 36af91ef45ba523a0171296debc2e909f7861936
<pre>
Initialize organization storage access prompt quirks if needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=270206">https://bugs.webkit.org/show_bug.cgi?id=270206</a>
<a href="https://rdar.apple.com/123728311">rdar://123728311</a>

Reviewed by NOBODY (OOPS!).

The API tests I added in 271821@main directly initialize the cache, but in
reality we actually need another mechanism to pull existing data from the
framework. This patch adds initialization support.

The callback now dispatches onto the runloop because refing an APIObject in its
own constructor is not supported on some architectures.

Also this change now fetches the quirked domains to be a little earlier in the
page-load process, making the quirk behavior less racy. It also resets resource
load statistics database for some tests where stale data was causing issues.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::finishedLoading):
* Source/WebCore/loader/FrameLoader.cpp:

Fetch the quirk data from the network process when the main document is
finished loading.

(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::StorageAccessPromptQuirkController::setCachedQuirksForTesting):
(WebKit::StorageAccessPromptQuirkController::initialize):
(WebKit::StorageAccessUserAgentStringQuirkController::setCachedQuirksForTesting):
(WebKit::StorageAccessUserAgentStringQuirkController::initialize):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST):
</pre>