### PR TITLE
Fix invisible scrollbars on webkit.org

### DIFF
--- a/Websites/webkit.org/wp-content/themes/webkit/header.php
+++ b/Websites/webkit.org/wp-content/themes/webkit/header.php
@@ -5,6 +5,7 @@
     <meta name="robots" content="noodp">
 
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes, viewport-fit=cover">
+    <meta name="theme-color" content="hsl(203.6, 100%, 12%)">
 
     <title><?php if ( is_front_page() ) echo "WebKit";
         else { wp_title(''); echo ' | WebKit'; } ?></title>

--- a/Websites/webkit.org/wp-content/themes/webkit/style.css
+++ b/Websites/webkit.org/wp-content/themes/webkit/style.css
@@ -8,7 +8,6 @@ Version: 1.0
 */
 
 :root {
-    --background-color: hsl(203.6, 100%, 12%);
     --link-color: hsl(200, 100%, 40%);
     --text-color: hsl(0, 0%, 20%);
     --text-color-light: hsl(0, 0%, 87%);
@@ -19,6 +18,7 @@ Version: 1.0
     --inverse-link-color: hsl(206.7, 100%, 70%);
 
     --content-background-color: hsl(0, 0%, 96.9%);
+    --header-background-color: hsl(203.6, 100%, 12%);
     --horizontal-rule-color: hsl(0, 0%, 86.7%);
 
     --code-background-color: hsl(0, 0%, 94.9%);
@@ -128,7 +128,6 @@ Version: 1.0
 
 @media(prefers-color-scheme:dark) {
     :root {
-        --background-color: hsl(203.6, 100%, 12%);
         --link-color: hsl(206.7, 100%, 70%);
         --text-color: hsl(240, 1.3%, 84.5%);
         --text-color-light: hsl(0, 0%, 33.3%);
@@ -139,6 +138,7 @@ Version: 1.0
         --inverse-link-color: hsl(206.7, 100%, 70%);
 
         --content-background-color: hsl(120, 2%, 9%);
+        --header-background-color: hsl(203.6, 100%, 12%);
         --horizontal-rule-color: hsl(0, 0%, 33.3%);
 
         --code-background-color: hsl(120, 1%, 19.4%);
@@ -281,7 +281,7 @@ body {
     line-height: 1.52947;
     letter-spacing: -0.021rem;
     background-color: hsl(203.6, 100%, 12%);
-    background-color: var(--background-color);
+    background-color: var(--content-background-color);
     color: hsl(0, 0%, 20%);
     color: var(--text-color);
 }
@@ -505,6 +505,7 @@ input[type=submit] {
 
 /** Header **/
 header {
+    background-color: var(--header-background-color);
     overflow: visible;
     width: 100vw;
     max-width: 100%;
@@ -739,6 +740,8 @@ a.download {
 
 /** Footer **/
 footer {
+    background-color: var(--header-background-color);
+    box-shadow: 0 100vh 0 100vh var(--header-background-color);
     content: "";
     display: table;
     clear: both;


### PR DESCRIPTION
#### 0960edb5f34c825f84edc406484850030c2eda4a
<pre>
Fix invisible scrollbars on webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=270528">https://bugs.webkit.org/show_bug.cgi?id=270528</a>

Reviewed by Timothy Hatcher.

* Websites/webkit.org/wp-content/themes/webkit/header.php:
* Websites/webkit.org/wp-content/themes/webkit/style.css:
(:root):
(@media(prefers-color-scheme:dark) :root):
(body):
(header):
(footer):

Canonical link: <a href="https://commits.webkit.org/275701@main">https://commits.webkit.org/275701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c210cd38becc6b7f6178b1eb1aa3c4e18d595dc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42573 "Failed to checkout and rebase branch from PR 25492") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/24845 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/18960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43147 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16189 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/630 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46666 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/18960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5749 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->