### PR TITLE
[Cocoa] Legacy EME tests time out with SampleBufferContentKeySessionSupportEnabled enabled

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -355,6 +355,7 @@ platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
 platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
 platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
+platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
 platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -248,8 +248,8 @@ RefPtr<SharedBuffer> CDMPrivateFairPlayStreaming::sanitizeMpts(const SharedBuffe
 
 const Vector<Ref<SharedBuffer>>& CDMPrivateFairPlayStreaming::mptsKeyIDs() {
     static NeverDestroyed<Vector<Ref<SharedBuffer>>> mptsKeyID = [] {
-        Vector<uint8_t> keyData { std::initializer_list<uint8_t> { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1  } };
-        Ref<SharedBuffer> keyBuffer = SharedBuffer::create(WTFMove(keyData));
+        ASCIILiteral keyID = "TransportStreamIdentifier"_s;
+        Ref keyBuffer = SharedBuffer::create(keyID.characters(), keyID.length());
         return Vector { 1, WTFMove(keyBuffer) };
     }();
     return mptsKeyID;

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
@@ -30,6 +30,8 @@
 #include "CDMFactory.h"
 #include "CDMPrivate.h"
 
+OBJC_CLASS AVContentKeyRequest;
+
 namespace WebCore {
 
 struct FourCC;
@@ -94,6 +96,10 @@ public:
 #endif
 
     static const Vector<FourCC>& validFairPlayStreamingSchemes();
+
+#if HAVE(AVCONTENTKEYSESSION)
+    static Vector<Ref<SharedBuffer>> keyIDsForRequest(AVContentKeyRequest *);
+#endif
 
 private:
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CDMFairPlayStreaming.h"
+
+#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+
+#import "SharedBuffer.h"
+#import <pal/spi/cocoa/AVFoundationSPI.h>
+#import <wtf/Ref.h>
+#import <wtf/Vector.h>
+
+namespace WebCore {
+
+Vector<Ref<SharedBuffer>> CDMPrivateFairPlayStreaming::keyIDsForRequest(AVContentKeyRequest *request)
+{
+    if ([request.identifier isKindOfClass:NSString.class])
+        return { SharedBuffer::create([(NSString *)request.identifier dataUsingEncoding:NSUTF8StringEncoding]) };
+    if ([request.identifier isKindOfClass:NSData.class])
+        return { SharedBuffer::create((NSData *)request.identifier) };
+    if (request.initializationData) {
+        if (auto sinfKeyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsSinf(SharedBuffer::create(request.initializationData)))
+            return WTFMove(sinfKeyIDs.value());
+#if HAVE(FAIRPLAYSTREAMING_MTPS_INITDATA)
+        if (auto mptsKeyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsMpts(SharedBuffer::create(request.initializationData)))
+            return WTFMove(mptsKeyIDs.value());
+#endif
+    }
+    return { };
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -62,6 +62,8 @@ public:
     // CDMSessionMediaSourceAVFObjC
     void addParser(AVStreamDataParser *) override;
     void removeParser(AVStreamDataParser *) override;
+    bool isAnyKeyUsable(const Keys&) const override;
+    void attachContentKeyToSample(const MediaSampleAVFObjC&) override;
 
     void didProvideContentKeyRequest(AVContentKeyRequest *);
 
@@ -72,7 +74,7 @@ protected:
     AVContentKeySession* contentKeySession();
 
     bool hasContentKeyRequest() const;
-    RetainPtr<AVContentKeyRequest> contentKeyRequest();
+    RetainPtr<AVContentKeyRequest> contentKeyRequest() const;
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const { return "CDMSessionAVContentKeySession"; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
@@ -62,6 +62,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void removeSourceBuffer(SourceBufferPrivateAVFObjC*);
     void setSessionId(const String& sessionId) { m_sessionId = sessionId; }
 
+    using Keys = Vector<Ref<SharedBuffer>>;
+    virtual bool isAnyKeyUsable(const Keys&) const = 0;
+    virtual void attachContentKeyToSample(const MediaSampleAVFObjC&) = 0;
+
     void invalidateCDM() { m_cdm = nullptr; }
 
 protected:

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -973,7 +973,7 @@ bool SourceBufferPrivateAVFObjC::canEnqueueSample(TrackID trackID, const MediaSa
         return true;
 
     // if sample is encrypted, but we are not attached to a CDM: do not enqueue sample.
-    if (!m_cdmInstance)
+    if (!m_cdmInstance && !m_session)
         return false;
 
     // DecompressionSessions doesn't support encrypted media.
@@ -986,10 +986,16 @@ bool SourceBufferPrivateAVFObjC::canEnqueueSample(TrackID trackID, const MediaSa
 
     // if sample's set of keyIDs does not match the current set of keyIDs, consult with the CDM
     // to determine if the keyIDs are usable; if so, update the current set of keyIDs and enqueue sample.
-    if (m_cdmInstance->isAnyKeyUsable(sample.keyIDs())) {
+    if (m_cdmInstance && m_cdmInstance->isAnyKeyUsable(sample.keyIDs())) {
         m_currentTrackIDs.try_emplace(trackID, sample.keyIDs());
         return true;
     }
+
+    if (m_session && m_session->isAnyKeyUsable(sample.keyIDs())) {
+        m_currentTrackIDs.try_emplace(trackID, sample.keyIDs());
+        return true;
+    }
+
     return false;
 #else
     return true;
@@ -1119,10 +1125,13 @@ void SourceBufferPrivateAVFObjC::enqueueSampleBuffer(MediaSampleAVFObjC& sample)
 
 void SourceBufferPrivateAVFObjC::attachContentKeyToSampleIfNeeded(const MediaSampleAVFObjC& sample)
 {
-    if (!m_cdmInstance || !sampleBufferRenderersSupportKeySession() || !supportsAttachContentKey())
+    if (!sampleBufferRenderersSupportKeySession() || !supportsAttachContentKey())
         return;
 
-    m_cdmInstance->attachContentKeyToSample(sample);
+    if (m_cdmInstance)
+        m_cdmInstance->attachContentKeyToSample(sample);
+    else if (m_session)
+        m_session->attachContentKeyToSample(sample);
 }
 
 bool SourceBufferPrivateAVFObjC::isReadyForMoreSamples(TrackID trackID)


### PR DESCRIPTION
#### 7a74dcab081bf155995c7eb7fb745d444dbb4eae
<pre>
[Cocoa] Legacy EME tests time out with SampleBufferContentKeySessionSupportEnabled enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=270678">https://bugs.webkit.org/show_bug.cgi?id=270678</a>
<a href="https://rdar.apple.com/problem/123089013">rdar://problem/123089013</a>

Reviewed by Jer Noble.

The following legacy EME + MSE tests time out when enabling SampleBufferContentKeySessionSupportEnabled:
- http/tests/media/fairplay/legacy-fairplay-mse-v2.html
- http/tests/media/fairplay/legacy-fairplay-mse-v3.html

This occurred because SourceBufferPrivateAVFObjC::canEnqueueSample would only consult m_cdmInstance
(the modern CDM) to determine if a usable key existed to decrypt a sample. When legacy EME is in use
there would not be a modern CDM instance, so all samples would be considered un-enqueueable and
ultimately the canplay event would never be dispatched.

Addressed this by teaching SourceBufferPrivateAVFObjC to check m_session (the legacy CDM) for usable
keys if m_cdmInstance is null. Also, taught CDMSessionAVContentKeySession to attach content keys to
samples rather than relying on AVStreamDataParser to do so; this matches how
CDMInstanceSessionFairPlayStreamingAVFObjC attaches handles content key attachment.

To fully resolve these timeouts, one additional change was necessary. In 274351@main we taught the
FairPlay CDM how to decrypt MPEG2-TS streams, but we used a keyID that is incompatible with the
AVContentKeyRequests vended by AVContentKeySession. Since AVContentKeySession vends MPEG2-TS key
requests with an identifier of &quot;TransportStreamIdentifier&quot; and our CDM prefers to use the request
identifier over request initialization data to represent the keyID, this commit changes
CDMPrivateFairPlayStreaming::mptsKeyIDs() to return &quot;TransportStreamIdentifier&quot; instead of the
preivious 16-byte value

No new tests; covered by existing tests.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMPrivateFairPlayStreaming::mptsKeyIDs):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm: Added.
(WebCore::CDMPrivateFairPlayStreaming::keyIDsForRequest):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::keyIDsForRequest):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequest):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequests):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::updateKeyStatuses):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyForSample):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::isAnyKeyUsable const):
(WebCore::CDMSessionAVContentKeySession::attachContentKeyToSample):
(WebCore::CDMSessionAVContentKeySession::contentKeyRequest const):
(WebCore::CDMSessionAVContentKeySession::contentKeyRequest): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::canEnqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::attachContentKeyToSampleIfNeeded):

Canonical link: <a href="https://commits.webkit.org/275839@main">https://commits.webkit.org/275839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7f8ecbc7a02f1bb82b4427fa1749b9119fb3b7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/21981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19405 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38038 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1013 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39128 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42296 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19409 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40953 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9581 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->