### PR TITLE
[visionOS] AudioSession interruptions do not stop playback

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-noresumeafterpause-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-noresumeafterpause-expected.txt
@@ -1,0 +1,20 @@
+
+RUN(source = new ManagedMediaSource())
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(2)))
+EVENT(update)
+RUN(video.play())
+EVENT(playing)
+EVENT(waiting)
+EXPECTED (video.currentTime >= '1') OK
+RUN(video.pause())
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
+EXPECTED (video.currentTime == currentTimeWhenStalling == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-noresumeafterpause.html
+++ b/LayoutTests/media/media-source/media-managedmse-noresumeafterpause.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>MSE playback doesn't resume when pause is called following a stall.</title>
+    <script src="../../media/media-source/media-source-loader.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../utilities.js"></script>
+    <script>
+
+    var source;
+    var sourceBuffer;
+    var index;
+    var loader;
+    var currentTimeWhenStalling;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    async function init() {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-video-manifest.json');
+        await loaderPromise(loader);
+        video.disableRemotePlayback = true;
+        video.muted = true;
+        run('source = new ManagedMediaSource()');
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+        await waitFor(sourceBuffer,'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(2))');
+        await waitFor(sourceBuffer,'update');
+        run('video.play()');
+        await waitFor(video, 'playing');
+        await Promise.all([
+        testExpectedEventuallySilent('video.currentTime', 1, '>='),
+            waitFor(video, 'waiting')
+        ]);
+        testExpected('video.currentTime', 1, '>=');
+        currentTimeWhenStalling = video.currentTime;
+
+        // Issue pause() command while playback has stalled.
+        run('video.pause()');
+        // Fill gap, playback shouldn't continue, even briefly.
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
+        await sleepFor(1000);
+        testExpected('video.currentTime == currentTimeWhenStalling', true);
+        endTest();
+    };
+    </script>
+</head>
+<body onload="init()">
+    <video playsinline></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1071,6 +1071,7 @@ webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavai
 
 webkit.org/b/218317 media/media-source/media-source-trackid-change.html [ Failure ]
 webkit.org/b/238201 media/media-source/media-mp4-hevc-bframes.html [ Failure ]
+webkit.org/b/270622 media/media-source/media-managedmse-noresumeafterpause.html [ Timeout ]
 
 # GStreamer (< 1.24) doesn't set the track's id to the container's value.
 webkit.org/b/265919 media/track/media-audio-track.html [ Failure ]

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -147,6 +147,9 @@ public:
     virtual void setPreservesPitch(bool) { }
     virtual void setPitchCorrectionAlgorithm(MediaPlayer::PitchCorrectionAlgorithm) { }
 
+    // Indicates whether playback is currently paused indefinitely: such as having been paused
+    // explictly by the HTMLMediaElement or through remote media playback control.
+    // This excludes video potentially playing but having stalled.
     virtual bool paused() const = 0;
 
     virtual void setVolume(float) { }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -371,7 +371,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal(std::optional<Monotonic
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::paused() const
 {
-    return ![m_synchronizer rate];
+    return !m_isPlaying;
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setVolume(float volume)

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -306,7 +306,7 @@ void MediaPlayerPrivateWebM::pause()
 
 bool MediaPlayerPrivateWebM::paused() const
 {
-    return ![m_synchronizer rate];
+    return !m_isPlaying;
 }
 
 bool MediaPlayerPrivateWebM::timeIsProgressing() const


### PR DESCRIPTION
#### f25ae590196b3cf576f1140a6c627927761cdaa5
<pre>
[visionOS] AudioSession interruptions do not stop playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=270614">https://bugs.webkit.org/show_bug.cgi?id=270614</a>
<a href="https://rdar.apple.com/116891193">rdar://116891193</a>

Reviewed by Eric Carlson.

In 266665@main changes were made and then later reverted.
The original description of 266665@main was:

&quot;Timing differences on visionOS result in `AVSampleBufferRenderSynchronizer`&apos;s
rate being set to zero, prior to the interruption notification being dispatched
when an interruption occurs. This difference ordering in ordering results in a
sequence of events that causes WebKit to automatically resume playback following
an interruption.

Specifically:
1. `CMTimebaseEffectiveRateChangedCallback` is fired as AVSBRS has its rate changed, by the system.
2. Through the callback, the rate is observed as zero, resulting in playback being considered paused in the GPU process.
3. The GPU process state is reflected in the web process with a call to `MediaPlayerPrivateRemote::updateCachedState`.
4. `AVAudioSessionInterruptionNotification` is dispatched in the GPU process, by the system.
5. `HTMLMediaElement::updatePlayState()` is called in the web process.
6. The web process believes that playback is already paused, due to (3).
7. Consequently, the GPU process is never told to pause content; specifically, `MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal()` is elided.
8. Importantly, that method sets a flag variable, `m_playing` to false.
9. Since `m_playing` is not set to false, `MediaPlayerPrivateMediaSourceAVFObjC::shouldBePlaying()` will return true.
10. `MediaPlayerPrivateMediaSourceAVFObjC::updateAllRenderersHaveAvailableSamples()` eventually restarts playback, since `shouldBePlaying()` is true.
&quot;

The observed effect description was correct, but the explanation  wasn&apos;t.
MediaPlayerPrivateMediaSourceAVFObjC::m_playing (later renamed m_isPlaying)
indicates if the video &quot;should be playing&quot;, which exclude the state where
playback has paused due to the lack of data.

MediaPlayerPrivateInterface::paused() was originally designed to determine
if the CRABS player had been paused indirectly by the AVPlay through AirPlay
interaction.
As AirPlay doesn&apos;t support MSE, the only possible way the player is paused
is if the MediaPlayerPrivateInterface::pause() got called. The
implementation of MediaPlayerPrivateMediaSourceAVFObjC incorrectly reported
the player as being paused if playback had stalled (the rate of the synchroniser
had changed to 0). This leads to step 7. above happening.

While the issue was noted on visionOS, side-effects could be observed elsewhere:
if you called video.pause() while the video playback had stalled, currentTime
could be seen temporarily progressing once more data was added due to
MediaPlayerPrivate::pause() only being called once the media element&apos;s readyState
changed.

Test Added.
* LayoutTests/media/media-source/media-managedmse-noresumeafterpause-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-noresumeafterpause.html: Added.
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h: Add API documentation for future references.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::paused const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm: WebM player copies the logic of the AVF MSE player.
(WebCore::MediaPlayerPrivateWebM::paused const): apply the same fix as for MSE.

Canonical link: <a href="https://commits.webkit.org/275838@main">https://commits.webkit.org/275838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bde327dc80b8c5b81d6fb1414bd056f3861bdbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39132 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35562 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38096 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47163 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42346 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40999 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9579 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->