### PR TITLE
Update browserbench.org for Speedometer 3.0 launch - Merge PR 397

### DIFF
--- a/Websites/browserbench.org/Speedometer3.0/package.json
+++ b/Websites/browserbench.org/Speedometer3.0/package.json
@@ -21,11 +21,11 @@
         "lint:fix": "eslint \"**/*.{js,mjs,jsx,ts,tsx}\" --fix",
         "pretty:check": "prettier --check ./",
         "pretty:fix": "prettier --write ./",
-        "format": "npm run pretty:fix ; npm run lint:fix",
-        "test:chrome": "BROWSER=chrome node tests/run.mjs",
-        "test:firefox": "BROWSER=firefox node tests/run.mjs",
-        "test:safari": "BROWSER=safari node tests/run.mjs",
-        "test:edge": "BROWSER=edge node tests/run.mjs"
+        "format": "npm run pretty:fix && npm run lint:fix",
+        "test:chrome": "node tests/run.mjs --browser chrome",
+        "test:firefox": "node tests/run.mjs --browser firefox",
+        "test:safari": "node tests/run.mjs --browser safari",
+        "test:edge": "node tests/run.mjs --browser edge"
     },
     "devDependencies": {
         "@babel/core": "^7.21.3",

--- a/Websites/browserbench.org/Speedometer3.0/tests/run.mjs
+++ b/Websites/browserbench.org/Speedometer3.0/tests/run.mjs
@@ -39,7 +39,7 @@ const options = commandLineArgs(optionDefinitions);
 if ("help" in options)
     printHelp();
 
-const BROWSER = options?.browser || process.env.BROWSER;
+const BROWSER = options?.browser;
 if (!BROWSER)
     printHelp("No browser specified, use $BROWSER or --browser");
 


### PR DESCRIPTION
#### 8c5c642d5299408e1f3a71dea5e368f1a53ed781
<pre>
Update browserbench.org for Speedometer 3.0 launch - Merge PR 397
<a href="https://bugs.webkit.org/show_bug.cgi?id=270626">https://bugs.webkit.org/show_bug.cgi?id=270626</a>

Reviewed by Anne van Kesteren.

Merge <a href="https://github.com/WebKit/Speedometer/pull/397">https://github.com/WebKit/Speedometer/pull/397</a> into browserbench.org.

* Websites/browserbench.org/Speedometer3.0/package.json:
* Websites/browserbench.org/Speedometer3.0/tests/run.mjs:

Canonical link: <a href="https://commits.webkit.org/275782@main">https://commits.webkit.org/275782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19147d997d44f0a156146050ff79ed98b25e22c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38953 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19229 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43401 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/18870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/36866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39000 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46956 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14550 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19280 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19444 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5796 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->