### PR TITLE
The functions threadSelfRestrictSupported, threadSelfRestrictRWXToRW and threadSelfRestrictRWXToRX are incompatible with AddressSanitizer.

### DIFF
--- a/Source/JavaScriptCore/assembler/FastJITPermissions.h
+++ b/Source/JavaScriptCore/assembler/FastJITPermissions.h
@@ -78,18 +78,18 @@ static ALWAYS_INLINE void threadSelfRestrictRWXToRX()
 #elif USE(APPLE_INTERNAL_SDK)
 #include <os/thread_self_restrict.h>
 
-static ALWAYS_INLINE bool threadSelfRestrictSupported()
+SUPPRESS_ASAN static ALWAYS_INLINE bool threadSelfRestrictSupported()
 {
     return !!os_thread_self_restrict_rwx_is_supported();
 }
 
-static ALWAYS_INLINE void threadSelfRestrictRWXToRW()
+SUPPRESS_ASAN static ALWAYS_INLINE void threadSelfRestrictRWXToRW()
 {
     ASSERT(g_jscConfig.useFastJITPermissions);
     os_thread_self_restrict_rwx_to_rw();
 }
 
-static ALWAYS_INLINE void threadSelfRestrictRWXToRX()
+SUPPRESS_ASAN static ALWAYS_INLINE void threadSelfRestrictRWXToRX()
 {
     ASSERT(g_jscConfig.useFastJITPermissions);
     os_thread_self_restrict_rwx_to_rx();


### PR DESCRIPTION
#### 7cbf038b3af6dc95f13ec60e11ddbb1b2ca6b6f6
<pre>
The functions threadSelfRestrictSupported, threadSelfRestrictRWXToRW and threadSelfRestrictRWXToRX are incompatible with AddressSanitizer.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270569">https://bugs.webkit.org/show_bug.cgi?id=270569</a>

Reviewed by Keith Miller.

Suppress ASan instrumentation on threadSelfRestrictSupported,
threadSelfRestrictRWXToRW and threadSelfRestrictRWXToRX.

* Source/JavaScriptCore/assembler/FastJITPermissions.h:

Canonical link: <a href="https://commits.webkit.org/275744@main">https://commits.webkit.org/275744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51dd1abfdf7bc5903625b948877bf7dfd68a70f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38807 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35331 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43257 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16287 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37803 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/740 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/36140 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46800 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42311 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42048 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40674 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19300 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49321 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5774 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18766 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9988 "Passed tests") | 
<!--EWS-Status-Bubble-End-->