### PR TITLE
[JSC] Fix thread-local AssemblerBuffer

### DIFF
--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.cpp
@@ -46,14 +46,14 @@ ThreadSpecificAssemblerData& threadSpecificAssemblerData()
 }
 
 #if CPU(ARM64E)
-static ThreadSpecificAssemblerData* threadSpecificAssemblerHashesPtr;
-ThreadSpecificAssemblerData& threadSpecificAssemblerHashes()
+static ThreadSpecificAssemblerHashes* threadSpecificAssemblerHashesPtr;
+ThreadSpecificAssemblerHashes& threadSpecificAssemblerHashes()
 {
     static std::once_flag flag;
     std::call_once(
         flag,
         [] () {
-            threadSpecificAssemblerHashesPtr = new ThreadSpecificAssemblerData();
+            threadSpecificAssemblerHashesPtr = new ThreadSpecificAssemblerHashes();
         });
     return *threadSpecificAssemblerHashesPtr;
 }

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -391,7 +391,7 @@ private:
 #if ENABLE(BRANCH_COMPACTION)
     AssemblerData m_assemblerStorage;
 #if CPU(ARM64E)
-    AssemblerData m_assemblerHashesStorage;
+    AssemblerHashes m_assemblerHashesStorage;
 #endif
     bool m_shouldPerformBranchCompaction { true };
 #endif


### PR DESCRIPTION
#### 6f9503bb480411badefe27802aff3edc4dc131a9
<pre>
[JSC] Fix thread-local AssemblerBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=270642">https://bugs.webkit.org/show_bug.cgi?id=270642</a>
<a href="https://rdar.apple.com/124221850">rdar://124221850</a>

Reviewed by Keith Miller.

ARM64EHash broke thread-local AssemblerBuffer mechanism since it took the ownership of AssemblerData (not AssemblerBuffer) from MacroAssembler to LinkBuffer.
So when destroying AssemblerBuffer, its underlying AssemblerData is always zero-sized. This broke thread-local AssemblerBuffer mechanism.
This patch fixes it by

1. Moving thread-local AssemblerData access code from AssemblerBuffer to AssemblerData.
2. Tagging AssemblerData with enum class AssemblerDataType to specify which thread-local should be used.

* Source/JavaScriptCore/assembler/AssemblerBuffer.cpp:
(JSC::threadSpecificAssemblerHashes):
* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
(JSC::AssemblerDataImpl::AssemblerDataImpl):
(JSC::AssemblerDataImpl::operator=):
(JSC::AssemblerDataImpl::takeBufferIfLarger):
(JSC::AssemblerDataImpl::~AssemblerDataImpl):
(JSC::AssemblerBuffer::AssemblerBuffer):
(JSC::AssemblerBuffer::~AssemblerBuffer):
(JSC::AssemblerBuffer::releaseAssemblerHashes):
(JSC::AssemblerData::AssemblerData): Deleted.
(JSC::AssemblerData::operator=): Deleted.
(JSC::AssemblerData::takeBufferIfLarger): Deleted.
(JSC::AssemblerData::~AssemblerData): Deleted.
(JSC::AssemblerData::clear): Deleted.
(JSC::AssemblerData::buffer const): Deleted.
(JSC::AssemblerData::capacity const): Deleted.
(JSC::AssemblerData::grow): Deleted.
(JSC::AssemblerData::isInlineBuffer const): Deleted.
* Source/JavaScriptCore/assembler/LinkBuffer.h:

Canonical link: <a href="https://commits.webkit.org/275845@main">https://commits.webkit.org/275845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47025ea223b6a8e508198df589d64823e37cd949

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43041 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39166 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19490 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19104 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1097 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/36497 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47199 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42668 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19672 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49678 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5831 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10037 "Passed tests") | 
<!--EWS-Status-Bubble-End-->