### PR TITLE
PresentationContextIOSurface::configure should check for invalid height before creating MTLTexture

### DIFF
--- a/LayoutTests/fast/webgpu/invalid-surface-height-expected.txt
+++ b/LayoutTests/fast/webgpu/invalid-surface-height-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/invalid-surface-height.html
+++ b/LayoutTests/fast/webgpu/invalid-surface-height.html
@@ -1,0 +1,89 @@
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+
+onload = async () => {
+  try {
+    let adapter0 = await navigator.gpu.requestAdapter(
+    {
+    }
+    );
+    let device0 = await adapter0.requestDevice(
+    {
+    label: '\u5b22',
+    requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage'
+    ],
+    requiredLimits: {
+    maxColorAttachmentBytesPerSample: 48,
+    maxVertexAttributes: 17,
+    maxVertexBufferArrayStride: 18611,
+    maxStorageTexturesPerShaderStage: 41,
+    maxBindingsPerBindGroup: 7922,
+    maxTextureArrayLayers: 402,
+    maxTextureDimension1D: 12869,
+    maxTextureDimension2D: 8698,
+    maxVertexBuffers: 10,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 32,
+    },
+    }
+    );
+
+    let adapter1 = await navigator.gpu.requestAdapter(
+    {
+    }
+    );
+    let offscreenCanvas3 = new OffscreenCanvas(605, 2935663512);
+
+    let gpuCanvasContext1 = offscreenCanvas3.getContext('webgpu');
+    gpuCanvasContext1.configure(
+    {
+    device: device0,
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_DST,
+    viewFormats: [
+    'astc-5x5-unorm',
+    'rg8sint',
+    'r16sint',
+    'bgra8unorm-srgb',
+    'etc2-rgb8a1unorm-srgb',
+    'rgba32float',
+    'astc-4x4-unorm',
+    'astc-8x6-unorm',
+    'astc-12x12-unorm'
+    ],
+    colorSpace: 'srgb',
+    alphaMode: 'premultiplied',
+    }
+    );
+    let device1 = await adapter1.requestDevice(
+    {
+    label: '\u0d54',
+    requiredLimits: {
+    maxColorAttachmentBytesPerSample: 61,
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 51506,
+    maxStorageTexturesPerShaderStage: 26,
+    maxBindingsPerBindGroup: 9286,
+    maxTextureArrayLayers: 1815,
+    maxTextureDimension1D: 9422,
+    maxTextureDimension2D: 15639,
+    maxVertexBuffers: 12,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 64,
+    },
+    }
+    );
+  } catch (e) {
+
+  }
+  if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash.

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -106,6 +106,10 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
     textureDescriptor.usage = Texture::usage(descriptor.usage, effectiveFormat);
     bool needsLuminanceClampFunction = false;
     for (IOSurface *iosurface in m_ioSurfaces) {
+        if (iosurface.height != static_cast<NSInteger>(height) || iosurface.width != static_cast<NSInteger>(width))
+            return device.generateAValidationError("Invalid surface size"_s);
+    }
+    for (IOSurface *iosurface in m_ioSurfaces) {
         RefPtr<Texture> parentLuminanceClampTexture;
         if (textureDescriptor.pixelFormat == MTLPixelFormatRGBA16Float) {
             auto existingUsage = textureDescriptor.usage;


### PR DESCRIPTION
#### 055511d1aab8adce779b45c6dff36d74e3b8d381
<pre>
PresentationContextIOSurface::configure should check for invalid height before creating MTLTexture
<a href="https://bugs.webkit.org/show_bug.cgi?id=270608">https://bugs.webkit.org/show_bug.cgi?id=270608</a>
<a href="https://rdar.apple.com/124143113">rdar://124143113</a>

Reviewed by Mike Wyrzykowski.

* LayoutTests/fast/webgpu/invalid-surface-height-expected.txt: Added.
* LayoutTests/fast/webgpu/invalid-surface-height.html: Added.
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):

Canonical link: <a href="https://commits.webkit.org/275772@main">https://commits.webkit.org/275772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45cb119db6943aad6d01f0b5c6655faa7471fba4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38923 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19200 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18827 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16376 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/37899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/855 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/38963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46923 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14523 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40782 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19415 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5792 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->