### PR TITLE
[GTK][WPE] Add a setting to enable/disable directory upload.

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -174,6 +174,7 @@ enum {
     PROP_MEDIA_CONTENT_TYPES_REQUIRING_HARDWARE_SUPPORT,
     PROP_ENABLE_WEBRTC,
     PROP_DISABLE_WEB_SECURITY,
+    PROP_ENABLE_DIRECTORY_UPLOAD,
     N_PROPERTIES,
 };
 
@@ -409,6 +410,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     case PROP_DISABLE_WEB_SECURITY:
         webkit_settings_set_disable_web_security(settings, g_value_get_boolean(value));
         break;
+    case PROP_ENABLE_DIRECTORY_UPLOAD:
+        webkit_settings_set_enable_directory_upload(settings, g_value_get_boolean(value));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -616,6 +620,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         break;
     case PROP_DISABLE_WEB_SECURITY:
         g_value_set_boolean(value, webkit_settings_get_disable_web_security(settings));
+        break;
+    case PROP_ENABLE_DIRECTORY_UPLOAD:
+        g_value_set_boolean(value, webkit_settings_get_enable_directory_upload(settings));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -1616,6 +1623,23 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
         _("Disable web security"),
         _("Whether web security should be disabled."),
         FALSE,
+        readWriteConstructParamFlags);
+
+    /**
+     * WebKitSettings:enable-directory-upload:
+     *
+     * Enable or disable directory upload on file input elements.
+     *
+     * This setting controls whether the user is to be allowed to select a directory rather
+     * than a file or files when using a file input element.
+     *
+     * Since: 2.44
+     */
+    sObjProperties[PROP_ENABLE_DIRECTORY_UPLOAD] = g_param_spec_boolean(
+        "enable-directory-upload",
+        _("Enable directory upload"),
+        _("Whether directory upload should be enabled."),
+        TRUE,
         readWriteConstructParamFlags);
 
     g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
@@ -4027,6 +4051,45 @@ void webkit_settings_set_disable_web_security(WebKitSettings* settings, gboolean
 
     priv->preferences->setWebSecurityEnabled(!disabled);
     g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_DISABLE_WEB_SECURITY]);
+}
+
+/**
+ * webkit_settings_get_enable_directory_upload:
+ * @settings: a #WebKitSettings
+ *
+ * Get the #WebKitSettings:enable-directory-upload property.
+ *
+ * Returns: %TRUE if directory upload is enabled or %FALSE otherwise.
+ *
+ * Since: 2.44
+ */
+gboolean webkit_settings_get_enable_directory_upload(WebKitSettings* settings)
+{
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+
+    return settings->priv->preferences->directoryUploadEnabled();
+}
+
+/**
+ * webkit_settings_set_enable_directory_upload:
+ * @settings: a #WebKitSettings
+ * @enabled: Value to be set
+ *
+ * Set the #WebKitSettings:enable-directory-upload property.
+ *
+ * Since: 2.44
+ */
+void webkit_settings_set_enable_directory_upload(WebKitSettings* settings, gboolean enabled)
+{
+    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
+
+    WebKitSettingsPrivate* priv = settings->priv;
+    bool currentValue = priv->preferences->directoryUploadEnabled();
+    if (currentValue == enabled)
+        return;
+
+    priv->preferences->setDirectoryUploadEnabled(enabled);
+    g_object_notify(G_OBJECT(settings), "enable-directory-upload");
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -541,6 +541,13 @@ WEBKIT_API void
 webkit_settings_set_disable_web_security                       (WebKitSettings *settings,
                                                                 gboolean        disabled);
 
+WEBKIT_API gboolean
+webkit_settings_get_enable_directory_upload                    (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_enable_directory_upload                    (WebKitSettings *settings,
+                                                                gboolean        enabled);
+
 typedef struct _WebKitFeature WebKitFeature;
 typedef struct _WebKitFeatureList WebKitFeatureList;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -394,6 +394,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     webkit_settings_set_disable_web_security(settings, TRUE);
     g_assert_true(webkit_settings_get_disable_web_security(settings));
 
+    // Directory upload is enabled by default.
+    g_assert_true(webkit_settings_get_enable_directory_upload(settings));
+    webkit_settings_set_enable_directory_upload(settings, FALSE);
+    g_assert_false(webkit_settings_get_enable_directory_upload(settings));
+
     g_object_unref(G_OBJECT(settings));
 }
 


### PR DESCRIPTION
#### 24406e13cae4869bdb305e64b5249ebb526b3c0c
<pre>
[GTK][WPE] Add a setting to enable/disable directory upload.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270692">https://bugs.webkit.org/show_bug.cgi?id=270692</a>

Reviewed by NOBODY (OOPS!).

Add a new setting to enable/disable the DirectoryUploadEnabled preference.

* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webKitSettingsSetProperty):
(webKitSettingsGetProperty):
(webkit_settings_class_init):
(webkit_settings_get_enable_directory_upload):
(webkit_settings_set_enable_directory_upload):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24406e13cae4869bdb305e64b5249ebb526b3c0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45308 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/25769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35559 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16554 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16654 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38082 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1058 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47156 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42334 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19454 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40987 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->