### PR TITLE
[Text Extraction] Ignore transparent (or nearly-transparent) elements when extracting text

### DIFF
--- a/LayoutTests/fast/text-extraction/basic-text-extraction.html
+++ b/LayoutTests/fast/text-extraction/basic-text-extraction.html
@@ -6,6 +6,10 @@
 body {
     white-space: pre-wrap;
 }
+
+.transparent {
+    opacity: 0;
+}
 </style>
 <script src="../../resources/ui-helper.js"></script>
 </head>
@@ -17,6 +21,7 @@ body {
     <li><a href="https://example.com">Link in list item</a></li>
     <li><img src="../images/resources/green-256x256.jpg" alt="Green square" /></li>
 </ul>
+<div class="transparent"><p>This transparent text should not be extracted</p></div>
 <div contenteditable="true">This is an editable area: <a href="https://webkit.org">WebKit</a> <a href="https://webkit.org/downloads">downloads</a>.</div>
 <script>
 addEventListener("load", async () => {


### PR DESCRIPTION
#### e23f17abb853a4aab8361f679ed5ca467d6e46fa
<pre>
[Text Extraction] Ignore transparent (or nearly-transparent) elements when extracting text
<a href="https://bugs.webkit.org/show_bug.cgi?id=270598">https://bugs.webkit.org/show_bug.cgi?id=270598</a>
<a href="https://rdar.apple.com/124102506">rdar://124102506</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

When extracting visible text, ignore subtrees where the renderer is transparent (or nearly
transparent). To do this, we adjust `extractItemData` to return an enum (`SkipExtraction`)
indicating whether we should skip text extraction for just the current node, or for the entire
subtree; we then use this to skip subtrees where there is either no renderer (i.e. `display: none;`)
or the opacity is near 0.

* LayoutTests/fast/text-extraction/basic-text-extraction.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractRenderedText):

Canonical link: <a href="https://commits.webkit.org/275769@main">https://commits.webkit.org/275769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e13df5661043d5c16d750b9342e5061c446fbb80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35384 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37856 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/808 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46874 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42112 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37125 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40741 "Found 2 new API test failures: /WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9545 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->