### PR TITLE
Implement invoke defaults for popover

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
@@ -1,22 +1,23 @@
 
 
-FAIL invoking (as auto) closed popover opens assert_true: expected true got false
+PASS invoking (as auto) closed popover opens
 PASS invoking (as auto) closed popover with preventDefault does not open
+PASS changing invokeaction attribute inside invokeevent doesn't impact the invocation
 PASS invoking (as auto) open popover closes
-FAIL invoking (as auto) from within open popover closes assert_false: expected false got true
+PASS invoking (as auto) from within open popover closes
 PASS invoking (as auto) open popover with preventDefault does not close
-FAIL invoking (as togglepopover) closed popover opens assert_true: expected true got false
-FAIL invoking (as togglepopover - case insensitive) closed popover opens assert_true: expected true got false
+PASS invoking (as togglepopover) closed popover opens
+PASS invoking (as togglepopover - case insensitive) closed popover opens
 PASS invoking (as togglepopover) closed popover with preventDefault does not open
 PASS invoking (as togglepopover) open popover closes
-FAIL invoking (as togglepopover) from within open popover closes assert_false: expected false got true
+PASS invoking (as togglepopover) from within open popover closes
 PASS invoking (as togglepopover) open popover with preventDefault does not close
-FAIL invoking (as showpopover) closed popover opens assert_true: expected true got false
-FAIL invoking (as showpopover - case insensitive) closed popover opens assert_true: expected true got false
-FAIL invoking (as showpopover) open popover is noop assert_true: expected true got false
+PASS invoking (as showpopover) closed popover opens
+PASS invoking (as showpopover - case insensitive) closed popover opens
+PASS invoking (as showpopover) open popover is noop
 PASS invoking (as showpopover) closed popover with preventDefault does not open
 PASS invoking (as hidepopover) closed popover is noop
-FAIL invoking (as hidepopover) open popover closes assert_false: expected false got true
-FAIL invoking (as hidepopover - case insensitive) open popover closes assert_false: expected false got true
+PASS invoking (as hidepopover) open popover closes
+PASS invoking (as hidepopover - case insensitive) open popover closes
 PASS invoking (as hidepopover) open popover with preventDefault does not close
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
@@ -35,6 +35,19 @@
   }, "invoking (as auto) closed popover with preventDefault does not open");
 
   promise_test(async function (t) {
+    assert_false(invokee.matches(":popover-open"));
+    invokee.addEventListener("invoke", (e) => { invokerbutton.setAttribute('invokeaction', 'hidepopover'); }, {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    t.add_cleanup(() => {
+      invokee.hidePopover();
+      invokerbutton.removeAttribute("invokeaction");
+    });
+    assert_true(invokee.matches(":popover-open"));
+  }, "changing invokeaction attribute inside invokeevent doesn't impact the invocation");
+
+  promise_test(async function (t) {
     invokee.showPopover();
     assert_true(invokee.matches(":popover-open"));
     await clickOn(invokerbutton);

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
@@ -2,6 +2,7 @@
 
 FAIL invoking (as auto) closed popover opens assert_true: expected true got false
 PASS invoking (as auto) closed popover with preventDefault does not open
+FAIL changing invokeaction attribute inside invokeevent doesn't impact the invocation assert_true: expected true got false
 FAIL invoking (as auto) open popover closes assert_false: expected false got true
 FAIL invoking (as auto) from within open popover closes assert_false: expected false got true
 PASS invoking (as auto) open popover with preventDefault does not close

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9756,7 +9756,9 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
 
                     if (!invokerPopover) {
                         if (RefPtr button = dynamicDowncast<HTMLFormControlElement>(*htmlElement)) {
-                            if (RefPtr popover = button->popoverTargetElement(); popover && isShowingAutoPopover(*popover))
+                            if (RefPtr popover = dynamicDowncast<HTMLElement>(button->invokeTargetElement()); popover && isShowingAutoPopover(*popover))
+                                invokerPopover = WTFMove(popover);
+                            else if (RefPtr popover = button->popoverTargetElement(); popover && isShowingAutoPopover(*popover))
                                 invokerPopover = WTFMove(popover);
                         }
                     }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -64,6 +64,7 @@ class ElementRareData;
 class FormAssociatedCustomElement;
 class FormListedElement;
 class HTMLDocument;
+class HTMLFormControlElement;
 class IntSize;
 class JSCustomElementInterface;
 class KeyframeEffectStack;
@@ -620,7 +621,7 @@ public:
     void clearPopoverData();
     bool isPopoverShowing() const;
 
-    virtual void handleInvokeInternal(const AtomString&) { }
+    virtual bool handleInvokeInternal(const HTMLFormControlElement&, const AtomString&) { return false; }
 
     ExceptionOr<void> setPointerCapture(int32_t);
     ExceptionOr<void> releasePointerCapture(int32_t);

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1573,6 +1573,36 @@ void HTMLElement::popoverAttributeChanged(const AtomString& value)
         ensurePopoverData().setPopoverState(newPopoverState);
 }
 
+constexpr ASCIILiteral togglePopoverLiteral = "togglepopover"_s;
+constexpr ASCIILiteral showPopoverLiteral = "showpopover"_s;
+constexpr ASCIILiteral hidePopoverLiteral = "hidepopover"_s;
+
+bool HTMLElement::handleInvokeInternal(const HTMLFormControlElement& invoker, const AtomString& action)
+{
+    if (popoverState() == PopoverState::None)
+        return false;
+
+    if (isPopoverShowing()) {
+        bool shouldHide = action.isEmpty()
+            || equalLettersIgnoringASCIICase(action, togglePopoverLiteral)
+            || equalLettersIgnoringASCIICase(action, hidePopoverLiteral);
+        if (shouldHide) {
+            hidePopover();
+            return true;
+        }
+    } else {
+        bool shouldShow = action.isEmpty()
+            || equalLettersIgnoringASCIICase(action, togglePopoverLiteral)
+            || equalLettersIgnoringASCIICase(action, showPopoverLiteral);
+        if (shouldShow) {
+            showPopover(&invoker);
+            return true;
+        }
+    }
+
+    return false;
+}
+
 const AtomString& HTMLElement::popover() const
 {
     switch (popoverState()) {

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -160,6 +160,8 @@ public:
     void setPopover(const AtomString& value) { setAttributeWithoutSynchronization(HTMLNames::popoverAttr, value); };
     void popoverAttributeChanged(const AtomString& value);
 
+    bool handleInvokeInternal(const HTMLFormControlElement& invoker, const AtomString& action) final;
+
 #if PLATFORM(IOS_FAMILY)
     static SelectionRenderingBehavior selectionRenderingBehavior(const Node*);
 #endif

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -447,7 +447,7 @@ void HTMLFormControlElement::handleInvokeAction()
     invokee->dispatchEvent(event);
 
     if (!event->defaultPrevented())
-        invokee->handleInvokeInternal(action);
+        invokee->handleInvokeInternal(*this, action);
 }
 
 // FIXME: We should remove the quirk once <rdar://problem/47334655> is fixed.


### PR DESCRIPTION
#### 8b3a40134afa148adf04eeae3ca908ce0f5a1c40
<pre>
Implement invoke defaults for popover
<a href="https://bugs.webkit.org/show_bug.cgi?id=263513">https://bugs.webkit.org/show_bug.cgi?id=263513</a>

Reviewed by Darin Adler.

This adds the `handleInvokeInternal` logic to toggle popovers.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::handlePopoverLightDismiss):
* Source/WebCore/dom/Element.h:
(WebCore::Element::handleInvokeInternal):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::handleInvokeInternal):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::handleInvokeAction):

Canonical link: <a href="https://commits.webkit.org/276694@main">https://commits.webkit.org/276694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791f253434d2a079aa4a3f999fb9e1faf761269d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37195 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40210 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3401 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41640 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49736 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44243 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43055 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10093 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->