### PR TITLE
[WPE] WPE Platform: make functions to get DRM device and render node members of WPEDisplay

### DIFF
--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp
@@ -219,7 +219,7 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorDRM::create(PlatformDi
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     String filename;
     if (usingWPEPlatformAPI)
-        filename = String::fromUTF8(wpe_render_device());
+        filename = String::fromUTF8(wpe_display_get_drm_device(wpe_display_get_primary()));
     else
         filename = WebCore::PlatformDisplay::sharedDisplay().drmDeviceFile();
 #else

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -87,7 +87,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #if USE(GBM)
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     if (usingWPEPlatformAPI)
-        parameters.renderDeviceFile = String::fromUTF8(wpe_render_node_device());
+        parameters.renderDeviceFile = String::fromUTF8(wpe_display_get_drm_render_node(wpe_display_get_primary()));
     else
         parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
 #else

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -58,6 +58,8 @@ struct _WPEDisplayClass
     guint        (* get_n_monitors)                (WPEDisplay *display);
     WPEMonitor  *(* get_monitor)                   (WPEDisplay *display,
                                                     guint       index);
+    const char  *(* get_drm_device)                (WPEDisplay *display);
+    const char  *(* get_drm_render_node)           (WPEDisplay *display);
 
     gpointer padding[32];
 };
@@ -94,9 +96,8 @@ WPE_API void         wpe_display_monitor_added                 (WPEDisplay *disp
                                                                 WPEMonitor *monitor);
 WPE_API void         wpe_display_monitor_removed               (WPEDisplay *display,
                                                                 WPEMonitor *monitor);
-
-WPE_API const char  *wpe_render_node_device                    (void);
-WPE_API const char  *wpe_render_device                         (void);
+WPE_API const char  *wpe_display_get_drm_device                (WPEDisplay *display);
+WPE_API const char  *wpe_display_get_drm_render_node           (WPEDisplay *display);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -2,6 +2,7 @@ configure_file(wpe-platform-drm.pc.in ${CMAKE_BINARY_DIR}/wpe-platform-drm-${WPE
 configure_file(wpe-platform-drm-uninstalled.pc.in ${CMAKE_BINARY_DIR}/wpe-platform-drm-${WPE_API_VERSION}-uninstalled.pc @ONLY)
 
 set(WPEPlatformDRM_SOURCES
+    ${WEBKIT_DIR}/WPEPlatform/wpe/drm/RefPtrUdev.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDRM.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp

--- a/Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RefPtrUdev.h"
+
+#include <libudev.h>
+
+namespace WTF {
+
+struct udev* DefaultRefDerefTraits<struct udev>::refIfNotNull(struct udev* ptr)
+{
+    if (LIKELY(ptr))
+        udev_ref(ptr);
+    return ptr;
+}
+
+void DefaultRefDerefTraits<struct udev>::derefIfNotNull(struct udev* ptr)
+{
+    if (LIKELY(ptr))
+        udev_unref(ptr);
+}
+
+struct udev_device* DefaultRefDerefTraits<struct udev_device>::refIfNotNull(struct udev_device* ptr)
+{
+    if (LIKELY(ptr))
+        udev_device_ref(ptr);
+    return ptr;
+}
+
+void DefaultRefDerefTraits<struct udev_device>::derefIfNotNull(struct udev_device* ptr)
+{
+    if (LIKELY(ptr))
+        udev_device_unref(ptr);
+}
+
+struct udev_enumerate* DefaultRefDerefTraits<struct udev_enumerate>::refIfNotNull(struct udev_enumerate* ptr)
+{
+    if (LIKELY(ptr))
+        udev_enumerate_ref(ptr);
+    return ptr;
+}
+
+void DefaultRefDerefTraits<struct udev_enumerate>::derefIfNotNull(struct udev_enumerate* ptr)
+{
+    if (LIKELY(ptr))
+        udev_enumerate_unref(ptr);
+}
+
+} // namespace WTF

--- a/Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/RefPtr.h>
+
+struct udev;
+struct udev_device;
+struct udev_enumerate;
+
+namespace WTF {
+
+template<>
+struct DefaultRefDerefTraits<struct udev> {
+    static struct udev* refIfNotNull(struct udev*);
+    static void derefIfNotNull(struct udev*);
+};
+
+template<>
+struct DefaultRefDerefTraits<struct udev_device> {
+    static struct udev_device* refIfNotNull(struct udev_device*);
+    static void derefIfNotNull(struct udev_device*);
+};
+
+template<>
+struct DefaultRefDerefTraits<struct udev_enumerate> {
+    static struct udev_enumerate* refIfNotNull(struct udev_enumerate*);
+    static void derefIfNotNull(struct udev_enumerate*);
+};
+
+} // namespace WTF

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp
@@ -52,24 +52,18 @@ static struct libinput_interface s_libinputInterface = {
     }
 };
 
-std::unique_ptr<Seat> Seat::create()
+std::unique_ptr<Seat> Seat::create(struct udev* udev, Session& session)
 {
-    struct udev* udev = udev_new();
-    if (!udev)
-        return nullptr;
-
-    auto session = Session::create();
-    auto* libinput = libinput_udev_create_context(&s_libinputInterface, session.get(), udev);
-    udev_unref(udev);
+    auto* libinput = libinput_udev_create_context(&s_libinputInterface, &session, udev);
     if (!libinput)
         return nullptr;
 
-    if (libinput_udev_assign_seat(libinput, session->seatID()) == -1) {
+    if (libinput_udev_assign_seat(libinput, session.seatID()) == -1) {
         libinput_unref(libinput);
         return nullptr;
     }
 
-    return makeUnique<Seat>(libinput, WTFMove(session));
+    return makeUnique<Seat>(libinput);
 }
 
 struct EventSource {
@@ -107,9 +101,8 @@ GSourceFuncs EventSource::sourceFuncs = {
     nullptr, // closure_marshall
 };
 
-Seat::Seat(struct libinput* libinput, std::unique_ptr<Session>&& session)
+Seat::Seat(struct libinput* libinput)
     : m_libinput(libinput)
-    , m_session(WTFMove(session))
     , m_keymap(adoptGRef(wpe_keymap_xkb_new()))
 {
     // FIXME: consider moving input handling to a separate thread.

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h
@@ -33,6 +33,8 @@
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GWeakPtr.h>
 
+struct udev;
+
 namespace WPE {
 
 namespace DRM {
@@ -42,8 +44,8 @@ class Session;
 class Seat {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<Seat> create();
-    Seat(struct libinput*, std::unique_ptr<Session>&&);
+    static std::unique_ptr<Seat> create(struct udev*, Session&);
+    explicit Seat(struct libinput*);
     ~Seat();
 
     void setView(WPEView* view);
@@ -60,7 +62,6 @@ private:
     void handleKey(uint32_t time, uint32_t key, bool pressed, bool fromRepeat);
 
     struct libinput* m_libinput { nullptr };
-    std::unique_ptr<Session> m_session;
     GRefPtr<GSource> m_inputSource;
     GRefPtr<WPEKeymap> m_keymap;
     GWeakPtr<WPEView> m_view;

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -27,13 +27,17 @@
 #include "WPEDisplayDRM.h"
 
 #include "DRMUniquePtr.h"
+#include "RefPtrUdev.h"
+#include "WPEDRMSession.h"
 #include "WPEDisplayDRMPrivate.h"
 #include "WPEExtensions.h"
 #include "WPEMonitorDRMPrivate.h"
 #include "WPEViewDRM.h"
 #include <fcntl.h>
 #include <gio/gio.h>
+#include <libudev.h>
 #include <wtf/glib/WTFGType.h>
+#include <wtf/text/CString.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 /**
@@ -41,6 +45,9 @@
  *
  */
 struct _WPEDisplayDRMPrivate {
+    std::unique_ptr<WPE::DRM::Session> session;
+    CString drmDevice;
+    CString drmRenderNode;
     UnixFileDescriptor fd;
     struct gbm_device* device;
     bool atomicSupported;
@@ -71,42 +78,59 @@ static void wpeDisplayDRMDispose(GObject* object)
     G_OBJECT_CLASS(wpe_display_drm_parent_class)->dispose(object);
 }
 
-static UnixFileDescriptor findDevice(GError** error)
+// This is based on weston function find_primary_gpu(). It tries to find the boot VGA device that is KMS capable, or the first KMS device.
+static std::optional<std::pair<UnixFileDescriptor, CString>> findDevice(struct udev* udev, const char* seatID)
 {
-    drmDevicePtr devices[64];
-    memset(devices, 0, sizeof(devices));
-
-    int numDevices = drmGetDevices2(0, devices, std::size(devices));
-    if (numDevices <= 0) {
-        g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "No DRM devices found");
-        return { };
-    }
+    RefPtr<struct udev_enumerate> udevEnumerate = adoptRef(udev_enumerate_new(udev));
+    udev_enumerate_add_match_subsystem(udevEnumerate.get(), "drm");
+    udev_enumerate_add_match_sysname(udevEnumerate.get(), "card[0-9]*");
+    udev_enumerate_scan_devices(udevEnumerate.get());
 
     UnixFileDescriptor fd;
-    for (int i = 0; i < numDevices; ++i) {
-        drmDevice* device = devices[i];
-        if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY)))
+    RefPtr<struct udev_device> drmDevice;
+    struct udev_list_entry* entry;
+    udev_list_entry_foreach(entry, udev_enumerate_get_list_entry(udevEnumerate.get())) {
+        RefPtr<struct udev_device> udevDevice = adoptRef(udev_device_new_from_syspath(udev, udev_list_entry_get_name(entry)));
+        if (!udevDevice)
             continue;
 
-        fd = UnixFileDescriptor { open(device->nodes[DRM_NODE_PRIMARY], O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+        const char* deviceSeatID = udev_device_get_property_value(udevDevice.get(), "ID_SEAT");
+        if (!deviceSeatID)
+            deviceSeatID = "seat0";
+        if (g_strcmp0(deviceSeatID, seatID))
+            continue;
+
+        bool isbootVGA = false;
+        if (auto* pciDevice = udev_device_get_parent_with_subsystem_devtype(udevDevice.get(), "pci", nullptr)) {
+            const char* id = udev_device_get_sysattr_value(pciDevice, "boot_vga");
+            isbootVGA = id && !strcmp(id, "1");
+        }
+
+        if (!isbootVGA && drmDevice)
+            continue;
+
+        const char* filename = udev_device_get_devnode(udevDevice.get());
+        fd = UnixFileDescriptor { open(filename, O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
         if (!fd)
             continue;
 
         WPE::DRM::UniquePtr<drmModeRes> resources(drmModeGetResources(fd.value()));
-        if (resources && resources->count_crtcs && resources->count_connectors && resources->count_encoders)
-            break;
+        if (!resources || !resources->count_crtcs || !resources->count_connectors || !resources->count_encoders) {
+            fd = { };
+            continue;
+        }
+
+        drmDevice = WTFMove(udevDevice);
+        if (isbootVGA)
+            return std::pair<UnixFileDescriptor, CString> { WTFMove(fd), CString(filename) };
 
         fd = { };
     }
 
-    drmFreeDevices(devices, numDevices);
+    if (!fd || !drmDevice)
+        return std::nullopt;
 
-    if (!fd) {
-        g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "No suitable DRM device found");
-        return { };
-    }
-
-    return fd;
+    return std::pair<UnixFileDescriptor, CString> { WTFMove(fd), CString(udev_device_get_devnode(drmDevice.get())) };
 }
 
 static bool wpeDisplayDRMInitializeCapabilities(WPEDisplayDRM* display, int fd, GError** error)
@@ -206,11 +230,20 @@ static std::unique_ptr<WPE::DRM::Plane> choosePlaneForCrtc(int fd, WPE::DRM::Pla
 
 static gboolean wpeDisplayDRMConnect(WPEDisplay* display, GError** error)
 {
-    // FIXME: make it possible to pass a device.
-    auto fd = findDevice(error);
-    if (!fd)
+    RefPtr<struct udev> udev = adoptRef(udev_new());
+    if (!udev) {
+        g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "Failed to create udev context");
         return FALSE;
+    }
 
+    auto session = WPE::DRM::Session::create();
+    auto fdAndFilename = findDevice(udev.get(), session->seatID());
+    if (!fdAndFilename) {
+        g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "No suitable DRM device found");
+        return FALSE;
+    }
+
+    auto fd = WTFMove(fdAndFilename->first);
     if (drmSetMaster(fd.value()) == -1) {
         g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "Failed to become DRM master");
         return FALSE;
@@ -246,12 +279,23 @@ static gboolean wpeDisplayDRMConnect(WPEDisplay* display, GError** error)
         return FALSE;
     }
 
+    auto seat = WPE::DRM::Seat::create(udev.get(), *session);
+    if (!seat) {
+        g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "Failed to initialize input");
+        return FALSE;
+    }
+
+    std::unique_ptr<char, decltype(free)*> renderNodePath(drmGetRenderDeviceNameFromFd(fd.value()), free);
+
+    displayDRM->priv->session = WTFMove(session);
     displayDRM->priv->fd = WTFMove(fd);
+    displayDRM->priv->drmDevice = WTFMove(fdAndFilename->second);
+    displayDRM->priv->drmRenderNode = renderNodePath.get();
     displayDRM->priv->device = device;
     displayDRM->priv->connector = WTFMove(connector);
     displayDRM->priv->monitor = wpeMonitorDRMCreate(WTFMove(crtc), *displayDRM->priv->connector);
     displayDRM->priv->primaryPlane = WTFMove(primaryPlane);
-    displayDRM->priv->seat = WPE::DRM::Seat::create();
+    displayDRM->priv->seat = WTFMove(seat);
     if (cursorPlane)
         displayDRM->priv->cursor = makeUnique<WPE::DRM::Cursor>(WTFMove(cursorPlane), device, displayDRM->priv->cursorWidth, displayDRM->priv->cursorHeight);
 
@@ -291,6 +335,19 @@ static WPEMonitor* wpeDisplayDRMGetMonitor(WPEDisplay* display, guint index)
     return WPE_DISPLAY_DRM(display)->priv->monitor.get();
 }
 
+static const char* wpeDisplayDRMGetDRMDevice(WPEDisplay* display)
+{
+    return WPE_DISPLAY_DRM(display)->priv->drmDevice.data();
+}
+
+static const char* wpeDisplayDRMGetDRMRenderNode(WPEDisplay* display)
+{
+    auto* priv = WPE_DISPLAY_DRM(display)->priv;
+    if (!priv->drmRenderNode.isNull())
+        priv->drmRenderNode.data();
+    return priv->drmDevice.data();
+}
+
 static void wpe_display_drm_class_init(WPEDisplayDRMClass* displayDRMClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(displayDRMClass);
@@ -302,6 +359,8 @@ static void wpe_display_drm_class_init(WPEDisplayDRMClass* displayDRMClass)
     displayClass->get_preferred_dma_buf_formats = wpeDisplayDRMGetPreferredDMABufFormats;
     displayClass->get_n_monitors = wpeDisplayDRMGetNMonitors;
     displayClass->get_monitor = wpeDisplayDRMGetMonitor;
+    displayClass->get_drm_device = wpeDisplayDRMGetDRMDevice;
+    displayClass->get_drm_render_node = wpeDisplayDRMGetDRMRenderNode;
 }
 
 const WPE::DRM::Connector& wpeDisplayDRMGetConnector(WPEDisplayDRM* display)
@@ -347,7 +406,7 @@ WPEDisplay* wpe_display_drm_new(void)
  *
  * Get the GBM device for @display
  *
- * Returns: (transfer none) (nullable): a `struct gbm_display`,
+ * Returns: (transfer none) (nullable): a `struct gbm_device`,
      or %NULL if display is not connected
  */
 struct gbm_device* wpe_display_drm_get_device(WPEDisplayDRM* display)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -40,11 +40,20 @@
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
+#include <wtf/text/CString.h>
 
 // These includes need to be in this order because wayland-egl.h defines WL_EGL_PLATFORM
 // and egl.h checks that to decide whether it's Wayland platform.
 #include <wayland-egl.h>
 #include <epoxy/egl.h>
+
+#if USE(LIBDRM)
+#include <xf86drm.h>
+#endif
+
+#ifndef EGL_DRM_RENDER_NODE_FILE_EXT
+#define EGL_DRM_RENDER_NODE_FILE_EXT 0x3377
+#endif
 
 /**
  * WPEDisplayWayland:
@@ -56,9 +65,14 @@ struct _WPEDisplayWaylandPrivate {
     struct xdg_wm_base* xdgWMBase;
     struct wl_shm* wlSHM;
     struct zwp_linux_dmabuf_v1* linuxDMABuf;
+#if USE(LIBDRM)
+    struct zwp_linux_dmabuf_feedback_v1* dmabufFeedback;
+#endif
     Vector<std::pair<uint32_t, uint64_t>> linuxDMABufFormats;
     std::unique_ptr<WPE::WaylandSeat> wlSeat;
     std::unique_ptr<WPE::WaylandCursor> wlCursor;
+    CString drmDevice;
+    CString drmRenderNode;
     Vector<GRefPtr<WPEMonitor>, 1> monitors;
     GRefPtr<GSource> eventSource;
 };
@@ -160,6 +174,9 @@ static void wpeDisplayWaylandDispose(GObject* object)
         auto monitor = priv->monitors.takeLast();
         wpe_monitor_invalidate(monitor.get());
     }
+#if USE(LIBDRM)
+    g_clear_pointer(&priv->dmabufFeedback, zwp_linux_dmabuf_feedback_v1_destroy);
+#endif
     g_clear_pointer(&priv->linuxDMABuf, zwp_linux_dmabuf_v1_destroy);
     g_clear_pointer(&priv->wlSHM, wl_shm_destroy);
     g_clear_pointer(&priv->xdgWMBase, xdg_wm_base_destroy);
@@ -217,6 +234,52 @@ const struct xdg_wm_base_listener xdgWMBaseListener = {
     },
 };
 
+#if USE(LIBDRM)
+static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackListener = {
+    // done
+    [](void*, struct zwp_linux_dmabuf_feedback_v1*)
+    {
+    },
+    // format_table
+    [](void*, struct zwp_linux_dmabuf_feedback_v1*, int32_t, uint32_t)
+    {
+    },
+    // main_device
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* device)
+    {
+        dev_t deviceID;
+        memcpy(&deviceID, device->data, sizeof(dev_t));
+
+        drmDevicePtr drmDevice;
+        if (drmGetDeviceFromDevId(deviceID, 0, &drmDevice))
+            return;
+
+        auto* priv = WPE_DISPLAY_WAYLAND(data)->priv;
+        if (drmDevice->available_nodes & (1 << DRM_NODE_PRIMARY))
+            priv->drmDevice = drmDevice->nodes[DRM_NODE_PRIMARY];
+        if (drmDevice->available_nodes & (1 << DRM_NODE_RENDER))
+            priv->drmRenderNode = drmDevice->nodes[DRM_NODE_RENDER];
+        drmFreeDevice(&drmDevice);
+    },
+    // tranche_done
+    [](void*, struct zwp_linux_dmabuf_feedback_v1*)
+    {
+    },
+    // tranche_target_device
+    [](void*, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array*)
+    {
+    },
+    // tranche_formats
+    [](void*, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array*)
+    {
+    },
+    // tranche_flags
+    [](void*, struct zwp_linux_dmabuf_feedback_v1*, uint32_t)
+    {
+    }
+};
+#endif
+
 static const struct zwp_linux_dmabuf_v1_listener linuxDMABufListener = {
     // format
     [](void*, struct zwp_linux_dmabuf_v1*, uint32_t) {
@@ -230,10 +293,34 @@ static const struct zwp_linux_dmabuf_v1_listener linuxDMABufListener = {
     }
 };
 
+static void wpeDisplayWaylandInitializeDRMDeviceFromEGL(WPEDisplayWayland* display)
+{
+    auto* priv = display->priv;
+    auto* eglDisplay = eglGetDisplay(priv->wlDisplay);
+    if (!eglDisplay)
+        return;
+
+    if (!eglInitialize(eglDisplay, nullptr, nullptr))
+        return;
+
+    if (!epoxy_has_egl_extension(eglDisplay, "EGL_EXT_device_query"))
+        return;
+
+    EGLDeviceEXT eglDevice;
+    if (!eglQueryDisplayAttribEXT(eglDisplay, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
+        return;
+
+    const char* extensions = eglQueryDeviceStringEXT(eglDevice, EGL_EXTENSIONS);
+    if (epoxy_extension_in_string(extensions, "EGL_EXT_device_drm"))
+        priv->drmDevice = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_DEVICE_FILE_EXT);
+    if (epoxy_extension_in_string(extensions, "EGL_EXT_device_drm_render_node"))
+        priv->drmRenderNode = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_RENDER_NODE_FILE_EXT);
+}
+
 static gboolean wpeDisplayWaylandConnect(WPEDisplay* display, GError** error)
 {
-    auto* displayWaylnd = WPE_DISPLAY_WAYLAND(display);
-    auto* priv = displayWaylnd->priv;
+    auto* displayWayland = WPE_DISPLAY_WAYLAND(display);
+    auto* priv = displayWayland->priv;
     if (priv->wlDisplay) {
         g_set_error_literal(error, WPE_DISPLAY_ERROR, WPE_DISPLAY_ERROR_CONNECTION_FAILED, "Wayland display is already connected");
         return FALSE;
@@ -245,7 +332,7 @@ static gboolean wpeDisplayWaylandConnect(WPEDisplay* display, GError** error)
         return FALSE;
     }
 
-    priv->eventSource = wpeDisplayWaylandCreateEventSource(displayWaylnd);
+    priv->eventSource = wpeDisplayWaylandCreateEventSource(displayWayland);
 
     auto* registry = wl_display_get_registry(priv->wlDisplay);
     wl_registry_add_listener(registry, &registryListener, display);
@@ -258,13 +345,23 @@ static gboolean wpeDisplayWaylandConnect(WPEDisplay* display, GError** error)
     if (priv->xdgWMBase)
         xdg_wm_base_add_listener(priv->xdgWMBase, &xdgWMBaseListener, nullptr);
     if (priv->wlSeat) {
-        priv->wlCursor = makeUnique<WPE::WaylandCursor>(displayWaylnd);
+        priv->wlCursor = makeUnique<WPE::WaylandCursor>(displayWayland);
         priv->wlSeat->startListening();
     }
+
     if (priv->linuxDMABuf) {
+#if USE(LIBDRM)
+        if (zwp_linux_dmabuf_v1_get_version(priv->linuxDMABuf) >= ZWP_LINUX_DMABUF_V1_GET_DEFAULT_FEEDBACK_SINCE_VERSION) {
+            priv->dmabufFeedback = zwp_linux_dmabuf_v1_get_default_feedback(priv->linuxDMABuf);
+            zwp_linux_dmabuf_feedback_v1_add_listener(priv->dmabufFeedback, &linuxDMABufFeedbackListener, display);
+        }
+#endif
         zwp_linux_dmabuf_v1_add_listener(priv->linuxDMABuf, &linuxDMABufListener, display);
         wl_display_roundtrip(priv->wlDisplay);
     }
+
+    if (priv->drmDevice.isNull())
+        wpeDisplayWaylandInitializeDRMDeviceFromEGL(displayWayland);
 
     return TRUE;
 }
@@ -342,6 +439,19 @@ static WPEMonitor* wpeDisplayWaylandGetMonitor(WPEDisplay* display, guint index)
     return priv->monitors[index].get();
 }
 
+static const char* wpeDisplayWaylandGetDRMDevice(WPEDisplay* display)
+{
+    return WPE_DISPLAY_WAYLAND(display)->priv->drmDevice.data();
+}
+
+static const char* wpeDisplayWaylandGetDRMRenderNode(WPEDisplay* display)
+{
+    auto* priv = WPE_DISPLAY_WAYLAND(display)->priv;
+    if (!priv->drmRenderNode.isNull())
+        return priv->drmRenderNode.data();
+    return priv->drmDevice.data();
+}
+
 struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland* display)
 {
     return display->priv->xdgWMBase;
@@ -385,6 +495,8 @@ static void wpe_display_wayland_class_init(WPEDisplayWaylandClass* displayWaylan
     displayClass->get_preferred_dma_buf_formats = wpeDisplayWaylandGetPreferredDMABufFormats;
     displayClass->get_n_monitors = wpeDisplayWaylandGetNMonitors;
     displayClass->get_monitor = wpeDisplayWaylandGetMonitor;
+    displayClass->get_drm_device = wpeDisplayWaylandGetDRMDevice;
+    displayClass->get_drm_render_node = wpeDisplayWaylandGetDRMRenderNode;
 }
 
 /**


### PR DESCRIPTION
#### c2361c31a74159368c4298faa9049cd0cc3a3453
<pre>
[WPE] WPE Platform: make functions to get DRM device and render node members of WPEDisplay
<a href="https://bugs.webkit.org/show_bug.cgi?id=270629">https://bugs.webkit.org/show_bug.cgi?id=270629</a>

Reviewed by Alejandro G. Castro.

They are currently global, and in the case of DRM might not be
consistent with what it&apos;s actually used. Now that we have the primary
display, we can move the API to WPEDisplay and return what every
platform is actually using.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp:
(WebKit::DisplayVBlankMonitorDRM::create):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp:
(wpeBufferDMABufDispose):
(wpeBufferDMABufTryEnsureGBMDevice):
(wpeBufferDMABufImportToPixels):
(gbmDevice): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpe_display_get_drm_device):
(wpe_display_get_drm_render_node):
(renderNodeFile): Deleted.
(wpeDRMRenderNodeFile): Deleted.
(wpe_render_node_device): Deleted.
(renderDeviceFile): Deleted.
(wpeDRMRenderDeviceFile): Deleted.
(wpe_render_device): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.cpp: Added.
(WTF::udev&gt;::refIfNotNull):
(WTF::udev&gt;::derefIfNotNull):
(WTF::udev_device&gt;::refIfNotNull):
(WTF::udev_device&gt;::derefIfNotNull):
(WTF::udev_enumerate&gt;::refIfNotNull):
(WTF::udev_enumerate&gt;::derefIfNotNull):
* Source/WebKit/WPEPlatform/wpe/drm/RefPtrUdev.h: Added.
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp:
(WPE::DRM::Seat::create):
(WPE::DRM::Seat::Seat):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(findDevice):
(wpeDisplayDRMConnect):
(wpeDisplayDRMGetDRMDevice):
(wpeDisplayDRMGetDRMRenderNode):
(wpe_display_drm_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):
(wpeDisplayWaylandConnect):
(wpeDisplayWaylandGetDRMDevice):
(wpeDisplayWaylandGetDRMRenderNode):
(wpe_display_wayland_class_init):

Canonical link: <a href="https://commits.webkit.org/275830@main">https://commits.webkit.org/275830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d061331932a9b0e9fcde1b3c21e3ff755257dfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42835 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45451 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38960 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35444 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16488 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/891 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/46966 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42183 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19287 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40823 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19451 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5820 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->