### PR TITLE
[Webauthn] We need to use a different access group for test local credentials

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -459,25 +459,6 @@ imported/w3c/web-platform-tests/server-timing/test_server_timing.https.html [ Sk
 imported/w3c/web-platform-tests/server-timing/navigation_timing_idl.html [ Skip ]
 imported/w3c/web-platform-tests/server-timing/navigation_timing_idl.https.html [ Skip ]
 
-# These need test devlopment to populate clientDataJSON in AuthenticatorResponseData
-webkit.org/b/269751 http/wpt/webauthn/ctap-hid-success.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/idl.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-create-success-ccid.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-create-success-hid.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-create-success-nfc.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-create-success-u2f.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-cross-origin.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-get-success-ccid.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-get-success-hid.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-get-success-nfc.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-get-success-u2f.https.html [ Crash ]
-webkit.org/b/269751 http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html [ Crash ]
-
-webkit.org/b/270583 http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html [ Pass Failure ]
-webkit.org/b/270583 http/wpt/webauthn/public-key-credential-create-failure-local.https.html [ Pass Failure ]
-webkit.org/b/270583 http/wpt/webauthn/public-key-credential-create-success-local.https.html [ Pass Failure ]
-webkit.org/b/270583 http/wpt/webauthn/public-key-credential-get-failure-local.https.html [ Pass Failure ]
-
 # Console log lines may appear in a different order so we silence them.
 http/tests/security/cookie-module.html [ DumpJSConsoleLogInStdErr ]
 http/tests/security/cookie-module-import-propagate.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -940,15 +940,6 @@ webkit.org/b/186362 [ Release ] http/tests/resourceLoadStatistics/prevalent-reso
 
 webkit.org/b/189598 compositing/backing/backing-store-attachment-fill-forwards-animation.html [ Pass Failure ]
 
-# Local authenticator tests require restricted keychain entitlement, which cannot be signed with ad hoc signing.
-# Therefore, tests fail on OpenSource bots. They will be covered by Internal bots.
-http/wpt/webauthn/public-key-credential-create-failure-local.https.html [ Skip ]
-http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html [ Skip ]
-http/wpt/webauthn/public-key-credential-create-success-local.https.html [ Skip ]
-http/wpt/webauthn/public-key-credential-get-failure-local.https.html [ Skip ]
-http/wpt/webauthn/public-key-credential-get-failure-local-silent.https.html [ Skip ]
-http/wpt/webauthn/public-key-credential-get-success-local.https.html [ Skip ]
-
 webkit.org/b/194826 http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html [ Pass Timeout ]
 
 webkit.org/b/187391 accessibility/mac/async-increment-decrement-action.html [ Skip ]

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h
@@ -84,6 +84,7 @@ enum class ShouldZeroAAGUID : bool {
 };
 
 constexpr const char LocalAuthenticatorAccessGroup[] = "com.apple.webkit.webauthn";
+constexpr const char LocalAuthenticatorAccessGroupForTests[] = "com.apple.webkit.webauthn";
 
 // Credential serialization
 constexpr const char privateKeyKey[] = "priv";

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -923,6 +923,11 @@ static std::span<const uint8_t> asUInt8Span(NSData* data)
 }
 #endif
 
++ (void)useTestAccessGroup
+{
+    WebKit::LocalAuthenticator::useTestingAccessGroup();
+}
+
 + (WebCore::PublicKeyCredentialCreationOptions)convertToCoreCreationOptionsWithOptions:(_WKPublicKeyCredentialCreationOptions *)options
 {
     WebCore::PublicKeyCredentialCreationOptions result;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h
@@ -45,6 +45,8 @@ WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 + (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithRPIDAndAccessGroup:(NSString *)accessGroup rpID:(NSString *)rpID WK_API_AVAILABLE(macos(13.0), ios(16.0));
 + (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithCredentialIDAndAccessGroup:(NSString *)accessGroup credentialID:(NSData *)credentialID WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
++ (void)useTestAccessGroup WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 // For details of configuration, refer to MockWebAuthenticationConfiguration.h.
 @property (nonatomic, copy) NSDictionary *mockConfiguration;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
@@ -61,6 +61,8 @@ public:
 
     static void clearAllCredentials();
 
+    static void useTestingAccessGroup();
+
 private:
     explicit LocalAuthenticator(UniqueRef<LocalConnection>&&);
 


### PR DESCRIPTION
#### 72ac417a0c6478f648e0507ff3d93c8ee4f623aa
<pre>
[Webauthn] We need to use a different access group for test local credentials
<a href="https://bugs.webkit.org/show_bug.cgi?id=270583">https://bugs.webkit.org/show_bug.cgi?id=270583</a>
<a href="https://rdar.apple.com/problem/124150813">rdar://problem/124150813</a>

Reviewed by NOBODY (OOPS!).

Draft test development patch to re-enable webauthn tests.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(+[_WKWebAuthenticationPanel useTestAccessGroup]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::shouldUseTestingAccessGroup):
(WebKit::LocalAuthenticatorInternal::getExistingCredentials):
(WebKit::LocalAuthenticator::useTestingAccessGroup):
(WebKit::LocalAuthenticator::clearAllCredentials):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::WebCore::reset):
(TestWebKitAPI::WebCore::addKeyToKeychain):
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72ac417a0c6478f648e0507ff3d93c8ee4f623aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45238 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25700 "Failed to checkout and rebase branch from PR 25603") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35520 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16496 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16587 "layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38022 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39109 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38381 "Found 5 new test failures: http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html, http/wpt/webauthn/public-key-credential-create-failure-local.https.html, http/wpt/webauthn/public-key-credential-create-success-local.https.html, http/wpt/webauthn/public-key-credential-get-failure-local.https.html, http/wpt/webauthn/public-key-credential-get-success-local.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47075 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17760 "Failed to checkout and rebase branch from PR 25603") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14639 "Found 6 new test failures: http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html, http/wpt/webauthn/public-key-credential-create-failure-local.https.html, http/wpt/webauthn/public-key-credential-create-success-local.https.html, http/wpt/webauthn/public-key-credential-get-failure-local-silent.https.html, http/wpt/webauthn/public-key-credential-get-failure-local.https.html, http/wpt/webauthn/public-key-credential-get-success-local.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42274 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19384 "Failed to checkout and rebase branch from PR 25603") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40942 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19548 "Failed to checkout and rebase branch from PR 25603") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19014 "Failed to checkout and rebase branch from PR 25603") | | | 
<!--EWS-Status-Bubble-End-->