### PR TITLE
Rename RenderStyle effectiveAccentColor() to usedAccentColor()

### DIFF
--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
@@ -275,14 +275,14 @@ LengthBox ThemeAdwaita::controlBorder(StyleAppearance appearance, const FontCasc
     return Theme::controlBorder(appearance, font, zoomedBox, zoomFactor);
 }
 
-void ThemeAdwaita::paint(StyleAppearance appearance, OptionSet<ControlStyle::State> states, GraphicsContext& context, const FloatRect& zoomedRect, bool useDarkAppearance, const Color& effectiveAccentColor)
+void ThemeAdwaita::paint(StyleAppearance appearance, OptionSet<ControlStyle::State> states, GraphicsContext& context, const FloatRect& zoomedRect, bool useDarkAppearance, const Color& usedAccentColor)
 {
     switch (appearance) {
     case StyleAppearance::Checkbox:
-        paintCheckbox(states, context, zoomedRect, useDarkAppearance, effectiveAccentColor);
+        paintCheckbox(states, context, zoomedRect, useDarkAppearance, usedAccentColor);
         break;
     case StyleAppearance::Radio:
-        paintRadio(states, context, zoomedRect, useDarkAppearance, effectiveAccentColor);
+        paintRadio(states, context, zoomedRect, useDarkAppearance, usedAccentColor);
         break;
     case StyleAppearance::PushButton:
     case StyleAppearance::DefaultButton:
@@ -298,7 +298,7 @@ void ThemeAdwaita::paint(StyleAppearance appearance, OptionSet<ControlStyle::Sta
     }
 }
 
-void ThemeAdwaita::paintCheckbox(OptionSet<ControlStyle::State> states, GraphicsContext& graphicsContext, const FloatRect& zoomedRect, bool useDarkAppearance, const Color& effectiveAccentColor)
+void ThemeAdwaita::paintCheckbox(OptionSet<ControlStyle::State> states, GraphicsContext& graphicsContext, const FloatRect& zoomedRect, bool useDarkAppearance, const Color& usedAccentColor)
 {
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
@@ -323,7 +323,7 @@ void ThemeAdwaita::paintCheckbox(OptionSet<ControlStyle::State> states, Graphics
         toggleBorderHoverColor = toggleBorderHoveredColorLight;
     }
 
-    Color accentColor = effectiveAccentColor.isValid() ? effectiveAccentColor : m_accentColor;
+    Color accentColor = usedAccentColor.isValid() ? usedAccentColor : m_accentColor;
     Color foregroundColor = accentColor.luminance() > 0.5 ? Color(SRGBA<uint8_t> { 0, 0, 0, 204 }) : Color::white;
     Color accentHoverColor = blendSourceOver(accentColor, foregroundColor.colorWithAlphaMultipliedBy(0.1));
 
@@ -383,7 +383,7 @@ void ThemeAdwaita::paintCheckbox(OptionSet<ControlStyle::State> states, Graphics
         graphicsContext.endTransparencyLayer();
 }
 
-void ThemeAdwaita::paintRadio(OptionSet<ControlStyle::State> states, GraphicsContext& graphicsContext, const FloatRect& zoomedRect, bool useDarkAppearance, const Color& effectiveAccentColor)
+void ThemeAdwaita::paintRadio(OptionSet<ControlStyle::State> states, GraphicsContext& graphicsContext, const FloatRect& zoomedRect, bool useDarkAppearance, const Color& usedAccentColor)
 {
     GraphicsContextStateSaver stateSaver(graphicsContext);
     FloatRect fieldRect = zoomedRect;
@@ -407,7 +407,7 @@ void ThemeAdwaita::paintRadio(OptionSet<ControlStyle::State> states, GraphicsCon
         toggleBorderHoverColor = toggleBorderHoveredColorLight;
     }
 
-    Color accentColor = effectiveAccentColor.isValid() ? effectiveAccentColor : m_accentColor;
+    Color accentColor = usedAccentColor.isValid() ? usedAccentColor : m_accentColor;
     Color foregroundColor = accentColor.luminance() > 0.5 ? Color(SRGBA<uint8_t> { 0, 0, 0, 204 }) : Color::white;
     Color accentHoverColor = blendSourceOver(accentColor, foregroundColor.colorWithAlphaMultipliedBy(0.1));
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -735,7 +735,7 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderObject& ren
         extractControlStyleStatesForRendererInternal(*renderer),
         renderer->style().computedFontSize(),
         renderer->style().effectiveZoom(),
-        renderer->style().effectiveAccentColor(),
+        renderer->style().usedAccentColor(),
         renderer->style().visitedDependentColorWithColorFilter(CSSPropertyColor),
         renderer->style().borderWidth()
     };
@@ -802,7 +802,7 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     case StyleAppearance::Button:
     case StyleAppearance::InnerSpinButton: {
         auto states = extractControlStyleStatesForRenderer(box);
-        Theme::singleton().paint(appearance, states, paintInfo.context(), devicePixelSnappedRect, box.useDarkAppearance(), box.style().effectiveAccentColor());
+        Theme::singleton().paint(appearance, states, paintInfo.context(), devicePixelSnappedRect, box.useDarkAppearance(), box.style().usedAccentColor());
         return false;
     }
 #else // !USE(THEME_ADWAITA)

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -107,7 +107,7 @@ static inline Color getSystemAccentColor()
 static inline Color getAccentColor(const RenderObject& renderObject)
 {
     if (!renderObject.style().hasAutoAccentColor())
-        return renderObject.style().effectiveAccentColor();
+        return renderObject.style().usedAccentColor();
 
     return getSystemAccentColor();
 }
@@ -416,7 +416,7 @@ bool RenderThemeAdwaita::paintMenuList(const RenderObject& renderObject, const P
         states.add(ControlStyle::State::Pressed);
     if (isHovered(renderObject))
         states.add(ControlStyle::State::Hovered);
-    Theme::singleton().paint(StyleAppearance::Button, states, graphicsContext, rect, renderObject.useDarkAppearance(), renderObject.style().effectiveAccentColor());
+    Theme::singleton().paint(StyleAppearance::Button, states, graphicsContext, rect, renderObject.useDarkAppearance(), renderObject.style().usedAccentColor());
 
     auto zoomedArrowSize = menuListButtonArrowSize * renderObject.style().effectiveZoom();
     FloatRect fieldRect = rect;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -895,7 +895,7 @@ void RenderThemeIOS::adjustButtonLikeControlStyle(RenderStyle& style, const Elem
         return;
 
     if (!style.hasAutoAccentColor()) {
-        auto tintColor = style.effectiveAccentColor();
+        auto tintColor = style.usedAccentColor();
         if (isSubmitStyleButton(element))
             style.setBackgroundColor(tintColor);
         else
@@ -1232,7 +1232,7 @@ Color RenderThemeIOS::pictureFrameColor(const RenderObject& buttonRenderer)
 Color RenderThemeIOS::controlTintColor(const RenderStyle& style, OptionSet<StyleColorOptions> options) const
 {
     if (!style.hasAutoAccentColor())
-        return style.effectiveAccentColor();
+        return style.usedAccentColor();
 
     return systemColor(CSSValueAppleSystemBlue, options);
 }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3095,7 +3095,7 @@ Color RenderStyle::colorWithColorFilter(const StyleColor& color) const
     return colorByApplyingColorFilter(colorResolvingCurrentColor(color));
 }
 
-Color RenderStyle::effectiveAccentColor() const
+Color RenderStyle::usedAccentColor() const
 {
     if (hasAutoAccentColor())
         return { };

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2139,7 +2139,7 @@ public:
     inline const StyleColor& floodColor() const;
     inline const StyleColor& lightingColor() const;
 
-    Color effectiveAccentColor() const;
+    Color usedAccentColor() const;
     inline const StyleColor& accentColor() const;
     inline bool hasAutoAccentColor() const;
 


### PR DESCRIPTION
#### 0268a598d4f5ffa22507cfe582e6e5f6d6c14e6c
<pre>
Rename RenderStyle effectiveAccentColor() to usedAccentColor()
<a href="https://bugs.webkit.org/show_bug.cgi?id=270632">https://bugs.webkit.org/show_bug.cgi?id=270632</a>

Reviewed by Aditya Keerthi.

This aligns it with terminology used in CSS standards.

* Source/WebCore/platform/adwaita/ThemeAdwaita.cpp:
(WebCore::ThemeAdwaita::paint):
(WebCore::ThemeAdwaita::paintCheckbox):
(WebCore::ThemeAdwaita::paintRadio):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::extractControlStyleForRenderer const):
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::getAccentColor):
(WebCore::RenderThemeAdwaita::paintMenuList):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustButtonLikeControlStyle const):
(WebCore::RenderThemeIOS::controlTintColor const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::usedAccentColor const):
(WebCore::RenderStyle::effectiveAccentColor const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:

Canonical link: <a href="https://commits.webkit.org/275833@main">https://commits.webkit.org/275833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60f42293a68d58a5ce43232184e0a562d8f3e43e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/43013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39138 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/45319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19462 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/43586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1069 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47169 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5822 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->