### PR TITLE
Add iOS and iPadOS to baseline search paths for visionOS

### DIFF
--- a/Tools/Scripts/webkitpy/port/visionos.py
+++ b/Tools/Scripts/webkitpy/port/visionos.py
@@ -56,6 +56,10 @@ class VisionOSPort(DevicePort):
         return VersionNameMap.map(self.host.platform).to_name(self._os_version, platform=VisionOSPort.port_name)
 
     def default_baseline_search_path(self, **kwargs):
+        wk_string = 'wk1'
+        if self.get_option('webkit_test_runner'):
+            wk_string = 'wk2'
+
         versions_to_fallback = []
         if self.device_version() == self.CURRENT_VERSION:
             versions_to_fallback = [self.CURRENT_VERSION]
@@ -91,6 +95,22 @@ class VisionOSPort(DevicePort):
         if apple_additions():
             expectations.append(self._apple_baseline_path(VisionOSPort.port_name))
         expectations.append(self._webkit_baseline_path(VisionOSPort.port_name))
+
+        override_variants = []
+        if 'simulator' in self.SDK:
+            override_variants.append('ipad-simulator')
+        override_variants.append('ipad')
+        if 'simulator' in self.SDK:
+            override_variants.append('ios-simulator')
+        override_variants.append('ios')
+
+        for variant in override_variants:
+            if apple_additions():
+                expectations.append(self._apple_baseline_path(u'{}-{}'.format(variant, wk_string)))
+            expectations.append(self._webkit_baseline_path(u'{}-{}'.format(variant, wk_string)))
+            if apple_additions():
+                expectations.append(self._apple_baseline_path(variant))
+            expectations.append(self._webkit_baseline_path(variant))
 
         expectations.append(self._webkit_baseline_path('wk2'))
 

--- a/Tools/Scripts/webkitpy/port/visionos_testcase.py
+++ b/Tools/Scripts/webkitpy/port/visionos_testcase.py
@@ -44,5 +44,7 @@ class VisionOSTest(darwin_testcase.DarwinTest):
 
     def test_baseline_searchpath(self):
         search_path = self.make_port().default_baseline_search_path()
+        print(search_path)
         self.assertEqual(search_path[-1], '/mock-checkout/LayoutTests/platform/wk2')
-        self.assertEqual(search_path[-2], '/mock-checkout/LayoutTests/platform/visionos')
+        self.assertEqual(search_path[-2], '/mock-checkout/LayoutTests/platform/ios')
+        self.assertEqual(search_path[-10], '/mock-checkout/LayoutTests/platform/visionos')


### PR DESCRIPTION
#### a0e74aa8f57ae719c7939c7aeea5d5122b7854e5
<pre>
Add iOS and iPadOS to baseline search paths for visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=270702">https://bugs.webkit.org/show_bug.cgi?id=270702</a>
<a href="https://rdar.apple.com/124280089">rdar://124280089</a>

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/webkitpy/port/visionos.py:
(VisionOSPort.default_baseline_search_path):
* Tools/Scripts/webkitpy/port/visionos_testcase.py:
(VisionOSTest.test_baseline_searchpath):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0e74aa8f57ae719c7939c7aeea5d5122b7854e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19488 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35587 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19101 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37066 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16583 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/42910 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16692 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38123 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1095 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39222 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38454 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47197 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/17912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14742 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42366 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19491 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41023 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->