### PR TITLE
[WebGPU] createView on a rgba16float canvas may crash

### DIFF
--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -116,6 +116,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
             parentLuminanceClampTexture = Texture::create(luminanceClampTexture, wgpuTextureDescriptor, WTFMove(viewFormats), device);
             parentLuminanceClampTexture->makeCanvasBacking();
             textureDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
+            wgpuTextureDescriptor.format = WGPUTextureFormat_BGRA8Unorm;
             textureDescriptor.usage = existingUsage | MTLTextureUsageShaderWrite;
             needsLuminanceClampFunction = true;
         }
@@ -142,6 +143,11 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
     for (auto viewFormat : descriptor.viewFormats) {
         if (!allowedFormat(viewFormat)) {
             device.generateAValidationError("Requested texture view format BGRA8UnormStorage is not enabled"_s);
+            return;
+        }
+
+        if (!Texture::textureViewFormatCompatible(descriptor.format, viewFormat)) {
+            device.generateAValidationError("Requested texture view format is not compatible with the descriptor format"_s);
             return;
         }
     }

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -114,6 +114,7 @@ public:
     static bool supportsMultisampling(WGPUTextureFormat, const Device&);
     static bool supportsResolve(WGPUTextureFormat, const Device&);
     static bool supportsBlending(WGPUTextureFormat, const Device&);
+    static bool textureViewFormatCompatible(WGPUTextureFormat, WGPUTextureFormat);
     void recreateIfNeeded();
     void makeCanvasBacking();
     void setCommandEncoder(CommandEncoder&) const;


### PR DESCRIPTION
#### 53ebed3cf56ae327cbf832e5b1edd3f1ee0949ab
<pre>
[WebGPU] createView on a rgba16float canvas may crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=270559">https://bugs.webkit.org/show_bug.cgi?id=270559</a>
&lt;<a href="https://rdar.apple.com/problem/124117002">rdar://problem/124117002</a>&gt;

Reviewed by Alex Christensen.

We were setting the pixel format to bgra8unorm but leaving
the WGPU texture format as rgba16float.

That is incorrect.

Additionally add validation around createView in a few additional
places.

* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::textureViewFormatCompatible):
(WebGPU::Device::errorValidatingTextureCreation):
(WebGPU::Texture::createView):
(WebGPU::textureViewFormatCompatible): Deleted.

Canonical link: <a href="https://commits.webkit.org/275740@main">https://commits.webkit.org/275740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c155299587f89cf58494de4c5ea01efa3cb46a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38781 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35307 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16261 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/714 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46765 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14401 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42018 "Found 1 new test failure: http/tests/inspector/network/har/har-page.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19095 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40639 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19274 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5770 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->