### PR TITLE
Inline CustomElementElementQueue into CustomElementReactionStack

### DIFF
--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -319,9 +319,6 @@ void CustomElementReactionQueue::invokeAll(Element& element)
     }
 }
 
-CustomElementQueue::CustomElementQueue() = default;
-CustomElementQueue::~CustomElementQueue() = default;
-
 inline void CustomElementQueue::add(Element& element)
 {
     ASSERT(!m_invoking);
@@ -346,7 +343,7 @@ inline void CustomElementQueue::invokeAll()
     m_elements.clear();
 }
 
-inline void CustomElementQueue::processQueue(JSC::JSGlobalObject* state)
+void CustomElementQueue::processQueue(JSC::JSGlobalObject* state)
 {
     if (!state) {
         invokeAll();
@@ -393,10 +390,7 @@ void CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue(Element
         return;
     }
 
-    auto& queue = CustomElementReactionStack::s_currentProcessingStack->m_queue;
-    if (!queue)
-        queue = makeUnique<CustomElementQueue>();
-    queue->add(element);
+    CustomElementReactionStack::s_currentProcessingStack->m_queue.add(element);
 }
 
 #if ASSERT_ENABLED
@@ -404,22 +398,6 @@ unsigned CustomElementReactionDisallowedScope::s_customElementReactionDisallowed
 #endif
 
 CustomElementReactionStack* CustomElementReactionStack::s_currentProcessingStack = nullptr;
-
-void CustomElementReactionStack::processQueue(JSC::JSGlobalObject* state)
-{
-    ASSERT(m_queue);
-    m_queue->processQueue(state);
-    m_queue = nullptr;
-}
-
-Vector<GCReachableRef<Element>, 4> CustomElementReactionStack::takeElements()
-{
-    if (!m_queue)
-        return { };
-    auto elements = m_queue->takeElements();
-    m_queue = nullptr;
-    return elements;
-}
 
 void CustomElementReactionQueue::processBackupQueue(CustomElementQueue& backupElementQueue)
 {

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CustomElementFormValue.h"
+#include "Element.h"
 #include "GCReachableRef.h"
 #include "QualifiedName.h"
 #include <wtf/CheckedRef.h>
@@ -99,11 +100,12 @@ class CustomElementQueue {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(CustomElementQueue);
 public:
-    CustomElementQueue();
-    WEBCORE_EXPORT ~CustomElementQueue();
+    CustomElementQueue() = default;
+    ~CustomElementQueue() { ASSERT(isEmpty()); }
 
+    bool isEmpty() const { return m_elements.isEmpty(); }
     void add(Element&);
-    void processQueue(JSC::JSGlobalObject*);
+    WEBCORE_EXPORT void processQueue(JSC::JSGlobalObject*);
 
     Vector<GCReachableRef<Element>, 4> takeElements();
 
@@ -224,17 +226,15 @@ public:
 
     ALWAYS_INLINE ~CustomElementReactionStack()
     {
-        if (UNLIKELY(m_queue))
-            processQueue(m_state);
+        if (UNLIKELY(!m_queue.isEmpty()))
+            m_queue.processQueue(m_state);
         s_currentProcessingStack = m_previousProcessingStack;
     }
 
-    Vector<GCReachableRef<Element>, 4> takeElements();
+    Vector<GCReachableRef<Element>, 4> takeElements() { return m_queue.takeElements(); }
 
 private:
-    WEBCORE_EXPORT void processQueue(JSC::JSGlobalObject*);
-
-    std::unique_ptr<CustomElementQueue> m_queue;
+    CustomElementQueue m_queue;
     CustomElementReactionStack* const m_previousProcessingStack;
     JSC::JSGlobalObject* const m_state;
 

--- a/Source/WebCore/dom/GCReachableRef.h
+++ b/Source/WebCore/dom/GCReachableRef.h
@@ -49,7 +49,7 @@ public:
     }
 
 private:
-    static HashCountedSet<EventTarget*>& map();
+    WEBCORE_EXPORT static HashCountedSet<EventTarget*>& map();
 };
 
 template <typename T, typename = std::enable_if_t<std::is_same<T, typename std::remove_const<T>::type>::value>>


### PR DESCRIPTION
#### c602819ddeb10b0600e9c1adebce3a73686f1ead
<pre>
Inline CustomElementElementQueue into CustomElementReactionStack
<a href="https://bugs.webkit.org/show_bug.cgi?id=270551">https://bugs.webkit.org/show_bug.cgi?id=270551</a>

Reviewed by Chris Dumez.

Inline CustomElementElementQueue into CustomElementReactionStack to avoid heap allocation.

* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementQueue::processQueue):
(WebCore::CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue):
(WebCore::CustomElementReactionStack::processQueue): Deleted.
(WebCore::CustomElementReactionStack::takeElements): Deleted.
* Source/WebCore/dom/CustomElementReactionQueue.h:
(WebCore::CustomElementQueue::CustomElementQueue): Inlined.
(WebCore::CustomElementQueue::~CustomElementQueue): Ditto.
(WebCore::CustomElementQueue::isEmpty const): Added.
(WebCore::CustomElementReactionStack::~CustomElementReactionStack):
(WebCore::CustomElementReactionStack::takeElements): Inlined.
* Source/WebCore/dom/GCReachableRef.h:

Canonical link: <a href="https://commits.webkit.org/275734@main">https://commits.webkit.org/275734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a68cddfae722125c14ab4976fadc3ffed23a67b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35290 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43214 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16240 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37760 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/697 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46744 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14385 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19257 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5766 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->