### PR TITLE
[Modern Media Controls] HTMLMediaElement is never destoyed when showing media controls

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -265,6 +265,15 @@ class MediaController
         return true;
     }
 
+    deinitialize()
+    {
+        this.media = null;
+        this.shadowRoot.removeChild(this.container);
+        this.shadowRoot = null;
+        iconService.shadowRoot = null;
+        return true;
+    }
+
     // Private
 
     _supportingObjectClasses()


### PR DESCRIPTION
#### 329c272714bbb136645e20755ba525d71d7de482
<pre>
[Modern Media Controls] HTMLMediaElement is never destoyed when showing media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=270571">https://bugs.webkit.org/show_bug.cgi?id=270571</a>

Reviewed by NOBODY (OOPS!).

At least in GStreamer-based ports (WPE and WebKitGTK, I haven&apos;t checked
on Mac ports because I don&apos;t have the proper environment easily
available), the media element is leaked after explicit deinitialization
and detaching from the HTML document, even after manually triggering
garbage collection (GC) using the web inspector.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1285">https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1285</a>

After some debugging, we&apos;ve detected that 2 extra references to
HTMLMediaElement appear when using the controls (3 refs in total), while
in a scenario where the controls are hidden on purpose only 1 reference
remains, which is released as soon as the GC kicks in.

Those references are held (or transitively held) by the MediaController,
the shadowRoot referenced by the MediaController and by the IconService,
and the &lt;div&gt; element that MediaController adds to the shadowRoot as a
container for the controls.

This commit adds code to deinitialize the MediaController when
HTMLMediaElement is no longer in use. The best place mathing that
instant is pauseAfterDetachedTask(). This deinitialization takes care of
properly nulling the mentioned objects that hold (or transitively hold)
the references to HTMLMediaElement. A new MediaController.deinitialize()
method has been added to the JavaScript code for this purpose.

* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype.deinitialize): Set references to the media element and the shadow root to null and also detach the UI container from the shadow root, so no references to HTMLMediaElement are held anymore, either directly or transitively.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::pauseAfterDetachedTask): Add code to call to the MediaController.deinitialize() JavaScript method.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/329c272714bbb136645e20755ba525d71d7de482

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36045 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44195 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19679 "Found 14 new test failures: editing/text-iterator/backwards-text-iterator-basic.html, http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html, media/modern-media-controls/controls-visibility-support/controls-visibility-support-controls-on-audio.html, media/modern-media-controls/fullscreen-support/fullscreen-support-disabled-video-with-audio-tracks-only.html, media/modern-media-controls/media-controller/ios/media-controller-scale-factor-audio.html, media/modern-media-controls/media-controller/ios/media-controller-scale-factor.html, media/modern-media-controls/media-controller/media-controller-controls-sizing-with-border-and-padding.html, media/modern-media-controls/media-controller/media-controller-resize.html, media/modern-media-controls/mute-support/mute-support-media-api.html, media/modern-media-controls/placard-support/placard-support-error-recover.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17228 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38624 "10 flakes 18 failures") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39774 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38935 "Found 13 new test failures: http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-delete-during-setup.html, media/airplay-allows-buffering.html, media/modern-media-controls/media-controller/media-controller-controls-sizing-with-border-and-padding.html, media/modern-media-controls/media-controller/media-controller-resize.html, media/modern-media-controls/mute-support/mute-support-media-api.html, media/modern-media-controls/placard-support/placard-support-error-recover.html, media/modern-media-controls/playback-support/playback-support-media-api.html, media/remove-from-document-no-load.html, media/remove-from-document.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47811 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18661 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15258 "Found 12 new test failures: http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html, imported/blink/fast/forms/label/label-contains-other-interactive-content.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-delete-during-setup.html, media/airplay-allows-buffering.html, media/modern-media-controls/media-controller/media-controller-controls-sizing-with-border-and-padding.html, media/modern-media-controls/media-controller/media-controller-resize.html, media/modern-media-controls/placard-support/placard-support-error-recover.html, media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html, media/remove-from-document-no-load.html, media/track/track-delete-during-setup.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42832 "Failure limit exceed. At least found 2 new test failures: editing/text-iterator/backwards-text-iterator-basic.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-delete-during-setup.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20079 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41503 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->