### PR TITLE
Speedometer 3: buildTransaction spends a lot of time destroying mach port objects.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -51,7 +51,7 @@ public:
 
     // Ensures frontBuffer is valid, either by swapping an existing back
     // buffer, or allocating a new one.
-    void ensureBufferForDisplay(ImageBufferSetPrepareBufferForDisplayInputData&, SwapBuffersDisplayRequirement&, RenderingUpdateID);
+    void ensureBufferForDisplay(ImageBufferSetPrepareBufferForDisplayInputData&, SwapBuffersDisplayRequirement&);
 
     // Initializes the contents of the new front buffer using the previous
     // frames (if applicable), clips to the dirty region, and clears the pixels
@@ -70,8 +70,7 @@ private:
 
     // Messages
     void updateConfiguration(const WebCore::FloatSize&, WebCore::RenderingMode, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat);
-    void setFlushSignal(IPC::Signal&&);
-    void flush();
+    void endPrepareForDisplay(RenderingUpdateID);
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     void dynamicContentScalingDisplayList(CompletionHandler<void(std::optional<WebCore::DynamicContentScalingDisplayList>&&)>&&);
@@ -83,9 +82,9 @@ private:
         return m_pixelFormat == WebCore::PixelFormat::RGB10 || m_pixelFormat == WebCore::PixelFormat::BGRX8;
     }
 
+    const RemoteImageBufferSetIdentifier m_identifier;
+    const WebCore::RenderingResourceIdentifier m_displayListIdentifier;
     RefPtr<RemoteRenderingBackend> m_backend;
-    RemoteImageBufferSetIdentifier m_identifier;
-    WebCore::RenderingResourceIdentifier m_displayListIdentifier;
 
     RefPtr<WebCore::ImageBuffer> m_frontBuffer;
     RefPtr<WebCore::ImageBuffer> m_backBuffer;
@@ -100,10 +99,9 @@ private:
     WebCore::DestinationColorSpace m_colorSpace { WebCore::DestinationColorSpace::SRGB() };
     WebCore::PixelFormat m_pixelFormat;
     bool m_frontBufferIsCleared { false };
+    bool m_displayListCreated { false };
 
     std::optional<WebCore::IntRect> m_previouslyPaintedRect;
-
-    std::optional<IPC::Signal> m_flushSignal;
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     WebCore::DynamicContentScalingResourceCache m_dynamicContentScalingResourceCache;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in
@@ -24,8 +24,7 @@
 
 messages -> RemoteImageBufferSet NotRefCounted Stream {
     UpdateConfiguration(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::PixelFormat pixelFormat)
-    SetFlushSignal(IPC::Signal signal) NotStreamEncodable
-    Flush()
+    EndPrepareForDisplay(WebKit::RenderingUpdateID renderingUpdateID)
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     DynamicContentScalingDisplayList() -> (std::optional<WebCore::DynamicContentScalingDisplayList> displayList) Synchronous NotStreamEncodableReply

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -416,7 +416,7 @@ void RemoteRenderingBackend::flush(IPC::Semaphore&& semaphore)
 #endif
 
 #if PLATFORM(COCOA)
-void RemoteRenderingBackend::prepareImageBufferSetsForDisplay(Vector<ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput, RenderingUpdateID renderingUpdateID)
+void RemoteRenderingBackend::prepareImageBufferSetsForDisplay(Vector<ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput)
 {
     assertIsCurrent(workQueue());
 
@@ -424,7 +424,7 @@ void RemoteRenderingBackend::prepareImageBufferSetsForDisplay(Vector<ImageBuffer
         RefPtr<RemoteImageBufferSet> remoteImageBufferSet = m_remoteImageBufferSets.get(swapBuffersInput[i].remoteBufferSet);
         MESSAGE_CHECK(remoteImageBufferSet, "BufferSet is being updated before being created"_s);
         SwapBuffersDisplayRequirement displayRequirement = SwapBuffersDisplayRequirement::NeedsNormalDisplay;
-        remoteImageBufferSet->ensureBufferForDisplay(swapBuffersInput[i], displayRequirement, renderingUpdateID);
+        remoteImageBufferSet->ensureBufferForDisplay(swapBuffersInput[i], displayRequirement);
         MESSAGE_CHECK(displayRequirement != SwapBuffersDisplayRequirement::NeedsFullDisplay, "Can't asynchronously require full display for a buffer set"_s);
 
         if (displayRequirement != SwapBuffersDisplayRequirement::NeedsNoDisplay)
@@ -432,7 +432,7 @@ void RemoteRenderingBackend::prepareImageBufferSetsForDisplay(Vector<ImageBuffer
     }
 }
 
-void RemoteRenderingBackend::prepareImageBufferSetsForDisplaySync(Vector<ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput, RenderingUpdateID renderingUpdateID,  CompletionHandler<void(Vector<SwapBuffersDisplayRequirement>&&)>&& completionHandler)
+void RemoteRenderingBackend::prepareImageBufferSetsForDisplaySync(Vector<ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput, CompletionHandler<void(Vector<SwapBuffersDisplayRequirement>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
 
@@ -442,7 +442,7 @@ void RemoteRenderingBackend::prepareImageBufferSetsForDisplaySync(Vector<ImageBu
     for (unsigned i = 0; i < swapBuffersInput.size(); ++i) {
         RefPtr<RemoteImageBufferSet> remoteImageBufferSet = m_remoteImageBufferSets.get(swapBuffersInput[i].remoteBufferSet);
         MESSAGE_CHECK(remoteImageBufferSet, "BufferSet is being updated before being created"_s);
-        remoteImageBufferSet->ensureBufferForDisplay(swapBuffersInput[i], outputData[i], renderingUpdateID);
+        remoteImageBufferSet->ensureBufferForDisplay(swapBuffersInput[i], outputData[i]);
     }
 
     completionHandler(WTFMove(outputData));

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -163,8 +163,8 @@ private:
 #endif
 
 #if PLATFORM(COCOA)
-    void prepareImageBufferSetsForDisplay(Vector<ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput, RenderingUpdateID);
-    void prepareImageBufferSetsForDisplaySync(Vector<ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput, RenderingUpdateID, CompletionHandler<void(Vector<SwapBuffersDisplayRequirement>&&)>&&);
+    void prepareImageBufferSetsForDisplay(Vector<ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput);
+    void prepareImageBufferSetsForDisplaySync(Vector<ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput, CompletionHandler<void(Vector<SwapBuffersDisplayRequirement>&&)>&&);
 
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -43,8 +43,8 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     // These messages also result in the 'DidPrepareForDisplay' message being
     // returned on the RemoteImageBufferSetProxy message receiver (one for each
     // inputData)
-    PrepareImageBufferSetsForDisplay(Vector<WebKit::ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput, WebKit::RenderingUpdateID renderingUpdateID)
-    PrepareImageBufferSetsForDisplaySync(Vector<WebKit::ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput, WebKit::RenderingUpdateID renderingUpdateID)  -> (Vector<WebKit::SwapBuffersDisplayRequirement> displayRequirements) Synchronous
+    PrepareImageBufferSetsForDisplay(Vector<WebKit::ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput)
+    PrepareImageBufferSetsForDisplaySync(Vector<WebKit::ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput)  -> (Vector<WebKit::SwapBuffersDisplayRequirement> displayRequirements) Synchronous
 #endif
 
     MarkSurfacesVolatile(WebKit::MarkSurfacesAsVolatileRequestIdentifier requestIdentifier, Vector<std::pair<WebKit::RemoteImageBufferSetIdentifier, OptionSet<WebKit::BufferInSetType>>> renderingResourceIdentifiers, bool forcePurge)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -116,8 +116,6 @@ private:
     template<typename T> void send(T&& message);
     template<typename T> auto sendSync(T&& message);
 
-    void createFlushFence() WTF_REQUIRES_LOCK(m_lock);
-
     WeakPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
 
     WebCore::RenderingResourceIdentifier m_displayListIdentifier;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -391,7 +391,7 @@ Vector<SwapBuffersDisplayRequirement> RemoteRenderingBackendProxy::prepareImageB
 
     Vector<SwapBuffersDisplayRequirement> result;
     if (needsSync) {
-        auto sendResult = streamConnection().sendSync(Messages::RemoteRenderingBackend::PrepareImageBufferSetsForDisplaySync(inputData, m_renderingUpdateID), renderingBackendIdentifier(), defaultTimeout);
+        auto sendResult = streamConnection().sendSync(Messages::RemoteRenderingBackend::PrepareImageBufferSetsForDisplaySync(inputData), renderingBackendIdentifier(), defaultTimeout);
         if (!sendResult.succeeded()) {
             result.grow(inputData.size());
             for (auto& displayRequirement : result)
@@ -399,7 +399,7 @@ Vector<SwapBuffersDisplayRequirement> RemoteRenderingBackendProxy::prepareImageB
         } else
             std::tie(result) = sendResult.takeReply();
     } else {
-        streamConnection().send(Messages::RemoteRenderingBackend::PrepareImageBufferSetsForDisplay(inputData, m_renderingUpdateID), renderingBackendIdentifier(), defaultTimeout);
+        streamConnection().send(Messages::RemoteRenderingBackend::PrepareImageBufferSetsForDisplay(inputData), renderingBackendIdentifier(), defaultTimeout);
         result.grow(inputData.size());
         for (auto& displayRequirement : result)
             displayRequirement = SwapBuffersDisplayRequirement::NeedsNormalDisplay;


### PR DESCRIPTION
#### b3f5ccb38cd2800b166d39aeb366186f94a38f93
<pre>
Speedometer 3: buildTransaction spends a lot of time destroying mach port objects.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270549">https://bugs.webkit.org/show_bug.cgi?id=270549</a>
&lt;<a href="https://rdar.apple.com/123661156">rdar://123661156</a>&gt;

Reviewed by Kimmo Kinnunen.

Flusing a RemoteImageBufferSetProxy waits on both the `didPrepareForDisplay` message
to be delivered to the WorkQueue, and the semaphore to be signaled when drawing command
flushing is completed.

This was previously required, since building of the transaction on the main thread was
blocked on the didPrepareForDisplay message, so it was delivered as early as possible.

The current state is that all waiting happens on a background thread, so there&apos;s no
longer any benefit to having two separate notifications.

This changes moves sending of the didPrepareForDisplay message to happen once drawing
flushing is completed, and removes the seamphore signaling.

This should be a small performance win in some cases, since we no longer need to allocate
and destroy the semaphore objects.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::RemoteImageBufferSet):
(WebKit::RemoteImageBufferSet::endPrepareForDisplay):
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
(WebKit::RemoteImageBufferSet::setFlushSignal): Deleted.
(WebKit::RemoteImageBufferSet::flush): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::prepareImageBufferSetsForDisplay):
(WebKit::RemoteRenderingBackend::prepareImageBufferSetsForDisplaySync):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxyFlushFence::create):
(WebKit::RemoteImageBufferSetProxyFlushFence::waitFor):
(WebKit::RemoteImageBufferSetProxyFlushFence::RemoteImageBufferSetProxyFlushFence):
(WebKit::RemoteImageBufferSetProxy::flushFrontBufferAsync):
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxyFlushFence::~RemoteImageBufferSetProxyFlushFence): Deleted.
(WebKit::RemoteImageBufferSetProxyFlushFence::tryTakeEvent): Deleted.
(WebKit::RemoteImageBufferSetProxyFlushFence::setWaitingForSignal): Deleted.
(): Deleted.
(WebKit::RemoteImageBufferSetProxy::createFlushFence): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::prepareImageBufferSetsForDisplay):

Canonical link: <a href="https://commits.webkit.org/276421@main">https://commits.webkit.org/276421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8538e58bbe10fba4b3bfa13f968a3bcc2fa92e1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40191 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20627 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36385 "Found 13 new test failures: imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-with-inline-block.html, imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-left-001.xht, imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-right-001.xht, imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html, imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vertical-001.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-001.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-002.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-003.html, imported/w3c/web-platform-tests/css/css-values/ch-unit-018.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17767 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48406 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43259 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20505 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41985 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9931 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->