### PR TITLE
[webkitbugspy] Opening radars and setting status should be conditional on existing properties

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -441,6 +441,11 @@ class Tracker(GenericTracker):
 
         return issue
 
+    def open(self, issue, why):
+        if issue.opened:
+            return False
+        return self.set(issue, opened=True, why=why)
+
     def add_comment(self, issue, text):
         response = None
         try:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -448,6 +448,11 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             sys.stderr.write('Could not assign {} to issue'.format(missed_assignees))
         return response_assignees
 
+    def open(self, issue, why):
+        if issue.opened:
+            return False
+        return self.set(issue, opened=True, why=why)
+
     def add_comment(self, issue, text):
         data = self.request(
             'issues/{id}/comments'.format(id=issue.id),

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -119,9 +119,7 @@ class Issue(object):
         return self._opened
 
     def open(self, why=None):
-        if self.opened:
-            return False
-        return bool(self.tracker.set(self, opened=True, why=why))
+        return bool(self.tracker.open(self, why=why))
 
     def close(self, why=None, original=None):
         if not self.opened:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -393,6 +393,20 @@ class Tracker(GenericTracker):
             radar.commit_changes()
         return self.add_comment(issue, why) if why else issue
 
+    def open(self, issue, why):
+        if not self.client or not self.library:
+            sys.stderr.write('radarclient inaccessible on this machine\n')
+            return None
+
+        radar = self.client.radar_for_id(issue.id)
+        if not radar:
+            sys.stderr.write("Failed to fetch '{}'\n".format(issue.link))
+            return None
+
+        if issue.opened and radar.state != 'Integrate':
+            return False
+        return self.set(issue, opened=True, why=why)
+
     def add_comment(self, issue, text):
         if not self.client or not self.library:
             sys.stderr.write('radarclient inaccessible on this machine\n')

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
@@ -180,6 +180,9 @@ class Tracker(object):
     def set(self, issue, **properties):
         raise NotImplementedError()
 
+    def open(self, issue, why):
+        raise NotImplementedError()
+
     def relate(self, issue, **relations):
         raise NotImplementedError()
 


### PR DESCRIPTION
#### fb1af533a5576fe4c63a33b26fe13ad4e5d861aa
<pre>
[webkitbugspy] Opening radars and setting status should be conditional on existing properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=270601">https://bugs.webkit.org/show_bug.cgi?id=270601</a>
<a href="https://rdar.apple.com/124165667">rdar://124165667</a>

Reviewed by NOBODY (OOPS!).

Implement Tracker.open to check if a radar is in Integrate and keep other bug behaviour the same.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.open):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.open):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.open):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py:
(Tracker.open):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb1af533a5576fe4c63a33b26fe13ad4e5d861aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38882 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35387 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16346 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/42628 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37858 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/814 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42115 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19195 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40744 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->