### PR TITLE
[Skia] Stub out BackingStore implementation

### DIFF
--- a/Source/WebKit/Platform/WC.cmake
+++ b/Source/WebKit/Platform/WC.cmake
@@ -40,6 +40,10 @@ if (USE_CAIRO)
     list(APPEND WebKit_SOURCES
         UIProcess/cairo/BackingStoreCairo.cpp
     )
+elseif (USE_SKIA)
+    list(APPEND WebKit_SOURCES
+        UIProcess/skia/BackingStoreSkia.cpp
+    )
 endif ()
 
 if (USE_GRAPHICS_LAYER_TEXTURE_MAPPER)

--- a/Source/WebKit/UIProcess/skia/BackingStoreSkia.cpp
+++ b/Source/WebKit/UIProcess/skia/BackingStoreSkia.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,51 +23,42 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "BackingStore.h"
 
-#if USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#if USE(SKIA)
 
-#include <WebCore/IntSize.h>
-#include <WebCore/PlatformImage.h>
-#include <pal/HysteresisActivity.h>
-#include <wtf/Noncopyable.h>
-
-namespace WebCore {
-class IntRect;
-}
+#include "UpdateInfo.h"
+#include <WebCore/NotImplemented.h>
 
 namespace WebKit {
-struct UpdateInfo;
 
-#if USE(CAIRO)
-using PlatformPaintContextPtr = cairo_t*;
-#elif USE(SKIA)
-using PlatformPaintContextPtr = void*;
-#endif
+static const Seconds s_scrollHysteresisDuration { 300_ms };
 
-class BackingStore {
-    WTF_MAKE_FAST_ALLOCATED;
-    WTF_MAKE_NONCOPYABLE(BackingStore);
-public:
-    BackingStore(const WebCore::IntSize&, float deviceScaleFactor);
-    ~BackingStore();
+BackingStore::BackingStore(const WebCore::IntSize& size, float deviceScaleFactor)
+    : m_size(size)
+    , m_deviceScaleFactor(deviceScaleFactor)
+    , m_scrolledHysteresis([this](PAL::HysteresisState state) { if (state == PAL::HysteresisState::Stopped) m_scrollSurface = nullptr; }, s_scrollHysteresisDuration)
+{
+}
 
-    const WebCore::IntSize& size() const { return m_size; }
-    float deviceScaleFactor() const { return m_deviceScaleFactor; }
+BackingStore::~BackingStore() = default;
 
-    void paint(PlatformPaintContextPtr, const WebCore::IntRect&);
-    void incorporateUpdate(UpdateInfo&&);
+void BackingStore::paint(PlatformPaintContextPtr cr, const WebCore::IntRect& rect)
+{
+    notImplemented();
+}
 
-private:
-    void scroll(const WebCore::IntRect&, const WebCore::IntSize&);
+void BackingStore::incorporateUpdate(UpdateInfo&& updateInfo)
+{
+    notImplemented();
+}
 
-    WebCore::IntSize m_size;
-    float m_deviceScaleFactor { 1 };
-    WebCore::PlatformImagePtr m_surface;
-    WebCore::PlatformImagePtr m_scrollSurface;
-    PAL::HysteresisActivity m_scrolledHysteresis;
-};
+void BackingStore::scroll(const WebCore::IntRect& scrollRect, const WebCore::IntSize& scrollOffset)
+{
+    notImplemented();
+}
 
 } // namespace WebKit
 
-#endif // USE(GRAPHICS_LAYER_WC) || (USE(CAIRO) && !PLATFORM(WPE))
+#endif // USE(SKIA)


### PR DESCRIPTION
#### de89f2977a314e5ddbe49384e35b953061d17f29
<pre>
[Skia] Stub out BackingStore implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=270537">https://bugs.webkit.org/show_bug.cgi?id=270537</a>

Reviewed by Adrian Perez de Castro.

Add a stub of BackingStore when `USE(SKIA)` is turned `ON`. Actual
implementation to come later.

* Source/WebKit/Platform/WC.cmake:
* Source/WebKit/UIProcess/BackingStore.h:
* Source/WebKit/UIProcess/skia/BackingStoreSkia.cpp: Copied from Source\WebKit\UIProcess\BackingStore.h.

Canonical link: <a href="https://commits.webkit.org/275752@main">https://commits.webkit.org/275752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/560f8e75fafc93e1de6bb988ee30d9f4cc66fe5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42590 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45198 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38713 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35260 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16201 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16321 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/647 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46719 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41977 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19028 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40595 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9538 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->