### PR TITLE
Conversion from rgba to rg8unorm should copy correct pixel values

### DIFF
--- a/LayoutTests/fast/webgpu/conversion-to-rg8unorm-expected.txt
+++ b/LayoutTests/fast/webgpu/conversion-to-rg8unorm-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/conversion-to-rg8unorm.html
+++ b/LayoutTests/fast/webgpu/conversion-to-rg8unorm.html
@@ -1,0 +1,80 @@
+<script>
+if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone() }
+onload = async () => {
+  try {
+    let adapter0 = await navigator.gpu.requestAdapter(
+    {
+    }
+    );
+
+    let device0 = await adapter0.requestDevice(
+    {
+    label: 'a',
+    requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage'
+    ],
+    requiredLimits: {
+    maxVertexAttributes: 23,
+    maxVertexBufferArrayStride: 46861,
+    maxStorageTexturesPerShaderStage: 33,
+    maxBindingsPerBindGroup: 1499,
+    },
+    }
+    );
+    
+    let canvas0 = document.createElement('canvas');
+    let imageBitMap0 = await createImageBitmap(canvas0);
+    
+    let videoFrame1 = new VideoFrame(imageBitMap0, {timestamp: 0});
+
+    let texture0 = device0.createTexture(
+    {
+    label: 'a',
+    size: {
+    width: 373,
+    depthOrArrayLayers: 1,
+    },
+    mipLevelCount: 6,
+    sampleCount: 1,
+    format: 'rg8unorm',
+    usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT,
+    }
+    );
+    
+    device0.queue.copyExternalImageToTexture(
+    {
+    source: videoFrame1,
+    origin: {
+    x: 2707,
+    y: 4310,
+    },
+    },
+    {
+    texture: texture0,
+    mipLevel: 2591,
+    origin: [
+    5319,
+    466,
+    9625,
+    6005,
+    622
+    ],
+    aspect: 'stencil-only',
+    colorSpace: 'srgb',
+    premultipliedAlpha: true,
+    },
+    [
+    4191
+    ]
+    );
+  } catch { }
+  if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash.

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -541,7 +541,7 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
 
     case GPUTextureFormat::Rg8unorm: {
         uint8_t* data = (uint8_t*)malloc(sizeInBytes / 2);
-        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 2, ++i0) {
+        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
             data[i0] = rgbaBytes[i];
             data[i0 + 1] = rgbaBytes[i + 1];
         }


### PR DESCRIPTION
#### 4e0d0a195db543549fc827e2252061de45c22016
<pre>
Conversion from rgba to rg8unorm should copy correct pixel values
<a href="https://bugs.webkit.org/show_bug.cgi?id=270558">https://bugs.webkit.org/show_bug.cgi?id=270558</a>
<a href="https://rdar.apple.com/123810638">rdar://123810638</a>

Reviewed by Mike Wyrzykowski.

* LayoutTests/fast/webgpu/conversion-to-rg8unorm-expected.txt: Added.
* LayoutTests/fast/webgpu/conversion-to-rg8unorm.html: Added.
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::copyToDestinationFormat):

Canonical link: <a href="https://commits.webkit.org/275738@main">https://commits.webkit.org/275738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecbeb2d6e93fc1c34557820748a22d71e5c253e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35304 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43229 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16258 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37772 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/712 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46763 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42015 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40630 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19272 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5768 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->