### PR TITLE
ModelProcessModelPlayerProxy should perform the work of SeparatedModelPlayer directly

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -33,12 +33,23 @@
 #import "ModelConnectionToWebProcess.h"
 #import "ModelProcessModelPlayerManagerProxy.h"
 #import "ModelProcessModelPlayerMessages.h"
+#import "WKModelProcessModelLayer.h"
+#import <RealitySystemSupport/RealitySystemSupport.h>
+#import <SurfBoardServices/SurfBoardServices.h>
 #import <WebCore/Color.h>
 #import <WebCore/LayerHostingContextIdentifier.h>
 #import <WebCore/Model.h>
-#import <WebKitAdditions/SeparatedModelPlayer.h>
-#import <WebKitAdditions/WKSeparatedModelLayer.h>
+#import <WebCore/ResourceError.h>
+#import <WebKitAdditions/REModel.h>
+#import <WebKitAdditions/REModelLoader.h>
+#import <WebKitAdditions/REPtr.h>
+#import <WebKitAdditions/SeparatedLayerAdditions.h>
+#import <WebKitAdditions/WKREEngine.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/MathExtras.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/text/TextStream.h>
 
 namespace WebKit {
 
@@ -57,6 +68,9 @@ ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy(ModelProcessModelPlay
 
 ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy()
 {
+    if (m_loader)
+        m_loader->cancel();
+
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy deallocated id=%" PRIu64, this, m_id.toUInt64());
 }
 
@@ -74,9 +88,13 @@ ALWAYS_INLINE void ModelProcessModelPlayerProxy::send(T&& message)
 void ModelProcessModelPlayerProxy::createLayer()
 {
     dispatch_assert_queue(dispatch_get_main_queue());
+    ASSERT(!m_layer);
 
-    m_layer = adoptNS([[WKSeparatedModelLayer alloc] init]);
-    [m_layer setIsPortal:YES];
+    m_layer = adoptNS([[WKModelProcessModelLayer alloc] init]);
+    [m_layer setName:@"WKModelProcessModelLayer"];
+    [m_layer setValue:@YES forKeyPath:@"separatedOptions.isPortal"];
+    [m_layer setValue:(__bridge id)CGColorGetConstantColor(kCGColorWhite) forKeyPath:@"separatedOptions.material.clearColor"];
+    [m_layer setPlayer:RefPtr { this }];
 
     LayerHostingContextOptions contextOptions;
     m_layerHostingContext = LayerHostingContext::createForExternalHostingProcess(contextOptions);
@@ -90,16 +108,347 @@ void ModelProcessModelPlayerProxy::createLayer()
 
 void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize)
 {
-    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::loadModel size=%zu id=%" PRIu64, this, model->data()->size(), m_id.toUInt64());
+    // FIXME: Change the IPC message to land on load() directly
+    load(model, layoutSize);
+}
+
+static inline simd_float2 makeMeterSizeFromPointSize(CGSize pointSize, CGFloat pointsPerMeter)
+{
+    return simd_make_float2(pointSize.width / pointsPerMeter, pointSize.height / pointsPerMeter);
+}
+
+static simd_float3 computeExtents(simd_float2 boundsOfLayerInMeters, simd_float3 originalBoundingBoxExtents)
+{
+    if (simd_reduce_min(originalBoundingBoxExtents) - FLT_EPSILON > 0) {
+        auto boundsScaleRatios = simd_make_float2(
+            boundsOfLayerInMeters.x / originalBoundingBoxExtents.x,
+            boundsOfLayerInMeters.y / originalBoundingBoxExtents.y
+        );
+        return simd_reduce_min(boundsScaleRatios) * originalBoundingBoxExtents;
+    }
+
+    return originalBoundingBoxExtents;
+}
+
+static RESRT computeSRT(CALayer *layer, simd_float3 originalBoundingBoxExtents, float pitch, float yaw, bool isPortal, CGFloat pointsPerMeter)
+{
+    auto boundsOfLayerInMeters = makeMeterSizeFromPointSize(layer.bounds.size, pointsPerMeter);
+    auto extents = computeExtents(boundsOfLayerInMeters, originalBoundingBoxExtents);
+
+    RESRT srt;
+    srt.scale = simd_make_float3(extents.x / originalBoundingBoxExtents.x, extents.y / originalBoundingBoxExtents.y, extents.z / originalBoundingBoxExtents.z);
+
+    // Must be normalized, but these obviously are.
+    simd_float3 xAxis = simd_make_float3(1, 0, 0);
+    simd_float3 yAxis = simd_make_float3(0, 1, 0);
+
+    // FIXME: These should rotate around the center point of the model.
+    simd_quatf pitchQuat = simd_quaternion(deg2rad(pitch), xAxis);
+    simd_quatf yawQuat = simd_quaternion(deg2rad(yaw), yAxis);
+    srt.rotation = simd_mul(pitchQuat, yawQuat);
+
+    if (isPortal)
+        srt.translation = simd_make_float3(0, -boundsOfLayerInMeters.y / 2.0f, -extents.z / 2.0f);
+    else
+        srt.translation = simd_make_float3(0, -boundsOfLayerInMeters.y / 2.0f, extents.z / 2.0f);
+
+    return srt;
+}
+
+static CGFloat effectivePointsPerMeter(CALayer *caLayer)
+{
+    constexpr CGFloat defaultPointsPerMeter = 1360;
+
+    CALayer *layer = caLayer;
+    do {
+        if (CGFloat pointsPerMeter = [[layer valueForKeyPath:@"separatedOptions.pointsPerMeter"] floatValue])
+            return pointsPerMeter;
+        layer = layer.superlayer;
+    } while (layer);
+
+    return defaultPointsPerMeter;
+}
+
+void ModelProcessModelPlayerProxy::updateTransform()
+{
+    if (!m_model || !m_layer)
+        return;
+
+    // FIXME: Use the value of the 'object-fit' property here to compute an appropriate SRT.
+    RESRT newSRT = computeSRT(m_layer.get(), m_originalBoundingBoxExtents, m_pitch, m_yaw, true, effectivePointsPerMeter(m_layer.get()));
+
+    auto transform = REEntityGetOrAddComponentByClass(m_model->rootEntity(), RETransformComponentGetComponentType());
+    RETransformComponentSetLocalSRT(transform, newSRT);
+    RENetworkMarkComponentDirty(transform);
+}
+
+void ModelProcessModelPlayerProxy::updateOpacity()
+{
+    if (!m_model || !m_layer)
+        return;
+
+    auto opacity = std::max(0.0f, [m_layer opacity]);
+
+    if (opacity >= 1.0f) {
+        // If the hosting layer is completely opaque, remove any fade component that might have been set
+        // previously.
+        REEntityRemoveComponentByClass(m_model->rootEntity(), REHierarchicalFadeComponentGetComponentType());
+        // FIXME: Do we need to mark anything as dirty when removing a component?
+        return;
+    }
+
+    auto hierarchicalFadeComponent = REEntityGetOrAddComponentByClass(m_model->rootEntity(), REHierarchicalFadeComponentGetComponentType());
+    REHierarchicalFadeComponentSetOpacity(hierarchicalFadeComponent, opacity);
+    RENetworkMarkComponentDirty(hierarchicalFadeComponent);
+}
+
+void ModelProcessModelPlayerProxy::startAnimating()
+{
+    if (!m_model || !m_layer)
+        return;
+
+    auto animationLibraryComponent = REEntityGetComponentByClass(m_model->rootEntity(), REAnimationLibraryComponentGetComponentType());
+    if (!animationLibraryComponent)
+        return;
+
+    auto animationLibraryAsset = REAnimationLibraryComponentGetAnimationLibraryAsset(animationLibraryComponent);
+    if (!animationLibraryAsset)
+        return;
+
+    auto engine = REEngineGetShared();
+    auto serviceLocator = REEngineGetServiceLocator(engine);
+    auto assetManager = REServiceLocatorGetAssetManager(serviceLocator);
+
+    auto animationLibraryDefinition = adoptRE(REAnimationLibraryDefinitionCreateFromAnimationLibraryAsset(assetManager, animationLibraryAsset));
+    if (!animationLibraryDefinition)
+        return;
+
+    // FIXME: Allow passing in the name of the animation to run, and then loop over all the
+    // entries in the animationLibraryDefinition, extracting the root timelines and getting
+    // their names via RETimelineDefinitionGetName().
+
+    auto animationAsset = REAnimationLibraryDefinitionGetEntryAsset(animationLibraryDefinition.get(), 0);
+    if (!animationAsset)
+        return;
+
+    auto extractRootTimelineDefinition = [] (auto animationAsset) -> REPtr<RETimelineDefinitionRef> {
+        auto animationAssetType = REAssetHandleAssetType(animationAsset);
+        if (animationAssetType == kREAssetTypeTimeline)
+            return adoptRE(RETimelineDefinitionCreateFromTimeline(animationAsset));
+        if (animationAssetType == kREAssetTypeAnimationScene) {
+            auto rootTimelineAsset = REAnimationSceneAssetGetRootTimeline(animationAsset);
+            return adoptRE(RETimelineDefinitionCreateFromTimeline(rootTimelineAsset));
+        }
+        return nullptr;
+    };
+
+    auto rootTimelineDefinition = extractRootTimelineDefinition(animationAsset);
+    if (!rootTimelineDefinition) {
+        RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy Could not extract root timeline from animation asset due to unknown asset type id=%" PRIu64 " type=%@", this, m_id.toUInt64(), (NSString *)REAssetGetType(animationAsset));
+        return;
+    }
+
+    // FIXME: Allow passing in options to control looping behavior.
+
+    // Wrap animation asset in an infinitely repeating clip.
+
+    auto repeatingTimelineClipDefinition = adoptRE(RETimelineDefinitionCreateTimelineClip("Repeater", assetManager, rootTimelineDefinition.get()));
+    RETimelineDefinitionSetClipLoopBehavior(repeatingTimelineClipDefinition.get(), kREAnimationLoopBehaviorRepeat);
+    double duration = std::numeric_limits<double>::infinity();
+    RETimelineDefinitionSetClipDuration(repeatingTimelineClipDefinition.get(), &duration);
+    auto repeatingTimelineAsset = adoptRE(RETimelineDefinitionCreateTimelineAsset(repeatingTimelineClipDefinition.get(), assetManager));
+
+    auto animationComponent = REEntityGetOrAddComponentByClass(m_model->rootEntity(), REAnimationComponentGetComponentType());
+    auto animationHandoffDescription = REAnimationHandoffDefaultDescEx();
+    m_animationPlaybackToken = REAnimationComponentPlay(animationComponent, repeatingTimelineAsset.get(), animationHandoffDescription, kREAnimationMarkComponentsDirty);
+}
+
+// MARK: - WebCore::RELoaderClient
+
+static RECALayerService *webDefaultLayerService(void)
+{
+    return REServiceLocatorGetCALayerService(REEngineGetServiceLocator(REEngineGetShared()));
+}
+
+void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& loader, Ref<WebCore::REModel> model)
+{
+    dispatch_assert_queue(dispatch_get_main_queue());
+    ASSERT(&loader == m_loader.get());
+
+    m_loader = nullptr;
+    m_model = WTFMove(model);
+
+    auto modelBoundingBox = REEntityComputeMeshBounds(m_model->rootEntity(), true, matrix_identity_float4x4, kREEntityStatusNone);
+    m_originalBoundingBoxExtents = REAABBExtents(modelBoundingBox);
+
+    REEntitySubtreeAddNetworkComponentRecursive(m_model->rootEntity());
+
+    [m_layer setValue:@YES forKeyPath:@"separatedOptions.updates.transform"];
+    [m_layer setValue:@YES forKeyPath:@"separatedOptions.updates.collider"];
+    [m_layer setValue:@YES forKeyPath:@"separatedOptions.updates.mesh"];
+    [m_layer setValue:@YES forKeyPath:@"separatedOptions.updates.material"];
+    [m_layer setValue:@YES forKeyPath:@"separatedOptions.updates.texture"];
+    [m_layer setValue:@YES forKeyPath:@"separatedOptions.updates.clippingPrimitive"];
+    [m_layer setValue:(__bridge id)CGColorGetConstantColor(kCGColorWhite) forKeyPath:@"separatedOptions.material.clearColor"];
+
+    REPtr<REEntityRef> hostingEntity = adoptRE(REEntityCreate());
+    REEntitySetName(hostingEntity.get(), "WebKit:EntityWithRootComponent");
+
+    REPtr<REComponentRef> layerComponent = adoptRE(RECALayerServiceCreateRootComponent(webDefaultLayerService(), CALayerGetContext(m_layer.get()), hostingEntity.get(), nil));
+    RESceneAddEntity(m_scene.get(), hostingEntity.get());
+
+    CALayer *contextEntityLayer = RECALayerClientComponentGetCALayer(layerComponent.get());
+    [contextEntityLayer setSeparatedState:kCALayerSeparatedStateSeparated];
+
+    RECALayerClientComponentSetShouldSyncToRemotes(layerComponent.get(), true);
+
+    auto clientComponent = RECALayerGetCALayerClientComponent(m_layer.get());
+    auto rootEntity = REComponentGetEntity(clientComponent);
+    REEntitySetName(rootEntity, "WebKit:ClientComponentRoot");
+    REEntitySetName(m_model->rootEntity(), "WebKit:ModelRootEntity");
+    REEntitySetParent(m_model->rootEntity(), rootEntity);
+
+    updateTransform();
+    updateOpacity();
+    startAnimating();
+}
+
+void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader, const WebCore::ResourceError& error)
+{
+    dispatch_assert_queue(dispatch_get_main_queue());
+    ASSERT(&loader == m_loader.get());
+
+    m_loader = nullptr;
+
+    RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy failed to load model id=%" PRIu64 " error=\"%@\"", this, m_id.toUInt64(), error.nsError().localizedDescription);
+
+    // FIXME: Do something sensible in the failure case.
+}
+
+// MARK: - WebCore::ModelPlayer
+
+void ModelProcessModelPlayerProxy::load(WebCore::Model& model, WebCore::LayoutSize layoutSize)
+{
+    dispatch_assert_queue(dispatch_get_main_queue());
+
+    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::load size=%zu id=%" PRIu64, this, model.data()->size(), m_id.toUInt64());
     sizeDidChange(layoutSize);
-    [m_layer setPlayer:WebKit::SeparatedModelPlayer::create(SeparatedModelPlayer::ProcessEnvironment::ModelProcess)];
-    [m_layer player]->load(model);
+
+    WKREEngine::shared().runWithSharedScene([this, protectedThis = Ref { *this }, model = Ref { model }] (RESceneRef scene) {
+        m_scene = scene;
+        m_loader = WebCore::loadREModel(model.get(), *this);
+    });
 }
 
 void ModelProcessModelPlayerProxy::sizeDidChange(WebCore::LayoutSize layoutSize)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::sizeDidChange w=%lf h=%lf id=%" PRIu64, this, layoutSize.width().toDouble(), layoutSize.width().toDouble(), m_id.toUInt64());
     [m_layer setFrame:CGRectMake(0, 0, layoutSize.width().toDouble(), layoutSize.width().toDouble())];
+}
+
+PlatformLayer* ModelProcessModelPlayerProxy::layer()
+{
+    return nullptr;
+}
+
+std::optional<WebCore::LayerHostingContextIdentifier> ModelProcessModelPlayerProxy::layerHostingContextIdentifier()
+{
+    return WebCore::LayerHostingContextIdentifier(m_layerHostingContext->contextID());
+}
+
+void ModelProcessModelPlayerProxy::enterFullscreen()
+{
+}
+
+bool ModelProcessModelPlayerProxy::supportsMouseInteraction()
+{
+    return false;
+}
+
+bool ModelProcessModelPlayerProxy::supportsDragging()
+{
+    return false;
+}
+
+void ModelProcessModelPlayerProxy::setInteractionEnabled(bool isInteractionEnabled)
+{
+}
+
+void ModelProcessModelPlayerProxy::handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime)
+{
+}
+
+void ModelProcessModelPlayerProxy::handleMouseMove(const WebCore::LayoutPoint&, MonotonicTime)
+{
+}
+
+void ModelProcessModelPlayerProxy::handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime)
+{
+}
+
+void ModelProcessModelPlayerProxy::getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
+
+void ModelProcessModelPlayerProxy::setCamera(WebCore::HTMLModelElementCamera camera, CompletionHandler<void(bool success)>&& completionHandler)
+{
+    completionHandler(false);
+}
+
+void ModelProcessModelPlayerProxy::isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
+
+void ModelProcessModelPlayerProxy::setAnimationIsPlaying(bool isPlaying, CompletionHandler<void(bool success)>&& completionHandler)
+{
+    completionHandler(false);
+}
+
+void ModelProcessModelPlayerProxy::isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
+
+void ModelProcessModelPlayerProxy::setIsLoopingAnimation(bool isLooping, CompletionHandler<void(bool success)>&& completionHandler)
+{
+    completionHandler(false);
+}
+
+void ModelProcessModelPlayerProxy::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
+
+void ModelProcessModelPlayerProxy::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
+
+void ModelProcessModelPlayerProxy::setAnimationCurrentTime(Seconds currentTime, CompletionHandler<void(bool success)>&& completionHandler)
+{
+    completionHandler(false);
+}
+
+void ModelProcessModelPlayerProxy::hasAudio(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
+
+void ModelProcessModelPlayerProxy::isMuted(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
+{
+    completionHandler(std::nullopt);
+}
+
+void ModelProcessModelPlayerProxy::setIsMuted(bool isMuted, CompletionHandler<void(bool success)>&& completionHandler)
+{
+    completionHandler(false);
+}
+
+Vector<RetainPtr<id>> ModelProcessModelPlayerProxy::accessibilityChildren()
+{
+    return { };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.h
+++ b/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ */
+
+#pragma once
+
+#if ENABLE(MODEL_PROCESS)
+
+#import <QuartzCore/QuartzCore.h>
+#import <wtf/RefPtr.h>
+
+namespace WebKit {
+class ModelProcessModelPlayerProxy;
+}
+
+@interface WKModelProcessModelLayer : CALayer
+
+@property (direct) RefPtr<WebKit::ModelProcessModelPlayerProxy> player;
+
+@end
+
+#endif // MODEL_PROCESS

--- a/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm
+++ b/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ */
+
+#import "config.h"
+
+#if ENABLE(MODEL_PROCESS)
+#import "WKModelProcessModelLayer.h"
+
+#import "ModelProcessModelPlayerProxy.h"
+#import <wtf/RefPtr.h>
+
+@implementation WKModelProcessModelLayer {
+    RefPtr<WebKit::ModelProcessModelPlayerProxy> _player;
+}
+
+- (void)setPlayer:(RefPtr<WebKit::ModelProcessModelPlayerProxy>)player
+{
+    _player = WTFMove(player);
+}
+
+- (RefPtr<WebKit::ModelProcessModelPlayerProxy>)player
+{
+    return _player;
+}
+
+- (void)setOpacity:(float)opacity
+{
+    [super setOpacity:opacity];
+
+    _player->updateOpacity();
+}
+
+- (void)layoutSublayers
+{
+    [super layoutSublayers];
+
+    _player->updateTransform();
+}
+
+@end
+
+
+#endif // MODEL_PROCESS

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -79,8 +79,9 @@ GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
 
 ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
 ModelProcess/cocoa/ModelProcessCocoa.mm
-ModelProcess/ios/ModelProcessIOS.mm
+ModelProcess/cocoa/WKModelProcessModelLayer.mm
 ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+ModelProcess/ios/ModelProcessIOS.mm
 
 Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
 Platform/classifier/ResourceLoadStatisticsClassifier.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5833,6 +5833,8 @@
 		54BBB6062B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelProcessModelPlayerProxy.h; sourceTree = "<group>"; };
 		54BBB6072B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ModelProcessModelPlayerProxy.messages.in; sourceTree = "<group>"; };
 		54BBB6092B80177C00BF1A8A /* ModelProcessModelPlayer.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ModelProcessModelPlayer.messages.in; sourceTree = "<group>"; };
+		54BD52C72B99787A00B9EF66 /* WKModelProcessModelLayer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKModelProcessModelLayer.mm; sourceTree = "<group>"; };
+		54BD52C82B99787A00B9EF66 /* WKModelProcessModelLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKModelProcessModelLayer.h; sourceTree = "<group>"; };
 		5506409D2407160900AAE045 /* RemoteRenderingBackendProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteRenderingBackendProxy.cpp; sourceTree = "<group>"; };
 		5506409E2407160900AAE045 /* RemoteRenderingBackendProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteRenderingBackendProxy.h; sourceTree = "<group>"; };
 		5506409F2407196A00AAE045 /* RenderingBackendIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RenderingBackendIdentifier.h; sourceTree = "<group>"; };
@@ -10480,6 +10482,8 @@
 				54BBB6062B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.h */,
 				54BBB6072B7ED58400BF1A8A /* ModelProcessModelPlayerProxy.messages.in */,
 				540D14C72B840E9A007FD5DE /* ModelProcessModelPlayerProxy.mm */,
+				54BD52C82B99787A00B9EF66 /* WKModelProcessModelLayer.h */,
+				54BD52C72B99787A00B9EF66 /* WKModelProcessModelLayer.mm */,
 			);
 			path = cocoa;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### 027113676fd2bb2657ee93ef93e5aff751129097
<pre>
ModelProcessModelPlayerProxy should perform the work of SeparatedModelPlayer directly
<a href="https://rdar.apple.com/124232154">rdar://124232154</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270660">https://bugs.webkit.org/show_bug.cgi?id=270660</a>

Reviewed by Tim Horton.

ModelProcessModelPlayerProxy should should itself be a WebCore::ModelPlayer,
instead of further delegating it to SeparatedModelPlayer.

SeparatedModelPlayer was designed to work inside UIProcess, and thus has never
been an ideal choice for our purpose. By upstreaming the code from
SeparatedModelPlayer, we can now invoke the ModelPlayer calls directly through
XPC messages from ModelProcessModelPlayer without further boilerplate code
to propagate the calls.

At the same time we also upstream WKSeparatedModelLayer into the new
WKModelProcessModelLayer, which is a thin CALayer subclass just to listen to
layout and opacity changes should they occur.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
Now conforms to WebCore::ModelPlayer properly, so that it can handle
all calls from ModelProcessModelPlayer 1:1.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
Most code addition here are copied directly from SeparatedModelPlayer.
The rest are empty placeholders to satisfy WebCore::ModelPlayer
for the time being.

(WebKit::ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy):
(WebKit::ModelProcessModelPlayerProxy::createLayer):
(WebKit::ModelProcessModelPlayerProxy::loadModel):
(WebKit::makeMeterSizeFromPointSize):
(WebKit::computeExtents):
(WebKit::degreesToRadians):
(WebKit::computeSRT):
(WebKit::effectivePointsPerMeter):
(WebKit::ModelProcessModelPlayerProxy::updateTransform):
(WebKit::ModelProcessModelPlayerProxy::updateOpacity):
(WebKit::ModelProcessModelPlayerProxy::startAnimating):
(WebKit::webDefaultLayerService):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::didFailLoading):
(WebKit::ModelProcessModelPlayerProxy::load):
(WebKit::ModelProcessModelPlayerProxy::layer):
(WebKit::ModelProcessModelPlayerProxy::layerHostingContextIdentifier):
(WebKit::ModelProcessModelPlayerProxy::enterFullscreen):
(WebKit::ModelProcessModelPlayerProxy::supportsMouseInteraction):
(WebKit::ModelProcessModelPlayerProxy::supportsDragging):
(WebKit::ModelProcessModelPlayerProxy::setInteractionEnabled):
(WebKit::ModelProcessModelPlayerProxy::handleMouseDown):
(WebKit::ModelProcessModelPlayerProxy::handleMouseMove):
(WebKit::ModelProcessModelPlayerProxy::handleMouseUp):
(WebKit::ModelProcessModelPlayerProxy::getCamera):
(WebKit::ModelProcessModelPlayerProxy::setCamera):
(WebKit::ModelProcessModelPlayerProxy::isPlayingAnimation):
(WebKit::ModelProcessModelPlayerProxy::setAnimationIsPlaying):
(WebKit::ModelProcessModelPlayerProxy::isLoopingAnimation):
(WebKit::ModelProcessModelPlayerProxy::setIsLoopingAnimation):
(WebKit::ModelProcessModelPlayerProxy::animationDuration):
(WebKit::ModelProcessModelPlayerProxy::animationCurrentTime):
(WebKit::ModelProcessModelPlayerProxy::setAnimationCurrentTime):
(WebKit::ModelProcessModelPlayerProxy::hasAudio):
(WebKit::ModelProcessModelPlayerProxy::isMuted):
(WebKit::ModelProcessModelPlayerProxy::setIsMuted):
(WebKit::ModelProcessModelPlayerProxy::accessibilityChildren):
* Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.h: Added.
* Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm: Added.
(-[WKModelProcessModelLayer setPlayer:]):
(-[WKModelProcessModelLayer player]):
(-[WKModelProcessModelLayer setOpacity:]):
(-[WKModelProcessModelLayer layoutSublayers]):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/275940@main">https://commits.webkit.org/275940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76700ad394e66ead5a8cc312d59f66292385cfdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45969 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39460 "Hash 76700ad3 for PR 25613 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35821 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19384 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1390 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47513 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19785 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41266 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5890 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->