### PR TITLE
Add missing `enum class : bool` declarations in serialization.in files

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -23,6 +23,7 @@
 headers: "NetworkResourceLoadParameters.h"
 
 enum class WebKit::PreconnectOnly : bool;
+enum class WebKit::NavigatingToAppBoundDomain : bool;
 
 class WebKit::NetworkLoadParameters {
     WebKit::WebPageProxyIdentifier webPageProxyID;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -20,6 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+enum class WebKit::AllowsCellularAccess : bool;
+
 [RValue] struct WebKit::NetworkSessionCreationParameters {
     PAL::SessionID sessionID;
     Markable<WTF::UUID> dataStoreIdentifier;

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -175,6 +175,8 @@ class WebCore::PaymentSessionError {
     bool phoneticName;
 };
 
+[Nested] enum class WebCore::ApplePaySessionPaymentRequest::Requester : bool;
+
 [CustomHeader] class WebCore::ApplePaySessionPaymentRequest {
     String countryCode();
     String currencyCode();

--- a/Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in
@@ -31,4 +31,6 @@ enum class WebKit::WebExtensionContextInstallReason : uint8_t {
     BrowserUpdate,
 };
 
+[Nested] enum class WebKit::WebExtensionContext::WindowIsClosing : bool;
+
 #endif

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -20,6 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+enum class WebCore::LockHistory : bool;
+enum class WebCore::LockBackForwardList : bool;
+enum class WebKit::NavigatingToAppBoundDomain : bool;
+
 [RValue] struct WebKit::LoadParameters {
 #if ENABLE(PUBLIC_SUFFIX_LIST)
     String topPrivatelyControlledDomain;

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -20,6 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+enum class WebCore::LockHistory : bool;
+enum class WebCore::LockBackForwardList : bool;
+
 struct WebKit::NavigationActionData {
     WebCore::NavigationType navigationType;
     OptionSet<WebKit::WebEventModifier> modifiers;

--- a/Source/WebKit/Shared/PolicyDecision.serialization.in
+++ b/Source/WebKit/Shared/PolicyDecision.serialization.in
@@ -20,6 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+enum class WebKit::NavigatingToAppBoundDomain : bool;
+
 [RValue] struct WebKit::PolicyDecision {
     std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
     WebCore::PolicyAction policyAction;

--- a/Source/WebKit/Shared/PushMessageForTesting.serialization.in
+++ b/Source/WebKit/Shared/PushMessageForTesting.serialization.in
@@ -22,6 +22,8 @@
 
 webkit_platform_headers: "ArgumentCoders.h" "PushMessageForTesting.h"
 
+enum class WebKit::WebPushD::PushMessageDisposition : bool;
+
 [CustomHeader, WebKitPlatform] struct WebKit::WebPushD::PushMessageForTesting {
     String targetAppCodeSigningIdentifier;
     String pushPartitionString;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -92,6 +92,8 @@ enum class WebKit::LayerContentsType : uint8_t {
 };
 
 header: "RemoteLayerBackingStore.h"
+[Nested] enum class WebKit::RemoteLayerBackingStore::Type : bool;
+
 [CustomEncoder, CustomHeader, LegacyPopulateFromEmptyConstructor, Nested] class WebKit::RemoteLayerBackingStoreProperties {
     bool m_isOpaque;
     WebKit::RemoteLayerBackingStore::Type m_type;

--- a/Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in
+++ b/Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in
@@ -20,6 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+enum class WebCore::SameSiteStrictEnforcementEnabled : bool;
+
 [RValue] struct WebKit::ResourceLoadStatisticsParameters {
     String directory;
     WebKit::SandboxExtension::Handle directoryExtensionHandle;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -574,6 +574,8 @@ class WebCore::IDBTransactionInfo {
     std::unique_ptr<WebCore::IDBDatabaseInfo> originalDatabaseInfo();
 };
 
+enum class WebCore::IDBGetRecordDataType : bool;
+
 struct WebCore::IDBGetRecordData {
     WebCore::IDBKeyRangeData keyRangeData;
     WebCore::IDBGetRecordDataType type;
@@ -1482,6 +1484,8 @@ struct WebCore::WebLockManagerSnapshot {
     Vector<WebCore::WebLockManagerSnapshot::Info> pending;
 };
 
+enum class WebCore::WebLockMode : bool;
+
 [Nested] struct WebCore::WebLockManagerSnapshot::Info {
     String name;
     WebCore::WebLockMode mode;
@@ -2347,6 +2351,14 @@ enum class WebCore::PublicKeyCredentialType : bool
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+enum class WebCore::SelectionRenderingBehavior : bool;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+enum class WebCore::TextDirection : bool;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
 class WebCore::SelectionGeometry {
     WebCore::FloatQuad quad();
     WebCore::SelectionRenderingBehavior behavior();
@@ -2915,6 +2927,8 @@ header: <WebCore/BasicShapes.h>
     WebCore::BasicShapeRadius radiusY();
 }
 
+enum class WebCore::WindRule : bool;
+
 [RefCounted, CustomHeader] class WebCore::BasicShapePolygon {
     WebCore::WindRule windRule();
     Vector<WebCore::Length> values();
@@ -3016,10 +3030,6 @@ struct WebCore::LengthPoint {
     WebCore::BoxPathOperation,
     WebCore::RayPathOperation
 }
-
-#if PLATFORM(IOS_FAMILY)
-enum class WebCore::SelectionRenderingBehavior : bool
-#endif
 
 #if ENABLE(WEB_AUTHN)
 enum class WebCore::UserVerificationRequirement : uint8_t {
@@ -3147,6 +3157,9 @@ class WebCore::ResourceResponse : WebCore::ResourceResponseBase {
 }
 
 header: <WebCore/ResourceResponseBase.h>
+enum class WebCore::UsedLegacyTLS : bool;
+enum class WebCore::WasPrivateRelayed : bool;
+
 [CustomHeader] struct WebCore::ResourceResponseData {
     URL url;
     String mimeType;
@@ -4007,6 +4020,9 @@ header: <WebCore/ScrollingStateNode.h>
 };
 #endif
 
+enum class WebCore::ScrollClamping : bool;
+enum class WebCore::ScrollType : bool;
+
 [CustomHeader] struct WebCore::RequestedScrollData {
     WebCore::ScrollRequestType requestType;
     std::variant<WebCore::FloatPoint, WebCore::FloatSize> scrollPositionOrDelta;
@@ -4023,6 +4039,8 @@ header: <WebCore/ScrollingStateNode.h>
     Vector<WebCore::FloatRect> snapAreas;
     Vector<WebCore::ElementIdentifier> snapAreasIDs;
 }
+
+enum class WebCore::ScrollSnapStop : bool;
 
 [Alias=struct SnapOffset<float>, CustomHeader] alias WebCore::FloatSnapOffset {
     float offset;
@@ -4948,6 +4966,8 @@ enum class WebCore::ServiceWorkerUpdateViaCache : uint8_t {
     All,
     None,
 };
+
+enum class WebCore::LastNavigationWasAppInitiated : bool;
 
 struct WebCore::ServiceWorkerClientData {
     WebCore::ScriptExecutionContextIdentifier identifier;
@@ -6901,6 +6921,8 @@ header: <WebCore/GraphicsContextState.h>
     std::variant<Ref<WebCore::Gradient>, WebCore::RenderingResourceIdentifier> serializableGradient();
     WebCore::AffineTransform spaceTransform;
 };
+
+enum class WebCore::ContentSecurityPolicyHeaderType : bool;
 
 class WebCore::ContentSecurityPolicyResponseHeaders {
     Vector<std::pair<String, WebCore::ContentSecurityPolicyHeaderType>> headers();

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -158,6 +158,8 @@ class WebKit::WebTouchEvent : WebKit::WebEvent {
     TwoFingerTap
 };
 
+enum class WebKit::GestureWasCancelled : bool;
+
 class WebKit::WebMouseEvent : WebKit::WebEvent {
     WebKit::WebMouseEventButton button();
     unsigned short buttons();

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -22,6 +22,8 @@
 
 headers: "ArgumentCoders.h"
 
+enum class WebCore::UserInterfaceLayoutDirection : bool;
+
 [RValue] struct WebKit::WebPageCreationParameters {
     WebCore::IntSize viewSize;
 

--- a/Source/WebKit/Shared/WebPopupItem.serialization.in
+++ b/Source/WebKit/Shared/WebPopupItem.serialization.in
@@ -22,6 +22,8 @@
 
 [Nested] enum class WebKit::WebPopupItem::Type : bool
 
+enum class WebCore::TextDirection : bool;
+
 struct WebKit::WebPopupItem {
     WebKit::WebPopupItem::Type m_type;
     String m_text;

--- a/Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in
+++ b/Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in
@@ -22,7 +22,11 @@
 
 
 #if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
-   
+
+enum class WebKit::ContextMenuItemEnablement : bool;
+enum class WebKit::ContextMenuItemHasAction : bool;
+enum class WebKit::ContextMenuItemIsSeparator : bool;
+
 [CustomHeader] struct WebKit::PDFContextMenuItem {
     String title;
     int state;


### PR DESCRIPTION
#### aaa1cd08bd5412fc62008f14859175869efd2999
<pre>
Add missing `enum class : bool` declarations in serialization.in files
<a href="https://bugs.webkit.org/show_bug.cgi?id=270686">https://bugs.webkit.org/show_bug.cgi?id=270686</a>
<a href="https://rdar.apple.com/problem/124262567">rdar://problem/124262567</a>

Reviewed by Timothy Hatcher.

These will provide more metadata for the fuzzer.

* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/Shared/PolicyDecision.serialization.in:
* Source/WebKit/Shared/PushMessageForTesting.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/Shared/WebPopupItem.serialization.in:
* Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in:

Canonical link: <a href="https://commits.webkit.org/275905@main">https://commits.webkit.org/275905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaca52baaa5d710cb787fac59901a1d484874986

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39128 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35560 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16555 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16670 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1059 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47158 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42336 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19455 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40989 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19634 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5871 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->