### PR TITLE
Optimize text layout in text heavy web pages

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -434,6 +434,9 @@ TextBreakIterator::ContentAnalysis TextUtil::contentAnalysis(WordBreak wordBreak
 
 bool TextUtil::isStrongDirectionalityCharacter(char32_t character)
 {
+    if (isLatin1(character))
+        return false;
+
     auto bidiCategory = u_charDirection(character);
     return bidiCategory == U_RIGHT_TO_LEFT
         || bidiCategory == U_RIGHT_TO_LEFT_ARABIC

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -34,6 +34,7 @@
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/StringImpl.h>
+#include <wtf/text/WYHash.h>
 
 namespace WebCore {
 
@@ -44,59 +45,56 @@ private:
     // Used to optimize small strings as hash table keys. Avoids malloc'ing an out-of-line StringImpl.
     class SmallStringKey {
     public:
-        static unsigned capacity() { return s_capacity; }
+        static constexpr unsigned capacity() { return s_capacity; }
 
-        SmallStringKey()
-            : m_length(s_emptyValueLength)
-        {
-        }
+        constexpr SmallStringKey() = default;
 
-        SmallStringKey(WTF::HashTableDeletedValueType)
-            : m_length(s_deletedValueLength)
+        constexpr SmallStringKey(WTF::HashTableDeletedValueType)
+            : m_hashAndLength(s_deletedValueLength)
         {
         }
 
         SmallStringKey(StringView string)
-            : m_hash(string.hash())
-            , m_length(string.length())
         {
-            ASSERT(m_length <= s_capacity);
+            unsigned length = string.length();
+            ASSERT(length <= s_capacity);
             if (string.is8Bit())
-                StringImpl::copyCharacters(m_characters, string.characters8(), m_length);
+                StringImpl::copyCharacters(m_characters.data(), string.characters8(), length);
             else
-                StringImpl::copyCharacters(m_characters, string.characters16(), m_length);
+                StringImpl::copyCharacters(m_characters.data(), string.characters16(), length);
+            m_hashAndLength = WYHash::computeHashAndMaskTop8Bits(m_characters.data(), s_capacity) | (length << 24);
         }
 
-        const UChar* characters() const { return m_characters; }
-        unsigned short length() const { return m_length; }
-        unsigned hash() const { return m_hash; }
+        const UChar* characters() const { return m_characters.data(); }
+        unsigned length() const { return m_hashAndLength >> 24; }
+        unsigned hash() const { return m_hashAndLength & 0x00ffffffU; }
 
-        bool isHashTableDeletedValue() const { return m_length == s_deletedValueLength; }
-        bool isHashTableEmptyValue() const { return m_length == s_emptyValueLength; }
+        bool isHashTableDeletedValue() const { return m_hashAndLength == s_deletedValueLength; }
+        bool isHashTableEmptyValue() const { return !m_hashAndLength; }
+
+        friend bool operator==(const SmallStringKey&, const SmallStringKey&) = default;
+        friend bool operator!=(const SmallStringKey&, const SmallStringKey&) = default;
 
     private:
-        static const unsigned s_capacity = 15;
-        static const unsigned s_emptyValueLength = s_capacity + 1;
-        static const unsigned s_deletedValueLength = s_capacity + 2;
+        static constexpr unsigned s_capacity = 16;
+        static constexpr unsigned s_deletedValueLength = s_capacity + 1;
 
-        unsigned m_hash;
-        unsigned short m_length;
-        UChar m_characters[s_capacity];
+        std::array<UChar, s_capacity> m_characters { };
+        unsigned m_hashAndLength { 0 };
     };
 
     struct SmallStringKeyHash {
         static unsigned hash(const SmallStringKey& key) { return key.hash(); }
         static bool equal(const SmallStringKey& a, const SmallStringKey& b) { return a == b; }
-        static const bool safeToCompareToEmptyOrDeleted = true; // Empty and deleted values have lengths that are not equal to any valid length.
+        static constexpr bool safeToCompareToEmptyOrDeleted = true; // Empty and deleted values have lengths that are not equal to any valid length.
     };
 
     struct SmallStringKeyHashTraits : SimpleClassHashTraits<SmallStringKey> {
-        static const bool hasIsEmptyValueFunction = true;
+        static constexpr bool emptyValueIsZero = true;
+        static constexpr bool hasIsEmptyValueFunction = true;
         static bool isEmptyValue(const SmallStringKey& key) { return key.isHashTableEmptyValue(); }
-        static const int minimumTableSize = 16;
+        static constexpr int minimumTableSize = 16;
     };
-
-    friend bool operator==(const SmallStringKey&, const SmallStringKey&);
 
 public:
     WidthCache()
@@ -107,23 +105,25 @@ public:
 
     float* add(StringView text, float entry)
     {
-        if (MemoryPressureHandler::singleton().isUnderMemoryPressure())
+        unsigned length = text.length();
+
+        // Do not allow length = 0. This allows SmallStringKey empty-value-is-zero.
+        if (UNLIKELY(!length))
             return nullptr;
 
-        if (text.length() > SmallStringKey::capacity())
+        if (length > SmallStringKey::capacity())
             return nullptr;
 
         if (m_countdown > 0) {
             --m_countdown;
             return nullptr;
         }
+
         return addSlowCase(text, entry);
     }
 
     float* add(const TextRun& run, float entry, bool hasKerningOrLigatures, bool hasWordSpacingOrLetterSpacing, GlyphOverflow* glyphOverflow)
     {
-        if (MemoryPressureHandler::singleton().isUnderMemoryPressure())
-            return nullptr;
         // The width cache is not really profitable unless we're doing expensive glyph transformations.
         if (!hasKerningOrLigatures)
             return nullptr;
@@ -136,15 +136,8 @@ public:
         // If we allow tabs and a tab occurs inside a word, the width of the word varies based on its position on the line.
         if (run.allowTabs())
             return nullptr;
-        if (run.length() > SmallStringKey::capacity())
-            return nullptr;
 
-        if (m_countdown > 0) {
-            --m_countdown;
-            return nullptr;
-        }
-
-        return addSlowCase(run.text(), entry);
+        return add(run.text(), entry);
     }
 
     void clear()
@@ -157,7 +150,10 @@ private:
 
     float* addSlowCase(StringView text, float entry)
     {
-        int length = text.length();
+        if (MemoryPressureHandler::singleton().isUnderMemoryPressure())
+            return nullptr;
+
+        unsigned length = text.length();
         bool isNewEntry;
         float* value;
         if (length == 1) {
@@ -190,10 +186,11 @@ private:
         return nullptr;
     }
 
-    typedef HashMap<SmallStringKey, float, SmallStringKeyHash, SmallStringKeyHashTraits> Map;
-    typedef HashMap<uint32_t, float, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> SingleCharMap;
-    static const int s_minInterval = -3; // A cache hit pays for about 3 cache misses.
-    static const int s_maxInterval = 20; // Sampling at this interval has almost no overhead.
+    using Map = HashMap<SmallStringKey, float, SmallStringKeyHash, SmallStringKeyHashTraits>;
+    using SingleCharMap = HashMap<uint32_t, float, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+
+    static constexpr int s_minInterval = -3; // A cache hit pays for about 3 cache misses.
+    static constexpr int s_maxInterval = 20; // Sampling at this interval has almost no overhead.
     static constexpr unsigned s_maxSize = 500000; // Just enough to guard against pathological growth.
 
     int m_interval;
@@ -201,13 +198,6 @@ private:
     SingleCharMap m_singleCharMap;
     Map m_map;
 };
-
-inline bool operator==(const WidthCache::SmallStringKey& a, const WidthCache::SmallStringKey& b)
-{
-    if (a.length() != b.length())
-        return false;
-    return WTF::equal(a.characters(), b.characters(), a.length());
-}
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 3795d9da24e4418ea3ed7f191e56e390738c6dac
<pre>
Optimize text layout in text heavy web pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=270612">https://bugs.webkit.org/show_bug.cgi?id=270612</a>
<a href="https://rdar.apple.com/problem/124177964">rdar://problem/124177964</a>

Reviewed by Chris Dumez.

This patch applies several changes.

1. isStrongDirectionalityCharacter is not used when the characters are 8Bit. We should apply isLatin1 fast path as the same to the caller.
   u_charDirection is ICU function and it is quite slow.
2. Move non-cach-hitting part of FontCascade::widthForSimpleText to FontCascade::widthForSimpleTextSlow. It has GlyphBuffer, and it has
   huge stack size. Let&apos;s extract the cache-hitting fast path from this function and avoid putting this on the stack.
3. This patch optimizes WidthCache.
    3.1. We do not need to check MemoryPressureHandler status unless we extend the cache.
    3.2. Since SmallStringKey&apos;s string size is small, we can make it much more like non-variable-length data and make it super fast.
         This patch changes the layout of SmallStringKey a bit so that we hold characters in std::array&lt;UChar, 16&gt;. So, comparison becomes
         `std::array&lt;UChar, 16&gt; == std::array&lt;UChar, 16&gt;` and because it is 32-bytes (16 size is picked for that), comparison gets done in a bulk style (e.g. 4 characters at once)
         automatically via compiler and it becomes super fast. By combining hash and length into one unsigned, we keep std::pair&lt;SmallStringKey, float&gt; 40-bytes.
    3.3. We also use WYHash for SmallStringKey&apos;s hashing. Plus, we now always hash all 16 characters (and if it is smaller than 16, then zeros follow).
         WYHash::computeHashAndMaskTop8Bits can see constant 16 size, so hashing gets done in a extremely fast way without branches (since now the size is always 16).
         Also, 16 is good number for WYHash since it can do 8-length hashing in a bulk way.
    3.4. Making empty value of SmallStringKey zero. This allows HashMap to initialize newly rehashed table with zeroed-malloc.

* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::isStrongDirectionalityCharacter):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForSimpleTextSlow const):
(WebCore::addGlyphsFromText): Deleted.
(WebCore::FontCascade::widthForSimpleText const): Deleted.
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::widthForSimpleText const):
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::SmallStringKey::capacity):
(WebCore::WidthCache::SmallStringKey::SmallStringKey):
(WebCore::WidthCache::SmallStringKey::characters const):
(WebCore::WidthCache::SmallStringKey::length const):
(WebCore::WidthCache::SmallStringKey::hash const):
(WebCore::WidthCache::SmallStringKey::isHashTableDeletedValue const):
(WebCore::WidthCache::SmallStringKey::isHashTableEmptyValue const):
(WebCore::WidthCache::add):
(WebCore::WidthCache::addSlowCase):
(WebCore::operator==): Deleted.

Canonical link: <a href="https://commits.webkit.org/275987@main">https://commits.webkit.org/275987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/799f6ae00daed14f27a2752539413bdd9d40b2cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43473 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/22508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46108 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19922 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44047 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1529 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47652 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5912 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->