### PR TITLE
[WebDriver][WPE][GTK] Enable WebDriver connection to already running browser

### DIFF
--- a/Source/WebDriver/Capabilities.h
+++ b/Source/WebDriver/Capabilities.h
@@ -75,6 +75,8 @@ struct Capabilities {
     std::optional<PageLoadStrategy> pageLoadStrategy;
     std::optional<UnhandledPromptBehavior> unhandledPromptBehavior;
     std::optional<Proxy> proxy;
+    std::optional<String> targetAddr;
+    std::optional<int> targetPort;
 #if PLATFORM(GTK) || PLATFORM(WPE)
     std::optional<String> browserBinary;
     std::optional<Vector<String>> browserArguments;
@@ -82,10 +84,6 @@ struct Capabilities {
 #endif
 #if PLATFORM(GTK)
     std::optional<bool> useOverlayScrollbars;
-#endif
-#if USE(INSPECTOR_SOCKET_SERVER)
-    std::optional<String> targetAddr;
-    std::optional<int> targetPort;
 #endif
 };
 

--- a/Source/WebDriver/SessionHost.h
+++ b/Source/WebDriver/SessionHost.h
@@ -56,9 +56,7 @@ public:
     }
     ~SessionHost();
 
-#if USE(INSPECTOR_SOCKET_SERVER)
     void setHostAddress(const String& ip, uint16_t port) { m_targetIp = ip; m_targetPort = port; }
-#endif
     bool isConnected() const;
 
     const String& sessionID() const { return m_sessionID; }
@@ -116,14 +114,16 @@ private:
 
     HashMap<long, Function<void (CommandResponse&&)>> m_commandRequests;
 
+    String m_targetIp;
+    uint16_t m_targetPort { 0 };
+
 #if USE(GLIB)
     Function<void (bool, std::optional<String>)> m_startSessionCompletionHandler;
     GRefPtr<GSubprocess> m_browser;
     RefPtr<SocketConnection> m_socketConnection;
     GRefPtr<GCancellable> m_cancellable;
+    bool m_isRemoteBrowser { false };
 #elif USE(INSPECTOR_SOCKET_SERVER)
-    String m_targetIp;
-    uint16_t m_targetPort { 0 };
     Function<void(bool, std::optional<String>)> m_startSessionCompletionHandler;
     std::optional<Inspector::ConnectionID> m_clientID;
 #endif

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -143,10 +143,8 @@ private:
     HTTPServer m_server;
     RefPtr<Session> m_session;
 
-#if USE(INSPECTOR_SOCKET_SERVER)
     String m_targetAddress;
     uint16_t m_targetPort { 0 };
-#endif
 };
 
 } // namespace WebDriver

--- a/Source/WebDriver/gtk/WebDriverServiceGtk.cpp
+++ b/Source/WebDriver/gtk/WebDriverServiceGtk.cpp
@@ -29,6 +29,7 @@
 #include "Capabilities.h"
 #include "CommandResult.h"
 #include <wtf/JSONValues.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebDriver {
 
@@ -157,6 +158,15 @@ void WebDriverService::platformParseCapabilities(const JSON::Object& matchedCapa
             ASSERT(!certificateFile.isNull());
 
             capabilities.certificates->append({ WTFMove(host), WTFMove(certificateFile) });
+        }
+    }
+
+    String targetString;
+    if (browserOptions->getString("targetAddress"_s, targetString)) {
+        auto position = targetString.reverseFind(':');
+        if (position != notFound) {
+            capabilities.targetAddr = targetString.left(position);
+            capabilities.targetPort = parseIntegerAllowingTrailingJunk<uint16_t>(StringView { targetString }.substring(position + 1)).value_or(0);
         }
     }
 }

--- a/Source/WebDriver/wpe/WebDriverServiceWPE.cpp
+++ b/Source/WebDriver/wpe/WebDriverServiceWPE.cpp
@@ -29,6 +29,7 @@
 #include "Capabilities.h"
 #include "CommandResult.h"
 #include <wtf/JSONValues.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebDriver {
 
@@ -146,6 +147,15 @@ void WebDriverService::platformParseCapabilities(const JSON::Object& matchedCapa
             ASSERT(!certificateFile.isNull());
 
             capabilities.certificates->append({ WTFMove(host), WTFMove(certificateFile) });
+        }
+    }
+
+    String targetString;
+    if (browserOptions->getString("targetAddress"_s, targetString)) {
+        auto position = targetString.reverseFind(':');
+        if (position != notFound) {
+            capabilities.targetAddr = targetString.left(position);
+            capabilities.targetPort = parseIntegerAllowingTrailingJunk<uint16_t>(StringView { targetString }.substring(position + 1)).value_or(0);
         }
     }
 }


### PR DESCRIPTION
#### 56dbdddc059f3ee1689f34d8626600722aebcc73
<pre>
[WebDriver][WPE][GTK] Enable WebDriver connection to already running browser
<a href="https://bugs.webkit.org/show_bug.cgi?id=270630">https://bugs.webkit.org/show_bug.cgi?id=270630</a>

Reviewed by Carlos Garcia Campos.

In some embedded cases WebDriver needs to be able to connect to already
existing instance of browser running automation session. There&apos;s already
code in WebDriver to support this scenario but it&apos;s not used in WPE/GTK.

* Source/WebDriver/Capabilities.h:
* Source/WebDriver/SessionHost.h:
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::printUsageStatement):
(WebDriver::WebDriverService::run):
(WebDriver::WebDriverService::connectToBrowser):
* Source/WebDriver/WebDriverService.h:
* Source/WebDriver/glib/SessionHostGlib.cpp:
(WebDriver::SessionHost::isConnected const):
(WebDriver::SessionHost::launchBrowser):
(WebDriver::SessionHost::connectToBrowser):
(WebDriver::SessionHost::connectionDidClose):
* Source/WebDriver/gtk/WebDriverServiceGtk.cpp:
(WebDriver::WebDriverService::platformParseCapabilities const):
* Source/WebDriver/wpe/WebDriverServiceWPE.cpp:
(WebDriver::WebDriverService::platformParseCapabilities const):

Canonical link: <a href="https://commits.webkit.org/276231@main">https://commits.webkit.org/276231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aad7cf914174bfb2fb1c939c8d890c195ff11ad3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39982 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20359 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36227 "Failure limit exceed. At least found 2 new test failures: compositing/animation/animation-compositing.html, compositing/animation/busy-indicator.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38898 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1963 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48116 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43044 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20302 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41762 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20506 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6049 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->