### PR TITLE
Find in Note: Dark gray outline (shadow) appears behind gray/yellow highlights when matched text found in HTML note.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -247,7 +247,13 @@ struct PerWebProcessState {
 
     BOOL _findInteractionEnabled;
 #if HAVE(UIFINDINTERACTION)
-    RetainPtr<UIView> _findOverlay;
+    struct FindOverlays {
+        RetainPtr<UIView> top;
+        RetainPtr<UIView> right;
+        RetainPtr<UIView> bottom;
+        RetainPtr<UIView> left;
+    };
+    std::optional<FindOverlays> _findOverlaysOutsideContentView;
     RetainPtr<UIFindInteraction> _findInteraction;
 #endif
 


### PR DESCRIPTION
#### 89bc7dd33ce84e204457c2f54d27bafa85cf8ace
<pre>
Find in Note: Dark gray outline (shadow) appears behind gray/yellow highlights when matched text found in HTML note.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270666">https://bugs.webkit.org/show_bug.cgi?id=270666</a>
<a href="https://rdar.apple.com/122843511">rdar://122843511</a>

Reviewed by Aditya Keerthi.

In notes, the WKContentView is transparent, so our original solution of putting an additional
grey layer behind the content view that filled up the empty parts of the scroll view would show
through and make the find ui have a incorrect grey cast. So instead, we make four views that surround
the WKContentView to fill in any part of the scrollView that isn&apos;t covered by the contentView.
These are arranged around the content view like so:

----- -----------
|    |          |
|    |----------|
|    |     |    |
|    |     |    |
----- ------    |
|          |    |
|__________|____|

Each view is expanded to reach the edges of the scroll view every time the view is scrolled or the bounds change.
This means that no matter where the content view is scrolled to, there will be a view that gives the correct
grey cast to the scroll view.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollViewDidScroll:]):
(-[WKWebView _frameOrBoundsMayHaveChanged]):
(-[WKWebView _updateFindOverlayForOverflowScrollPositions]):
(-[WKWebView _showFindOverlay]):
(-[WKWebView _hideFindOverlay]):
(-[WKWebView _didAddLayerForFindOverlay:]):
(-[WKWebView _updateFindOverlayPosition]): Deleted.

Canonical link: <a href="https://commits.webkit.org/275873@main">https://commits.webkit.org/275873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2c2fcab3ecd48e167271a3d7272b10b674a0d15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43126 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45752 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39249 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35648 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16646 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16786 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39323 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42441 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19577 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41100 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9596 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->