### PR TITLE
Make WTF::Identified work with strongly typed identifiers

### DIFF
--- a/Source/WTF/wtf/Identified.h
+++ b/Source/WTF/wtf/Identified.h
@@ -26,19 +26,18 @@
 #pragma once
 
 #include <atomic>
+#include <type_traits>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/ObjectIdentifier.h>
 #include <wtf/ThreadAssertions.h>
 #include <wtf/UUID.h>
 
 namespace WTF {
 
-template <typename IdentifierType, typename ClassType>
+template <typename IdentifierType>
 class IdentifiedBase {
 public:
-    IdentifierType identifier() const
-    {
-        return m_identifier;
-    }
+    IdentifierType identifier() const { return m_identifier; }
 
 protected:
     IdentifiedBase(const IdentifiedBase&) = default;
@@ -54,19 +53,30 @@ private:
     IdentifierType m_identifier;
 };
 
-template <typename T>
-class Identified : public IdentifiedBase<uint64_t, T> {
+template <typename ObjectIdentifierType>
+class Identified : public IdentifiedBase<ObjectIdentifierType> {
 protected:
     Identified()
-        : IdentifiedBase<uint64_t, T>(generateIdentifier())
+        : IdentifiedBase<ObjectIdentifierType>(ObjectIdentifierType::generate())
     {
     }
 
     Identified(const Identified&) = default;
-    Identified& operator=(const Identified&) = default;
+};
 
-    explicit Identified(uint64_t identifier)
-        : IdentifiedBase<uint64_t, T>(identifier)
+template <typename T>
+class LegacyIdentified : public IdentifiedBase<uint64_t> {
+protected:
+    LegacyIdentified()
+        : IdentifiedBase<uint64_t>(generateIdentifier())
+    {
+    }
+
+    LegacyIdentified(const LegacyIdentified&) = default;
+    LegacyIdentified& operator=(const LegacyIdentified&) = default;
+
+    explicit LegacyIdentified(uint64_t identifier)
+        : IdentifiedBase<uint64_t>(identifier)
     {
     }
 
@@ -82,18 +92,18 @@ private:
 };
 
 template <typename T>
-class ThreadSafeIdentified : public IdentifiedBase<uint64_t, T> {
+class LegacyThreadSafeIdentified : public IdentifiedBase<uint64_t> {
 protected:
-    ThreadSafeIdentified()
-        : IdentifiedBase<uint64_t, T>(generateIdentifier())
+    LegacyThreadSafeIdentified()
+        : IdentifiedBase<uint64_t>(generateIdentifier())
     {
     }
 
-    ThreadSafeIdentified(const ThreadSafeIdentified&) = default;
-    ThreadSafeIdentified& operator=(const ThreadSafeIdentified&) = default;
+    LegacyThreadSafeIdentified(const LegacyThreadSafeIdentified&) = default;
+    LegacyThreadSafeIdentified& operator=(const LegacyThreadSafeIdentified&) = default;
 
-    explicit ThreadSafeIdentified(uint64_t identifier)
-        : IdentifiedBase<uint64_t, T>(identifier)
+    explicit LegacyThreadSafeIdentified(uint64_t identifier)
+        : IdentifiedBase<uint64_t>(identifier)
     {
     }
 
@@ -110,10 +120,10 @@ private:
 };
 
 template <typename T>
-class UUIDIdentified : public IdentifiedBase<UUID, T> {
+class UUIDIdentified : public IdentifiedBase<UUID> {
 protected:
     UUIDIdentified()
-        : IdentifiedBase<UUID, T>(UUID::createVersion4())
+        : IdentifiedBase<UUID>(UUID::createVersion4())
     {
     }
 
@@ -123,5 +133,6 @@ protected:
 } // namespace WTF
 
 using WTF::Identified;
-using WTF::ThreadSafeIdentified;
+using WTF::LegacyIdentified;
+using WTF::LegacyThreadSafeIdentified;
 using WTF::UUIDIdentified;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -49,7 +49,6 @@ Ref<MediaKeySystemRequest> MediaKeySystemRequest::create(Document& document, con
 
 MediaKeySystemRequest::MediaKeySystemRequest(Document& document, const String& keySystem, Ref<DeferredPromise>&& promise)
     : ActiveDOMObject(document)
-    , m_identifier(MediaKeySystemRequestIdentifier::generate())
     , m_keySystem(keySystem)
     , m_promise(WTFMove(promise))
 {

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
@@ -32,6 +32,7 @@
 #include "MediaKeySystemRequestIdentifier.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/Identified.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/UniqueRef.h>
 
@@ -42,13 +43,12 @@ class MediaKeySystem;
 
 template <typename IDLType> class DOMPromiseDeferred;
 
-class MediaKeySystemRequest : public RefCounted<MediaKeySystemRequest>, public ActiveDOMObject {
+class MediaKeySystemRequest : public RefCounted<MediaKeySystemRequest>, public ActiveDOMObject, public Identified<MediaKeySystemRequestIdentifier> {
 public:
     WEBCORE_EXPORT static Ref<MediaKeySystemRequest> create(Document&, const String& keySystem, Ref<DeferredPromise>&&);
     virtual ~MediaKeySystemRequest();
 
     void setAllowCallback(CompletionHandler<void(Ref<DeferredPromise>&&)>&& callback) { m_allowCompletionHandler = WTFMove(callback); }
-    MediaKeySystemRequestIdentifier identifier() const { return m_identifier; }
     WEBCORE_EXPORT void start();
 
     WEBCORE_EXPORT void allow();
@@ -64,8 +64,6 @@ private:
 
     void stop() final;
     const char* activeDOMObjectName() const final;
-
-    MediaKeySystemRequestIdentifier m_identifier;
 
     String m_keySystem;
     Ref<DeferredPromise> m_promise;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -44,7 +44,7 @@ class ServerOpenDBRequest;
 class UniqueIDBDatabase;
 class UniqueIDBDatabaseTransaction;
 
-class UniqueIDBDatabaseConnection : public RefCounted<UniqueIDBDatabaseConnection>, public ThreadSafeIdentified<UniqueIDBDatabaseConnection>, public CanMakeWeakPtr<UniqueIDBDatabaseConnection> {
+class UniqueIDBDatabaseConnection : public RefCounted<UniqueIDBDatabaseConnection>, public LegacyThreadSafeIdentified<UniqueIDBDatabaseConnection>, public CanMakeWeakPtr<UniqueIDBDatabaseConnection> {
 public:
     static Ref<UniqueIDBDatabaseConnection> create(UniqueIDBDatabase&, ServerOpenDBRequest&);
 

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -62,7 +62,6 @@ Ref<UserMediaRequest> UserMediaRequest::create(Document& document, MediaStreamRe
 
 UserMediaRequest::UserMediaRequest(Document& document, MediaStreamRequest&& request, TrackConstraints&& audioConstraints, TrackConstraints&& videoConstraints, DOMPromiseDeferred<IDLInterface<MediaStream>>&& promise)
     : ActiveDOMObject(document)
-    , m_identifier(UserMediaRequestIdentifier::generate())
     , m_promise(makeUniqueRef<DOMPromiseDeferred<IDLInterface<MediaStream>>>(WTFMove(promise)))
     , m_request(WTFMove(request))
     , m_audioConstraints(WTFMove(audioConstraints))

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.h
@@ -44,6 +44,7 @@
 #include "MediaStreamRequest.h"
 #include "UserMediaRequestIdentifier.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/Identified.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/UniqueRef.h>
 
@@ -54,13 +55,12 @@ class SecurityOrigin;
 
 template<typename IDLType> class DOMPromiseDeferred;
 
-class UserMediaRequest : public RefCounted<UserMediaRequest>, public ActiveDOMObject {
+class UserMediaRequest : public RefCounted<UserMediaRequest>, public ActiveDOMObject, public Identified<UserMediaRequestIdentifier> {
 public:
     using TrackConstraints = std::variant<bool, MediaTrackConstraints>;
     static Ref<UserMediaRequest> create(Document&, MediaStreamRequest&&, TrackConstraints&&, TrackConstraints&&, DOMPromiseDeferred<IDLInterface<MediaStream>>&&);
     virtual ~UserMediaRequest();
 
-    UserMediaRequestIdentifier identifier() const { return m_identifier; }
     void start();
 
     WEBCORE_EXPORT void setAllowedMediaDeviceUIDs(const String& audioDeviceUID, const String& videoDeviceUID);
@@ -85,8 +85,6 @@ private:
 
     void stop() final;
     const char* activeDOMObjectName() const final;
-
-    UserMediaRequestIdentifier m_identifier;
 
     Vector<String> m_videoDeviceUIDs;
     Vector<String> m_audioDeviceUIDs;

--- a/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "SpeechRecognitionConnectionClientIdentifier.h"
+#include <wtf/Identified.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -33,12 +34,9 @@ namespace WebCore {
 struct SpeechRecognitionError;
 struct SpeechRecognitionResultData;
 
-class SpeechRecognitionConnectionClient : public CanMakeWeakPtr<SpeechRecognitionConnectionClient> {
+class SpeechRecognitionConnectionClient : public Identified<SpeechRecognitionConnectionClientIdentifier>, public CanMakeWeakPtr<SpeechRecognitionConnectionClient> {
 public:
-    SpeechRecognitionConnectionClient()
-        : m_identifier(SpeechRecognitionConnectionClientIdentifier::generate())
-    {
-    }
+    SpeechRecognitionConnectionClient() = default;
 
     virtual ~SpeechRecognitionConnectionClient() { }
 
@@ -53,11 +51,6 @@ public:
     virtual void didReceiveResult(Vector<SpeechRecognitionResultData>&& resultDatas) = 0;
     virtual void didError(const SpeechRecognitionError&) = 0;
     virtual void didEnd() = 0;
-
-    SpeechRecognitionConnectionClientIdentifier identifier() const { return m_identifier; };
-
-private:
-    SpeechRecognitionConnectionClientIdentifier m_identifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -66,10 +66,7 @@ RefPtr<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(ScriptExec
     return create(downcast<Document>(context), client, provider);
 }
 
-ThreadableWebSocketChannel::ThreadableWebSocketChannel()
-    : m_identifier(WebSocketIdentifier::generate())
-{
-}
+ThreadableWebSocketChannel::ThreadableWebSocketChannel() = default;
 
 std::optional<ThreadableWebSocketChannel::ValidatedURL> ThreadableWebSocketChannel::validateURL(Document& document, const URL& requestedURL)
 {

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h
@@ -32,6 +32,7 @@
 
 #include "WebSocketIdentifier.h"
 #include <wtf/Forward.h>
+#include <wtf/Identified.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/URL.h>
@@ -54,7 +55,7 @@ class WebSocketChannelClient;
 
 using WebSocketChannelIdentifier = AtomicObjectIdentifier<WebSocketChannel>;
 
-class ThreadableWebSocketChannel {
+class ThreadableWebSocketChannel : public Identified<WebSocketIdentifier> {
     WTF_MAKE_NONCOPYABLE(ThreadableWebSocketChannel);
 public:
     static RefPtr<ThreadableWebSocketChannel> create(Document&, WebSocketChannelClient&, SocketProvider&);
@@ -63,8 +64,6 @@ public:
 
     void ref() { refThreadableWebSocketChannel(); }
     void deref() { derefThreadableWebSocketChannel(); }
-
-    WebSocketIdentifier identifier() const { return m_identifier; };
 
     enum class ConnectStatus { KO, OK };
     virtual ConnectStatus connect(const URL&, const String& protocol) = 0;
@@ -123,8 +122,6 @@ protected:
     };
     WEBCORE_EXPORT static std::optional<ValidatedURL> validateURL(Document&, const URL&);
     WEBCORE_EXPORT static std::optional<ResourceRequest> webSocketConnectRequest(Document&, const URL&);
-
-    WebSocketIdentifier m_identifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -49,6 +49,7 @@
 #include "VisibilityChangeClient.h"
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/Identified.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/Observer.h>
 #include <wtf/WallTime.h>
@@ -146,6 +147,7 @@ class HTMLMediaElement
     , public ActiveDOMObject
     , public MediaControllerInterface
     , public PlatformMediaSessionClient
+    , public Identified<HTMLMediaElementIdentifier>
     , private MediaCanStartListener
     , private MediaPlayerClient
     , private MediaProducer
@@ -169,8 +171,6 @@ public:
     using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::weakPtrFactory;
     using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::WeakValueType;
     using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::WeakPtrImplType;
-
-    HTMLMediaElementIdentifier identifier() const { return m_identifier; }
 
     MediaPlayer* player() const { return m_player.get(); }
     RefPtr<MediaPlayer> protectedPlayer() const { return m_player; }
@@ -582,6 +582,8 @@ public:
 #endif
 
     bool supportsSeeking() const override;
+
+    using Identified<HTMLMediaElementIdentifier>::identifier;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return *m_logger.get(); }
@@ -1067,8 +1069,6 @@ private:
 #endif
 
     bool shouldDisableHDR() const;
-
-    HTMLMediaElementIdentifier m_identifier { HTMLMediaElementIdentifier::generate() };
 
     Timer m_progressEventTimer;
     Timer m_playbackProgressTimer;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -243,7 +243,6 @@ void BackgroundFetch::unsetRecordsAvailableFlag()
 
 BackgroundFetch::Record::Record(BackgroundFetch& fetch, BackgroundFetchRequest&& request, size_t index)
     : m_fetch(fetch)
-    , m_identifier(BackgroundFetchRecordIdentifier::generate())
     , m_fetchIdentifier(fetch.m_identifier)
     , m_registrationKey(fetch.m_registrationKey)
     , m_request(WTFMove(request))
@@ -269,7 +268,7 @@ bool BackgroundFetch::Record::isMatching(const ResourceRequest& request, const C
 
 BackgroundFetchRecordInformation BackgroundFetch::Record::information() const
 {
-    return BackgroundFetchRecordInformation { m_identifier, m_request.internalRequest, m_request.options, m_request.guard, m_request.httpHeaders, m_request.referrer };
+    return BackgroundFetchRecordInformation { identifier(), m_request.internalRequest, m_request.options, m_request.guard, m_request.httpHeaders, m_request.referrer };
 }
 
 void BackgroundFetch::Record::complete(const CreateLoaderCallback& createLoaderCallback)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
@@ -36,6 +36,7 @@
 #include "ResourceResponse.h"
 #include "ServiceWorkerRegistrationKey.h"
 #include "ServiceWorkerTypes.h"
+#include <wtf/Identified.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -70,7 +71,7 @@ public:
     void pause();
     void resume(const CreateLoaderCallback&);
 
-    class Record final : public BackgroundFetchRecordLoader::Client, public RefCounted<Record> {
+    class Record final : public BackgroundFetchRecordLoader::Client, public RefCounted<Record>, private Identified<BackgroundFetchRecordIdentifier> {
         WTF_MAKE_FAST_ALLOCATED;
     public:
         static Ref<Record> create(BackgroundFetch& fetch, BackgroundFetchRequest&& request, size_t size) { return adoptRef(*new Record(fetch, WTFMove(request), size)); }
@@ -103,7 +104,6 @@ public:
         void didFinish(const ResourceError&) final;
 
         WeakPtr<BackgroundFetch> m_fetch;
-        BackgroundFetchRecordIdentifier m_identifier;
         String m_fetchIdentifier;
         ServiceWorkerRegistrationKey m_registrationKey;
         BackgroundFetchRequest m_request;

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -36,19 +36,13 @@
 
 namespace WebCore {
 
-static ServiceWorkerRegistrationIdentifier generateServiceWorkerRegistrationIdentifier()
-{
-    return ServiceWorkerRegistrationIdentifier::generate();
-}
-
 Ref<SWServerRegistration> SWServerRegistration::create(SWServer& server, const ServiceWorkerRegistrationKey& key, ServiceWorkerUpdateViaCache updateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&& navigationPreloadState)
 {
     return adoptRef(*new SWServerRegistration(server, key, updateViaCache, scopeURL, scriptURL, serviceWorkerPageIdentifier, WTFMove(navigationPreloadState)));
 }
 
 SWServerRegistration::SWServerRegistration(SWServer& server, const ServiceWorkerRegistrationKey& key, ServiceWorkerUpdateViaCache updateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&& navigationPreloadState)
-    : m_identifier(generateServiceWorkerRegistrationIdentifier())
-    , m_registrationKey(key)
+    : m_registrationKey(key)
     , m_updateViaCache(updateViaCache)
     , m_scopeURL(scopeURL)
     , m_scriptURL(scriptURL)

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -32,6 +32,7 @@
 #include "ServiceWorkerTypes.h"
 #include "Timer.h"
 #include <wtf/HashCountedSet.h>
+#include <wtf/Identified.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakPtr.h>
@@ -47,14 +48,13 @@ struct ServiceWorkerContextData;
 
 enum class IsAppInitiated : bool { No, Yes };
 
-class SWServerRegistration : public RefCounted<SWServerRegistration>, public CanMakeWeakPtr<SWServerRegistration> {
+class SWServerRegistration : public RefCounted<SWServerRegistration>, public CanMakeWeakPtr<SWServerRegistration>, public Identified<ServiceWorkerRegistrationIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<SWServerRegistration> create(SWServer&, const ServiceWorkerRegistrationKey&, ServiceWorkerUpdateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&&);
     WEBCORE_EXPORT ~SWServerRegistration();
 
     const ServiceWorkerRegistrationKey& key() const { return m_registrationKey; }
-    ServiceWorkerRegistrationIdentifier identifier() const { return m_identifier; }
 
     SWServerWorker* getNewestWorker();
     WEBCORE_EXPORT ServiceWorkerRegistrationData data() const;
@@ -122,7 +122,6 @@ private:
 
     RefPtr<SWServer> protectedServer() const { return m_server.get(); }
 
-    ServiceWorkerRegistrationIdentifier m_identifier;
     ServiceWorkerRegistrationKey m_registrationKey;
     ServiceWorkerUpdateViaCache m_updateViaCache;
     URL m_scopeURL;

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -33,14 +33,8 @@
 
 namespace WebCore {
 
-static SWServerToContextConnectionIdentifier generateServerToContextConnectionIdentifier()
-{
-    return SWServerToContextConnectionIdentifier::generate();
-}
-
 SWServerToContextConnection::SWServerToContextConnection(SWServer& server, RegistrableDomain&& registrableDomain, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier)
     : m_server(server)
-    , m_identifier(generateServerToContextConnectionIdentifier())
     , m_registrableDomain(WTFMove(registrableDomain))
     , m_serviceWorkerPageIdentifier(serviceWorkerPageIdentifier)
 {

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -36,6 +36,7 @@
 #include "ServiceWorkerIdentifier.h"
 #include "ServiceWorkerTypes.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/Identified.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
 
@@ -50,15 +51,13 @@ struct ServiceWorkerContextData;
 struct ServiceWorkerJobDataIdentifier;
 enum class WorkerThreadMode : bool;
 
-class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection>, public CanMakeCheckedPtr {
+class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection>, public CanMakeCheckedPtr, public Identified<SWServerToContextConnectionIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();
 
     WEBCORE_EXPORT SWServer* server() const;
     WEBCORE_EXPORT RefPtr<SWServer> protectedServer() const;
-
-    SWServerToContextConnectionIdentifier identifier() const { return m_identifier; }
 
     // This flag gets set when the service worker process is no longer clean (because it has loaded several eTLD+1s).
     bool shouldTerminateWhenPossible() const { return m_shouldTerminateWhenPossible; }
@@ -110,7 +109,6 @@ protected:
 
 private:
     WeakPtr<WebCore::SWServer> m_server;
-    SWServerToContextConnectionIdentifier m_identifier;
     RegistrableDomain m_registrableDomain;
     std::optional<ScriptExecutionContextIdentifier> m_serviceWorkerPageIdentifier;
     bool m_shouldTerminateWhenPossible { false };

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -30,6 +30,7 @@
 #include "SharedWorkerKey.h"
 #include "SharedWorkerObjectIdentifier.h"
 #include "URLKeepingBlobAlive.h"
+#include <wtf/Identified.h>
 #include <wtf/MonotonicTime.h>
 
 namespace WebCore {
@@ -39,14 +40,13 @@ class ResourceError;
 
 struct WorkerOptions;
 
-class SharedWorker final : public AbstractWorker, public ActiveDOMObject {
+class SharedWorker final : public AbstractWorker, public ActiveDOMObject, public Identified<SharedWorkerObjectIdentifier> {
     WTF_MAKE_ISO_ALLOCATED(SharedWorker);
 public:
     static ExceptionOr<Ref<SharedWorker>> create(Document&, String&& scriptURL, std::optional<std::variant<String, WorkerOptions>>&&);
     ~SharedWorker();
 
     static SharedWorker* fromIdentifier(SharedWorkerObjectIdentifier);
-    SharedWorkerObjectIdentifier identifier() const { return m_identifier; }
     MessagePort& port() const { return m_port.get(); }
 
     const String& identifierForInspector() const { return m_identifierForInspector; }
@@ -71,7 +71,6 @@ private:
 
 
     SharedWorkerKey m_key;
-    SharedWorkerObjectIdentifier m_identifier;
     Ref<MessagePort> m_port;
     String m_identifierForInspector;
     URLKeepingBlobAlive m_blobURLExtension;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -44,12 +44,11 @@ static HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>& allWo
 
 WebSharedWorker::WebSharedWorker(WebSharedWorkerServer& server, const WebCore::SharedWorkerKey& key, const WebCore::WorkerOptions& workerOptions)
     : m_server(server)
-    , m_identifier(WebCore::SharedWorkerIdentifier::generate())
     , m_key(key)
     , m_workerOptions(workerOptions)
 {
-    ASSERT(!allWorkers().contains(m_identifier));
-    allWorkers().add(m_identifier, *this);
+    ASSERT(!allWorkers().contains(identifier()));
+    allWorkers().add(identifier(), *this);
 }
 
 WebSharedWorker::~WebSharedWorker()
@@ -59,8 +58,8 @@ WebSharedWorker::~WebSharedWorker()
             connection->removeSharedWorkerObject(sharedWorkerObject.identifier);
     }
 
-    ASSERT(allWorkers().get(m_identifier) == this);
-    allWorkers().remove(m_identifier);
+    ASSERT(allWorkers().get(identifier()) == this);
+    allWorkers().remove(identifier());
 }
 
 WebSharedWorker* WebSharedWorker::fromIdentifier(WebCore::SharedWorkerIdentifier identifier)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -33,6 +33,7 @@
 #include <WebCore/WorkerInitializationData.h>
 #include <WebCore/WorkerOptions.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/Identified.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -45,7 +46,7 @@ namespace WebKit {
 class WebSharedWorkerServer;
 class WebSharedWorkerServerToContextConnection;
 
-class WebSharedWorker : public CanMakeWeakPtr<WebSharedWorker> {
+class WebSharedWorker : public CanMakeWeakPtr<WebSharedWorker>, public Identified<WebCore::SharedWorkerIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WebSharedWorker(WebSharedWorkerServer&, const WebCore::SharedWorkerKey&, const WebCore::WorkerOptions&);
@@ -53,7 +54,6 @@ public:
 
     static WebSharedWorker* fromIdentifier(WebCore::SharedWorkerIdentifier);
 
-    WebCore::SharedWorkerIdentifier identifier() const { return m_identifier; }
     const WebCore::SharedWorkerKey& key() const { return m_key; }
     const WebCore::WorkerOptions& workerOptions() const { return m_workerOptions; }
     const WebCore::ClientOrigin& origin() const { return m_key.origin; }
@@ -103,7 +103,6 @@ private:
     void resumeIfNeeded();
 
     WebSharedWorkerServer& m_server;
-    WebCore::SharedWorkerIdentifier m_identifier;
     WebCore::SharedWorkerKey m_key;
     WebCore::WorkerOptions m_workerOptions;
     ListHashSet<Object> m_sharedWorkerObjects;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -64,7 +64,6 @@ static Ref<CacheStorageStore> createStore(const String& uniqueName, const String
 
 CacheStorageCache::CacheStorageCache(CacheStorageManager& manager, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&& queue)
     : m_manager(manager)
-    , m_identifier(WebCore::DOMCacheIdentifier::generate())
     , m_name(name)
     , m_uniqueName(uniqueName)
 #if ASSERT_ENABLED
@@ -113,7 +112,7 @@ void CacheStorageCache::open(WebCore::DOMCacheEngine::CacheIdentifierCallback&& 
     assertIsOnCorrectQueue();
 
     if (m_isInitialized)
-        return callback(WebCore::DOMCacheEngine::CacheIdentifierOperationResult { m_identifier, false });
+        return callback(WebCore::DOMCacheEngine::CacheIdentifierOperationResult { identifier(), false });
 
     m_pendingInitializationCallbacks.append(WTFMove(callback));
     if (m_pendingInitializationCallbacks.size() > 1)
@@ -139,7 +138,7 @@ void CacheStorageCache::open(WebCore::DOMCacheEngine::CacheIdentifierCallback&& 
 
         m_isInitialized = true;
         for (auto& callback : m_pendingInitializationCallbacks)
-            callback(WebCore::DOMCacheEngine::CacheIdentifierOperationResult { m_identifier, false });
+            callback(WebCore::DOMCacheEngine::CacheIdentifierOperationResult { identifier(), false });
         m_pendingInitializationCallbacks.clear();
     });
 }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -29,18 +29,18 @@
 #include "CacheStorageStore.h"
 #include "NetworkCacheKey.h"
 #include <WebCore/RetrieveRecordsOptions.h>
+#include <wtf/Identified.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebKit {
 
 class CacheStorageManager;
 
-class CacheStorageCache : public CanMakeWeakPtr<CacheStorageCache> {
+class CacheStorageCache : public CanMakeWeakPtr<CacheStorageCache>, public Identified<WebCore::DOMCacheIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     CacheStorageCache(CacheStorageManager&, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&&);
     ~CacheStorageCache();
-    WebCore::DOMCacheIdentifier identifier() const { return m_identifier; }
     const String& name() const { return m_name; }
     const String& uniqueName() const { return m_uniqueName; }
     CacheStorageManager* manager();
@@ -67,7 +67,6 @@ private:
     WeakPtr<CacheStorageManager> m_manager;
     bool m_isInitialized { false };
     Vector<WebCore::DOMCacheEngine::CacheIdentifierCallback> m_pendingInitializationCallbacks;
-    WebCore::DOMCacheIdentifier m_identifier;
     String m_name;
     String m_uniqueName;
     HashMap<String, Vector<CacheStorageRecordInformation>> m_records;

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -66,8 +66,7 @@ std::unique_ptr<FileSystemStorageHandle> FileSystemStorageHandle::create(FileSys
 }
 
 FileSystemStorageHandle::FileSystemStorageHandle(FileSystemStorageManager& manager, Type type, String&& path, String&& name)
-    : m_identifier(WebCore::FileSystemHandleIdentifier::generate())
-    , m_manager(manager)
+    : m_manager(manager)
     , m_type(type)
     , m_path(WTFMove(path))
     , m_name(WTFMove(name))
@@ -185,7 +184,7 @@ Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError> FileSystemStora
     if (!m_manager)
         return makeUnexpected(FileSystemStorageError::Unknown);
 
-    bool acquired = m_manager->acquireLockForFile(m_path, m_identifier);
+    bool acquired = m_manager->acquireLockForFile(m_path, identifier());
     if (!acquired)
         return makeUnexpected(FileSystemStorageError::InvalidState);
 
@@ -213,7 +212,7 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::closeSyncAccessHa
     if (!m_manager)
         return FileSystemStorageError::Unknown;
 
-    m_manager->releaseLockForFile(m_path, m_identifier);
+    m_manager->releaseLockForFile(m_path, identifier());
     m_activeSyncAccessHandle = std::nullopt;
 
     return std::nullopt;

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -29,6 +29,7 @@
 #include "FileSystemSyncAccessHandleInfo.h"
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
+#include <wtf/Identified.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -40,13 +41,12 @@ namespace WebKit {
 class FileSystemStorageManager;
 enum class FileSystemStorageError : uint8_t;
 
-class FileSystemStorageHandle : public CanMakeWeakPtr<FileSystemStorageHandle, WeakPtrFactoryInitialization::Eager> {
+class FileSystemStorageHandle : public CanMakeWeakPtr<FileSystemStorageHandle, WeakPtrFactoryInitialization::Eager>, public Identified<WebCore::FileSystemHandleIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type : uint8_t { File, Directory, Any };
     static std::unique_ptr<FileSystemStorageHandle> create(FileSystemStorageManager&, Type, String&& path, String&& name);
 
-    WebCore::FileSystemHandleIdentifier identifier() const { return m_identifier; }
     const String& path() const { return m_path; }
     Type type() const { return m_type; }
     uint64_t allocatedUnusedCapacity();
@@ -71,7 +71,6 @@ private:
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> requestCreateHandle(IPC::Connection::UniqueID, Type, String&& name, bool createIfNecessary);
     bool isActiveSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier);
 
-    WebCore::FileSystemHandleIdentifier m_identifier;
     WeakPtr<FileSystemStorageManager> m_manager;
     Type m_type;
     String m_path;

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp
@@ -37,8 +37,7 @@ uint64_t StorageAreaBase::nextMessageIdentifier()
 }
 
 StorageAreaBase::StorageAreaBase(unsigned quota, const WebCore::ClientOrigin& origin)
-    : m_identifier(StorageAreaIdentifier::generate())
-    , m_quota(quota)
+    : m_quota(quota)
     , m_origin(origin)
 {
 }

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaBase.h
@@ -30,6 +30,7 @@
 #include "StorageAreaImplIdentifier.h"
 #include "StorageAreaMapIdentifier.h"
 #include <WebCore/ClientOrigin.h>
+#include <wtf/Identified.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -44,7 +45,7 @@ enum class StorageError : uint8_t {
     QuotaExceeded,
 };
 
-class StorageAreaBase : public CanMakeWeakPtr<StorageAreaBase> {
+class StorageAreaBase : public CanMakeWeakPtr<StorageAreaBase>, public Identified<StorageAreaIdentifier> {
     WTF_MAKE_NONCOPYABLE(StorageAreaBase);
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -58,7 +59,6 @@ public:
     virtual bool isEmpty() = 0;
     virtual void clear() = 0;
 
-    StorageAreaIdentifier identifier() const { return m_identifier; }
     WebCore::ClientOrigin origin() const { return m_origin; }
     unsigned quota() const { return m_quota; }
     void addListener(IPC::Connection::UniqueID, StorageAreaMapIdentifier);
@@ -76,7 +76,6 @@ protected:
     void dispatchEvents(IPC::Connection::UniqueID, StorageAreaImplIdentifier, const String& key, const String& oldValue, const String& newValue, const String& urlString) const;
 
 private:
-    StorageAreaIdentifier m_identifier;
     unsigned m_quota;
     WebCore::ClientOrigin m_origin;
     HashMap<IPC::Connection::UniqueID, StorageAreaMapIdentifier> m_listeners;

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -41,8 +41,7 @@ void NetworkTransportSession::initialize(NetworkConnectionToWebProcess& connecti
 }
 
 NetworkTransportSession::NetworkTransportSession(NetworkConnectionToWebProcess& connection)
-    : m_identifier(WebTransportSessionIdentifier::generate())
-    , m_connection(connection)
+    : m_connection(connection)
 {
 }
 
@@ -55,7 +54,7 @@ IPC::Connection* NetworkTransportSession::messageSenderConnection() const
 
 uint64_t NetworkTransportSession::messageSenderDestinationID() const
 {
-    return m_identifier.toUInt64();
+    return identifier().toUInt64();
 }
 
 void NetworkTransportSession::sendDatagram(std::span<const uint8_t>, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -28,6 +28,7 @@
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include <WebCore/ProcessQualified.h>
+#include <wtf/Identified.h>
 #include <wtf/RefCounted.h>
 
 namespace WebKit {
@@ -43,15 +44,13 @@ struct WebTransportStreamIdentifierType;
 using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdentifierType>;
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
 
-class NetworkTransportSession : public IPC::MessageReceiver, public IPC::MessageSender {
+class NetworkTransportSession : public IPC::MessageReceiver, public IPC::MessageSender, public Identified<WebTransportSessionIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static void initialize(NetworkConnectionToWebProcess&, URL&&, CompletionHandler<void(std::unique_ptr<NetworkTransportSession>&&)>&&);
 
     NetworkTransportSession(NetworkConnectionToWebProcess&);
     ~NetworkTransportSession();
-
-    WebTransportSessionIdentifier identifier() const { return m_identifier; }
 
     void sendDatagram(std::span<const uint8_t>, CompletionHandler<void()>&&);
     void createOutgoingUnidirectionalStream(CompletionHandler<void(std::optional<WebTransportStreamIdentifier>)>&&);
@@ -72,7 +71,6 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
-    WebTransportSessionIdentifier m_identifier;
     HashMap<WebTransportStreamIdentifier, UniqueRef<NetworkTransportBidirectionalStream>> m_bidirectionalStreams;
     HashMap<WebTransportStreamIdentifier, UniqueRef<NetworkTransportReceiveStream>> m_receiveStreams;
     HashMap<WebTransportStreamIdentifier, UniqueRef<NetworkTransportSendStream>> m_sendStreams;

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
@@ -46,7 +46,7 @@ namespace WebKit {
 
 class MediaTrackReader;
 
-class MediaSampleCursor : public CoreMediaWrapped<MediaSampleCursor>, ThreadSafeIdentified<MediaSampleCursor> {
+class MediaSampleCursor : public CoreMediaWrapped<MediaSampleCursor>, LegacyThreadSafeIdentified<MediaSampleCursor> {
 public:
     using DecodeOrderIterator = WebCore::DecodeOrderSampleMap::iterator;
     using PresentationOrderIterator = WebCore::PresentationOrderSampleMap::iterator;

--- a/Source/WebKit/UIProcess/API/APIUserScript.h
+++ b/Source/WebKit/UIProcess/API/APIUserScript.h
@@ -32,7 +32,7 @@
 
 namespace API {
 
-class UserScript final : public ObjectImpl<Object::Type::UserScript>, public Identified<UserScript> {
+class UserScript final : public ObjectImpl<Object::Type::UserScript>, public LegacyIdentified<UserScript> {
 public:
     static WTF::URL generateUniqueURL();
 

--- a/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
+++ b/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
@@ -32,7 +32,7 @@
 
 namespace API {
 
-class UserStyleSheet final : public ObjectImpl<Object::Type::UserStyleSheet>, public Identified<UserStyleSheet> {
+class UserStyleSheet final : public ObjectImpl<Object::Type::UserStyleSheet>, public LegacyIdentified<UserStyleSheet> {
 public:
     static WTF::URL generateUniqueURL();
 

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -104,7 +104,7 @@ bool DrawingAreaProxyCoordinatedGraphics::forceUpdateIfNeeded()
 
     SetForScope inForceUpdate(m_inForceUpdate, true);
     send(Messages::DrawingArea::ForceUpdate());
-    m_webProcessProxy->connection()->waitForAndDispatchImmediately<Messages::DrawingAreaProxy::Update>(m_identifier, 500_ms);
+    m_webProcessProxy->connection()->waitForAndDispatchImmediately<Messages::DrawingAreaProxy::Update>(identifier(), 500_ms);
     return !!m_backingStore;
 }
 

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -42,7 +42,6 @@ using namespace WebCore;
 
 DrawingAreaProxy::DrawingAreaProxy(DrawingAreaType type, WebPageProxy& webPageProxy, WebProcessProxy& webProcessProxy)
     : m_type(type)
-    , m_identifier(DrawingAreaIdentifier::generate())
     , m_webPageProxy(webPageProxy)
     , m_webProcessProxy(webProcessProxy)
     , m_size(webPageProxy.viewSize())
@@ -62,13 +61,13 @@ Ref<WebPageProxy> DrawingAreaProxy::protectedWebPageProxy() const
 void DrawingAreaProxy::startReceivingMessages(WebProcessProxy& process)
 {
     for (auto& name : messageReceiverNames())
-        process.addMessageReceiver(name, m_identifier, *this);
+        process.addMessageReceiver(name, identifier(), *this);
 }
 
 void DrawingAreaProxy::stopReceivingMessages(WebProcessProxy& process)
 {
     for (auto& name : messageReceiverNames())
-        process.removeMessageReceiver(name, m_identifier);
+        process.removeMessageReceiver(name, identifier());
 }
 
 std::span<IPC::ReceiverName> DrawingAreaProxy::messageReceiverNames() const

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -35,6 +35,7 @@
 #include <WebCore/IntSize.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <stdint.h>
+#include <wtf/Identified.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TypeCasts.h>
@@ -63,7 +64,7 @@ class WebProcessProxy;
 struct UpdateInfo;
 #endif
 
-class DrawingAreaProxy : public IPC::MessageReceiver, public IPC::MessageSender {
+class DrawingAreaProxy : public IPC::MessageReceiver, public IPC::MessageSender, public Identified<DrawingAreaIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(DrawingAreaProxy);
 
@@ -71,7 +72,6 @@ public:
     virtual ~DrawingAreaProxy();
 
     DrawingAreaType type() const { return m_type; }
-    DrawingAreaIdentifier identifier() const { return m_identifier; }
 
     void startReceivingMessages(WebProcessProxy&);
     void stopReceivingMessages(WebProcessProxy&);
@@ -149,7 +149,6 @@ protected:
     Ref<WebPageProxy> protectedWebPageProxy() const;
 
     DrawingAreaType m_type;
-    DrawingAreaIdentifier m_identifier;
     WeakRef<WebPageProxy> m_webPageProxy;
     Ref<WebProcessProxy> m_webProcessProxy;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -243,7 +243,7 @@ bool WebExtensionController::load(WebExtensionContext& extensionContext, NSError
         return false;
     }
 
-    sendToAllProcesses(Messages::WebExtensionControllerProxy::Load(extensionContext.parameters()), m_identifier);
+    sendToAllProcesses(Messages::WebExtensionControllerProxy::Load(extensionContext.parameters()), identifier());
 
     return true;
 }
@@ -266,7 +266,7 @@ bool WebExtensionController::unload(WebExtensionContext& extensionContext, NSErr
     UNUSED_VARIABLE(result);
     ASSERT(result);
 
-    sendToAllProcesses(Messages::WebExtensionControllerProxy::Unload(extensionContext.identifier()), m_identifier);
+    sendToAllProcesses(Messages::WebExtensionControllerProxy::Unload(extensionContext.identifier()), identifier());
 
     for (Ref processPool : m_processPools)
         processPool->removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.identifier());
@@ -328,7 +328,7 @@ void WebExtensionController::addProcessPool(WebProcessPool& processPool)
         processPool.setDomainRelaxationForbiddenForURLScheme(urlScheme);
     }
 
-    processPool.addMessageReceiver(Messages::WebExtensionController::messageReceiverName(), m_identifier, *this);
+    processPool.addMessageReceiver(Messages::WebExtensionController::messageReceiverName(), identifier(), *this);
 
     for (Ref context : m_extensionContexts)
         processPool.addMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context->identifier(), context);
@@ -342,7 +342,7 @@ void WebExtensionController::removeProcessPool(WebProcessPool& processPool)
             return;
     }
 
-    processPool.removeMessageReceiver(Messages::WebExtensionController::messageReceiverName(), m_identifier);
+    processPool.removeMessageReceiver(Messages::WebExtensionController::messageReceiverName(), identifier());
 
     for (Ref context : m_extensionContexts)
         processPool.removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), context->identifier());

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -52,8 +52,7 @@
 namespace WebKit {
 
 WebExtensionTab::WebExtensionTab(const WebExtensionContext& context, _WKWebExtensionTab *delegate)
-    : m_identifier(WebExtensionTabIdentifier::generate())
-    , m_extensionContext(context)
+    : m_extensionContext(context)
     , m_delegate(delegate)
     , m_respondsToWindow([delegate respondsToSelector:@selector(windowForWebExtensionContext:)])
     , m_respondsToParentTab([delegate respondsToSelector:@selector(parentTabForWebExtensionContext:)])
@@ -105,7 +104,7 @@ WebExtensionContext* WebExtensionTab::extensionContext() const
 
 bool WebExtensionTab::operator==(const WebExtensionTab& other) const
 {
-    return this == &other || (m_identifier == other.m_identifier && m_extensionContext == other.m_extensionContext && m_delegate.get() == other.m_delegate.get());
+    return this == &other || (identifier() == other.identifier() && m_extensionContext == other.m_extensionContext && m_delegate.get() == other.m_delegate.get());
 }
 
 WebExtensionTabParameters WebExtensionTab::parameters() const

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -44,8 +44,7 @@
 namespace WebKit {
 
 WebExtensionWindow::WebExtensionWindow(const WebExtensionContext& context, _WKWebExtensionWindow* delegate)
-    : m_identifier(WebExtensionWindowIdentifier::generate())
-    , m_extensionContext(context)
+    : m_extensionContext(context)
     , m_delegate(delegate)
     , m_respondsToTabs([delegate respondsToSelector:@selector(tabsForWebExtensionContext:)])
     , m_respondsToActiveTab([delegate respondsToSelector:@selector(activeTabForWebExtensionContext:)])
@@ -69,7 +68,7 @@ WebExtensionContext* WebExtensionWindow::extensionContext() const
 
 bool WebExtensionWindow::operator==(const WebExtensionWindow& other) const
 {
-    return this == &other || (m_identifier == other.m_identifier && m_extensionContext == other.m_extensionContext && m_delegate.get() == other.m_delegate.get());
+    return this == &other || (identifier() == other.identifier() && m_extensionContext == other.m_extensionContext && m_delegate.get() == other.m_delegate.get());
 }
 
 WebExtensionWindowParameters WebExtensionWindow::parameters(PopulateTabs populate) const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -51,10 +51,9 @@ WebExtensionContext* WebExtensionContext::get(WebExtensionContextIdentifier iden
 }
 
 WebExtensionContext::WebExtensionContext()
-    : m_identifier(WebExtensionContextIdentifier::generate())
 {
-    ASSERT(!get(m_identifier));
-    webExtensionContexts().add(m_identifier, *this);
+    ASSERT(!get(identifier()));
+    webExtensionContexts().add(identifier(), *this);
 }
 
 WebExtensionContextParameters WebExtensionContext::parameters() const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -62,6 +62,7 @@
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/Identified.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
@@ -127,7 +128,7 @@ enum class WebExtensionContextInstallReason : uint8_t {
     BrowserUpdate,
 };
 
-class WebExtensionContext : public API::ObjectImpl<API::Object::Type::WebExtensionContext>, public IPC::MessageReceiver {
+class WebExtensionContext : public API::ObjectImpl<API::Object::Type::WebExtensionContext>, public IPC::MessageReceiver, public Identified<WebExtensionContextIdentifier> {
     WTF_MAKE_NONCOPYABLE(WebExtensionContext);
 
 public:
@@ -246,7 +247,6 @@ public:
         Tab,
     };
 
-    WebExtensionContextIdentifier identifier() const { return m_identifier; }
     WebExtensionContextParameters parameters() const;
 
     bool operator==(const WebExtensionContext& other) const { return (this == &other); }
@@ -802,8 +802,6 @@ private:
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-
-    WebExtensionContextIdentifier m_identifier;
 
     String m_storageDirectory;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -52,10 +52,9 @@ WebExtensionController* WebExtensionController::get(WebExtensionControllerIdenti
 
 WebExtensionController::WebExtensionController(Ref<WebExtensionControllerConfiguration> configuration)
     : m_configuration(configuration)
-    , m_identifier(WebExtensionControllerIdentifier::generate())
 {
-    ASSERT(!get(m_identifier));
-    webExtensionControllers().add(m_identifier, *this);
+    ASSERT(!get(identifier()));
+    webExtensionControllers().add(identifier(), *this);
 
     // A freshly created extension controller will be used to determine if the startup event
     // should be fired for any loaded extensions during a brief time window. Start a timer

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -42,6 +42,7 @@
 #include "WebUserContentControllerProxy.h"
 #include <WebCore/Timer.h>
 #include <wtf/Forward.h>
+#include <wtf/Identified.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakHashSet.h>
 
@@ -68,7 +69,7 @@ struct WebExtensionControllerParameters;
 class WebInspectorUIProxy;
 #endif
 
-class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
+class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver, public Identified<WebExtensionControllerIdentifier> {
     WTF_MAKE_NONCOPYABLE(WebExtensionController);
 
 public:
@@ -94,7 +95,6 @@ public:
     enum class ForPrivateBrowsing { No, Yes };
 
     WebExtensionControllerConfiguration& configuration() const { return m_configuration.get(); }
-    WebExtensionControllerIdentifier identifier() const { return m_identifier; }
     WebExtensionControllerParameters parameters() const;
 
     bool operator==(const WebExtensionController& other) const { return (this == &other); }
@@ -225,7 +225,6 @@ private:
     };
 
     Ref<WebExtensionControllerConfiguration> m_configuration;
-    WebExtensionControllerIdentifier m_identifier;
 
     WebExtensionContextSet m_extensionContexts;
     WebExtensionContextBaseURLMap m_extensionContextBaseURLMap;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -33,6 +33,7 @@
 #include "WebExtensionTabIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
+#include <wtf/Identified.h>
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS NSArray;
@@ -54,7 +55,7 @@ enum class WebExtensionTabImageFormat : uint8_t {
     JPEG,
 };
 
-class WebExtensionTab : public RefCounted<WebExtensionTab>, public CanMakeWeakPtr<WebExtensionTab> {
+class WebExtensionTab : public RefCounted<WebExtensionTab>, public CanMakeWeakPtr<WebExtensionTab>, public Identified<WebExtensionTabIdentifier> {
     WTF_MAKE_NONCOPYABLE(WebExtensionTab);
     WTF_MAKE_FAST_ALLOCATED;
 
@@ -101,7 +102,6 @@ public:
 
     using WebProcessProxySet = HashSet<Ref<WebProcessProxy>>;
 
-    WebExtensionTabIdentifier identifier() const { return m_identifier; }
     WebExtensionTabParameters parameters() const;
     WebExtensionTabParameters changedParameters(OptionSet<ChangedProperties> = { }) const;
 
@@ -199,7 +199,6 @@ public:
 #endif
 
 private:
-    WebExtensionTabIdentifier m_identifier;
     WeakPtr<WebExtensionContext> m_extensionContext;
     WeakObjCPtr<_WKWebExtensionTab> m_delegate;
     RefPtr<WebExtensionMatchPattern> m_temporaryPermissionMatchPattern;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -31,6 +31,7 @@
 #include "WebExtensionWindowIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
+#include <wtf/Identified.h>
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_PROTOCOL(_WKWebExtensionWindow);
@@ -59,7 +60,7 @@ static constexpr OptionSet<WebExtensionWindowTypeFilter> allWebExtensionWindowTy
     };
 }
 
-class WebExtensionWindow : public RefCounted<WebExtensionWindow>, public CanMakeWeakPtr<WebExtensionWindow> {
+class WebExtensionWindow : public RefCounted<WebExtensionWindow>, public CanMakeWeakPtr<WebExtensionWindow>, public Identified<WebExtensionWindowIdentifier> {
     WTF_MAKE_NONCOPYABLE(WebExtensionWindow);
     WTF_MAKE_FAST_ALLOCATED;
 
@@ -90,7 +91,6 @@ public:
 
     using TabVector = Vector<Ref<WebExtensionTab>>;
 
-    WebExtensionWindowIdentifier identifier() const { return m_identifier; }
     WebExtensionWindowParameters parameters(PopulateTabs = PopulateTabs::No) const;
     WebExtensionWindowParameters minimalParameters() const;
 
@@ -139,7 +139,6 @@ public:
 #endif
 
 private:
-    WebExtensionWindowIdentifier m_identifier;
     WeakPtr<WebExtensionContext> m_extensionContext;
     WeakObjCPtr<_WKWebExtensionWindow> m_delegate;
     bool m_isOpen : 1 { false };

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.cpp
@@ -32,8 +32,7 @@
 namespace WebKit {
 
 WebNotification::WebNotification(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection* sourceConnection)
-    : m_identifier(WebNotificationIdentifier::generate())
-    , m_data(data)
+    : m_data(data)
     , m_origin(API::SecurityOrigin::createFromString(data.originString))
     , m_pageIdentifier(pageIdentifier)
     , m_dataStoreIdentifier(dataStoreIdentifier)

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.h
@@ -31,6 +31,7 @@
 #include "WebNotificationIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/NotificationData.h>
+#include <wtf/Identified.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>
@@ -42,7 +43,7 @@ struct NotificationData;
 
 namespace WebKit {
 
-class WebNotification : public API::ObjectImpl<API::Object::Type::Notification> {
+class WebNotification : public API::ObjectImpl<API::Object::Type::Notification>, public Identified<WebNotificationIdentifier> {
 public:
     static Ref<WebNotification> createNonPersistent(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, IPC::Connection& sourceConnection)
     {
@@ -72,15 +73,12 @@ public:
     const API::SecurityOrigin* origin() const { return m_origin.get(); }
     API::SecurityOrigin* origin() { return m_origin.get(); }
 
-    WebNotificationIdentifier identifier() const { return m_identifier; }
-
     WebPageProxyIdentifier pageIdentifier() const { return m_pageIdentifier; }
     RefPtr<IPC::Connection> sourceConnection() const { return m_sourceConnection.get(); }
 
 private:
     WebNotification(const WebCore::NotificationData&, WebPageProxyIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection*);
 
-    WebNotificationIdentifier m_identifier;
     WebCore::NotificationData m_data;
     RefPtr<API::SecurityOrigin> m_origin;
     WebPageProxyIdentifier m_pageIdentifier;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -526,7 +526,7 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(ProcessState& state, IPC
     // Waiting for CA to commit is insufficient, because the render server can still be
     // using our backing store. We can improve this by waiting for the render server to commit
     // if we find API to do so, but for now we will make extra buffers if need be.
-    connection.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
+    connection.send(Messages::DrawingArea::DisplayDidRefresh(), identifier());
 
 #if ASSERT_ENABLED
     state.lastVisibleTransactionID = state.transactionIDForPendingCACommit;
@@ -579,7 +579,7 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
 
     WeakPtr weakThis { *this };
     auto startTime = MonotonicTime::now();
-    while (connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(m_identifier, activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError) {
+    while (connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError) {
         if (!weakThis || activityStateChangeID <= state.activityStateChangeID)
             return;
 

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h
@@ -48,7 +48,7 @@ class WebPageProxy;
 class WebFrameProxy;
 struct FrameInfoData;
 
-class WebScriptMessageHandler : public RefCounted<WebScriptMessageHandler>, public Identified<WebScriptMessageHandler>  {
+class WebScriptMessageHandler : public RefCounted<WebScriptMessageHandler>, public LegacyIdentified<WebScriptMessageHandler>  {
 public:
     class Client {
     public:

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -65,11 +65,10 @@ WebUserContentControllerProxy* WebUserContentControllerProxy::get(UserContentCon
 }
     
 WebUserContentControllerProxy::WebUserContentControllerProxy()
-    : m_identifier(UserContentControllerIdentifier::generate())
-    , m_userScripts(API::Array::create())
+    : m_userScripts(API::Array::create())
     , m_userStyleSheets(API::Array::create())
 {
-    webUserContentControllerProxies().add(m_identifier, *this);
+    webUserContentControllerProxies().add(identifier(), *this);
 }
 
 WebUserContentControllerProxy::~WebUserContentControllerProxy()
@@ -80,7 +79,7 @@ WebUserContentControllerProxy::~WebUserContentControllerProxy()
         world->userContentControllerProxyDestroyed(*this);
     }
     
-    webUserContentControllerProxies().remove(m_identifier);
+    webUserContentControllerProxies().remove(identifier());
     for (auto& process : m_processes) {
         process.removeMessageReceiver(Messages::WebUserContentControllerProxy::messageReceiverName(), identifier());
         process.didDestroyWebUserContentControllerProxy(*this);

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -36,6 +36,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
+#include <wtf/Identified.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/URL.h>
@@ -66,7 +67,7 @@ struct WebPageCreationParameters;
 struct UserContentControllerParameters;
 enum class InjectUserScriptImmediately : bool;
 
-class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, public IPC::MessageReceiver {
+class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, public IPC::MessageReceiver, public Identified<UserContentControllerIdentifier> {
 public:
     static Ref<WebUserContentControllerProxy> create()
     { 
@@ -111,8 +112,6 @@ public:
     Vector<std::pair<WebCompiledContentRuleListData, URL>> contentRuleListData() const;
 #endif
 
-    UserContentControllerIdentifier identifier() const { return m_identifier; }
-
     void contentWorldDestroyed(API::ContentWorld&);
 
     bool operator==(const WebUserContentControllerProxy& other) const { return (this == &other); }
@@ -125,7 +124,6 @@ private:
 
     void addContentWorld(API::ContentWorld&);
 
-    UserContentControllerIdentifier m_identifier;
     WeakHashSet<WebProcessProxy> m_processes;
     Ref<API::Array> m_userScripts;
     Ref<API::Array> m_userStyleSheets;

--- a/Source/WebKit/UIProcess/VisitedLinkStore.cpp
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.cpp
@@ -47,8 +47,7 @@ VisitedLinkStore::~VisitedLinkStore()
 }
 
 VisitedLinkStore::VisitedLinkStore()
-    : m_identifier(VisitedLinkTableIdentifier::generate())
-    , m_linkHashStore(*this)
+    : m_linkHashStore(*this)
 {
 }
 

--- a/Source/WebKit/UIProcess/VisitedLinkStore.h
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.h
@@ -31,6 +31,7 @@
 #include "VisitedLinkTableIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
+#include <wtf/Identified.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakHashSet.h>
 
@@ -38,14 +39,12 @@ namespace WebKit {
 
 class WebProcessProxy;
     
-class VisitedLinkStore final : public API::ObjectImpl<API::Object::Type::VisitedLinkStore>, public IPC::MessageReceiver, private SharedStringHashStore::Client {
+class VisitedLinkStore final : public API::ObjectImpl<API::Object::Type::VisitedLinkStore>, public IPC::MessageReceiver, public Identified<VisitedLinkTableIdentifier>, private SharedStringHashStore::Client {
 public:
     static Ref<VisitedLinkStore> create();
     VisitedLinkStore();
 
     virtual ~VisitedLinkStore();
-
-    VisitedLinkTableIdentifier identifier() const { return m_identifier; }
 
     void addProcess(WebProcessProxy&);
     void removeProcess(WebProcessProxy&);
@@ -67,7 +66,6 @@ private:
 
     void sendStoreHandleToProcess(WebProcessProxy&);
 
-    VisitedLinkTableIdentifier m_identifier;
     WeakHashSet<WebProcessProxy> m_processes;
     SharedStringHashStore m_linkHashStore;
 };

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.cpp
@@ -33,10 +33,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-WebURLSchemeHandler::WebURLSchemeHandler()
-    : m_identifier(WebURLSchemeHandlerIdentifier::generate())
-{
-}
+WebURLSchemeHandler::WebURLSchemeHandler() = default;
 
 WebURLSchemeHandler::~WebURLSchemeHandler()
 {

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.h
@@ -30,6 +30,7 @@
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/Identified.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
@@ -45,12 +46,10 @@ class WebProcessProxy;
 
 using SyncLoadCompletionHandler = CompletionHandler<void(const WebCore::ResourceResponse&, const WebCore::ResourceError&, Vector<uint8_t>&&)>;
 
-class WebURLSchemeHandler : public RefCounted<WebURLSchemeHandler> {
+class WebURLSchemeHandler : public RefCounted<WebURLSchemeHandler>, public Identified<WebURLSchemeHandlerIdentifier> {
     WTF_MAKE_NONCOPYABLE(WebURLSchemeHandler);
 public:
     virtual ~WebURLSchemeHandler();
-
-    WebURLSchemeHandlerIdentifier identifier() const { return m_identifier; }
 
     void startTask(WebPageProxy&, WebProcessProxy&, WebCore::PageIdentifier, URLSchemeTaskParameters&&, SyncLoadCompletionHandler&&);
     void stopTask(WebPageProxy&, WebCore::ResourceLoaderIdentifier taskIdentifier);
@@ -69,8 +68,6 @@ private:
 
     void removeTaskFromPageMap(WebPageProxyIdentifier, WebCore::ResourceLoaderIdentifier);
     WebProcessProxy* processForTaskIdentifier(WebPageProxy&, WebCore::ResourceLoaderIdentifier) const;
-
-    WebURLSchemeHandlerIdentifier m_identifier;
 
     HashMap<std::pair<WebCore::ResourceLoaderIdentifier, WebPageProxyIdentifier>, Ref<WebURLSchemeTask>> m_tasks;
     HashMap<WebPageProxyIdentifier, HashSet<WebCore::ResourceLoaderIdentifier>> m_tasksByPageIdentifier;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -32,6 +32,7 @@
 #include "RemoteImageBufferSetIdentifier.h"
 #include "RenderingUpdateID.h"
 #include "WorkQueueMessageReceiver.h"
+#include <wtf/Identified.h>
 #include <wtf/Lock.h>
 
 #if ENABLE(GPU_PROCESS)
@@ -75,12 +76,10 @@ public:
 // Usage is done through RemoteRenderingBackendProxy::prepareImageBufferSetsForDisplay,
 // so that a Vector of RemoteImageBufferSets can be used with a single
 // IPC call.
-class RemoteImageBufferSetProxy : public IPC::WorkQueueMessageReceiver {
+class RemoteImageBufferSetProxy : public IPC::WorkQueueMessageReceiver, public Identified<RemoteImageBufferSetIdentifier> {
 public:
     RemoteImageBufferSetProxy(RemoteRenderingBackendProxy&);
     ~RemoteImageBufferSetProxy();
-
-    RemoteImageBufferSetIdentifier identifier() const { return m_identifier; }
 
     OptionSet<BufferInSetType> requestedVolatility() { return m_requestedVolatility; }
     OptionSet<BufferInSetType> confirmedVolatility() { return m_confirmedVolatility; }
@@ -120,7 +119,6 @@ private:
     void createFlushFence() WTF_REQUIRES_LOCK(m_lock);
 
     WeakPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
-    RemoteImageBufferSetIdentifier m_identifier;
 
     WebCore::RenderingResourceIdentifier m_displayListIdentifier;
     std::unique_ptr<RemoteDisplayListRecorderProxy> m_displayListRecorder;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
@@ -44,20 +44,19 @@ Ref<RemoteAudioHardwareListener> RemoteAudioHardwareListener::create(AudioHardwa
 
 RemoteAudioHardwareListener::RemoteAudioHardwareListener(AudioHardwareListener::Client& client)
     : AudioHardwareListener(client)
-    , m_identifier(RemoteAudioHardwareListenerIdentifier::generate())
     , m_gpuProcessConnection(WebProcess::singleton().ensureGPUProcessConnection())
 {
     auto gpuProcessConnection = m_gpuProcessConnection.get();
     gpuProcessConnection->addClient(*this);
-    gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteAudioHardwareListener::messageReceiverName(), m_identifier.toUInt64(), *this);
-    gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateAudioHardwareListener(m_identifier), { });
+    gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteAudioHardwareListener::messageReceiverName(), identifier().toUInt64(), *this);
+    gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateAudioHardwareListener(identifier()), { });
 }
 
 RemoteAudioHardwareListener::~RemoteAudioHardwareListener()
 {
     if (auto gpuProcessConnection = m_gpuProcessConnection.get()) {
         gpuProcessConnection->messageReceiverMap().removeMessageReceiver(*this);
-        gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::ReleaseAudioHardwareListener(m_identifier), 0);
+        gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::ReleaseAudioHardwareListener(identifier()), 0);
     }
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "RemoteAudioHardwareListenerIdentifier.h"
 #include <WebCore/AudioHardwareListener.h>
+#include <wtf/Identified.h>
 
 namespace IPC {
 class Connection;
@@ -43,6 +44,7 @@ class WebProcess;
 
 class RemoteAudioHardwareListener final
     : public WebCore::AudioHardwareListener
+    , private Identified<RemoteAudioHardwareListenerIdentifier>
     , private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener> {
@@ -69,7 +71,6 @@ private:
     void audioHardwareDidBecomeInactive();
     void audioOutputDeviceChanged(size_t bufferSizeMinimum, size_t bufferSizeMaximum);
 
-    RemoteAudioHardwareListenerIdentifier m_identifier;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
@@ -45,7 +45,6 @@ Ref<RemoteRemoteCommandListener> RemoteRemoteCommandListener::create(RemoteComma
 
 RemoteRemoteCommandListener::RemoteRemoteCommandListener(RemoteCommandListenerClient& client)
     : RemoteCommandListener(client)
-    , m_identifier(RemoteRemoteCommandListenerIdentifier::generate())
 {
     ensureGPUProcessConnection();
 }
@@ -54,7 +53,7 @@ RemoteRemoteCommandListener::~RemoteRemoteCommandListener()
 {
     if (auto gpuProcessConnection = m_gpuProcessConnection.get()) {
         gpuProcessConnection->messageReceiverMap().removeMessageReceiver(*this);
-        gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::ReleaseRemoteCommandListener(m_identifier), 0);
+        gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::ReleaseRemoteCommandListener(identifier()), 0);
     }
 }
 
@@ -65,8 +64,8 @@ GPUProcessConnection& RemoteRemoteCommandListener::ensureGPUProcessConnection()
         gpuProcessConnection = &WebProcess::singleton().ensureGPUProcessConnection();
         m_gpuProcessConnection = gpuProcessConnection;
         gpuProcessConnection->addClient(*this);
-        gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteRemoteCommandListener::messageReceiverName(), m_identifier.toUInt64(), *this);
-        gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateRemoteCommandListener(m_identifier), { });
+        gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteRemoteCommandListener::messageReceiverName(), identifier().toUInt64(), *this);
+        gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateRemoteCommandListener(identifier()), { });
     }
     return *gpuProcessConnection;
 }
@@ -94,7 +93,7 @@ void RemoteRemoteCommandListener::updateSupportedCommands()
     m_currentCommands = supportedCommands;
     m_currentSupportSeeking = supportsSeeking();
 
-    ensureGPUProcessConnection().connection().send(Messages::RemoteRemoteCommandListenerProxy::UpdateSupportedCommands { copyToVector(supportedCommands), m_currentSupportSeeking }, m_identifier);
+    ensureGPUProcessConnection().connection().send(Messages::RemoteRemoteCommandListenerProxy::UpdateSupportedCommands { copyToVector(supportedCommands), m_currentSupportSeeking }, identifier());
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "RemoteRemoteCommandListenerIdentifier.h"
 #include <WebCore/RemoteCommandListener.h>
+#include <wtf/Identified.h>
 
 namespace IPC {
 class Connection;
@@ -43,6 +44,7 @@ class WebProcess;
 
 class RemoteRemoteCommandListener final
     : public WebCore::RemoteCommandListener
+    , private Identified<RemoteRemoteCommandListenerIdentifier>
     , private GPUProcessConnection::Client
     , private IPC::MessageReceiver
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener> {
@@ -71,7 +73,6 @@ private:
 
     GPUProcessConnection& ensureGPUProcessConnection();
 
-    RemoteRemoteCommandListenerIdentifier m_identifier;
     WebCore::RemoteCommandListener::RemoteCommandsSet m_currentCommands;
     bool m_currentSupportSeeking { false };
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -32,6 +32,7 @@
 #include "SharedVideoFrame.h"
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/MediaRecorderPrivate.h>
+#include <wtf/Identified.h>
 #include <wtf/MediaTime.h>
 #include <wtf/WeakPtr.h>
 
@@ -50,7 +51,8 @@ class MediaRecorderPrivateGPUProcessDidCloseObserver;
 
 class MediaRecorderPrivate final
     : public WebCore::MediaRecorderPrivate
-    , public CanMakeWeakPtr<MediaRecorderPrivate> {
+    , public CanMakeWeakPtr<MediaRecorderPrivate>
+    , private Identified<MediaRecorderIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     MediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);
@@ -70,7 +72,6 @@ private:
     friend class MediaRecorderPrivateGPUProcessDidCloseObserver;
     void gpuProcessConnectionDidClose();
 
-    MediaRecorderIdentifier m_identifier;
     Ref<WebCore::MediaStreamPrivate> m_stream;
     Ref<IPC::Connection> m_connection;
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -32,6 +32,7 @@
 #include "SampleBufferDisplayLayerIdentifier.h"
 #include "SharedVideoFrame.h"
 #include <WebCore/SampleBufferDisplayLayer.h>
+#include <wtf/Identified.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -42,12 +43,10 @@ namespace WebKit {
 
 class SampleBufferDisplayLayerManager;
 
-class SampleBufferDisplayLayer final : public WebCore::SampleBufferDisplayLayer, public IPC::MessageReceiver, public GPUProcessConnection::Client {
+class SampleBufferDisplayLayer final : public WebCore::SampleBufferDisplayLayer, public IPC::MessageReceiver, public GPUProcessConnection::Client, public Identified<SampleBufferDisplayLayerIdentifier> {
 public:
     static Ref<SampleBufferDisplayLayer> create(SampleBufferDisplayLayerManager&, WebCore::SampleBufferDisplayLayer::Client&);
     ~SampleBufferDisplayLayer();
-
-    SampleBufferDisplayLayerIdentifier identifier() const { return m_identifier; }
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
@@ -86,7 +85,6 @@ private:
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     WeakPtr<SampleBufferDisplayLayerManager> m_manager;
     Ref<IPC::Connection> m_connection;
-    SampleBufferDisplayLayerIdentifier m_identifier;
 
     PlatformLayerContainer m_videoLayer;
     bool m_didFail { false };

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -97,7 +97,7 @@ IPC::Connection* WebSocketChannel::messageSenderConnection() const
 
 uint64_t WebSocketChannel::messageSenderDestinationID() const
 {
-    return m_identifier.toUInt64();
+    return identifier().toUInt64();
 }
 
 String WebSocketChannel::subprotocol()
@@ -160,7 +160,7 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& url, const 
 
     m_inspector.didCreateWebSocket(url);
     m_url = request->url();
-    MessageSender::send(Messages::NetworkConnectionToWebProcess::CreateSocketChannel { *request, protocol, m_identifier, m_webPageProxyID, frameID, pageID, m_document->clientOrigin(), WebProcess::singleton().hadMainFrameMainResourcePrivateRelayed(), allowPrivacyProxy, advancedPrivacyProtections, shouldRelaxThirdPartyCookieBlocking, storedCredentialsPolicy });
+    MessageSender::send(Messages::NetworkConnectionToWebProcess::CreateSocketChannel { *request, protocol, identifier(), m_webPageProxyID, frameID, pageID, m_document->clientOrigin(), WebProcess::singleton().hadMainFrameMainResourcePrivateRelayed(), allowPrivacyProxy, advancedPrivacyProtections, shouldRelaxThirdPartyCookieBlocking, storedCredentialsPolicy });
     return ConnectStatus::OK;
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
@@ -47,8 +47,8 @@ void LibWebRTCResolver::sendOnMainThread(Function<void(IPC::Connection&)>&& call
 
 LibWebRTCResolver::~LibWebRTCResolver()
 {
-    WebProcess::singleton().libWebRTCNetwork().socketFactory().removeResolver(m_identifier);
-    sendOnMainThread([identifier = m_identifier](IPC::Connection& connection) {
+    WebProcess::singleton().libWebRTCNetwork().socketFactory().removeResolver(identifier());
+    sendOnMainThread([identifier = this->identifier()](IPC::Connection& connection) {
         connection.send(Messages::NetworkRTCProvider::StopResolver(identifier), 0);
     });
 }
@@ -70,7 +70,7 @@ void LibWebRTCResolver::start(const rtc::SocketAddress& address, Function<void()
         return;
     }
 
-    sendOnMainThread([identifier = m_identifier, name = WTFMove(name).isolatedCopy()](IPC::Connection& connection) {
+    sendOnMainThread([identifier = this->identifier(), name = WTFMove(name).isolatedCopy()](IPC::Connection& connection) {
         connection.send(Messages::NetworkRTCProvider::CreateResolver(identifier, name), 0);
     });
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
@@ -30,6 +30,7 @@
 #include "LibWebRTCDnsResolverFactory.h"
 #include "LibWebRTCResolverIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
+#include <wtf/Identified.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -40,13 +41,11 @@ class Connection;
 namespace WebKit {
 class LibWebRTCSocketFactory;
 
-class LibWebRTCResolver final : public LibWebRTCDnsResolverFactory::Resolver, private webrtc::AsyncDnsResolverResult, public CanMakeWeakPtr<LibWebRTCResolver> {
+class LibWebRTCResolver final : public LibWebRTCDnsResolverFactory::Resolver, private webrtc::AsyncDnsResolverResult, public CanMakeWeakPtr<LibWebRTCResolver>, public Identified<LibWebRTCResolverIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    LibWebRTCResolver() : m_identifier(LibWebRTCResolverIdentifier::generate()) { }
+    LibWebRTCResolver() = default;
     ~LibWebRTCResolver();
-
-    LibWebRTCResolverIdentifier identifier() const { return m_identifier; }
 
     void start(const rtc::SocketAddress&, Function<void()>&&) final;
 
@@ -65,7 +64,6 @@ private:
 
     static void sendOnMainThread(Function<void(IPC::Connection&)>&&);
 
-    LibWebRTCResolverIdentifier m_identifier;
     Vector<rtc::IPAddress> m_addresses;
     rtc::SocketAddress m_addressToResolve;
     Function<void()> m_callback;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -43,7 +43,6 @@ namespace WebKit {
 
 LibWebRTCSocket::LibWebRTCSocket(LibWebRTCSocketFactory& factory, WebCore::ScriptExecutionContextIdentifier contextIdentifier, Type type, const rtc::SocketAddress& localAddress, const rtc::SocketAddress& remoteAddress)
     : m_factory(factory)
-    , m_identifier(WebCore::LibWebRTCSocketIdentifier::generate())
     , m_type(type)
     , m_localAddress(localAddress)
     , m_remoteAddress(remoteAddress)
@@ -116,7 +115,7 @@ int LibWebRTCSocket::SendTo(const void *value, size_t size, const rtc::SocketAdd
         return size;
 
     std::span data(static_cast<const uint8_t*>(value), size);
-    connection->send(Messages::NetworkRTCProvider::SendToSocket { m_identifier, data, RTCNetwork::SocketAddress { address }, RTCPacketOptions { options } }, 0);
+    connection->send(Messages::NetworkRTCProvider::SendToSocket { identifier(), data, RTCNetwork::SocketAddress { address }, RTCPacketOptions { options } }, 0);
 
     return size;
 }
@@ -129,7 +128,7 @@ int LibWebRTCSocket::Close()
 
     m_state = STATE_CLOSED;
 
-    connection->send(Messages::NetworkRTCProvider::CloseSocket { m_identifier }, 0);
+    connection->send(Messages::NetworkRTCProvider::CloseSocket { identifier() }, 0);
 
     return 0;
 }
@@ -151,7 +150,7 @@ int LibWebRTCSocket::SetOption(rtc::Socket::Option option, int value)
     m_options[option] = value;
 
     if (auto* connection = m_factory.connection())
-        connection->send(Messages::NetworkRTCProvider::SetSocketOption { m_identifier, option, value }, 0);
+        connection->send(Messages::NetworkRTCProvider::SetSocketOption { identifier(), option, value }, 0);
 
     return 0;
 }
@@ -170,7 +169,7 @@ void LibWebRTCSocket::suspend()
 
     signalClose(-1);
     if (auto* connection = m_factory.connection())
-        connection->send(Messages::NetworkRTCProvider::CloseSocket { m_identifier }, 0);
+        connection->send(Messages::NetworkRTCProvider::CloseSocket { identifier() }, 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -30,6 +30,7 @@
 #include <WebCore/LibWebRTCProvider.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
 #include <wtf/Forward.h>
+#include <wtf/Identified.h>
 #include <wtf/WeakPtr.h>
 
 ALLOW_COMMA_BEGIN
@@ -47,7 +48,7 @@ namespace WebKit {
 
 class LibWebRTCSocketFactory;
 
-class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeWeakPtr<LibWebRTCSocket> {
+class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeWeakPtr<LibWebRTCSocket>, public Identified<WebCore::LibWebRTCSocketIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type { UDP, ClientTCP, ServerConnectionTCP };
@@ -56,7 +57,6 @@ public:
     ~LibWebRTCSocket();
 
     WebCore::ScriptExecutionContextIdentifier contextIdentifier() const { return m_contextIdentifier; }
-    WebCore::LibWebRTCSocketIdentifier identifier() const { return m_identifier; }
     const rtc::SocketAddress& localAddress() const { return m_localAddress; }
     const rtc::SocketAddress& remoteAddress() const { return m_remoteAddress; }
 
@@ -90,7 +90,6 @@ private:
     int SetOption(rtc::Socket::Option, int) final;
 
     LibWebRTCSocketFactory& m_factory;
-    WebCore::LibWebRTCSocketIdentifier m_identifier;
     Type m_type;
     rtc::SocketAddress m_localAddress;
     rtc::SocketAddress m_remoteAddress;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -49,7 +49,7 @@ using namespace WebCore;
 // We'll assume any size over 4GB is PDFKit noticing non-linearized data.
 static const uint32_t nonLinearizedPDFSentinel = std::numeric_limits<uint32_t>::max();
 
-class ByteRangeRequest : public Identified<ByteRangeRequest> {
+class ByteRangeRequest : public LegacyIdentified<ByteRangeRequest> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     ByteRangeRequest() = default;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1114,7 +1114,7 @@ bool PDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
     }
     PDFContextMenu contextMenu { point, WTFMove(items), WTFMove(openInPreviewTag) };
 
-    webPage->sendWithAsyncReply(Messages::WebPageProxy::ShowPDFContextMenu { contextMenu, m_identifier }, [itemCount, nsMenu = WTFMove(nsMenu), weakThis = WeakPtr { *this }](std::optional<int32_t>&& selectedIndex) {
+    webPage->sendWithAsyncReply(Messages::WebPageProxy::ShowPDFContextMenu { contextMenu, identifier() }, [itemCount, nsMenu = WTFMove(nsMenu), weakThis = WeakPtr { *this }](std::optional<int32_t>&& selectedIndex) {
         if (RefPtr protectedThis = weakThis.get()) {
             if (selectedIndex && selectedIndex.value() >= 0 && selectedIndex.value() < itemCount)
                 [nsMenu performActionForItemAtIndex:*selectedIndex];

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -39,6 +39,7 @@
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ScrollableArea.h>
 #include <WebCore/TextIndicator.h>
+#include <wtf/Identified.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeTraits.h>
@@ -77,7 +78,7 @@ class WebWheelEvent;
 struct LookupTextResult;
 struct WebHitTestResultData;
 
-class PDFPluginBase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFPluginBase>, public WebCore::ScrollableArea, public PDFScriptEvaluator::Client {
+class PDFPluginBase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFPluginBase>, public WebCore::ScrollableArea, public PDFScriptEvaluator::Client, public Identified<PDFPluginIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(PDFPluginBase);
     friend class PDFIncrementalLoader;
@@ -95,8 +96,6 @@ public:
 
     virtual bool isUnifiedPDFPlugin() const { return false; }
     virtual bool isLegacyPDFPlugin() const { return false; }
-
-    PDFPluginIdentifier identifier() const { return m_identifier; }
 
     virtual WebCore::PluginLayerHostingStrategy layerHostingStrategy() const = 0;
     virtual PlatformLayer* platformLayer() const { return nullptr; }
@@ -333,8 +332,6 @@ protected:
     SingleThreadWeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;
     WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> m_element;
-
-    PDFPluginIdentifier m_identifier;
 
     // m_data grows as we receive data in the primary request (PDFPluginBase::streamDidReceiveData())
     // but also as byte range requests are received via m_incrementalLoader, so it may have "holes"

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -101,7 +101,6 @@ PluginInfo PDFPluginBase::pluginInfo()
 PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
     : m_frame(*WebFrame::fromCoreFrame(*element.document().frame()))
     , m_element(element)
-    , m_identifier(PDFPluginIdentifier::generate())
 #if HAVE(INCREMENTAL_PDF_APIS)
     , m_incrementalPDFLoadingEnabled(element.document().settings().incrementalPDFLoadingEnabled())
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1884,7 +1884,7 @@ bool UnifiedPDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
     if (!contextMenu)
         return false;
 
-    webPage->sendWithAsyncReply(Messages::WebPageProxy::ShowPDFContextMenu { *contextMenu, m_identifier }, [eventPosition = event.position(), this, weakThis = WeakPtr { *this }](std::optional<int32_t>&& selectedItemTag) {
+    webPage->sendWithAsyncReply(Messages::WebPageProxy::ShowPDFContextMenu { *contextMenu, identifier() }, [eventPosition = event.position(), this, weakThis = WeakPtr { *this }](std::optional<int32_t>&& selectedItemTag) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.cpp
@@ -43,8 +43,7 @@ Ref<StorageAreaImpl> StorageAreaImpl::create(StorageAreaMap& storageAreaMap)
 }
 
 StorageAreaImpl::StorageAreaImpl(StorageAreaMap& storageAreaMap)
-    : m_identifier(Identifier::generate())
-    , m_storageAreaMap(storageAreaMap)
+    : m_storageAreaMap(storageAreaMap)
 {
     storageAreaMap.incrementUseCount();
 }

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.h
@@ -29,6 +29,7 @@
 #include "StorageAreaImplIdentifier.h"
 #include <WebCore/StorageArea.h>
 #include <wtf/HashMap.h>
+#include <wtf/Identified.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -39,14 +40,12 @@ namespace WebKit {
 
 class StorageAreaMap;
 
-class StorageAreaImpl final : public WebCore::StorageArea {
+class StorageAreaImpl final : public WebCore::StorageArea, public Identified<StorageAreaImplIdentifier> {
 public:
     using Identifier = StorageAreaImplIdentifier;
 
     static Ref<StorageAreaImpl> create(StorageAreaMap&);
     virtual ~StorageAreaImpl();
-
-    Identifier identifier() const { return m_identifier; }
 
 private:
     StorageAreaImpl(StorageAreaMap&);
@@ -63,7 +62,6 @@ private:
     size_t memoryBytesUsedByCache() override;
     void prewarm() final;
 
-    Identifier m_identifier;
     WeakPtr<StorageAreaMap> m_storageAreaMap;
 };
 

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
@@ -51,8 +51,7 @@ namespace WebKit {
 using namespace WebCore;
 
 StorageAreaMap::StorageAreaMap(StorageNamespaceImpl& storageNamespace, Ref<const WebCore::SecurityOrigin>&& securityOrigin)
-    : m_identifier(StorageAreaMapIdentifier::generate())
-    , m_namespace(storageNamespace)
+    : m_namespace(storageNamespace)
     , m_securityOrigin(WTFMove(securityOrigin))
     , m_quotaInBytes(storageNamespace.quotaInBytes())
     , m_type(storageNamespace.storageType())
@@ -291,7 +290,7 @@ void StorageAreaMap::sendConnectMessage(SendMode mode)
     auto type = computeStorageType();
 
     if (mode == SendMode::Sync) {
-        auto sendResult = ipcConnection->sendSync(Messages::NetworkStorageManager::ConnectToStorageAreaSync(type, m_identifier, namespaceIdentifier, origin), 0);
+        auto sendResult = ipcConnection->sendSync(Messages::NetworkStorageManager::ConnectToStorageAreaSync(type, identifier(), namespaceIdentifier, origin), 0);
         auto [remoteAreaIdentifier, items, messageIdentifier] = sendResult.takeReplyOr(StorageAreaIdentifier { }, HashMap<String, String> { }, 0);
         didConnect(remoteAreaIdentifier, WTFMove(items), messageIdentifier);
         return;
@@ -302,7 +301,7 @@ void StorageAreaMap::sendConnectMessage(SendMode mode)
             return didConnect(remoteAreaIdentifier, WTFMove(items), messageIdentifier);
     };
 
-    ipcConnection->sendWithAsyncReply(Messages::NetworkStorageManager::ConnectToStorageArea(type, m_identifier, namespaceIdentifier, origin), WTFMove(completionHandler));
+    ipcConnection->sendWithAsyncReply(Messages::NetworkStorageManager::ConnectToStorageArea(type, identifier(), namespaceIdentifier, origin), WTFMove(completionHandler));
 }
 
 void StorageAreaMap::connectSync()

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -33,6 +33,7 @@
 #include <WebCore/StorageArea.h>
 #include <wtf/Forward.h>
 #include <wtf/HashCountedSet.h>
+#include <wtf/Identified.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
@@ -48,7 +49,7 @@ namespace WebKit {
 class StorageAreaImpl;
 class StorageNamespaceImpl;
 
-class StorageAreaMap final : public IPC::MessageReceiver {
+class StorageAreaMap final : public IPC::MessageReceiver, public Identified<StorageAreaMapIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     StorageAreaMap(StorageNamespaceImpl&, Ref<const WebCore::SecurityOrigin>&&);
@@ -68,7 +69,6 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     const WebCore::SecurityOrigin& securityOrigin() const { return m_securityOrigin.get(); }
-    StorageAreaMapIdentifier identifier() const { return m_identifier; }
 
     void connect();
     void disconnect();
@@ -99,7 +99,6 @@ private:
     void connectSync();
     void didConnect(StorageAreaIdentifier, HashMap<String, String>&&, uint64_t messageIdentifier);
 
-    StorageAreaMapIdentifier m_identifier;
     uint64_t m_lastHandledMessageIdentifier { 0 };
     StorageNamespaceImpl& m_namespace;
     Ref<const WebCore::SecurityOrigin> m_securityOrigin;

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -61,7 +61,7 @@ using WebKit::WebPushD::WebPushDaemonConnectionConfiguration;
 
 namespace WebPushD {
 
-class PushClientConnection : public RefCounted<PushClientConnection>, public Identified<PushClientConnection>, public IPC::MessageReceiver {
+class PushClientConnection : public RefCounted<PushClientConnection>, public LegacyIdentified<PushClientConnection>, public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<PushClientConnection> create(xpc_connection_t);


### PR DESCRIPTION
#### 1b1dcd66b5d65444ff9e2c75ef940712ba2c31e1
<pre>
Make WTF::Identified work with strongly typed identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=270560">https://bugs.webkit.org/show_bug.cgi?id=270560</a>

Reviewed by Darin Adler.

Make WTF::Identified work with strongly typed identifiers instead of uint64_t.
Keep existing code that was using the legacy WTF::Identified working by having
it subclass WTF::LegacyIdentified instead. We should eventually port those to
the new WTF::Identified.

Also adopt WTF::Identified more broadly to reduce boilerplate code in the code
base.

* Source/WTF/wtf/Identified.h:
(WTF::IdentifiedBase::identifier const):
(WTF::Identified::Identified):
(WTF::LegacyIdentified::LegacyIdentified):
(WTF::LegacyThreadSafeIdentified::LegacyThreadSafeIdentified):
(WTF::UUIDIdentified::UUIDIdentified):
(WTF::Identified::generateIdentifier): Deleted.
(WTF::ThreadSafeIdentified::ThreadSafeIdentified): Deleted.
(WTF::ThreadSafeIdentified::generateIdentifier): Deleted.
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
(WebCore::MediaKeySystemRequest::MediaKeySystemRequest):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h:
(WebCore::MediaKeySystemRequest::setAllowCallback):
(WebCore::MediaKeySystemRequest::identifier const): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::UserMediaRequest):
* Source/WebCore/Modules/mediastream/UserMediaRequest.h:
(WebCore::UserMediaRequest::identifier const): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h:
(WebCore::SpeechRecognitionConnectionClient::SpeechRecognitionConnectionClient): Deleted.
(WebCore::SpeechRecognitionConnectionClient::identifier const): Deleted.
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::ThreadableWebSocketChannel): Deleted.
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h:
(WebCore::ThreadableWebSocketChannel::identifier const): Deleted.
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::MainThreadBridge::name const):
(WebCore::BroadcastChannel::MainThreadBridge::MainThreadBridge):
(WebCore::BroadcastChannel::MainThreadBridge::registerChannel):
(WebCore::BroadcastChannel::MainThreadBridge::unregisterChannel):
(WebCore::BroadcastChannel::MainThreadBridge::postMessage):
(WebCore::BroadcastChannel::MainThreadBridge::identifier const): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::identifier const): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::Record::Record):
(WebCore::BackgroundFetch::Record::information const):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h:
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::SWServerRegistration):
(WebCore::generateServiceWorkerRegistrationIdentifier): Deleted.
* Source/WebCore/workers/service/server/SWServerRegistration.h:
(WebCore::SWServerRegistration::key const):
(WebCore::SWServerRegistration::identifier const): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
(WebCore::SWServerToContextConnection::SWServerToContextConnection):
(WebCore::generateServerToContextConnectionIdentifier): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::SharedWorker):
(WebCore::SharedWorker::~SharedWorker):
(WebCore::SharedWorker::stop):
(WebCore::SharedWorker::suspend):
(WebCore::SharedWorker::resume):
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
(WebKit::WebSharedWorker::WebSharedWorker):
(WebKit::WebSharedWorker::~WebSharedWorker):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
(WebKit::WebSharedWorker::identifier const): Deleted.
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::CacheStorageCache):
(WebKit::CacheStorageCache::open):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
(WebKit::CacheStorageCache::identifier const): Deleted.
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::FileSystemStorageHandle):
(WebKit::FileSystemStorageHandle::createSyncAccessHandle):
(WebKit::FileSystemStorageHandle::closeSyncAccessHandle):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
(WebKit::FileSystemStorageHandle::identifier const): Deleted.
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.cpp:
(WebKit::StorageAreaBase::StorageAreaBase):
* Source/WebKit/NetworkProcess/storage/StorageAreaBase.h:
(WebKit::StorageAreaBase::identifier const): Deleted.
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::NetworkTransportSession):
(WebKit::NetworkTransportSession::messageSenderDestinationID const):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
(WebKit::NetworkTransportSession::identifier const): Deleted.
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h:
* Source/WebKit/UIProcess/API/APIUserScript.h:
* Source/WebKit/UIProcess/API/APIUserStyleSheet.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::DrawingAreaProxy):
(WebKit::DrawingAreaProxy::startReceivingMessages):
(WebKit::DrawingAreaProxy::stopReceivingMessages):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::type const):
(WebKit::DrawingAreaProxy::identifier const): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
(WebKit::WebExtensionController::unload):
(WebKit::WebExtensionController::addProcessPool):
(WebKit::WebExtensionController::removeProcessPool):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::operator== const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::WebExtensionWindow):
(WebKit::WebExtensionWindow::operator== const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::WebExtensionContext):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::identifier const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::WebExtensionController):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::configuration const):
(WebKit::WebExtensionController::identifier const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
(WebKit::WebExtensionTab::identifier const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
(WebKit::WebExtensionWindow::identifier const): Deleted.
* Source/WebKit/UIProcess/Notifications/WebNotification.cpp:
(WebKit::WebNotification::WebNotification):
* Source/WebKit/UIProcess/Notifications/WebNotification.h:
(WebKit::WebNotification::identifier const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
* Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::WebUserContentControllerProxy):
(WebKit::WebUserContentControllerProxy::~WebUserContentControllerProxy):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
(WebKit::WebUserContentControllerProxy::identifier const): Deleted.
* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::VisitedLinkStore):
* Source/WebKit/UIProcess/VisitedLinkStore.h:
* Source/WebKit/UIProcess/WebURLSchemeHandler.cpp:
(WebKit::WebURLSchemeHandler::WebURLSchemeHandler): Deleted.
* Source/WebKit/UIProcess/WebURLSchemeHandler.h:
(WebKit::WebURLSchemeHandler::identifier const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::send):
(WebKit::RemoteImageBufferSetProxy::sendSync):
(WebKit::RemoteImageBufferSetProxy::RemoteImageBufferSetProxy):
(WebKit::RemoteImageBufferSetProxy::didPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::close):
(WebKit::RemoteImageBufferSetProxy::flushFrontBufferAsync):
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::remoteBufferSetWasDestroyed):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
(WebKit::RemoteImageBufferSetProxy::identifier const): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp:
(WebKit::RemoteAudioHardwareListener::RemoteAudioHardwareListener):
(WebKit::RemoteAudioHardwareListener::~RemoteAudioHardwareListener):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp:
(WebKit::RemoteRemoteCommandListener::RemoteRemoteCommandListener):
(WebKit::RemoteRemoteCommandListener::~RemoteRemoteCommandListener):
(WebKit::RemoteRemoteCommandListener::ensureGPUProcessConnection):
(WebKit::RemoteRemoteCommandListener::updateSupportedCommands):
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::Proxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::~Proxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::createRemoteUnit):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::start):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::stop):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::setAudioOutputDevice):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::MediaRecorderPrivate):
(WebKit::MediaRecorderPrivate::startRecording):
(WebKit::MediaRecorderPrivate::~MediaRecorderPrivate):
(WebKit::MediaRecorderPrivate::videoFrameAvailable):
(WebKit::MediaRecorderPrivate::audioSamplesAvailable):
(WebKit::MediaRecorderPrivate::fetchData):
(WebKit::MediaRecorderPrivate::stopRecording):
(WebKit::MediaRecorderPrivate::pauseRecording):
(WebKit::MediaRecorderPrivate::resumeRecording):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp:
(WebKit::SampleBufferDisplayLayer::SampleBufferDisplayLayer):
(WebKit::SampleBufferDisplayLayer::initialize):
(WebKit::SampleBufferDisplayLayer::setLogIdentifier):
(WebKit::SampleBufferDisplayLayer::~SampleBufferDisplayLayer):
(WebKit::SampleBufferDisplayLayer::updateDisplayMode):
(WebKit::SampleBufferDisplayLayer::updateBoundsAndPosition):
(WebKit::SampleBufferDisplayLayer::flush):
(WebKit::SampleBufferDisplayLayer::flushAndRemoveImage):
(WebKit::SampleBufferDisplayLayer::play):
(WebKit::SampleBufferDisplayLayer::pause):
(WebKit::SampleBufferDisplayLayer::enqueueBlackFrameFrom):
(WebKit::SampleBufferDisplayLayer::enqueueVideoFrame):
(WebKit::SampleBufferDisplayLayer::clearVideoFrames):
(WebKit::SampleBufferDisplayLayer::setShouldMaintainAspectRatio):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h:
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::messageSenderDestinationID const):
(WebKit::WebSocketChannel::connect):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp:
(WebKit::LibWebRTCResolver::~LibWebRTCResolver):
(WebKit::LibWebRTCResolver::start):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::LibWebRTCSocket):
(WebKit::LibWebRTCSocket::SendTo):
(WebKit::LibWebRTCSocket::Close):
(WebKit::LibWebRTCSocket::SetOption):
(WebKit::LibWebRTCSocket::suspend):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::handleContextMenuEvent):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::identifier const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleContextMenuEvent):
* Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.cpp:
(WebKit::StorageAreaImpl::StorageAreaImpl):
* Source/WebKit/WebProcess/WebStorage/StorageAreaImpl.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
(WebKit::StorageAreaMap::StorageAreaMap):
(WebKit::StorageAreaMap::sendConnectMessage):
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/webpushd/PushClientConnection.h:

Canonical link: <a href="https://commits.webkit.org/275739@main">https://commits.webkit.org/275739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/297f2d5cb61ec287b136053aa534c93d109d27c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35310 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43236 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16266 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37779 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/719 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/36119 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46784 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42290 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42032 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19100 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40655 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19279 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49299 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5769 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18745 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9985 "Passed tests") | 
<!--EWS-Status-Bubble-End-->