### PR TITLE
[run-webkit-tests] introduce --add-baselines-to-platform=PLATFORM_DIR

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -256,6 +256,12 @@ class SingleTestRunner(object):
                 port.baseline_version_dir(device_type=device_type),
                 fs.dirname(self._test_name),
             )
+        elif self._options.add_baselines_to_platform:
+            # Whatever was passed.
+            output_dir = fs.join(
+                self._options.add_baselines_to_platform,
+                fs.dirname(self._test_name),
+            )
         elif rebaselining:
             # The directory containing the existing baseline or the generic path.
             output_dir = fs.dirname(
@@ -282,6 +288,48 @@ class SingleTestRunner(object):
         )
 
         output_path = fs.join(output_dir, output_basename)
+
+        if not self._options.add_redundant_platform_results:
+            baseline_search_path = [
+                fs.join(p, fs.dirname(self._test_name))
+                for p in (
+                    port.baseline_search_path(device_type=device_type)
+                    + [port.layout_tests_dir()]
+                )
+            ]
+            seen_output_dir = False
+            abs_output_dir = fs.abspath(output_dir)
+            for path in baseline_search_path:
+                if fs.abspath(path) == abs_output_dir:
+                    seen_output_dir = True
+                    continue
+
+                if not seen_output_dir:
+                    continue
+
+                candidate = fs.join(path, output_basename)
+                if fs.isfile(candidate):
+                    if (
+                        fs.getsize(candidate) == len(data)
+                        and fs.read_binary_file(candidate) == data
+                    ):
+                        _log.info(
+                            'Skipping writing redundant expected result "{}" due to existing "{}"'.format(
+                                port.relative_test_filename(output_path),
+                                port.relative_test_filename(candidate),
+                            )
+                        )
+
+                        if fs.exists(output_path):
+                            _log.info(
+                                'Removing existing expected result "{}"'.format(
+                                    port.relative_test_filename(output_path),
+                                )
+                            )
+                            fs.remove(output_path)
+                        return
+                    break
+
         _log.info('Writing new expected result "%s"' % port.relative_test_filename(output_path))
         fs.maybe_make_directory(output_dir)
         fs.write_binary_file(output_path, data)

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -171,6 +171,11 @@ def parse_args(args):
             help="Path to the directory under which build files are kept (should not include configuration)"),
         optparse.make_option("--add-platform-exceptions", action="store_true", default=False,
             help="Save generated results into the *most-specific-platform* directory rather than the *generic-platform* directory"),
+        optparse.make_option("--add-baselines-to-platform", default=False,
+            help="Save generated results into a specified platform directory",
+            metavar="PLATFORM_DIR"),
+        optparse.make_option("--add-redundant-platform-results", action="store_true",
+            help="Save generated results the platform even if they're redundant"),
         optparse.make_option("--new-baseline", action="store_true",
             default=False, help="Save generated results as new baselines "
                  "into the *most-specific-platform* directory, overwriting whatever's "
@@ -263,6 +268,7 @@ def parse_args(args):
         optparse.make_option("--test-list", action="append",
             help="read list of tests to run from file", metavar="FILE"),
         optparse.make_option("--skipped", action="store", default="default",
+            choices=["default", "ignore", "only", "always"],
             help=("control how tests marked SKIP are run. "
                  "'default' == Skip tests unless explicitly listed on the command line, "
                  "'ignore' == Run them anyway, "
@@ -274,6 +280,7 @@ def parse_args(args):
         optparse.make_option("--time-out-ms", "--timeout",
             help="Set the timeout for each test in milliseconds"),
         optparse.make_option("--order", action="store", default="natural",
+            choices=["none", "natural", "random"],
             help=("determine the order in which the test cases will be run. "
                   "'none' == use the order in which the tests were listed either in arguments or test list, "
                   "'natural' == use the natural order (default), "

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -1219,7 +1219,7 @@ class RebaselineTest(unittest.TestCase, StreamTestingMixin):
         host = MockHost()
         host.filesystem.clear_written_files()
         details, err, _ = logging_run(
-            ['--pixel-tests', '--new-baseline', 'passes/image.html', 'failures/expected/missing_image.html'],
+            ['--pixel-tests', '--new-baseline', '--add-redundant-platform-results', 'passes/image.html', 'failures/expected/missing_image.html'],
             tests_included=True, host=host, new_results=True)
         file_list = host.filesystem.written_files.keys()
         self.assertEqual(details.exit_code, 0)


### PR DESCRIPTION
#### 9a62ea99c1e322fc188e3b7738056899e39e5395
<pre>
[run-webkit-tests] introduce --add-baselines-to-platform=PLATFORM_DIR
<a href="https://bugs.webkit.org/show_bug.cgi?id=270483">https://bugs.webkit.org/show_bug.cgi?id=270483</a>
<a href="https://rdar.apple.com/problem/124034416">rdar://problem/124034416</a>

Reviewed by Jonathan Bedard.

This provides the ability to generate baselines for a specified platform
directory (rather than the default, overriding the existing baseline, or
with --add-platform-exceptions into the most specific directory).

Along with this, add --add-redundant-platform-results, and change the
default to _not_ write new baselines if they are redundant (i.e., they
match something further up the baseline search path).

* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner): Remove uneeded constants.
(SingleTestRunner._add_missing_baselines): Let _save_baseline_data compute paths.
(SingleTestRunner._location_for_new_baseline): Deleted.
(SingleTestRunner._overwrite_baselines): Let _save_baseline_data compute paths.
(SingleTestRunner._save_baseline_data):
Make this find the location itself, use TestResultWriter.expected_filename, optionally skip redundant results.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args): Add new args; drive-by: add choice to other args so run-webkit-tests errors with invalid options
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RebaselineTest.test_new_baseline): Pass --add-redundant-platform-results as it tests they&apos;re written.
* Tools/Scripts/webkitpy/port/base.py:
(Port.baseline_version_dir): Correctly pass along device_type.
(Port.update_baseline): Deleted.

Canonical link: <a href="https://commits.webkit.org/282858@main">https://commits.webkit.org/282858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4d1a369542837b3149b5b796c192b6b4e5b6bd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64494 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17090 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68517 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/10425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40566 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/55811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/32514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/64005 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13189 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13975 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70216 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13029 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55900 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14224 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6983 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39672 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->