### PR TITLE
Miscellaneous clean-up in `MathExtras.h`

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2022 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,7 +21,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -28,48 +29,27 @@
 #include <algorithm>
 #include <climits>
 #include <cmath>
-#include <float.h>
 #include <limits>
+#include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <wtf/StdLibExtras.h>
 
 #if OS(OPENBSD)
 #include <sys/types.h>
 #include <machine/ieee.h>
 #endif
 
-#ifndef M_PI
-constexpr double piDouble = 3.14159265358979323846;
-constexpr float piFloat = 3.14159265358979323846f;
-#else
 constexpr double piDouble = M_PI;
 constexpr float piFloat = static_cast<float>(M_PI);
-#endif
 
-#ifndef M_PI_2
-constexpr double piOverTwoDouble = 1.57079632679489661923;
-constexpr float piOverTwoFloat = 1.57079632679489661923f;
-#else
 constexpr double piOverTwoDouble = M_PI_2;
 constexpr float piOverTwoFloat = static_cast<float>(M_PI_2);
-#endif
 
-#ifndef M_PI_4
-constexpr double piOverFourDouble = 0.785398163397448309616;
-constexpr float piOverFourFloat = 0.785398163397448309616f;
-#else
 constexpr double piOverFourDouble = M_PI_4;
 constexpr float piOverFourFloat = static_cast<float>(M_PI_4);
-#endif
 
-#ifndef M_SQRT2
-constexpr double sqrtOfTwoDouble = 1.41421356237309504880;
-constexpr float sqrtOfTwoFloat = 1.41421356237309504880f;
-#else
 constexpr double sqrtOfTwoDouble = M_SQRT2;
 constexpr float sqrtOfTwoFloat = static_cast<float>(M_SQRT2);
-#endif
 
 #if COMPILER(MSVC)
 
@@ -114,7 +94,6 @@ constexpr inline double grad2deg(double g) { return g * degreesPerGradientDouble
 constexpr inline double deg2turn(double d) { return d * turnsPerDegreeDouble; }
 constexpr inline double turn2deg(double t) { return t * degreesPerTurnDouble; }
 
-
 // Note that these differ from the casting the double values above in their rounding errors.
 constexpr float radiansPerDegreeFloat = piFloat / 180.0f;
 constexpr float degreesPerRadianFloat = 180.0f / piFloat;
@@ -145,9 +124,7 @@ inline double roundTowardsPositiveInfinity(double value) { return std::floor(val
 inline float roundTowardsPositiveInfinity(float value) { return std::floor(value + 0.5f); }
 
 // std::numeric_limits<T>::min() returns the smallest positive value for floating point types
-template<typename T> constexpr T defaultMinimumForClamp() { return std::numeric_limits<T>::min(); }
-template<> constexpr float defaultMinimumForClamp() { return -std::numeric_limits<float>::max(); }
-template<> constexpr double defaultMinimumForClamp() { return -std::numeric_limits<double>::max(); }
+template<typename T> constexpr T defaultMinimumForClamp() { return std::numeric_limits<T>::lowest(); }
 template<typename T> constexpr T defaultMaximumForClamp() { return std::numeric_limits<T>::max(); }
 
 // Same type in and out.


### PR DESCRIPTION
<pre>
Miscellaneous clean-up in `MathExtras.h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=270682">https://bugs.webkit.org/show_bug.cgi?id=270682</a>

Reviewed by NOBODY (OOPS!).

This patch do following:

1) Remove extra `includes`
2) Remove unused `ifndef` etc.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/5006c006bef460192be21172a6cbc21e8f53fd45">https://chromium.googlesource.com/chromium/blink/+/5006c006bef460192be21172a6cbc21e8f53fd45</a>

3) Change `defaultMinimumForClamp` to use `std::numeric_limits<>::lowest`

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/e40fac2fb8529c88349ab8cc64343448c058dcc7">https://source.chromium.org/chromium/chromium/src/+/e40fac2fb8529c88349ab8cc64343448c058dcc7</a>

* Source/WTF/wtf/MathExtras.h:
(defaultMinimumForClamp):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c29d10fbaa9a96ebaae7088f950f2712fe1c5039

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45642 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39143 "Hash c29d10fb for PR 25614 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19467 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38105 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1074 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/36474 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47175 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42645 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42351 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19470 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41005 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19649 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49655 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19100 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10033 "Passed tests") | 
<!--EWS-Status-Bubble-End-->