### PR TITLE
[WGSL] Build call graph during staticCheck

### DIFF
--- a/Source/WebGPU/WGSL/CallGraph.h
+++ b/Source/WebGPU/WGSL/CallGraph.h
@@ -25,21 +25,17 @@
 
 #pragma once
 
-// FIXME: move Stage out of StageAttribute so we don't need to include this
 #include "ASTForward.h"
-#include "ASTStageAttribute.h"
+#include "WGSLEnums.h"
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WGSL {
 
 class ShaderModule;
 struct PipelineLayout;
 struct PrepareResult;
-
-namespace Reflection {
-struct EntryPointInformation;
-}
 
 class CallGraph {
     friend class CallGraphBuilder;
@@ -53,22 +49,20 @@ public:
     struct EntryPoint {
         AST::Function& function;
         ShaderStage stage;
-        Reflection::EntryPointInformation& information;
+        String originalName;
     };
 
-    ShaderModule& ast() const { return m_ast; }
     const Vector<EntryPoint>& entrypoints() const { return m_entrypoints; }
     const Vector<Callee>& callees(AST::Function& function) const { return m_calleeMap.find(&function)->value; }
 
 private:
-    CallGraph(ShaderModule&);
+    CallGraph() { }
 
-    ShaderModule& m_ast;
     Vector<EntryPoint> m_entrypoints;
     HashMap<String, AST::Function*> m_functionsByName;
     HashMap<AST::Function*, Vector<Callee>> m_calleeMap;
 };
 
-CallGraph buildCallGraph(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts, HashMap<String, Reflection::EntryPointInformation>&);
+void buildCallGraph(ShaderModule&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/EntryPointRewriter.h
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.h
@@ -25,11 +25,13 @@
 
 #pragma once
 
+#include <wtf/text/WTFString.h>
+
 namespace WGSL {
 
-class CallGraph;
-struct PrepareResult;
+class ShaderModule;
+struct PipelineLayout;
 
-void rewriteEntryPoints(CallGraph&);
+void rewriteEntryPoints(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.h
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.h
@@ -26,15 +26,18 @@
 #pragma once
 
 #include "CompilationMessage.h"
+#include <wtf/HashMap.h>
 #include <wtf/text/WTFString.h>
 
 namespace WGSL {
 
-class CallGraph;
 class ShaderModule;
-
 struct PipelineLayout;
 
-std::optional<Error> rewriteGlobalVariables(CallGraph&, const HashMap<String, std::optional<PipelineLayout>>&, const ShaderModule&);
+namespace Reflection {
+struct EntryPointInformation;
+};
+
+std::optional<Error> rewriteGlobalVariables(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&, HashMap<String, Reflection::EntryPointInformation>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/MangleNames.h
+++ b/Source/WebGPU/WGSL/MangleNames.h
@@ -29,12 +29,8 @@
 
 namespace WGSL {
 
-class CallGraph;
+class ShaderModule;
 
-namespace Reflection {
-struct EntryPointInformation;
-}
-
-void mangleNames(CallGraph&, HashMap<String, Reflection::EntryPointInformation>&);
+void mangleNames(ShaderModule&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -57,12 +57,12 @@ static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
     }
 }
 
-String generateMetalCode(const CallGraph& callGraph, const HashMap<String, ConstantValue>& constantValues)
+String generateMetalCode(ShaderModule& shaderModule, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues)
 {
     StringBuilder stringBuilder;
     stringBuilder.append(metalCodePrologue());
 
-    Metal::emitMetalFunctions(stringBuilder, callGraph, constantValues);
+    Metal::emitMetalFunctions(stringBuilder, shaderModule, prepareResult, constantValues);
 
     dumpMetalCodeIfNeeded(stringBuilder);
 

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
@@ -29,13 +29,14 @@
 
 namespace WGSL {
 
-class CallGraph;
+class ShaderModule;
 struct ConstantValue;
+struct PrepareResult;
 
 namespace Metal {
 
 // Can't fail. Any failure checks need to be done earlier, in the backend-agnostic part of the compiler.
-String generateMetalCode(const CallGraph&, const HashMap<String, ConstantValue>&);
+String generateMetalCode(ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
@@ -29,12 +29,13 @@
 
 namespace WGSL {
 
-class CallGraph;
+class ShaderModule;
 struct ConstantValue;
+struct PrepareResult;
 
 namespace Metal {
 
-void emitMetalFunctions(StringBuilder&, const CallGraph&, const HashMap<String, ConstantValue>&);
+void emitMetalFunctions(StringBuilder&, ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/PointerRewriter.h
+++ b/Source/WebGPU/WGSL/PointerRewriter.h
@@ -27,8 +27,8 @@
 
 namespace WGSL {
 
-class CallGraph;
+class ShaderModule;
 
-void rewritePointers(CallGraph&);
+void rewritePointers(ShaderModule&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "CallGraph.h"
 #include "CompilationMessage.h"
 #include "CompilationScope.h"
 #include "ConstantValue.h"
@@ -227,7 +226,6 @@ struct EntryPointInformation {
 } // namespace Reflection
 
 struct PrepareResult {
-    CallGraph callGraph;
     HashMap<String, Reflection::EntryPointInformation> entryPoints;
     CompilationScope compilationScope;
 };
@@ -235,7 +233,7 @@ struct PrepareResult {
 std::variant<PrepareResult, Error> prepare(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&);
 std::variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPointName, const std::optional<PipelineLayout>&);
 
-String generate(const CallGraph&, HashMap<String, ConstantValue>&);
+String generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&);
 
 ConstantValue evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -29,6 +29,7 @@
 #include "ASTDeclaration.h"
 #include "ASTDirective.h"
 #include "ASTIdentityExpression.h"
+#include "CallGraph.h"
 #include "TypeStore.h"
 #include "WGSL.h"
 #include "WGSLEnums.h"
@@ -59,6 +60,12 @@ public:
     AST::Directive::List& directives() { return m_directives; }
     TypeStore& types() { return m_types; }
     AST::Builder& astBuilder() { return m_astBuilder; }
+
+    const CallGraph& callGraph() const { return *m_callGraph; }
+    void setCallGraph(CallGraph&& callGraph)
+    {
+        m_callGraph = WTFMove(callGraph);
+    }
 
     bool usesExternalTextures() const { return m_usesExternalTextures; }
     void setUsesExternalTextures() { m_usesExternalTextures = true; }
@@ -275,6 +282,7 @@ private:
     AST::Directive::List m_directives;
     TypeStore m_types;
     AST::Builder m_astBuilder;
+    std::optional<CallGraph> m_callGraph;
     Vector<std::function<void()>> m_replacements;
     HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_pipelineOverrideIds;
 };

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -145,7 +145,7 @@ static int runWGSL(const CommandLine& options)
     }
 
     HashMap<String, WGSL::ConstantValue> constantValues;
-    auto msl = WGSL::generate(result.callGraph, constantValues);
+    auto msl = WGSL::generate(shaderModule, result, constantValues);
 
     if (options.dumpASTAtEnd())
         WGSL::AST::dumpAST(shaderModule);

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -134,7 +134,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
         }
     }
 
-    auto msl = WGSL::generate(result.callGraph, wgslConstantValues);
+    auto msl = WGSL::generate(*ast, result, wgslConstantValues);
     auto library = ShaderModule::createLibrary(device, msl, label);
 
     return { { library, entryPointInformation, wgslConstantValues } };

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -107,12 +107,13 @@ static RefPtr<ShaderModule> earlyCompileShaderModule(Device& device, std::varian
         wgslHints.add(hintKey, WTFMove(convertedPipelineLayout));
     }
 
-    auto prepareResult = WGSL::prepare(std::get<WGSL::SuccessfulCheck>(checkResult).ast, wgslHints);
+    auto& shaderModule = std::get<WGSL::SuccessfulCheck>(checkResult).ast;
+    auto prepareResult = WGSL::prepare(shaderModule, wgslHints);
     if (std::holds_alternative<WGSL::Error>(prepareResult))
         return nullptr;
     auto& result = std::get<WGSL::PrepareResult>(prepareResult);
     HashMap<String, WGSL::ConstantValue> wgslConstantValues;
-    auto msl = WGSL::generate(result.callGraph, wgslConstantValues);
+    auto msl = WGSL::generate(shaderModule, result, wgslConstantValues);
     auto library = ShaderModule::createLibrary(device.device(), msl, WTFMove(label));
     if (!library)
         return nullptr;

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -40,11 +40,12 @@ inline Expected<String, WGSL::FailedCheck> translate(const String& wgsl, const S
     if (auto* maybeError = std::get_if<WGSL::FailedCheck>(&result))
         return makeUnexpected(*maybeError);
 
-    auto prepareResult = WGSL::prepare(std::get<WGSL::SuccessfulCheck>(result).ast, entryPointName, { });
+    auto& ast = std::get<WGSL::SuccessfulCheck>(result).ast;
+    auto prepareResult = WGSL::prepare(ast, entryPointName, { });
     if (auto* maybeError = std::get_if<WGSL::Error>(&prepareResult))
         return makeUnexpected(WGSL::FailedCheck { { *maybeError }, { } });
     HashMap<String, WGSL::ConstantValue> constantValues;
-    auto msl = WGSL::generate(std::get<WGSL::PrepareResult>(prepareResult).callGraph, constantValues);
+    auto msl = WGSL::generate(ast, std::get<WGSL::PrepareResult>(prepareResult), constantValues);
     return { WTFMove(msl) };
 }
 


### PR DESCRIPTION
#### 9af7ee6fac32f75aa909bb9ef3a69478da926a3d
<pre>
[WGSL] Build call graph during staticCheck
<a href="https://bugs.webkit.org/show_bug.cgi?id=270540">https://bugs.webkit.org/show_bug.cgi?id=270540</a>
<a href="https://rdar.apple.com/124095995">rdar://124095995</a>

Reviewed by Mike Wyrzykowski.

Some validations that must happen during staticCheck/shader creation time require
knowing in which stages variables are used, and for that we need the call graph.
This patch just refactors the call graph creation into staticCheck, so that we
can use it in a subsequent patch to perform the validations.

* Source/WebGPU/WGSL/CallGraph.cpp:
(WGSL::CallGraphBuilder::CallGraphBuilder):
(WGSL::CallGraphBuilder::build):
(WGSL::CallGraphBuilder::initializeMappings):
(WGSL::buildCallGraph):
(WGSL::CallGraph::CallGraph): Deleted.
* Source/WebGPU/WGSL/CallGraph.h:
(WGSL::CallGraph::CallGraph):
(WGSL::CallGraph::ast const): Deleted.
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::EntryPointRewriter):
(WGSL::rewriteEntryPoints):
* Source/WebGPU/WGSL/EntryPointRewriter.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::RewriteGlobalVariables):
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::visitCallee):
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::bufferLengthType):
(WGSL::RewriteGlobalVariables::bufferLengthReferenceType):
(WGSL::RewriteGlobalVariables::packStructResource):
(WGSL::RewriteGlobalVariables::packArrayResource):
(WGSL::RewriteGlobalVariables::updateReference):
(WGSL::RewriteGlobalVariables::packStructType):
(WGSL::RewriteGlobalVariables::packArrayType):
(WGSL::RewriteGlobalVariables::insertParameter):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::RewriteGlobalVariables::createArgumentBufferEntry):
(WGSL::RewriteGlobalVariables::finalizeArgumentBufferStruct):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertDynamicOffsetsBufferIfNeeded):
(WGSL::RewriteGlobalVariables::insertMaterializations):
(WGSL::RewriteGlobalVariables::insertLocalDefinitions):
(WGSL::RewriteGlobalVariables::initializeVariables):
(WGSL::RewriteGlobalVariables::insertWorkgroupBarrier):
(WGSL::RewriteGlobalVariables::findOrInsertLocalInvocationIndex):
(WGSL::RewriteGlobalVariables::storeInitialValue):
(WGSL::rewriteGlobalVariables):
* Source/WebGPU/WGSL/GlobalVariableRewriter.h:
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::NameManglerVisitor):
(WGSL::NameManglerVisitor::run):
(WGSL::NameManglerVisitor::visit):
(WGSL::NameManglerVisitor::introduceVariable):
(WGSL::NameManglerVisitor::readVariable const):
(WGSL::mangleNames):
* Source/WebGPU/WGSL/MangleNames.h:
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::generateMetalCode):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::FunctionDefinitionWriter):
(WGSL::Metal::FunctionDefinitionWriter::write):
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitMetalFunctions):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h:
* Source/WebGPU/WGSL/PointerRewriter.cpp:
(WGSL::PointerRewriter::PointerRewriter):
(WGSL::PointerRewriter::run):
(WGSL::PointerRewriter::rewrite):
(WGSL::PointerRewriter::visit):
(WGSL::rewritePointers):
* Source/WebGPU/WGSL/PointerRewriter.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
(WGSL::prepareImpl):
(WGSL::generate):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::callGraph const):
(WGSL::ShaderModule::setCallGraph):
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::earlyCompileShaderModule):

Canonical link: <a href="https://commits.webkit.org/275826@main">https://commits.webkit.org/275826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/927ce14970afbe2c41c7c91058f4087eede3fc02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35337 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37808 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46807 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42053 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19128 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40678 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9574 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18773 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->