### PR TITLE
Add myself as a contributor of the WebKit repository

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -40,6 +40,7 @@
 #if TARGET_OS_IPHONE
 @class UIMenuElement;
 #else
+@class NSEvent;
 @class NSMenuItem;
 #endif
 
@@ -364,6 +365,12 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @discussion The extension context will still need to be loaded and have granted website permissions for its content to actually be injected.
  */
 - (BOOL)hasInjectedContentForURL:(NSURL *)url;
+
+/*!
+ @abstract A boolean value indicating whether the extension includes rules used for content modification or blocking.
+ @discussion This includes both static rules available in the extension's manifest and dynamic rules applied during a browsing session.
+ */
+@property (nonatomic, readonly) BOOL hasContentModificationRules;
 
 /*!
  @abstract Checks the specified permission against the currently denied, granted, and requested permissions.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -510,6 +510,11 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     return _webExtensionContext->hasInjectedContentForURL(url);
 }
 
+- (BOOL)hasContentModificationRules
+{
+    return _webExtensionContext->hasContentModificationRules();
+}
+
 - (_WKWebExtensionAction *)actionForTab:(id<_WKWebExtensionTab>)tab
 {
     if (tab)
@@ -1032,6 +1037,11 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (BOOL)hasInjectedContentForURL:(NSURL *)url
+{
+    return NO;
+}
+
+- (BOOL)hasContentModificationRules
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3704,6 +3704,11 @@ void WebExtensionContext::addDeclarativeNetRequestRulesToPrivateUserContentContr
     });
 }
 
+bool WebExtensionContext::hasContentModificationRules()
+{
+    return declarativeNetRequestEnabledRulesetCount() || !m_sessionRulesIDs.isEmpty() || !m_dynamicRulesIDs.isEmpty();
+}
+
 static NSString *computeStringHashForContentBlockerRules(NSString *rules)
 {
     SHA1 sha1;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -285,6 +285,8 @@ public:
     bool hasInjectedContentForURL(const URL&);
     bool hasInjectedContent();
 
+    bool hasContentModificationRules();
+
     URL optionsPageURL() const;
     URL overrideNewTabPageURL() const;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -526,9 +526,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionDeclarativeNetRequest];
 
+    EXPECT_FALSE(manager.get().context.hasContentModificationRules);
+
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+    EXPECT_TRUE(manager.get().context.hasContentModificationRules);
 
     auto webView = manager.get().defaultTab.mainWebView;
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
@@ -582,9 +585,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionDeclarativeNetRequest];
 
+    EXPECT_FALSE(manager.get().context.hasContentModificationRules);
+
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Unload extension");
+    EXPECT_TRUE(manager.get().context.hasContentModificationRules);
 
     auto *storageDirectory = manager.get().controller.configuration._storageDirectoryPath;
     storageDirectory = [storageDirectory stringByAppendingPathComponent:manager.get().context.uniqueIdentifier];

--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -2566,6 +2566,15 @@
    },
    {
       "emails" : [
+         "elijahsawyers@gmail.com",
+         "esawyers@apple.com"
+      ],
+      "github" : "elijahsawyers",
+      "name" : "Elijah Sawyers",
+      "status" : "committer"
+   },
+   {
+      "emails" : [
          "fantasai.bugs@inkedblade.net",
          "fantasai@apple.com"
       ],


### PR DESCRIPTION
#### f54ccc2743abf01915ff6a43024311503e454bd8
<pre>
Add myself as a contributor of the WebKit repository

Reviewed by NOBODY (OOPS!).

* metadata/contributors.json:
</pre>
----------------------------------------------------------------------
#### 0138b6b6e25b58ab579a8d961c919fac65c08c68
<pre>
Reload without content blockers may not appear for extensions that use DNR
<a href="https://webkit.org/b/270552">https://webkit.org/b/270552</a>
<a href="https://rdar.apple.com/124033486">rdar://124033486</a>

Reviewed by NOBODY (OOPS!).

Clients need to be aware of whether or not a web extension context has any
content modification rules rules. This patch adds a new property to expose
that information.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext hasContentModificationRules]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::hasContentModificationRules):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f54ccc2743abf01915ff6a43024311503e454bd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/42747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/21768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/45148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45359 "Failed to checkout and rebase branch from PR 25549") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38871 "Failed to checkout and rebase branch from PR 25549") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/45053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25435 "Failed to checkout and rebase branch from PR 25549") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/19133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/45359 "Failed to checkout and rebase branch from PR 25549") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/43320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/25435 "Failed to checkout and rebase branch from PR 25549") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/45148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/45359 "Failed to checkout and rebase branch from PR 25549") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/42617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/25435 "Failed to checkout and rebase branch from PR 25549") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/45148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/25435 "Failed to checkout and rebase branch from PR 25549") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/45148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46868 "Failed to checkout and rebase branch from PR 25549") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/19133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/46868 "Failed to checkout and rebase branch from PR 25549") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/45148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/46868 "Failed to checkout and rebase branch from PR 25549") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->