### PR TITLE
[WPE] WPE Platform: do not release buffers when rendered

### DIFF
--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -47,9 +47,13 @@ AcceleratedBackingStoreDMABuf::AcceleratedBackingStoreDMABuf(WebPageProxy& webPa
     : m_webPage(webPage)
     , m_wpeView(view)
 {
-    g_signal_connect(m_wpeView.get(), "buffer-rendered", G_CALLBACK(+[](WPEView*, WPEBuffer* buffer, gpointer userData) {
+    g_signal_connect(m_wpeView.get(), "buffer-rendered", G_CALLBACK(+[](WPEView*, WPEBuffer*, gpointer userData) {
         auto& backingStore = *static_cast<AcceleratedBackingStoreDMABuf*>(userData);
         backingStore.bufferRendered();
+    }), this);
+    g_signal_connect(m_wpeView.get(), "buffer-released", G_CALLBACK(+[](WPEView*, WPEBuffer* buffer, gpointer userData) {
+        auto& backingStore = *static_cast<AcceleratedBackingStoreDMABuf*>(userData);
+        backingStore.bufferReleased(buffer);
     }), this);
 }
 
@@ -68,7 +72,6 @@ void AcceleratedBackingStoreDMABuf::updateSurfaceID(uint64_t surfaceID)
             frameDone();
             m_pendingBuffer = nullptr;
         }
-        m_committedBuffer = nullptr;
         m_buffers.clear();
         m_bufferIDs.clear();
         m_webPage.process().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID);
@@ -82,19 +85,17 @@ void AcceleratedBackingStoreDMABuf::updateSurfaceID(uint64_t surfaceID)
 
 void AcceleratedBackingStoreDMABuf::didCreateBuffer(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
 {
-    auto* display = wpe_view_get_display(m_wpeView.get());
     Vector<int> fileDescriptors;
     fileDescriptors.reserveInitialCapacity(fds.size());
     for (auto& fd : fds)
         fileDescriptors.append(fd.release());
-    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_dma_buf_new(display, size.width(), size.height(), format, fds.size(), fileDescriptors.data(), offsets.data(), strides.data(), modifier)));
+    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_dma_buf_new(m_wpeView.get(), size.width(), size.height(), format, fds.size(), fileDescriptors.data(), offsets.data(), strides.data(), modifier)));
     m_bufferIDs.add(buffer.get(), id);
     m_buffers.add(id, WTFMove(buffer));
 }
 
 void AcceleratedBackingStoreDMABuf::didCreateBufferSHM(uint64_t id, ShareableBitmap::Handle&& handle)
 {
-    auto* display = wpe_view_get_display(m_wpeView.get());
     auto bitmap = ShareableBitmap::create(WTFMove(handle), SharedMemory::Protection::ReadOnly);
     if (!bitmap)
         return;
@@ -107,7 +108,7 @@ void AcceleratedBackingStoreDMABuf::didCreateBufferSHM(uint64_t id, ShareableBit
         delete static_cast<ShareableBitmap*>(userData);
     }, bitmap.leakRef()));
 
-    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_shm_new(display, size.width(), size.height(), WPE_PIXEL_FORMAT_ARGB8888, bytes.get(), stride)));
+    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_shm_new(m_wpeView.get(), size.width(), size.height(), WPE_PIXEL_FORMAT_ARGB8888, bytes.get(), stride)));
     m_bufferIDs.add(buffer.get(), id);
     m_buffers.add(id, WTFMove(buffer));
 }
@@ -142,15 +143,14 @@ void AcceleratedBackingStoreDMABuf::frameDone()
 
 void AcceleratedBackingStoreDMABuf::bufferRendered()
 {
-    if (m_pendingBuffer) {
-        if (m_committedBuffer) {
-            if (auto id = m_bufferIDs.get(m_committedBuffer.get()))
-                m_webPage.process().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(id), m_surfaceID);
-        }
-        m_committedBuffer = WTFMove(m_pendingBuffer);
-    }
-
     frameDone();
+    m_pendingBuffer = nullptr;
+}
+
+void AcceleratedBackingStoreDMABuf::bufferReleased(WPEBuffer* buffer)
+{
+    if (auto id = m_bufferIDs.get(buffer))
+        m_webPage.process().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(id), m_surfaceID);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -68,12 +68,12 @@ private:
     void frame(uint64_t bufferID);
     void frameDone();
     void bufferRendered();
+    void bufferReleased(WPEBuffer*);
 
     WebPageProxy& m_webPage;
     GRefPtr<WPEView> m_wpeView;
     uint64_t m_surfaceID { 0 };
     GRefPtr<WPEBuffer> m_pendingBuffer;
-    GRefPtr<WPEBuffer> m_committedBuffer;
     HashMap<uint64_t, GRefPtr<WPEBuffer>> m_buffers;
     HashMap<WPEBuffer*, uint64_t> m_bufferIDs;
 };

--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp
@@ -34,7 +34,7 @@
  *
  */
 struct _WPEBufferPrivate {
-    GRefPtr<WPEDisplay> display;
+    GRefPtr<WPEView> view;
     int width;
     int height;
 
@@ -58,7 +58,7 @@ G_DEFINE_QUARK(wpe-buffer-error-quark, wpe_buffer_error)
 enum {
     PROP_0,
 
-    PROP_DISPLAY,
+    PROP_VIEW,
     PROP_WIDTH,
     PROP_HEIGHT,
 
@@ -72,8 +72,8 @@ static void wpeBufferSetProperty(GObject* object, guint propId, const GValue* va
     auto* buffer = WPE_BUFFER(object);
 
     switch (propId) {
-    case PROP_DISPLAY:
-        buffer->priv->display = WPE_DISPLAY(g_value_get_object(value));
+    case PROP_VIEW:
+        buffer->priv->view = WPE_VIEW(g_value_get_object(value));
         break;
     case PROP_WIDTH:
         buffer->priv->width = g_value_get_int(value);
@@ -91,8 +91,8 @@ static void wpeBufferGetProperty(GObject* object, guint propId, GValue* value, G
     auto* buffer = WPE_BUFFER(object);
 
     switch (propId) {
-    case PROP_DISPLAY:
-        g_value_set_object(value, wpe_buffer_get_display(buffer));
+    case PROP_VIEW:
+        g_value_set_object(value, wpe_buffer_get_view(buffer));
         break;
     case PROP_WIDTH:
         g_value_set_int(value, wpe_buffer_get_width(buffer));
@@ -120,15 +120,15 @@ static void wpe_buffer_class_init(WPEBufferClass* bufferClass)
     objectClass->dispose = wpeBufferDispose;
 
     /**
-     * WPEBuffer:display:
+     * WPEBuffer:view:
      *
-     * The #WPEDisplay of the buffer.
+     * The #WPEView of the buffer.
      */
-    sObjProperties[PROP_DISPLAY] =
+    sObjProperties[PROP_VIEW] =
         g_param_spec_object(
-            "display",
+            "view",
             nullptr, nullptr,
-            WPE_TYPE_DISPLAY,
+            WPE_TYPE_VIEW,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
     /**
@@ -159,18 +159,18 @@ static void wpe_buffer_class_init(WPEBufferClass* bufferClass)
 }
 
 /**
- * wpe_buffer_get_display:
+ * wpe_buffer_get_view:
  * @buffer: a #WPEBuffer
  *
- * Get the #WPEDisplay of @buffer
+ * Get the #WPEView of @buffer
  *
- * Returns: (transfer none): a #WPEDisplay
+ * Returns: (transfer none): a #WPEView
  */
-WPEDisplay* wpe_buffer_get_display(WPEBuffer* buffer)
+WPEView* wpe_buffer_get_view(WPEBuffer* buffer)
 {
     g_return_val_if_fail(WPE_IS_BUFFER(buffer), nullptr);
 
-    return buffer->priv->display.get();
+    return buffer->priv->view.get();
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
@@ -32,7 +32,7 @@
 
 #include <glib-object.h>
 #include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
+#include <wpe/WPEView.h>
 
 G_BEGIN_DECLS
 
@@ -66,7 +66,7 @@ typedef enum {
 } WPEBufferError;
 
 WPE_API GQuark      wpe_buffer_error_quark         (void);
-WPE_API WPEDisplay *wpe_buffer_get_display         (WPEBuffer     *buffer);
+WPE_API WPEView    *wpe_buffer_get_view            (WPEBuffer     *buffer);
 WPE_API int         wpe_buffer_get_width           (WPEBuffer     *buffer);
 WPE_API int         wpe_buffer_get_height          (WPEBuffer     *buffer);
 WPE_API void        wpe_buffer_set_user_data       (WPEBuffer     *buffer,

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
@@ -67,7 +67,7 @@ static void wpeBufferDMABufDispose(GObject* object)
     auto* priv = WPE_BUFFER_DMA_BUF(object)->priv;
 
     if (priv->eglImage) {
-        if (auto* eglDisplay = wpe_display_get_egl_display(wpe_buffer_get_display(WPE_BUFFER(object)), nullptr)) {
+        if (auto* eglDisplay = wpe_display_get_egl_display(wpe_view_get_display(wpe_buffer_get_view(WPE_BUFFER(object))), nullptr)) {
             static PFNEGLDESTROYIMAGEPROC s_eglDestroyImageKHR;
             if (!s_eglDestroyImageKHR)
                 s_eglDestroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEPROC>(epoxy_eglGetProcAddress("eglDestroyImageKHR"));
@@ -96,7 +96,7 @@ static gpointer wpeBufferDMABufImportToEGLImage(WPEBuffer* buffer, GError** erro
         return priv->eglImage;
 
     GUniqueOutPtr<GError> eglError;
-    auto* display = wpe_buffer_get_display(buffer);
+    auto* display = wpe_view_get_display(wpe_buffer_get_view(buffer));
     auto* eglDisplay = wpe_display_get_egl_display(display, &eglError.outPtr());
     if (eglDisplay == EGL_NO_DISPLAY) {
         g_set_error(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "Failed to get EGLDisplay when importing buffer to EGL image: %s", eglError->message);
@@ -164,7 +164,7 @@ static bool wpeBufferDMABufTryEnsureGBMDevice(WPEBufferDMABuf* buffer)
         return !!priv->device.value();
 
     priv->device = nullptr;
-    auto* display = wpe_buffer_get_display(WPE_BUFFER(buffer));
+    auto* display = wpe_view_get_display(wpe_buffer_get_view(WPE_BUFFER(buffer)));
     const char* filename = wpe_display_get_drm_render_node(display);
     if (!filename)
         return false;
@@ -245,7 +245,7 @@ static void wpe_buffer_dma_buf_class_init(WPEBufferDMABufClass* bufferDMABufClas
 
 /**
  * wpe_buffer_dma_buf_new:
- * @display: a #WPEDisplay
+ * @view: a #WPEView
  * @width: the buffer width
  * @height: the buffer height
  * @format: the buffer format
@@ -260,16 +260,16 @@ static void wpe_buffer_dma_buf_class_init(WPEBufferDMABufClass* bufferDMABufClas
  *
  * Returns: (transfer full): a #WPEBufferDMABuf
  */
-WPEBufferDMABuf* wpe_buffer_dma_buf_new(WPEDisplay* display, int width, int height, guint32 format, guint32 planeCount, int* fds, guint32* offsets, guint32* strides, guint64 modifier)
+WPEBufferDMABuf* wpe_buffer_dma_buf_new(WPEView* view, int width, int height, guint32 format, guint32 planeCount, int* fds, guint32* offsets, guint32* strides, guint64 modifier)
 {
-    g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
     g_return_val_if_fail(planeCount > 0, nullptr);
     g_return_val_if_fail(fds, nullptr);
     g_return_val_if_fail(offsets, nullptr);
     g_return_val_if_fail(strides, nullptr);
 
     auto* buffer = WPE_BUFFER_DMA_BUF(g_object_new(WPE_TYPE_BUFFER_DMA_BUF,
-        "display", display,
+        "view", view,
         "width", width,
         "height", height,
         nullptr));

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.h
@@ -39,7 +39,7 @@ G_BEGIN_DECLS
 #define WPE_TYPE_BUFFER_DMA_BUF (wpe_buffer_dma_buf_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEBufferDMABuf, wpe_buffer_dma_buf, WPE, BUFFER_DMA_BUF, WPEBuffer)
 
-WPE_API WPEBufferDMABuf *wpe_buffer_dma_buf_new          (WPEDisplay      *display,
+WPE_API WPEBufferDMABuf *wpe_buffer_dma_buf_new          (WPEView         *view,
                                                           int              width,
                                                           int              height,
                                                           guint32          format,

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
@@ -147,7 +147,7 @@ static void wpe_buffer_shm_class_init(WPEBufferSHMClass* bufferSHMClass)
 
 /**
  * wpe_buffer_shm_new:
- * @display: a #WPEDisplay
+ * @view: a #WPEView
  * @width: the buffer width
  * @height: the buffer height
  * @format: the buffer format
@@ -158,13 +158,13 @@ static void wpe_buffer_shm_class_init(WPEBufferSHMClass* bufferSHMClass)
  *
  * Returns: (transfer full): a #WPEBufferSHM
  */
-WPEBufferSHM* wpe_buffer_shm_new(WPEDisplay* display, int width, int height, WPEPixelFormat format, GBytes* data, guint stride)
+WPEBufferSHM* wpe_buffer_shm_new(WPEView* view, int width, int height, WPEPixelFormat format, GBytes* data, guint stride)
 {
-    g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
     g_return_val_if_fail(data, nullptr);
 
     return WPE_BUFFER_SHM(g_object_new(WPE_TYPE_BUFFER_SHM,
-        "display", display,
+        "view", view,
         "width", width,
         "height", height,
         "format", format,

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.h
@@ -49,7 +49,7 @@ typedef enum {
     WPE_PIXEL_FORMAT_ARGB8888
 } WPEPixelFormat;
 
-WPE_API WPEBufferSHM  *wpe_buffer_shm_new        (WPEDisplay    *display,
+WPE_API WPEBufferSHM  *wpe_buffer_shm_new        (WPEView       *view,
                                                   int            width,
                                                   int            height,
                                                   WPEPixelFormat format,

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -137,6 +137,8 @@ WPE_API gboolean     wpe_view_render_buffer                 (WPEView      *view,
                                                              GError      **error);
 WPE_API void         wpe_view_buffer_rendered               (WPEView      *view,
                                                              WPEBuffer    *buffer);
+WPE_API void         wpe_view_buffer_released               (WPEView      *view,
+                                                             WPEBuffer    *buffer);
 WPE_API void         wpe_view_event                         (WPEView      *view,
                                                              WPEEvent     *event);
 WPE_API guint        wpe_view_compute_press_count           (WPEView      *view,

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -436,10 +436,19 @@ static void wpeViewWaylandDispose(GObject* object)
     G_OBJECT_CLASS(wpe_view_wayland_parent_class)->dispose(object);
 }
 
-static struct wl_buffer* createWaylandBufferFromEGLImage(WPEBuffer* buffer, GError** error)
+static const struct wl_buffer_listener bufferListener = {
+    // release
+    [](void* userData, struct wl_buffer*)
+    {
+        auto* buffer = WPE_BUFFER(userData);
+        wpe_view_buffer_released(wpe_buffer_get_view(buffer), buffer);
+    }
+};
+
+static struct wl_buffer* createWaylandBufferFromEGLImage(WPEView* view, WPEBuffer* buffer, GError** error)
 {
     GUniqueOutPtr<GError> bufferError;
-    auto* eglDisplay = wpe_display_get_egl_display(wpe_buffer_get_display(buffer), &bufferError.outPtr());
+    auto* eglDisplay = wpe_display_get_egl_display(wpe_view_get_display(view), &bufferError.outPtr());
     if (!eglDisplay) {
         g_set_error(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: can't create Wayland buffer because failed to get EGL display: %s", bufferError->message);
         return nullptr;
@@ -468,13 +477,13 @@ static struct wl_buffer* createWaylandBufferFromEGLImage(WPEBuffer* buffer, GErr
     return nullptr;
 }
 
-static struct wl_buffer* createWaylandBufferFromDMABuf(WPEBuffer* buffer, GError** error)
+static struct wl_buffer* createWaylandBufferFromDMABuf(WPEView* view, WPEBuffer* buffer, GError** error)
 {
     if (auto* wlBuffer = static_cast<struct wl_buffer*>(wpe_buffer_get_user_data(buffer)))
         return wlBuffer;
 
     struct wl_buffer* wlBuffer = nullptr;
-    if (auto* dmabuf = wpeDisplayWaylandGetLinuxDMABuf(WPE_DISPLAY_WAYLAND(wpe_buffer_get_display(buffer)))) {
+    if (auto* dmabuf = wpeDisplayWaylandGetLinuxDMABuf(WPE_DISPLAY_WAYLAND(wpe_view_get_display(view)))) {
         auto* bufferDMABuf = WPE_BUFFER_DMA_BUF(buffer);
         auto modifier = wpe_buffer_dma_buf_get_modifier(bufferDMABuf);
         auto* params = zwp_linux_dmabuf_v1_create_params(dmabuf);
@@ -492,10 +501,12 @@ static struct wl_buffer* createWaylandBufferFromDMABuf(WPEBuffer* buffer, GError
             return nullptr;
         }
     } else {
-        wlBuffer = createWaylandBufferFromEGLImage(buffer, error);
+        wlBuffer = createWaylandBufferFromEGLImage(view, buffer, error);
         if (!wlBuffer)
             return nullptr;
     }
+
+    wl_buffer_add_listener(wlBuffer, &bufferListener, buffer);
 
     wpe_buffer_set_user_data(buffer, wlBuffer, reinterpret_cast<GDestroyNotify>(wl_buffer_destroy));
     return wlBuffer;
@@ -533,7 +544,7 @@ static SharedMemoryBuffer* sharedMemoryBufferCreate(WPEDisplayWayland* display, 
     return sharedMemoryBuffer;
 }
 
-static struct wl_buffer* createWaylandBufferSHM(WPEBuffer* buffer, GError** error)
+static struct wl_buffer* createWaylandBufferSHM(WPEView* view, WPEBuffer* buffer, GError** error)
 {
     if (auto* sharedMemoryBuffer = static_cast<SharedMemoryBuffer*>(wpe_buffer_get_user_data(buffer))) {
         GBytes* bytes = wpe_buffer_shm_get_data(WPE_BUFFER_SHM(buffer));
@@ -547,7 +558,7 @@ static struct wl_buffer* createWaylandBufferSHM(WPEBuffer* buffer, GError** erro
         return nullptr;
     }
 
-    auto* display = WPE_DISPLAY_WAYLAND(wpe_buffer_get_display(buffer));
+    auto* display = WPE_DISPLAY_WAYLAND(wpe_view_get_display(view));
     auto* sharedMemoryBuffer = sharedMemoryBufferCreate(display, wpe_buffer_shm_get_data(bufferSHM),
         wpe_buffer_get_width(buffer), wpe_buffer_get_height(buffer), wpe_buffer_shm_get_stride(bufferSHM));
     if (!sharedMemoryBuffer) {
@@ -555,17 +566,19 @@ static struct wl_buffer* createWaylandBufferSHM(WPEBuffer* buffer, GError** erro
         return nullptr;
     }
 
+    wl_buffer_add_listener(sharedMemoryBuffer->wlBuffer, &bufferListener, buffer);
+
     wpe_buffer_set_user_data(buffer, sharedMemoryBuffer, reinterpret_cast<GDestroyNotify>(sharedMemoryBufferDestroy));
     return sharedMemoryBuffer->wlBuffer;
 }
 
-static struct wl_buffer* createWaylandBuffer(WPEBuffer* buffer, GError** error)
+static struct wl_buffer* createWaylandBuffer(WPEView* view, WPEBuffer* buffer, GError** error)
 {
     struct wl_buffer* wlBuffer = nullptr;
     if (WPE_IS_BUFFER_DMA_BUF(buffer))
-        wlBuffer = createWaylandBufferFromDMABuf(buffer, error);
+        wlBuffer = createWaylandBufferFromDMABuf(view, buffer, error);
     else if (WPE_IS_BUFFER_SHM(buffer))
-        wlBuffer = createWaylandBufferSHM(buffer, error);
+        wlBuffer = createWaylandBufferSHM(view, buffer, error);
     else
         RELEASE_ASSERT_NOT_REACHED();
 
@@ -588,7 +601,7 @@ const struct wl_callback_listener frameListener = {
 
 static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, GError** error)
 {
-    auto* wlBuffer = createWaylandBuffer(buffer, error);
+    auto* wlBuffer = createWaylandBuffer(view, buffer, error);
     if (!wlBuffer)
         return FALSE;
 


### PR DESCRIPTION
#### 01716ada465537d722308dd31ec31171ffeffe86
<pre>
[WPE] WPE Platform: do not release buffers when rendered
<a href="https://bugs.webkit.org/show_bug.cgi?id=270693">https://bugs.webkit.org/show_bug.cgi?id=270693</a>

Reviewed by Alejandro G. Castro.

The buffers can be rendered again, so we need to keep them locked until
a new frame is ready to be rendered. This patch adds
WPEView::buffer-released in addition to the existing
WPEView::buffer-rendered to notify that the buffer is no longer used and
can be destroyed or reused. This patch also changes the WPEBuffer API to
receive a WPEView in constructor instead of WPEDisplay, since buffers
are actually attached to a specific WPEView, because we need to easily
get the WPEView from the wayland buffer release callback.

* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::AcceleratedBackingStoreDMABuf):
(WebKit::AcceleratedBackingStoreDMABuf::updateSurfaceID):
(WebKit::AcceleratedBackingStoreDMABuf::didCreateBuffer):
(WebKit::AcceleratedBackingStoreDMABuf::didCreateBufferSHM):
(WebKit::AcceleratedBackingStoreDMABuf::bufferRendered):
(WebKit::AcceleratedBackingStoreDMABuf::bufferReleased):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp:
(wpeBufferGetProperty):
(wpe_buffer_class_init):
(wpe_buffer_get_view):
(wpe_buffer_get_display): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPEBuffer.h:
* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp:
(wpeBufferDMABufDispose):
(wpeBufferDMABufImportToEGLImage):
(wpeBufferDMABufTryEnsureGBMDevice):
(wpe_buffer_dma_buf_new):
* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.h:
* Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp:
(wpe_buffer_shm_new):
* Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.h:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):
(wpe_view_buffer_released):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(drmBufferCreateDMABuf):
(drmBufferCreate):
(wpeViewDRMRequestUpdate):
(wpeViewDRMRenderBuffer):
(wpeViewDRMDidPageFlip):
* Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp:
(wpeViewHeadlessRenderBuffer):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(createWaylandBufferFromDMABuf):
(createWaylandBufferSHM):
(createWaylandBuffer):
(createWaylandBufferFromEGLImage): Deleted.

Canonical link: <a href="https://commits.webkit.org/275903@main">https://commits.webkit.org/275903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36ffe27e4ab96acf35126b9cf1319daa43f34cc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39135 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35567 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16673 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47166 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42342 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19462 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/40995 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19641 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5867 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->