### PR TITLE
[WPE] [LibWebRTC] Fix build for ARM 32-bit

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -1870,8 +1870,16 @@ if (WTF_CPU_X86_64 OR WTF_CPU_X86)
     add_definitions(-DWEBRTC_ENABLE_AVX2)
 endif()
 
+if (WTF_CPU_ARM_THUMB2)
+    add_definitions(-DWEBRTC_ARCH_ARM_V7)
+endif ()
+
 if (WTF_CPU_ARM64)
-    list(APPEND webrtc_SOURCES
+    add_definitions(-DWEBRTC_ARCH_ARM64)
+endif ()
+
+if (WTF_CPU_ARM OR WTF_CPU_ARM64)
+    list(APPEND webrtc_neon_SOURCES
         Source/webrtc/common_audio/fir_filter_neon.cc
         Source/webrtc/common_audio/resampler/sinc_resampler_neon.cc
         Source/webrtc/common_audio/signal_processing/cross_correlation_neon.c
@@ -1880,9 +1888,22 @@ if (WTF_CPU_ARM64)
         Source/webrtc/common_audio/third_party/ooura/fft_size_128/ooura_fft_neon.cc
         Source/webrtc/modules/audio_processing/aecm/aecm_core_neon.cc
     )
-    add_definitions(-DWEBRTC_ARCH_ARM64)
+    list(APPEND webrtc_SOURCES ${webrtc_neon_SOURCES})
     add_definitions(-DWEBRTC_HAS_NEON)
-endif()
+endif ()
+
+if (WTF_CPU_ARM)
+    list(APPEND webrtc_neon_SOURCES
+        Source/third_party/pffft/src/pffft.c
+        Source/webrtc/modules/audio_processing/aec3/adaptive_fir_filter.cc
+        Source/webrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl.cc
+        Source/webrtc/modules/audio_processing/aec3/comfort_noise_generator.cc
+        Source/webrtc/modules/audio_processing/aec3/matched_filter.cc
+        Source/webrtc/modules/audio_processing/aec3/suppression_filter.cc
+        Source/webrtc/modules/audio_processing/aec3/suppression_gain.cc
+    )
+    set_source_files_properties(${webrtc_neon_SOURCES} PROPERTIES COMPILE_OPTIONS "-mfpu=neon;-mfloat-abi=hard")
+endif ()
 
 if (WTF_CPU_MIPS)
     list(APPEND webrtc_SOURCES


### PR DESCRIPTION
#### 565848432d81dc7bb57f62ae1413eb4417d680e9
<pre>
[WPE] [LibWebRTC] Fix build for ARM 32-bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=270689">https://bugs.webkit.org/show_bug.cgi?id=270689</a>

Reviewed by Philippe Normand.

Set build flags &quot;-mfpu=neon;-mfloat-abi=hard&quot; on several files that need them.

* Source/ThirdParty/libwebrtc/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/275915@main">https://commits.webkit.org/275915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0aa76732e2ffe9ebf6c54a186b2c44811862036f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/42998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45622 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39123 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35556 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38084 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1054 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47157 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42335 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19450 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40988 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9628 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->