### PR TITLE
<input type=checkbox switch> paints outside its box and the thumb is slightly misaligned on macOS

### DIFF
--- a/LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html
+++ b/LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html class="reftest-wait" dir=rtl>
-<meta name="fuzzy" content="maxDifference=0-38; totalPixels=0-1290">
+<meta name="fuzzy" content="maxDifference=0-33; totalPixels=0-626">
 <style>
 body { zoom: 5; display: grid; writing-mode:vertical-lr }
 span { display: inline-block; background: white }

--- a/LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html
+++ b/LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html class="reftest-wait">
-<meta name="fuzzy" content="maxDifference=0-38; totalPixels=0-1290">
+<meta name="fuzzy" content="maxDifference=0-33; totalPixels=0-626">
 <style>
 body { zoom: 5; display: grid }
 span { display: inline-block; background: white }

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
@@ -29,7 +29,7 @@
 namespace WebCore::SwitchMacUtilities {
 
 IntSize cellSize(NSControlSize);
-FloatSize visualCellSize(NSControlSize, const ControlStyle&);
+FloatSize visualCellSize(IntSize, const ControlStyle&);
 IntOutsets cellOutsets(NSControlSize);
 IntOutsets visualCellOutsets(NSControlSize, bool);
 FloatRect rectForBounds(const FloatRect&);
@@ -38,6 +38,7 @@ float easeInOut(float);
 FloatRect rectWithTransposedSize(const FloatRect&, bool);
 FloatRect trackRectForBounds(const FloatRect&, const FloatSize&);
 void rotateContextForVerticalWritingMode(GraphicsContext&, const FloatRect&);
+RefPtr<ImageBuffer> trackMaskImage(GraphicsContext&, FloatSize, float, bool, NSString *);
 
 } // namespace WebCore::SwitchMacUtilities
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -46,8 +46,6 @@ SwitchThumbMac::SwitchThumbMac(SwitchThumbPart& part, ControlFactoryMac& control
 
 IntSize SwitchThumbMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
 {
-    // For now we need the track sizes to paint the thumb. As it happens the thumb is the square
-    // of the track's height. We (ab)use that fact with drawingThumbLength below.
     return SwitchMacUtilities::cellSize(controlSize);
 }
 
@@ -76,35 +74,51 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 
     auto logicalBounds = SwitchMacUtilities::rectWithTransposedSize(borderRect.rect(), isVertical);
     auto controlSize = controlSizeForSize(logicalBounds.size(), style);
-    auto size = SwitchMacUtilities::visualCellSize(controlSize, style);
+    auto logicalTrackSize = cellSize(controlSize, style);
+    auto logicalThumbSize = IntSize { logicalTrackSize.height(), logicalTrackSize.height() };
+    auto trackSize = SwitchMacUtilities::visualCellSize(logicalTrackSize, style);
+    auto thumbSize = SwitchMacUtilities::visualCellSize(logicalThumbSize, style);
     auto outsets = SwitchMacUtilities::visualCellOutsets(controlSize, isVertical);
 
-    auto trackRect = SwitchMacUtilities::trackRectForBounds(logicalBounds, size);
-    auto inflatedTrackRect = inflatedRect(trackRect, size, outsets, style);
-    if (isVertical)
+    auto trackRect = SwitchMacUtilities::trackRectForBounds(logicalBounds, trackSize);
+    auto thumbRect = SwitchMacUtilities::trackRectForBounds(logicalBounds, thumbSize);
+
+    auto inflatedTrackRect = inflatedRect(trackRect, trackSize, outsets, style);
+    auto inflatedThumbRect = inflatedRect(thumbRect, thumbSize, outsets, style);
+    if (isVertical) {
         inflatedTrackRect.setSize(inflatedTrackRect.size().transposedSize());
+        inflatedThumbRect.setSize(inflatedThumbRect.size().transposedSize());
+    }
 
     if (style.zoomFactor != 1) {
         inflatedTrackRect.scale(1 / style.zoomFactor);
+        inflatedThumbRect.scale(1 / style.zoomFactor);
         context.scale(style.zoomFactor);
     }
 
-    auto drawingThumbLength = inflatedTrackRect.height();
     auto drawingThumbIsLogicallyLeft = (!isRTL && !isOn) || (isRTL && isOn);
-    auto drawingThumbLogicalXAxis = inflatedTrackRect.width() - drawingThumbLength;
+    auto drawingThumbLogicalXAxis = inflatedTrackRect.width() - inflatedThumbRect.width();
     auto drawingThumbLogicalXAxisProgress = drawingThumbLogicalXAxis * progress;
     auto drawingThumbLogicalX = drawingThumbIsLogicallyLeft ? drawingThumbLogicalXAxis - drawingThumbLogicalXAxisProgress : drawingThumbLogicalXAxisProgress;
-    auto drawingThumbRect = NSMakeRect(drawingThumbLogicalX, 0, drawingThumbLength, drawingThumbLength);
+    auto drawingThumbRect = NSMakeRect(drawingThumbLogicalX, 0, inflatedThumbRect.width(), inflatedThumbRect.height());
 
-    auto trackBuffer = context.createImageBuffer(inflatedTrackRect.size(), deviceScaleFactor);
+    auto coreUISize = SwitchMacUtilities::coreUISizeForControlSize(controlSize);
 
-    if (!trackBuffer)
+    auto maskImage = SwitchMacUtilities::trackMaskImage(context, inflatedTrackRect.size(), deviceScaleFactor, isRTL, coreUISize);
+    if (!maskImage)
         return;
 
-    auto cgContext = trackBuffer->context().platformContext();
+    auto trackImage = context.createImageBuffer(inflatedTrackRect.size(), deviceScaleFactor);
+    if (!trackImage)
+        return;
+
+    auto cgContext = trackImage->context().platformContext();
 
     {
         CGContextStateSaver stateSaverTrack(cgContext);
+
+        // FIXME: clipping in context() might not always be accurate for context().platformContext().
+        trackImage->context().clipToImageBuffer(*maskImage, NSMakeRect(0, 0, inflatedTrackRect.width(), inflatedTrackRect.height()));
 
         [[NSAppearance currentDrawingAppearance] _drawInRect:drawingThumbRect context:cgContext options:@{
             (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchKnob,
@@ -118,7 +132,7 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     if (isVertical)
         SwitchMacUtilities::rotateContextForVerticalWritingMode(context, inflatedTrackRect);
 
-    context.drawConsumingImageBuffer(WTFMove(trackBuffer), inflatedTrackRect.location());
+    context.drawConsumingImageBuffer(WTFMove(trackImage), inflatedTrackRect.location());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 5381f48e7a048d58bf8b46f15a4318f38457acc8
<pre>
&lt;input type=checkbox switch&gt; paints outside its box and the thumb is slightly misaligned on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=267679">https://bugs.webkit.org/show_bug.cgi?id=267679</a>
<a href="https://rdar.apple.com/121579531">rdar://121579531</a>

Reviewed by Aditya Keerthi.

This fixes two problems:

1. The thumb was misplaced by half a pixel. The error here was not
   calculating the inflated box for the thumb independently and instead
   assuming it would be the inflated track&apos;s height squared. The new
   code calculates the thumb boxes (mostly) independently from the
   track boxes.

2. Drawing the thumb was not masked in any way. This resulted in some
   pixel bleeding at the top of the control. This was noticed, but
   initially not deemed a problem. It&apos;s now deemed a problem and
   corrected by using the same masking code we use for the track. There
   remains some slight bleeding, though noticeably less.

* LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html:
* LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html:
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm:
(WebCore::SwitchMacUtilities::visualCellSize):
(WebCore::SwitchMacUtilities::trackMaskImage):
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm:
(WebCore::SwitchThumbMac::cellSize const):
(WebCore::SwitchThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm:
(WebCore::SwitchTrackMac::draw):
(WebCore::trackMaskImage): Deleted.

Canonical link: <a href="https://commits.webkit.org/275808@main">https://commits.webkit.org/275808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34cb9e34c2b6c36e46e0e62d400a5bfb0d2362ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35482 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37970 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47016 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42229 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40887 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9567 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->