### PR TITLE
[view-transitions] Support chaining `:only-child` after pseudo-elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL :only-child should match because ::view-transition-group is generated for root element only promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-group is generated for multiple elements promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should match because ::view-transition-group is generated for sub element only promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-group is generated for multiple sub elements promise_test: Unhandled rejection with value: " and "
+PASS :only-child should match because ::view-transition-group is generated for root element only
+PASS :only-child should not match because ::view-transition-group is generated for multiple elements
+PASS :only-child should match because ::view-transition-group is generated for sub element only
+PASS :only-child should not match because ::view-transition-group is generated for multiple sub elements
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait foo">
 <title>View transitions: ensure :only-child is supported on view-transition-group</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -54,8 +54,7 @@ promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-group(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-group(root)");
       if (style.backgroundColor == "rgb(255, 0, 0)" && style.color == "rgb(255, 0, 0)")
         resolve();
       else
@@ -70,8 +69,7 @@ promise_test(() => {
     target.style.viewTransitionName = "target";
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-group(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-group(root)");
       if (style.backgroundColor == "rgb(0, 0, 255)" && style.color == "rgb(0, 0, 255)")
         resolve();
       else
@@ -87,8 +85,7 @@ promise_test(() => {
     target.style.viewTransitionName = "target";
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-group(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-group(target)");
       if (style.backgroundColor == "rgb(255, 0, 0)" && style.color == "rgb(255, 0, 0)")
         resolve();
       else
@@ -105,8 +102,7 @@ promise_test(() => {
     target2.style.viewTransitionName = "target2";
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-group(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-group(target)");
       if (style.backgroundColor == "rgb(0, 0, 255)" && style.color == "rgb(0, 0, 255)")
         resolve();
       else

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL :only-child should always match for ::view-transition-image-pair promise_test: Unhandled rejection with value: " and "
+PASS :only-child should always match for ::view-transition-image-pair
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait foo">
 <title>View transitions: ensure :only-child is supported on view-transition-image-pair</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -38,8 +38,7 @@ promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-image-pair(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-image-pair(root)");
       if (style.backgroundColor == "rgb(255, 0, 0)" && style.color == "rgb(255, 0, 0)")
         resolve();
       else

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL :only-child should match because ::view-transition-old is not generated (none to root) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-old is generated (root to root) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-old is generated (element to root) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should match because ::view-transition-old is not generated (none to element) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-old is generated (root to element) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-old is generated (element to element) promise_test: Unhandled rejection with value: " and "
+PASS :only-child should match because ::view-transition-old is not generated (none to root)
+PASS :only-child should not match because ::view-transition-old is generated (root to root)
+PASS :only-child should not match because ::view-transition-old is generated (element to root)
+PASS :only-child should match because ::view-transition-old is not generated (none to element)
+PASS :only-child should not match because ::view-transition-old is generated (root to element)
+PASS :only-child should not match because ::view-transition-old is generated (element to element)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait foo">
 <title>View transitions: ensure :only-child is supported on view-transition-new</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -61,8 +61,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(root)");
       if (style.backgroundColor == matchedColor && style.color == matchedColor)
         resolve();
       else
@@ -79,8 +78,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -100,8 +98,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -120,8 +117,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(target)");
       if (style.backgroundColor == matchedColor && style.color == matchedColor)
         resolve();
       else
@@ -141,8 +137,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -159,8 +154,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-new(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-new(target)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-no-transition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-no-transition.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
 <title>View transitions: :only-child style queries without transition shouldn't crash</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -21,11 +21,11 @@
 promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let elements = [
-      "view-transition",
-      "view-transition-group(foo)",
-      "view-transition-image-pair(foo)",
-      "view-transition-old(foo)",
-      "view-transition-old(foo)"
+      "::view-transition",
+      "::view-transition-group(foo)",
+      "::view-transition-image-pair(foo)",
+      "::view-transition-old(foo)",
+      "::view-transition-old(foo)"
     ];
 
     for (let i = 0; i < elements.length; i++) {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL :only-child should match because ::view-transition-new is not generated (root to none) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-new is generated (root to root) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-new is generated (root to element) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should match because ::view-transition-new is not generated (element to none) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-new is generated (element to root) promise_test: Unhandled rejection with value: " and "
-FAIL :only-child should not match because ::view-transition-new is generated (element to element) promise_test: Unhandled rejection with value: " and "
+PASS :only-child should match because ::view-transition-new is not generated (root to none)
+PASS :only-child should not match because ::view-transition-new is generated (root to root)
+PASS :only-child should not match because ::view-transition-new is generated (root to element)
+PASS :only-child should match because ::view-transition-new is not generated (element to none)
+PASS :only-child should not match because ::view-transition-new is generated (element to root)
+PASS :only-child should not match because ::view-transition-new is generated (element to element)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait foo">
 <title>View transitions: ensure :only-child is supported on view-transition-old</title>
-<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:khushalsagar@chromium.org">
 
 <script src="/resources/testharness.js"></script>
@@ -61,8 +61,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(root)");
       if (style.backgroundColor == matchedColor && style.color == matchedColor)
         resolve();
       else
@@ -79,8 +78,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -100,8 +98,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -121,7 +118,7 @@ promise_test(() => {
 
     transition.ready.then(() => {
       let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(target)");
+        document.documentElement, "::view-transition-old(target)");
       if (style.backgroundColor == matchedColor && style.color == matchedColor)
         resolve();
       else
@@ -141,8 +138,7 @@ promise_test(() => {
     });
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(root)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(root)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else
@@ -159,8 +155,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
 
     transition.ready.then(() => {
-      let style = getComputedStyle(
-        document.documentElement, ":view-transition-old(target)");
+      let style = getComputedStyle(document.documentElement, "::view-transition-old(target)");
       if (style.backgroundColor == notMatchedColor && style.color == notMatchedColor)
         resolve();
       else

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-expected.txt
@@ -7,96 +7,96 @@ PASS "::view-transition-group(*)" should be a valid selector
 PASS ":root::view-transition-group(*)" should be a valid selector
 PASS ".a::view-transition-group(*)" should be a valid selector
 PASS "div ::view-transition-group(*)" should be a valid selector
-FAIL "::view-transition-group(*):only-child" should be a valid selector '::view-transition-group(*):only-child' is not a valid selector.
-FAIL ":root::view-transition-group(*):only-child" should be a valid selector ':root::view-transition-group(*):only-child' is not a valid selector.
-FAIL ".a::view-transition-group(*):only-child" should be a valid selector '.a::view-transition-group(*):only-child' is not a valid selector.
-FAIL "div ::view-transition-group(*):only-child" should be a valid selector 'div ::view-transition-group(*):only-child' is not a valid selector.
+PASS "::view-transition-group(*):only-child" should be a valid selector
+PASS ":root::view-transition-group(*):only-child" should be a valid selector
+PASS ".a::view-transition-group(*):only-child" should be a valid selector
+PASS "div ::view-transition-group(*):only-child" should be a valid selector
 PASS "::view-transition-group(root)" should be a valid selector
 PASS ":root::view-transition-group(root)" should be a valid selector
 PASS ".a::view-transition-group(root)" should be a valid selector
 PASS "div ::view-transition-group(root)" should be a valid selector
-FAIL "::view-transition-group(root):only-child" should be a valid selector '::view-transition-group(root):only-child' is not a valid selector.
-FAIL ":root::view-transition-group(root):only-child" should be a valid selector ':root::view-transition-group(root):only-child' is not a valid selector.
-FAIL ".a::view-transition-group(root):only-child" should be a valid selector '.a::view-transition-group(root):only-child' is not a valid selector.
-FAIL "div ::view-transition-group(root):only-child" should be a valid selector 'div ::view-transition-group(root):only-child' is not a valid selector.
+PASS "::view-transition-group(root):only-child" should be a valid selector
+PASS ":root::view-transition-group(root):only-child" should be a valid selector
+PASS ".a::view-transition-group(root):only-child" should be a valid selector
+PASS "div ::view-transition-group(root):only-child" should be a valid selector
 PASS "::view-transition-group(dashed-ident)" should be a valid selector
 PASS ":root::view-transition-group(dashed-ident)" should be a valid selector
 PASS ".a::view-transition-group(dashed-ident)" should be a valid selector
 PASS "div ::view-transition-group(dashed-ident)" should be a valid selector
-FAIL "::view-transition-group(dashed-ident):only-child" should be a valid selector '::view-transition-group(dashed-ident):only-child' is not a valid selector.
-FAIL ":root::view-transition-group(dashed-ident):only-child" should be a valid selector ':root::view-transition-group(dashed-ident):only-child' is not a valid selector.
-FAIL ".a::view-transition-group(dashed-ident):only-child" should be a valid selector '.a::view-transition-group(dashed-ident):only-child' is not a valid selector.
-FAIL "div ::view-transition-group(dashed-ident):only-child" should be a valid selector 'div ::view-transition-group(dashed-ident):only-child' is not a valid selector.
+PASS "::view-transition-group(dashed-ident):only-child" should be a valid selector
+PASS ":root::view-transition-group(dashed-ident):only-child" should be a valid selector
+PASS ".a::view-transition-group(dashed-ident):only-child" should be a valid selector
+PASS "div ::view-transition-group(dashed-ident):only-child" should be a valid selector
 PASS "::view-transition-image-pair(*)" should be a valid selector
 PASS ":root::view-transition-image-pair(*)" should be a valid selector
 PASS ".a::view-transition-image-pair(*)" should be a valid selector
 PASS "div ::view-transition-image-pair(*)" should be a valid selector
-FAIL "::view-transition-image-pair(*):only-child" should be a valid selector '::view-transition-image-pair(*):only-child' is not a valid selector.
-FAIL ":root::view-transition-image-pair(*):only-child" should be a valid selector ':root::view-transition-image-pair(*):only-child' is not a valid selector.
-FAIL ".a::view-transition-image-pair(*):only-child" should be a valid selector '.a::view-transition-image-pair(*):only-child' is not a valid selector.
-FAIL "div ::view-transition-image-pair(*):only-child" should be a valid selector 'div ::view-transition-image-pair(*):only-child' is not a valid selector.
+PASS "::view-transition-image-pair(*):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(*):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(*):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(*):only-child" should be a valid selector
 PASS "::view-transition-image-pair(root)" should be a valid selector
 PASS ":root::view-transition-image-pair(root)" should be a valid selector
 PASS ".a::view-transition-image-pair(root)" should be a valid selector
 PASS "div ::view-transition-image-pair(root)" should be a valid selector
-FAIL "::view-transition-image-pair(root):only-child" should be a valid selector '::view-transition-image-pair(root):only-child' is not a valid selector.
-FAIL ":root::view-transition-image-pair(root):only-child" should be a valid selector ':root::view-transition-image-pair(root):only-child' is not a valid selector.
-FAIL ".a::view-transition-image-pair(root):only-child" should be a valid selector '.a::view-transition-image-pair(root):only-child' is not a valid selector.
-FAIL "div ::view-transition-image-pair(root):only-child" should be a valid selector 'div ::view-transition-image-pair(root):only-child' is not a valid selector.
+PASS "::view-transition-image-pair(root):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(root):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(root):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(root):only-child" should be a valid selector
 PASS "::view-transition-image-pair(dashed-ident)" should be a valid selector
 PASS ":root::view-transition-image-pair(dashed-ident)" should be a valid selector
 PASS ".a::view-transition-image-pair(dashed-ident)" should be a valid selector
 PASS "div ::view-transition-image-pair(dashed-ident)" should be a valid selector
-FAIL "::view-transition-image-pair(dashed-ident):only-child" should be a valid selector '::view-transition-image-pair(dashed-ident):only-child' is not a valid selector.
-FAIL ":root::view-transition-image-pair(dashed-ident):only-child" should be a valid selector ':root::view-transition-image-pair(dashed-ident):only-child' is not a valid selector.
-FAIL ".a::view-transition-image-pair(dashed-ident):only-child" should be a valid selector '.a::view-transition-image-pair(dashed-ident):only-child' is not a valid selector.
-FAIL "div ::view-transition-image-pair(dashed-ident):only-child" should be a valid selector 'div ::view-transition-image-pair(dashed-ident):only-child' is not a valid selector.
+PASS "::view-transition-image-pair(dashed-ident):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(dashed-ident):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(dashed-ident):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(dashed-ident):only-child" should be a valid selector
 PASS "::view-transition-old(*)" should be a valid selector
 PASS ":root::view-transition-old(*)" should be a valid selector
 PASS ".a::view-transition-old(*)" should be a valid selector
 PASS "div ::view-transition-old(*)" should be a valid selector
-FAIL "::view-transition-old(*):only-child" should be a valid selector '::view-transition-old(*):only-child' is not a valid selector.
-FAIL ":root::view-transition-old(*):only-child" should be a valid selector ':root::view-transition-old(*):only-child' is not a valid selector.
-FAIL ".a::view-transition-old(*):only-child" should be a valid selector '.a::view-transition-old(*):only-child' is not a valid selector.
-FAIL "div ::view-transition-old(*):only-child" should be a valid selector 'div ::view-transition-old(*):only-child' is not a valid selector.
+PASS "::view-transition-old(*):only-child" should be a valid selector
+PASS ":root::view-transition-old(*):only-child" should be a valid selector
+PASS ".a::view-transition-old(*):only-child" should be a valid selector
+PASS "div ::view-transition-old(*):only-child" should be a valid selector
 PASS "::view-transition-old(root)" should be a valid selector
 PASS ":root::view-transition-old(root)" should be a valid selector
 PASS ".a::view-transition-old(root)" should be a valid selector
 PASS "div ::view-transition-old(root)" should be a valid selector
-FAIL "::view-transition-old(root):only-child" should be a valid selector '::view-transition-old(root):only-child' is not a valid selector.
-FAIL ":root::view-transition-old(root):only-child" should be a valid selector ':root::view-transition-old(root):only-child' is not a valid selector.
-FAIL ".a::view-transition-old(root):only-child" should be a valid selector '.a::view-transition-old(root):only-child' is not a valid selector.
-FAIL "div ::view-transition-old(root):only-child" should be a valid selector 'div ::view-transition-old(root):only-child' is not a valid selector.
+PASS "::view-transition-old(root):only-child" should be a valid selector
+PASS ":root::view-transition-old(root):only-child" should be a valid selector
+PASS ".a::view-transition-old(root):only-child" should be a valid selector
+PASS "div ::view-transition-old(root):only-child" should be a valid selector
 PASS "::view-transition-old(dashed-ident)" should be a valid selector
 PASS ":root::view-transition-old(dashed-ident)" should be a valid selector
 PASS ".a::view-transition-old(dashed-ident)" should be a valid selector
 PASS "div ::view-transition-old(dashed-ident)" should be a valid selector
-FAIL "::view-transition-old(dashed-ident):only-child" should be a valid selector '::view-transition-old(dashed-ident):only-child' is not a valid selector.
-FAIL ":root::view-transition-old(dashed-ident):only-child" should be a valid selector ':root::view-transition-old(dashed-ident):only-child' is not a valid selector.
-FAIL ".a::view-transition-old(dashed-ident):only-child" should be a valid selector '.a::view-transition-old(dashed-ident):only-child' is not a valid selector.
-FAIL "div ::view-transition-old(dashed-ident):only-child" should be a valid selector 'div ::view-transition-old(dashed-ident):only-child' is not a valid selector.
+PASS "::view-transition-old(dashed-ident):only-child" should be a valid selector
+PASS ":root::view-transition-old(dashed-ident):only-child" should be a valid selector
+PASS ".a::view-transition-old(dashed-ident):only-child" should be a valid selector
+PASS "div ::view-transition-old(dashed-ident):only-child" should be a valid selector
 PASS "::view-transition-new(*)" should be a valid selector
 PASS ":root::view-transition-new(*)" should be a valid selector
 PASS ".a::view-transition-new(*)" should be a valid selector
 PASS "div ::view-transition-new(*)" should be a valid selector
-FAIL "::view-transition-new(*):only-child" should be a valid selector '::view-transition-new(*):only-child' is not a valid selector.
-FAIL ":root::view-transition-new(*):only-child" should be a valid selector ':root::view-transition-new(*):only-child' is not a valid selector.
-FAIL ".a::view-transition-new(*):only-child" should be a valid selector '.a::view-transition-new(*):only-child' is not a valid selector.
-FAIL "div ::view-transition-new(*):only-child" should be a valid selector 'div ::view-transition-new(*):only-child' is not a valid selector.
+PASS "::view-transition-new(*):only-child" should be a valid selector
+PASS ":root::view-transition-new(*):only-child" should be a valid selector
+PASS ".a::view-transition-new(*):only-child" should be a valid selector
+PASS "div ::view-transition-new(*):only-child" should be a valid selector
 PASS "::view-transition-new(root)" should be a valid selector
 PASS ":root::view-transition-new(root)" should be a valid selector
 PASS ".a::view-transition-new(root)" should be a valid selector
 PASS "div ::view-transition-new(root)" should be a valid selector
-FAIL "::view-transition-new(root):only-child" should be a valid selector '::view-transition-new(root):only-child' is not a valid selector.
-FAIL ":root::view-transition-new(root):only-child" should be a valid selector ':root::view-transition-new(root):only-child' is not a valid selector.
-FAIL ".a::view-transition-new(root):only-child" should be a valid selector '.a::view-transition-new(root):only-child' is not a valid selector.
-FAIL "div ::view-transition-new(root):only-child" should be a valid selector 'div ::view-transition-new(root):only-child' is not a valid selector.
+PASS "::view-transition-new(root):only-child" should be a valid selector
+PASS ":root::view-transition-new(root):only-child" should be a valid selector
+PASS ".a::view-transition-new(root):only-child" should be a valid selector
+PASS "div ::view-transition-new(root):only-child" should be a valid selector
 PASS "::view-transition-new(dashed-ident)" should be a valid selector
 PASS ":root::view-transition-new(dashed-ident)" should be a valid selector
 PASS ".a::view-transition-new(dashed-ident)" should be a valid selector
 PASS "div ::view-transition-new(dashed-ident)" should be a valid selector
-FAIL "::view-transition-new(dashed-ident):only-child" should be a valid selector '::view-transition-new(dashed-ident):only-child' is not a valid selector.
-FAIL ":root::view-transition-new(dashed-ident):only-child" should be a valid selector ':root::view-transition-new(dashed-ident):only-child' is not a valid selector.
-FAIL ".a::view-transition-new(dashed-ident):only-child" should be a valid selector '.a::view-transition-new(dashed-ident):only-child' is not a valid selector.
-FAIL "div ::view-transition-new(dashed-ident):only-child" should be a valid selector 'div ::view-transition-new(dashed-ident):only-child' is not a valid selector.
+PASS "::view-transition-new(dashed-ident):only-child" should be a valid selector
+PASS ":root::view-transition-new(dashed-ident):only-child" should be a valid selector
+PASS ".a::view-transition-new(dashed-ident):only-child" should be a valid selector
+PASS "div ::view-transition-new(dashed-ident):only-child" should be a valid selector
 

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -117,6 +117,7 @@ private:
     bool matchHasPseudoClass(CheckingContext&, const Element&, const CSSSelector&) const;
 
     bool checkScrollbarPseudoClass(const CheckingContext&, const Element&, const CSSSelector&) const;
+    bool checkViewTransitionPseudoClass(const CheckingContext&, const Element&, const CSSSelector&) const;
 
     bool m_strictParsing;
     bool m_documentIsHTML;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -454,6 +454,11 @@ static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClass pseudo
         return isScrollbarPseudoClass(pseudoClass);
     case CSSSelector::PseudoElement::Selection:
         return pseudoClass == CSSSelector::PseudoClass::WindowInactive;
+    case CSSSelector::PseudoElement::ViewTransitionGroup:
+    case CSSSelector::PseudoElement::ViewTransitionImagePair:
+    case CSSSelector::PseudoElement::ViewTransitionNew:
+    case CSSSelector::PseudoElement::ViewTransitionOld:
+        return pseudoClass == CSSSelector::PseudoClass::OnlyChild;
     case CSSSelector::PseudoElement::UserAgentPart:
     case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:
     case CSSSelector::PseudoElement::WebKitUnknown:

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -52,7 +52,9 @@ enum class ViewTransitionPhase : uint8_t {
 struct CapturedElement {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    RefPtr<ImageBuffer> oldImage;
+    // std::nullopt represents an non-capturable element.
+    // nullptr represents an absent snapshot on an capturable element.
+    std::optional<RefPtr<ImageBuffer>> oldImage;
     LayoutRect oldOverflowRect;
     LayoutSize oldSize;
     RefPtr<MutableStyleProperties> oldProperties;
@@ -98,6 +100,11 @@ public:
     bool isEmpty() const
     {
         return m_keys.isEmpty();
+    }
+
+    size_t size() const
+    {
+        return m_keys.size();
     }
 
     CapturedElement* find(const AtomString& key)


### PR DESCRIPTION
#### d1418bf98d34738599cef6f5f77255c3174f6a8f
<pre>
[view-transitions] Support chaining `:only-child` after pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=265223">https://bugs.webkit.org/show_bug.cgi?id=265223</a>
<a href="https://rdar.apple.com/118703154">rdar://118703154</a>

Reviewed by Antti Koivisto.

::view-transition-group(name):only-child matches a group with no siblings.

::view-transition-image-pair(name):only-child should always match, since there is only one image-pair.

::view-transition-old(name):only-child matches an old capture with no associated new element.

::view-transition-new(name):only-child matches a new element with no associated old capture.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-no-transition.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-expected.txt:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::LocalContext::LocalContext):
(WebCore::SelectorChecker::match const):
(WebCore::SelectorChecker::matchHostPseudoClass const):
(WebCore::hasViewTransitionPseudoElement):
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::matchHasPseudoClass const):
(WebCore::SelectorChecker::checkViewTransitionPseudoClass const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isPseudoClassValidAfterPseudoElement):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::OrderedNamedElementsMap::size const):
(WebCore::OrderedNamedElementsMap::find const):
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::createRendererIfNeeded):

Canonical link: <a href="https://commits.webkit.org/275841@main">https://commits.webkit.org/275841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c62b10914eb3b9872b0c1093be0ee0f8445d69d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39157 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/45338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19481 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43605 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1088 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47190 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/37384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5827 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->