### PR TITLE
:empty selector with animation not working properly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/empty-pseudo-class-with-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/empty-pseudo-class-with-animation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Setting an "animation" style property on an element does not interfere with the :empty pseudo-class.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/empty-pseudo-class-with-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/empty-pseudo-class-with-animation.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<link rel="author" href="mailto:graouts@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-animations/">
+<link rel="help" href="https://drafts.csswg.org/selectors/#the-empty-pseudo">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/css-animations/support/testcommon.js"></script>
+
+<div class="container"></div>
+
+<style>
+
+.container {
+  width: 100px;
+  height: 100px;
+  background-color: rgb(0, 255, 0);
+}
+
+.container:empty {
+  background-color: rgb(255, 0, 0);
+  animation: anim 1s;
+}
+
+@keyframes anim { }
+
+</style>
+
+<script>
+
+promise_test(async () => {
+  const container = document.querySelector(".container");
+  const computedStyle = getComputedStyle(container);
+
+  // Check that the :empty rule applies initially.
+  assert_equals(computedStyle.backgroundColor, 'rgb(255, 0, 0)',
+    'The initial background-color matches the value set by the :empty rule.');
+
+  // Await a couple of frames to let any animation-related style updates happen.
+  await waitForAnimationFrames(2);
+
+  // Append a child which should no longer let the :empty rule apply.
+  container.appendChild(document.createElement("span"));
+  assert_equals(computedStyle.backgroundColor, 'rgb(0, 255, 0)',
+    'The background-color after inserting a child into the container no longer matches the value set by the :empty rule.');
+}, 'Setting an "animation" style property on an element does not interfere with the :empty pseudo-class.');
+
+</script>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -999,7 +999,9 @@ void TreeResolver::resolveComposedTree()
         auto resolutionType = determineResolutionType(element, style, parent.descendantsToResolve, parent.change);
         if (resolutionType) {
             element.resetComputedStyle();
-            element.resetStyleRelations();
+
+            if (*resolutionType != ResolutionType::AnimationOnly)
+                element.resetStyleRelations();
 
             if (element.hasCustomStyleResolveCallbacks())
                 element.willRecalcStyle(parent.change);


### PR DESCRIPTION
#### 319ecb9c28e377b3bd11e6cbd878008f84e87bb7
<pre>
:empty selector with animation not working properly
<a href="https://bugs.webkit.org/show_bug.cgi?id=269051">https://bugs.webkit.org/show_bug.cgi?id=269051</a>
<a href="https://rdar.apple.com/122838142">rdar://122838142</a>

Reviewed by Antti Koivisto.

If an element is targeted by an animation, it may cause style updates with an `AnimationOnly` resolution type.
When `Style::TreeResolver::resolveElement()` is called for that element, `resetStyleRelations()` is called on
that element first under `Style::TreeResolver::resolveComposedTree()` while iterating through the composed tree.

If an `:empty` pseudo-class rule matches that element, that call to `resetStyleRelations()` will remove the
`StyleAffectedByEmpty` flag on that element, but it will not be recomputed under `resolveElement()` because when
`styleForStyleable()` is called the `AnimationOnly` resolution type will mean that we clone the cached last style
resolution style to return the `ResolvedStyle` value, clear of any relations.

We now avoid calling `resetStyleRelations()` if the resolution type is `AnimationOnly`, ensuring that relations
are preserved throughout animation updates.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/empty-pseudo-class-with-animation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/empty-pseudo-class-with-animation.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):

Canonical link: <a href="https://commits.webkit.org/275832@main">https://commits.webkit.org/275832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1923f332f558359adf485c542202b55c7d99fa8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35476 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/37967 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/926 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47012 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42230 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40881 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19486 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5821 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/18952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->