### PR TITLE
Unified PDF: HUD zoom buttons don't work on embedded pdfs

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -135,12 +135,30 @@ private:
     float initialScale() const;
     float scaleForFitToView() const;
 
+    /*
+        Unified PDF Plugin scales, in depth order:
+
+        - "device": same as the rest of WebKit. CSS-to-screen pixel ratio.
+
+        - "page": the scale of the WebPage.
+
+        - "scale factor": the user's chosen scale for the PDF contents (by zoom buttons, pinch-zoom, etc.).
+            for main frame plugins, this is synced with the page scale
+            for embedded plugins, this is on top of the page scale
+
+        - "document layout scale": the scale between contents and document space, to fit the pages in the scroll view's contents
+
+        Convenience names:
+
+        - "contentScaleFactor": the scale between the plugin and document space (scaleFactor * document layout scale)
+    */
     CGFloat scaleFactor() const override;
     float contentScaleFactor() const final;
 
     void didBeginMagnificationGesture() override;
     void didEndMagnificationGesture() override;
     void setPageScaleFactor(double scale, std::optional<WebCore::IntPoint> origin) final;
+    void setScaleFactor(double scale, std::optional<WebCore::IntPoint> origin = std::nullopt);
 
     WebCore::IntSize documentSize() const;
     WebCore::IntSize contentsSize() const override;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -346,15 +346,21 @@ void PluginView::setPageScaleFactor(double scaleFactor, std::optional<IntPoint> 
     if (!m_isInitialized)
         return;
 
-    RefPtr webPage = m_webPage.get();
-    webPage->send(Messages::WebPageProxy::PluginScaleFactorDidChange(scaleFactor));
-    webPage->send(Messages::WebPageProxy::PluginZoomFactorDidChange(scaleFactor));
+    pluginScaleFactorDidChange();
     protectedPlugin()->setPageScaleFactor(scaleFactor, origin);
 }
 
 double PluginView::pageScaleFactor() const
 {
     return protectedPlugin()->scaleFactor();
+}
+
+void PluginView::pluginScaleFactorDidChange()
+{
+    auto scaleFactor = pageScaleFactor();
+    RefPtr webPage = m_webPage.get();
+    webPage->send(Messages::WebPageProxy::PluginScaleFactorDidChange(scaleFactor));
+    webPage->send(Messages::WebPageProxy::PluginZoomFactorDidChange(scaleFactor));
 }
 
 void PluginView::webPageDestroyed()

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -90,6 +90,7 @@ public:
     void didEndMagnificationGesture();
     void setPageScaleFactor(double, std::optional<WebCore::IntPoint> origin);
     double pageScaleFactor() const;
+    void pluginScaleFactorDidChange();
 
     void topContentInsetDidChange();
 


### PR DESCRIPTION
#### 2bcded219334d8aa6965b3ccb3ce6c52282f3732
<pre>
Unified PDF: HUD zoom buttons don&apos;t work on embedded pdfs
<a href="https://bugs.webkit.org/show_bug.cgi?id=270536">https://bugs.webkit.org/show_bug.cgi?id=270536</a>
<a href="https://rdar.apple.com/122034458">rdar://122034458</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
Document the scale factors.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::ensureLayers):
Always apply the &quot;page scale&quot; (which is actually determined by us, not the page)
to the root layer, even for embedded plugins.

(WebKit::UnifiedPDFPlugin::setScaleFactor):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):
(WebKit::UnifiedPDFPlugin::zoomIn):
(WebKit::UnifiedPDFPlugin::zoomOut):
(WebKit::UnifiedPDFPlugin::resetZoom):
(WebKit::UnifiedPDFPlugin::updateLayout):
Factor setScaleFactor (for the UnifiedPDF-owned scale) out, and adopt it internally.

(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
For actual page scale changes, bail if we are an embedded plugin. We don&apos;t want
the PDF content to follow page scale changes for embeds, only for the main frame,
where page scale and UnifiedPDF-scale are synchronized.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::setPageScaleFactor):
(WebKit::PluginView::pluginScaleFactorDidChange):
Factor pluginScaleFactorDidChange out of setPageScaleFactor so that we can
call it from setScaleFactor in UnifiedPDFPlugin instead of having to round-trip
through PluginView::setPageScaleFactor, which allows us to correctly identify
UnifiedPDFPlugin-originated scales vs. changes to the main frame page scale.

* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/275712@main">https://commits.webkit.org/275712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d2f57e34b74fd9bb3dda3826c3951de10983925

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45207 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38722 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/25285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18986 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43173 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18648 "Unexpected infrastructure issue, retrying build") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16211 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16283 "Unexpected infrastructure issue, retrying build") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/656 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46696 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17418 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19037 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9523 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->