### PR TITLE
[visionOS] Audio in a background tab does not pause when UIWindowScene is backgrounded

### DIFF
--- a/Source/WebKit/UIProcess/ApplicationStateTracker.h
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.h
@@ -33,9 +33,18 @@
 
 OBJC_CLASS BKSApplicationStateMonitor;
 OBJC_CLASS UIView;
+OBJC_CLASS UIViewController;
 OBJC_CLASS UIWindow;
+OBJC_CLASS UIScene;
+OBJC_CLASS WKUIWindowSceneObserver;
 
 namespace WebKit {
+
+enum class ApplicationType : uint8_t {
+    Application,
+    ViewService,
+    Extension,
+};
 
 class ApplicationStateTracker : public CanMakeWeakPtr<ApplicationStateTracker> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -45,7 +54,12 @@ public:
 
     bool isInBackground() const { return m_isInBackground; }
 
+    void setWindow(UIWindow *);
+    void setScene(UIScene *);
+
 private:
+    void setViewController(UIViewController *);
+
     void applicationDidEnterBackground();
     void applicationDidFinishSnapshottingAfterEnteringBackground();
     void applicationWillEnterForeground();
@@ -53,6 +67,14 @@ private:
     void didCompleteSnapshotSequence();
 
     WeakObjCPtr<UIView> m_view;
+    WeakObjCPtr<UIWindow> m_window;
+    WeakObjCPtr<UIScene> m_scene;
+    WeakObjCPtr<UIViewController> m_viewController;
+
+    RetainPtr<WKUIWindowSceneObserver> m_observer;
+
+    ApplicationType m_applicationType { ApplicationType::Application };
+
     SEL m_didEnterBackgroundSelector;
     SEL m_willEnterForegroundSelector;
     SEL m_willBeginSnapshotSequenceSelector;
@@ -64,12 +86,6 @@ private:
     id m_willEnterForegroundObserver;
     id m_willBeginSnapshotSequenceObserver;
     id m_didCompleteSnapshotSequenceObserver;
-};
-
-enum class ApplicationType {
-    Application,
-    ViewService,
-    Extension,
 };
 
 ApplicationType applicationType(UIWindow *);


### PR DESCRIPTION
#### 86489e41e7b65569d848851ea8149a8553c7f3fd
<pre>
[visionOS] Audio in a background tab does not pause when UIWindowScene is backgrounded
<a href="https://bugs.webkit.org/show_bug.cgi?id=270683">https://bugs.webkit.org/show_bug.cgi?id=270683</a>
<a href="https://rdar.apple.com/123911798">rdar://123911798</a>

Reviewed by Ben Nham and Chris Dumez.

When a WKWebView is removed from its UIWindow, it destroys its ApplicationStateTracker, which was
observing the view&apos;s window&apos;s UIWindowScene to detect changes to the scene&apos;s foreground/background
state. So unparented WKWebViews with audible media playback are not notified when their former
UIWindowScene is backgrounded; only when the entire application is. This can result in backgrounded
tabs continuing to play when only one scene (and not the entire app) is backgrounded.

Rather than tear down the ApplicationStateTracker when unparented, the WKWebView should leave the
UIWindowScene observer in place, and recreate the tracker when moved to a new window. Additionally,
the UIWindow&apos;s windowScene property is dynamic, and clients of WKWebWiew may move the view&apos;s window
between UIWindowScenes. Refactor ApplicationStateTracker to have explicit setters for the window,
scene, and viewController being observed, and allow clients to update the window being tracked dynamically.

This handles the case where a WKWebView is removed from a window (the tracker remains, and notifies
the WKWebView when its former UIWindowScene is backgrounded/foregrounded), when the WKWebView is added
to a different window (the tracker is recreated), when the WKWebView&apos;s window is moved to a different
scene (the tracker is recreated), and should even handle the currently-impossible scenario of a
WKWebView changing from being hosted in an Application to hosted in a View Service.

* Source/WebKit/UIProcess/ApplicationStateTracker.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::ApplicationStateTracker::ApplicationStateTracker):
(WebKit::ApplicationStateTracker::~ApplicationStateTracker):
(WebKit::ApplicationStateTracker::setWindow):
(WebKit::ApplicationStateTracker::setScene):
(WebKit::ApplicationStateTracker::setViewController):
* Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm:
(-[WKApplicationStateTrackingView willMoveToWindow:]):
(-[WKApplicationStateTrackingView didMoveToWindow]):
(-[WKApplicationStateTrackingView observeValueForKeyPath:ofObject:change:context:]):
(-[WKApplicationStateTrackingView _willBeginSnapshotSequence]):
(-[WKApplicationStateTrackingView _didCompleteSnapshotSequence]):

Canonical link: <a href="https://commits.webkit.org/275943@main">https://commits.webkit.org/275943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0ee975724cd59469bc8f81848591008d20dd879

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45958 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39449 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35822 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16802 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1379 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39506 "Found 43 new API test failures: TestWebKitAPI.AdvancedPrivacyProtections.ClampScreenSizeToFixedValues, TestWebKitAPI.EditorStateTests.MarkedTextRange_HorizontalRangeSelection, TestWebKitAPI.EditorStateTests.MarkedTextRange_VerticalRangeSelection, TestWebKitAPI.RequestTextInputContext.TextInteraction_FocusDefocusDisableFocusAgainShouldNotScrollToReveal, TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithResourceLoadStatisticsEnabled, TestWebKitAPI.RequestTextInputContext.TextInteraction_FocusingReadOnlyElementShouldScrollToReveal, TestWebKitAPI.ActionSheetTests.DataDetectorsLinkIsNotPresentedAsALink, TestWebKitAPI.Viewport.RespectInitialScaleExceptOnWikipediaDomain, TestWebKitAPI.AdvancedPrivacyProtections.HideScreenSizeWithScaledPage, TestWebKitAPI.WebAuthenticationPanel.PanelTwice ... (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47502 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18237 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42604 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19774 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41260 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9641 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->