### PR TITLE
[Skia] Fix double-free in WebKitTestRunner

### DIFF
--- a/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
+++ b/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
@@ -165,7 +165,7 @@ PlatformImage HeadlessViewBackend::snapshot()
 #if defined(USE_CAIRO) && USE_CAIRO
     return cairo_surface_reference(m_snapshot);
 #elif defined(USE_SKIA) && USE_SKIA
-    return m_snapshot.get();
+    return SkRef(m_snapshot.get());
 #endif
 }
 


### PR DESCRIPTION
#### 669cd08179b221aa3a22360738e260d1caef5a4b
<pre>
[Skia] Fix double-free in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=270585">https://bugs.webkit.org/show_bug.cgi?id=270585</a>

Reviewed by Carlos Garcia Campos and Adrian Perez de Castro.

sk_sp::get() returns a raw pointer without increasing
the reference count. To preserve semantics we need
to explicitly increase it when returning the snapshot,
otherwise we risk a double-free.

* Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp:
(WPEToolingBackends::HeadlessViewBackend::snapshot):

Canonical link: <a href="https://commits.webkit.org/275784@main">https://commits.webkit.org/275784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/999bcdefa6d6bdacd778f03a9331497c17f5f835

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42832 "Failed to checkout and rebase branch from PR 25543") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38957 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45138 "Failed to checkout and rebase branch from PR 25543") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19233 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/43405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18873 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/888 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39003 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/46967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17659 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42177 "layout-tests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19284 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19448 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5797 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->