### PR TITLE
getDisplayMedia captured windows get black frames when window gets resized

### DIFF
--- a/Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.h
+++ b/Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.h
@@ -45,5 +45,11 @@ SOFT_LINK_CLASS_FOR_HEADER(PAL, SCContentSharingPickerConfiguration)
 
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, ScreenCaptureKit, SCStreamFrameInfoStatus, NSString *)
 #define SCStreamFrameInfoStatus PAL::get_ScreenCaptureKit_SCStreamFrameInfoStatus()
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, ScreenCaptureKit, SCStreamFrameInfoScaleFactor, NSString *)
+#define SCStreamFrameInfoScaleFactor PAL::get_ScreenCaptureKit_SCStreamFrameInfoScaleFactor()
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, ScreenCaptureKit, SCStreamFrameInfoContentScale, NSString *)
+#define SCStreamFrameInfoContentScale PAL::get_ScreenCaptureKit_SCStreamFrameInfoContentScale()
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, ScreenCaptureKit, SCStreamFrameInfoContentRect, NSString *)
+#define SCStreamFrameInfoContentRect PAL::get_ScreenCaptureKit_SCStreamFrameInfoContentRect()
 
 #endif // HAVE(SCREEN_CAPTURE_KIT)

--- a/Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.mm
+++ b/Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.mm
@@ -44,5 +44,8 @@ SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT(PAL, ScreenCaptureKit, SCContent
 #endif
 
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, ScreenCaptureKit, SCStreamFrameInfoStatus, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, ScreenCaptureKit, SCStreamFrameInfoScaleFactor, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, ScreenCaptureKit, SCStreamFrameInfoContentScale, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, ScreenCaptureKit, SCStreamFrameInfoContentRect, NSString *, PAL_EXPORT)
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -111,6 +111,7 @@ private:
     uint32_t m_deviceID { 0 };
     mutable std::optional<IntSize> m_intrinsicSize;
 
+    FloatSize m_contentSize;
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
     float m_frameRate { 0 };

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -323,21 +323,15 @@ RetainPtr<SCStreamConfiguration> ScreenCaptureKitCaptureSource::streamConfigurat
     auto width = m_width;
     auto height = m_height;
 
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    if (m_contentFilter) {
-        FloatSize contentSize = FloatSize { m_contentFilter.get().contentRect.size };
-        contentSize.scale(m_contentFilter.get().pointPixelScale);
-        if (!width && !height) {
-            width = contentSize.width();
-            height = contentSize.height();
-        } else if (contentSize.width() && contentSize.height()) {
-            if (!width)
-                width = height * contentSize.width() / contentSize.height();
-            else if (!height)
-                height = width * contentSize.height() / contentSize.width();
-        }
+    if (!width && !height) {
+        width = m_contentSize.width();
+        height = m_contentSize.height();
+    } else if (!m_contentSize.isEmpty()) {
+        if (!width)
+            width = height * m_contentSize.aspectRatio();
+        else
+            height = width / m_contentSize.aspectRatio();
     }
-#endif
 
     if (width && height) {
         [m_streamConfiguration setWidth:width];
@@ -361,6 +355,11 @@ void ScreenCaptureKitCaptureSource::startContentStream()
         auto filterAndSession = ScreenCaptureKitSharingSessionManager::singleton().contentFilterAndSharingSessionFromCaptureDevice(m_captureDevice);
         m_contentFilter = WTFMove(filterAndSession.first);
         m_sharingSession = WTFMove(filterAndSession.second);
+
+#if HAVE(SC_CONTENT_SHARING_PICKER)
+        m_contentSize = FloatSize { m_contentFilter.get().contentRect.size };
+        m_contentSize.scale(m_contentFilter.get().pointPixelScale);
+#endif
     }
 
 #if HAVE(SC_CONTENT_SHARING_PICKER)
@@ -491,7 +490,23 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
 
     auto attachments = (__bridge NSArray *)PAL::CMSampleBufferGetSampleAttachmentsArray(sampleBuffer.get(), false);
     SCFrameStatus status = SCFrameStatusStopped;
+
+    double contentScale = 1;
+    double scaleFactor = 1;
+    FloatSize contentSize;
     [attachments enumerateObjectsUsingBlock:makeBlockPtr([&] (NSDictionary *attachment, NSUInteger, BOOL *stop) {
+        if (auto scaleFactorNumber = (NSNumber *)attachment[SCStreamFrameInfoScaleFactor])
+            scaleFactor = [scaleFactorNumber floatValue];
+
+        if (auto contentScaleNumber = (NSNumber *)attachment[SCStreamFrameInfoContentScale])
+            contentScale = [contentScaleNumber floatValue];
+
+        if (auto contentRectDictionary = (CFDictionaryRef)attachment[SCStreamFrameInfoContentRect]) {
+            CGRect contentRect;
+            if (CGRectMakeWithDictionaryRepresentation(contentRectDictionary, &contentRect))
+                contentSize = FloatSize { contentRect.size };
+        }
+
         auto statusNumber = (NSNumber *)attachment[SCStreamFrameInfoStatus];
         if (!statusNumber)
             return;
@@ -512,6 +527,17 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
     }
 
     m_currentFrame = WTFMove(sampleBuffer);
+
+    if (scaleFactor != 1)
+        contentSize.scale(scaleFactor);
+    if (contentScale && contentScale != 1)
+        contentSize.scale(1 / contentScale);
+
+    if (m_contentSize != contentSize) {
+        m_contentSize = contentSize;
+        m_streamConfiguration = nullptr;
+        updateStreamConfiguration();
+    }
 
     auto intrinsicSize = IntSize(PAL::CMVideoFormatDescriptionGetPresentationDimensions(PAL::CMSampleBufferGetFormatDescription(m_currentFrame.get()), true, true));
     if (!m_intrinsicSize || *m_intrinsicSize != intrinsicSize) {


### PR DESCRIPTION
#### bc5355f67f69e837837f1519fdf132976f40d2c2
<pre>
getDisplayMedia captured windows get black frames when window gets resized
<a href="https://bugs.webkit.org/show_bug.cgi?id=270568">https://bugs.webkit.org/show_bug.cgi?id=270568</a>
<a href="https://rdar.apple.com/124131045">rdar://124131045</a>

Reviewed by Eric Carlson.

When a window size changes, we may need to update the capture size so as to respect aspect ratio and not introduce black frames.
For that purpose, we store the content size in ScreenCaptureKitCaptureSource::m_contentSize and we initialize it at start up using SCContentFilter.

Then, when capture has started, we get the content size from the sample buffer attachment, using SCStreamFrameInfoScaleFactor, SCStreamFrameInfoContentScale and SCStreamFrameInfoContentRect.
If m_contentSize changes, we update the capture size.
We ensure that the capture size keeps the aspect ratio even in case where width and height are set via media constraints by either computing width from height or the reverse but keeping aspect ratio computed from m_contentSize.

* Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.h:
* Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.mm:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::streamConfiguration):
(WebCore::ScreenCaptureKitCaptureSource::startContentStream):
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/275794@main">https://commits.webkit.org/275794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14adebbb1acbb12f10ab0c9890437aca80a36ed0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19261 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37959 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46998 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42214 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19312 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40860 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9559 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->