### PR TITLE
AX: CSS content property replacement text ignored when it is the empty string

### DIFF
--- a/LayoutTests/accessibility/mac/alt-for-css-content-expected.txt
+++ b/LayoutTests/accessibility/mac/alt-for-css-content-expected.txt
@@ -39,6 +39,18 @@ AXDescription:
 AXTitle:
 AXValue: ALTERNATIVE CONTENT TEST6
 
+Test7 - alt on input element ::before
+AXRole: AXRadioButton
+AXDescription:
+AXTitle: test7 before alt
+AXValue: 0
+
+Test8 - alt on input element ::before that is the empty string
+AXRole: AXRadioButton
+AXDescription:
+AXTitle:
+AXValue: 0
+
 alt accessed through Javascript: "ALTERNATIVE CONTENT TEST2"
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/alt-for-css-content.html
+++ b/LayoutTests/accessibility/mac/alt-for-css-content.html
@@ -37,6 +37,20 @@
 [aria-expanded="test6"]::before {
     content: "\25BC" / attr(test6);
 }
+
+#test7 {
+    appearance:none;
+}
+#test7::before {
+    content: "test7 before" / "test7 before alt";
+}
+
+#test8 {
+    appearance:none;
+}
+#test8::before {
+    content: "test8 before" / "";
+}
 </style>
 
 <div id="content">
@@ -46,6 +60,8 @@
 <div id="test4" aria-expanded="test4">test4</div>
 <div id="test5" test5="ALTERNATIVE CONTENT TEST5" aria-expanded="test5">test5</div>
 <div id="test6" test6="ALTERNATIVE CONTENT TEST6" aria-expanded="test6">test6</div>
+<input id=test7 type=radio>
+<input id=test8 type=radio>
 </div>
 
 <p id="description"></p>
@@ -89,6 +105,12 @@
 
         debug("Test6 - alt on text content that uses the attr() function.");
         outputElement(accessibilityController.accessibleElementById("test6").childAtIndex(0));
+
+        debug("Test7 - alt on input element ::before");
+        outputElement(accessibilityController.accessibleElementById("test7"));
+
+        debug("Test8 - alt on input element ::before that is the empty string");
+        outputElement(accessibilityController.accessibleElementById("test8"));
 
         debug("alt accessed through Javascript: " + getComputedStyle(document.getElementById("test2"), ':after').content.split(" / ")[1]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt
@@ -81,6 +81,12 @@ label
 
 label
 
+Empty alternative text for CSS content in pseudo-elements when applied to primitive appearance form controls
+
+
+
+
+
 simple w/ for each child
 
 one two three
@@ -191,6 +197,8 @@ PASS link name from fallback content with ::before and ::after
 PASS button name from fallback content mixing attr() and strings with ::before and ::after
 PASS heading name from fallback content mixing attr() and strings with ::before and ::after
 PASS link name from fallback content mixing attr() and strings with ::before and ::after
+PASS primitive radio input with ::before containing empty alternative text
+PASS primitive radio input with ::before containing empty alternative text for an image
 PASS button name from content for each child
 PASS heading name from content for each child
 PASS link name from content for each child

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html
@@ -49,6 +49,12 @@
       content: " after "; /* [sic] leading and trailing space */
       content: " after " / " alt-after "; /* Override the previous line for engines that support the Alternative Text syntax. */
     }
+    .fallback-before-empty::before {
+      content: "before"  / "";
+    }
+    .fallback-before-image-empty::before {
+      content: "before " url(/images/blue.png) / "";
+    }
     .fallback-before-mixed::before {
       content: " before "; /* [sic] leading and trailing space */
       content: " before " / " start " attr(data-alt-text-before) " end "; /* Override the previous line for engines that support the Alternative Text syntax. */
@@ -144,6 +150,10 @@
 <h3 data-alt-text-before="alt-before" data-alt-text-after="alt-after" data-expectedlabel="start alt-before end label start alt-after end" data-testname="heading name from fallback content mixing attr() and strings with ::before and ::after" class="ex fallback-before-mixed fallback-after-mixed">label</h3>
 <a href="#" data-alt-text-before="alt-before" data-alt-text-after="alt-after" data-expectedlabel="start alt-before end label start alt-after end" data-testname="link name from fallback content mixing attr() and strings with ::before and ::after" class="ex fallback-before-mixed fallback-after-mixed">label</a><br>
 <br>
+
+<h1>Empty alternative text for CSS content in pseudo-elements when applied to primitive appearance form controls</h1>
+<p><input data-expectedlabel="" data-testname="primitive radio input with ::before containing empty alternative text" class="ex fallback-before-empty" type=radio style=appearance:none>
+<p><input data-expectedlabel="" data-testname="primitive radio input with ::before containing empty alternative text for an image" class="ex fallback-before-image-empty" type=radio style=appearance:none>
 
 <h1>simple w/ for each child</h1>
 <button data-expectedlabel="one two three" data-testname="button name from content for each child" class="ex"><span>one</span> <span>two</span> <span>three</span></button><br>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -717,13 +717,11 @@ String AccessibilityRenderObject::textUnderElement(AccessibilityTextUnderElement
         if (WeakPtr renderText = dynamicDowncast<RenderText>(*m_renderer)) {
             if (WeakPtr renderTextFragment = dynamicDowncast<RenderTextFragment>(*renderText)) {
                 // The alt attribute may be set on a text fragment through CSS, which should be honored.
-                const auto& altText = renderTextFragment->altText();
-                if (!altText.isEmpty())
+                if (auto& altText = renderTextFragment->altText(); !altText.isNull())
                     return altText;
-                return renderTextFragment ? renderTextFragment->contentString() : String();
+                return renderTextFragment->contentString();
             }
-
-            return renderText ? renderText->text() : String();
+            return renderText->text();
         }
     }
 


### PR DESCRIPTION
#### 93c3eb8ac99a6b6e3894deaf14e5d38304898b48
<pre>
AX: CSS content property replacement text ignored when it is the empty string
<a href="https://bugs.webkit.org/show_bug.cgi?id=270377">https://bugs.webkit.org/show_bug.cgi?id=270377</a>
<a href="https://rdar.apple.com/123919677">rdar://123919677</a>

Reviewed by Antoine Quint.

This issue came to light as part of the &lt;input type=checkbox switch&gt;
demo, but is more universally applicable as shown in the tests.

While here, also cleanup some of the code as the render objects
involved cannot become null.

New web-platform-tests tests are exported:
<a href="https://github.com/web-platform-tests/wpt/pull/44971">https://github.com/web-platform-tests/wpt/pull/44971</a>

* LayoutTests/accessibility/mac/alt-for-css-content-expected.txt:
* LayoutTests/accessibility/mac/alt-for-css-content.html:
* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textUnderElement const):

Canonical link: <a href="https://commits.webkit.org/275872@main">https://commits.webkit.org/275872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2f5056817c8fd61f80d5cf9f7bd04c5cbff785a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45635 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19460 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35565 "Found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38098 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1067 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39193 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47167 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42343 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40996 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9595 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19642 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->