### PR TITLE
REGRESSION (iOS 17): Animation flicker with multiple accelerated animations and direction change

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1780,6 +1780,7 @@ webkit.org/b/215945 webanimations/accelerated-css-animation-with-easing.html [ I
 
 webkit.org/b/216539 webanimations/accelerated-animation-easing-and-direction-update.html [ ImageOnlyFailure ]
 
+webkit.org/b/221021 webanimations/accelerated-animation-immediate-prevetion-direction-reverse.html [ Skip ]
 webkit.org/b/221021 webanimations/combining-transform-animations-with-different-acceleration-capabilities-2.html [ Skip ]
 webkit.org/b/221021 webanimations/combining-transform-animations-with-different-acceleration-capabilities-3.html [ Skip ]
 webkit.org/b/221021 webanimations/combining-transform-animations-with-different-acceleration-capabilities-4.html [ Skip ]

--- a/LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Changing 'direction' to 'reverse' in flight should immediately prevent acceleration of the entire effect stack.
+

--- a/LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse.html
+++ b/LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<body>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<style>
+
+div {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+<script>
+
+const createDiv = test => {
+    const div = document.createElement("div");
+    test.add_cleanup(() => div.remove());
+    return document.body.appendChild(div);
+}
+
+const animationFrame = async => new Promise(requestAnimationFrame);
+
+const animationReadyToAnimateAccelerated = async animation => {
+    await animation.ready;
+    await animationFrame();
+    await animationFrame();
+    await animationFrame();
+}
+
+const duration = 1000 * 1000; // 1000s.
+
+promise_test(async test => {
+    const target = createDiv(test);
+    const firstAnimation = target.animate({ transform: ["translateX(100px)", "translateX(200px)"] }, { fill: "both", duration });
+    await animationReadyToAnimateAccelerated(firstAnimation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+
+    firstAnimation.finish();
+    const secondAnimation = target.animate({ transform: ["translateX(400px)", "translateX(300px)"] }, { fill: "both", duration });
+    await animationReadyToAnimateAccelerated(secondAnimation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+
+    secondAnimation.effect.updateTiming({ direction: 'reverse' });
+    await animationFrame();
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Changing 'direction' to 'reverse' in flight should immediately prevent acceleration of the entire effect stack.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2549,6 +2549,21 @@ void KeyframeEffect::effectStackNoLongerAllowsAcceleration()
     addPendingAcceleratedAction(AcceleratedAction::Stop);
 }
 
+void KeyframeEffect::effectStackNoLongerAllowsAccelerationDuringAcceleratedActionApplication()
+{
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    if (threadedAnimationResolutionEnabled()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+#endif
+
+    m_pendingAcceleratedActions.append(AcceleratedAction::Stop);
+    m_lastRecordedAcceleratedAction = AcceleratedAction::Stop;
+    applyPendingAcceleratedActions();
+    m_pendingAcceleratedActions.clear();
+}
+
 void KeyframeEffect::abilityToBeAcceleratedDidChange()
 {
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -175,9 +175,11 @@ public:
     void customPropertyRegistrationDidChange(const AtomString&);
 
     bool canBeAccelerated() const;
+    bool accelerationWasPrevented() const { return m_runningAccelerated == RunningAccelerated::Prevented; }
     bool preventsAcceleration() const;
     void effectStackNoLongerPreventsAcceleration();
     void effectStackNoLongerAllowsAcceleration();
+    void effectStackNoLongerAllowsAccelerationDuringAcceleratedActionApplication();
     void wasAddedToEffectStack();
     void wasRemovedFromEffectStack();
 

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -286,11 +286,19 @@ void KeyframeEffectStack::applyPendingAcceleratedActions() const
         return effect->canBeAccelerated() && effect->animation()->playState() == WebAnimation::PlayState::Running;
     });
 
+    auto accelerationWasPrevented = false;
+
     for (auto& effect : m_effects) {
         if (hasActiveAcceleratedEffect)
             effect->applyPendingAcceleratedActionsOrUpdateTimingProperties();
         else
             effect->applyPendingAcceleratedActions();
+        accelerationWasPrevented = accelerationWasPrevented || effect->accelerationWasPrevented() || effect->preventsAcceleration();
+    }
+
+    if (accelerationWasPrevented) {
+        for (auto& effect : m_effects)
+            effect->effectStackNoLongerAllowsAccelerationDuringAcceleratedActionApplication();
     }
 }
 


### PR DESCRIPTION
#### 9d57f1f6519a812dda9dbb476a24ce8ed73c976c
<pre>
REGRESSION (iOS 17): Animation flicker with multiple accelerated animations and direction change
<a href="https://bugs.webkit.org/show_bug.cgi?id=263996">https://bugs.webkit.org/show_bug.cgi?id=263996</a>
<a href="https://rdar.apple.com/117815004">rdar://117815004</a>

Reviewed by Dean Jackson.

While we have a mechanism to deal with changes in ability to accelerate effects based on logic ran
at the KeyframeEffect level (see `KeyframeEffect::canBeAccelerated()`) we do not have anything
specific in place to deal with the inability to accelerate effects at the GraphicsLayerCA level.

In the case of reversed animations, or any playback rate other than 1, we reject acceleration
in GraphicsLayerCA in the static function `animationCanBeAccelerated()`. This happens while
accelerated actions are applied throughout a keyframe effect stack. With the existing system
in place, this would result in preventing acceleration in the next animation frame. This bug
showed this with animations being in an incorrect state for one single frame.

We now check in `KeyframeEffectStack::applyPendingAcceleratedActions()` whether the application
of pending accelerated actions resulted in an effect preventing acceleration of the effect
stack and now immediately stop all effects in that stack.

The newly added test would reliably fail prior to this patch.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse-expected.txt: Added.
* LayoutTests/webanimations/accelerated-animation-immediate-prevetion-direction-reverse.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::effectStackNoLongerAllowsAccelerationDuringAcceleratedActionApplication):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyPendingAcceleratedActions const):

Canonical link: <a href="https://commits.webkit.org/275773@main">https://commits.webkit.org/275773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c85fa4e920732c902801379c8d010f3bedc54129

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35374 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37845 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/795 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42097 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40726 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19355 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5793 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->