### PR TITLE
Handle custom property applying in Style::Builder

### DIFF
--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3622,18 +3622,13 @@ class GenerateStyleBuilderGenerated:
 
     def _generate_style_builder_generated_cpp_builder_generated_apply(self, *, to):
         to.write_block("""
-            void BuilderGenerated::applyProperty(CSSPropertyID id, BuilderState& builderState, CSSValue& value, bool isInitial, bool isInherit, const CSSRegisteredCustomProperty* registered)
+            void BuilderGenerated::applyProperty(CSSPropertyID id, BuilderState& builderState, CSSValue& value, ApplyValueType valueType)
             {
                 switch (id) {
                 case CSSPropertyID::CSSPropertyInvalid:
                     break;
                 case CSSPropertyID::CSSPropertyCustom:
-                    if (isInitial)
-                        BuilderCustom::applyInitialCustomProperty(builderState, registered, downcast<CSSCustomPropertyValue>(value).name());
-                    else if (isInherit)
-                        BuilderCustom::applyInheritCustomProperty(builderState, registered, downcast<CSSCustomPropertyValue>(value).name());
-                    else
-                        BuilderCustom::applyValueCustomProperty(builderState, registered, downcast<CSSCustomPropertyValue>(value));
+                    ASSERT_NOT_REACHED();
                     break;""")
 
         with to.indent():
@@ -3668,15 +3663,20 @@ class GenerateStyleBuilderGenerated:
                         if property.codegen_properties.fill_layer_property:
                             apply_value_arguments.insert(0, "id")
 
-                        to.write(f"if (isInitial)")
+                        to.write(f"switch (valueType) {{")
+                        to.write(f"case ApplyValueType::Initial:")
                         with to.indent():
                             to.write(f"{scope_for_function(property, 'Initial')}::applyInitial{property.id_without_prefix}({', '.join(apply_initial_arguments)});")
-                        to.write(f"else if (isInherit)")
+                            to.write(f"break;")
+                        to.write(f"case ApplyValueType::Inherit:")
                         with to.indent():
                             to.write(f"{scope_for_function(property, 'Inherit')}::applyInherit{property.id_without_prefix}({', '.join(apply_inherit_arguments)});")
-                        to.write(f"else")
+                            to.write(f"break;")
+                        to.write("case ApplyValueType::Value:")
                         with to.indent():
                             to.write(f"{scope_for_function(property, 'Value')}::applyValue{property.id_without_prefix}({', '.join(apply_value_arguments)});")
+                            to.write(f"break;")
+                        to.write(f"}}")
 
                     to.write(f"break;")
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -30,6 +30,8 @@
 
 namespace WebCore {
 
+struct CSSRegisteredCustomProperty;
+
 namespace Style {
 
 class Builder {
@@ -64,6 +66,7 @@ private:
     void applyCascadeProperty(const PropertyCascade::Property&);
     void applyRollbackCascadeProperty(const PropertyCascade::Property&, SelectorChecker::LinkMatchMask);
     void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask);
+    void applyCustomPropertyValue(const CSSCustomPropertyValue&, ApplyValueType, const CSSRegisteredCustomProperty*);
 
     Ref<CSSValue> resolveVariableReferences(CSSPropertyID, CSSValue&);
     RefPtr<CSSCustomPropertyValue> resolveCustomPropertyValue(CSSCustomPropertyValue&);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -159,10 +159,6 @@ public:
     static void applyValueStrokeWidth(BuilderState&, CSSValue&);
     static void applyValueStrokeColor(BuilderState&, CSSValue&);
 
-    static void applyInitialCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const AtomString& name);
-    static void applyInheritCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const AtomString& name);
-    static void applyValueCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const CSSCustomPropertyValue&);
-
 private:
     static void resetEffectiveZoom(BuilderState&);
 
@@ -1979,36 +1975,6 @@ inline void BuilderCustom::applyInheritColor(BuilderState& builderState)
 
     builderState.style().setDisallowsFastPathInheritance();
     builderState.style().setHasExplicitlySetColor(builderState.isAuthorOrigin());
-}
-
-inline void BuilderCustom::applyInitialCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, const AtomString& name)
-{
-    if (registered && registered->initialValue) {
-        applyValueCustomProperty(builderState, registered, *registered->initialValue);
-        return;
-    }
-
-    auto invalid = CSSCustomPropertyValue::createWithID(name, CSSValueInvalid);
-    applyValueCustomProperty(builderState, registered, invalid.get());
-}
-
-inline void BuilderCustom::applyInheritCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, const AtomString& name)
-{
-    auto* parentValue = builderState.parentStyle().inheritedCustomProperties().get(name);
-    if (parentValue && !(registered && !registered->inherits))
-        applyValueCustomProperty(builderState, registered, const_cast<CSSCustomPropertyValue&>(*parentValue));
-    else if (auto* nonInheritedParentValue = builderState.parentStyle().nonInheritedCustomProperties().get(name))
-        applyValueCustomProperty(builderState, registered, const_cast<CSSCustomPropertyValue&>(*nonInheritedParentValue));
-    else
-        applyInitialCustomProperty(builderState, registered, name);
-}
-
-inline void BuilderCustom::applyValueCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, const CSSCustomPropertyValue& value)
-{
-    ASSERT(value.isResolved());
-
-    bool isInherited = !registered || registered->inherits;
-    builderState.style().setCustomPropertyValue(value, isInherited);
 }
 
 inline void BuilderCustom::applyInitialContainIntrinsicWidth(BuilderState& builderState)

--- a/Source/WebCore/style/StyleBuilderGenerated.h
+++ b/Source/WebCore/style/StyleBuilderGenerated.h
@@ -35,9 +35,11 @@ struct CSSRegisteredCustomProperty;
 namespace Style {
 class BuilderState;
 
+enum class ApplyValueType : uint8_t;
+
 class BuilderGenerated {
 public:
-    static void applyProperty(CSSPropertyID, Style::BuilderState&, CSSValue&, bool isInitial, bool isInherit, const CSSRegisteredCustomProperty*);
+    static void applyProperty(CSSPropertyID, Style::BuilderState&, CSSValue&, ApplyValueType);
 };
 
 }

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -49,6 +49,7 @@ class BuilderState;
 void maybeUpdateFontForLetterSpacing(BuilderState&, CSSValue&);
 
 enum class ForVisitedLink : bool { No, Yes };
+enum class ApplyValueType : uint8_t { Value, Initial, Inherit };
 
 struct BuilderContext {
     Ref<const Document> document;


### PR DESCRIPTION
#### 264120dc6a7eede1bfa2399da6db11f255b0efa9
<pre>
Handle custom property applying in Style::Builder
<a href="https://bugs.webkit.org/show_bug.cgi?id=270581">https://bugs.webkit.org/show_bug.cgi?id=270581</a>
<a href="https://rdar.apple.com/124149638">rdar://124149638</a>

Reviewed by Alan Baradlay.

Move it outside the giant switch. This simplifies the code.

* Source/WebCore/css/process-css-properties.py:

Generate switch instead of a series of ifs for value/initial/inherit.

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):

We no longer need to pass the registered property to the normal apply function.
Also pass the value/initial/inherit as a three-value enum rather than as separate bits (which were mutually exclusive).

(WebCore::Style::Builder::applyCustomPropertyValue):

Apply custom properties here.

* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialCustomProperty): Deleted.
(WebCore::Style::BuilderCustom::applyInheritCustomProperty): Deleted.
(WebCore::Style::BuilderCustom::applyValueCustomProperty): Deleted.
* Source/WebCore/style/StyleBuilderGenerated.h:
* Source/WebCore/style/StyleBuilderState.h:

Canonical link: <a href="https://commits.webkit.org/275774@main">https://commits.webkit.org/275774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/936a883844fd71d1b58bf3dcff77a526e7bb102f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45335 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35362 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37840 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/779 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46841 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17541 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14462 "Found 1 new test failure: ipc/message-listener-async-message-reply-id.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42080 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19160 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40712 "Found 1 new API test failure: /WebKitGTK/TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9547 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18805 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->