### PR TITLE
[WebCore] Cache inline styles

### DIFF
--- a/Source/WebCore/css/CSSBasicShapes.h
+++ b/Source/WebCore/css/CSSBasicShapes.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 enum class WindRule : bool;
 
-class CSSInsetShapeValue : public CSSValue {
+class CSSInsetShapeValue final : public CSSValue {
 public:
     static Ref<CSSInsetShapeValue> create(Ref<CSSValue>&& top, Ref<CSSValue>&& right, Ref<CSSValue>&& bottom, Ref<CSSValue>&& left,
         RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius);
@@ -63,6 +63,35 @@ public:
     String customCSSText() const;
     bool equals(const CSSInsetShapeValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_top.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_right.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_bottom.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_left.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (m_topLeftRadius) {
+            if (func(*m_topLeftRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_topRightRadius) {
+            if (func(*m_topRightRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_bottomRightRadius) {
+            if (func(*m_bottomRightRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_bottomLeftRadius) {
+            if (func(*m_bottomLeftRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSInsetShapeValue(Ref<CSSValue>&& top, Ref<CSSValue>&& right, Ref<CSSValue>&& bottom, Ref<CSSValue>&& left, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius);
 
@@ -77,7 +106,7 @@ private:
     RefPtr<CSSValue> m_bottomLeftRadius;
 };
 
-class CSSCircleValue : public CSSValue {
+class CSSCircleValue final : public CSSValue {
 public:
     static Ref<CSSCircleValue> create(RefPtr<CSSValue>&& radius, RefPtr<CSSValue>&& centerX, RefPtr<CSSValue>&& centerY);
 
@@ -91,6 +120,23 @@ public:
     String customCSSText() const;
     bool equals(const CSSCircleValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (m_radius) {
+            if (func(*m_radius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_centerX) {
+            if (func(*m_centerX) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_centerY) {
+            if (func(*m_centerY) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSCircleValue(RefPtr<CSSValue>&& radius, RefPtr<CSSValue>&& centerX, RefPtr<CSSValue>&& centerY);
 
@@ -99,7 +145,7 @@ private:
     RefPtr<CSSValue> m_centerY;
 };
 
-class CSSEllipseValue : public CSSValue {
+class CSSEllipseValue final : public CSSValue {
 public:
     static Ref<CSSEllipseValue> create(RefPtr<CSSValue>&& radiusX, RefPtr<CSSValue>&& radiusY, RefPtr<CSSValue>&& centerX, RefPtr<CSSValue>&& centerY);
 
@@ -115,6 +161,27 @@ public:
     String customCSSText() const;
     bool equals(const CSSEllipseValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (m_radiusX) {
+            if (func(*m_radiusX) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_radiusY) {
+            if (func(*m_radiusY) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_centerX) {
+            if (func(*m_centerX) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_centerY) {
+            if (func(*m_centerY) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSEllipseValue(RefPtr<CSSValue>&& radiusX, RefPtr<CSSValue>&& radiusY, RefPtr<CSSValue>&& centerX, RefPtr<CSSValue>&& centerY);
 
@@ -124,7 +191,7 @@ private:
     RefPtr<CSSValue> m_centerY;
 };
 
-class CSSPolygonValue : public CSSValueContainingVector {
+class CSSPolygonValue final : public CSSValueContainingVector {
 public:
     static Ref<CSSPolygonValue> create(CSSValueListBuilder values, WindRule);
 
@@ -139,7 +206,7 @@ private:
     WindRule m_windRule { };
 };
 
-class CSSRectShapeValue : public CSSValue {
+class CSSRectShapeValue final : public CSSValue {
 public:
     static Ref<CSSRectShapeValue> create(Ref<CSSValue>&& top, Ref<CSSValue>&& right, Ref<CSSValue>&& bottom, Ref<CSSValue>&& left, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius);
 
@@ -164,6 +231,35 @@ public:
     String customCSSText() const;
     bool equals(const CSSRectShapeValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_top.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_right.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_bottom.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_left.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (m_topLeftRadius) {
+            if (func(*m_topLeftRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_topRightRadius) {
+            if (func(*m_topRightRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_bottomRightRadius) {
+            if (func(*m_bottomRightRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_bottomLeftRadius) {
+            if (func(*m_bottomLeftRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSRectShapeValue(Ref<CSSValue>&& top, Ref<CSSValue>&& right, Ref<CSSValue>&& bottom, Ref<CSSValue>&& left, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius);
 
@@ -178,7 +274,7 @@ private:
     RefPtr<CSSValue> m_bottomLeftRadius;
 };
 
-class CSSXywhValue : public CSSValue {
+class CSSXywhValue final : public CSSValue {
 public:
     static Ref<CSSXywhValue> create(Ref<CSSValue>&& insetX, Ref<CSSValue>&& insetY, Ref<CSSValue>&& width, Ref<CSSValue>&& height, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius);
 
@@ -203,6 +299,36 @@ public:
     String customCSSText() const;
     bool equals(const CSSXywhValue&) const;
 
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_insetX.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_insetY.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_width.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_height.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (m_topLeftRadius) {
+            if (func(*m_topLeftRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_topRightRadius) {
+            if (func(*m_topRightRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_bottomRightRadius) {
+            if (func(*m_bottomRightRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_bottomLeftRadius) {
+            if (func(*m_bottomLeftRadius) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSXywhValue(Ref<CSSValue>&& insetX, Ref<CSSValue>&& insetY, Ref<CSSValue>&& width, Ref<CSSValue>&& height, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius);
 
@@ -217,7 +343,7 @@ private:
     RefPtr<CSSValue> m_bottomLeftRadius;
 };
 
-class CSSPathValue : public CSSValue {
+class CSSPathValue final : public CSSValue {
 public:
     static Ref<CSSPathValue> create(SVGPathByteStream, WindRule);
 

--- a/Source/WebCore/css/CSSCounterValue.h
+++ b/Source/WebCore/css/CSSCounterValue.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class CSSCounterValue : public CSSValue {
+class CSSCounterValue final : public CSSValue {
 public:
     static Ref<CSSCounterValue> create(AtomString identifier, AtomString separator, RefPtr<CSSValue> counterStyle);
 
@@ -41,6 +41,15 @@ public:
 
     String customCSSText() const;
     bool equals(const CSSCounterValue&) const;
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (m_counterStyle) {
+            if (func(*m_counterStyle) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
 
 private:
     CSSCounterValue(AtomString identifier, AtomString separator, RefPtr<CSSValue> counterStyle);

--- a/Source/WebCore/css/CSSCrossfadeValue.h
+++ b/Source/WebCore/css/CSSCrossfadeValue.h
@@ -50,6 +50,17 @@ public:
 
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_fromValueOrNone.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_toValueOrNone.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_percentageValue.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSCrossfadeValue(Ref<CSSValue>&& fromValueOrNone, Ref<CSSValue>&& toValueOrNone, Ref<CSSPrimitiveValue>&& percentageValue, bool isPrefixed);
 

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -45,6 +45,11 @@ public:
     String customCSSText() const;
     bool equals(const CSSCursorImageValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        return func(m_imageValue.get());
+    }
+
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
 private:

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -107,6 +107,18 @@ public:
 
     Ref<const CSSVariableData> asVariableData() const;
 
+    // Say true conservatively.
+    bool customMayDependOnBaseURL() const { return true; }
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (auto* value = std::get_if<Ref<CSSVariableReferenceValue>>(&m_value)) {
+            if (func(*value) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSCustomPropertyValue(const AtomString& name, VariantValue&& value)
         : CSSValue(CustomPropertyClass)

--- a/Source/WebCore/css/CSSFilterImageValue.h
+++ b/Source/WebCore/css/CSSFilterImageValue.h
@@ -53,6 +53,16 @@ public:
 
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_imageValueOrNone.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_filterValue.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        return IterationStatus::Continue;
+    }
+
 private:
     explicit CSSFilterImageValue(Ref<CSSValue>&& imageValueOrNone, Ref<CSSValue>&& filterValue);
 

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -135,6 +135,11 @@ void CSSFontFaceSrcResourceValue::customClearReplacementURLForSubresources()
     m_replacementURLString = { };
 }
 
+bool CSSFontFaceSrcResourceValue::customMayDependOnBaseURL() const
+{
+    return WebCore::mayDependOnBaseURL(m_location);
+}
+
 String CSSFontFaceSrcResourceValue::customCSSText() const
 {
     StringBuilder builder;

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -118,6 +118,7 @@ public:
     bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
     void customSetReplacementURLForSubresources(const HashMap<String, String>&);
     void customClearReplacementURLForSubresources();
+    bool customMayDependOnBaseURL() const;
     bool equals(const CSSFontFaceSrcResourceValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h
@@ -60,6 +60,15 @@ public:
 
     bool equals(const CSSFontPaletteValuesOverrideColorsValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_key.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_color.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSFontPaletteValuesOverrideColorsValue(Ref<CSSPrimitiveValue>&& key, Ref<CSSPrimitiveValue>&& color)
         : CSSValue(FontPaletteValuesOverrideColorsClass)

--- a/Source/WebCore/css/CSSFontStyleRangeValue.h
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.h
@@ -46,6 +46,17 @@ public:
 
     bool equals(const CSSFontStyleRangeValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(fontStyleValue.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (obliqueValues) {
+            if (func(*obliqueValues) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
     Ref<CSSPrimitiveValue> fontStyleValue;
     RefPtr<CSSValueList> obliqueValues;
 

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.h
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.h
@@ -39,6 +39,13 @@ public:
     String customCSSText() const;
     bool equals(const CSSFontStyleWithAngleValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_obliqueAngle.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSFontStyleWithAngleValue(Ref<CSSPrimitiveValue>&& obliqueAngle);
 

--- a/Source/WebCore/css/CSSFontValue.cpp
+++ b/Source/WebCore/css/CSSFontValue.cpp
@@ -59,4 +59,37 @@ bool CSSFontValue::equals(const CSSFontValue& other) const
         && compareCSSValuePtr(family, other.family);
 }
 
+IterationStatus CSSFontValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+{
+    if (style) {
+        if (func(*style) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    if (variant) {
+        if (func(*variant) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    if (weight) {
+        if (func(*weight) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    if (stretch) {
+        if (func(*stretch) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    if (size) {
+        if (func(*size) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    if (lineHeight) {
+        if (func(*lineHeight) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    if (family) {
+        if (func(*family) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    return IterationStatus::Continue;
+}
+
 }

--- a/Source/WebCore/css/CSSFontValue.h
+++ b/Source/WebCore/css/CSSFontValue.h
@@ -39,6 +39,8 @@ public:
 
     bool equals(const CSSFontValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+
     RefPtr<CSSValue> style;
     RefPtr<CSSPrimitiveValue> variant;
     RefPtr<CSSPrimitiveValue> weight;

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -107,6 +107,34 @@ public:
     bool equals(const CSSLinearGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        {
+            auto result = WTF::switchOn(m_data.gradientLine,
+                [&](const Angle& data) {
+                    if (func(data.value.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    return IterationStatus::Continue;
+                },
+                [&](const auto&) {
+                    return IterationStatus::Continue;
+                });
+            if (result == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        for (auto& stop : m_stops) {
+            if (stop.color) {
+                if (func(*stop.color) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+            if (stop.position) {
+                if (func(*stop.position) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSLinearGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
         : CSSValue(LinearGradientClass)
@@ -158,6 +186,34 @@ public:
     bool equals(const CSSPrefixedLinearGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        {
+            auto result = WTF::switchOn(m_data.gradientLine,
+                [&](const Angle& data) {
+                    if (func(data.value.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    return IterationStatus::Continue;
+                },
+                [&](const auto&) {
+                    return IterationStatus::Continue;
+                });
+            if (result == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        for (auto& stop : m_stops) {
+            if (stop.color) {
+                if (func(*stop.color) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+            if (stop.position) {
+                if (func(*stop.position) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSPrefixedLinearGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
         : CSSValue(PrefixedLinearGradientClass)
@@ -202,6 +258,29 @@ public:
     String customCSSText() const;
     bool equals(const CSSDeprecatedLinearGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_data.firstX.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_data.firstY.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_data.secondX.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_data.secondY.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        for (auto& stop : m_stops) {
+            if (stop.color) {
+                if (func(*stop.color) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+            if (stop.position) {
+                if (func(*stop.position) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+        }
+        return IterationStatus::Continue;
+    }
 
 private:
     CSSDeprecatedLinearGradientValue(Data&& data, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
@@ -291,6 +370,120 @@ public:
     bool equals(const CSSRadialGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        {
+            auto result = WTF::switchOn(m_data.gradientBox,
+                [&](const Shape& data) {
+                    if (data.position) {
+                        if (func(data.position->first.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                        if (func(data.position->second.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                },
+                [&](const Extent& data) {
+                    if (data.position) {
+                        if (func(data.position->first.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                        if (func(data.position->second.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                },
+                [&](const Length& data) {
+                    if (func(data.length.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    if (data.position) {
+                        if (func(data.position->first.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                        if (func(data.position->second.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                },
+                [&](const Size& data) {
+                    if (func(data.size.first.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    if (func(data.size.second.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    if (data.position) {
+                        if (func(data.position->first.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                        if (func(data.position->second.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                },
+                [&](const CircleOfLength& data) {
+                    if (func(data.length.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    if (data.position) {
+                        if (func(data.position->first.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                        if (func(data.position->second.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                },
+                [&](const CircleOfExtent& data) {
+                    if (data.position) {
+                        if (func(data.position->first.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                        if (func(data.position->second.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                },
+                [&](const EllipseOfSize& data) {
+                    if (func(data.size.first.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    if (func(data.size.second.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    if (data.position) {
+                        if (func(data.position->first.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                        if (func(data.position->second.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                },
+                [&](const EllipseOfExtent& data) {
+                    if (data.position) {
+                        if (func(data.position->first.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                        if (func(data.position->second.get()) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
+                    return IterationStatus::Continue;
+                },
+                [&](const CSSGradientPosition& data) {
+                    if (func(data.first.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    if (func(data.second.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    return IterationStatus::Continue;
+                },
+                [&](const auto&) {
+                    return IterationStatus::Continue;
+                });
+            if (result == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        for (auto& stop : m_stops) {
+            if (stop.color) {
+                if (func(*stop.color) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+            if (stop.position) {
+                if (func(*stop.position) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSRadialGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
         : CSSValue(RadialGradientClass)
@@ -350,6 +543,42 @@ public:
     bool equals(const CSSPrefixedRadialGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        {
+            auto result = WTF::switchOn(m_data.gradientBox,
+                [&](const MeasuredSize& data) {
+                    if (func(data.size.first.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    if (func(data.size.second.get()) == IterationStatus::Done)
+                        return IterationStatus::Done;
+                    return IterationStatus::Continue;
+                },
+                [&](const auto&) {
+                    return IterationStatus::Continue;
+                });
+            if (result == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_data.position) {
+            if (func(m_data.position->first.get()) == IterationStatus::Done)
+                return IterationStatus::Done;
+            if (func(m_data.position->second.get()) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        for (auto& stop : m_stops) {
+            if (stop.color) {
+                if (func(*stop.color) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+            if (stop.position) {
+                if (func(*stop.position) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSPrefixedRadialGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
         : CSSValue(PrefixedRadialGradientClass)
@@ -396,6 +625,33 @@ public:
     String customCSSText() const;
     bool equals(const CSSDeprecatedRadialGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_data.firstX.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_data.firstY.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_data.secondX.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_data.secondY.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_data.firstRadius.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_data.secondRadius.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        for (auto& stop : m_stops) {
+            if (stop.color) {
+                if (func(*stop.color) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+            if (stop.position) {
+                if (func(*stop.position) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+        }
+        return IterationStatus::Continue;
+    }
 
 private:
     CSSDeprecatedRadialGradientValue(Data&& data, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
@@ -447,6 +703,31 @@ public:
     String customCSSText() const;
     bool equals(const CSSConicGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (m_data.angle.value) {
+            if (func(*m_data.angle.value) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_data.position) {
+            if (func(m_data.position->first.get()) == IterationStatus::Done)
+                return IterationStatus::Done;
+            if (func(m_data.position->second.get()) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        for (auto& stop : m_stops) {
+            if (stop.color) {
+                if (func(*stop.color) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+            if (stop.position) {
+                if (func(*stop.position) == IterationStatus::Done)
+                    return IterationStatus::Done;
+            }
+        }
+        return IterationStatus::Continue;
+    }
 
 private:
     explicit CSSConicGradientValue(Data&& data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)

--- a/Source/WebCore/css/CSSImageSetOptionValue.h
+++ b/Source/WebCore/css/CSSImageSetOptionValue.h
@@ -49,6 +49,15 @@ public:
     String type() const { return m_mimeType; }
     void setType(String);
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_image.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_resolution.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSImageSetOptionValue(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&);
     CSSImageSetOptionValue(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&, String&&);

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -130,6 +130,11 @@ void CSSImageValue::customSetReplacementURLForSubresources(const HashMap<String,
         m_replacementURLString = replacementURLString;
 }
 
+bool CSSImageValue::customMayDependOnBaseURL() const
+{
+    return WebCore::mayDependOnBaseURL(m_location);
+}
+
 void CSSImageValue::customClearReplacementURLForSubresources()
 {
     m_replacementURLString = { };

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -63,6 +63,7 @@ public:
     bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
     void customSetReplacementURLForSubresources(const HashMap<String, String>&);
     void customClearReplacementURLForSubresources();
+    bool customMayDependOnBaseURL() const;
 
     bool equals(const CSSImageValue&) const;
 
@@ -71,6 +72,15 @@ public:
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
     bool isLoadedFromOpaqueSource() const { return m_loadedFromOpaqueSource == LoadedFromOpaqueSource::Yes; }
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (m_unresolvedValue) {
+            if (func(*m_unresolvedValue) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
 
 private:
     CSSImageValue();

--- a/Source/WebCore/css/CSSOffsetRotateValue.h
+++ b/Source/WebCore/css/CSSOffsetRotateValue.h
@@ -46,6 +46,19 @@ public:
 
     bool equals(const CSSOffsetRotateValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (m_modifier) {
+            if (func(*m_modifier) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_angle) {
+            if (func(*m_angle) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSOffsetRotateValue(RefPtr<CSSPrimitiveValue>&& modifier, RefPtr<CSSPrimitiveValue>&& angle)
         : CSSValue(OffsetRotateClass)

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.h
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class CSSProperty;
 
-class CSSPendingSubstitutionValue : public CSSValue {
+class CSSPendingSubstitutionValue final : public CSSValue {
 public:
     static Ref<CSSPendingSubstitutionValue> create(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)
     {
@@ -50,6 +50,13 @@ public:
     static String customCSSText() { return emptyString(); }
 
     RefPtr<CSSValue> resolveValue(Style::BuilderState&, CSSPropertyID) const;
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_shorthandValue.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        return IterationStatus::Continue;
+    }
 
 private:
     CSSPendingSubstitutionValue(CSSPropertyID shorthandPropertyId, Ref<CSSVariableReferenceValue>&& shorthandValue)

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1784,4 +1784,13 @@ bool CSSPrimitiveValue::convertingToLengthHasRequiredConversionData(int lengthCo
     return true;
 }
 
+IterationStatus CSSPrimitiveValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+{
+    if (auto* calc = cssCalcValue()) {
+        if (func(const_cast<CSSCalcValue&>(*calc)) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    return IterationStatus::Continue;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -190,6 +190,8 @@ public:
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+
 private:
     friend class CSSValuePool;
     friend class StaticCSSValuePool;

--- a/Source/WebCore/css/CSSQuadValue.h
+++ b/Source/WebCore/css/CSSQuadValue.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class CSSQuadValue : public CSSValue {
+class CSSQuadValue final : public CSSValue {
 public:
     static Ref<CSSQuadValue> create(Quad);
 

--- a/Source/WebCore/css/CSSRayValue.h
+++ b/Source/WebCore/css/CSSRayValue.h
@@ -58,6 +58,17 @@ public:
 
     bool equals(const CSSRayValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_angle.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (m_position) {
+            if (func(*m_position) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSRayValue(Ref<CSSPrimitiveValue>&& angle, CSSValueID size, bool isContaining, RefPtr<CSSValuePair>&& position)
         : CSSValue(RayClass)

--- a/Source/WebCore/css/CSSRectValue.h
+++ b/Source/WebCore/css/CSSRectValue.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class CSSRectValue : public CSSValue {
+class CSSRectValue final : public CSSValue {
 public:
     static Ref<CSSRectValue> create(Rect);
 

--- a/Source/WebCore/css/CSSReflectValue.h
+++ b/Source/WebCore/css/CSSReflectValue.h
@@ -42,6 +42,17 @@ public:
     String customCSSText() const;
     bool equals(const CSSReflectValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_offset.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (m_mask) {
+            if (func(*m_mask) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSReflectValue(CSSValueID direction, Ref<CSSPrimitiveValue> offset, RefPtr<CSSValue> mask);
 

--- a/Source/WebCore/css/CSSScrollValue.h
+++ b/Source/WebCore/css/CSSScrollValue.h
@@ -54,6 +54,19 @@ public:
 
     bool equals(const CSSScrollValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (m_scroller) {
+            if (func(*m_scroller) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_axis) {
+            if (func(*m_axis) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
 private:
     CSSScrollValue(RefPtr<CSSValue>&& scroller, RefPtr<CSSValue>&& axis)
         : CSSValue(ScrollClass)

--- a/Source/WebCore/css/CSSShadowValue.h
+++ b/Source/WebCore/css/CSSShadowValue.h
@@ -44,6 +44,35 @@ public:
 
     bool equals(const CSSShadowValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (x) {
+            if (func(*x) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (y) {
+            if (func(*y) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (blur) {
+            if (func(*blur) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (spread) {
+            if (func(*spread) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (style) {
+            if (func(*style) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (color) {
+            if (func(*color) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
     RefPtr<CSSPrimitiveValue> x;
     RefPtr<CSSPrimitiveValue> y;
     RefPtr<CSSPrimitiveValue> blur;

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -271,6 +271,20 @@ void CSSValue::clearReplacementURLForSubresources()
     });
 }
 
+IterationStatus CSSValue::visitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+{
+    return visitDerived([&](auto& value) {
+        return value.customVisitChildren(func);
+    });
+}
+
+bool CSSValue::mayDependOnBaseURL() const
+{
+    return visitDerived([&](auto& value) {
+        return value.customMayDependOnBaseURL();
+    });
+}
+
 ComputedStyleDependencies CSSValue::computedStyleDependencies() const
 {
     ComputedStyleDependencies dependencies;

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <wtf/IterationStatus.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
@@ -151,9 +152,15 @@ public:
 
     Ref<DeprecatedCSSOMValue> createDeprecatedCSSOMWrapper(CSSStyleDeclaration&) const;
 
+    // FIXME: These three traversing functions are buggy. It should be rewritten with visitChildren.
+    // https://bugs.webkit.org/show_bug.cgi?id=270600
     bool traverseSubresources(const Function<bool(const CachedResource&)>&) const;
     void setReplacementURLForSubresources(const HashMap<String, String>&);
     void clearReplacementURLForSubresources();
+
+    IterationStatus visitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+
+    bool mayDependOnBaseURL() const;
 
     // What properties does this value rely on (eg, font-size for em units)
     ComputedStyleDependencies computedStyleDependencies() const;
@@ -196,6 +203,8 @@ public:
 
     void customSetReplacementURLForSubresources(const HashMap<String, String>&) { }
     void customClearReplacementURLForSubresources() { }
+    bool customMayDependOnBaseURL() const { return false; }
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const { return IterationStatus::Continue; }
 
 protected:
     static const size_t ClassTypeBits = 7;

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -290,4 +290,13 @@ void CSSValueContainingVector::customClearReplacementURLForSubresources()
         const_cast<CSSValue&>(value).clearReplacementURLForSubresources();
 }
 
+IterationStatus CSSValueContainingVector::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+{
+    for (auto& value : *this) {
+        if (func(const_cast<CSSValue&>(value)) == IterationStatus::Done)
+            return IterationStatus::Done;
+    }
+    return IterationStatus::Continue;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -77,6 +77,8 @@ public:
     RefPtr<const CSSValue> protectedItem(unsigned index) const { return item(index); }
     const CSSValue* itemWithoutBoundsCheck(unsigned index) const { return &(*this)[index]; }
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+
 protected:
     friend bool CSSValue::addHash(Hasher&) const;
 
@@ -96,7 +98,7 @@ private:
     const CSSValue** m_additionalStorage;
 };
 
-class CSSValueList : public CSSValueContainingVector {
+class CSSValueList final : public CSSValueContainingVector {
 public:
     static Ref<CSSValueList> create(UChar separator, CSSValueListBuilder);
 

--- a/Source/WebCore/css/CSSValuePair.h
+++ b/Source/WebCore/css/CSSValuePair.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class CSSValuePair : public CSSValue {
+class CSSValuePair final : public CSSValue {
 public:
     static Ref<CSSValuePair> create(Ref<CSSValue>, Ref<CSSValue>);
     static Ref<CSSValuePair> createSlashSeparated(Ref<CSSValue>, Ref<CSSValue>);
@@ -42,6 +42,15 @@ public:
 
     String customCSSText() const;
     bool equals(const CSSValuePair&) const;
+
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (func(m_first.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        if (func(m_second.get()) == IterationStatus::Done)
+            return IterationStatus::Done;
+        return IterationStatus::Continue;
+    }
 
 private:
     friend bool CSSValue::addHash(Hasher&) const;

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -47,7 +47,7 @@ class BuilderState;
 
 enum CSSPropertyID : uint16_t;
 
-class CSSVariableReferenceValue : public CSSValue {
+class CSSVariableReferenceValue final : public CSSValue {
 public:
     static Ref<CSSVariableReferenceValue> create(const CSSParserTokenRange&, const CSSParserContext&);
     static Ref<CSSVariableReferenceValue> create(Ref<CSSVariableData>&&);

--- a/Source/WebCore/css/CSSViewValue.h
+++ b/Source/WebCore/css/CSSViewValue.h
@@ -55,6 +55,24 @@ public:
 
     bool equals(const CSSViewValue&) const;
 
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+    {
+        if (m_axis) {
+            if (func(*m_axis) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_startInset) {
+            if (func(*m_startInset) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        if (m_endInset) {
+            if (func(*m_endInset) == IterationStatus::Done)
+                return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }
+
+
 private:
     CSSViewValue(RefPtr<CSSValue>&& axis, RefPtr<CSSValue>&& startInset, RefPtr<CSSValue>&& endInset)
         : CSSValue(ViewClass)

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -349,6 +349,24 @@ bool StyleProperties::traverseSubresources(const Function<bool(const CachedResou
     return false;
 }
 
+bool StyleProperties::mayDependOnBaseURL() const
+{
+    bool result = false;
+    Function<IterationStatus(CSSValue&)> func = [&](CSSValue& value) -> IterationStatus {
+        if (value.mayDependOnBaseURL()) {
+            result = true;
+            return IterationStatus::Done;
+        }
+        return value.visitChildren(func);
+    };
+
+    for (auto property : *this) {
+        if (func(*property.value()) == IterationStatus::Done)
+            return result;
+    }
+    return false;
+}
+
 void StyleProperties::setReplacementURLForSubresources(const HashMap<String, String>& replacementURLStrings)
 {
     for (auto property : *this)

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -132,6 +132,7 @@ public:
     bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
     void setReplacementURLForSubresources(const HashMap<String, String>&);
     void clearReplacementURLForSubresources();
+    bool mayDependOnBaseURL() const;
 
     static unsigned averageSizeInBytes();
 

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -72,6 +72,7 @@ public:
     WEBCORE_EXPORT bool parseString(const String&);
 
     bool isCacheable() const;
+    bool isCacheableWithNoBaseURLDependency() const;
 
     bool isLoading() const;
     bool subresourcesAllowReuse(CachePolicy, FrameLoader&) const;
@@ -87,6 +88,8 @@ public:
     const String& charset() const { return m_parserContext.charset; }
 
     bool loadCompleted() const { return m_loadCompleted; }
+
+    bool mayDependOnBaseURL() const;
 
     bool traverseRules(const Function<bool(const StyleRuleBase&)>& handler) const;
     bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -186,4 +186,18 @@ ResolvedURL CSSParserContext::completeURL(const String& string) const
     return result;
 }
 
+bool mayDependOnBaseURL(const ResolvedURL& resolved)
+{
+    if (resolved.specifiedURLString.isEmpty())
+        return false;
+
+    if (CSSValue::isCSSLocalURL(resolved.specifiedURLString))
+        return false;
+
+    if (protocolIs(resolved.specifiedURLString, "data"_s))
+        return false;
+
+    return true;
+}
+
 }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -55,6 +55,8 @@ inline bool operator==(const ResolvedURL& a, const ResolvedURL& b)
     return a.specifiedURLString == b.specifiedURLString && a.resolvedURL == b.resolvedURL;
 }
 
+bool mayDependOnBaseURL(const ResolvedURL&);
+
 struct CSSParserContext {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 


### PR DESCRIPTION
#### a8cb9e6d85cf4333473241f52f4de68b7ae352bf
<pre>
[WebCore] Cache inline styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=270521">https://bugs.webkit.org/show_bug.cgi?id=270521</a>
<a href="https://rdar.apple.com/124074797">rdar://124074797</a>

Reviewed by Antti Koivisto.

CSS in JS is frequently used in the wild. As a result, we can see many
duplicate inline styles randomly, even outside of shadow DOM. Sometimes,
even we use very large strings for inline styles. So we should cache the
inline styles even if it is not inside shadow DOM. This patch adds following
two changes.

1. Caching inline styles for non shadow DOM elements.
2. Adding the mechanism to scan base URL dependecy in CSS rules so that we can disable caching for that case.
   Right now, it is a bit conservative. We disable caching when CSS custom properties exist for example.
3. Originally, we considered using the same mechanism to `setReplacementURLForSubresources` since it needs to
   scan CSSValues too. But it turned out that the implementation is broken and we cannot use it. Since that
   feature also needs to have the correct mechanism to scan CSSValues anyway, this patch implements customVisitChildren
   mechanism to CSSValue, which lists up CSSValue children. So by using this feature, we implement mayDependOnBaseURL
   function by scanning CSSValues. Existing buggy `setReplacementURLForSubresources` / `clearReplacementURLForSubresources` / `traverseSubresources`
   can be rewritten by using this `visitChildren` function. But this patch&apos;s intent is not fixing these existing bugs, so
   we separate the fix from this change. (<a href="https://bugs.webkit.org/show_bug.cgi?id=270600)">https://bugs.webkit.org/show_bug.cgi?id=270600)</a>
4. We found a bug in StyleSheetContents where we didn&apos;t check m_namespaceRules size for `isCacheable()` condition (As a result,
   we observed crashes in some of LayoutTests). This patch fixes it so that we do not say `isCacheable()` =&gt; true when there is
   m_namespaceRules.

* Source/WebCore/css/CSSBasicShapes.h:
(WebCore::CSSInsetShapeValue::top const): Deleted.
(WebCore::CSSInsetShapeValue::right const): Deleted.
(WebCore::CSSInsetShapeValue::bottom const): Deleted.
(WebCore::CSSInsetShapeValue::left const): Deleted.
(WebCore::CSSInsetShapeValue::protectedTop const): Deleted.
(WebCore::CSSInsetShapeValue::protectedRight const): Deleted.
(WebCore::CSSInsetShapeValue::protectedBottom const): Deleted.
(WebCore::CSSInsetShapeValue::protectedLeft const): Deleted.
(WebCore::CSSInsetShapeValue::topLeftRadius const): Deleted.
(WebCore::CSSInsetShapeValue::topRightRadius const): Deleted.
(WebCore::CSSInsetShapeValue::bottomRightRadius const): Deleted.
(WebCore::CSSInsetShapeValue::bottomLeftRadius const): Deleted.
(WebCore::CSSInsetShapeValue::protectedTopLeftRadius const): Deleted.
(WebCore::CSSInsetShapeValue::protectedTopRightRadius const): Deleted.
(WebCore::CSSInsetShapeValue::protectedBottomRightRadius const): Deleted.
(WebCore::CSSInsetShapeValue::protectedBottomLeftRadius const): Deleted.
(WebCore::CSSCircleValue::radius const): Deleted.
(WebCore::CSSCircleValue::centerX const): Deleted.
(WebCore::CSSCircleValue::centerY const): Deleted.
(WebCore::CSSCircleValue::protectedRadius const): Deleted.
(WebCore::CSSCircleValue::protectedCenterX const): Deleted.
(WebCore::CSSCircleValue::protectedCenterY const): Deleted.
(WebCore::CSSEllipseValue::radiusX const): Deleted.
(WebCore::CSSEllipseValue::radiusY const): Deleted.
(WebCore::CSSEllipseValue::centerX const): Deleted.
(WebCore::CSSEllipseValue::centerY const): Deleted.
(WebCore::CSSEllipseValue::protectedRadiusX const): Deleted.
(WebCore::CSSEllipseValue::protectedRadiusY const): Deleted.
(WebCore::CSSEllipseValue::protectedCenterX const): Deleted.
(WebCore::CSSEllipseValue::protectedCenterY const): Deleted.
(WebCore::CSSPolygonValue::windRule const): Deleted.
(WebCore::CSSRectShapeValue::top const): Deleted.
(WebCore::CSSRectShapeValue::right const): Deleted.
(WebCore::CSSRectShapeValue::bottom const): Deleted.
(WebCore::CSSRectShapeValue::left const): Deleted.
(WebCore::CSSRectShapeValue::protectedTop const): Deleted.
(WebCore::CSSRectShapeValue::protectedRight const): Deleted.
(WebCore::CSSRectShapeValue::protectedBottom const): Deleted.
(WebCore::CSSRectShapeValue::protectedLeft const): Deleted.
(WebCore::CSSRectShapeValue::topLeftRadius const): Deleted.
(WebCore::CSSRectShapeValue::topRightRadius const): Deleted.
(WebCore::CSSRectShapeValue::bottomRightRadius const): Deleted.
(WebCore::CSSRectShapeValue::bottomLeftRadius const): Deleted.
(WebCore::CSSRectShapeValue::protectedTopLeftRadius const): Deleted.
(WebCore::CSSRectShapeValue::protectedTopRightRadius const): Deleted.
(WebCore::CSSRectShapeValue::protectedBottomRightRadius const): Deleted.
(WebCore::CSSRectShapeValue::protectedBottomLeftRadius const): Deleted.
(WebCore::CSSXywhValue::insetX const): Deleted.
(WebCore::CSSXywhValue::insetY const): Deleted.
(WebCore::CSSXywhValue::width const): Deleted.
(WebCore::CSSXywhValue::height const): Deleted.
(WebCore::CSSXywhValue::protectedInsetX const): Deleted.
(WebCore::CSSXywhValue::protectedInsetY const): Deleted.
(WebCore::CSSXywhValue::protectedWidth const): Deleted.
(WebCore::CSSXywhValue::protectedHeight const): Deleted.
(WebCore::CSSXywhValue::topLeftRadius const): Deleted.
(WebCore::CSSXywhValue::topRightRadius const): Deleted.
(WebCore::CSSXywhValue::bottomRightRadius const): Deleted.
(WebCore::CSSXywhValue::bottomLeftRadius const): Deleted.
(WebCore::CSSXywhValue::protectedTopLeftRadius const): Deleted.
(WebCore::CSSXywhValue::protectedTopRightRadius const): Deleted.
(WebCore::CSSXywhValue::protectedBottomRightRadius const): Deleted.
(WebCore::CSSXywhValue::protectedBottomLeftRadius const): Deleted.
(WebCore::CSSPathValue::pathData const): Deleted.
(WebCore::CSSPathValue::windRule const): Deleted.
* Source/WebCore/css/CSSCounterValue.h:
(WebCore::CSSCounterValue::identifier const): Deleted.
(WebCore::CSSCounterValue::separator const): Deleted.
(WebCore::CSSCounterValue::counterStyle const): Deleted.
* Source/WebCore/css/CSSCrossfadeValue.h:
* Source/WebCore/css/CSSCursorImageValue.h:
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSFilterImageValue.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::customMayDependOnBaseURL const):
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h:
* Source/WebCore/css/CSSFontStyleRangeValue.h:
* Source/WebCore/css/CSSFontStyleWithAngleValue.h:
* Source/WebCore/css/CSSFontValue.cpp:
(WebCore::CSSFontValue::customVisitChildren const):
* Source/WebCore/css/CSSFontValue.h:
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/CSSImageSetOptionValue.h:
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::customMayDependOnBaseURL const):
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/CSSOffsetRotateValue.h:
* Source/WebCore/css/CSSPendingSubstitutionValue.h:
(WebCore::CSSPendingSubstitutionValue::customVisitChildren const):
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::customVisitChildren const):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSRayValue.h:
* Source/WebCore/css/CSSReflectValue.h:
* Source/WebCore/css/CSSScrollValue.h:
* Source/WebCore/css/CSSShadowValue.h:
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitChildren const):
(WebCore::CSSValue::mayDependOnBaseURL const):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::customMayDependOnBaseURL const):
(WebCore::CSSValue::customVisitChildren const):
* Source/WebCore/css/CSSValueList.h:
(WebCore::CSSValueContainingVector::customVisitChildren const):
* Source/WebCore/css/CSSValuePair.h:
(WebCore::CSSValuePair::customVisitChildren const):
* Source/WebCore/css/CSSVariableReferenceValue.h:
(WebCore::CSSVariableReferenceValue::customMayDependOnBaseURL const):
* Source/WebCore/css/CSSViewValue.h:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::mayDependOnBaseURL const):
* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::StyleSheetContents):
(WebCore::StyleSheetContents::isCacheable const):
(WebCore::StyleSheetContents::isCacheableAndNoBaseURLDependency const):
(WebCore::StyleSheetContents::mayDependOnBaseURL const):
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::mayDependOnBaseURL):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/dom/InlineStyleSheetOwner.cpp:
(WebCore::InlineStyleSheetOwner::createSheet):
(WebCore::makeStyleSheetContentsCacheKey): Deleted.

Canonical link: <a href="https://commits.webkit.org/275795@main">https://commits.webkit.org/275795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5b8a0dc5fa11afb086e1e1ce681e54ee8603a82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19268 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18921 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16531 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/923 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39052 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47006 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14589 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19319 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19483 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5802 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->