### PR TITLE
Reload without content blockers may not appear for extensions that use DNR

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -40,6 +40,7 @@
 #if TARGET_OS_IPHONE
 @class UIMenuElement;
 #else
+@class NSEvent;
 @class NSMenuItem;
 #endif
 
@@ -364,6 +365,12 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @discussion The extension context will still need to be loaded and have granted website permissions for its content to actually be injected.
  */
 - (BOOL)hasInjectedContentForURL:(NSURL *)url;
+
+/*!
+ @abstract A boolean value indicating whether the extension includes rules used for content modification or blocking.
+ @discussion This includes both static rules available in the extension's manifest and dynamic rules applied during a browsing session.
+ */
+@property (nonatomic, readonly) BOOL hasContentModificationRules;
 
 /*!
  @abstract Checks the specified permission against the currently denied, granted, and requested permissions.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -510,6 +510,11 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     return _webExtensionContext->hasInjectedContentForURL(url);
 }
 
+- (BOOL)hasContentModificationRules
+{
+    return _webExtensionContext->hasContentModificationRules();
+}
+
 - (_WKWebExtensionAction *)actionForTab:(id<_WKWebExtensionTab>)tab
 {
     if (tab)
@@ -1032,6 +1037,11 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (BOOL)hasInjectedContentForURL:(NSURL *)url
+{
+    return NO;
+}
+
+- (BOOL)hasContentModificationRules
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3704,6 +3704,11 @@ void WebExtensionContext::addDeclarativeNetRequestRulesToPrivateUserContentContr
     });
 }
 
+bool WebExtensionContext::hasContentModificationRules()
+{
+    return declarativeNetRequestEnabledRulesetCount() || !m_sessionRulesIDs.isEmpty() || !m_dynamicRulesIDs.isEmpty();
+}
+
 static NSString *computeStringHashForContentBlockerRules(NSString *rules)
 {
     SHA1 sha1;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -285,6 +285,8 @@ public:
     bool hasInjectedContentForURL(const URL&);
     bool hasInjectedContent();
 
+    bool hasContentModificationRules();
+
     URL optionsPageURL() const;
     URL overrideNewTabPageURL() const;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -526,9 +526,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionDeclarativeNetRequest];
 
+    EXPECT_FALSE(manager.get().context.hasContentModificationRules);
+
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+    EXPECT_TRUE(manager.get().context.hasContentModificationRules);
 
     auto webView = manager.get().defaultTab.mainWebView;
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
@@ -582,9 +585,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionDeclarativeNetRequest];
 
+    EXPECT_FALSE(manager.get().context.hasContentModificationRules);
+
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Unload extension");
+    EXPECT_TRUE(manager.get().context.hasContentModificationRules);
 
     auto *storageDirectory = manager.get().controller.configuration._storageDirectoryPath;
     storageDirectory = [storageDirectory stringByAppendingPathComponent:manager.get().context.uniqueIdentifier];


### PR DESCRIPTION
#### 97e744cbfdca05fad698f53a482b5c00c3c38a58
<pre>
Reload without content blockers may not appear for extensions that use DNR
<a href="https://webkit.org/b/270552">https://webkit.org/b/270552</a>
<a href="https://rdar.apple.com/124033486">rdar://124033486</a>

Reviewed by Timothy Hatcher.

Clients need to be aware of whether or not a web extension context has any
content modification rules rules. This patch adds a new property to expose
that information.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext hasContentModificationRules]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::hasContentModificationRules):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/275768@main">https://commits.webkit.org/275768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0138b6b6e25b58ab579a8d961c919fac65c08c68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35377 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37848 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42102 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19179 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40730 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9544 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->