### PR TITLE
Implement trusted types integration with DOM node conversion APIs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-expected.txt
@@ -22,13 +22,11 @@
 'mixed';
 'mixed';
 'mixed';
-'mixed';
 'mixed';'script';
 'mixed';'script';
 'mixed';'script';
 'mixed';'script';
 'mixed';'script';
-'script';
 'script';
 'script';
 'script';

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Node-multiple-arguments-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Node-multiple-arguments-expected.txt
@@ -1,3 +1,38 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 'createScript';
 'createScript';
 'createScript';
@@ -18,11 +53,13 @@
 'plain text #1';'plain text #2';
 'plain text #1';'plain text #2';
 'plain text #1';'plain text #2';
+'node';
+'node #1';'node #2';
 'mixed';
 'mixed';
 'mixed';
 'mixed';
-'mixed';
+'mixed';'node';
 'mixed';'script';
 'mixed';'script';
 'mixed';'script';
@@ -32,7 +69,7 @@
 'script';
 'script';
 'script';
-'script';
+'node';'script';
 
 PASS replaceWith('createScript';) on <div> should pass
 PASS after('createScript';) on <div> should pass
@@ -89,39 +126,39 @@ PASS after('createScript #1';,'#2;') on <script> should pass
 PASS before('createScript #1';,'#2;') on <script> should pass
 PASS append('createScript #1';,'#2;') on <script> should pass
 PASS prepend('createScript #1';,'#2;') on <script> should pass
-FAIL replaceWith('plain text';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL after('plain text';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL before('plain text';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL append('plain text';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL prepend('plain text';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL replaceWith('plain text #1';,'plain text #2';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL after('plain text #1';,'plain text #2';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL before('plain text #1';,'plain text #2';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL append('plain text #1';,'plain text #2';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL prepend('plain text #1';,'plain text #2';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL replaceWith([object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL after([object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL before([object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL append([object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL prepend([object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL replaceWith([object Text],[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL after([object Text],[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL before([object Text],[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL append([object Text],[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL prepend([object Text],[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL replaceWith('mixed';,[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL after('mixed';,[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL before('mixed';,[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL append('mixed';,[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL prepend('mixed';,[object Text]) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL replaceWith('mixed';,'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL after('mixed';,'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL before('mixed';,'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL append('mixed';,'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL prepend('mixed';,'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL replaceWith([object Text],'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL after([object Text],'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL before([object Text],'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(inner, args); }" did not throw
-FAIL append([object Text],'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
-FAIL prepend([object Text],'script';) on <script> should fail assert_throws_js: This should throw. function "_ => { setter.apply(outer, args); }" did not throw
+PASS replaceWith('plain text';) on <script> should fail
+PASS after('plain text';) on <script> should fail
+PASS before('plain text';) on <script> should fail
+PASS append('plain text';) on <script> should fail
+PASS prepend('plain text';) on <script> should fail
+PASS replaceWith('plain text #1';,'plain text #2';) on <script> should fail
+PASS after('plain text #1';,'plain text #2';) on <script> should fail
+PASS before('plain text #1';,'plain text #2';) on <script> should fail
+PASS append('plain text #1';,'plain text #2';) on <script> should fail
+PASS prepend('plain text #1';,'plain text #2';) on <script> should fail
+PASS replaceWith([object Text]) on <script> should fail
+PASS after([object Text]) on <script> should fail
+PASS before([object Text]) on <script> should fail
+PASS append([object Text]) on <script> should fail
+PASS prepend([object Text]) on <script> should fail
+PASS replaceWith([object Text],[object Text]) on <script> should fail
+PASS after([object Text],[object Text]) on <script> should fail
+PASS before([object Text],[object Text]) on <script> should fail
+PASS append([object Text],[object Text]) on <script> should fail
+PASS prepend([object Text],[object Text]) on <script> should fail
+PASS replaceWith('mixed';,[object Text]) on <script> should fail
+PASS after('mixed';,[object Text]) on <script> should fail
+PASS before('mixed';,[object Text]) on <script> should fail
+PASS append('mixed';,[object Text]) on <script> should fail
+PASS prepend('mixed';,[object Text]) on <script> should fail
+PASS replaceWith('mixed';,'script';) on <script> should fail
+PASS after('mixed';,'script';) on <script> should fail
+PASS before('mixed';,'script';) on <script> should fail
+PASS append('mixed';,'script';) on <script> should fail
+PASS prepend('mixed';,'script';) on <script> should fail
+PASS replaceWith([object Text],'script';) on <script> should fail
+PASS after([object Text],'script';) on <script> should fail
+PASS before([object Text],'script';) on <script> should fail
+PASS append([object Text],'script';) on <script> should fail
+PASS prepend([object Text],'script';) on <script> should fail
 

--- a/Source/WebCore/dom/ChildNode.idl
+++ b/Source/WebCore/dom/ChildNode.idl
@@ -20,8 +20,8 @@
 
 // https://dom.spec.whatwg.org/#childnode
 interface mixin ChildNode {
-    [CEReactions=Needed, Unscopable] undefined before((Node or DOMString)... nodes);
-    [CEReactions=Needed, Unscopable] undefined after((Node or DOMString)... nodes);
-    [CEReactions=Needed, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
+    [CEReactions=Needed, Unscopable] undefined before((Node or DOMString or TrustedScript)... nodes);
+    [CEReactions=Needed, Unscopable] undefined after((Node or DOMString or TrustedScript)... nodes);
+    [CEReactions=Needed, Unscopable] undefined replaceWith((Node or DOMString or TrustedScript)... nodes);
     [CEReactions=Needed, Unscopable] undefined remove();
 };

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1163,9 +1163,9 @@ unsigned ContainerNode::childElementCount() const
     return std::distance(children.begin(), { });
 }
 
-ExceptionOr<void> ContainerNode::append(FixedVector<NodeOrString>&& vector)
+ExceptionOr<void> ContainerNode::append(FixedVector<NodeOrStringOrTrustedScript>&& vector)
 {
-    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(vector));
+    auto result = convertNodesOrStringsOrTrustedScriptsIntoNodeVector(this, WTFMove(vector));
     if (result.hasException())
         return result.releaseException();
 
@@ -1184,9 +1184,9 @@ ExceptionOr<void> ContainerNode::append(FixedVector<NodeOrString>&& vector)
     return { };
 }
 
-ExceptionOr<void> ContainerNode::prepend(FixedVector<NodeOrString>&& vector)
+ExceptionOr<void> ContainerNode::prepend(FixedVector<NodeOrStringOrTrustedScript>&& vector)
 {
-    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(vector));
+    auto result = convertNodesOrStringsOrTrustedScriptsIntoNodeVector(this, WTFMove(vector));
     if (result.hasException())
         return result.releaseException();
 
@@ -1207,9 +1207,9 @@ ExceptionOr<void> ContainerNode::prepend(FixedVector<NodeOrString>&& vector)
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
-ExceptionOr<void> ContainerNode::replaceChildren(FixedVector<NodeOrString>&& vector)
+ExceptionOr<void> ContainerNode::replaceChildren(FixedVector<NodeOrStringOrTrustedScript>&& vector)
 {
-    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(vector));
+    auto result = convertNodesOrStringsOrTrustedScriptsIntoNodeVector(this, WTFMove(vector));
     if (result.hasException())
         return result.releaseException();
     auto newChildren = result.releaseReturnValue();

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -135,10 +135,10 @@ public:
     WEBCORE_EXPORT Element* firstElementChild() const;
     WEBCORE_EXPORT Element* lastElementChild() const;
     WEBCORE_EXPORT unsigned childElementCount() const;
-    ExceptionOr<void> append(FixedVector<NodeOrString>&&);
-    ExceptionOr<void> prepend(FixedVector<NodeOrString>&&);
+    ExceptionOr<void> append(FixedVector<NodeOrStringOrTrustedScript>&&);
+    ExceptionOr<void> prepend(FixedVector<NodeOrStringOrTrustedScript>&&);
 
-    ExceptionOr<void> replaceChildren(FixedVector<NodeOrString>&&);
+    ExceptionOr<void> replaceChildren(FixedVector<NodeOrStringOrTrustedScript>&&);
 
     ExceptionOr<void> ensurePreInsertionValidity(Node& newChild, Node* refChild);
     ExceptionOr<void> ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild = nullptr);

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -72,6 +72,7 @@ class RenderStyle;
 class SVGQualifiedName;
 class ShadowRoot;
 class TouchEvent;
+class TrustedScript;
 class WebCoreOpaqueRoot;
 
 namespace Style {
@@ -90,7 +91,7 @@ enum class MutationObserverOptionType : uint8_t;
 using MutationObserverOptions = OptionSet<MutationObserverOptionType>;
 using MutationRecordDeliveryOptions = OptionSet<MutationObserverOptionType>;
 
-using NodeOrString = std::variant<RefPtr<Node>, String>;
+using NodeOrStringOrTrustedScript = std::variant<RefPtr<Node>, String, RefPtr<TrustedScript>>;
 
 const int initialNodeVectorSize = 11; // Covers 99.5%. See webkit.org/b/80706
 typedef Vector<Ref<Node>, initialNodeVectorSize> NodeVector;
@@ -217,9 +218,9 @@ public:
     WEBCORE_EXPORT Element* nextElementSibling() const;
 
     // From the ChildNode - https://dom.spec.whatwg.org/#childnode
-    ExceptionOr<void> before(FixedVector<NodeOrString>&&);
-    ExceptionOr<void> after(FixedVector<NodeOrString>&&);
-    ExceptionOr<void> replaceWith(FixedVector<NodeOrString>&&);
+    ExceptionOr<void> before(FixedVector<NodeOrStringOrTrustedScript>&&);
+    ExceptionOr<void> after(FixedVector<NodeOrStringOrTrustedScript>&&);
+    ExceptionOr<void> replaceWith(FixedVector<NodeOrStringOrTrustedScript>&&);
     WEBCORE_EXPORT ExceptionOr<void> remove();
 
     // Other methods (not part of DOM)
@@ -767,9 +768,9 @@ protected:
     template<typename NodeClass>
     static NodeClass& traverseToRootNodeInternal(const NodeClass&);
 
-    // FIXME: Replace all uses of convertNodesOrStringsIntoNode by convertNodesOrStringsIntoNodeVector.
-    ExceptionOr<RefPtr<Node>> convertNodesOrStringsIntoNode(FixedVector<NodeOrString>&&);
-    ExceptionOr<NodeVector> convertNodesOrStringsIntoNodeVector(FixedVector<NodeOrString>&&);
+    // FIXME: Replace all uses of convertNodesOrStringsOrTrustedScriptsIntoNode by convertNodesOrStringsOrTrustedScriptsIntoNodeVector.
+    ExceptionOr<RefPtr<Node>> convertNodesOrStringsOrTrustedScriptsIntoNode(RefPtr<Node>, FixedVector<NodeOrStringOrTrustedScript>&&);
+    ExceptionOr<NodeVector> convertNodesOrStringsOrTrustedScriptsIntoNodeVector(RefPtr<Node>, FixedVector<NodeOrStringOrTrustedScript>&&);
 
 private:
     virtual PseudoId customPseudoId() const

--- a/Source/WebCore/dom/ParentNode.idl
+++ b/Source/WebCore/dom/ParentNode.idl
@@ -31,9 +31,9 @@ interface mixin ParentNode {
     readonly attribute Element? lastElementChild;
     readonly attribute unsigned long childElementCount;
 
-    [CEReactions=Needed, Unscopable] undefined prepend((Node or DOMString)... nodes);
-    [CEReactions=Needed, Unscopable] undefined append((Node or DOMString)... nodes);
-    [CEReactions=Needed, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
+    [CEReactions=Needed, Unscopable] undefined prepend((Node or DOMString or TrustedScript)... nodes);
+    [CEReactions=Needed, Unscopable] undefined append((Node or DOMString or TrustedScript)... nodes);
+    [CEReactions=Needed, Unscopable] undefined replaceChildren((Node or DOMString or TrustedScript)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -32,8 +32,11 @@
 
 namespace WebCore {
 
+class Document;
 class Exception;
+class Node;
 class ScriptExecutionContext;
+class Text;
 
 enum class TrustedType : int8_t {
     TrustedHTML,
@@ -49,5 +52,7 @@ WEBCORE_EXPORT std::variant<std::monostate, Exception, Ref<TrustedHTML>, Ref<Tru
 WEBCORE_EXPORT ExceptionOr<String> trustedTypeCompliantString(TrustedType, ScriptExecutionContext&, const String& input, const String& sink);
 
 WEBCORE_EXPORT ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecutionContext&, const String& urlString);
+
+ExceptionOr<RefPtr<Text>> processNodeOrStringAsTrustedType(Ref<Document>, RefPtr<Node> parent, std::variant<RefPtr<Node>, String, RefPtr<TrustedScript>>);
 
 } // namespace WebCore


### PR DESCRIPTION
#### bb9ca28dcac916cb783096b485f9c589b147f21d
<pre>
Implement trusted types integration with DOM node conversion APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=270435">https://bugs.webkit.org/show_bug.cgi?id=270435</a>

Reviewed by Ryosuke Niwa.

Update the &quot;converting nodes into a node&quot; algorithm to integrate Trusted Types protection.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Node-multiple-arguments-expected.txt:
* Source/WebCore/dom/ChildNode.idl:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::append):
(WebCore::ContainerNode::prepend):
(WebCore::ContainerNode::replaceChildren):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::nodeSetPreTransformedFromNodeOrStringOrTrustedScriptVector):
(WebCore::Node::convertNodesOrStringsOrTrustedScriptsIntoNode):
(WebCore::Node::convertNodesOrStringsOrTrustedScriptsIntoNodeVector):
(WebCore::Node::before):
(WebCore::Node::after):
(WebCore::Node::replaceWith):
(WebCore::nodeSetPreTransformedFromNodeOrStringVector): Deleted.
(WebCore::Node::convertNodesOrStringsIntoNode): Deleted.
(WebCore::Node::convertNodesOrStringsIntoNodeVector): Deleted.
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/ParentNode.idl:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::processNodeOrStringAsTrustedType):
* Source/WebCore/dom/TrustedType.h:

Canonical link: <a href="https://commits.webkit.org/276942@main">https://commits.webkit.org/276942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3dee18c95721eb4fb02e1e897ed96009c6bd73a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37762 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40950 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4254 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39443 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50690 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45684 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44952 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43867 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10232 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22865 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52835 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22200 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10816 "Passed tests") | 
<!--EWS-Status-Bubble-End-->