### PR TITLE
Do not promote MediaStream HTMLMediaElement to be NowPlaying without the web page using the MediaSession API

### DIFF
--- a/LayoutTests/fast/mediastream/now-playing-and-mediastream-expected.txt
+++ b/LayoutTests/fast/mediastream/now-playing-and-mediastream-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS HTMLMediaElement will become the now playing info source if using mediaSession API
+

--- a/LayoutTests/fast/mediastream/now-playing-and-mediastream.html
+++ b/LayoutTests/fast/mediastream/now-playing-and-mediastream.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id=video autoplay playsinline></video>
+        <script>
+function waitFor(delay)
+{
+    return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+async function waitForCriteria(test, criteria)
+{
+    let counter = 0;
+    while (!criteria() && ++counter < 100)
+        await waitFor(50);
+}
+
+promise_test(async test => {
+    if (!window.internals)
+        return;
+
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test1");
+
+    video.srcObject = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+    await video.play();
+
+    await waitFor(500);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test2");
+
+    navigator.mediaSession.metadata = new MediaMetadata({ title: "test" });
+    await waitForCriteria(test, () => !!internals.nowPlayingState.uniqueIdentifier);
+    assert_true(!!internals.nowPlayingState.uniqueIdentifier, "test3");
+
+    navigator.mediaSession.metadata = null;
+    await waitForCriteria(test, () => !internals.nowPlayingState.uniqueIdentifier);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test4");
+
+    navigator.mediaSession.setActionHandler("pause", () => { });
+    await waitForCriteria(test, () => !!internals.nowPlayingState.uniqueIdentifier);
+    assert_true(!!internals.nowPlayingState.uniqueIdentifier, "test5");
+
+    navigator.mediaSession.setActionHandler("pause", null);
+    await waitForCriteria(test, () => !internals.nowPlayingState.uniqueIdentifier);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test6");
+}, "HTMLMediaElement will become the now playing info source if using mediaSession API");
+
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -270,8 +270,10 @@ media/mediacapabilities/mediacapabilities-types.html [ Pass ]
 media/video-controller-currentTime-rate.html [ Pass ]
 webaudio/codec-tests/aac/vbr-128kbps-44khz.html [ Pass ]
 webaudio/codec-tests/mp3/128kbps-44khz.html [ Pass ]
+
 media/now-playing-webaudio.html [ Failure ]
 media/webaudio-background-playback.html [ Failure ]
+fast/mediastream/now-playing-and-mediastream.html [ Failure ]
 
 # uiController.simulateRotationLikeSafari() is not implemented on glib ports.
 fast/screen-orientation/orientation-in-resize-event.html [ Skip ]

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1246,14 +1246,16 @@ void MediaElementSession::didReceiveRemoteControlCommand(RemoteControlCommandTyp
 
 bool MediaElementSession::hasNowPlayingInfo() const
 {
-#if ENABLE(MEDIA_SESSION) && ENABLE(MEDIA_STREAM)
+#if ENABLE(MEDIA_SESSION)
     if (!canShowControlsManager(MediaElementSession::PlaybackControlsPurpose::NowPlaying))
         return false;
 
+#if ENABLE(MEDIA_STREAM)
     RefPtr session = mediaSession();
-    if (isDocumentPlayingSeveralMediaStreamsAndCapturing(m_element.document()) && (!session || !session->hasActiveActionHandlers()))
+    if (m_element.hasMediaStreamSrcObject() && (!session || (!session->hasActiveActionHandlers() && !session->metadata())))
         return false;
-#endif
+#endif // ENABLE(MEDIA_STREAM)
+#endif // ENABLE(MEDIA_SESSION)
 
     return true;
 }
@@ -1413,9 +1415,14 @@ void MediaElementSession::positionStateChanged(const std::optional<MediaPosition
     clientCharacteristicsChanged(false);
 }
 
-void MediaElementSession::playbackStateChanged(MediaSessionPlaybackState) { }
+void MediaElementSession::playbackStateChanged(MediaSessionPlaybackState)
+{
+}
 
-void MediaElementSession::actionHandlersChanged() { }
+void MediaElementSession::actionHandlersChanged()
+{
+    clientCharacteristicsChanged(false);
+}
 
 void MediaElementSession::clientCharacteristicsChanged(bool positionChanged)
 {


### PR DESCRIPTION
#### 40a84b10af90bfa6acfd1a8506517a304c699381
<pre>
Do not promote MediaStream HTMLMediaElement to be NowPlaying without the web page using the MediaSession API
<a href="https://bugs.webkit.org/show_bug.cgi?id=270522">https://bugs.webkit.org/show_bug.cgi?id=270522</a>
<a href="https://rdar.apple.com/121562032">rdar://121562032</a>

Reviewed by Eric Carlson.

When a web page is becoming NowPlaying, it has to react to Play/Pause commands from the user or from user actions like removing AirPods.
Pausing/Resuming media from regular video streaming is a good default, but pausing/resuming live video streaming (no buffering) is not a great default,
like can be seen in video conferencing or game streaming web sites.

We further restrict MediaStream HTMLMediaElement to becoming NowPlaying to the case where the website is using MediaSession API.
Either it should set metadata or provide action handlers.

* LayoutTests/fast/mediastream/now-playing-and-mediastream-expected.txt: Added.
* LayoutTests/fast/mediastream/now-playing-and-mediastream.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::hasNowPlayingInfo const):
(WebCore::MediaElementSession::playbackStateChanged):
(WebCore::MediaElementSession::actionHandlersChanged):

Canonical link: <a href="https://commits.webkit.org/276028@main">https://commits.webkit.org/276028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92a524958608a9c57c5ef4276d04ec50dc4f4348

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45670 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39170 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38145 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47264 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42415 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41072 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9696 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->