### PR TITLE
compare-results should be updated to support MotionMark 1.3

### DIFF
--- a/Tools/Scripts/compare-results
+++ b/Tools/Scripts/compare-results
@@ -65,6 +65,7 @@ MotionMark = "MotionMark"
 MotionMark1_1 = "MotionMark-1.1"
 MotionMark1_1_1 = "MotionMark-1.1.1"
 MotionMark1_2 = "MotionMark-1.2"
+MotionMark1_3 = "MotionMark-1.3"
 
 unitMarker = "__unit__"
 
@@ -173,6 +174,8 @@ def motionMarkBreakdown(jsonObject):
         name = "MotionMark-1.1.1"
     elif detectMotionMark1_2(jsonObject):
         name = "MotionMark-1.2"
+    elif detectMotionMark1_3(jsonObject):
+        name = "MotionMark-1.3"
 
     for test in breakdown._results[name]["tests"].keys():
         result[test] = breakdown._results[name]["tests"][test]["metrics"]["Score"][None]["current"]
@@ -514,17 +517,22 @@ def detectMotionMark1_1_1(payload):
 def detectMotionMark1_2(payload):
     return "MotionMark-1.2" in payload
 
+def detectMotionMark1_3(payload):
+    return "MotionMark-1.3" in payload
+
 
 def motionMarkResults(payload):
-    assert any(validMotionMarkDetector(payload) for validMotionMarkDetector in [detectMotionMark, detectMotionMark1_1, detectMotionMark1_1_1, detectMotionMark1_2])
+    assert any(validMotionMarkDetector(payload) for validMotionMarkDetector in [detectMotionMark, detectMotionMark1_1, detectMotionMark1_1_1, detectMotionMark1_2, detectMotionMark1_3])
     if detectMotionMark(payload):
         payload = payload["MotionMark"]
     elif detectMotionMark1_1(payload):
         payload = payload["MotionMark-1.1"]
     elif detectMotionMark1_1_1(payload):
         payload = payload["MotionMark-1.1.1"]
-    else:
+    elif detectMotionMark1_2(payload):
         payload = payload["MotionMark-1.2"]
+    else:
+        payload = payload["MotionMark-1.3"]
     testNames = list(payload["tests"].keys())
     numTests = len(payload["tests"][testNames[0]]["metrics"]["Score"]["current"])
     results = []
@@ -559,10 +567,12 @@ def detectBenchmark(payload):
         return MotionMark1_1
     if detectMotionMark1_2(payload):
         return MotionMark1_2
+    if detectMotionMark1_3(payload):
+        return MotionMark1_3
     return None
 
 def biggerIsBetter(benchmarkType):
-    if benchmarkType in [JetStream2, JetStream3, Speedometer2, Speedometer3, MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2]:
+    if benchmarkType in [JetStream2, JetStream3, Speedometer2, Speedometer3, MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2, MotionMark1_3]:
         return True
     elif benchmarkType in [PLT5, CompetitivePLT, PLUM3]:
         return False
@@ -696,7 +706,7 @@ def main():
 
         if args.csv:
             writeCSV(speedometer3Breakdown(a), speedometer3Breakdown(b), args.csv)
-    elif any(typeA == validMotionMarkTest for validMotionMarkTest in [MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2]):
+    elif any(typeA == validMotionMarkTest for validMotionMarkTest in [MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2, MotionMark1_3]):
         if args.breakdown:
             dumpBreakdowns(motionMarkBreakdown(a), motionMarkBreakdown(b))
 


### PR DESCRIPTION
#### a1c9c2d867f25527bf685106d4f47f72ee4eb970
<pre>
compare-results should be updated to support MotionMark 1.3
<a href="https://bugs.webkit.org/show_bug.cgi?id=270529">https://bugs.webkit.org/show_bug.cgi?id=270529</a>
<a href="https://rdar.apple.com/124081628">rdar://124081628</a>

Reviewed by Stephanie Lewis.

Add MotionMark 1.3 support to compare-results

* Tools/Scripts/compare-results:
(motionMarkBreakdown):
(detectMotionMark1_2):
(detectMotionMark1_3):
(motionMarkResults):
(detectBenchmark):
(biggerIsBetter):
(main):

Canonical link: <a href="https://commits.webkit.org/275709@main">https://commits.webkit.org/275709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/055d7ec37e1361fc5dbab9909192f81d921e04a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18959 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43146 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16188 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37706 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/629 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46665 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19010 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40552 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9521 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19091 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->