### PR TITLE
[Unified Text Replacement] Replacements should maintain the original text attributes

### DIFF
--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -488,7 +488,7 @@ public:
 
 #if ENABLE(TREE_DEBUGGING)
     void showNode(const char* prefix = "") const;
-    void showTreeForThis() const;
+    WEBCORE_EXPORT void showTreeForThis() const;
     void showNodePathForThis() const;
     void showTreeAndMark(const Node* markedNode1, const char* markedLabel1, const Node* markedNode2 = nullptr, const char* markedLabel2 = nullptr) const;
     void showTreeForThisAcrossFrame() const;

--- a/Source/WebCore/editing/WebContentReader.h
+++ b/Source/WebCore/editing/WebContentReader.h
@@ -128,7 +128,11 @@ struct FragmentAndResources {
     Vector<Ref<ArchiveResource>> resources;
 };
 
-RefPtr<DocumentFragment> createFragmentAndAddResources(LocalFrame&, NSAttributedString *);
+enum class AddResources : bool {
+    No, Yes
+};
+
+WEBCORE_EXPORT RefPtr<DocumentFragment> createFragment(LocalFrame&, NSAttributedString *, AddResources);
 #endif
 
 }

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -242,7 +242,7 @@ void Editor::replaceSelectionWithAttributedString(NSAttributedString *attributed
         return;
 
     if (document->selection().selection().isContentRichlyEditable()) {
-        if (auto fragment = createFragmentAndAddResources(*document->frame(), attributedString)) {
+        if (auto fragment = createFragment(*document->frame(), attributedString, AddResources::Yes)) {
             if (shouldInsertFragment(*fragment, selectedRange(), EditorInsertAction::Pasted))
                 pasteAsFragment(fragment.releaseNonNull(), false, false, mailBlockquoteHandling);
         }

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -407,7 +407,7 @@ static void replaceRichContentWithAttachments(LocalFrame& frame, DocumentFragmen
 #endif
 }
 
-RefPtr<DocumentFragment> createFragmentAndAddResources(LocalFrame& frame, NSAttributedString *string)
+RefPtr<DocumentFragment> createFragment(LocalFrame& frame, NSAttributedString *string, AddResources addResources)
 {
     if (!frame.page() || !frame.document())
         return nullptr;
@@ -420,6 +420,9 @@ RefPtr<DocumentFragment> createFragmentAndAddResources(LocalFrame& frame, NSAttr
     auto fragmentAndResources = createFragment(frame, string);
     if (!fragmentAndResources.fragment)
         return nullptr;
+
+    if (addResources == AddResources::No)
+        return fragmentAndResources.fragment;
 
     if (!DeprecatedGlobalSettings::customPasteboardDataEnabled()) {
         if (DocumentLoader* loader = frame.loader().documentLoader()) {
@@ -646,7 +649,7 @@ bool WebContentReader::readRTFD(SharedBuffer& buffer)
         return false;
 
     auto string = adoptNS([[NSAttributedString alloc] initWithRTFD:buffer.createNSData().get() documentAttributes:nullptr]);
-    auto fragment = createFragmentAndAddResources(frame, string.get());
+    auto fragment = createFragment(frame, string.get(), AddResources::Yes);
     if (!fragment)
         return false;
     addFragment(fragment.releaseNonNull());
@@ -660,7 +663,7 @@ bool WebContentMarkupReader::readRTFD(SharedBuffer& buffer)
     if (!frame->document())
         return false;
     auto string = adoptNS([[NSAttributedString alloc] initWithRTFD:buffer.createNSData().get() documentAttributes:nullptr]);
-    auto fragment = createFragmentAndAddResources(frame, string.get());
+    auto fragment = createFragment(frame, string.get(), AddResources::Yes);
     if (!fragment)
         return false;
 
@@ -675,7 +678,7 @@ bool WebContentReader::readRTF(SharedBuffer& buffer)
         return false;
 
     auto string = adoptNS([[NSAttributedString alloc] initWithRTF:buffer.createNSData().get() documentAttributes:nullptr]);
-    auto fragment = createFragmentAndAddResources(frame, string.get());
+    auto fragment = createFragment(frame, string.get(), AddResources::Yes);
     if (!fragment)
         return false;
     addFragment(fragment.releaseNonNull());
@@ -689,7 +692,7 @@ bool WebContentMarkupReader::readRTF(SharedBuffer& buffer)
     if (!frame->document())
         return false;
     auto string = adoptNS([[NSAttributedString alloc] initWithRTF:buffer.createNSData().get() documentAttributes:nullptr]);
-    auto fragment = createFragmentAndAddResources(frame, string.get());
+    auto fragment = createFragment(frame, string.get(), AddResources::Yes);
     if (!fragment)
         return false;
     m_markup = serializeFragment(*fragment, SerializedNodes::SubtreeIncludingNode);

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -849,7 +849,6 @@ WebProcess/WebPage/FindController.cpp
 WebProcess/WebPage/IPCTestingAPI.cpp
 WebProcess/WebPage/MomentumEventDispatcher.cpp
 WebProcess/WebPage/PageBanner.cpp
-WebProcess/WebPage/UnifiedTextReplacementController.cpp
 WebProcess/WebPage/VisitedLinkTableController.cpp
 WebProcess/WebPage/WebBackForwardListProxy.cpp
 WebProcess/WebPage/WebContextMenu.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -730,6 +730,7 @@ WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
 WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
+WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
 
 WebProcess/WebPage/ios/FindControllerIOS.mm
 WebProcess/WebPage/ios/WebPageIOS.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3158,7 +3158,7 @@
 		074879B72373A90900F5678E /* AppKitSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppKitSoftLink.h; path = ios/AppKitSoftLink.h; sourceTree = "<group>"; };
 		074879B82373A90900F5678E /* AppKitSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = AppKitSoftLink.mm; path = ios/AppKitSoftLink.mm; sourceTree = "<group>"; };
 		074AD71E2B61D51E00FFA67B /* UnifiedTextReplacementController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnifiedTextReplacementController.h; sourceTree = "<group>"; };
-		074AD7202B61D58F00FFA67B /* UnifiedTextReplacementController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedTextReplacementController.cpp; sourceTree = "<group>"; };
+		074AD7202B61D58F00FFA67B /* UnifiedTextReplacementController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UnifiedTextReplacementController.mm; sourceTree = "<group>"; };
 		074E75FB1DF1FD1300D318EC /* UserMediaProcessManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserMediaProcessManager.h; sourceTree = "<group>"; };
 		074E75FC1DF2002400D318EC /* UserMediaProcessManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserMediaProcessManager.cpp; sourceTree = "<group>"; };
 		074E76001DF7075D00D318EC /* MediaDeviceSandboxExtensions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaDeviceSandboxExtensions.cpp; sourceTree = "<group>"; };
@@ -10388,6 +10388,7 @@
 				2D9CD5ED21FA503F0029ACFA /* TextCheckingControllerProxy.h */,
 				2D9CD5EB21FA503F0029ACFA /* TextCheckingControllerProxy.messages.in */,
 				2D9CD5EC21FA503F0029ACFA /* TextCheckingControllerProxy.mm */,
+				074AD7202B61D58F00FFA67B /* UnifiedTextReplacementController.mm */,
 				3A8997E029B25E8E00AB88B6 /* WebCookieCacheCocoa.mm */,
 				3A36AFAF2B9667770098631A /* WebCookieJarCocoa.mm */,
 				2DC4CF7A1D2DE24B00ECCC94 /* WebPageCocoa.mm */,
@@ -13684,7 +13685,6 @@
 				2DEE709D2755A46800FBF864 /* MomentumEventDispatcher.h */,
 				7C387433172F5615001BD88A /* PageBanner.cpp */,
 				7CF47FF917275C57008ACB91 /* PageBanner.h */,
-				074AD7202B61D58F00FFA67B /* UnifiedTextReplacementController.cpp */,
 				074AD71E2B61D51E00FFA67B /* UnifiedTextReplacementController.h */,
 				2D819B99186275B3001F03D1 /* ViewGestureGeometryCollector.cpp */,
 				2D819B9A186275B3001F03D1 /* ViewGestureGeometryCollector.h */,

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -41,6 +41,8 @@ namespace WebKit {
 
 class WebPage;
 
+struct WebUnifiedTextReplacementContextData;
+
 class UnifiedTextReplacementController final {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(UnifiedTextReplacementController);
@@ -63,17 +65,11 @@ public:
     void textReplacementSessionDidReceiveEditAction(const WTF::UUID&, WebKit::WebTextReplacementData::EditAction);
 
 private:
-    struct Replacement {
-        WebCore::AttributedString attributedText;
-        WebCore::CharacterRange range;
-    };
-
     WeakPtr<WebPage> m_webPage;
 
     HashMap<WTF::UUID, Ref<WebCore::Range>> m_contextRanges;
     HashMap<WTF::UUID, Ref<WebCore::DocumentFragment>> m_originalDocumentNodes;
     HashMap<WTF::UUID, Ref<WebCore::DocumentFragment>> m_replacedDocumentNodes;
-    HashMap<WTF::UUID, Vector<Replacement>> m_replacements;
 };
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
@@ -89,7 +89,7 @@ static void checkColor(PlatformColor *color, CGFloat red, CGFloat green, CGFloat
     [color getRed:&observedRed green:&observedGreen blue:&observedBlue alpha:&observedAlpha];
 
     EXPECT_EQ(red, observedRed);
-    EXPECT_EQ(green, observedRed);
+    EXPECT_EQ(green, observedGreen);
     EXPECT_EQ(blue, observedBlue);
     EXPECT_EQ(alpha, observedAlpha);
 }


### PR DESCRIPTION
#### 6cffe2c43cbad3173e4431d13a8c37881ad218fc
<pre>
[Unified Text Replacement] Replacements should maintain the original text attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=270606">https://bugs.webkit.org/show_bug.cgi?id=270606</a>
<a href="https://rdar.apple.com/122835651">rdar://122835651</a>

Reviewed by Wenson Hsieh.

Add support for attributed strings to work properly and have their attributes persisted.

Also, add `WEBCORE_EXPORT` to `showTreeForThis` to ease future debugging, and make a correctness
fix for an unrelated API test.

* Source/WebCore/dom/Node.h:
* Source/WebCore/editing/WebContentReader.h:
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::replaceSelectionWithAttributedString):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::createFragment):
(WebCore::WebContentReader::readRTFD):
(WebCore::WebContentMarkupReader::readRTFD):
(WebCore::WebContentReader::readRTF):
(WebCore::WebContentMarkupReader::readRTF):
(WebCore::createFragmentAndAddResources): Deleted.
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm: Renamed from Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp.
(WebKit::replaceTextInRange):
(WebKit::replaceContentsInRange):
(WebKit::extendedBoundaryPoint):
(WebKit::findReplacementMarkerByUUID):
(WebKit::UnifiedTextReplacementController::UnifiedTextReplacementController):
(WebKit::UnifiedTextReplacementController::willBeginTextReplacementSession):
(WebKit::UnifiedTextReplacementController::didBeginTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveEditAction):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm:
(checkColor):

Canonical link: <a href="https://commits.webkit.org/275821@main">https://commits.webkit.org/275821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba0c4ae603db429bafb1ee71671fd9670f7ce388

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19406 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16607 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1014 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47106 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14659 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9571 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19588 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->