### PR TITLE
[web-animations] composed keyframe animation behaves differently in Webkit than Firefox and Chrome

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2711,6 +2711,7 @@ webanimations/frame-rate/document-timeline-maximum-frame-rate.html [ Skip ]
 webanimations/transform-animation-with-delay-yields-accelerated-animation.html [ Skip ]
 webanimations/partly-accelerated-transition-by-removing-property.html [ Skip ]
 webanimations/accelerated-animations-and-composite.html [ Skip ]
+webanimations/accelerated-animations-and-implicit-keyframes.html [ Skip ]
 
 # OT-SVG is not implemented on GTK/WPE
 fast/text/otsvg-canvas.html [ ImageOnlyFailure ]

--- a/LayoutTests/webanimations/accelerated-animations-and-composite-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animations-and-composite-expected.txt
@@ -9,7 +9,6 @@ PASS Dynamically setting 'composite' on an effect should toggle acceleration
 PASS Dynamically setting 'composite' on a keyframe should toggle acceleration
 PASS Dynamically setting 'composite' to 'add' on an animation further up the stack should toggle acceleration on lower animations in the stack
 PASS Dynamically setting 'composite' to 'add' on an animation lower down the stack should toggle acceleration but always allow replace animations further up the stack to be accelerated
-PASS Dynamically setting 'composite' to 'add' on an animation lower down the stack should toggle acceleration on replace animations with an implicity keyframe further up the stack
 PASS Dynamically setting 'composite' to 'add' on an animation lower down the stack targeting a property that isn't accelerated shouldn't prevent acceleration of animations with implicit keyframes further up the stack to be accelerated
 PASS Adding a composing effect on top of an existing replace effect should prevent both effects from running accelerated
 

--- a/LayoutTests/webanimations/accelerated-animations-and-composite.html
+++ b/LayoutTests/webanimations/accelerated-animations-and-composite.html
@@ -171,8 +171,8 @@ promise_test(async test => {
     const target = createDiv(test);
     const animations = [];
 
-    animations.push(target.animate({ transform: "translateX(100px)" }, duration));
-    animations.push(target.animate({ transform: "translateY(100px)" }, duration));
+    animations.push(target.animate({ transform: ["none", "translateX(200px)"] }, duration));
+    animations.push(target.animate({ transform: ["none", "translateY(200px)"] }, duration));
 
     await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 2, "Step 1");
@@ -208,28 +208,6 @@ promise_test(async test => {
     await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 2);
 }, "Dynamically setting 'composite' to 'add' on an animation lower down the stack should toggle acceleration but always allow replace animations further up the stack to be accelerated");
-
-promise_test(async test => {
-    const target = createDiv(test);
-    const animations = [];
-
-    animations.push(target.animate({ transform: "translateX(100px)" }, duration));
-    animations.push(target.animate({ transform: "translateX(100px)" }, duration));
-    await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 2);
-
-    // Make the first animation a composing animation. This will prevent both animations
-    // from running accelerated since the second animation uses the first animation as
-    // input due to using an implicit 0% keyframe.
-    animations[0].effect.composite = "add";
-    await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
-
-    // Reset to the original state.
-    animations[0].effect.composite = "replace";
-    await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 2);
-}, "Dynamically setting 'composite' to 'add' on an animation lower down the stack should toggle acceleration on replace animations with an implicity keyframe further up the stack");
 
 promise_test(async test => {
     const target = createDiv(test);

--- a/LayoutTests/webanimations/accelerated-animations-and-implicit-keyframes-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animations-and-implicit-keyframes-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Two replacing animations with explicit keyframes for the same accelerated property can run accelerated.
+PASS An animation with an implicit keyframe for an accelerated property can run accelerated.
+PASS Two animations with implicit keyframes for the same accelerated property prevents acceleration throughout the stack.
+PASS Dynamically adding an animation with an implicit keyframe for an accelerated property with an accelerated animation targeting that same property lower down the stack prevents the stack from being accelerated.
+

--- a/LayoutTests/webanimations/accelerated-animations-and-implicit-keyframes.html
+++ b/LayoutTests/webanimations/accelerated-animations-and-implicit-keyframes.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<body>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<style>
+
+div {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+<script>
+
+const createDiv = test => {
+    const div = document.createElement("div");
+    test.add_cleanup(() => div.remove());
+    return document.body.appendChild(div);
+}
+
+const animationReadyToAnimateAccelerated = async animation => {
+    await animation.ready;
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+}
+
+const allAnimationsAreReadyToAnimateAccelerated = async animations => {
+    await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
+}
+
+const duration = 1000 * 1000; // 1000s.
+
+promise_test(async test => {
+    const target = createDiv(test);
+    const animations = [];
+
+    animations.push(target.animate({ transform: ["none", "translateX(100px)"] }, duration));
+    animations.push(target.animate({ transform: ["none", "translateY(100px)"] }, duration));
+    await allAnimationsAreReadyToAnimateAccelerated(animations);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 2);
+}, "Two replacing animations with explicit keyframes for the same accelerated property can run accelerated.");
+
+promise_test(async test => {
+    const target = createDiv(test);
+    const animation = target.animate({ transform: ["translateX(100px)"] }, duration);
+    await animationReadyToAnimateAccelerated(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+}, "An animation with an implicit keyframe for an accelerated property can run accelerated.");
+
+promise_test(async test => {
+    const target = createDiv(test);
+    const animations = [];
+
+    animations.push(target.animate({ transform: "translateX(100px)" }, duration));
+    animations.push(target.animate({ transform: "translateY(100px)" }, duration));
+    await allAnimationsAreReadyToAnimateAccelerated(animations);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Two animations with implicit keyframes for the same accelerated property prevents acceleration throughout the stack.");
+
+promise_test(async test => {
+    const target = createDiv(test);
+    const animations = [];
+
+    // Start with a single animation targeting an accelerated property with explicit keyframes.
+    animations.push(target.animate({ transform: ["none", "translateX(100px)"] }, duration));
+    await allAnimationsAreReadyToAnimateAccelerated(animations);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+
+    // Adding a second animation with an implicit keyframe for an accelerated property prevents acceleration
+    // throughout the effect stack.
+    animations.push(target.animate({ transform: "translateY(100px)" }, duration));
+    await allAnimationsAreReadyToAnimateAccelerated(animations);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+
+    // Reset to the original state.
+    animations[1].cancel();
+    await allAnimationsAreReadyToAnimateAccelerated(animations);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+}, "Dynamically adding an animation with an implicit keyframe for an accelerated property with an accelerated animation targeting that same property lower down the stack prevents the stack from being accelerated.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -101,6 +101,11 @@ bool BlendingKeyframes::hasImplicitKeyframes() const
     return size() && (m_keyframes[0].offset() || m_keyframes[size() - 1].offset() != 1);
 }
 
+bool BlendingKeyframes::hasImplicitKeyframeForProperty(AnimatableCSSProperty property) const
+{
+    return hasImplicitKeyframes() && (!m_explicitFromProperties.contains(property) || !m_explicitToProperties.contains(property));
+}
+
 void BlendingKeyframes::copyKeyframes(const BlendingKeyframes& other)
 {
     for (auto& keyframe : other) {
@@ -351,8 +356,17 @@ void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
             m_hasExplicitlyInheritedKeyframeProperty = style->hasExplicitlyInheritedProperties();
     };
 
+    auto analyzeKeyframeForExplicitProperties = [&] {
+        auto& properties = keyframe.properties();
+        if (!keyframe.offset())
+            m_explicitFromProperties.add(properties.begin(), properties.end());
+        if (keyframe.offset() == 1)
+            m_explicitToProperties.add(properties.begin(), properties.end());
+    };
+
     analyzeSizeDependentTransform();
     analyzeExplicitlyInheritedKeyframeProperty();
+    analyzeKeyframeForExplicitProperties();
 }
 
 void BlendingKeyframe::addProperty(const AnimatableCSSProperty& property)

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -111,6 +111,7 @@ public:
 
     void copyKeyframes(const BlendingKeyframes&);
     bool hasImplicitKeyframes() const;
+    bool hasImplicitKeyframeForProperty(AnimatableCSSProperty) const;
     void fillImplicitKeyframes(const KeyframeEffect&, const RenderStyle& elementStyle);
 
     auto begin() const { return m_keyframes.begin(); }
@@ -135,6 +136,8 @@ private:
     AtomString m_animationName;
     Vector<BlendingKeyframe> m_keyframes; // Kept sorted by key.
     HashSet<AnimatableCSSProperty> m_properties; // The properties being animated.
+    HashSet<AnimatableCSSProperty> m_explicitToProperties; // The properties with an explicit value for the 100% keyframe.
+    HashSet<AnimatableCSSProperty> m_explicitFromProperties; // The properties with an explicit value for the 0% keyframe.
     HashSet<AnimatableCSSProperty> m_propertiesSetToInherit;
     HashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
     bool m_usesRelativeFontWeight { false };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1014,10 +1014,27 @@ void KeyframeEffect::setBlendingKeyframes(BlendingKeyframes&& blendingKeyframes)
     computeHasAcceleratedPropertyOverriddenByCascadeProperty();
     computeHasReferenceFilter();
     computeHasSizeDependentTransform();
+    analyzeAcceleratedProperties();
 
     checkForMatchingTransformFunctionLists();
 
     updateAcceleratedAnimationIfNecessary();
+}
+
+void KeyframeEffect::analyzeAcceleratedProperties()
+{
+    m_acceleratedProperties.clear();
+    m_acceleratedPropertiesWithImplicitKeyframe.clear();
+
+    ASSERT(document());
+    auto& settings = document()->settings();
+    for (auto& property : m_blendingKeyframes.properties()) {
+        if (!CSSPropertyAnimation::animationOfPropertyIsAccelerated(property, settings))
+            continue;
+        m_acceleratedProperties.add(property);
+        if (m_blendingKeyframes.hasImplicitKeyframeForProperty(property))
+            m_acceleratedPropertiesWithImplicitKeyframe.add(property);
+    }
 }
 
 void KeyframeEffect::checkForMatchingTransformFunctionLists()

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -157,6 +157,8 @@ public:
     const BlendingKeyframes& blendingKeyframes() const { return m_blendingKeyframes; }
     const HashSet<AnimatableCSSProperty>& animatedProperties();
     bool animatesProperty(const AnimatableCSSProperty&) const;
+    const HashSet<AnimatableCSSProperty>& acceleratedProperties() const { return m_acceleratedProperties; }
+    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesWithImplicitKeyframe() const { return m_acceleratedPropertiesWithImplicitKeyframe; }
 
     bool computeExtentOfTransformAnimation(LayoutRect&) const;
     bool computeTransformedExtentViaTransformList(const FloatRect&, const RenderStyle&, LayoutRect&) const;
@@ -243,6 +245,8 @@ private:
     void computeHasAcceleratedPropertyOverriddenByCascadeProperty();
     void computeHasReferenceFilter();
     void computeHasSizeDependentTransform();
+    void analyzeAcceleratedProperties();
+
     void abilityToBeAcceleratedDidChange();
     void updateAcceleratedAnimationIfNecessary();
 
@@ -290,6 +294,8 @@ private:
     AtomString m_keyframesName;
     BlendingKeyframes m_blendingKeyframes { emptyAtom() };
     HashSet<AnimatableCSSProperty> m_animatedProperties;
+    HashSet<AnimatableCSSProperty> m_acceleratedProperties;
+    HashSet<AnimatableCSSProperty> m_acceleratedPropertiesWithImplicitKeyframe;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;
     RefPtr<Element> m_target;

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -236,10 +236,26 @@ bool KeyframeEffectStack::allowsAcceleration() const
     // all effects that could support acceleration using acceleration, then we might
     // as well not run any at all since we'll be updating effects for this stack
     // for each animation frame. So for now, we simply return false if any effect in the
-    // stack is unable to be accelerated.
-    return !hasMatchingEffect([] (const KeyframeEffect& effect) {
-        return effect.preventsAcceleration();
-    });
+    // stack is unable to be accelerated, or if we have more than one effect animating
+    // an accelerated property with an implicit keyframe.
+
+    HashSet<AnimatableCSSProperty> allAcceleratedProperties;
+
+    for (auto& effect : m_effects) {
+        if (effect->preventsAcceleration())
+            return false;
+        auto& acceleratedProperties = effect->acceleratedProperties();
+        if (!allAcceleratedProperties.isEmpty()) {
+            auto previouslySeenAcceleratedPropertiesAffectingCurrentEffect = allAcceleratedProperties.intersectionWith(acceleratedProperties);
+            if (!previouslySeenAcceleratedPropertiesAffectingCurrentEffect.isEmpty()
+                && !effect->acceleratedPropertiesWithImplicitKeyframe().intersectionWith(previouslySeenAcceleratedPropertiesAffectingCurrentEffect).isEmpty()) {
+                return false;
+            }
+        }
+        allAcceleratedProperties.add(acceleratedProperties.begin(), acceleratedProperties.end());
+    }
+
+    return true;
 }
 
 void KeyframeEffectStack::startAcceleratedAnimationsIfPossible()


### PR DESCRIPTION
#### e9e959922d195e8daa40a74c08f00fe06a615206
<pre>
[web-animations] composed keyframe animation behaves differently in Webkit than Firefox and Chrome
<a href="https://bugs.webkit.org/show_bug.cgi?id=269858">https://bugs.webkit.org/show_bug.cgi?id=269858</a>
<a href="https://rdar.apple.com/123777133">rdar://123777133</a>

Reviewed by Dean Jackson.

The reported broken content for this bug used two animations targeting an accelerated property (`transform`)
and using an implicit keyframe in both cases. When we encounter an accelerated animation with an implicit
keyframe, we resolve the implicit keyframes using the underlying style.

In this case, this breaks the content because the underlying style should be used only for the first of the
two `transform` animations, and the second animation ought to use the output of the first animation to use as
its underlying value. Since that values will change for each animation frame, we have to not run accelerated
animations in this particular instance.

So we now analyze the effect stack in `KeyframeEffectStack::allowsAcceleration()` for a case where an effect
targets an accelerated property using an implicit keyframe when an effect lower down the stack is already
animating that property. If we find this to be the case, we disable acceleration throughout the stack.

Note that with threaded animation resolution, we are able to run this same scenario in the animation thread
because we correctly resolve an effect stack with implicit keyframes no matter the configuration. The code
path modified by this patch is not exercised when threaded animation resolution is enabled.

We add a new test devoted to testing implicit keyframes for accelerated properties and modify the existing
test for the `composite` property and acceleration to not contain implicit keyframes.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/webanimations/accelerated-animations-and-composite-expected.txt:
* LayoutTests/webanimations/accelerated-animations-and-composite.html:
* LayoutTests/webanimations/accelerated-animations-and-implicit-keyframes-expected.txt: Added.
* LayoutTests/webanimations/accelerated-animations-and-implicit-keyframes.html: Added.
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::hasImplicitKeyframeForProperty const):
(WebCore::BlendingKeyframes::analyzeKeyframe):
* Source/WebCore/animation/BlendingKeyframes.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::analyzeAcceleratedProperties):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::allowsAcceleration const):

Canonical link: <a href="https://commits.webkit.org/275887@main">https://commits.webkit.org/275887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1cb5575c6afcf353318a84b27439818319e1da9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35653 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38219 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1185 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39329 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47304 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42446 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41106 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19760 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5853 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->