### PR TITLE
[WebXR] Skip freezing layer tree with an active WebXR immersive session only when there's video content

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2680,6 +2680,20 @@ void Page::setMuted(MediaProducerMutedStateFlags muted)
     });
 }
 
+bool Page::shouldBlockLayerTreeFreezingForVideo()
+{
+    bool shouldBlockLayerTreeFreezingForVideo = false;
+    forEachMediaElement([&shouldBlockLayerTreeFreezingForVideo] (HTMLMediaElement& element) {
+        // FIXME: Consider only returning true when `element.readyState >=
+        // HTMLMediaElementEnums::HAVE_METADATA` and forcing an update to the layer tree
+        // freeze state when an element's readyState gets to HAVE_METADATA in
+        // `HTMLMediaElement::setReadyState`
+        if (element.isVideo())
+            shouldBlockLayerTreeFreezingForVideo = true;
+    });
+    return shouldBlockLayerTreeFreezingForVideo;
+}
+
 void Page::stopMediaCapture(MediaProducerMediaCaptureKind kind)
 {
     UNUSED_PARAM(kind);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -883,6 +883,7 @@ public:
     void playbackControlsMediaEngineChanged();
 #endif
     WEBCORE_EXPORT void setMuted(MediaProducerMutedStateFlags);
+    WEBCORE_EXPORT bool shouldBlockLayerTreeFreezingForVideo();
 
     WEBCORE_EXPORT void stopMediaCapture(MediaProducerMediaCaptureKind);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3276,7 +3276,7 @@ void WebPage::updateDrawingAreaLayerTreeFreezeState()
 #endif
 #if PLATFORM(VISION) && ENABLE(WEBXR)
         if (RefPtr page = m_page) {
-            if (page->hasActiveImmersiveSession())
+            if (page->hasActiveImmersiveSession() && page->shouldBlockLayerTreeFreezingForVideo())
                 shouldSkipFreezingLayerTreeOnBackgrounding = true;
         }
 #endif


### PR DESCRIPTION
#### 2b9b6bf2f2fb0ba67a772554d4dcc8fbb756b503
<pre>
[WebXR] Skip freezing layer tree with an active WebXR immersive session only when there&apos;s video content
<a href="https://bugs.webkit.org/show_bug.cgi?id=270669">https://bugs.webkit.org/show_bug.cgi?id=270669</a>
<a href="https://rdar.apple.com/123777699">rdar://123777699</a>

Reviewed by Eric Carlson.

We initially skip freezing the layer tree with an active WebXR immersive session
so videos can continue to get their requestVideoFrameCallback serviced. However,
since this also incurs a power cost, we&apos;ll only do this when there&apos;s video
content on the page.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::shouldBlockLayerTreeFreezingForVideo):
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateDrawingAreaLayerTreeFreezeState):

Canonical link: <a href="https://commits.webkit.org/275842@main">https://commits.webkit.org/275842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1953d40edc924ac5c50175b82771522c098aa3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35521 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16498 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38027 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47076 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42273 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19385 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40941 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9582 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->