### PR TITLE
[GTK][Debug] ASSERTs on inspector tests

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -224,6 +224,8 @@ void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDept
             pushCurrentRecord(TimelineRecordFactory::createRenderingFrameData(name), TimelineRecordType::RenderingFrame, false, nullptr);
             break;
         case RunLoop::Event::DidDispatch:
+            if (m_startedComposite)
+                didComposite();
             didCompleteCurrentRecord(TimelineRecordType::RenderingFrame);
             break;
         }


### PR DESCRIPTION
#### 4a1b2c8aedf261c714415790469da38d3dee7f38
<pre>
[GTK][Debug] ASSERTs on inspector tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=270447">https://bugs.webkit.org/show_bug.cgi?id=270447</a>

Reviewed by Carlos Garcia Campos.

`InspectorTimelineAgent` uses a stack to store timeline records and
expects `pushCurrentRecord()`/`didCompleteCurrentRecord()` to be called
in the correct order.

But since frame rendering occurs more frequently than compositing,
associated records may be processed in the wrong order:

- push `TimelineRecordType::RenderingFrame`
- push `TimelineRecordType::Composite`
- complete `TimelineRecordType::RenderingFrame`
- complete `TimelineRecordType::Composite`

To prevent this, we must explicitly call `didComposite()` before pushing
a new `RenderingFrame` record, like it&apos;s done on Mac.

* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::internalStart):

Canonical link: <a href="https://commits.webkit.org/275785@main">https://commits.webkit.org/275785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d692f6727d2b13b29bff0d837fb2bb68c3c8599d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35347 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36754 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16303 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16368 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37815 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46817 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42064 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19137 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40691 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9554 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->