### PR TITLE
Web Inspector: Proposing feature: Display font selected as the font under identity in the font tab

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -463,6 +463,14 @@
             ]
         },
         {
+            "name": "getLoadedFonts",
+            "description": "Returns all loaded fonts (system and custom).",
+            "targetTypes": ["page"],
+            "returns": [
+                { "name": "fontFamilyNames", "type": "array", "items": { "type": "string" }, "description": "Loaded font families." }
+            ]
+        },
+        {
             "name": "forcePseudoState",
             "description": "Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser.",
             "targetTypes": ["page"],

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -47,6 +47,8 @@
 #include "Font.h"
 #include "FontCache.h"
 #include "FontCascade.h"
+#include "FontFace.h"
+#include "FontFaceSet.h"
 #include "FontPlatformData.h"
 #include "HTMLHeadElement.h"
 #include "HTMLHtmlElement.h"
@@ -912,6 +914,23 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorCSSAgent
     Vector<String> systemFontFamilies = FontCache::forCurrentThread().systemFontFamilies();
     for (const auto& familyName : systemFontFamilies)
         fontFamilyNames->addItem(familyName);
+
+    return fontFamilyNames;
+}
+
+Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> InspectorCSSAgent::getLoadedFonts()
+{
+    auto fontFamilyNames = JSON::ArrayOf<String>::create();
+    auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
+
+    for (auto* document : domAgent->documents()) {
+        auto iterator = document->fonts().get().createIterator(document->scriptExecutionContext());
+
+        while (auto font = iterator.next()) {
+            if (font->status() == FontFace::LoadStatus::Loaded)
+                fontFamilyNames->addItem(font.get()->family());
+        }
+    }
 
     return fontFamilyNames;
 }

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -112,6 +112,7 @@ public:
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSRule>> addRule(const Inspector::Protocol::CSS::StyleSheetId&, const String& selector);
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>>> getSupportedCSSProperties();
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> getSupportedSystemFontFamilyNames();
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> getLoadedFonts();
     Inspector::Protocol::ErrorStringOr<void> forcePseudoState(Inspector::Protocol::DOM::NodeId, Ref<JSON::Array>&& forcedPseudoClasses);
     Inspector::Protocol::ErrorStringOr<void> setLayoutContextTypeChangedMode(Inspector::Protocol::CSS::LayoutContextTypeChangedMode);
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -156,6 +156,10 @@ localizedStrings["All Changes"] = "All Changes";
 localizedStrings["All Events @ Event Breakpoint"] = "All Events";
 /* Break (pause) on all exceptions */
 localizedStrings["All Exceptions @ JavaScript Breakpoint"] = "All Exceptions";
+/* Font Details Panel */
+localizedStrings["All Fonts @ Font Details Sidebar Property"] = "All Fonts";
+localizedStrings["All Fonts Properties @ Font Details Sidebar Section"] = "All Fonts Properties";
+localizedStrings["All Fonts ToolTip @ Font Details Sidebar"] = "All Fonts ToolTip";
 /* Break (pause) on all intervals */
 localizedStrings["All Intervals @ Event Breakpoint"] = "All Intervals";
 localizedStrings["All Layers"] = "All Layers";

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -49,6 +49,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         this._propertyNameToEffectivePropertyMap = {};
         this._usedCSSVariables = new Set;
         this._allCSSVariables = new Set;
+        this._usedFonts = [];
 
         this._pendingRefreshTask = null;
         this.refresh();
@@ -134,6 +135,8 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
     get computedPrimaryFont() { return this._computedPrimaryFont; }
     get usedCSSVariables() { return this._usedCSSVariables; }
     get allCSSVariables() { return this._allCSSVariables; }
+
+    get usedFonts() { return this._usedFonts; }
 
     set ignoreNextContentDidChangeForStyleSheet(ignoreNextContentDidChangeForStyleSheet) { this._ignoreNextContentDidChangeForStyleSheet = ignoreNextContentDidChangeForStyleSheet; }
 
@@ -339,6 +342,16 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         target.CSSAgent.getMatchedStylesForNode.invoke({nodeId: this._node.id, includePseudo: true, includeInherited: true}, wrap.call(this, fetchedMatchedStyles, fetchedMatchedStylesPromise));
         target.CSSAgent.getInlineStylesForNode.invoke({nodeId: this._node.id}, wrap.call(this, fetchedInlineStyles, fetchedInlineStylesPromise));
         target.CSSAgent.getComputedStyleForNode.invoke({nodeId: this._node.id}, wrap.call(this, fetchedComputedStyle, fetchedComputedStylesPromise));
+
+
+        if (InspectorBackend.hasCommand("CSS.getLoadedFonts")) {
+            target.CSSAgent.getLoadedFonts((error, fontFamilyNames) =>{
+                if (error)
+                    return;
+                this._usedFonts = fontFamilyNames;
+                console.log(fontFamilyNames);
+            });
+        }
 
         // COMPATIBILITY (iOS 14.0): `CSS.getFontDataForNode` did not exist yet.
         if (InspectorBackend.hasCommand("CSS.getFontDataForNode"))

--- a/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
@@ -122,6 +122,16 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
 
             this._fontVariationsGroup.rows = [emptyRow];
         }
+
+        console.log("In Font Details Panel");
+        console.log(this.nodeStyles.usedFonts);
+
+        for (let fontName of this.nodeStyles.usedFonts) {
+            let row = document.createElement("div");
+            row.textContent = fontName;
+            row.style.fontFamily = fontName;
+            this._allFontsGroup.element.appendChild(row);
+        }
     }
 
     // Protected
@@ -220,6 +230,15 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
 
         let fontVariationPropertiesSection = new WI.DetailsSection("font-variation-properties", WI.UIString("Variation Properties", "Variation Properties @ Font Details Sidebar Section", "Section title for font variation properties."), [this._fontVariationsGroup]);
         this.element.appendChild(fontVariationPropertiesSection.element);
+
+        // All Fonts Properties
+        let allFontsRow = new WI.DetailsSectionSimpleRow(WI.UIString("All Fonts", "All Fonts @ Font Details Sidebar Property", "Font title for the family name of the font."))
+        this._allFontsGroup = new WI.DetailsSectionGroup(allFontsRow);
+
+        let allFontsSection = new WI.DetailsSection("all-fonts-properties", WI.UIString("All Fonts Properties", "All Fonts Properties @ Font Details Sidebar Section", "Section title for all fonts properties."), [this._allFontsGroup]);
+
+        this.element.appendChild(allFontsSection.element);
+
     }
 
     // Private


### PR DESCRIPTION
#### 00dfac4ac7d775d4838023cd7dcf3072061ed7e1
<pre>
Web Inspector: Proposing feature: Display font selected as the font under identity in the font tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=260177">https://bugs.webkit.org/show_bug.cgi?id=260177</a>

Reviewed by NOBODY (OOPS!).

The purpose of this pr is create All Fonts Properties Section that returns
all of the loaded fonts on the webpage consisting of system and custom.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getLoadedFonts):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles):
(WI.DOMNodeStyles.prototype.get usedFonts):
(WI.DOMNodeStyles.prototype.refresh):
* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js:
(WI.FontDetailsPanel.prototype.update):
(WI.FontDetailsPanel.prototype.initialLayout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00dfac4ac7d775d4838023cd7dcf3072061ed7e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/246 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40472 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23847 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43883 "Found 29 new test failures: inspector/css/add-css-property.html, inspector/css/css-property.html, inspector/css/forcePseudoState.html, inspector/css/generateFormattedText.html, inspector/css/getComputedPrimaryFontForNode.html, inspector/css/getMatchedStylesForNodeBackdropPseudoId.html, inspector/css/getMatchedStylesForNodeContainerGrouping.html, inspector/css/getMatchedStylesForNodeLargeSelectors.html, inspector/css/getMatchedStylesForNodeLayerGrouping.html, inspector/css/getMatchedStylesForNodeMarkerPseudoId.html ... (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7941 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42885 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45761 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44398 "Found 29 new test failures: inspector/css/add-css-property.html, inspector/css/css-property.html, inspector/css/forcePseudoState.html, inspector/css/generateFormattedText.html, inspector/css/getComputedPrimaryFontForNode.html, inspector/css/getMatchedStylesForNodeBackdropPseudoId.html, inspector/css/getMatchedStylesForNodeContainerGrouping.html, inspector/css/getMatchedStylesForNodeLargeSelectors.html, inspector/css/getMatchedStylesForNodeLayerGrouping.html, inspector/css/getMatchedStylesForNodeMarkerPseudoId.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54389 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49065 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24655 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20842 "Found 27 new test failures: inspector/css/add-css-property.html, inspector/css/css-property.html, inspector/css/forcePseudoState.html, inspector/css/generateFormattedText.html, inspector/css/getComputedPrimaryFontForNode.html, inspector/css/getMatchedStylesForNodeBackdropPseudoId.html, inspector/css/getMatchedStylesForNodeContainerGrouping.html, inspector/css/getMatchedStylesForNodeLargeSelectors.html, inspector/css/getMatchedStylesForNodeLayerGrouping.html, inspector/css/getMatchedStylesForNodeMarkerPseudoId.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47840 "Found 14 new test failures: inspector/css/add-css-property.html, inspector/css/css-property.html, inspector/css/forcePseudoState.html, inspector/css/getMatchedStylesForNodeContainerGrouping.html, inspector/css/getMatchedStylesForNodeLargeSelectors.html, inspector/css/getMatchedStylesForNodeLayerGrouping.html, inspector/css/getMatchedStylesForNodeMarkerPseudoId.html, inspector/css/pseudo-element-matches-for-pseudo-element-node.html, inspector/css/pseudo-element-matches.html, inspector/css/resolve-variable-value.html ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42845 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46886 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26768 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56552 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25648 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11625 "Passed tests") | 
<!--EWS-Status-Bubble-End-->