### PR TITLE
[GTK] Receive dropped files using the File Transfer portal

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/DropTarget.h
+++ b/Source/WebKit/UIProcess/API/gtk/DropTarget.h
@@ -65,6 +65,7 @@ private:
 
 #if USE(GTK4)
     void loadData(const char* mimeType, CompletionHandler<void(GRefPtr<GBytes>&&)>&&);
+    void loadData(CompletionHandler<void(Vector<String>&&)>&&);
     void didLoadData();
 #else
     void dataReceived(WebCore::IntPoint&&, GtkSelectionData*, unsigned, unsigned);
@@ -83,6 +84,7 @@ private:
     std::optional<WebCore::DragOperation> m_operation;
 #if USE(GTK4)
     GRefPtr<GCancellable> m_cancellable;
+    StringBuilder m_uriListBuilder;
 #else
     RunLoop::Timer m_leaveTimer;
 #endif


### PR DESCRIPTION
#### ff20e457cb9cfffad9d1a6b9ccc9bb8a8537fb89
<pre>
[GTK] Receive dropped files using the File Transfer portal
<a href="https://bugs.webkit.org/show_bug.cgi?id=212079">https://bugs.webkit.org/show_bug.cgi?id=212079</a>

Reviewed by Carlos Garcia Campos.

GTK4 has content serializers and deserializers that are able to read
from, and write to, the File Transfer portal. They&apos;re used when using
the high level content formats API, i.e. using GTypes. In particular,
GTK4 is able to convert from &quot;application/vnd.portal.filetransfer&quot; (and
the legacy &quot;application/vnd.portal.files&quot;) from and into GdkFileLists.

The DropTargetGtk4 code did not advertise the GdkFileList GType as a
potential data offering, so GTK4 was never able to let the File Transfer
portal conversion happen.

Add the GdkFileList GType to the content formats.

This creates a small conflict: many apps, e.g. Nautilus, advertise files
both as &quot;application/vnd.portal.filetransfer&quot;, and as &quot;text/uri-list&quot;.
The file URIs under &quot;text/uri-list&quot; are meaningless to sandboxed apps,
as they might be in innaccessible locations. Which is why I&apos;ve made the
executive decision to ignore &quot;file://&quot; URIs when the File Transfer portal
is used. Other types of URIs are preserved.

(Other browsers take a more radical approach of ignoring all URIs on the
presence of the File Transfer portal vendor.)

* Source/WebKit/UIProcess/API/gtk/DropTarget.h:
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::DropTarget):
(WebKit::DropTarget::accept):
(WebKit::DropReadAsyncData::DropReadAsyncData):
(WebKit::DropTarget::loadData):
(WebKit::DropTarget::didLoadData):

Canonical link: <a href="https://commits.webkit.org/275908@main">https://commits.webkit.org/275908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7049eee5ec1ff3ac1c2e1da914981b6bf30b6e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43264 "Failed to checkout and rebase branch from PR 25575") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/22288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/45676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26042 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/19711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/45900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/43837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/45676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/45676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/1322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/45676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/19711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/47445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/45676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5872 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->