### PR TITLE
build-and-collect-pgo-profiles script should be updated to use run-benchmarks' built-in HTTP server by default

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -87,6 +87,7 @@ jsargs=(
     --plan jetstream2
     --diagnose-directory="$BASE/jetstream"
     --generate-pgo-profiles
+    --http-server-type builtin
     --count 1
 )
 
@@ -94,6 +95,7 @@ sp3args=(
     --plan speedometer3
     --diagnose-directory="$BASE/speedometer3"
     --generate-pgo-profiles
+    --http-server-type builtin
     --count 1
 )
 
@@ -101,6 +103,7 @@ mmargs=(
     --plan motionmark
     --diagnose-directory="$BASE/motionmark"
     --generate-pgo-profiles
+    --http-server-type builtin
     --count 1
 )
 


### PR DESCRIPTION
#### e176fe28ba1e968d28c125454ef137234ffdf238
<pre>
build-and-collect-pgo-profiles script should be updated to use run-benchmarks&apos; built-in HTTP server by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=270530">https://bugs.webkit.org/show_bug.cgi?id=270530</a>
<a href="https://rdar.apple.com/124083240">rdar://124083240</a>

Reviewed by Stephanie Lewis and Dewei Zhu.

Update build-and-collect-pgo-profiles script to use run-benchmarks&apos; built-in HTTP server mode. This helps reduce our dependency on Twisted.

* Tools/Scripts/build-and-collect-pgo-profiles:

Canonical link: <a href="https://commits.webkit.org/275714@main">https://commits.webkit.org/275714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ce7bde3ca1fa1c52c4d4d5975801ddce64f42ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45182 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35251 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43148 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16190 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37700 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/631 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46667 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41939 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19012 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9525 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->