### PR TITLE
Support non-persistent background pages in Web Extensions.

### DIFF
--- a/Source/WTF/wtf/HashCountedSet.h
+++ b/Source/WTF/wtf/HashCountedSet.h
@@ -117,7 +117,7 @@ public:
     template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, unsigned>::type count(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
     template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
 
-    static bool isValidValue(const ValueType& value) { return ImplType::isValidValue(value); }
+    static bool isValidValue(const ValueType&);
 
 private:
     ImplType m_impl;
@@ -284,6 +284,23 @@ template<typename Value, typename HashFunctions, typename Traits>
 inline void HashCountedSet<Value, HashFunctions, Traits>::clear()
 {
     m_impl.clear();
+}
+
+template<typename Value, typename HashFunctions, typename Traits>
+inline bool HashCountedSet<Value, HashFunctions, Traits>::isValidValue(const ValueType& value)
+{
+    if (Traits::isDeletedValue(value))
+        return false;
+
+    if (HashFunctions::safeToCompareToEmptyOrDeleted) {
+        if (value == Traits::emptyValue())
+            return false;
+    } else {
+        if (isHashTraitsEmptyValue<Traits>(value))
+            return false;
+    }
+
+    return true;
 }
 
 template<typename Value, typename HashFunctions, typename Traits>

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -624,7 +624,7 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Argume
     {
         unsigned hashCountedSetSize;
         if (!decoder.decode(hashCountedSetSize))
-            return false;
+            return std::nullopt;
 
         HashCountedSetType tempHashCountedSet;
         for (unsigned i = 0; i < hashCountedSetSize; ++i) {

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -675,6 +675,7 @@ def class_template_headers(template_string):
     class_template_types = {
         'WebCore::RectEdges': {'headers': ['<WebCore/RectEdges.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'Expected': {'headers': ['<wtf/Expected.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
+        'HashCountedSet': {'headers': ['<wtf/HashCountedSet.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'HashMap': {'headers': ['<wtf/HashMap.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'HashSet': {'headers': ['<wtf/HashSet.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},
         'KeyValuePair': {'headers': ['<wtf/KeyValuePair.h>'], 'argument_coder_headers': ['"ArgumentCoders.h"']},

--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
@@ -41,6 +41,16 @@ enum class WebExtensionContentWorldType : uint8_t {
 #endif
 };
 
+inline bool isEqual(WebExtensionContentWorldType a, WebExtensionContentWorldType b)
+{
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    // Inspector content world is a special alias of Main. Consider them equal.
+    if ((a == WebExtensionContentWorldType::Main || a == WebExtensionContentWorldType::Inspector) && (b == WebExtensionContentWorldType::Main || b == WebExtensionContentWorldType::Inspector))
+        return true;
+#endif
+    return a == b;
+}
+
 inline String toDebugString(WebExtensionContentWorldType contentWorldType)
 {
     switch (contentWorldType) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -268,7 +268,7 @@ void WebExtensionContext::actionSetEnabled(std::optional<WebExtensionTabIdentifi
 void WebExtensionContext::fireActionClickedEventIfNeeded(WebExtensionTab* tab)
 {
     constexpr auto type = WebExtensionEventListenerType::ActionOnClicked;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }, tab = RefPtr { tab }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchActionClickedEvent(tab ? std::optional(tab->parameters()) : std::nullopt));
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
@@ -83,8 +83,8 @@ void WebExtensionContext::alarmsClearAll(CompletionHandler<void()>&& completionH
 void WebExtensionContext::fireAlarmsEventIfNeeded(const WebExtensionAlarm& alarm)
 {
     constexpr auto type = WebExtensionEventListenerType::AlarmsOnAlarm;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
-        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchAlarmsEvent(alarm.parameters()));
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }, alarm = Ref { alarm }] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchAlarmsEvent(alarm->parameters()));
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm
@@ -58,16 +58,16 @@ void WebExtensionContext::commandsGetAll(CompletionHandler<void(Vector<WebExtens
 void WebExtensionContext::fireCommandEventIfNeeded(const WebExtensionCommand& command, WebExtensionTab* tab)
 {
     constexpr auto type = WebExtensionEventListenerType::CommandsOnCommand;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
-        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchCommandsCommandEvent(command.identifier(), tab ? std::optional(tab->parameters()) : std::nullopt));
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }, command = Ref { command }, tab = RefPtr { tab }] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchCommandsCommandEvent(command->identifier(), tab ? std::optional(tab->parameters()) : std::nullopt));
     });
 }
 
 void WebExtensionContext::fireCommandChangedEventIfNeeded(const WebExtensionCommand& command, const String& oldShortcut)
 {
     constexpr auto type = WebExtensionEventListenerType::CommandsOnChanged;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
-        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchCommandsChangedEvent(command.identifier(), oldShortcut, command.shortcutString()));
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }, command = Ref { command }] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchCommandsChangedEvent(command->identifier(), oldShortcut, command->shortcutString()));
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -236,7 +236,7 @@ void WebExtensionContext::cookiesGetAllCookieStores(CompletionHandler<void(Expec
 void WebExtensionContext::fireCookiesChangedEventIfNeeded()
 {
     constexpr auto type = WebExtensionEventListenerType::CookiesOnChanged;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchCookiesChangedEvent());
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -49,7 +49,7 @@ void WebExtensionContext::addListener(WebPageProxyIdentifier identifier, WebExte
 
     RELEASE_LOG_DEBUG(Extensions, "Registered event listener for type %{public}hhu in %{public}@ world", enumToUnderlyingType(type), (NSString *)toDebugString(contentWorldType));
 
-    if (!extension().backgroundContentIsPersistent() && m_backgroundWebView && m_backgroundWebView.get()._page->identifier() == identifier)
+    if (!extension().backgroundContentIsPersistent() && isBackgroundPage(identifier))
         m_backgroundContentEventListeners.add(type);
 
     auto result = m_eventListenerPages.add({ type, contentWorldType }, WeakPageCountedSet { });
@@ -66,7 +66,7 @@ void WebExtensionContext::removeListener(WebPageProxyIdentifier identifier, WebE
 
     RELEASE_LOG_DEBUG(Extensions, "Unregistered %{public}zu event listener(s) for type %{public}hhu in %{public}@ world", removedCount, enumToUnderlyingType(type), (NSString *)toDebugString(contentWorldType));
 
-    if (!extension().backgroundContentIsPersistent() && m_backgroundWebView && m_backgroundWebView.get()._page->identifier() == identifier) {
+    if (!extension().backgroundContentIsPersistent() && isBackgroundPage(identifier)) {
         for (size_t i = 0; i < removedCount; ++i)
             m_backgroundContentEventListeners.remove(type);
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIMenusCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIMenusCocoa.mm
@@ -157,8 +157,8 @@ void WebExtensionContext::fireMenusClickedEventIfNeeded(const WebExtensionMenuIt
     RefPtr tab = contextParameters.tabIdentifier ? getTab(contextParameters.tabIdentifier.value()) : nullptr;
 
     constexpr auto type = WebExtensionEventListenerType::MenusOnClicked;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
-        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchMenusClickedEvent(menuItem.minimalParameters(), wasChecked, contextParameters, tab ? std::optional { tab->parameters() } : std::nullopt));
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }, menuItem = Ref { menuItem }] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchMenusClickedEvent(menuItem->minimalParameters(), wasChecked, contextParameters, tab ? std::optional { tab->parameters() } : std::nullopt));
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
@@ -167,7 +167,7 @@ void WebExtensionContext::firePermissionsEventListenerIfNecessary(WebExtensionEv
 
     HashSet<String> origins = toStrings(matchPatterns);
 
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPermissionsEvent(type, permissions, origins));
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
@@ -34,14 +34,19 @@
 
 #import "CocoaHelpers.h"
 #import "Logging.h"
+#import "WKWebViewInternal.h"
 #import "WebExtensionContentWorldType.h"
 #import "WebExtensionContextProxyMessages.h"
+#import "WebPageProxy.h"
 
 namespace WebKit {
 
-void WebExtensionContext::portPostMessage(WebExtensionContentWorldType targetContentWorldType, std::optional<WebPageProxyIdentifier> sendingPageProxyIdentifier, WebExtensionPortChannelIdentifier channelIdentifier, const String& messageJSON)
+void WebExtensionContext::portPostMessage(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, std::optional<WebPageProxyIdentifier> sendingPageProxyIdentifier, WebExtensionPortChannelIdentifier channelIdentifier, const String& messageJSON)
 {
-    if (!m_ports.contains({ targetContentWorldType, channelIdentifier })) {
+    if (sendingPageProxyIdentifier && isBackgroundPage(sendingPageProxyIdentifier.value()))
+        m_lastBackgroundPortActivityTime = MonotonicTime::now();
+
+    if (!isPortConnected(sourceContentWorldType, targetContentWorldType, channelIdentifier)) {
         // The port might not be open on the other end yet. Queue the message until it does open.
         RELEASE_LOG_DEBUG(Extensions, "Enqueued message for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
 
@@ -63,9 +68,7 @@ void WebExtensionContext::portPostMessage(WebExtensionContentWorldType targetCon
 #if ENABLE(INSPECTOR_EXTENSIONS)
     case WebExtensionContentWorldType::Inspector:
 #endif
-        wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
-            sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortMessageEvent(sendingPageProxyIdentifier, channelIdentifier, messageJSON));
-        });
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortMessageEvent(sendingPageProxyIdentifier, channelIdentifier, messageJSON));
         return;
 
     case WebExtensionContentWorldType::ContentScript:
@@ -83,56 +86,124 @@ void WebExtensionContext::portPostMessage(WebExtensionContentWorldType targetCon
     }
 }
 
-void WebExtensionContext::portRemoved(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+void WebExtensionContext::portRemoved(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionPortChannelIdentifier channelIdentifier)
 {
-    RELEASE_LOG_DEBUG(Extensions, "Port for channel %{public}llu removed in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(sourceContentWorldType));
-
-    removePort(sourceContentWorldType, channelIdentifier);
+    removePort(sourceContentWorldType, targetContentWorldType, channelIdentifier, webPageProxyIdentifier);
 
     firePortDisconnectEventIfNeeded(sourceContentWorldType, targetContentWorldType, channelIdentifier);
 }
 
-void WebExtensionContext::addPorts(WebExtensionContentWorldType contentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, size_t totalPortObjects)
+bool WebExtensionContext::pageHasOpenPorts(WebPageProxy& page)
 {
-    ASSERT(totalPortObjects);
-
-    RELEASE_LOG_DEBUG(Extensions, "Added %{public}zu port(s) for channel %{public}llu in %{public}@ world", totalPortObjects, channelIdentifier.toUInt64(), (NSString *)toDebugString(contentWorldType));
-
-    for (size_t i = 0; i < totalPortObjects; ++i)
-        m_ports.add({ contentWorldType, channelIdentifier });
+    return !m_pagePortMap.get(page.identifier()).isEmpty();
 }
 
-void WebExtensionContext::removePort(WebExtensionContentWorldType contentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+void WebExtensionContext::disconnectPortsForPage(WebPageProxy& page)
 {
-    RELEASE_LOG_DEBUG(Extensions, "Removed 1 port for channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(contentWorldType));
+    auto portCounts = m_pagePortMap.take(page.identifier());
+    if (portCounts.isEmpty())
+        return;
 
-    m_portQueuedMessages.remove({ contentWorldType, channelIdentifier });
-    m_ports.remove({ contentWorldType, channelIdentifier });
+    RELEASE_LOG_DEBUG(Extensions, "Disconnecting ports for page %{public}llu", page.identifier().toUInt64());
+
+    for (auto& entry : portCounts) {
+        auto sourceContentWorldType = std::get<0>(entry.key);
+        auto targetContentWorldType = std::get<1>(entry.key);
+        auto channelIdentifier = std::get<WebExtensionPortChannelIdentifier>(entry.key);
+
+        for (size_t i = 0; i < entry.value; ++i)
+            removePort(sourceContentWorldType, targetContentWorldType, channelIdentifier, page.identifier());
+
+        firePortDisconnectEventIfNeeded(sourceContentWorldType, targetContentWorldType, channelIdentifier);
+    }
+}
+
+void WebExtensionContext::addPorts(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, HashCountedSet<WebPageProxyIdentifier>&& addedPortCounts)
+{
+    ASSERT(!addedPortCounts.isEmpty());
+
+    for (auto& entry : addedPortCounts) {
+        RELEASE_LOG_DEBUG(Extensions, "Added %{public}u port(s) for channel %{public}llu in %{public}@ world for page %{public}llu", entry.value, channelIdentifier.toUInt64(), (NSString *)toDebugString(sourceContentWorldType), entry.key.toUInt64());
+
+        if (isBackgroundPage(entry.key))
+            m_lastBackgroundPortActivityTime = MonotonicTime::now();
+
+        m_ports.add({ sourceContentWorldType, channelIdentifier }, entry.value);
+
+        auto& pagePorts = m_pagePortMap.ensure(entry.key, [&] {
+            return HashCountedSet<PortWorldTuple> { };
+        }).iterator->value;
+
+        pagePorts.add({ sourceContentWorldType, targetContentWorldType, channelIdentifier });
+    }
+}
+
+void WebExtensionContext::removePort(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, WebPageProxyIdentifier webPageProxyIdentifier)
+{
+    RELEASE_LOG_DEBUG(Extensions, "Removed 1 port for channel %{public}llu in %{public}@ world for page %{public}llu", channelIdentifier.toUInt64(), (NSString *)toDebugString(sourceContentWorldType), webPageProxyIdentifier.toUInt64());
+
+    if (m_ports.remove({ sourceContentWorldType, channelIdentifier }))
+        clearQueuedPortMessages(targetContentWorldType, channelIdentifier);
+
+    auto entry = m_pagePortMap.find(webPageProxyIdentifier);
+    if (entry == m_pagePortMap.end())
+        return;
+
+    auto& pagePorts = entry->value;
+    if (pagePorts.remove({ sourceContentWorldType, targetContentWorldType, channelIdentifier }))
+        m_pagePortMap.remove(webPageProxyIdentifier);
 }
 
 void WebExtensionContext::addNativePort(WebExtensionMessagePort& nativePort)
 {
-    addPorts(WebExtensionContentWorldType::Native, nativePort.channelIdentifier(), 1);
-    m_nativePortMap.add(nativePort.channelIdentifier(), nativePort);
+    constexpr auto contentWorldType = WebExtensionContentWorldType::Native;
+    auto channelIdentifier = nativePort.channelIdentifier();
+
+    RELEASE_LOG_DEBUG(Extensions, "Added 1 port for channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(contentWorldType));
+
+    m_ports.add({ contentWorldType, channelIdentifier });
+    m_nativePortMap.add(channelIdentifier, nativePort);
 }
 
 void WebExtensionContext::removeNativePort(WebExtensionMessagePort& nativePort)
 {
-    removePort(WebExtensionContentWorldType::Native, nativePort.channelIdentifier());
-    m_nativePortMap.remove(nativePort.channelIdentifier());
+    constexpr auto contentWorldType = WebExtensionContentWorldType::Native;
+    auto channelIdentifier = nativePort.channelIdentifier();
+
+    RELEASE_LOG_DEBUG(Extensions, "Removed 1 port for channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(contentWorldType));
+
+    clearQueuedPortMessages(WebExtensionContentWorldType::Main, channelIdentifier);
+
+    m_ports.remove({ contentWorldType, channelIdentifier });
+    m_nativePortMap.remove(channelIdentifier);
+}
+
+unsigned WebExtensionContext::openPortCount(WebExtensionContentWorldType contentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+{
+    auto count = m_ports.count({ contentWorldType, channelIdentifier });
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    // Inspector content world is a special alias of Main. Include it when Main is requested (and vice versa).
+    if (contentWorldType == WebExtensionContentWorldType::Main)
+        count += m_ports.count({ WebExtensionContentWorldType::Inspector, channelIdentifier });
+    else if (contentWorldType == WebExtensionContentWorldType::Inspector)
+        count += m_ports.count({ WebExtensionContentWorldType::Main, channelIdentifier });
+#endif
+
+    return count;
 }
 
 bool WebExtensionContext::isPortConnected(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
 {
-    const auto sourceWorldCount = m_ports.count({ sourceContentWorldType, channelIdentifier });
+    const auto sourceWorldCount = openPortCount(sourceContentWorldType, channelIdentifier);
 
     RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu has %{public}u port(s) open in %{public}@ world", channelIdentifier.toUInt64(), sourceWorldCount, (NSString *)toDebugString(sourceContentWorldType));
 
     // When the worlds are the same, it is connected if there are 2 ports remaining.
-    if (sourceContentWorldType == targetContentWorldType)
+    if (isEqual(sourceContentWorldType, targetContentWorldType))
         return sourceWorldCount >= 2;
 
-    const auto targetWorldCount = m_ports.count({ targetContentWorldType, channelIdentifier });
+    const auto targetWorldCount = openPortCount(targetContentWorldType, channelIdentifier);
 
     RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu has %{public}u port(s) open in %{public}@ world", channelIdentifier.toUInt64(), targetWorldCount, (NSString *)toDebugString(targetContentWorldType));
 
@@ -140,9 +211,24 @@ bool WebExtensionContext::isPortConnected(WebExtensionContentWorldType sourceCon
     return sourceWorldCount && targetWorldCount;
 }
 
+Vector<WebExtensionContext::MessagePageProxyIdentifierPair> WebExtensionContext::portQueuedMessages(WebExtensionContentWorldType contentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+{
+    auto messages = m_portQueuedMessages.get({ contentWorldType, channelIdentifier });
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    // Inspector content world is a special alias of Main. Include it when Main is requested (and vice versa).
+    if (contentWorldType == WebExtensionContentWorldType::Main)
+        messages.appendVector(m_portQueuedMessages.get({ WebExtensionContentWorldType::Inspector, channelIdentifier }));
+    else if (contentWorldType == WebExtensionContentWorldType::Inspector)
+        messages.appendVector(m_portQueuedMessages.get({ WebExtensionContentWorldType::Main, channelIdentifier }));
+#endif
+
+    return messages;
+}
+
 void WebExtensionContext::fireQueuedPortMessageEventsIfNeeded(WebProcessProxy& process, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
 {
-    auto messages = m_portQueuedMessages.get({ targetContentWorldType, channelIdentifier });
+    auto messages = portQueuedMessages(targetContentWorldType, channelIdentifier);
     if (messages.isEmpty())
         return;
 
@@ -159,7 +245,7 @@ void WebExtensionContext::fireQueuedPortMessageEventsIfNeeded(WebProcessProxy& p
 void WebExtensionContext::sendQueuedNativePortMessagesIfNeeded(WebExtensionPortChannelIdentifier channelIdentifier)
 {
     constexpr auto targetContentWorldType = WebExtensionContentWorldType::Native;
-    auto messages = m_portQueuedMessages.get({ targetContentWorldType, channelIdentifier });
+    auto messages = portQueuedMessages(targetContentWorldType, channelIdentifier);
     if (messages.isEmpty())
         return;
 
@@ -179,9 +265,17 @@ void WebExtensionContext::sendQueuedNativePortMessagesIfNeeded(WebExtensionPortC
     }
 }
 
-void WebExtensionContext::clearQueuedPortMessages(WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+void WebExtensionContext::clearQueuedPortMessages(WebExtensionContentWorldType contentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
 {
-    m_portQueuedMessages.remove({ targetContentWorldType, channelIdentifier });
+    m_portQueuedMessages.remove({ contentWorldType, channelIdentifier });
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+    // Inspector content world is a special alias of Main. Include it when Main is requested (and vice versa).
+    if (contentWorldType == WebExtensionContentWorldType::Main)
+        m_portQueuedMessages.remove({ WebExtensionContentWorldType::Inspector, channelIdentifier });
+    else if (contentWorldType == WebExtensionContentWorldType::Inspector)
+        m_portQueuedMessages.remove({ WebExtensionContentWorldType::Main, channelIdentifier });
+#endif
 }
 
 void WebExtensionContext::firePortDisconnectEventIfNeeded(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
@@ -199,10 +293,7 @@ void WebExtensionContext::firePortDisconnectEventIfNeeded(WebExtensionContentWor
 #if ENABLE(INSPECTOR_EXTENSIONS)
     case WebExtensionContentWorldType::Inspector:
 #endif
-        wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
-            sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortDisconnectEvent(channelIdentifier));
-        });
-
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortDisconnectEvent(channelIdentifier));
         return;
 
     case WebExtensionContentWorldType::ContentScript:

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
@@ -238,13 +238,13 @@ void WebExtensionContext::fireStorageChangedEventIfNeeded(NSDictionary *oldKeysA
         return;
 
     constexpr auto type = WebExtensionEventListenerType::StorageOnChanged;
-    auto jsonString = encodeJSONString(changedData);
+    auto jsonString = String(encodeJSONString(changedData));
 
     // Unlike other extension events which are only dispatched to the web process that hosts all the extension-related web views (background page, popup, full page extension content),
     // content scripts are allowed to listen to storage.onChanged events.
     sendToContentScriptProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchStorageChangedEvent(jsonString, dataType, WebExtensionContentWorldType::ContentScript));
 
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchStorageChangedEvent(jsonString, dataType, WebExtensionContentWorldType::Main));
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -37,6 +37,7 @@
 #import "WKWebViewPrivate.h"
 #import "WebExtensionContextProxy.h"
 #import "WebExtensionContextProxyMessages.h"
+#import "WebExtensionMessageSenderParameters.h"
 #import "WebExtensionScriptInjectionParameters.h"
 #import "WebExtensionTabIdentifier.h"
 #import "WebExtensionUtilities.h"
@@ -452,29 +453,31 @@ void WebExtensionContext::tabsSendMessage(WebExtensionTabIdentifier tabIdentifie
 
 void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebExtensionFrameIdentifier> frameIdentifier, const WebExtensionMessageSenderParameters& senderParameters, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    // Add 1 for the starting port here so disconnect will balance with a decrement.
+    static NSString * const apiName = @"tabs.connect()";
+
     constexpr auto sourceContentWorldType = WebExtensionContentWorldType::Main;
-    addPorts(sourceContentWorldType, channelIdentifier, 1);
+    constexpr auto targetContentWorldType = WebExtensionContentWorldType::ContentScript;
+
+    // Add 1 for the starting port here so disconnect will balance with a decrement.
+    addPorts(sourceContentWorldType, targetContentWorldType, channelIdentifier, { senderParameters.pageProxyIdentifier });
 
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.connect()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
         return;
     }
 
-    constexpr auto targetContentWorldType = WebExtensionContentWorldType::ContentScript;
-
     auto contentScriptProcesses = tab->processes(WebExtensionEventListenerType::RuntimeOnConnect, targetContentWorldType);
     if (contentScriptProcesses.isEmpty()) {
-        completionHandler(toWebExtensionError(@"tabs.connect()", nil, @"no runtime.onConnect listeners found"));
+        completionHandler(toWebExtensionError(apiName, nil, @"no runtime.onConnect listeners found"));
         return;
     }
 
     ASSERT(contentScriptProcesses.size() == 1);
     auto process = contentScriptProcesses.takeAny();
 
-    process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, frameIdentifier, senderParameters), [=, protectedThis = Ref { *this }](size_t firedEventCount) mutable {
-        protectedThis->addPorts(targetContentWorldType, channelIdentifier, firedEventCount);
+    process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, frameIdentifier, senderParameters), [=, protectedThis = Ref { *this }](HashCountedSet<WebPageProxyIdentifier>&& addedPortCounts) mutable {
+        protectedThis->addPorts(targetContentWorldType, sourceContentWorldType, channelIdentifier, WTFMove(addedPortCounts));
         protectedThis->fireQueuedPortMessageEventsIfNeeded(*process, targetContentWorldType, channelIdentifier);
         protectedThis->firePortDisconnectEventIfNeeded(sourceContentWorldType, targetContentWorldType, channelIdentifier);
         protectedThis->clearQueuedPortMessages(targetContentWorldType, channelIdentifier);
@@ -644,7 +647,7 @@ void WebExtensionContext::tabsRemoveCSS(WebPageProxyIdentifier webPageProxyIdent
 void WebExtensionContext::fireTabsCreatedEventIfNeeded(const WebExtensionTabParameters& parameters)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnCreated;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsCreatedEvent(parameters));
     });
 }
@@ -652,7 +655,7 @@ void WebExtensionContext::fireTabsCreatedEventIfNeeded(const WebExtensionTabPara
 void WebExtensionContext::fireTabsUpdatedEventIfNeeded(const WebExtensionTabParameters& parameters, const WebExtensionTabParameters& changedParameters)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnUpdated;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsUpdatedEvent(parameters, changedParameters));
     });
 }
@@ -660,7 +663,7 @@ void WebExtensionContext::fireTabsUpdatedEventIfNeeded(const WebExtensionTabPara
 void WebExtensionContext::fireTabsReplacedEventIfNeeded(WebExtensionTabIdentifier replacedTabIdentifier, WebExtensionTabIdentifier newTabIdentifier)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnReplaced;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsReplacedEvent(replacedTabIdentifier, newTabIdentifier));
     });
 }
@@ -668,7 +671,7 @@ void WebExtensionContext::fireTabsReplacedEventIfNeeded(WebExtensionTabIdentifie
 void WebExtensionContext::fireTabsDetachedEventIfNeeded(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier oldWindowIdentifier, size_t oldIndex)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnDetached;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsDetachedEvent(tabIdentifier, oldWindowIdentifier, oldIndex));
     });
 }
@@ -676,7 +679,7 @@ void WebExtensionContext::fireTabsDetachedEventIfNeeded(WebExtensionTabIdentifie
 void WebExtensionContext::fireTabsMovedEventIfNeeded(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier windowIdentifier, size_t oldIndex, size_t newIndex)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnMoved;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsMovedEvent(tabIdentifier, windowIdentifier, oldIndex, newIndex));
     });
 }
@@ -684,7 +687,7 @@ void WebExtensionContext::fireTabsMovedEventIfNeeded(WebExtensionTabIdentifier t
 void WebExtensionContext::fireTabsAttachedEventIfNeeded(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier newWindowIdentifier, size_t newIndex)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnAttached;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsAttachedEvent(tabIdentifier, newWindowIdentifier, newIndex));
     });
 }
@@ -692,7 +695,7 @@ void WebExtensionContext::fireTabsAttachedEventIfNeeded(WebExtensionTabIdentifie
 void WebExtensionContext::fireTabsActivatedEventIfNeeded(WebExtensionTabIdentifier previousActiveTabIdentifier, WebExtensionTabIdentifier newActiveTabIdentifier, WebExtensionWindowIdentifier windowIdentifier)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnActivated;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsActivatedEvent(previousActiveTabIdentifier, newActiveTabIdentifier, windowIdentifier));
     });
 }
@@ -700,7 +703,7 @@ void WebExtensionContext::fireTabsActivatedEventIfNeeded(WebExtensionTabIdentifi
 void WebExtensionContext::fireTabsHighlightedEventIfNeeded(Vector<WebExtensionTabIdentifier> tabIdentifiers, WebExtensionWindowIdentifier windowIdentifier)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnHighlighted;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsHighlightedEvent(tabIdentifiers, windowIdentifier));
     });
 }
@@ -708,7 +711,7 @@ void WebExtensionContext::fireTabsHighlightedEventIfNeeded(Vector<WebExtensionTa
 void WebExtensionContext::fireTabsRemovedEventIfNeeded(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier windowIdentifier, WindowIsClosing windowIsClosing)
 {
     constexpr auto type = WebExtensionEventListenerType::TabsOnRemoved;
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsRemovedEvent(tabIdentifier, windowIdentifier, windowIsClosing));
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -299,7 +299,7 @@ void WebExtensionContext::windowsRemove(WebExtensionWindowIdentifier windowIdent
 
 void WebExtensionContext::fireWindowsEventIfNeeded(WebExtensionEventListenerType type, std::optional<WebExtensionWindowParameters> windowParameters)
 {
-    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [=, protectedThis = Ref { *this }] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchWindowsEvent(type, windowParameters));
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -315,6 +315,9 @@ void WebExtensionController::removePage(WebPageProxy& page)
 
     Ref controller = page.userContentController();
     removeUserContentController(controller);
+
+    for (Ref context : m_extensionContexts)
+        context->removePage(page);
 }
 
 void WebExtensionController::addProcessPool(WebProcessPool& processPool)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
@@ -111,8 +111,8 @@ void WebExtensionMessagePort::remove()
     if (isDisconnected())
         return;
 
-    m_extensionContext->portRemoved(WebExtensionContentWorldType::Native, WebExtensionContentWorldType::Main, m_channelIdentifier);
     m_extensionContext->removeNativePort(*this);
+    m_extensionContext->firePortDisconnectEventIfNeeded(WebExtensionContentWorldType::Native, WebExtensionContentWorldType::Main, m_channelIdentifier);
     m_extensionContext = nullptr;
 }
 
@@ -125,7 +125,7 @@ void WebExtensionMessagePort::sendMessage(id message, CompletionHandler<void(Err
 
     THROW_UNLESS(isValidJSONObject(message, { JSONOptions::FragmentsAllowed }), @"Message object is not JSON-serializable");
 
-    m_extensionContext->portPostMessage(WebExtensionContentWorldType::Main, std::nullopt, m_channelIdentifier, encodeJSONString(message, { JSONOptions::FragmentsAllowed }) );
+    m_extensionContext->portPostMessage(WebExtensionContentWorldType::Native, WebExtensionContentWorldType::Main, std::nullopt, m_channelIdentifier, encodeJSONString(message, { JSONOptions::FragmentsAllowed }) );
 
     completionHandler(std::nullopt);
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -92,6 +92,9 @@ const WebExtensionContext::UserContentControllerProxySet& WebExtensionContext::u
 
 bool WebExtensionContext::pageListensForEvent(const WebPageProxy& page, WebExtensionEventListenerType type, WebExtensionContentWorldType contentWorldType) const
 {
+    if (!isLoaded())
+        return false;
+
     if (!hasAccessInPrivateBrowsing() && page.sessionID().isEphemeral())
         return false;
 
@@ -118,6 +121,9 @@ bool WebExtensionContext::pageListensForEvent(const WebPageProxy& page, WebExten
 WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventListenerTypeSet&& typeSet, ContentWorldTypeSet&& contentWorldTypeSet) const
 {
     WebProcessProxySet result;
+
+    if (!isLoaded())
+        return result;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // Inspector content world is a special alias of Main. Include it when Main is requested (and vice versa).

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -93,8 +93,8 @@ messages -> WebExtensionContext {
     [EnabledIf='isLoaded()'] PermissionsRemove(HashSet<String> permissions, HashSet<String> origins) -> (bool success)
 
     // Port APIs
-    [EnabledIf='isLoaded()'] PortPostMessage(WebKit::WebExtensionContentWorldType targetContentWorldType, std::optional<WebKit::WebPageProxyIdentifier> sendingPageProxyIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON)
-    [EnabledIf='isLoaded()'] PortRemoved(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier)
+    [EnabledIf='isLoaded()'] PortPostMessage(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, std::optional<WebKit::WebPageProxyIdentifier> sendingPageProxyIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON)
+    [EnabledIf='isLoaded()'] PortRemoved(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebPageProxyIdentifier pageProxyIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier)
 
     // Runtime APIs
     [EnabledIf='isLoaded()'] RuntimeGetBackgroundPage() -> (Expected<std::optional<WebCore::PageIdentifier>, WebKit::WebExtensionError> result)
@@ -103,7 +103,7 @@ messages -> WebExtensionContext {
     [EnabledIf='isLoaded()'] RuntimeSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<String, WebKit::WebExtensionError> result)
     [EnabledIf='isLoaded()'] RuntimeConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<void, WebKit::WebExtensionError> result)
     [EnabledIf='isLoaded()'] RuntimeSendNativeMessage(String applicationID, String messageJSON) -> (Expected<String, WebKit::WebExtensionError> result)
-    [EnabledIf='isLoaded()'] RuntimeConnectNative(String applicationID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
+    [EnabledIf='isLoaded()'] RuntimeConnectNative(String applicationID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, WebKit::WebPageProxyIdentifier pageProxyIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
     [EnabledIf='isLoaded()'] RuntimeWebPageSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<String, WebKit::WebExtensionError> result)
     [EnabledIf='isLoaded()'] RuntimeWebPageConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (Expected<void, WebKit::WebExtensionError> result)
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -91,7 +91,7 @@ void WebExtensionAPIPort::remove()
     if (entry == webExtensionPorts().end())
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::PortRemoved(contentWorldType(), targetContentWorldType(), channelIdentifier()), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::PortRemoved(contentWorldType(), targetContentWorldType(), owningPageProxyIdentifier(), channelIdentifier()), extensionContext().identifier());
 
     entry->value.remove(*this);
 
@@ -140,7 +140,7 @@ void WebExtensionAPIPort::postMessage(WebFrame& frame, NSString *message, NSStri
 
     RELEASE_LOG_DEBUG(Extensions, "Sent port message for channel %{public}llu from %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::PortPostMessage(targetContentWorldType(), owningPageProxyIdentifier(), channelIdentifier(), message), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::PortPostMessage(contentWorldType(), targetContentWorldType(), owningPageProxyIdentifier(), channelIdentifier(), message), extensionContext().identifier());
 }
 
 void WebExtensionAPIPort::disconnect()

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -174,9 +174,9 @@ private:
 
     // Runtime
     void internalDispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(String&& replyJSON)>&&);
-    void internalDispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
+    void internalDispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(HashCountedSet<WebPageProxyIdentifier>&&)>&&);
     void dispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(String&& replyJSON)>&&);
-    void dispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
+    void dispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(HashCountedSet<WebPageProxyIdentifier>&&)>&&);
     void dispatchRuntimeInstalledEvent(WebExtensionContext::InstallReason, String previousVersion);
     void dispatchRuntimeStartupEvent();
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -66,7 +66,7 @@ messages -> WebExtensionContextProxy {
 
     // Runtime
     DispatchRuntimeMessageEvent(WebKit::WebExtensionContentWorldType contentWorldType, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (String replyJSON)
-    DispatchRuntimeConnectEvent(WebKit::WebExtensionContentWorldType contentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (size_t firedEventCount)
+    DispatchRuntimeConnectEvent(WebKit::WebExtensionContentWorldType contentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (HashCountedSet<WebKit::WebPageProxyIdentifier> addedPortCounts)
     DispatchRuntimeInstalledEvent(WebKit::WebExtensionContext::InstallReason installReason, String previousVersion)
     DispatchRuntimeStartupEvent()
 


### PR DESCRIPTION
#### cc9d7c9f1548c51d31b6695b7c06a43c3ffa50f7
<pre>
Support non-persistent background pages in Web Extensions.
<a href="https://webkit.org/b/246483">https://webkit.org/b/246483</a>
<a href="https://rdar.apple.com/problem/114823336">rdar://problem/114823336</a>

Reviewed by Brian Weinstein.

Fixes a number of things related to non-persistent pages. The main one was that all current uses
of wakeUpBackgroundContentIfNecessaryToFireEvents() were not capturing the lambda variables correctly.
This was mostly fine since the lambda was almost always called immediately, but not it will be stored
and called later when the page needs woken back up. Changed all lambdas to protect the context, and
copy their simple parameters and use Ref / RefPtr for counted objects.

The next issue was that ports were not being disconnected when the extension pages went away, leaving
a dangling port that the other pages could still message to no avail. We now disconnect ports for any
page when it is removed from the WebExtensionController, which is when WebPageProxy is deallocated.
This required having the UI process track what ports were open for which page.

And third, the runtime.connect() and runtime.sendMessage() implementations were not waking the background.
This was fine before since it was almost always guaranteed to exist (but likely a race condition). Now
we wait for the page to load before trying to deliver the messages.

Currently almost all tests use non-persistent pages, and this change is well exercised with the tests.
When using the TestWebKitAPI runner, the timeouts for the background page is shortened to 3 seconds, vs
the typical 30 seconds. And open and active ports is 6 seconds, vs the typical 2 minutes. Most tests will
only wake the background page once, but some do run long enough to have it terminated and get relaunched.

* Source/WTF/wtf/HashCountedSet.h:
(WTF::Traits&gt;::isValidValue): Added. The only impl passing off to HashMap was dead code, and
was removed from HashMap. Add back an implemetation copied from HashSet.
* Source/WebKit/Platform/IPC/ArgumentCoders.h: Fix return to be std::nullopt. This was also dead
code that is now being hit since we are using it again.
* Source/WebKit/Scripts/webkit/messages.py:
(class_template_headers): Added HashCountedSet.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::WebExtensionContext::fireActionClickedEventIfNeeded): Fix lambda to properly capture.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm:
(WebKit::WebExtensionContext::fireAlarmsEventIfNeeded): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm:
(WebKit::WebExtensionContext::fireCommandEventIfNeeded): Ditto.
(WebKit::WebExtensionContext::fireCommandChangedEventIfNeeded): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::fireCookiesChangedEventIfNeeded): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener): Use isBackgroundPage() helper.
(WebKit::WebExtensionContext::removeListener): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIMenusCocoa.mm:
(WebKit::WebExtensionContext::fireMenusClickedEventIfNeeded): Fix lambda to properly capture.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::firePermissionsEventListenerIfNecessary): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::portPostMessage): Track last time background used port. Don&apos;t use
wakeUpBackgroundContentIfNecessaryToFireEvents(), since the page needs loaded for ports to be
active and receive messages.
(WebKit::WebExtensionContext::portRemoved): Added WebPageProxyIdentifier param.
(WebKit::WebExtensionContext::pageHasOpenPorts): Added.
(WebKit::WebExtensionContext::disconnectPortsForPage): Added.
(WebKit::WebExtensionContext::addPorts): Added HashCountedSet param instead of simple count.
(WebKit::WebExtensionContext::removePort): Added WebPageProxyIdentifier param.
(WebKit::WebExtensionContext::addNativePort): Don&apos;t use addPorts() now, since that requires a page.
(WebKit::WebExtensionContext::removeNativePort): Ditto for removePort().
(WebKit::WebExtensionContext::firePortDisconnectEventIfNeeded): Don&apos;t wake up the background,
since the page needs loaded for ports to be active and receive messages.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeSendMessage): This was missing the wake up the background call.
(WebKit::WebExtensionContext::runtimeConnect): Ditto.
(WebKit::WebExtensionContext::runtimeConnectNative): Track added ports by page.
(WebKit::WebExtensionContext::runtimeWebPageConnect): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
(WebKit::WebExtensionContext::fireStorageChangedEventIfNeeded): Fix lambda to properly capture.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsConnect): Track added ports by page.
(WebKit::WebExtensionContext::fireTabsCreatedEventIfNeeded): Fix lambda to properly capture.
(WebKit::WebExtensionContext::fireTabsUpdatedEventIfNeeded): Ditto.
(WebKit::WebExtensionContext::fireTabsReplacedEventIfNeeded): Ditto.
(WebKit::WebExtensionContext::fireTabsDetachedEventIfNeeded): Ditto.
(WebKit::WebExtensionContext::fireTabsMovedEventIfNeeded): Ditto.
(WebKit::WebExtensionContext::fireTabsAttachedEventIfNeeded): Ditto.
(WebKit::WebExtensionContext::fireTabsActivatedEventIfNeeded): Ditto.
(WebKit::WebExtensionContext::fireTabsHighlightedEventIfNeeded): Ditto.
(WebKit::WebExtensionContext::fireTabsRemovedEventIfNeeded): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::fireWindowsEventIfNeeded): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::removePage): Added. Disconnect ports.
(WebKit::WebExtensionContext::getCurrentTab const): Use isBackgroundPage() helper.
(WebKit::WebExtensionContext::didChangeTabProperties): Return early in lambda for !isLoaded().
(WebKit::WebExtensionContext::didStartProvisionalLoadForFrame): Fix lambda to properly capture.
(WebKit::WebExtensionContext::didCommitLoadForFrame): Ditto.
(WebKit::WebExtensionContext::didFinishLoadForFrame): Ditto.
(WebKit::WebExtensionContext::didFailLoadForFrame): Ditto.
(WebKit::WebExtensionContext::resourceLoadDidSendRequest): Fix lambda to properly capture. Also
fetch the window outside the lambda so it is known before time passes and the tab might move windows.
(WebKit::WebExtensionContext::resourceLoadDidPerformHTTPRedirection): Ditto.
(WebKit::WebExtensionContext::resourceLoadDidReceiveChallenge): Ditto.
(WebKit::WebExtensionContext::resourceLoadDidReceiveResponse): Ditto.
(WebKit::WebExtensionContext::resourceLoadDidCompleteWithError): Ditto.
(WebKit::WebExtensionContext::relatedWebView): Skip over Inspector pages, they have different process pools.
(WebKit::WebExtensionContext::isBackgroundPage const): Added.
(WebKit::WebExtensionContext::backgroundContentIsLoaded const): Added.
(WebKit::WebExtensionContext::loadBackgroundWebViewIfNeeded): Added.
(WebKit::WebExtensionContext::loadBackgroundWebView): Added logging. Remove unused m_lastBackgroundContentLoadDate.
(WebKit::WebExtensionContext::unloadBackgroundWebView):
(WebKit::isNotRunningInTestRunner): Added.
(WebKit::WebExtensionContext::scheduleBackgroundContentToUnload): Removed FIXME and schedule a timer.
(WebKit::WebExtensionContext::unloadBackgroundContentIfPossible): Added.
(WebKit::WebExtensionContext::performTasksAfterBackgroundContentLoads): Shorten delay and added !isLoaded() early return.
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessary): Drastically simplified.
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents): Simplied. Uses wakeUpBackgroundContentIfNecessary().
(WebKit::WebExtensionContext::webViewWebContentProcessDidTerminate): Only reload background page if persistent. Removed FIXME
since that is handled by removePage() now.
(WebKit::WebExtensionContext::processes const): Return early if !isLoaded().
(WebKit::WebExtensionContext::queueEventToFireAfterBackgroundContentLoads): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::removePage): Call removePage() on each context.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm:
(WebKit::WebExtensionMessagePort::remove): Use firePortDisconnectEventIfNeeded() instead of page sentic portRemoved().
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::pageListensForEvent const): Return early if !isLoaded().
(WebKit::WebExtensionContext::processes const): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::sendToProcesses const): Return early if !isLoaded().
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::remove): Padd owningPageProxyIdentifier() in the message.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::connectNative): Pass webPageProxyIdentifier() in the message.
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeConnectEvent): Use a HashCountedSet to track page port counts.
(WebKit::WebExtensionContextProxy::dispatchRuntimeConnectEvent): Use HashCountedSet.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/275819@main">https://commits.webkit.org/275819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58efebb17d5289f11386b71f0ed33650df55b3e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45556 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39061 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19357 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16502 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/42807 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16593 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38028 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/992 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/36392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47079 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42563 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14641 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19557 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49573 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5816 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->