### PR TITLE
[ews] Build failure emails should include commit identifier

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3477,6 +3477,7 @@ class AnalyzeCompileWebKitResults(buildstep.BuildStep, BugzillaMixin, GitHubMixi
             builder_name = self.getProperty('buildername', '')
             worker_name = self.getProperty('workername', '')
             platform = self.getProperty('platform', '')
+            identifier = self.getProperty('identifier', None)
             build_url = '{}#/builders/{}/builds/{}'.format(self.master.config.buildbotURL, self.build._builderid, self.build.number)
             logs = self.error_logs.get(self.compile_webkit_step)
             if platform in ['wincairo']:
@@ -3485,7 +3486,8 @@ class AnalyzeCompileWebKitResults(buildstep.BuildStep, BugzillaMixin, GitHubMixi
                 logs = self.filter_logs_containing_error(logs)
 
             email_subject = 'Build failure on trunk on {}'.format(builder_name)
-            email_text = 'Failed to build WebKit without patch in {}\n\nBuilder: {}\n\nWorker: {}'.format(build_url, builder_name, worker_name)
+            email_text = f'Failed to build WebKit without change in {build_url}\n\nBuilder: {builder_name}\nWorker: {worker_name}'
+            email_text += f'\nIdentifier: {identifier}'
             if logs:
                 logs = logs.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
                 email_text += '\n\nError lines:\n\n<code>{}</code>'.format(logs)


### PR DESCRIPTION
#### 0b42e6c6ade0519487e119ae12ff6c54ac67ef6e
<pre>
[ews] Build failure emails should include commit identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=270637">https://bugs.webkit.org/show_bug.cgi?id=270637</a>

Reviewed by Ryan Haddad.

This would help in quickly identifying the potential regression point/range by
glancing over the emails.

* Tools/CISupport/ews-build/steps.py:
(AnalyzeCompileWebKitResults.send_email_for_preexisting_build_failure):

Canonical link: <a href="https://commits.webkit.org/275796@main">https://commits.webkit.org/275796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84c923e2c7bfd7f099f336e47e73393d9605e5bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42871 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/21892 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/45272 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45489 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/38996 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/45177 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/25591 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/19272 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/45489 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/43444 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/25591 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/45272 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45489 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/25591 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/45272 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/927 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/25591 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/45272 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47010 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17698 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/19272 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/42918 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/45272 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19487 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5803 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->