### PR TITLE
[GStreamer] Use integers as track ID instead of AtomString

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -56,6 +56,14 @@ AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPl
     installUpdateConfigurationHandlers();
 }
 
+AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
+    : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Audio, this, index, WTFMove(pad), trackId)
+    , m_player(WTFMove(player))
+{
+    ensureDebugCategoryInitialized();
+    installUpdateConfigurationHandlers();
+}
+
 AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GstStream* stream)
     : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Audio, this, index, stream)
     , m_player(WTFMove(player))
@@ -70,7 +78,7 @@ AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPl
     updateConfigurationFromTags(WTFMove(tags));
 }
 
-void AudioTrackPrivateGStreamer::capsChanged(const String& streamId, GRefPtr<GstCaps>&& caps)
+void AudioTrackPrivateGStreamer::capsChanged(TrackID streamId, GRefPtr<GstCaps>&& caps)
 {
     ASSERT(isMainThread());
     updateConfigurationFromCaps(WTFMove(caps));

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -46,12 +46,14 @@
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/UUID.h>
 #include <wtf/glib/GThreadSafeWeakPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringHash.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 #if USE(GSTREAMER_MPEGTS)
 #define GST_USE_UNSTABLE_API
@@ -229,6 +231,51 @@ bool getSampleVideoInfo(GstSample* sample, GstVideoInfo& videoInfo)
 }
 #endif
 
+std::optional<TrackID> getStreamIdFromPad(const GRefPtr<GstPad>& pad)
+{
+    GUniquePtr<gchar> streamIdAsCharacters(gst_pad_get_stream_id(pad.get()));
+    if (!streamIdAsCharacters) {
+        GST_DEBUG_OBJECT(pad.get(), "Failed to get stream-id from pad");
+        return std::nullopt;
+    }
+
+    std::optional<TrackID> streamId(parseStreamId(StringView::fromLatin1(streamIdAsCharacters.get())));
+    if (!streamId)
+        GST_WARNING_OBJECT(pad.get(), "Got invalid stream-id from pad: %s", streamIdAsCharacters.get());
+
+    return streamId;
+}
+
+std::optional<TrackID> getStreamIdFromStream(const GRefPtr<GstStream>& stream)
+{
+    const gchar* streamIdAsCharacters = gst_stream_get_stream_id(stream.get());
+    if (!streamIdAsCharacters) {
+        GST_DEBUG_OBJECT(stream.get(), "Failed to get stream-id from stream");
+        return std::nullopt;
+    }
+
+    std::optional<TrackID> streamId(parseStreamId(StringView::fromLatin1(streamIdAsCharacters)));
+    if (!streamId)
+        GST_WARNING_OBJECT(stream.get(), "Got invalid stream-id from stream: %s", streamIdAsCharacters);
+
+    return streamId;
+}
+
+std::optional<TrackID> parseStreamId(StringView stringId)
+{
+    auto maybeUUID = WTF::UUID::parse(stringId);
+    if (maybeUUID.has_value())
+        return maybeUUID.value().low();
+
+    // GStreamer docs advise against interpreting contents of a stream-id,
+    // however this is the format qtdemux uses for stream-id creation,
+    // so we can reasonably rely on it.
+    size_t position = stringId.find('/');
+    if (position == notFound || position + 1 == stringId.length())
+        return parseIntegerAllowingTrailingJunk<TrackID>(stringId);
+
+    return parseIntegerAllowingTrailingJunk<TrackID>(stringId.substring(position + 1));
+}
 
 StringView capsMediaType(const GstCaps* caps)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -37,6 +37,11 @@ namespace WebCore {
 class IntSize;
 class SharedBuffer;
 
+using TrackID = uint64_t;
+
+template<typename MappedArg>
+using TrackIDHashMap = HashMap<TrackID, MappedArg, WTF::IntHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>>;
+
 inline bool webkitGstCheckVersion(guint major, guint minor, guint micro)
 {
     guint currentMajor, currentMinor, currentMicro, currentNano;
@@ -69,6 +74,9 @@ std::optional<FloatSize> getVideoResolutionFromCaps(const GstCaps*);
 bool getSampleVideoInfo(GstSample*, GstVideoInfo&);
 #endif
 StringView capsMediaType(const GstCaps*);
+std::optional<TrackID> getStreamIdFromPad(const GRefPtr<GstPad>&);
+std::optional<TrackID> getStreamIdFromStream(const GRefPtr<GstStream>&);
+std::optional<TrackID> parseStreamId(StringView stringId);
 bool doCapsHaveType(const GstCaps*, const char*);
 bool areEncryptedCaps(const GstCaps*);
 Vector<String> extractGStreamerOptionsFromCommandLine();

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -54,6 +54,15 @@ InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index,
     installUpdateConfigurationHandlers();
 }
 
+InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
+    : InbandTextTrackPrivate(CueFormat::WebVTT)
+    , TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Text, this, index, WTFMove(pad), trackId)
+    , m_kind(Kind::Subtitles)
+{
+    ensureTextTrackDebugCategoryInitialized();
+    installUpdateConfigurationHandlers();
+}
+
 InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index, GstStream* stream)
     : InbandTextTrackPrivate(CueFormat::WebVTT)
     , TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Text, this, index, stream)
@@ -61,7 +70,7 @@ InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index,
     ensureTextTrackDebugCategoryInitialized();
     installUpdateConfigurationHandlers();
 
-    GST_INFO("Track %d got stream start for stream %s.", m_index, m_stringId.string().utf8().data());
+    GST_INFO("Track %d got stream start for stream %" PRIu64 ". GStreamer stream-id: %s", m_index, m_id, m_gstStreamId.string().utf8().data());
 
     GST_DEBUG("Stream %" GST_PTR_FORMAT, m_stream.get());
     auto caps = adoptGRef(gst_stream_get_caps(m_stream.get()));

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
@@ -42,6 +42,11 @@ public:
         return adoptRef(*new InbandTextTrackPrivateGStreamer(index, WTFMove(pad), shouldHandleStreamStartEvent));
     }
 
+    static Ref<InbandTextTrackPrivateGStreamer> create(unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
+    {
+        return adoptRef(*new InbandTextTrackPrivateGStreamer(index, WTFMove(pad), trackId));
+    }
+
     static Ref<InbandTextTrackPrivateGStreamer> create(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, unsigned index, GRefPtr<GstPad> pad)
     {
         return create(index, WTFMove(pad));
@@ -53,8 +58,8 @@ public:
     }
 
     Kind kind() const final { return m_kind; }
-    TrackID id() const final { return m_trackID.value_or(m_index); }
-    std::optional<AtomString> trackUID() const final { return m_stringId; }
+    TrackID id() const final { return m_trackID.value_or(m_id); }
+    std::optional<AtomString> trackUID() const final { return std::nullopt; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
     int trackIndex() const final { return m_index; }
@@ -66,6 +71,7 @@ protected:
 
 private:
     InbandTextTrackPrivateGStreamer(unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
+    InbandTextTrackPrivateGStreamer(unsigned index, GRefPtr<GstPad>&&, TrackID);
     InbandTextTrackPrivateGStreamer(unsigned index, GstStream*);
 
     void notifyTrackOfSample();

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1117,7 +1117,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
     ASSERT(m_isLegacyPlaybin);
 
     using TrackType = TrackPrivateBaseGStreamer::TrackType;
-    std::variant<UncheckedKeyHashMap<AtomString, Ref<AudioTrackPrivateGStreamer>>*, UncheckedKeyHashMap<AtomString, Ref<VideoTrackPrivateGStreamer>>*, UncheckedKeyHashMap<AtomString, Ref<InbandTextTrackPrivateGStreamer>>*> variantTracks = static_cast<UncheckedKeyHashMap<AtomString, Ref<TrackPrivateType>>*>(0);
+    std::variant<TrackIDHashMap<Ref<AudioTrackPrivateGStreamer>>*, TrackIDHashMap<Ref<VideoTrackPrivateGStreamer>>*, TrackIDHashMap<Ref<InbandTextTrackPrivateGStreamer>>*> variantTracks = static_cast<TrackIDHashMap<Ref<TrackPrivateType>>*>(0);
     auto type(static_cast<TrackType>(variantTracks.index()));
     const char* typeName;
     bool* hasType;
@@ -1140,7 +1140,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
     default:
         ASSERT_NOT_REACHED();
     }
-    auto& tracks = *std::get<UncheckedKeyHashMap<AtomString, Ref<TrackPrivateType>>*>(variantTracks);
+    auto& tracks = *std::get<TrackIDHashMap<Ref<TrackPrivateType>>*>(variantTracks);
 
     // Ignore notifications after a EOS. We don't want the tracks to disappear when the video is finished.
     if (m_isEndReached && (type == TrackType::Audio || type == TrackType::Video))
@@ -1163,7 +1163,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
             player->sizeChanged();
     }
 
-    Vector<AtomString> validStreams;
+    Vector<TrackID> validStreams;
     StringPrintStream getPadProperty;
     getPadProperty.printf("get-%s-pad", typeName);
 
@@ -1175,7 +1175,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
         if (!pad)
             continue;
 
-        AtomString streamId(TrackPrivateBaseGStreamer::trackIdFromPadStreamStartOrUniqueID(type, i, pad));
+        TrackID streamId(getStreamIdFromPad(pad).value_or(i));
         validStreams.append(streamId);
 
         if (i < tracks.size()) {
@@ -1193,7 +1193,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
         }
 
         auto track = TrackPrivateType::create(*this, i, GRefPtr(pad));
-        ASSERT(track->stringId() == streamId);
+        ASSERT(track->streamId() == streamId);
         if (!track->trackIndex() && (type == TrackType::Audio || type == TrackType::Video))
             track->setActive(true);
 
@@ -1209,7 +1209,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
             player->addTextTrack(*std::get<InbandTextTrackPrivate*>(variantTrack));
             break;
         }
-        tracks.add(track->stringId(), WTFMove(track));
+        tracks.add(track->streamId(), WTFMove(track));
         changed = true;
     }
 
@@ -1254,16 +1254,16 @@ void MediaPlayerPrivateGStreamer::videoSinkCapsChanged(GstPad* videoSinkPad)
     });
 }
 
-void MediaPlayerPrivateGStreamer::handleTextSample(GRefPtr<GstSample>&& sample, const String& streamId)
+void MediaPlayerPrivateGStreamer::handleTextSample(GRefPtr<GstSample>&& sample, TrackID streamId)
 {
     for (auto& track : m_textTracks.values()) {
-        if (track->stringId() == streamId) {
+        if (track->streamId() == streamId) {
             track->handleSample(WTFMove(sample));
             return;
         }
     }
 
-    GST_WARNING_OBJECT(m_pipeline.get(), "Got sample with unknown stream ID %s.", streamId.utf8().data());
+    GST_WARNING_OBJECT(m_pipeline.get(), "Got sample with unknown stream ID %" PRIu64 ".", streamId);
 }
 
 MediaTime MediaPlayerPrivateGStreamer::platformDuration() const
@@ -1554,7 +1554,7 @@ void MediaPlayerPrivateGStreamer::updateEnabledVideoTrack()
         GST_DEBUG_OBJECT(m_pipeline.get(), "Setting playbin2 current-video=%d", wantedTrack->trackIndex());
         g_object_set(m_pipeline.get(), "current-video", wantedTrack->trackIndex(), nullptr);
     } else {
-        m_wantedVideoStreamId = wantedTrack->stringId();
+        m_wantedVideoStreamId = wantedTrack->streamId();
         playbin3SendSelectStreamsIfAppropriate();
     }
 }
@@ -1578,7 +1578,7 @@ void MediaPlayerPrivateGStreamer::updateEnabledAudioTrack()
         GST_DEBUG_OBJECT(m_pipeline.get(), "Setting playbin2 current-audio=%d", wantedTrack->trackIndex());
         g_object_set(m_pipeline.get(), "current-audio", wantedTrack->trackIndex(), nullptr);
     } else {
-        m_wantedAudioStreamId = wantedTrack->stringId();
+        m_wantedAudioStreamId = wantedTrack->streamId();
         playbin3SendSelectStreamsIfAppropriate();
     }
 }
@@ -1595,17 +1595,20 @@ void MediaPlayerPrivateGStreamer::playbin3SendSelectStreamsIfAppropriate()
         return;
 
     GList* streams = nullptr;
-    if (!m_wantedVideoStreamId.isNull()) {
+    if (m_wantedVideoStreamId) {
+        auto track = m_videoTracks.get(m_wantedVideoStreamId.value());
         m_requestedVideoStreamId = m_wantedVideoStreamId;
-        streams = g_list_append(streams, g_strdup(m_wantedVideoStreamId.string().utf8().data()));
+        streams = g_list_append(streams, g_strdup(track->gstStreamId().string().utf8().data()));
     }
-    if (!m_wantedAudioStreamId.isNull()) {
+    if (m_wantedAudioStreamId) {
+        auto track = m_audioTracks.get(m_wantedAudioStreamId.value());
         m_requestedAudioStreamId = m_wantedAudioStreamId;
-        streams = g_list_append(streams, g_strdup(m_wantedAudioStreamId.string().utf8().data()));
+        streams = g_list_append(streams, g_strdup(track->gstStreamId().string().utf8().data()));
     }
-    if (!m_wantedTextStreamId.isNull()) {
+    if (m_wantedTextStreamId) {
+        auto track = m_textTracks.get(m_wantedTextStreamId.value());
         m_requestedTextStreamId = m_wantedTextStreamId;
-        streams = g_list_append(streams, g_strdup(m_wantedTextStreamId.string().utf8().data()));
+        streams = g_list_append(streams, g_strdup(track->gstStreamId().string().utf8().data()));
     }
 
     if (!streams)
@@ -1683,7 +1686,7 @@ void MediaPlayerPrivateGStreamer::updateTracks([[maybe_unused]] const GRefPtr<Gs
         auto track = m_##type##Tracks.get(streamId);                    \
         if (isTrackCached)                                              \
             track->updateConfigurationFromCaps(WTFMove(caps));          \
-        auto trackId = track->stringId();                               \
+        auto trackId = track->streamId();                               \
         if (!type##TrackIndex) { \
             m_wanted##Type##StreamId = trackId;                         \
             m_requested##Type##StreamId = trackId;                      \
@@ -1701,11 +1704,11 @@ void MediaPlayerPrivateGStreamer::updateTracks([[maybe_unused]] const GRefPtr<Gs
     for (unsigned i = 0; i < length; i++) {
         auto* stream = gst_stream_collection_get_stream(m_streamCollection.get(), i);
         RELEASE_ASSERT(stream);
-        auto streamId = AtomString::fromLatin1(gst_stream_get_stream_id(stream));
+        auto streamId = getStreamIdFromStream(stream).value();
         auto type = gst_stream_get_stream_type(stream);
         auto caps = adoptGRef(gst_stream_get_caps(stream));
 
-        GST_DEBUG_OBJECT(pipeline(), "#%u %s track with ID %s and caps %" GST_PTR_FORMAT, i, gst_stream_type_get_name(type), streamId.string().ascii().data(), caps.get());
+        GST_DEBUG_OBJECT(pipeline(), "#%u %s track with ID %" PRIu64 " and caps %" GST_PTR_FORMAT, i, gst_stream_type_get_name(type), streamId, caps.get());
 
         if (type & GST_STREAM_TYPE_AUDIO) {
             CREATE_OR_SELECT_TRACK(audio, Audio);
@@ -1715,7 +1718,7 @@ void MediaPlayerPrivateGStreamer::updateTracks([[maybe_unused]] const GRefPtr<Gs
         else if (type & GST_STREAM_TYPE_TEXT && !useMediaSource)
             CREATE_OR_SELECT_TRACK(text, Text);
         else
-            GST_WARNING("Unknown track type found for stream %s", streamId.string().ascii().data());
+            GST_WARNING("Unknown track type found for stream %" PRIu64 "", streamId);
     }
 #undef CREATE_OR_SELECT_TRACK
 }
@@ -3246,17 +3249,17 @@ void MediaPlayerPrivateGStreamer::setupCodecProbe(GstElement* element)
         if (!codec)
             return GST_PAD_PROBE_REMOVE;
 
-        GUniquePtr<char> streamId(gst_pad_get_stream_id(pad));
+        std::optional<TrackID> streamId(getStreamIdFromPad(pad));
         if (UNLIKELY(!streamId)) {
             // FIXME: This is a workaround for https://bugs.webkit.org/show_bug.cgi?id=256428.
             GST_WARNING_OBJECT(player->pipeline(), "Caps event received before stream-start. This shouldn't happen!");
             return GST_PAD_PROBE_REMOVE;
         }
 
-        GST_INFO_OBJECT(player->pipeline(), "Setting codec for stream %s to %s", streamId.get(), codec.get());
+        GST_INFO_OBJECT(player->pipeline(), "Setting codec for stream %" PRIu64 " to %s", streamId.value(), codec.get());
         {
             Locker locker { player->m_codecsLock };
-            player->m_codecs.add(String::fromLatin1(streamId.get()), String::fromLatin1(codec.get()));
+            player->m_codecs.add(streamId.value(), String::fromLatin1(codec.get()));
         }
         return GST_PAD_PROBE_REMOVE;
     }), this, nullptr);
@@ -4295,7 +4298,7 @@ void MediaPlayerPrivateGStreamer::checkPlayingConsistency()
     }
 }
 
-String MediaPlayerPrivateGStreamer::codecForStreamId(const String& streamId)
+String MediaPlayerPrivateGStreamer::codecForStreamId(TrackID streamId)
 {
     Locker locker { m_codecsLock };
     if (UNLIKELY(!m_codecs.contains(streamId)))

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -67,13 +67,14 @@ public:
     void setInitialCaps(GRefPtr<GstCaps>&& caps) { m_initialCaps = WTFMove(caps); }
     const GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
 
-    static String trackIdFromPadStreamStartOrUniqueID(TrackType, unsigned index, const GRefPtr<GstPad>&);
-    const AtomString& stringId() const { return m_stringId; };
+    TrackID streamId() const { return m_id; }
+    const AtomString& gstStreamId() const { return m_gstStreamId; }
 
     virtual void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) { }
 
 protected:
     TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
+    TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, TrackID);
     TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GstStream*);
 
     void notifyTrackOfTagsChanged();
@@ -82,7 +83,7 @@ protected:
     GstObject* objectForLogging() const;
 
     virtual void tagsChanged(GRefPtr<GstTagList>&&) { }
-    virtual void capsChanged(const String&, GRefPtr<GstCaps>&&) { }
+    virtual void capsChanged(TrackID, GRefPtr<GstCaps>&&) { }
     void installUpdateConfigurationHandlers();
     virtual void updateConfigurationFromTags(GRefPtr<GstTagList>&&) { }
 
@@ -98,7 +99,8 @@ protected:
     unsigned m_index;
     AtomString m_label;
     AtomString m_language;
-    AtomString m_stringId;
+    AtomString m_gstStreamId;
+    // Track ID parsed from stream-id.
     TrackID m_id;
     GRefPtr<GstPad> m_pad;
     GRefPtr<GstPad> m_bestUpstreamPad;
@@ -114,7 +116,6 @@ protected:
 private:
     bool getLanguageCode(GstTagList* tags, AtomString& value);
     static AtomString generateUniquePlaybin2StreamID(TrackType, unsigned index);
-    static TrackID trackIdFromStringIdOrIndex(TrackType, const AtomString&, unsigned);
     static char prefixForType(TrackType);
     template<class StringType>
     bool getTag(GstTagList* tags, const gchar* tagName, StringType& value);
@@ -126,6 +127,7 @@ private:
     TrackPrivateBase* m_owner;
     Lock m_tagMutex;
     GRefPtr<GstTagList> m_tags;
+    bool m_shouldUsePadStreamId { true };
     bool m_shouldHandleStreamStartEvent { true };
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -57,6 +57,14 @@ VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPl
     installUpdateConfigurationHandlers();
 }
 
+VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
+    : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Video, this, index, WTFMove(pad), trackId)
+    , m_player(WTFMove(player))
+{
+    ensureVideoTrackDebugCategoryInitialized();
+    installUpdateConfigurationHandlers();
+}
+
 VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GstStream* stream)
     : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Video, this, index, stream)
     , m_player(WTFMove(player))
@@ -71,7 +79,7 @@ VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPl
     updateConfigurationFromTags(WTFMove(tags));
 }
 
-void VideoTrackPrivateGStreamer::capsChanged(const String& streamId, GRefPtr<GstCaps>&& caps)
+void VideoTrackPrivateGStreamer::capsChanged(TrackID streamId, GRefPtr<GstCaps>&& caps)
 {
     ASSERT(isMainThread());
     updateConfigurationFromCaps(WTFMove(caps));

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -83,7 +83,7 @@ static GstPadProbeReturn appendPipelineAppsinkPadEventProbe(GstPad*, GstPadProbe
 #endif
 static GstPadProbeReturn appendPipelineDemuxerBlackHolePadProbe(GstPad*, GstPadProbeInfo*, gpointer);
 static GstPadProbeReturn matroskademuxForceSegmentStartToEqualZero(GstPad*, GstPadProbeInfo*, void*);
-static GRefPtr<GstElement> createOptionalParserForFormat(GstBin*, const AtomString&, const GstCaps*);
+static GRefPtr<GstElement> createOptionalParserForFormat(GstBin*, TrackID, const GstCaps*);
 
 // Wrapper for gst_element_set_state() that emits a critical if the state change fails or is not synchronous.
 static void assertedElementSetState(GstElement* element, GstState desiredState)
@@ -237,6 +237,7 @@ AppendPipeline::~AppendPipeline()
 #if ENABLE(ENCRYPTED_MEDIA)
         gst_pad_remove_probe(appsinkPad.get(), track->appsinkPadEventProbeInformation.probeId);
 #endif
+        m_sourceBufferPrivate.tryUnregisterTrackId(track->trackId);
     }
 
     // We can tear down the pipeline safely now.
@@ -426,9 +427,8 @@ void AppendPipeline::didReceiveInitializationSegment()
 
     if (isFirstInitializationSegment) {
         // Create a Track object per pad.
-        int trackIndex = 0;
         for (GstPad* pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(m_demux.get())))) {
-            auto [createTrackResult, track] = tryCreateTrackFromPad(pad, trackIndex);
+            auto [createTrackResult, track] = tryCreateTrackFromPad(pad);
             if (createTrackResult == CreateTrackResult::AppendParsingFailed) {
                 // appendParsingFailed() will immediately cause a resetParserState() which will stop demuxing, then the
                 // AppendPipeline will be destroyed.
@@ -437,7 +437,6 @@ void AppendPipeline::didReceiveInitializationSegment()
             }
             if (track)
                 linkPadWithTrack(pad, *track);
-            trackIndex++;
         }
     } else {
         HashSet<String> videoPadStreamIDs;
@@ -510,7 +509,7 @@ void AppendPipeline::didReceiveInitializationSegment()
 
     for (std::unique_ptr<Track>& track : m_tracks) {
 #ifndef GST_DISABLE_GST_DEBUG
-        GST_DEBUG_OBJECT(pipeline(), "Adding track to initialization with segment type %s, id %s.", streamTypeToString(track->streamType), track->trackStringId.string().utf8().data());
+        GST_DEBUG_OBJECT(pipeline(), "Adding track to initialization with segment type %s, id %" PRIu64 ".", streamTypeToString(track->streamType), track->trackId);
 #endif // GST_DISABLE_GST_DEBUG
         switch (track->streamType) {
         case Audio: {
@@ -538,8 +537,8 @@ void AppendPipeline::didReceiveInitializationSegment()
     if (isFirstInitializationSegment) {
         for (std::unique_ptr<Track>& track : m_tracks) {
             if (track->streamType == StreamType::Video) {
-                GST_DEBUG_OBJECT(pipeline(), "Setting initial video size to that of track with id '%s', %gx%g.",
-                    track->trackStringId.string().utf8().data(), static_cast<double>(track->presentationSize.width()), static_cast<double>(track->presentationSize.height()));
+                GST_DEBUG_OBJECT(pipeline(), "Setting initial video size to that of track with id '%" PRIu64 "', %gx%g.",
+                    track->trackId, static_cast<double>(track->presentationSize.width()), static_cast<double>(track->presentationSize.height()));
                 m_playerPrivate->setInitialVideoSize(track->presentationSize);
                 break;
             }
@@ -684,7 +683,7 @@ void AppendPipeline::handleAppsinkNewSampleFromStreamingThread(GstElement*)
     }
 }
 
-GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin* bin, const AtomString& trackStringId, const GstCaps* caps)
+GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin* bin, TrackID trackId, const GstCaps* caps)
 {
     // Parser elements have either or both of two functions:
     //
@@ -704,7 +703,7 @@ GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin* bin, 
 
     GstStructure* structure = gst_caps_get_structure(caps, 0);
     auto mediaType = gstStructureGetName(structure);
-    auto parserName = makeString(trackStringId, "_parser"_s);
+    auto parserName = makeString(trackId, "_parser"_s);
     // Since parsers are not needed in every case, we can use an identity element as pass-through
     // parser for cases where a parser is not needed, making the management of elements and pads
     // more orthogonal.
@@ -769,21 +768,7 @@ GRefPtr<GstElement> createOptionalParserForFormat([[maybe_unused]] GstBin* bin, 
     return result;
 }
 
-AtomString AppendPipeline::generateTrackId(StreamType streamType, int padIndex)
-{
-    switch (streamType) {
-    case Audio:
-        return makeAtomString('A', padIndex);
-    case Video:
-        return makeAtomString('V', padIndex);
-    case Text:
-        return makeAtomString('T', padIndex);
-    default:
-        return makeAtomString('O', padIndex);
-    }
-}
-
-std::pair<AppendPipeline::CreateTrackResult, AppendPipeline::Track*> AppendPipeline::tryCreateTrackFromPad(GstPad* demuxerSrcPad, int trackIndex)
+std::pair<AppendPipeline::CreateTrackResult, AppendPipeline::Track*> AppendPipeline::tryCreateTrackFromPad(GstPad* demuxerSrcPad)
 {
     ASSERT(isMainThread());
     ASSERT(!m_hasReceivedFirstInitializationSegment);
@@ -808,14 +793,20 @@ std::pair<AppendPipeline::CreateTrackResult, AppendPipeline::Track*> AppendPipel
         gst_pad_add_probe(demuxerSrcPad, GST_PAD_PROBE_TYPE_BUFFER, reinterpret_cast<GstPadProbeCallback>(appendPipelineDemuxerBlackHolePadProbe), nullptr, nullptr);
         return { CreateTrackResult::TrackIgnored, nullptr };
     }
-    AtomString trackStringId = generateTrackId(streamType, trackIndex);
 
-    GST_DEBUG_OBJECT(pipeline(), "Creating new AppendPipeline::Track with id '%s'", trackStringId.string().utf8().data());
     size_t newTrackIndex = m_tracks.size();
-    m_tracks.append(makeUnique<Track>(trackIndex, trackStringId, streamType, parsedCaps, presentationSize));
+    TrackID preferredTrackId = getStreamIdFromPad(demuxerSrcPad).value_or((reinterpret_cast<TrackID>(newTrackIndex)));
+    auto assignedTrackId = m_sourceBufferPrivate.tryRegisterTrackId(preferredTrackId);
+    TrackID trackId = assignedTrackId.value_or(preferredTrackId);
+
+    if (!assignedTrackId)
+        GST_WARNING_OBJECT(pipeline(), "Failed to register track ID %" PRIu64 ", this could cause ID collisions", preferredTrackId);
+
+    GST_DEBUG_OBJECT(pipeline(), "Creating new AppendPipeline::Track with id '%" PRIu64 "'", trackId);
+    m_tracks.append(makeUnique<Track>(trackId, streamType, parsedCaps, presentationSize));
     Track& track = *m_tracks.at(newTrackIndex);
     track.initializeElements(this, GST_BIN(m_pipeline.get()));
-    track.webKitTrack = makeWebKitTrack(newTrackIndex);
+    track.webKitTrack = makeWebKitTrack(newTrackIndex, trackId);
     hookTrackEvents(track);
     return { CreateTrackResult::TrackCreated, &track };
 }
@@ -836,9 +827,6 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
         if (track->streamType != streamType)
             continue;
         matchingTrack = &*track;
-        // FIXME: This test will never match, comparing track ID from demuxerSrcPad name
-        if (track->trackStringId == trackId)
-            break;
     }
 
     if (!matchingTrack) {
@@ -867,7 +855,7 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
         auto peer = adoptGRef(gst_pad_get_peer(matchingTrack->entryPad.get()));
         if (peer.get() != demuxerSrcPad) {
             if (peer) {
-                GST_DEBUG_OBJECT(peer.get(), "Unlinking from track %s", matchingTrack->trackStringId.string().ascii().data());
+                GST_DEBUG_OBJECT(peer.get(), "Unlinking from track %" PRIu64 "", matchingTrack->trackId);
                 gst_pad_unlink(peer.get(), matchingTrack->entryPad.get());
             }
 
@@ -880,7 +868,7 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
             matchingTrack->caps = WTFMove(parsedCaps);
             matchingTrack->presentationSize = presentationSize;
         } else
-            GST_DEBUG_OBJECT(pipeline(), "%s track pads match, nothing to re-link", matchingTrack->trackStringId.string().ascii().data());
+            GST_DEBUG_OBJECT(pipeline(), "%" PRIu64 " track pads match, nothing to re-link", matchingTrack->trackId);
 
     }
 
@@ -893,7 +881,7 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
 
 void AppendPipeline::linkPadWithTrack(GstPad* demuxerSrcPad, Track& track)
 {
-    GST_DEBUG_OBJECT(demuxerSrcPad, "Linking to track %s", track.trackStringId.string().ascii().data());
+    GST_DEBUG_OBJECT(demuxerSrcPad, "Linking to track %" PRIu64 "", track.trackId);
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, "append-pipeline-before-link");
     ASSERT(!GST_PAD_IS_LINKED(track.entryPad.get()));
     gst_pad_link(demuxerSrcPad, track.entryPad.get());
@@ -901,7 +889,7 @@ void AppendPipeline::linkPadWithTrack(GstPad* demuxerSrcPad, Track& track)
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, "append-pipeline-after-link");
 }
 
-Ref<WebCore::TrackPrivateBase> AppendPipeline::makeWebKitTrack(int trackIndex)
+Ref<WebCore::TrackPrivateBase> AppendPipeline::makeWebKitTrack(int trackIndex, TrackID trackId)
 {
     Track& appendPipelineTrack = *m_tracks.at(trackIndex);
 
@@ -911,19 +899,19 @@ Ref<WebCore::TrackPrivateBase> AppendPipeline::makeWebKitTrack(int trackIndex)
     GRefPtr<GstPad> pad(appendPipelineTrack.appsinkPad);
     switch (appendPipelineTrack.streamType) {
     case StreamType::Audio: {
-        auto specificTrack = AudioTrackPrivateGStreamer::create(m_playerPrivate, trackIndex, WTFMove(pad), false);
+        auto specificTrack = AudioTrackPrivateGStreamer::create(m_playerPrivate, trackIndex, WTFMove(pad), trackId);
         gstreamerTrack = specificTrack.ptr();
         track = static_cast<TrackPrivateBase*>(specificTrack.ptr());
         break;
     }
     case StreamType::Video: {
-        auto specificTrack = VideoTrackPrivateGStreamer::create(m_playerPrivate, trackIndex, WTFMove(pad), false);
+        auto specificTrack = VideoTrackPrivateGStreamer::create(m_playerPrivate, trackIndex, WTFMove(pad), trackId);
         gstreamerTrack = specificTrack.ptr();
         track = static_cast<TrackPrivateBase*>(specificTrack.ptr());
         break;
     }
     case StreamType::Text: {
-        auto specificTrack = InbandTextTrackPrivateGStreamer::create(trackIndex, WTFMove(pad), false);
+        auto specificTrack = InbandTextTrackPrivateGStreamer::create(trackIndex, WTFMove(pad), trackId);
         gstreamerTrack = specificTrack.ptr();
         track = static_cast<TrackPrivateBase*>(specificTrack.ptr());
         break;
@@ -958,7 +946,7 @@ void AppendPipeline::Track::emplaceOptionalParserForFormat(GstBin* bin, const GR
         gst_bin_remove(bin, parser.get());
     }
 
-    parser = createOptionalParserForFormat(bin, trackStringId, newCaps.get());
+    parser = createOptionalParserForFormat(bin, trackId, newCaps.get());
     gst_bin_add(bin, parser.get());
     gst_element_sync_state_with_parent(parser.get());
     gst_element_link(parser.get(), appsink.get());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -71,16 +71,14 @@ private:
         WTF_MAKE_NONCOPYABLE(Track);
     public:
 
-        Track(TrackID trackId, const AtomString& trackStringId, StreamType streamType, const GRefPtr<GstCaps>& caps, const FloatSize& presentationSize)
+        Track(TrackID trackId, StreamType streamType, const GRefPtr<GstCaps>& caps, const FloatSize& presentationSize)
             : trackId(trackId)
-            , trackStringId(trackStringId)
             , streamType(streamType)
             , caps(caps)
             , presentationSize(presentationSize)
         { }
 
         TrackID trackId;
-        const AtomString trackStringId;
         StreamType streamType;
         GRefPtr<GstCaps> caps;
         FloatSize presentationSize;
@@ -116,7 +114,7 @@ private:
 
     void hookTrackEvents(Track&);
     static std::tuple<GRefPtr<GstCaps>, AppendPipeline::StreamType, FloatSize> parseDemuxerSrcPadCaps(GstCaps*);
-    Ref<WebCore::TrackPrivateBase> makeWebKitTrack(int trackIndex);
+    Ref<WebCore::TrackPrivateBase> makeWebKitTrack(int trackIndex, TrackID);
     void appsinkCapsChanged(Track&);
     void appsinkNewSample(const Track&, GRefPtr<GstSample>&&);
     void handleEndOfAppend();
@@ -127,7 +125,7 @@ private:
 
     static AtomString generateTrackId(StreamType, int padIndex);
     enum class CreateTrackResult { TrackCreated, TrackIgnored, AppendParsingFailed };
-    std::pair<CreateTrackResult, AppendPipeline::Track*> tryCreateTrackFromPad(GstPad* demuxerSrcPad, int padIndex);
+    std::pair<CreateTrackResult, AppendPipeline::Track*> tryCreateTrackFromPad(GstPad* demuxerSrcPad);
 
     bool recycleTrackForPad(GstPad*);
     void linkPadWithTrack(GstPad* demuxerSrcPad, Track&);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -109,7 +109,7 @@ static Vector<RefPtr<MediaSourceTrackGStreamer>> filterOutRepeatingTracks(const 
     uniqueTracks.reserveInitialCapacity(tracks.size());
 
     for (const auto& track : tracks) {
-        if (!uniqueTracks.containsIf([&track](const auto& current) { return track->stringId() == current->stringId(); }))
+        if (!uniqueTracks.containsIf([&track](const auto& current) { return track->id() == current->id(); }))
             uniqueTracks.append(track);
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -77,6 +77,9 @@ public:
 
     void detach();
 
+    TrackID registerTrackId(TrackID);
+    bool unregisterTrackId(TrackID);
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     ASCIILiteral logClassName() const override { return "MediaSourcePrivateGStreamer"_s; }
@@ -96,6 +99,11 @@ private:
     Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
     uint64_t m_nextSourceBufferID { 0 };
+
+    // Stores known track IDs, so we can work around ID collisions between multiple source buffers.
+    // The registry is placed here to enforce ID uniqueness specifically by player, not by process,
+    // since its not an issue if multiple players use the same ID, and we want to preserve IDs as much as possible.
+    HashSet<TrackID> m_trackIdRegistry;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
@@ -39,12 +39,11 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_mse_debug);
 
 namespace WebCore {
 
-MediaSourceTrackGStreamer::MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType type, TrackID trackId, const AtomString& trackStringId, GRefPtr<GstCaps>&& initialCaps)
+MediaSourceTrackGStreamer::MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType type, TrackID trackId, GRefPtr<GstCaps>&& initialCaps)
     : m_type(type)
     , m_id(trackId)
-    , m_stringId(trackStringId)
     , m_initialCaps(WTFMove(initialCaps))
-    , m_queueDataMutex(trackStringId)
+    , m_queueDataMutex(trackId)
 { }
 
 MediaSourceTrackGStreamer::~MediaSourceTrackGStreamer()
@@ -52,9 +51,9 @@ MediaSourceTrackGStreamer::~MediaSourceTrackGStreamer()
     ASSERT(m_isRemoved);
 }
 
-Ref<MediaSourceTrackGStreamer> MediaSourceTrackGStreamer::create(TrackPrivateBaseGStreamer::TrackType type, TrackID trackId, const AtomString& trackStringId, GRefPtr<GstCaps>&& initialCaps)
+Ref<MediaSourceTrackGStreamer> MediaSourceTrackGStreamer::create(TrackPrivateBaseGStreamer::TrackType type, TrackID trackId, GRefPtr<GstCaps>&& initialCaps)
 {
-    return adoptRef(*new MediaSourceTrackGStreamer(type, trackId, trackStringId, WTFMove(initialCaps)));
+    return adoptRef(*new MediaSourceTrackGStreamer(type, trackId, WTFMove(initialCaps)));
 }
 
 bool MediaSourceTrackGStreamer::isReadyForMoreSamples()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
@@ -41,12 +41,11 @@ namespace WebCore {
 
 class MediaSourceTrackGStreamer final: public ThreadSafeRefCounted<MediaSourceTrackGStreamer> {
 public:
-    static Ref<MediaSourceTrackGStreamer> create(TrackPrivateBaseGStreamer::TrackType, TrackID, const AtomString&, GRefPtr<GstCaps>&& initialCaps);
+    static Ref<MediaSourceTrackGStreamer> create(TrackPrivateBaseGStreamer::TrackType, TrackID, GRefPtr<GstCaps>&& initialCaps);
     virtual ~MediaSourceTrackGStreamer();
 
     TrackPrivateBaseGStreamer::TrackType type() const { return m_type; }
     TrackID id() const { return m_id; }
-    const AtomString& stringId() const { return m_stringId; }
     GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
     DataMutex<TrackQueue>& queueDataMutex() { return m_queueDataMutex; }
 
@@ -65,11 +64,10 @@ public:
     void remove();
 
 private:
-    explicit MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType, TrackID, const AtomString&, GRefPtr<GstCaps>&& initialCaps);
+    explicit MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType, TrackID, GRefPtr<GstCaps>&& initialCaps);
 
     TrackPrivateBaseGStreamer::TrackType m_type;
     TrackID m_id;
-    const AtomString m_stringId;
     GRefPtr<GstCaps> m_initialCaps;
     DataMutex<TrackQueue> m_queueDataMutex;
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -81,6 +81,9 @@ public:
 
     ContentType type() const { return m_type; }
 
+    std::optional<TrackID> tryRegisterTrackId(TrackID);
+    bool tryUnregisterTrackId(TrackID);
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "SourceBufferPrivateGStreamer"_s; }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h
@@ -41,7 +41,7 @@ namespace WebCore {
 
 class TrackQueue {
 public:
-    TrackQueue(AtomString trackId);
+    TrackQueue(TrackID);
 
     typedef std::function<void(GRefPtr<GstMiniObject>&&)> NotEmptyHandler;
     typedef std::function<void()> LowLevelHandler;
@@ -79,7 +79,7 @@ private:
     GstClockTime durationEnqueued() const;
     void checkLowLevel();
 
-    AtomString m_trackId;
+    TrackID m_trackId;
     Deque<GRefPtr<GstMiniObject>> m_queue;
     LowLevelHandler m_lowLevelCallback;
     NotEmptyHandler m_notEmptyCallback;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
@@ -63,7 +63,7 @@ GType webkit_media_src_get_type(void);
 
 void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<WebCore::MediaSourceTrackGStreamer>>& tracks);
 
-void webKitMediaSrcFlush(WebKitMediaSrc*, const AtomString& streamName);
+void webKitMediaSrcFlush(WebKitMediaSrc*, TrackID streamId);
 
 void webKitMediaSrcSetPlayer(WebKitMediaSrc*, ThreadSafeWeakPtr<WebCore::MediaPlayerPrivateGStreamerMSE>&&);
 


### PR DESCRIPTION
#### 7a7367fb8f432c911a00f234ec49949324ca69ef
<pre>
[GStreamer] Use integers as track ID instead of AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=270638">https://bugs.webkit.org/show_bug.cgi?id=270638</a>

Reviewed by Philippe Normand.

Switch to using integers for track IDs internally instead of AtomString.

Some notable special cases:
- as MediaStream tracks are recommended by the spec to use UUID strings,
  we just truncate it to 64 bits for the internal TrackID,
  and return the full ID as String (stored in m_gstStreamId) in `trackUID()`
- In MSE, there is the potential for multiple SourceBuffers providing tracks
  with identical IDs. Previously, this was less of an issue since IDs were
  also based on track type, so two tracks &quot;A0&quot; and &quot;V0&quot; would still have
  distinct IDs. However, now they would both get ID 0, and one would get
  dropped in `MediaSourceTrackGStreamer::filterOutRepeatingTracks`
  To work around this, AppendPipeline will register any IDs it creates
  with `MediaSourcePrivateGStreamer::m_trackIdRegistry`, which will
  assign different IDs in case of a collision.
  There has been some consideration as to where to place this registry,
  and how to assign fallback IDs, which is both explained in comments.
  One test that produced these collisions is:
  imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-waitingforkey.https.html

* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
(WebCore::AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer):
Add constructor with an explicit TrackID argument.
(WebCore::AudioTrackPrivateGStreamer::capsChanged):
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h:
(WebCore::AudioTrackPrivateGStreamer::create):

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::getTrackIdFromPad): wrapper around gst_pad_get_stream_id, parses stream-id into a TrackID
(WebCore::getTrackIdFromStream): ditto, wraps around gst_stream_get_stream_id
(WebCore::trackIdFromString): parses a stream-id.
Can handle plain integers, the qtdemux-style &quot;.../&lt;ID&gt;&quot; format, and UUIDs.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:

* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp:
(WebCore::InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer):
Add constructor with an explicit TrackID argument.
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h:
(WebCore::InbandTextTrackPrivateGStreamer::create):

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfTrack):
(WebCore::MediaPlayerPrivateGStreamer::handleTextSample):
(WebCore::MediaPlayerPrivateGStreamer::updateEnabledVideoTrack):
(WebCore::MediaPlayerPrivateGStreamer::updateEnabledAudioTrack):
(WebCore::MediaPlayerPrivateGStreamer::playbin3SendSelectStreamsIfAppropriate):
(WebCore::MediaPlayerPrivateGStreamer::updateTracks):
(WebCore::MediaPlayerPrivateGStreamer::setupCodecProbe):
(WebCore::MediaPlayerPrivateGStreamer::codecForStreamId):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:

* Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp:
(webkitTextSinkHandleSample):

* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer):
Add constructor with an explicit TrackID argument.
Sets the new m_shouldUsePadStreamId field false, to avoid the ID being changed elsewhere.
(WebCore::TrackPrivateBaseGStreamer::setPad):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged):
(WebCore::TrackPrivateBaseGStreamer::installUpdateConfigurationHandlers):
(WebCore::TrackPrivateBaseGStreamer::updateTrackIDFromTags):
(WebCore::TrackPrivateBaseGStreamer::prefixForType): Deleted.
(WebCore::trimStreamId): Deleted.
(WebCore::TrackPrivateBaseGStreamer::generateUniquePlaybin2StreamID): Deleted.
(WebCore::TrackPrivateBaseGStreamer::trackIdFromPadStreamStartOrUniqueID): Deleted.
(WebCore::TrackPrivateBaseGStreamer::trackIdFromStringIdOrIndex): Deleted.
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:
(WebCore::TrackPrivateBaseGStreamer::streamId const):
Added, returns m_id. This is different to TrackPrivateBase::id(), since
its implementations first try to return the ID derived from the
container-specific-track-id tag if available.
(WebCore::TrackPrivateBaseGStreamer::gstStreamId const): Added.
(WebCore::TrackPrivateBaseGStreamer::capsChanged):
(WebCore::TrackPrivateBaseGStreamer::stringId const): Deleted.
- Removed m_stringId, instead using m_id everywhere.
- Added m_gstStreamId, storing the stream-id string as reported by
  GStreamer.

* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer):
(WebCore::VideoTrackPrivateGStreamer::capsChanged):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h:
Added constructor with an explicit TrackID argument.

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::~AppendPipeline):
(WebCore::AppendPipeline::didReceiveInitializationSegment):
(WebCore::createOptionalParserForFormat):
(WebCore::AppendPipeline::recycleTrackForPad):
(WebCore::AppendPipeline::linkPadWithTrack):
(WebCore::AppendPipeline::makeWebKitTrack):
Explicitly construct tracks with our IDs, as relying on
TrackPrivateBaseGStreamer to pick one up from stream-id risks collisions.
(WebCore::AppendPipeline::Track::emplaceOptionalParserForFormat):
(WebCore::AppendPipeline::generateTrackId): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h:
(WebCore::AppendPipeline::Track::Track):
(WebCore::AppendPipeline::tryCreateTrackFromPad):
Instead of generating an ID based on track type and index, parse stream-id,
and add it to the registry so potential ID collisions can be caught and avoided.

* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::filterOutRepeatingTracks):

* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::registerTrackId): Added.
(WebCore::MediaSourcePrivateGStreamer::unregisterTrackId): Added.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
- Added m_trackIdRegistry, to be used by AppendPipeline.

* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp:
(WebCore::MediaSourceTrackGStreamer::MediaSourceTrackGStreamer):
(WebCore::MediaSourceTrackGStreamer::create):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h:

* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::flush):
(WebCore::SourceBufferPrivateGStreamer::allSamplesInTrackEnqueued):
(WebCore::SourceBufferPrivateGStreamer::precheckInitializationSegment):
(WebCore::SourceBufferPrivateGStreamer::tryRegisterTrackId):
Added, calls `MediaSourcePrivateGStreamer` to try to register an ID.
(WebCore::SourceBufferPrivateGStreamer::tryUnregisterTrackId): ditto
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:

* Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.cpp:
(WebCore::TrackQueue::TrackQueue):
(WebCore::TrackQueue::enqueueObject):
(WebCore::TrackQueue::clear):
(WebCore::TrackQueue::flush):
(WebCore::TrackQueue::notifyWhenLowLevel):
(WebCore::TrackQueue::pop):
(WebCore::TrackQueue::notifyWhenNotEmpty):
(WebCore::TrackQueue::resetNotEmptyHandler):
(WebCore::TrackQueue::checkLowLevel):
* Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h:

* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(WebKitMediaSrcPrivate::streamById): Renamed from streamByName.
(dumpPipeline):
(webKitMediaSrcEmitStreams):
(webKitMediaSrcTearDownStream):
(webKitMediaSrcLoop):
(webKitMediaSrcStreamFlush):
(webKitMediaSrcFlush):
(WebKitMediaSrcPrivate::streamByName): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/286527@main">https://commits.webkit.org/286527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3da11cbd9c0ff0c1f80a0a5b694d0bb238dcbc9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3435 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59676 "Found 1 new test failure: webrtc/utf8-sdp.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17818 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22845 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25703 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82072 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67906 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67215 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9281 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3429 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6236 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3452 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6846 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->