### PR TITLE
Avoid using GCReachableRef for custom elements reaction queue

### DIFF
--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -71,7 +71,7 @@ bool JSNodeOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, v
 {
     auto& node = jsCast<JSNode*>(handle.slot()->asCell())->wrapped();
     if (!node.isConnected()) {
-        if (GCReachableRefMap::contains(node)) {
+        if (GCReachableRefMap::contains(node) || node.isInCustomElementReactionQueue()) {
             if (UNLIKELY(reason))
                 *reason = "Node is scheduled to be used in an async script invocation)";
             return true;

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -335,6 +335,7 @@ inline void CustomElementQueue::invokeAll()
     // Invoke callbacks slightly later here instead of crashing / ignoring those cases.
     for (unsigned i = 0; i < m_elements.size(); ++i) {
         Ref element = m_elements[i].get();
+        element->clearIsInCustomElementReactionQueue();
         auto* queue = element->reactionQueue();
         ASSERT(queue);
         queue->invokeAll(element);
@@ -369,7 +370,7 @@ void CustomElementQueue::processQueue(JSC::JSGlobalObject* state)
     }
 }
 
-Vector<GCReachableRef<Element>, 4> CustomElementQueue::takeElements()
+Vector<Ref<Element>, 4> CustomElementQueue::takeElements()
 {
     RELEASE_ASSERT(!m_invoking);
     return std::exchange(m_elements, { });
@@ -385,6 +386,7 @@ void CustomElementReactionQueue::enqueueElementsOnAppropriateElementQueue(const 
 void CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue(Element& element)
 {
     ASSERT(element.reactionQueue());
+    element.setIsInCustomElementReactionQueue();
     if (!CustomElementReactionStack::s_currentProcessingStack) {
         element.document().windowEventLoop().backupElementQueue().add(element);
         return;

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -107,12 +107,12 @@ public:
     void add(Element&);
     WEBCORE_EXPORT void processQueue(JSC::JSGlobalObject*);
 
-    Vector<GCReachableRef<Element>, 4> takeElements();
+    Vector<Ref<Element>, 4> takeElements();
 
 private:
     void invokeAll();
 
-    Vector<GCReachableRef<Element>, 4> m_elements;
+    Vector<Ref<Element>, 4> m_elements;
     bool m_invoking { false };
 };
 
@@ -231,7 +231,7 @@ public:
         s_currentProcessingStack = m_previousProcessingStack;
     }
 
-    Vector<GCReachableRef<Element>, 4> takeElements() { return m_queue.takeElements(); }
+    Vector<Ref<Element>, 4> takeElements() { return m_queue.takeElements(); }
 
 private:
     CustomElementQueue m_queue;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -286,6 +286,10 @@ public:
     bool isPrecustomizedCustomElement() const { return customElementState() == CustomElementState::FailedOrPrecustomized && !isUnknownElement(); }
     bool isPrecustomizedOrDefinedCustomElement() const { return isPrecustomizedCustomElement() || isDefinedCustomElement(); }
 
+    bool isInCustomElementReactionQueue() const { return hasStateFlag(StateFlag::IsInCustomElementReactionQueue); }
+    void setIsInCustomElementReactionQueue() { setStateFlag(StateFlag::IsInCustomElementReactionQueue); }
+    void clearIsInCustomElementReactionQueue() { clearStateFlag(StateFlag::IsInCustomElementReactionQueue); }
+
     // Returns null, a child of ShadowRoot, or a legacy shadow root.
     Node* nonBoundaryShadowTreeRootNode();
 
@@ -635,6 +639,7 @@ protected:
         ContainsOnlyASCIIWhitespaceIsValid = 1 << 12, // Only used on CharacterData.
         HasHeldBackChildrenChanged = 1 << 13,
         HasStartedDeletion = 1 << 14,
+        IsInCustomElementReactionQueue = 1 << 15,
     };
 
     enum class TabIndexState : uint8_t {


### PR DESCRIPTION
#### 4972d2d69403a9edc08e1b14470453dab10c5955
<pre>
Avoid using GCReachableRef for custom elements reaction queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=270675">https://bugs.webkit.org/show_bug.cgi?id=270675</a>

Reviewed by Yusuke Suzuki.

Add a new Node StateFlag to indicate that an element is in a custom element reaction queue,
and use this mechanism to keep JS wrapper alive instead of using GCReachableRef.

* Source/WebCore/bindings/js/JSNodeCustom.cpp:
(WebCore::JSNodeOwner::isReachableFromOpaqueRoots):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementQueue::invokeAll):
(WebCore::CustomElementQueue::takeElements):
(WebCore::CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue):
(WebCore::CustomElementReactionStack::takeElements):
* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/dom/Node.h:
(WebCore::Node::isInCustomElementReactionQueue const):
(WebCore::Node::setIsInCustomElementReactionQueue):
(WebCore::Node::clearIsInCustomElementReactionQueue):

Canonical link: <a href="https://commits.webkit.org/275824@main">https://commits.webkit.org/275824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7563d4e7921e77ff55daf91e0f3c84746f1deddc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19400 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/18999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38040 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47100 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42290 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19404 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/40956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19582 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5818 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->