### PR TITLE
Null check buffer in GPUCanvasContextCocoa::drawBufferToCanvas

### DIFF
--- a/LayoutTests/fast/webgpu/draw-null-buffer-to-canvas-expected.txt
+++ b/LayoutTests/fast/webgpu/draw-null-buffer-to-canvas-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/draw-null-buffer-to-canvas.html
+++ b/LayoutTests/fast/webgpu/draw-null-buffer-to-canvas.html
@@ -1,0 +1,33 @@
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+onload = async () => {
+    try {
+        let offscreenCanvas4 = new OffscreenCanvas(418158253, 427);
+
+        let adapter3 = await navigator.gpu.requestAdapter();
+        let promise1 = adapter3.requestDevice(
+        {
+        label: '\u3170',
+        }
+        );
+        let device3 = await promise1;
+        let gpuCanvasContext2 = offscreenCanvas4.getContext('webgpu');
+        gpuCanvasContext2.configure(
+        {
+        device: device3,
+        format: 'rgba16float',
+        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+        viewFormats: [
+        'rgba16float',
+        'rgba8unorm-srgb'
+        ],
+        colorSpace: 'srgb',
+        alphaMode: 'premultiplied',
+        }
+        );
+        let videoFrame12 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+    } catch { }
+    if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash.

--- a/LayoutTests/platform/ios/fast/webgpu/draw-null-buffer-to-canvas-expected.txt
+++ b/LayoutTests/platform/ios/fast/webgpu/draw-null-buffer-to-canvas-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -177,7 +177,7 @@ void GPUCanvasContextCocoa::drawBufferToCanvas(SurfaceBuffer)
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=263957): WebGPU should support obtaining drawing buffer for Web Inspector.
     auto& base = canvasBase();
     base.clearCopiedImage();
-    if (auto buffer = base.buffer(); m_configuration.has_value()) {
+    if (auto buffer = base.buffer(); buffer && m_configuration) {
         buffer->flushDrawingContext();
         m_compositorIntegration->paintCompositedResultsToCanvas(*buffer, m_configuration->frameCount);
     }


### PR DESCRIPTION
#### 88b3ecbe50b9c2b2fb330ede40e092d730a8a365
<pre>
Null check buffer in GPUCanvasContextCocoa::drawBufferToCanvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=270599">https://bugs.webkit.org/show_bug.cgi?id=270599</a>
<a href="https://rdar.apple.com/124143249">rdar://124143249</a>

Reviewed by Mike Wyrzykowski.

* LayoutTests/fast/webgpu/draw-null-buffer-to-canvas-expected.txt: Added.
* LayoutTests/fast/webgpu/draw-null-buffer-to-canvas.html: Added.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::drawBufferToCanvas):

Canonical link: <a href="https://commits.webkit.org/275770@main">https://commits.webkit.org/275770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3277cf07ad561f8845f7dec7a3f790eee602f0d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38903 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19175 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37878 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/835 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46901 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14506 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42132 "Found 1 new test failure: fast/webgpu/draw-null-buffer-to-canvas.html (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40765 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19395 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5791 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18861 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->