### PR TITLE
REGRESSION(267236@main): SVG may incorrectly be clipped when an SVGFilter is applied to its root

### DIFF
--- a/LayoutTests/svg/filters/filter-on-root-tile-boundary-expected.html
+++ b/LayoutTests/svg/filters/filter-on-root-tile-boundary-expected.html
@@ -1,0 +1,10 @@
+<style>
+    svg {
+        border: 1px solid black;
+    }
+</style>
+<body>
+    <svg width="600" height="600">
+        <circle cx="100%" cy="50%" r="50%" fill="green"/>
+    </svg>
+</body>

--- a/LayoutTests/svg/filters/filter-on-root-tile-boundary.html
+++ b/LayoutTests/svg/filters/filter-on-root-tile-boundary.html
@@ -1,0 +1,17 @@
+<meta name="fuzzy" content="maxDifference=1-40; totalPixels=0-1104" />
+<style>
+    svg {
+        border: 1px solid black;
+    }
+</style>
+<body>
+    <svg width="600" height="600" filter="url(#image-filter)">
+        <defs>
+            <circle id="green-circle" cx="50%" cy="50%" r="50%" fill="green"/>
+            <filter id="image-filter" x="0" y="0">
+                <feImage href="#green-circle" x="50%"/>
+            </filter>
+        </defs>
+        <rect width="100%" height="100%"/>
+    </svg>
+</body>

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -73,6 +73,11 @@ bool FilterOperations::hasReferenceFilter() const
     return false;
 }
 
+bool FilterOperations::isReferenceFilter() const
+{
+    return m_operations.size() == 1 && m_operations[0]->type() == FilterOperation::Type::Reference;
+}
+
 IntOutsets FilterOperations::outsets() const
 {
     IntOutsets totalOutsets;

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -62,6 +62,7 @@ public:
     bool hasFilterThatShouldBeRestrictedBySecurityOrigin() const;
 
     bool hasReferenceFilter() const;
+    bool isReferenceFilter() const;
 
     bool transformColor(Color&) const;
     bool inverseTransformColor(Color&) const;

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -160,9 +160,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
             return;
     }
 
-    // SVG roots with filters specified (using CSS or SVG presentation attributes) are applied
-    // as CSSFilter by RenderLayer, so don't reapply the filter here.
-    if (!isRenderingMask && !renderer.isRenderOrLegacyRenderSVGRoot()) {
+    if (!isRenderingMask) {
         m_filter = resources->filter();
         if (m_filter && !m_filter->isIdentity()) {
             m_savedContext = &m_paintInfo->context();


### PR DESCRIPTION
#### cb5290644a69386cd51a1cc1f8d681f2d275a631
<pre>
REGRESSION(267236@main): SVG may incorrectly be clipped when an SVGFilter is applied to its root
<a href="https://bugs.webkit.org/show_bug.cgi?id=265465">https://bugs.webkit.org/show_bug.cgi?id=265465</a>
<a href="https://rdar.apple.com/118938065">rdar://118938065</a>

Reviewed by Nikolas Zimmermann.

Ensure the SVGFilter is applied only once to the RenderSVGRoot through the SVG
rendering code.

But use the RenderLayerFilters to repaint the referenced SVGFilter clients when
its effects are changed.

* LayoutTests/svg/filters/filter-on-root-tile-boundary-expected.html: Added.
* LayoutTests/svg/filters/filter-on-root-tile-boundary.html: Added.
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::isReferenceFilter const):
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintsWithFilters const):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):

Canonical link: <a href="https://commits.webkit.org/277325@main">https://commits.webkit.org/277325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccde39275222e52b1227cea497e03829bc033ea9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38475 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19787 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41879 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5283 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51798 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22269 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18628 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45769 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44781 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10431 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->