### PR TITLE
[GTK][WPE] Make gamepad visible/connected on axis movement

### DIFF
--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
@@ -81,7 +81,7 @@ void GamepadLibWPE::absoluteAxisChanged(unsigned axis, double value)
     m_lastUpdateTime = MonotonicTime::now();
     m_axisValues[axis].setValue(value);
 
-    GamepadProviderLibWPE::singleton().scheduleInputNotification(*this, GamepadProviderLibWPE::ShouldMakeGamepadsVisible::No);
+    GamepadProviderLibWPE::singleton().scheduleInputNotification(*this, GamepadProviderLibWPE::ShouldMakeGamepadsVisible::Yes);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
@@ -171,7 +171,7 @@ void ManetteGamepad::absoluteAxisChanged(ManetteDevice*, StandardGamepadAxis axi
     m_lastUpdateTime = MonotonicTime::now();
     m_axisValues[static_cast<int>(axis)].setValue(value);
 
-    ManetteGamepadProvider::singleton().gamepadHadInput(*this, ManetteGamepadProvider::ShouldMakeGamepadsVisible::No);
+    ManetteGamepadProvider::singleton().gamepadHadInput(*this, ManetteGamepadProvider::ShouldMakeGamepadsVisible::Yes);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6b3a8aa7666d7d36e91fdc60a8307a12f8322ce2
<pre>
[GTK][WPE] Make gamepad visible/connected on axis movement
<a href="https://bugs.webkit.org/show_bug.cgi?id=270575">https://bugs.webkit.org/show_bug.cgi?id=270575</a>

Reviewed by Michael Catanzaro.

Dispatch the gamepadconnected event when an axis is moved.

* Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp:
(WebCore::GamepadLibWPE::absoluteAxisChanged):
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
(WebCore::ManetteGamepad::absoluteAxisChanged):

Canonical link: <a href="https://commits.webkit.org/275781@main">https://commits.webkit.org/275781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/624871ec5e830d57d19d6de668ec5bd52a92a024

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45311 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35346 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16302 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16367 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37811 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46816 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42063 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19136 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9553 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18781 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->