### PR TITLE
Remove unused `handleMouseUp` function from `EventHandler.cpp|h`

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1120,28 +1120,12 @@ void EventHandler::lostMouseCapture()
     protectedFrame()->selection().setCaretBlinkingSuspended(false);
 }
 
-bool EventHandler::handleMouseUp(const MouseEventWithHitTestResults& event)
-{
-    if (eventLoopHandleMouseUp(event))
-        return true;
-    
-    // If this was the first click in the window, we don't even want to clear the selection.
-    // This case occurs when the user clicks on a draggable element, since we have to process
-    // the mouse down and drag events to see if we might start a drag.  For other first clicks
-    // in a window, we just don't acceptFirstMouse, and the whole down-drag-up sequence gets
-    // ignored upstream of this layer.
-    return eventActivatedView(event.event());
-}    
-
 bool EventHandler::handleMouseReleaseEvent(const MouseEventWithHitTestResults& event)
 {
     if (autoscrollInProgress())
         stopAutoscrollTimer();
 
     Ref frame = m_frame.get();
-
-    if (handleMouseUp(event))
-        return true;
 
     // Used to prevent mouseMoveEvent from initiating a drag before
     // the mouse is pressed again.

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -467,8 +467,6 @@ private:
     bool handleDrag(const MouseEventWithHitTestResults&, CheckDragHysteresis);
 #endif
 
-    bool handleMouseUp(const MouseEventWithHitTestResults&);
-
 #if ENABLE(DRAG_SUPPORT)
     void clearDragState();
 
@@ -523,7 +521,7 @@ private:
     bool supportsSelectionUpdatesOnMouseDrag() const;
 #endif
 
-    // The following are called at the beginning of handleMouseUp and handleDrag.  
+    // The following are called at the beginning of handleDrag.
     // If they return true it indicates that they have consumed the event.
     bool eventLoopHandleMouseUp(const MouseEventWithHitTestResults&);
 


### PR DESCRIPTION
<pre>
Remove unused `handleMouseUp` function from `EventHandler.cpp|h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=270679">https://bugs.webkit.org/show_bug.cgi?id=270679</a>

Reviewed by NOBODY (OOPS!).

This patch removes unused function 'handleMouseUp()' from `EventHandler.cpp|h`.

* Source/WebCore/page/EventHandler.cpp:
(EventHandler::handleMouseUp): Deleted
(EventHandler::handleMouseReleaseEvent):
* Source/WebCore/page/EventHandler.h:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53f60ad0fd45a8b26836fe21398a8a7f3f7a4040

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39090 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16524 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38048 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1021 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47114 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42304 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19417 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40960 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->