### PR TITLE
WKInactiveSchedulingPolicyThrottle / WKInactiveSchedulingPolicyNone may still cause process suspension

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -187,14 +187,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     case WKInactiveSchedulingPolicySuspend:
         _preferences->setShouldTakeNearSuspendedAssertions(false);
         _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
+        _preferences->setShouldDropNearSuspendedAssertionAfterDelay(WebKit::defaultShouldDropNearSuspendedAssertionAfterDelay());
         break;
     case WKInactiveSchedulingPolicyThrottle:
         _preferences->setShouldTakeNearSuspendedAssertions(true);
         _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
+        _preferences->setShouldDropNearSuspendedAssertionAfterDelay(false);
         break;
     case WKInactiveSchedulingPolicyNone:
         _preferences->setShouldTakeNearSuspendedAssertions(true);
         _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(false);
+        _preferences->setShouldDropNearSuspendedAssertionAfterDelay(false);
         break;
     default:
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### f64effb7bba954716dc6376fe087526cc5825879
<pre>
WKInactiveSchedulingPolicyThrottle / WKInactiveSchedulingPolicyNone may still cause process suspension
<a href="https://bugs.webkit.org/show_bug.cgi?id=270609">https://bugs.webkit.org/show_bug.cgi?id=270609</a>
<a href="https://rdar.apple.com/123854747">rdar://123854747</a>

Reviewed by Ben Nham.

WKInactiveSchedulingPolicyThrottle / WKInactiveSchedulingPolicyNone may still
cause process suspension. They don&apos;t set the &quot;shouldDropNearSuspendedAssertionAfterDelay&quot;
setting, which means that we may end up dropping the suspended assertion after
some delay and the processes would suspend, even though the API indicates that
the processes will not suspend in those modes.

* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences setInactiveSchedulingPolicy:]):

Canonical link: <a href="https://commits.webkit.org/275807@main">https://commits.webkit.org/275807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ef96c761bcb153a73e359f50a8b4917b2dced0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38901 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35399 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16428 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46906 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42135 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19214 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40768 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9566 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->