### PR TITLE
Add additional WKWebView SPI to extract rendered text for a given CSS selector in the main frame

### DIFF
--- a/LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe-expected.txt
+++ b/LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe-expected.txt
@@ -1,0 +1,5 @@
+PASS extractedText is "zero one two three four five"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe.html
+++ b/LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div class="container">
+    <h1>zero</h1>
+    <iframe frameborder="0" width="350" height="200" src="resources/subframe.html"></iframe>
+    <h3>five</h3>
+</div>
+<script>
+jsTestIsAsync = true;
+remainingLoadCount = 2;
+
+document.querySelector("iframe").addEventListener("load", runTestIfPossible);
+addEventListener("load", runTestIfPossible);
+
+async function runTestIfPossible() {
+    if (--remainingLoadCount)
+        return;
+    extractedText = await UIHelper.requestRenderedTextForSelector("div.container");
+    shouldBeEqualToString("extractedText", "zero one two three four five");
+    document.querySelector("div.container").remove();
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/resources/subframe.html
+++ b/LayoutTests/fast/text-extraction/resources/subframe.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+    display: grid;
+    grid-template-rows: [header] 20px [title] auto [body] auto [button] 30px;
+    grid-gap: 20px;
+
+    width: 300px;
+    padding: 12px;
+    border-radius: 10px;
+    border: 1px solid lightgray;
+    font-family: system-ui;
+}
+
+.grid + .grid {
+    margin-top: 1em;
+}
+
+.header {
+    grid-row: header;
+}
+
+.title {
+    grid-row: title;
+
+    font-size: 1.1em;
+    font-weight: bold;
+    word-break: keep-all;
+}
+
+.body {
+    grid-row: body;
+}
+
+.button {
+    grid-row: button;
+
+    appearance: none;
+    border-radius: 5px;
+    border: none;
+    background: royalblue;
+    color: white;
+    font-size: 16px;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="header">one</div>
+    <div class="title">two</div>
+    <div class="description">three</div>
+    <button class="button">four</button>
+</div>
+<script>
+const grid = document.querySelector(".grid");
+grid.appendChild(grid.children[0]);
+grid.appendChild(grid.children[1]);
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2152,6 +2152,18 @@ window.UIHelper = class UIHelper {
             })()`, resolve);
         });
     }
+
+    static requestRenderedTextForSelector(selector)
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`(() => {
+                uiController.requestRenderedTextForSelector("${selector}", result => uiController.uiScriptComplete(result));
+            })()`, resolve);
+        });
+    }
 }
 
 UIHelper.EventStreamBuilder = class {

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -28,20 +28,29 @@
 
 #include "ComposedTreeIterator.h"
 #include "ElementInlines.h"
+#include "ExceptionCode.h"
+#include "ExceptionOr.h"
 #include "FrameSelection.h"
 #include "HTMLBodyElement.h"
 #include "HTMLButtonElement.h"
+#include "HTMLIFrameElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
+#include "LocalFrame.h"
 #include "Page.h"
 #include "RenderBox.h"
+#include "RenderDescendantIterator.h"
+#include "RenderIFrame.h"
 #include "RenderLayer.h"
 #include "RenderLayerModelObject.h"
 #include "RenderLayerScrollableArea.h"
+#include "RenderView.h"
 #include "SimpleRange.h"
 #include "Text.h"
 #include "TextIterator.h"
+#include "WritingMode.h"
+#include <unicode/uchar.h>
 
 namespace WebCore {
 namespace TextExtraction {
@@ -422,6 +431,137 @@ Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, P
     pruneRedundantItemsRecursive(root);
 
     return root;
+}
+
+struct StringsAndBlockOffset {
+    Vector<String> strings;
+    int offset { 0 };
+};
+
+static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets, ContainerNode& node, BlockFlowDirection direction)
+{
+    CheckedPtr renderer = node.renderer();
+    if (!renderer)
+        return;
+
+    auto appendStrings = [&](Vector<String>&& strings, IntRect bounds) mutable {
+        static constexpr auto minPixelDistanceForNearbyText = 5;
+        if (strings.isEmpty() || bounds.width() <= minPixelDistanceForNearbyText || bounds.height() <= minPixelDistanceForNearbyText)
+            return;
+
+        auto offset = [&] {
+            switch (direction) {
+            case BlockFlowDirection::TopToBottom:
+                return bounds.y();
+            case BlockFlowDirection::BottomToTop:
+                return bounds.maxY();
+            case BlockFlowDirection::LeftToRight:
+                return bounds.x();
+            case BlockFlowDirection::RightToLeft:
+                return bounds.maxX();
+            }
+            ASSERT_NOT_REACHED();
+            return 0;
+        }();
+
+        auto foundIndex = stringsAndOffsets.reverseFindIf([&](auto& item) {
+            return std::abs(offset - item.offset) <= minPixelDistanceForNearbyText;
+        });
+
+        if (foundIndex == notFound) {
+            stringsAndOffsets.append({ WTFMove(strings), offset });
+            return;
+        }
+
+        stringsAndOffsets[foundIndex].strings.appendVector(WTFMove(strings));
+    };
+
+    if (CheckedPtr frameRenderer = dynamicDowncast<RenderIFrame>(*renderer)) {
+        if (auto contentDocument = frameRenderer->iframeElement().protectedContentDocument())
+            extractRenderedText(stringsAndOffsets, *contentDocument, direction);
+        return;
+    }
+
+    auto frameView = renderer->view().protectedFrameView();
+    for (auto& descendant : descendantsOfType<RenderObject>(*renderer)) {
+        if (descendant.style().visibility() == Visibility::Hidden)
+            continue;
+
+        static constexpr auto minOpacityToConsiderVisible = 0.05;
+        if (descendant.style().opacity() < minOpacityToConsiderVisible)
+            continue;
+
+        if (CheckedPtr textRenderer = dynamicDowncast<RenderText>(descendant); textRenderer && textRenderer->hasRenderedText()) {
+            Vector<String> strings;
+            for (auto token : textRenderer->text().simplifyWhiteSpace(isASCIIWhitespace).split(' ')) {
+                auto candidate = token.removeCharacters([](UChar character) {
+                    return !u_isalpha(character) && !u_isdigit(character);
+                });
+                if (!candidate.isEmpty())
+                    strings.append(WTFMove(candidate));
+            }
+            appendStrings(WTFMove(strings), frameView->contentsToRootView(descendant.absoluteBoundingBoxRect()));
+            continue;
+        }
+
+        if (CheckedPtr frameRenderer = dynamicDowncast<RenderIFrame>(descendant)) {
+            if (auto contentDocument = frameRenderer->iframeElement().protectedContentDocument())
+                extractRenderedText(stringsAndOffsets, *contentDocument, direction);
+            continue;
+        }
+
+        if (descendant.isRenderReplaced()) {
+            auto bounds = frameView->contentsToRootView(descendant.absoluteBoundingBoxRect());
+            appendStrings({ makeString('{', bounds.width(), ',', bounds.height(), '}') }, bounds);
+            continue;
+        }
+    }
+}
+
+Expected<String, ExceptionCode> extractRenderedText(LocalFrame& frame, String&& selector)
+{
+    RefPtr document = frame.document();
+    if (!document)
+        return makeUnexpected(ExceptionCode::NotAllowedError);
+
+    auto result = document->querySelector(WTFMove(selector));
+    if (result.hasException())
+        return makeUnexpected(result.releaseException().code());
+
+    RefPtr element = result.releaseReturnValue();
+    if (!element)
+        return makeUnexpected(ExceptionCode::NotFoundError);
+
+    if (!element->renderer())
+        return emptyString();
+
+    auto direction = element->renderer()->style().blockFlowDirection();
+
+    Vector<StringsAndBlockOffset> stringsAndOffsets;
+    extractRenderedText(stringsAndOffsets, *element, direction);
+
+    bool ascendingOrder = [&] {
+        switch (direction) {
+        case BlockFlowDirection::TopToBottom:
+        case BlockFlowDirection::LeftToRight:
+            return true;
+        case BlockFlowDirection::BottomToTop:
+        case BlockFlowDirection::RightToLeft:
+            return false;
+        }
+        ASSERT_NOT_REACHED();
+        return true;
+    }();
+
+    std::sort(stringsAndOffsets.begin(), stringsAndOffsets.end(), [&](auto& a, auto& b) {
+        return ascendingOrder ? a.offset < b.offset : a.offset > b.offset;
+    });
+
+    auto flattenedStrings = stringsAndOffsets.map([](auto& item) {
+        return makeStringByJoining(item.strings, " "_s);
+    });
+
+    return makeStringByJoining(flattenedStrings, " "_s);
 }
 
 } // namespace TextExtractor

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -26,14 +26,19 @@
 #pragma once
 
 #include "TextExtractionTypes.h"
+#include <wtf/Expected.h>
 
 namespace WebCore {
 
+class LocalFrame;
 class Page;
+enum class ExceptionCode : uint8_t;
 
 namespace TextExtraction {
 
 WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
+
+WEBCORE_EXPORT Expected<String, ExceptionCode> extractRenderedText(LocalFrame&, String&& selector);
 
 } // namespace TextExtraction
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -534,6 +534,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 
 - (void)_setStatisticsCrossSiteLoadWithLinkDecorationForTesting:(NSString *)fromHost withToHost:(NSString *)toHost withWasFiltered:(BOOL)wasFiltered withCompletionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+- (void)_requestRenderedTextForElementSelector:(NSString *)selector completionHandler:(void(^)(NSString *, NSError *))completionHandler;
+
 @property (nonatomic, readonly) NSURL *_requiredWebExtensionBaseURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/AuthenticatorAttachment.h>
 #include <WebCore/AuthenticatorTransport.h>
 #include <WebCore/EventRegion.h>
+#include <WebCore/ExceptionCode.h>
 #include <WebCore/MediationRequirement.h>
 #include <WebCore/PublicKeyCredentialCreationOptions.h>
 #include <WebCore/WebAuthenticationConstants.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -193,6 +193,7 @@
 #include <WebCore/DragData.h>
 #include <WebCore/ElementContext.h>
 #include <WebCore/EventNames.h>
+#include <WebCore/ExceptionCode.h>
 #include <WebCore/ExceptionDetails.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/FocusDirection.h>
@@ -13748,6 +13749,13 @@ void WebPageProxy::requestTextExtraction(std::optional<FloatRect>&& collectionRe
     if (!hasRunningProcess())
         return completion({ });
     sendWithAsyncReply(Messages::WebPage::RequestTextExtraction(WTFMove(collectionRectInRootView)), WTFMove(completion));
+}
+
+void WebPageProxy::requestRenderedTextForElementSelector(String&& selector, CompletionHandler<void(Expected<String, WebCore::ExceptionCode>&&)>&& completion)
+{
+    if (!hasRunningProcess())
+        return completion(makeUnexpected(WebCore::ExceptionCode::NotAllowedError));
+    sendWithAsyncReply(Messages::WebPage::RequestRenderedTextForElementSelector(WTFMove(selector)), WTFMove(completion));
 }
 
 void WebPageProxy::addConsoleMessage(FrameIdentifier frameID, MessageSource messageSource, MessageLevel messageLevel, const String& message, std::optional<ResourceLoaderIdentifier> coreIdentifier)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -349,6 +349,7 @@ namespace WebCore {
 class ShareableBitmap;
 class ShareableBitmapHandle;
 class ShareableResourceHandle;
+enum class ExceptionCode : uint8_t;
 }
 
 namespace WebKit {
@@ -2369,6 +2370,7 @@ public:
     void setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&&);
 
     void requestTextExtraction(std::optional<WebCore::FloatRect>&& collectionRectInRootView, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void requestRenderedTextForElementSelector(String&& selector, CompletionHandler<void(Expected<String, WebCore::ExceptionCode>&&)>&&);
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     void willBeginTextReplacementSession(const WTF::UUID&, CompletionHandler<void(const Vector<WebUnifiedTextReplacementContextData>&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -197,6 +197,7 @@
 #include <WebCore/ElementIterator.h>
 #include <WebCore/EventHandler.h>
 #include <WebCore/EventNames.h>
+#include <WebCore/ExceptionCode.h>
 #include <WebCore/File.h>
 #include <WebCore/FocusController.h>
 #include <WebCore/FontAttributeChanges.h>
@@ -9343,6 +9344,15 @@ void WebPage::renderTreeAsText(WebCore::FrameIdentifier frameID, size_t baseInde
 void WebPage::requestTextExtraction(std::optional<FloatRect>&& collectionRectInRootView, CompletionHandler<void(TextExtraction::Item&&)>&& completion)
 {
     completion(TextExtraction::extractItem(WTFMove(collectionRectInRootView), Ref { *corePage() }));
+}
+
+void WebPage::requestRenderedTextForElementSelector(String&& selector, CompletionHandler<void(Expected<String, WebCore::ExceptionCode>&&)>&& completion)
+{
+    RefPtr mainFrame = dynamicDowncast<LocalFrame>(corePage()->protectedMainFrame());
+    if (!mainFrame)
+        return completion(makeUnexpected(ExceptionCode::NotAllowedError));
+
+    completion(TextExtraction::extractRenderedText(mainFrame.releaseNonNull(), WTFMove(selector)));
 }
 
 template<typename T> void WebPage::remoteViewToRootView(WebCore::FrameIdentifier frameID, T geometry, CompletionHandler<void(T)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -245,6 +245,7 @@ enum class DOMPasteAccessResponse : uint8_t;
 enum class DragApplicationFlags : uint8_t;
 enum class DragHandlingMethod : uint8_t;
 enum class EventMakesGamepadsVisible : bool;
+enum class ExceptionCode : uint8_t;
 enum class FinalizeRenderingUpdateFlags : uint8_t;
 enum class HighlightRequestOriginatedInApp : bool;
 enum class LinkDecorationFilteringTrigger : uint8_t;
@@ -2220,6 +2221,7 @@ private:
     void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
 
     void requestTextExtraction(std::optional<WebCore::FloatRect>&& collectionRectInRootView, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void requestRenderedTextForElementSelector(String&& selector, CompletionHandler<void(Expected<String, WebCore::ExceptionCode>&&)>&&);
 
 #if HAVE(SANDBOX_STATE_FLAGS)
     static void setHasLaunchedWebContentProcess();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -762,6 +762,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     RenderTreeAsText(WebCore::FrameIdentifier frameID, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
 
     RequestTextExtraction(std::optional<WebCore::FloatRect> collectionRectInRootView) -> (struct WebCore::TextExtraction::Item item)
+    RequestRenderedTextForElementSelector(String selector) -> (Expected<String, WebCore::ExceptionCode> result)
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     SetMediaEnvironment(String mediaEnvironment)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -412,4 +412,5 @@ interface UIScriptController {
     undefined acceptInlinePrediction();
 
     undefined requestTextExtraction(object callback);
+    undefined requestRenderedTextForSelector(DOMString selector, object callback);
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -408,6 +408,7 @@ public:
 
     // Text Extraction
     virtual void requestTextExtraction(JSValueRef) { notImplemented(); }
+    virtual void requestRenderedTextForSelector(JSStringRef, JSValueRef) { notImplemented(); }
 
 protected:
     explicit UIScriptController(UIScriptContext&);

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -89,6 +89,7 @@ private:
     void setSpellCheckerResults(JSValueRef) final;
 
     void requestTextExtraction(JSValueRef callback) final;
+    void requestRenderedTextForSelector(JSStringRef selector, JSValueRef callback) final;
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -336,4 +336,16 @@ void UIScriptControllerCocoa::requestTextExtraction(JSValueRef callback)
     }];
 }
 
+void UIScriptControllerCocoa::requestRenderedTextForSelector(JSStringRef selectorRef, JSValueRef callback)
+{
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+    [webView() _requestRenderedTextForElementSelector:toWTFString(selectorRef) completionHandler:^(NSString *text, NSError *error) {
+        if (!m_context)
+            return;
+
+        JSRetainPtr result = adopt(JSStringCreateWithCFString((__bridge CFStringRef)(error.description ?: text)));
+        m_context->asyncTaskComplete(callbackID, { JSValueMakeString(m_context->jsContext(), result.get()) });
+    }];
+}
+
 } // namespace WTR


### PR DESCRIPTION
#### 503f7e1ff8cef2d718e4dfa3612e1d9907d81e67
<pre>
Add additional WKWebView SPI to extract rendered text for a given CSS selector in the main frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=270544">https://bugs.webkit.org/show_bug.cgi?id=270544</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Add another `WKWebView` SPI method to extract rendered text from an element in the main frame, given
a CSS selector. This flattens all text content in the element subtree (including subframes) into a
single string, sorted in block layout direction order by the root view bounds of each rendered text
node.

Test: fast/text-extraction/extract-rendered-text-with-subframe.html

* LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe-expected.txt: Added.
* LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe.html: Added.

Add a layout test to exercise this SPI.

* LayoutTests/fast/text-extraction/resources/subframe.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.requestTextExtraction):
(window.UIHelper.requestRenderedTextForSelector):

Add a testing hook to exercise the new SPI from layout tests.

(window.UIHelper):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedText):

Implement the main logic here, by recursively traversing through the render tree to accumulate text
in a `Vector` of offsets (based on block writing direction — e.g. y-offsets, in top-down LTR text)
and strings, filtered to only contain letters (including non-Latin script) and numbers. We also
represent replaced renderers with `{w,h}`, representing the size of the renderer in root view
coordinates.

The final output is a space-separated string of extracted tokens.

* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestRenderedTextForElementSelector:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestTextExtraction):
(WebKit::WebPageProxy::requestRenderedTextForElementSelector):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::requestRenderedTextForElementSelector):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::requestRenderedTextForSelector):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::requestRenderedTextForSelector):

Canonical link: <a href="https://commits.webkit.org/275728@main">https://commits.webkit.org/275728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77220c540eb16aa99b7259a4d045348f05353f07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44943 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/25320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19023 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43210 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/25320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16246 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/25320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37756 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/693 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/25320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46739 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41994 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37025 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40613 "Found 2 new API test failures: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9530 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->