### PR TITLE
[Skia] Purge caches on memory pressure

### DIFF
--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -253,7 +253,9 @@ void logMemoryStatistics(LogMemoryStatisticsReason reason)
 #endif
 
 #if !PLATFORM(COCOA)
+#if !USE(SKIA)
 void platformReleaseMemory(Critical) { }
+#endif
 void platformReleaseGraphicsMemory(Critical) { }
 void jettisonExpensiveObjectsOnTopLevelNavigation() { }
 void registerMemoryReleaseNotifyCallbacks() { }

--- a/Source/WebCore/page/skia/MemoryReleaseSkia.cpp
+++ b/Source/WebCore/page/skia/MemoryReleaseSkia.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "MemoryRelease.h"
+
+#include <skia/core/SkGraphics.h>
+
+namespace WebCore {
+
+void platformReleaseMemory(Critical)
+{
+    SkGraphics::PurgeAllCaches();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -21,6 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+page/skia/MemoryReleaseSkia.cpp
+
 platform/graphics/skia/TransformationMatrixSkia.cpp
 platform/graphics/skia/ColorSkia.cpp
 platform/graphics/skia/ComplexTextControllerSkia.cpp


### PR DESCRIPTION
#### ba923386fa73c9fe13cab4d52a20e8f0d982935b
<pre>
[Skia] Purge caches on memory pressure
<a href="https://bugs.webkit.org/show_bug.cgi?id=270634">https://bugs.webkit.org/show_bug.cgi?id=270634</a>

Reviewed by Carlos Garcia Campos.

* Source/WebCore/PlatformWPE.cmake:
* Source/WebCore/page/MemoryRelease.cpp:
* Source/WebCore/page/skia/MemoryReleaseSkia.cpp: Added.
(WebCore::platformReleaseMemory):

Canonical link: <a href="https://commits.webkit.org/275967@main">https://commits.webkit.org/275967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2145de2b5632d384aa8fbe9e17eac688857b670

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35756 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38323 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47409 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42554 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19683 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41208 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19861 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5900 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->