### PR TITLE
REGRESSION (iOS 17): Video bug z-index pointer-events doesn't work well

### DIFF
--- a/LayoutTests/fast/scrolling/ios/video-atop-overflow-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/video-atop-overflow-scroll-expected.txt
@@ -1,0 +1,9 @@
+
+This tests the ability of a video element with pointer-events: none to be placed atop a div with overflow: none, and that scrolling div retaining the ability to scroll.
+RUN(video.src = findMediaFile("video", "../../../media/content/test"))
+RUN(video.play())
+Promise resolved OK
+Simulate drag on video element
+EVENT(scroll)
+END OF TEST
+

--- a/LayoutTests/fast/scrolling/ios/video-atop-overflow-scroll.html
+++ b/LayoutTests/fast/scrolling/ios/video-atop-overflow-scroll.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>video-scrolling</title>
+    <script src=../../../media/video-test.js></script>
+    <script src=../../../media/media-file.js></script>
+    <script src=../../../resources/basic-gestures.js></script>
+    <script>
+    async function runTest() {
+        findMediaElement();
+        run('video.src = findMediaFile("video", "../../../media/content/test")');
+        await shouldResolve(run('video.play()'));
+
+        consoleWrite('Simulate drag on video element');
+
+        let middleX = video.offsetLeft + video.offsetWidth / 2;
+        let middleY = video.offsetTop + video.offsetHeight / 2;
+        let scrollPromise = waitFor(scroller, 'scroll');
+
+        // It may require multiple attempts to scroll the video to succeed
+        while (scroller.scrollTop === 0) {
+            await tapAtPoint(middleX, middleY);
+            await touchAndDragFromPointToPoint(middleX, middleY, middleX, 0);
+            await Promise.race([scrollPromise, sleepFor(100)]);
+        }
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+    </script>
+    <style>
+        body {
+            overflow: hidden;
+        }
+        #container {
+            display: inline-block;
+            position: relative;
+        }
+        video {
+            pointer-events: none;
+            position: relative;
+            z-index: 2;
+        }
+        #scroller {
+            position:absolute;
+            top: 0;
+            height: 100%;
+            width: 100%;
+            overflow-x: hidden;
+            overflow-y: scroll;
+            z-index: 1;
+        }
+        .spacer {
+            width: 100%;
+            min-height: 100%;
+        }
+    </style>
+</head>
+<body>
+    <div id="container">
+        <video muted playsinline></video>
+        <div id="scroller">
+            <div class=spacer></div>
+            <div class=spacer></div>
+        </div>
+    </div>
+    <div>This tests the ability of a video element with <code>pointer-events: none</code> to be placed atop a div with <code>overflow: none</code>, and that scrolling div retaining the ability to scroll.</div>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4790,7 +4790,6 @@ webkit.org/b/271207 http/wpt/webauthn/public-key-credential-create-success-local
 webkit.org/b/271207 http/wpt/webauthn/public-key-credential-get-success-local.https.html [ Failure ]
 webkit.org/b/271207 http/wpt/webauthn/public-key-credential-get-failure-local.https.html [ Failure ]
 
-
 # --- imported from ios-wk2 ---
 
 # Animation tests with issues
@@ -7355,3 +7354,5 @@ tables/mozilla/bugs/bug2479-2.html [ Failure Pass ]
 # webkit.org/b/271792 [ MacOS iOS ] 2x fast/url/* (layout-tests) are constant text failures
 fast/url/idna2008.html [ Failure ]
 fast/url/url-hostname-encoding.html [ Failure ]
+
+webkit.org/b/271764 fast/scrolling/ios/video-atop-overflow-scroll.html [ Pass Failure ]

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -755,6 +755,9 @@ RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWit
     RetainPtr<WKLayerHostView> view = static_cast<WKLayerHostView*>(model->layerHostView());
     if (!view) {
         view = adoptNS([[WKLayerHostView alloc] init]);
+#if PLATFORM(IOS_FAMILY)
+        [view setUserInteractionEnabled:NO];
+#endif
 #if PLATFORM(MAC)
         [view setWantsLayer:YES];
 #endif
@@ -822,6 +825,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
         [playerLayer setVideoSublayer:[view layer]];
 
         [playerView addSubview:view.get()];
+        [playerView setUserInteractionEnabled:NO];
 
         // The videoView may already be reparented in fullscreen, so only parent the view
         // if it has no existing parent:


### PR DESCRIPTION
#### 3ee555da60e64a8fcdadcd1541e66eaeb6763a2f
<pre>
REGRESSION (iOS 17): Video bug z-index pointer-events doesn&apos;t work well
<a href="https://bugs.webkit.org/show_bug.cgi?id=265520">https://bugs.webkit.org/show_bug.cgi?id=265520</a>
<a href="https://rdar.apple.com/118936715">rdar://118936715</a>

Reviewed by Eric Carlson.

When a video is placed atop a scrolling element, the hit test machinery walks over the compositing
views that make up the compositing heirarchy, searching for views which are &quot;hit test&quot; targets.
For any view which is a subclass of WKCompositingView, collectDescendantViewsInRect() will query
that view&apos;s associated Node to tell if it&apos;s a hit test target. Any UIView that is _not_ a subclass
of WKCompositingView is assumed to be a hit-test target unless it specifically opts-out of hit
testing via -isUserInteractionEnabled. The subviews of WKVideoView (itself a subclass of
WKCompositingView) have not opted out of hit testing, so are selected as a hit testing view.

Opt out these utility views by setting their userInteractionEnabled property to NO.

* LayoutTests/fast/scrolling/ios/video-atop-overflow-scroll-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/video-atop-overflow-scroll.html: Added.
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::createViewWithID):

Canonical link: <a href="https://commits.webkit.org/276807@main">https://commits.webkit.org/276807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2893f3fa740ecf4818997d0c44999e64b917540

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48402 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41767 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22257 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18597 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40544 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3776 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50154 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44555 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43404 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10157 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->