### PR TITLE
Make WebCore::WebVTTParser testable

### DIFF
--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -44,7 +44,7 @@ class HTMLDivElement;
 class VTTCueBox;
 class VTTScanner;
 
-class VTTRegion final : public RefCounted<VTTRegion>, public ContextDestructionObserver {
+class WEBCORE_EXPORT VTTRegion final : public RefCounted<VTTRegion>, public ContextDestructionObserver {
 public:
     static Ref<VTTRegion> create(ScriptExecutionContext& context)
     {

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -96,7 +96,7 @@ private:
     String m_settings;
 };
 
-class WebVTTParser final {
+class WEBCORE_EXPORT WebVTTParser final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum ParseState {
@@ -111,6 +111,7 @@ public:
         Finished
     };
 
+    WebVTTParser() = delete;
     WebVTTParser(WebVTTParserClient&, Document&);
 
     static inline bool isRecognizedTag(const AtomString& tagName)


### PR DESCRIPTION
#### 9c85c7c81e33e375407199f3d3668e9d902e93ce
<pre>
Make WebCore::WebVTTParser testable
<a href="https://bugs.webkit.org/show_bug.cgi?id=270526">https://bugs.webkit.org/show_bug.cgi?id=270526</a>
&lt;<a href="https://rdar.apple.com/124077524">rdar://124077524</a>&gt;

Reviewed by Alex Christensen.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
- Make BufferedLineReader.h and WebVTTParser.h private headers.
* Source/WebCore/html/track/VTTRegion.h:
- Export WebCore::VTTRegion class.
* Source/WebCore/html/track/WebVTTParser.h:
- Export WebCore::WebVTTParser class.
(WebCore::WebVTTParser::WebVTTParser):
- Delete unused default constructor.

Canonical link: <a href="https://commits.webkit.org/275743@main">https://commits.webkit.org/275743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/042b72f17608e955a9668a7deb1b53d7e13969e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45177 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35246 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16185 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16305 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-disconnected-group-owner.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37693 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46660 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41932 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19007 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40545 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19071 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5773 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->