### PR TITLE
[Unified PDF] Form control partial repaint for "related" fields is broken, results in fields getting stuck.

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
@@ -117,6 +117,7 @@
 #if ENABLE(UNIFIED_PDF)
 @interface PDFDocument (IPI)
 - (PDFDestination *)namedDestination:(NSString *)name;
+- (NSArray *)annotationsForFieldName:(NSString *)fieldname;
 @end
 
 #if HAVE(COREGRAPHICS_WITH_PDF_AREA_OF_INTEREST_SUPPORT)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -112,6 +112,7 @@ public:
 #endif
     enum class IsAnnotationCommit : bool { No, Yes };
     static OptionSet<RepaintRequirement> repaintRequirementsForAnnotation(PDFAnnotation *, IsAnnotationCommit = IsAnnotationCommit::No);
+    void repaintAnnotationsForFormField(NSString *fieldName);
 
     void attemptToUnlockPDF(const String& password) final;
     void windowActivityDidChange() final;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -99,6 +99,9 @@
 - (void)formChanged:(NSNotification *)notification
 {
     _plugin->didMutatePDFDocument();
+
+    NSString *fieldName = (NSString *)[[notification userInfo] objectForKey:@"PDFFormFieldName"];
+    _plugin->repaintAnnotationsForFormField(fieldName);
 }
 @end
 
@@ -1931,6 +1934,13 @@ OptionSet<RepaintRequirement> UnifiedPDFPlugin::repaintRequirementsForAnnotation
     // No visual feedback for getPDFAnnotationLinkClass at this time.
 
     return { };
+}
+
+void UnifiedPDFPlugin::repaintAnnotationsForFormField(NSString *fieldName)
+{
+    RetainPtr annotations = [m_pdfDocument annotationsForFieldName:fieldName];
+    for (PDFAnnotation *annotation in annotations.get())
+        setNeedsRepaintInDocumentRect(repaintRequirementsForAnnotation(annotation), documentRectForAnnotation(annotation));
 }
 
 WebCore::FloatRect UnifiedPDFPlugin::documentRectForAnnotation(PDFAnnotation *annotation) const


### PR DESCRIPTION
#### d583f18ce8eded8a598b3aafd181c9f1864fd3f6
<pre>
[Unified PDF] Form control partial repaint for &quot;related&quot; fields is broken, results in fields getting stuck.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270539">https://bugs.webkit.org/show_bug.cgi?id=270539</a>
<a href="https://rdar.apple.com/123637341">rdar://123637341</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

In order to avoid repainting the world we attempt to perform very
targeted repaints. For annotations this generally means we need to find
the bounds for the annotation and provide the geometry of the area to
the async renderer to that it can repaint the affected area. However,
certain annotations may also have an effect on a set of related
annotations. For example, when interacting with radio buttons in the
same group we want to make sure that not only is the newly selected
radio button displayed as active but also that the previously selected one
is no longer active. For these annotations we want to make sure that
those get repainted as well in order to properly display the state
changes.

Since we already have an observer that listens for form field changes
that are sent by the document, we can use the same notification to tell
the plugin of the field that changed and get the geometry of the
annotations. We can take the field name given by the observer and ask
the document for all of the annotations associated with this field name
through IPI.

In order for the repainting to happen correctly we had to slightly
change how the async renderer handled requests for tile repaints.
Previously, it would check to see if a repaint request for a particular
tile had already been enqueued and drop the current request if it had.
This approach was too conservative since multiple annotations may need
to get repainted within a tile and observer gets notified of multiple
fields independently (e.g. a button action that resets form fields
sends a separate notification for each field in the form). Now the
async observer will drop the request if:

1.) There is not a clip rect provided for the request (to match current
behavior)
2.) The tile rect clip for the repaint request is already contained
completely within the tile rect clip for the enqueued tile update

If a repaint request comes in for the same tile but it is not being
handled by an enqueued tile update then we will take the existing
update&apos;s tile rect, combine it with the rect in the new request, and
update the enqueued tile update. As we complete the tile update we will
check to see if the area that was repainted is the same as the one that
was enqueued. If it is not this means that the tile update was updated
with a new rect so we do not proceed to cache the tile.

* Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::didCompleteTileUpdateRender):
(WebKit::AsyncPDFRenderer::updateTilesForPaintingRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(-[WKPDFFormMutationObserver formChanged:]):
(WebKit::UnifiedPDFPlugin::repaintAnnotationsForFormField):

Canonical link: <a href="https://commits.webkit.org/275727@main">https://commits.webkit.org/275727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6669a36f0b6df5993785ae09d206e2fff1726675

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38742 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/25303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35280 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43193 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/25303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16225 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/25303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/676 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/25303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46736 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41991 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40610 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9529 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->