### PR TITLE
UNREACHABLE in getQualifierString as some qualifier strings are missing.

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/BaseTypes.h
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/BaseTypes.h
@@ -1676,6 +1676,9 @@ inline const char *getQualifierString(TQualifier q)
     case EvqLocalInvocationIndex:      return "LocalInvocationIndex";
     case EvqReadOnly:                  return "readonly";
     case EvqWriteOnly:                 return "writeonly";
+    case EvqCoherent:                  return "coherent";
+    case EvqRestrict:                  return "restrict";
+    case EvqVolatile:                  return "volatile";
     case EvqGeometryIn:                return "in";
     case EvqGeometryOut:               return "out";
     case EvqPerVertexIn:               return "gl_in";

--- a/Source/ThirdParty/ANGLE/src/tests/compiler_tests/Parse_test.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/compiler_tests/Parse_test.cpp
@@ -84,6 +84,15 @@ class ParseTest : public testing::Test
     std::string mInfoLog;
 };
 
+TEST_F(ParseTest, CoherentCoherentNoCrash)
+{
+    const char kShader[] = R"(#version 310 es
+coherent coherent;)";
+    EXPECT_FALSE(compile(kShader));
+    EXPECT_TRUE(foundErrorInIntermediateTree());
+    EXPECT_TRUE(foundInIntermediateTree("coherent specified multiple times"));
+}
+
 TEST_F(ParseTest, UnsizedArrayConstructorNoCrash)
 {
     const char kShader[] = R"(#version 310 es\n"


### PR DESCRIPTION
#### 0ff55000798465ab9af96f4342cfd925bcc2bb0f
<pre>
UNREACHABLE in getQualifierString as some qualifier strings are missing.
<a href="https://rdar.apple.com/123840533">rdar://123840533</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270688">https://bugs.webkit.org/show_bug.cgi?id=270688</a>

Reviewed by NOBODY (OOPS!).

Added missing qualifier strings to the list and test case.

* Source/ThirdParty/ANGLE/src/compiler/translator/BaseTypes.h:
(sh::getQualifierString):
* Source/ThirdParty/ANGLE/src/tests/compiler_tests/Parse_test.cpp:
(TEST_F):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff55000798465ab9af96f4342cfd925bcc2bb0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39120 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35555 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16549 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38081 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47149 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42328 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19447 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40980 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19626 "Built successfully") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/5864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->