### PR TITLE
Use a strongly typed identifier for MediaSampleCursor

### DIFF
--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
@@ -46,7 +46,10 @@ namespace WebKit {
 
 class MediaTrackReader;
 
-class MediaSampleCursor : public CoreMediaWrapped<MediaSampleCursor>, LegacyThreadSafeIdentified<MediaSampleCursor> {
+enum class MediaSampleCursorIdentifierType { };
+using MediaSampleCursorIdentifier = AtomicObjectIdentifier<MediaSampleCursorIdentifierType>;
+
+class MediaSampleCursor : public CoreMediaWrapped<MediaSampleCursor>, private Identified<MediaSampleCursorIdentifier> {
 public:
     using DecodeOrderIterator = WebCore::DecodeOrderSampleMap::iterator;
     using PresentationOrderIterator = WebCore::PresentationOrderSampleMap::iterator;

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp
@@ -248,10 +248,10 @@ WTFLogChannel& MediaTrackReader::logChannel() const
     return JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, Media);
 }
 
-const void* MediaTrackReader::nextSampleCursorLogIdentifier(uint64_t cursorID) const
+const void* MediaTrackReader::nextSampleCursorLogIdentifier(MediaSampleCursorIdentifier cursorID) const
 {
     uint64_t trackID = reinterpret_cast<uint64_t>(m_logIdentifier) & 0xffffull;
-    uint64_t trackAndCursorID = trackID << 8 | (cursorID & 0xffull);
+    uint64_t trackAndCursorID = trackID << 8 | (cursorID.toUInt64() & 0xffull);
     return LoggerHelper::childLogIdentifier(m_logIdentifier, trackAndCursorID);
 }
 

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h
@@ -51,6 +51,9 @@ namespace WebKit {
 
 class MediaFormatReader;
 
+enum class MediaSampleCursorIdentifierType;
+using MediaSampleCursorIdentifier = AtomicObjectIdentifier<MediaSampleCursorIdentifierType>;
+
 class MediaTrackReader final : public CoreMediaWrapped<MediaTrackReader> {
 public:
     static constexpr WrapperClass wrapperClass();
@@ -71,7 +74,7 @@ public:
     void finishParsing();
 
     const WTF::Logger& logger() const { return m_logger; }
-    const void* nextSampleCursorLogIdentifier(uint64_t cursorID) const;
+    const void* nextSampleCursorLogIdentifier(MediaSampleCursorIdentifier) const;
 
 private:
     using CoreMediaWrapped<MediaTrackReader>::unwrap;


### PR DESCRIPTION
#### c85aece2384732b652c476ef65fae24d40b1d6a8
<pre>
Use a strongly typed identifier for MediaSampleCursor
<a href="https://bugs.webkit.org/show_bug.cgi?id=270615">https://bugs.webkit.org/show_bug.cgi?id=270615</a>

Reviewed by Darin Adler.

Use a strongly typed identifier for MediaSampleCursor. Subclass
WTF::Identified instead of WTF::LegacyThreadSafeIdentified.

* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h:
* Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp:
(WebKit::MediaTrackReader::nextSampleCursorLogIdentifier const):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.h:

Canonical link: <a href="https://commits.webkit.org/275790@main">https://commits.webkit.org/275790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/084c38c63e13212e4c03d54fda3d4a7214fb1766

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35415 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16453 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46927 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14527 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42150 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19255 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40788 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19419 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5799 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->