### PR TITLE
Rename RenderStyle effectiveAppearance() to usedAppearance()

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2680,7 +2680,7 @@ bool AccessibilityRenderObject::isApplePayButton() const
 {
     if (!m_renderer)
         return false;
-    return m_renderer->style().effectiveAppearance() == StyleAppearance::ApplePayButton;
+    return m_renderer->style().usedAppearance() == StyleAppearance::ApplePayButton;
 }
 
 ApplePayButtonType AccessibilityRenderObject::applePayButtonType() const

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -67,7 +67,7 @@ AccessibilityOrientation AccessibilitySlider::orientation() const
     if (!style)
         return AccessibilityOrientation::Horizontal;
 
-    auto styleAppearance = style->effectiveAppearance();
+    auto styleAppearance = style->usedAppearance();
     switch (styleAppearance) {
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderHorizontal:

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -61,7 +61,7 @@ Ref<HTMLMeterElement> HTMLMeterElement::create(const QualifiedName& tagName, Doc
 
 RenderPtr<RenderElement> HTMLMeterElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    if (!RenderTheme::singleton().supportsMeter(style.effectiveAppearance()))
+    if (!RenderTheme::singleton().supportsMeter(style.usedAppearance()))
         return RenderElement::createFor(*this, WTFMove(style));
 
     return createRenderer<RenderMeter>(*this, WTFMove(style));

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -207,7 +207,7 @@ auto RangeInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
 
     bool isVertical = false;
     if (auto* renderer = element()->renderer())
-        isVertical = renderer->style().effectiveAppearance() == StyleAppearance::SliderVertical;
+        isVertical = renderer->style().usedAppearance() == StyleAppearance::SliderVertical;
 
     Decimal newValue;
     if (key == "Up"_s)

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -79,7 +79,7 @@ inline static Decimal sliderPosition(HTMLInputElement& element)
 inline static bool hasVerticalAppearance(HTMLInputElement& input)
 {
     ASSERT(input.renderer());
-    return !input.renderer()->isHorizontalWritingMode() || input.renderer()->style().effectiveAppearance() == StyleAppearance::SliderVertical;
+    return !input.renderer()->isHorizontalWritingMode() || input.renderer()->style().usedAppearance() == StyleAppearance::SliderVertical;
 }
 
 // --------------------------------
@@ -563,12 +563,12 @@ std::optional<Style::ResolvedStyle> SliderThumbElement::resolveCustomStyle(const
         return std::nullopt;
 
     auto elementStyle = resolveStyle(resolutionContext);
-    switch (hostStyle->effectiveAppearance()) {
+    switch (hostStyle->usedAppearance()) {
     case StyleAppearance::SliderVertical:
-        elementStyle.style->setEffectiveAppearance(StyleAppearance::SliderThumbVertical);
+        elementStyle.style->setUsedAppearance(StyleAppearance::SliderThumbVertical);
         break;
     case StyleAppearance::SliderHorizontal:
-        elementStyle.style->setEffectiveAppearance(StyleAppearance::SliderThumbHorizontal);
+        elementStyle.style->setUsedAppearance(StyleAppearance::SliderThumbHorizontal);
         break;
     default:
         break;

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -238,7 +238,7 @@ std::optional<Style::ResolvedStyle> TextControlPlaceholderElement::resolveCustom
 static inline bool searchFieldStyleHasExplicitlySpecifiedTextFieldAppearance(const RenderStyle& style)
 {
     auto appearance = style.appearance();
-    return appearance == StyleAppearance::TextField && appearance == style.effectiveAppearance();
+    return appearance == StyleAppearance::TextField && appearance == style.usedAppearance();
 }
 
 inline SearchFieldResultsButtonElement::SearchFieldResultsButtonElement(Document& document)
@@ -270,8 +270,8 @@ std::optional<Style::ResolvedStyle> SearchFieldResultsButtonElement::resolveCust
 
     // By default, input[type=search] can use either the searchfield or textfield appearance depending
     // on the platform and writing mode. Only adjust the style when that default is used.
-    auto effectiveAppearance = shadowHostStyle->effectiveAppearance();
-    if (effectiveAppearance != StyleAppearance::SearchField && effectiveAppearance != StyleAppearance::TextField) {
+    auto usedAppearance = shadowHostStyle->usedAppearance();
+    if (usedAppearance != StyleAppearance::SearchField && usedAppearance != StyleAppearance::TextField) {
         SetForScope canAdjustStyleForAppearance(m_canAdjustStyleForAppearance, false);
         return resolveStyle(resolutionContext);
     }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -274,7 +274,7 @@ void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, s
         auto* blockFlow = dynamicDowncast<RenderBlockFlow>(renderBox);
         if (!blockFlow)
             return false;
-        auto hasAppareance = blockFlow->style().hasEffectiveAppearance() && !blockFlow->theme().isControlContainer(blockFlow->style().effectiveAppearance());
+        auto hasAppareance = blockFlow->style().hasEffectiveAppearance() && !blockFlow->theme().isControlContainer(blockFlow->style().usedAppearance());
         return hasAppareance || !blockFlow->childrenInline() || blockFlow->hasLines() || blockFlow->hasLineIfEmpty();
     }();
     if (hasNonSyntheticBaseline) {

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -114,7 +114,7 @@ LayoutUnit RenderAttachment::baselinePosition(FontBaseline, bool, LineDirectionM
 
 bool RenderAttachment::shouldDrawBorder() const
 {
-    if (style().effectiveAppearance() == StyleAppearance::BorderlessAttachment)
+    if (style().usedAppearance() == StyleAppearance::BorderlessAttachment)
         return false;
     return m_shouldDrawBorder;
 }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2456,7 +2456,7 @@ LayoutUnit RenderBlock::baselinePosition(FontBaseline baselineType, bool firstLi
         // FIXME: Might be better to have a custom CSS property instead, so that if the theme
         // is turned off, checkboxes/radios will still have decent baselines.
         // FIXME: Need to patch form controls to deal with vertical lines.
-        if (style().hasEffectiveAppearance() && !theme().isControlContainer(style().effectiveAppearance()))
+        if (style().hasEffectiveAppearance() && !theme().isControlContainer(style().usedAppearance()))
             return theme().baselinePosition(*this);
             
         // CSS2.1 states that the baseline of an inline block is the baseline of the last line box in

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1666,7 +1666,7 @@ BackgroundBleedAvoidance RenderBox::determineBackgroundBleedAvoidance(GraphicsCo
 ControlPart* RenderBox::ensureControlPart()
 {
     auto& rareData = ensureRareData();
-    auto type = style().effectiveAppearance();
+    auto type = style().usedAppearance();
 
     // Some form-controls may change because of zooming without recreating
     // a new renderer (e.g Menulist <-> MenulistButton).

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1250,7 +1250,7 @@ void RenderLayerScrollableArea::updateScrollbarsAfterStyleChange(const RenderSty
         return;
 
     // List box parts handle the scrollbars by themselves so we have nothing to do.
-    if (box->style().effectiveAppearance() == StyleAppearance::Listbox)
+    if (box->style().usedAppearance() == StyleAppearance::Listbox)
         return;
 
     bool hadVerticalScrollbar = hasVerticalScrollbar();
@@ -1270,7 +1270,7 @@ void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
     ASSERT(box);
 
     // List box parts handle the scrollbars by themselves so we have nothing to do.
-    if (box->style().effectiveAppearance() == StyleAppearance::Listbox)
+    if (box->style().usedAppearance() == StyleAppearance::Listbox)
         return;
 
     bool hadHorizontalScrollbar = hasHorizontalScrollbar();

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -566,7 +566,7 @@ PopupMenuStyle RenderMenuList::menuStyle() const
     IntRect absBounds = absoluteBoundingBoxRectIgnoringTransforms();
     return PopupMenuStyle(styleToUse.visitedDependentColorWithColorFilter(CSSPropertyColor), styleToUse.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor),
         styleToUse.fontCascade(), styleToUse.visibility() == Visibility::Visible, styleToUse.display() == DisplayType::None,
-        style().hasEffectiveAppearance() && style().effectiveAppearance() == StyleAppearance::Menulist, styleToUse.textIndent(),
+        style().hasEffectiveAppearance() && style().usedAppearance() == StyleAppearance::Menulist, styleToUse.textIndent(),
         style().direction(), isOverride(style().unicodeBidi()), PopupMenuStyle::DefaultBackgroundColor,
         PopupMenuStyle::SelectPopup, theme().popupMenuSize(styleToUse, absBounds));
 }
@@ -598,7 +598,7 @@ const int endOfLinePadding = 2;
 
 LayoutUnit RenderMenuList::clientPaddingLeft() const
 {
-    if ((style().effectiveAppearance() == StyleAppearance::Menulist || style().effectiveAppearance() == StyleAppearance::MenulistButton) && style().direction() == TextDirection::RTL) {
+    if ((style().usedAppearance() == StyleAppearance::Menulist || style().usedAppearance() == StyleAppearance::MenulistButton) && style().direction() == TextDirection::RTL) {
         // For these appearance values, the theme applies padding to leave room for the
         // drop-down button. But leaving room for the button inside the popup menu itself
         // looks strange, so we return a small default padding to avoid having a large empty
@@ -612,7 +612,7 @@ LayoutUnit RenderMenuList::clientPaddingLeft() const
 
 LayoutUnit RenderMenuList::clientPaddingRight() const
 {
-    if ((style().effectiveAppearance() == StyleAppearance::Menulist || style().effectiveAppearance() == StyleAppearance::MenulistButton) && style().direction() == TextDirection::LTR)
+    if ((style().usedAppearance() == StyleAppearance::Menulist || style().usedAppearance() == StyleAppearance::MenulistButton) && style().direction() == TextDirection::LTR)
         return endOfLinePadding;
 
     return paddingRight() + m_innerBlock->paddingRight();

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -100,11 +100,11 @@ RenderTheme::RenderTheme()
 StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, const Element* element, StyleAppearance autoAppearance) const
 {
     if (!element) {
-        style.setEffectiveAppearance(StyleAppearance::None);
+        style.setUsedAppearance(StyleAppearance::None);
         return StyleAppearance::None;
     }
 
-    auto appearance = style.effectiveAppearance();
+    auto appearance = style.usedAppearance();
     if (appearance == autoAppearance)
         return appearance;
 
@@ -122,7 +122,7 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
         || appearance == StyleAppearance::PushButton
         || appearance == StyleAppearance::SliderHorizontal
         || appearance == StyleAppearance::Menulist) {
-        style.setEffectiveAppearance(autoAppearance);
+        style.setUsedAppearance(autoAppearance);
         return autoAppearance;
     }
 
@@ -131,14 +131,14 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
     if (appearance == StyleAppearance::Button) {
         if (autoAppearance == StyleAppearance::PushButton || autoAppearance == StyleAppearance::SquareButton)
             return appearance;
-        style.setEffectiveAppearance(autoAppearance);
+        style.setUsedAppearance(autoAppearance);
         return autoAppearance;
     }
 
     if (appearance == StyleAppearance::MenulistButton) {
         if (autoAppearance == StyleAppearance::Menulist)
             return appearance;
-        style.setEffectiveAppearance(autoAppearance);
+        style.setUsedAppearance(autoAppearance);
         return autoAppearance;
     }
 
@@ -147,14 +147,14 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
     if (appearance == StyleAppearance::TextField) {
         if (inputElement && inputElement->isSearchField())
             return appearance;
-        style.setEffectiveAppearance(autoAppearance);
+        style.setUsedAppearance(autoAppearance);
         return autoAppearance;
     }
 
     if (appearance == StyleAppearance::SliderVertical) {
         if (inputElement && inputElement->isRangeControl())
             return appearance;
-        style.setEffectiveAppearance(autoAppearance);
+        style.setUsedAppearance(autoAppearance);
         return autoAppearance;
     }
 
@@ -199,19 +199,19 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
             break;
         }
 
-        style.setEffectiveAppearance(appearance);
+        style.setUsedAppearance(appearance);
     }
 
     if (appearance == StyleAppearance::SearchField && searchFieldShouldAppearAsTextField(style)) {
         appearance = StyleAppearance::TextField;
-        style.setEffectiveAppearance(appearance);
+        style.setUsedAppearance(appearance);
     }
 
     if (!isAppearanceAllowedForAllElements(appearance)
         && !userAgentAppearanceStyle
         && autoAppearance == StyleAppearance::None
         && !style.borderAndBackgroundEqual(RenderStyle::defaultStyle()))
-        style.setEffectiveAppearance(StyleAppearance::None);
+        style.setUsedAppearance(StyleAppearance::None);
 
     if (!style.hasEffectiveAppearance())
         return;
@@ -515,7 +515,7 @@ static void updateSwitchTrackPartForRenderer(SwitchTrackPart& switchTrackPart, c
 
 RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer) const
 {
-    auto appearance = renderer.style().effectiveAppearance();
+    auto appearance = renderer.style().usedAppearance();
 
     switch (appearance) {
     case StyleAppearance::None:
@@ -703,7 +703,7 @@ OptionSet<ControlStyle::State> RenderTheme::extractControlStyleStatesForRenderer
 static const RenderObject* effectiveRendererForAppearance(const RenderObject& renderObject)
 {
     const RenderObject* renderer = &renderObject;
-    auto type = renderObject.style().effectiveAppearance();
+    auto type = renderObject.style().usedAppearance();
 
     if (type == StyleAppearance::SearchFieldCancelButton
         || type == StyleAppearance::SwitchTrack
@@ -780,7 +780,7 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     if (paintInfo.context().paintingDisabled())
         return false;
     
-    auto appearance = box.style().effectiveAppearance();
+    auto appearance = box.style().usedAppearance();
 
     if (UNLIKELY(!canPaint(paintInfo, box.settings(), appearance)))
         return false;
@@ -882,11 +882,11 @@ bool RenderTheme::paintBorderOnly(const RenderBox& box, const PaintInfo& paintIn
 
 #if PLATFORM(IOS_FAMILY)
     UNUSED_PARAM(rect);
-    return box.style().effectiveAppearance() != StyleAppearance::None;
+    return box.style().usedAppearance() != StyleAppearance::None;
 #else
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, box.document().deviceScaleFactor());
     // Call the appropriate paint method based off the appearance value.
-    switch (box.style().effectiveAppearance()) {
+    switch (box.style().usedAppearance()) {
     case StyleAppearance::TextField:
         return paintTextField(box, paintInfo, devicePixelSnappedRect);
     case StyleAppearance::Listbox:
@@ -938,7 +938,7 @@ void RenderTheme::paintDecorations(const RenderBox& box, const PaintInfo& paintI
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, box.document().deviceScaleFactor());
 
     // Call the appropriate paint method based off the appearance value.
-    switch (box.style().effectiveAppearance()) {
+    switch (box.style().usedAppearance()) {
     case StyleAppearance::MenulistButton:
         paintMenuListButtonDecorations(box, paintInfo, devicePixelSnappedRect);
         break;
@@ -1111,7 +1111,7 @@ bool RenderTheme::isControlContainer(StyleAppearance appearance) const
 
 bool RenderTheme::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const
 {
-    switch (style.effectiveAppearance()) {
+    switch (style.usedAppearance()) {
     case StyleAppearance::PushButton:
     case StyleAppearance::SquareButton:
 #if ENABLE(INPUT_TYPE_COLOR)
@@ -1136,10 +1136,10 @@ bool RenderTheme::isControlStyled(const RenderStyle& style, const RenderStyle& u
 bool RenderTheme::supportsFocusRing(const RenderStyle& style) const
 {
     return style.hasEffectiveAppearance()
-        && style.effectiveAppearance() != StyleAppearance::TextField
-        && style.effectiveAppearance() != StyleAppearance::TextArea
-        && style.effectiveAppearance() != StyleAppearance::MenulistButton
-        && style.effectiveAppearance() != StyleAppearance::Listbox;
+        && style.usedAppearance() != StyleAppearance::TextField
+        && style.usedAppearance() != StyleAppearance::TextArea
+        && style.usedAppearance() != StyleAppearance::MenulistButton
+        && style.usedAppearance() != StyleAppearance::Listbox;
 }
 
 bool RenderTheme::isWindowActive(const RenderObject& renderer) const
@@ -1231,7 +1231,7 @@ bool RenderTheme::isDefault(const RenderObject& o) const
     if (!isWindowActive(o))
         return false;
 
-    return o.style().effectiveAppearance() == StyleAppearance::DefaultButton;
+    return o.style().usedAppearance() == StyleAppearance::DefaultButton;
 }
 
 #if ENABLE(DATALIST_ELEMENT)
@@ -1252,7 +1252,7 @@ bool RenderTheme::hasListButtonPressed(const RenderObject& renderer) const
 // investigate if we can bring the various ports closer together.
 void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(RenderStyle& style, const Element* element) const
 {
-    auto appearance = style.effectiveAppearance();
+    auto appearance = style.usedAppearance();
 
     LengthBox borderBox(style.borderTopWidth(), style.borderRightWidth(), style.borderBottomWidth(), style.borderLeftWidth());
     borderBox = Theme::singleton().controlBorder(appearance, style.fontCascade(), borderBox, style.effectiveZoom());
@@ -1418,7 +1418,7 @@ void RenderTheme::paintSliderTicks(const RenderObject& renderer, const PaintInfo
 
     double min = input->minimum();
     double max = input->maximum();
-    auto appearance = renderer.style().effectiveAppearance();
+    auto appearance = renderer.style().usedAppearance();
     // We don't support ticks on alternate sliders like MediaVolumeSliders.
     if (appearance != StyleAppearance::SliderHorizontal && appearance != StyleAppearance::SliderVertical)
         return;

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -120,7 +120,7 @@ RenderTheme& RenderTheme::singleton()
 
 bool RenderThemeAdwaita::supportsFocusRing(const RenderStyle& style) const
 {
-    switch (style.effectiveAppearance()) {
+    switch (style.usedAppearance()) {
     case StyleAppearance::PushButton:
     case StyleAppearance::Button:
     case StyleAppearance::TextField:
@@ -394,7 +394,7 @@ void RenderThemeAdwaita::adjustMenuListButtonStyle(RenderStyle& style, const Ele
 
 LengthBox RenderThemeAdwaita::popupInternalPaddingBox(const RenderStyle& style) const
 {
-    if (style.effectiveAppearance() == StyleAppearance::None)
+    if (style.usedAppearance() == StyleAppearance::None)
         return { };
 
     auto zoomedArrowSize = menuListButtonArrowSize * style.effectiveZoom();
@@ -517,7 +517,7 @@ bool RenderThemeAdwaita::paintSliderTrack(const RenderObject& renderObject, cons
     auto& graphicsContext = paintInfo.context();
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
-    auto appearance = renderObject.style().effectiveAppearance();
+    auto appearance = renderObject.style().usedAppearance();
     ASSERT(appearance == StyleAppearance::SliderHorizontal || appearance == StyleAppearance::SliderVertical);
 
     FloatRect fieldRect = rect;
@@ -596,7 +596,7 @@ bool RenderThemeAdwaita::paintSliderTrack(const RenderObject& renderObject, cons
 
 void RenderThemeAdwaita::adjustSliderThumbSize(RenderStyle& style, const Element*) const
 {
-    auto appearance = style.effectiveAppearance();
+    auto appearance = style.usedAppearance();
     if (appearance != StyleAppearance::SliderThumbHorizontal && appearance != StyleAppearance::SliderThumbVertical)
         return;
 
@@ -609,7 +609,7 @@ bool RenderThemeAdwaita::paintSliderThumb(const RenderObject& renderObject, cons
     auto& graphicsContext = paintInfo.context();
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
-    ASSERT(renderObject.style().effectiveAppearance() == StyleAppearance::SliderThumbHorizontal || renderObject.style().effectiveAppearance() == StyleAppearance::SliderThumbVertical);
+    ASSERT(renderObject.style().usedAppearance() == StyleAppearance::SliderThumbHorizontal || renderObject.style().usedAppearance() == StyleAppearance::SliderThumbVertical);
 
     SRGBA<uint8_t> sliderThumbBackgroundColor;
     SRGBA<uint8_t> sliderThumbBackgroundHoveredColor;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -120,7 +120,7 @@ RenderTheme& RenderTheme::singleton()
 
 bool RenderThemeIOS::canCreateControlPartForRenderer(const RenderObject& renderer) const
 {
-    auto type = renderer.style().effectiveAppearance();
+    auto type = renderer.style().usedAppearance();
 #if ENABLE(APPLE_PAY)
     return type == StyleAppearance::ApplePayButton;
 #else
@@ -183,7 +183,7 @@ void RenderThemeIOS::adjustCheckboxStyle(RenderStyle& style, const Element* elem
 LayoutRect RenderThemeIOS::adjustedPaintRect(const RenderBox& box, const LayoutRect& paintRect) const
 {
     // Workaround for <rdar://problem/6209763>. Force the painting bounds of checkboxes and radio controls to be square.
-    if (box.style().effectiveAppearance() == StyleAppearance::Checkbox || box.style().effectiveAppearance() == StyleAppearance::Radio) {
+    if (box.style().usedAppearance() == StyleAppearance::Checkbox || box.style().usedAppearance() == StyleAppearance::Radio) {
         float width = std::min(paintRect.width(), paintRect.height());
         float height = width;
         return enclosingLayoutRect(FloatRect(paintRect.x(), paintRect.y() + (box.height() - height) / 2, width, height)); // Vertically center the checkbox, like on desktop
@@ -198,9 +198,9 @@ int RenderThemeIOS::baselinePosition(const RenderBox& box) const
     if (!box.isHorizontalWritingMode())
         return baseline;
 
-    if (box.style().effectiveAppearance() == StyleAppearance::Checkbox || box.style().effectiveAppearance() == StyleAppearance::Radio)
+    if (box.style().usedAppearance() == StyleAppearance::Checkbox || box.style().usedAppearance() == StyleAppearance::Radio)
         return baseline - 2; // The baseline is 2px up from the bottom of the checkbox/radio in AppKit.
-    if (box.style().effectiveAppearance() == StyleAppearance::Menulist)
+    if (box.style().usedAppearance() == StyleAppearance::Menulist)
         return baseline - 5; // This is to match AppKit. There might be a better way to calculate this though.
     return baseline;
 }
@@ -208,14 +208,14 @@ int RenderThemeIOS::baselinePosition(const RenderBox& box) const
 bool RenderThemeIOS::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const
 {
     // Buttons and MenulistButtons are styled if they contain a background image.
-    if (style.effectiveAppearance() == StyleAppearance::PushButton || style.effectiveAppearance() == StyleAppearance::MenulistButton)
+    if (style.usedAppearance() == StyleAppearance::PushButton || style.usedAppearance() == StyleAppearance::MenulistButton)
         return !style.visitedDependentColor(CSSPropertyBackgroundColor).isVisible() || style.backgroundLayers().hasImage();
 
-    if (style.effectiveAppearance() == StyleAppearance::TextField || style.effectiveAppearance() == StyleAppearance::TextArea || style.effectiveAppearance() == StyleAppearance::SearchField)
+    if (style.usedAppearance() == StyleAppearance::TextField || style.usedAppearance() == StyleAppearance::TextArea || style.usedAppearance() == StyleAppearance::SearchField)
         return !style.borderAndBackgroundEqual(userAgentStyle);
 
 #if ENABLE(DATALIST_ELEMENT)
-    if (style.effectiveAppearance() == StyleAppearance::ListButton)
+    if (style.usedAppearance() == StyleAppearance::ListButton)
         return style.hasContent() || style.hasEffectiveContentNone();
 #endif
 
@@ -370,7 +370,7 @@ LengthBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& style) cons
     auto emSize = CSSPrimitiveValue::create(1.0, CSSUnitType::CSS_EM);
     auto padding = emSize->computeLength<float>({ style, nullptr, nullptr, nullptr });
 
-    if (style.effectiveAppearance() == StyleAppearance::MenulistButton) {
+    if (style.usedAppearance() == StyleAppearance::MenulistButton) {
         if (style.direction() == TextDirection::RTL)
             return { 0, 0, 0, static_cast<int>(padding + style.borderTopWidth()) };
         return { 0, static_cast<int>(padding + style.borderTopWidth()), 0, 0 };
@@ -396,7 +396,7 @@ static inline bool canAdjustBorderRadiusForAppearance(StyleAppearance appearance
 
 void RenderThemeIOS::adjustRoundBorderRadius(RenderStyle& style, RenderBox& box)
 {
-    if (!canAdjustBorderRadiusForAppearance(style.effectiveAppearance(), box) || style.backgroundLayers().hasImage())
+    if (!canAdjustBorderRadiusForAppearance(style.usedAppearance(), box) || style.backgroundLayers().hasImage())
         return;
 
     auto boxLogicalHeight = box.logicalHeight();
@@ -624,7 +624,7 @@ bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& 
     bool isHorizontal = true;
     FloatRect trackClip = rect;
 
-    switch (box.style().effectiveAppearance()) {
+    switch (box.style().usedAppearance()) {
     case StyleAppearance::SliderHorizontal:
         // Inset slightly so the thumb covers the edge.
         if (trackClip.width() > 2) {
@@ -690,7 +690,7 @@ bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& 
 
 void RenderThemeIOS::adjustSliderThumbSize(RenderStyle& style, const Element*) const
 {
-    if (style.effectiveAppearance() != StyleAppearance::SliderThumbHorizontal && style.effectiveAppearance() != StyleAppearance::SliderThumbVertical)
+    if (style.usedAppearance() != StyleAppearance::SliderThumbHorizontal && style.usedAppearance() != StyleAppearance::SliderThumbVertical)
         return;
 
     // Enforce "border-radius: 50%".
@@ -930,7 +930,7 @@ void RenderThemeIOS::adjustButtonStyle(RenderStyle& style, const Element* elemen
     }
 
 #if ENABLE(INPUT_TYPE_COLOR)
-    if (style.effectiveAppearance() == StyleAppearance::ColorWell)
+    if (style.usedAppearance() == StyleAppearance::ColorWell)
         return;
 #endif
 
@@ -1044,7 +1044,7 @@ bool RenderThemeIOS::supportsFocusRing(const RenderStyle&) const
 bool RenderThemeIOS::supportsBoxShadow(const RenderStyle& style) const
 {
     // FIXME: See if additional native controls can support box shadows.
-    switch (style.effectiveAppearance()) {
+    switch (style.usedAppearance()) {
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderThumbVertical:
         return true;
@@ -1770,7 +1770,7 @@ void RenderThemeIOS::paintSliderTicks(const RenderObject& box, const PaintInfo& 
     FloatRect tickRect;
     FloatRoundedRect::Radii tickCornerRadii(tickCornerRadius);
 
-    bool isHorizontal = box.style().effectiveAppearance() == StyleAppearance::SliderHorizontal;
+    bool isHorizontal = box.style().usedAppearance() == StyleAppearance::SliderHorizontal;
     if (isHorizontal) {
         tickRect.setWidth(tickWidth);
         tickRect.setHeight(tickHeight);

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -186,7 +186,7 @@ RenderThemeMac::RenderThemeMac()
 
 bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& renderer) const
 {
-    auto type = renderer.style().effectiveAppearance();
+    auto type = renderer.style().usedAppearance();
     return type == StyleAppearance::Button
         || type == StyleAppearance::Checkbox
 #if ENABLE(APPLE_PAY)
@@ -220,7 +220,7 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
 
 bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& renderer) const
 {
-    auto appearance = renderer.style().effectiveAppearance();
+    auto appearance = renderer.style().usedAppearance();
     return appearance == StyleAppearance::Listbox
         || appearance == StyleAppearance::TextArea
         || appearance == StyleAppearance::TextField;
@@ -228,12 +228,12 @@ bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& rende
 
 bool RenderThemeMac::canCreateControlPartForDecorations(const RenderObject& renderer) const
 {
-    return renderer.style().effectiveAppearance() == StyleAppearance::MenulistButton;
+    return renderer.style().usedAppearance() == StyleAppearance::MenulistButton;
 }
 
 int RenderThemeMac::baselinePosition(const RenderBox& renderer) const
 {
-    auto appearance = renderer.style().effectiveAppearance();
+    auto appearance = renderer.style().usedAppearance();
     auto baseline = RenderTheme::baselinePosition(renderer);
     if ((appearance == StyleAppearance::Checkbox || appearance == StyleAppearance::Radio) && renderer.isHorizontalWritingMode())
         return baseline - (2 * renderer.style().effectiveZoom());
@@ -689,7 +689,7 @@ bool RenderThemeMac::searchFieldShouldAppearAsTextField(const RenderStyle& style
 
 bool RenderThemeMac::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const
 {
-    auto appearance = style.effectiveAppearance();
+    auto appearance = style.usedAppearance();
     if (appearance == StyleAppearance::TextField || appearance == StyleAppearance::TextArea || appearance == StyleAppearance::SearchField || appearance == StyleAppearance::Listbox)
         return style.border() != userAgentStyle.border();
 
@@ -779,7 +779,7 @@ static const int* popupButtonPadding(NSControlSize size, bool isRTL)
 
 void RenderThemeMac::inflateRectForControlRenderer(const RenderObject& renderer, FloatRect& rect)
 {
-    auto appearance = renderer.style().effectiveAppearance();
+    auto appearance = renderer.style().usedAppearance();
 
     switch (appearance) {
     case StyleAppearance::Button:
@@ -789,7 +789,7 @@ void RenderThemeMac::inflateRectForControlRenderer(const RenderObject& renderer,
     case StyleAppearance::PushButton:
     case StyleAppearance::Radio:
     case StyleAppearance::Switch:
-        ThemeMac::inflateControlPaintRect(renderer.style().effectiveAppearance(), rect, renderer.style().effectiveZoom(), !renderer.style().isHorizontalWritingMode());
+        ThemeMac::inflateControlPaintRect(renderer.style().usedAppearance(), rect, renderer.style().effectiveZoom(), !renderer.style().isHorizontalWritingMode());
         break;
     case StyleAppearance::Menulist: {
         auto zoomLevel = renderer.style().effectiveZoom();
@@ -824,7 +824,7 @@ bool RenderThemeMac::controlSupportsTints(const RenderObject& o) const
         return false;
 
     // Checkboxes only have tint when checked.
-    if (o.style().effectiveAppearance() == StyleAppearance::Checkbox)
+    if (o.style().usedAppearance() == StyleAppearance::Checkbox)
         return isChecked(o);
 
     // For now assume other controls have tint if enabled.
@@ -987,7 +987,7 @@ void RenderThemeMac::adjustMenuListStyle(RenderStyle& style, const Element* e) c
 
 LengthBox RenderThemeMac::popupInternalPaddingBox(const RenderStyle& style) const
 {
-    if (style.effectiveAppearance() == StyleAppearance::Menulist) {
+    if (style.usedAppearance() == StyleAppearance::Menulist) {
         const int* padding = popupButtonPadding(controlSizeForFont(style), style.direction() == TextDirection::RTL);
         return { static_cast<int>(padding[topPadding] * style.effectiveZoom()),
             static_cast<int>(padding[rightPadding] * style.effectiveZoom()),
@@ -995,7 +995,7 @@ LengthBox RenderThemeMac::popupInternalPaddingBox(const RenderStyle& style) cons
             static_cast<int>(padding[leftPadding] * style.effectiveZoom()) };
     }
 
-    if (style.effectiveAppearance() == StyleAppearance::MenulistButton) {
+    if (style.usedAppearance() == StyleAppearance::MenulistButton) {
         float arrowWidth = baseArrowWidth * (style.computedFontSize() / baseFontSize);
         float rightPadding = ceilf(arrowWidth + (arrowPaddingBefore + arrowPaddingAfter + paddingBeforeSeparator) * style.effectiveZoom());
         float leftPadding = styledPopupPaddingLeft * style.effectiveZoom();
@@ -1181,7 +1181,7 @@ constexpr int sliderThumbThickness = 17;
 void RenderThemeMac::adjustSliderThumbSize(RenderStyle& style, const Element*) const
 {
     float zoomLevel = style.effectiveZoom();
-    if (style.effectiveAppearance() == StyleAppearance::SliderThumbHorizontal || style.effectiveAppearance() == StyleAppearance::SliderThumbVertical) {
+    if (style.usedAppearance() == StyleAppearance::SliderThumbHorizontal || style.usedAppearance() == StyleAppearance::SliderThumbVertical) {
         style.setWidth(Length(static_cast<int>(sliderThumbThickness * zoomLevel), LengthType::Fixed));
         style.setHeight(Length(static_cast<int>(sliderThumbThickness * zoomLevel), LengthType::Fixed));
     }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -551,7 +551,7 @@ static inline unsigned computeFontHash(const FontCascade& font)
 unsigned RenderStyle::hashForTextAutosizing() const
 {
     // FIXME: Not a very smart hash. Could be improved upon. See <https://bugs.webkit.org/show_bug.cgi?id=121131>.
-    unsigned hash = m_nonInheritedData->miscData->effectiveAppearance;
+    unsigned hash = m_nonInheritedData->miscData->usedAppearance;
     hash ^= m_nonInheritedData->rareData->lineClamp.value();
     hash ^= m_rareInheritedData->overflowWrap;
     hash ^= m_rareInheritedData->nbspMode;
@@ -571,7 +571,7 @@ unsigned RenderStyle::hashForTextAutosizing() const
 
 bool RenderStyle::equalForTextAutosizing(const RenderStyle& other) const
 {
-    return m_nonInheritedData->miscData->effectiveAppearance == other.m_nonInheritedData->miscData->effectiveAppearance
+    return m_nonInheritedData->miscData->usedAppearance == other.m_nonInheritedData->miscData->usedAppearance
         && m_nonInheritedData->rareData->lineClamp == other.m_nonInheritedData->rareData->lineClamp
         && m_rareInheritedData->textSizeAdjust == other.m_rareInheritedData->textSizeAdjust
         && m_rareInheritedData->overflowWrap == other.m_rareInheritedData->overflowWrap
@@ -735,7 +735,7 @@ static bool miscDataChangeRequiresLayout(const StyleMiscNonInheritedData& first,
 {
     ASSERT(&first != &second);
 
-    if (first.effectiveAppearance != second.effectiveAppearance
+    if (first.usedAppearance != second.usedAppearance
         || first.textOverflow != second.textOverflow)
         return true;
 
@@ -1798,7 +1798,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // hasExplicitlySetDirection
         // hasExplicitlySetWritingMode
         // appearance
-        // effectiveAppearance
+        // usedAppearance
         // userDrag
     };
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -699,7 +699,7 @@ public:
     inline float opacity() const;
     inline bool hasOpacity() const;
     inline StyleAppearance appearance() const;
-    inline StyleAppearance effectiveAppearance() const;
+    inline StyleAppearance usedAppearance() const;
     inline AspectRatioType aspectRatioType() const;
     inline double aspectRatioWidth() const;
     inline double aspectRatioHeight() const;
@@ -1388,7 +1388,7 @@ public:
     inline void setHasAutoAccentColor();
     inline void setOpacity(float);
     inline void setAppearance(StyleAppearance);
-    inline void setEffectiveAppearance(StyleAppearance);
+    inline void setUsedAppearance(StyleAppearance);
     inline void setBoxAlign(BoxAlignment);
     void setBoxDirection(BoxDirection d) { m_inheritedFlags.boxDirection = static_cast<unsigned>(d); }
     inline void setBoxFlex(float);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -195,7 +195,7 @@ inline const ContentData* RenderStyle::contentData() const { return m_nonInherit
 inline bool RenderStyle::contentDataEquivalent(const RenderStyle* otherStyle) const { return m_nonInheritedData->miscData->contentDataEquivalent(*otherStyle->m_nonInheritedData->miscData); }
 inline ContentVisibility RenderStyle::contentVisibility() const { return static_cast<ContentVisibility>(m_nonInheritedData->rareData->contentVisibility); }
 inline CursorList* RenderStyle::cursors() const { return m_rareInheritedData->cursorData.get(); }
-inline StyleAppearance RenderStyle::effectiveAppearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->effectiveAppearance); }
+inline StyleAppearance RenderStyle::usedAppearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->usedAppearance); }
 inline OptionSet<Containment> RenderStyle::effectiveContainment() const { return m_nonInheritedData->rareData->effectiveContainment(); }
 inline bool RenderStyle::effectiveInert() const { return m_rareInheritedData->effectiveInert; }
 inline PointerEvents RenderStyle::effectivePointerEvents() const { return effectiveInert() ? PointerEvents::None : pointerEvents(); }
@@ -274,7 +274,7 @@ inline bool RenderStyle::hasBorderImageOutsets() const { return borderImage().ha
 inline bool RenderStyle::hasBorderRadius() const { return border().hasBorderRadius(); }
 inline bool RenderStyle::hasClip() const { return m_nonInheritedData->rareData->hasClip; }
 inline bool RenderStyle::hasContent() const { return contentData(); }
-inline bool RenderStyle::hasEffectiveAppearance() const { return effectiveAppearance() != StyleAppearance::None; }
+inline bool RenderStyle::hasEffectiveAppearance() const { return usedAppearance() != StyleAppearance::None; }
 inline bool RenderStyle::hasEffectiveContentNone() const { return !contentData() && (m_nonInheritedFlags.hasContentNone || pseudoElementType() == PseudoId::Before || pseudoElementType() == PseudoId::After); }
 inline bool RenderStyle::hasExplicitlySetBorderBottomLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomLeftRadius; }
 inline bool RenderStyle::hasExplicitlySetBorderBottomRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderBottomRightRadius; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -79,7 +79,7 @@ inline void RenderStyle::setAlignItems(const StyleSelfAlignmentData& data) { SET
 inline void RenderStyle::setAlignItemsPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().alignItems.setPosition(position); }
 inline void RenderStyle::setAlignSelf(const StyleSelfAlignmentData& data) { SET_NESTED(m_nonInheritedData, miscData, alignSelf, data); }
 inline void RenderStyle::setAlignSelfPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().alignSelf.setPosition(position); }
-inline void RenderStyle::setAppearance(StyleAppearance appearance) { SET_NESTED_PAIR(m_nonInheritedData, miscData, appearance, static_cast<unsigned>(appearance), effectiveAppearance, static_cast<unsigned>(appearance)); }
+inline void RenderStyle::setAppearance(StyleAppearance appearance) { SET_NESTED_PAIR(m_nonInheritedData, miscData, appearance, static_cast<unsigned>(appearance), usedAppearance, static_cast<unsigned>(appearance)); }
 inline void RenderStyle::setAppleColorFilter(const FilterOperations& ops) { SET_NESTED(m_rareInheritedData, appleColorFilter, operations, ops); }
 inline void RenderStyle::setAspectRatio(double width, double height) { SET_NESTED_PAIR(m_nonInheritedData, miscData, aspectRatioWidth, width, aspectRatioHeight, height); }
 inline void RenderStyle::setAspectRatioType(AspectRatioType aspectRatioType) { SET_NESTED(m_nonInheritedData, miscData, aspectRatioType, static_cast<unsigned>(aspectRatioType)); }
@@ -151,7 +151,7 @@ inline void RenderStyle::setContainIntrinsicWidthType(ContainIntrinsicSizeType c
 inline void RenderStyle::setContainerNames(const Vector<Style::ScopedName>& names) { SET_NESTED(m_nonInheritedData, rareData, containerNames, names); }
 inline void RenderStyle::setContainerType(ContainerType type) { SET_NESTED(m_nonInheritedData, rareData, containerType, static_cast<unsigned>(type)); }
 inline void RenderStyle::setContentVisibility(ContentVisibility value) { SET_NESTED(m_nonInheritedData, rareData, contentVisibility, static_cast<unsigned>(value)); }
-inline void RenderStyle::setEffectiveAppearance(StyleAppearance a) { SET_NESTED(m_nonInheritedData, miscData, effectiveAppearance, static_cast<unsigned>(a)); }
+inline void RenderStyle::setUsedAppearance(StyleAppearance a) { SET_NESTED(m_nonInheritedData, miscData, usedAppearance, static_cast<unsigned>(a)); }
 inline void RenderStyle::setEffectiveInert(bool effectiveInert) { SET(m_rareInheritedData, effectiveInert, effectiveInert); }
 inline void RenderStyle::setEffectiveTouchActions(OptionSet<TouchAction> touchActions) { SET(m_rareInheritedData, effectiveTouchActions, touchActions); }
 inline void RenderStyle::setEventListenerRegionTypes(OptionSet<EventListenerRegionType> eventListenerTypes) { SET(m_rareInheritedData, eventListenerRegionTypes, eventListenerTypes); }

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
@@ -64,7 +64,7 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData()
     , order(RenderStyle::initialOrder())
     , aspectRatioType(static_cast<unsigned>(RenderStyle::initialAspectRatioType()))
     , appearance(static_cast<unsigned>(RenderStyle::initialAppearance()))
-    , effectiveAppearance(static_cast<unsigned>(RenderStyle::initialAppearance()))
+    , usedAppearance(static_cast<unsigned>(RenderStyle::initialAppearance()))
     , textOverflow(static_cast<unsigned>(RenderStyle::initialTextOverflow()))
     , userDrag(static_cast<unsigned>(RenderStyle::initialUserDrag()))
     , objectFit(static_cast<unsigned>(RenderStyle::initialObjectFit()))
@@ -105,7 +105,7 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData(const StyleMiscNonInherited
     , hasExplicitlySetWritingMode(o.hasExplicitlySetWritingMode)
     , aspectRatioType(o.aspectRatioType)
     , appearance(o.appearance)
-    , effectiveAppearance(o.effectiveAppearance)
+    , usedAppearance(o.usedAppearance)
     , textOverflow(o.textOverflow)
     , userDrag(o.userDrag)
     , objectFit(o.objectFit)
@@ -153,7 +153,7 @@ bool StyleMiscNonInheritedData::operator==(const StyleMiscNonInheritedData& o) c
         && hasExplicitlySetWritingMode == o.hasExplicitlySetWritingMode
         && aspectRatioType == o.aspectRatioType
         && appearance == o.appearance
-        && effectiveAppearance == o.effectiveAppearance
+        && usedAppearance == o.usedAppearance
         && textOverflow == o.textOverflow
         && userDrag == o.userDrag
         && objectFit == o.objectFit

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -98,7 +98,7 @@ public:
     unsigned hasExplicitlySetWritingMode : 1 { false };
     unsigned aspectRatioType : 2; // AspectRatioType
     unsigned appearance : appearanceBitWidth; // EAppearance
-    unsigned effectiveAppearance : appearanceBitWidth; // EAppearance
+    unsigned usedAppearance : appearanceBitWidth; // EAppearance
     unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
     unsigned userDrag : 2; // UserDrag
     unsigned objectFit : 3; // ObjectFit

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -287,7 +287,7 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(element); (input && input->isSearchField())
         || element.hasTagName(HTMLNames::meterTag)
         || is<HTMLProgressElement>(element)) {
-        if (existingStyle && update.style->effectiveAppearance() != existingStyle->effectiveAppearance()) {
+        if (existingStyle && update.style->usedAppearance() != existingStyle->usedAppearance()) {
             update.change = Change::Renderer;
             descendantsToResolve = DescendantsToResolve::All;
         }


### PR DESCRIPTION
#### c9cc9abad98277eaf64ffcea10679967a4114b45
<pre>
Rename RenderStyle effectiveAppearance() to usedAppearance()
<a href="https://bugs.webkit.org/show_bug.cgi?id=270701">https://bugs.webkit.org/show_bug.cgi?id=270701</a>

Reviewed by Sam Weinig.

This aligns it with terminology used in CSS standards.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::isApplePayButton const):
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::orientation const):
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::createElementRenderer):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::handleKeydownEvent):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::hasVerticalAppearance):
(WebCore::SliderThumbElement::resolveCustomStyle):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::searchFieldStyleHasExplicitlySpecifiedTextFieldAppearance):
(WebCore::SearchFieldResultsButtonElement::resolveCustomStyle):
* Source/WebCore/layout/integration/inline/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateLayoutBoxDimensions):
* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::shouldDrawBorder const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::baselinePosition const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::ensureControlPart):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterStyleChange):
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterLayout):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::menuStyle const):
(RenderMenuList::clientPaddingLeft const):
(RenderMenuList::clientPaddingRight const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::createControlPart const):
(WebCore::effectiveRendererForAppearance):
(WebCore::RenderTheme::paint):
(WebCore::RenderTheme::paintBorderOnly):
(WebCore::RenderTheme::paintDecorations):
(WebCore::RenderTheme::isControlStyled const):
(WebCore::RenderTheme::supportsFocusRing const):
(WebCore::RenderTheme::isDefault const):
(WebCore::RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle const):
(WebCore::RenderTheme::paintSliderTicks):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::supportsFocusRing const):
(WebCore::RenderThemeAdwaita::popupInternalPaddingBox const):
(WebCore::RenderThemeAdwaita::paintSliderTrack):
(WebCore::RenderThemeAdwaita::adjustSliderThumbSize const):
(WebCore::RenderThemeAdwaita::paintSliderThumb):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::canCreateControlPartForRenderer const):
(WebCore::RenderThemeIOS::adjustedPaintRect const):
(WebCore::RenderThemeIOS::baselinePosition const):
(WebCore::RenderThemeIOS::isControlStyled const):
(WebCore::RenderThemeIOS::popupInternalPaddingBox const):
(WebCore::RenderThemeIOS::adjustRoundBorderRadius):
(WebCore::RenderThemeIOS::paintSliderTrack):
(WebCore::RenderThemeIOS::adjustSliderThumbSize const):
(WebCore::RenderThemeIOS::adjustButtonStyle const):
(WebCore::RenderThemeIOS::supportsBoxShadow const):
(WebCore::RenderThemeIOS::paintSliderTicks):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::RenderThemeMac::canCreateControlPartForBorderOnly const):
(WebCore::RenderThemeMac::canCreateControlPartForDecorations const):
(WebCore::RenderThemeMac::baselinePosition const):
(WebCore::RenderThemeMac::isControlStyled const):
(WebCore::RenderThemeMac::inflateRectForControlRenderer):
(WebCore::RenderThemeMac::controlSupportsTints const):
(WebCore::RenderThemeMac::popupInternalPaddingBox const):
(WebCore::RenderThemeMac::adjustSliderThumbSize const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::hashForTextAutosizing const):
(WebCore::RenderStyle::equalForTextAutosizing const):
(WebCore::miscDataChangeRequiresLayout):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::usedAppearance const):
(WebCore::RenderStyle::hasEffectiveAppearance const):
(WebCore::RenderStyle::effectiveAppearance const): Deleted.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setAppearance):
(WebCore::RenderStyle::setUsedAppearance):
(WebCore::RenderStyle::setEffectiveAppearance): Deleted.
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp:
(WebCore::StyleMiscNonInheritedData::StyleMiscNonInheritedData):
(WebCore::StyleMiscNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):

Canonical link: <a href="https://commits.webkit.org/275850@main">https://commits.webkit.org/275850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72ebfc8cad552b8ae22c3a37f91af57b8a65ed07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43033 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16582 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38118 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47191 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14738 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19485 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9585 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->