### PR TITLE
Screen share / getDisplayMedia() buggy behavior and usability issues

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -320,9 +320,26 @@ RetainPtr<SCStreamConfiguration> ScreenCaptureKitCaptureSource::streamConfigurat
     if (m_frameRate)
         [m_streamConfiguration setMinimumFrameInterval:PAL::CMTimeMakeWithSeconds(1 / m_frameRate, 1000)];
 
-    if (m_width && m_height) {
-        [m_streamConfiguration setWidth:m_width];
-        [m_streamConfiguration setHeight:m_height];
+    auto width = m_width;
+    auto height = m_height;
+    if (m_contentFilter) {
+        auto contentSize = m_contentFilter.get().contentRect.size;
+        contentSize.width *= m_contentFilter.get().pointPixelScale;
+        contentSize.height *= m_contentFilter.get().pointPixelScale;
+        if (!width && !height) {
+            width = contentSize.width;
+            height = contentSize.height;
+        } else if (contentSize.width && contentSize.height) {
+            if (!width)
+                width = height * contentSize.width / contentSize.height;
+            else if (!height)
+                height = width * contentSize.height / contentSize.width;
+        }
+    }
+
+    if (width && height) {
+        [m_streamConfiguration setWidth:width];
+        [m_streamConfiguration setHeight:height];
     }
 
     return m_streamConfiguration;


### PR DESCRIPTION
#### ad55417ef5c24635d3716669d74cf18dc6bbf60f
<pre>
Screen share / getDisplayMedia() buggy behavior and usability issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=269961">https://bugs.webkit.org/show_bug.cgi?id=269961</a>
<a href="https://rdar.apple.com/123492622">rdar://123492622</a>

Reviewed by Eric Carlson.

The default width and height if not set are 1920x1080, which might not align with the actual window/screen sizes.
This triggers adding black pixels to preserve the aspect ratio.
If width and height are not provided, we use SCContentFilter contentRect information to fill width and height.

Manually tested for both window and screen capture.
This does not yet the case of window size changing, this will be done as a follow-up.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::streamConfiguration):

Canonical link: <a href="https://commits.webkit.org/275736@main">https://commits.webkit.org/275736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5735a25790948a0d0ccf9a2d5205507465fdf902

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45289 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35323 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43250 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16279 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37789 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/733 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46797 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42045 "") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40668 "Found 1 new API test failure: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9535 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->