### PR TITLE
[WebGPU] createView on a rgba16float canvas may crash

### DIFF
--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -149,11 +149,6 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
             device.generateAValidationError("Requested texture view format BGRA8UnormStorage is not enabled"_s);
             return;
         }
-
-        if (!Texture::textureViewFormatCompatible(descriptor.format, viewFormat)) {
-            device.generateAValidationError("Requested texture view format is not compatible with the descriptor format"_s);
-            return;
-        }
     }
 
     if ((descriptor.usage & WGPUTextureUsage_StorageBinding) && !device.hasFeature(WGPUFeatureName_BGRA8UnormStorage)) {

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -114,7 +114,6 @@ public:
     static bool supportsMultisampling(WGPUTextureFormat, const Device&);
     static bool supportsResolve(WGPUTextureFormat, const Device&);
     static bool supportsBlending(WGPUTextureFormat, const Device&);
-    static bool textureViewFormatCompatible(WGPUTextureFormat, WGPUTextureFormat);
     void recreateIfNeeded();
     void makeCanvasBacking();
     void setCommandEncoder(CommandEncoder&) const;

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -1786,7 +1786,7 @@ WGPUTextureFormat Texture::removeSRGBSuffix(WGPUTextureFormat format)
     }
 }
 
-bool Texture::textureViewFormatCompatible(WGPUTextureFormat format1, WGPUTextureFormat format2)
+static bool textureViewFormatCompatible(WGPUTextureFormat format1, WGPUTextureFormat format2)
 {
     // https://gpuweb.github.io/gpuweb/#texture-view-format-compatible
 
@@ -1901,7 +1901,7 @@ NSString *Device::errorValidatingTextureCreation(const WGPUTextureDescriptor& de
     }
 
     for (auto viewFormat : viewFormats) {
-        if (!Texture::textureViewFormatCompatible(descriptor.format, viewFormat))
+        if (!textureViewFormatCompatible(descriptor.format, viewFormat))
             return @"createTexture: !textureViewFormatCompatible(descriptor.format, viewFormat)";
     }
 
@@ -2943,11 +2943,6 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
     auto levels = NSMakeRange(descriptor->baseMipLevel, descriptor->mipLevelCount);
 
     auto slices = NSMakeRange(descriptor->baseArrayLayer, descriptor->arrayLayerCount);
-
-    if (!Texture::textureViewFormatCompatible(m_format, descriptor->format)) {
-        m_device->generateAValidationError("GPUTexture.createView: invalid texture format"_s);
-        return TextureView::createInvalid(*this, m_device);
-    }
 
     id<MTLTexture> texture = [m_texture newTextureViewWithPixelFormat:resolvedPixelFormat(pixelFormat, m_texture.pixelFormat) textureType:textureType levels:levels slices:slices];
     if (!texture)


### PR DESCRIPTION
#### dc5a9185627c7904742367325f6e3a1f6ab94a1e
<pre>
[WebGPU] createView on a rgba16float canvas may crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=270559">https://bugs.webkit.org/show_bug.cgi?id=270559</a>
&lt;<a href="https://rdar.apple.com/problem/124117002">rdar://problem/124117002</a>&gt;

Reviewed by Alex Christensen.

We were setting the pixel format to bgra8unorm but leaving
the WGPU texture format as rgba16float.

That is incorrect.

Revert of additional validation which is not needed to fix
the crash.

* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::textureViewFormatCompatible):
(WebGPU::Device::errorValidatingTextureCreation):
(WebGPU::Texture::createView):
(WebGPU::textureViewFormatCompatible): Deleted.

Canonical link: <a href="https://commits.webkit.org/275803@main">https://commits.webkit.org/275803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e97e51bc02f05bfe206a1143b665c0d7afa0c1df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45509 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39016 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19292 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/43464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36924 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47031 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14610 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9561 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/18973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->