### PR TITLE
NEW TEST [ iOS Debug ] TestWebKitAPI.Fullscreen.ResizeEventOrder is a constant crash

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3725,7 +3725,6 @@ static bool isLockdownModeWarningNeeded()
 // Deprecated SPI.
 - (CGSize)_minimumLayoutSizeOverride
 {
-    ASSERT(_overriddenLayoutParameters);
     if (!_overriddenLayoutParameters)
         return CGSizeZero;
 
@@ -3734,7 +3733,6 @@ static bool isLockdownModeWarningNeeded()
 
 - (CGSize)_minimumUnobscuredSizeOverride
 {
-    ASSERT(_overriddenLayoutParameters);
     if (!_overriddenLayoutParameters)
         return CGSizeZero;
 
@@ -3744,7 +3742,6 @@ static bool isLockdownModeWarningNeeded()
 // Deprecated SPI
 - (CGSize)_maximumUnobscuredSizeOverride
 {
-    ASSERT(_overriddenLayoutParameters);
     if (!_overriddenLayoutParameters)
         return CGSizeZero;
 


### PR DESCRIPTION
#### e936ac78d2812779552425a8e777618a407d9364
<pre>
NEW TEST [ iOS Debug ] TestWebKitAPI.Fullscreen.ResizeEventOrder is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=270527">https://bugs.webkit.org/show_bug.cgi?id=270527</a>
<a href="https://rdar.apple.com/124078618">rdar://124078618</a>

Reviewed by Tim Horton.

Remove incorrect assertions.

In WebKit, `_minimumUnobscuredSizeOverride` and `_maximumUnobscuredSizeOverride`
are only read in fullscreen code, and the values are unused, unless
`_hasOverriddenLayoutParameters` is also true.

Furthermore, SPI clients are free to use these methods as they wish, in which
case the lack of overridden layout parameters is already gracefully handled.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _minimumLayoutSizeOverride]):
(-[WKWebView _minimumUnobscuredSizeOverride]):
(-[WKWebView _maximumUnobscuredSizeOverride]):

Canonical link: <a href="https://commits.webkit.org/275724@main">https://commits.webkit.org/275724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26e2bb39414d76249df88c686a0d5f193be1911d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42642 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/21664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45252 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38766 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/25326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19029 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43216 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/25326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16243 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/25326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/699 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/25326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46746 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14387 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/41997 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19259 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5763 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->