### PR TITLE
REGRESSION(275690@main): [webkitpy][Win] NameError: name '_winreg' is not defined

### DIFF
--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -47,7 +47,7 @@ _log = logging.getLogger(__name__)
 
 
 try:
-    import _winreg
+    import winreg
 except ImportError:
     _log.debug("Not running on native Windows.")
 
@@ -70,10 +70,10 @@ class WinPort(ApplePort):
         WINDOWS_ERROR_REPORTING_KEY = r'SOFTWARE\Microsoft\Windows\Windows Error Reporting'
         WOW64_WINDOWS_ERROR_REPORTING_KEY = r'SOFTWARE\Wow6432Node\Microsoft\Windows\Windows Error Reporting'
         FILE_SYSTEM_KEY = r'SYSTEM\CurrentControlSet\Control\FileSystem'
-        _HKLM = _winreg.HKEY_LOCAL_MACHINE
-        _HKCU = _winreg.HKEY_CURRENT_USER
-        _REG_DWORD = _winreg.REG_DWORD
-        _REG_SZ = _winreg.REG_SZ
+        _HKLM = winreg.HKEY_LOCAL_MACHINE
+        _HKCU = winreg.HKEY_CURRENT_USER
+        _REG_DWORD = winreg.REG_DWORD
+        _REG_SZ = winreg.REG_SZ
     else:
         POST_MORTEM_DEBUGGER_KEY = "/%s/SOFTWARE/Microsoft/Windows NT/CurrentVersion/AeDebug/%s"
         WOW64_POST_MORTEM_DEBUGGER_KEY = "/%s/SOFTWARE/Wow6432Node/Microsoft/Windows NT/CurrentVersion/AeDebug/%s"
@@ -250,9 +250,9 @@ class WinPort(ApplePort):
         if sys.platform.startswith('win'):
             _log.debug("Trying to read %s\\%s" % (reg_path, key))
             try:
-                registry_key = _winreg.OpenKey(root, reg_path)
-                value = _winreg.QueryValueEx(registry_key, key)
-                _winreg.CloseKey(registry_key)
+                registry_key = winreg.OpenKey(root, reg_path)
+                value = winreg.QueryValueEx(registry_key, key)
+                winreg.CloseKey(registry_key)
             except WindowsError as ex:
                 _log.debug("Unable to read %s\\%s: %s" % (reg_path, key, str(ex)))
                 return ['', self._REG_SZ]
@@ -278,19 +278,19 @@ class WinPort(ApplePort):
         if sys.platform.startswith('win'):
             _log.debug("Trying to write %s\\%s = %s" % (reg_path, key, value))
             try:
-                registry_key = _winreg.OpenKey(root, reg_path, 0, _winreg.KEY_WRITE)
+                registry_key = winreg.OpenKey(root, reg_path, 0, winreg.KEY_WRITE)
             except WindowsError:
                 try:
                     _log.debug("Key doesn't exist -- must create it.")
-                    registry_key = _winreg.CreateKeyEx(root, reg_path, 0, _winreg.KEY_WRITE)
+                    registry_key = winreg.CreateKeyEx(root, reg_path, 0, winreg.KEY_WRITE)
                 except WindowsError as ex:
                     _log.error(r"Error setting (%s) %s\key: %s to value: %s.  Error=%s." % (arch, root, key, value, str(ex)))
                     _log.error("You many need to adjust permissions on the %s\\%s key." % (reg_path, key))
                     return False
 
             _log.debug("Writing {0} of type {1} to {2}\\{3}".format(value, regType, registry_key, key))
-            _winreg.SetValueEx(registry_key, key, 0, regType, value)
-            _winreg.CloseKey(registry_key)
+            winreg.SetValueEx(registry_key, key, 0, regType, value)
+            winreg.CloseKey(registry_key)
         else:
             registry_key = reg_path % (root, key)
             _log.debug("Writing to %s" % registry_key)


### PR DESCRIPTION
#### e6fda5d30717d28374a2a45f9604e87ae826f271
<pre>
REGRESSION(275690@main): [webkitpy][Win] NameError: name &apos;_winreg&apos; is not defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=270534">https://bugs.webkit.org/show_bug.cgi?id=270534</a>

Unreviewed fix for Windows port.

* Tools/Scripts/webkitpy/port/win.py:
Rename _winreg to winreg.

Canonical link: <a href="https://commits.webkit.org/275706@main">https://commits.webkit.org/275706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d97260bea08314edbbc76c15c16ee8ba2bd341e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/42580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44982 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38702 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/44887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/25016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/18967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/45188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/43154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/25016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/42451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/25016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/637 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/25016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/46674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17399 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/18967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/46674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/46674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5752 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->