### PR TITLE
Fix some assertions when using a canvas without a layer with webgpu

### DIFF
--- a/LayoutTests/fast/webgpu/use-canvas-without-layer-expected.txt
+++ b/LayoutTests/fast/webgpu/use-canvas-without-layer-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/use-canvas-without-layer.html
+++ b/LayoutTests/fast/webgpu/use-canvas-without-layer.html
@@ -1,0 +1,23 @@
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+onload = async () => {
+  try {
+    let adapter12 = await navigator.gpu.requestAdapter({ });
+    let device10 = await adapter12.requestDevice({ label: '\u0678' } );
+    let canvas25 = document.createElement('canvas');
+    canvas25.height = 1419621282;
+    let gpuCanvasContext17 = canvas25.getContext('webgpu');
+    gpuCanvasContext17.configure(
+    {
+    device: device10,
+    format: 'rgba16float',
+    colorSpace: 'srgb',
+    alphaMode: 'premultiplied',
+    }
+    );
+    let texture95 = gpuCanvasContext17.getCurrentTexture();
+  } catch (e) { }
+  if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash.

--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -77,14 +77,20 @@ Ref<WGSLLanguageFeatures> GPU::wgslLanguageFeatures() const
     return m_wgslLanguageFeatures;
 }
 
-Ref<GPUPresentationContext> GPU::createPresentationContext(const GPUPresentationContextDescriptor& presentationContextDescriptor)
+RefPtr<GPUPresentationContext> GPU::createPresentationContext(const GPUPresentationContextDescriptor& presentationContextDescriptor)
 {
-    return GPUPresentationContext::create(m_backing->createPresentationContext(presentationContextDescriptor.convertToBacking()));
+    RefPtr context = m_backing->createPresentationContext(presentationContextDescriptor.convertToBacking());
+    if (!context)
+        return nullptr;
+    return GPUPresentationContext::create(context.releaseNonNull());
 }
 
-Ref<GPUCompositorIntegration> GPU::createCompositorIntegration()
+RefPtr<GPUCompositorIntegration> GPU::createCompositorIntegration()
 {
-    return GPUCompositorIntegration::create(m_backing->createCompositorIntegration());
+    RefPtr integration = m_backing->createCompositorIntegration();
+    if (!integration)
+        return nullptr;
+    return GPUCompositorIntegration::create(integration.releaseNonNull());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPU.h
+++ b/Source/WebCore/Modules/WebGPU/GPU.h
@@ -58,9 +58,9 @@ public:
     GPUTextureFormat getPreferredCanvasFormat() const;
     Ref<WGSLLanguageFeatures> wgslLanguageFeatures() const;
 
-    Ref<GPUPresentationContext> createPresentationContext(const GPUPresentationContextDescriptor&);
+    RefPtr<GPUPresentationContext> createPresentationContext(const GPUPresentationContextDescriptor&);
 
-    Ref<GPUCompositorIntegration> createCompositorIntegration();
+    RefPtr<GPUCompositorIntegration> createCompositorIntegration();
 
     void paintToCanvas(NativeImage&, const IntSize&, GraphicsContext&);
 

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
@@ -56,8 +56,8 @@ public:
     String label() const;
     void setLabel(String&&);
 
-    Ref<GPURenderPassEncoder> beginRenderPass(const GPURenderPassDescriptor&);
-    Ref<GPUComputePassEncoder> beginComputePass(const std::optional<GPUComputePassDescriptor>&);
+    ExceptionOr<Ref<GPURenderPassEncoder>> beginRenderPass(const GPURenderPassDescriptor&);
+    ExceptionOr<Ref<GPUComputePassEncoder>> beginComputePass(const std::optional<GPUComputePassDescriptor>&);
 
     void copyBufferToBuffer(
         const GPUBuffer& source,
@@ -99,7 +99,7 @@ public:
         const GPUBuffer& destination,
         GPUSize64 destinationOffset);
 
-    Ref<GPUCommandBuffer> finish(const std::optional<GPUCommandBufferDescriptor>&);
+    ExceptionOr<Ref<GPUCommandBuffer>> finish(const std::optional<GPUCommandBufferDescriptor>&);
 
     WebGPU::CommandEncoder& backing() { return m_backing; }
     const WebGPU::CommandEncoder& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -102,22 +102,22 @@ public:
     ExceptionOr<Ref<GPUBuffer>> createBuffer(const GPUBufferDescriptor&);
     ExceptionOr<Ref<GPUTexture>> createTexture(const GPUTextureDescriptor&);
     bool isSupportedFormat(GPUTextureFormat) const;
-    Ref<GPUSampler> createSampler(const std::optional<GPUSamplerDescriptor>&);
-    Ref<GPUExternalTexture> importExternalTexture(const GPUExternalTextureDescriptor&);
+    ExceptionOr<Ref<GPUSampler>> createSampler(const std::optional<GPUSamplerDescriptor>&);
+    ExceptionOr<Ref<GPUExternalTexture>> importExternalTexture(const GPUExternalTextureDescriptor&);
 
     ExceptionOr<Ref<GPUBindGroupLayout>> createBindGroupLayout(const GPUBindGroupLayoutDescriptor&);
-    Ref<GPUPipelineLayout> createPipelineLayout(const GPUPipelineLayoutDescriptor&);
-    Ref<GPUBindGroup> createBindGroup(const GPUBindGroupDescriptor&);
+    ExceptionOr<Ref<GPUPipelineLayout>> createPipelineLayout(const GPUPipelineLayoutDescriptor&);
+    ExceptionOr<Ref<GPUBindGroup>> createBindGroup(const GPUBindGroupDescriptor&);
 
-    Ref<GPUShaderModule> createShaderModule(const GPUShaderModuleDescriptor&);
-    Ref<GPUComputePipeline> createComputePipeline(const GPUComputePipelineDescriptor&);
+    ExceptionOr<Ref<GPUShaderModule>> createShaderModule(const GPUShaderModuleDescriptor&);
+    ExceptionOr<Ref<GPUComputePipeline>> createComputePipeline(const GPUComputePipelineDescriptor&);
     ExceptionOr<Ref<GPURenderPipeline>> createRenderPipeline(const GPURenderPipelineDescriptor&);
     using CreateComputePipelineAsyncPromise = DOMPromiseDeferred<IDLInterface<GPUComputePipeline>>;
     void createComputePipelineAsync(const GPUComputePipelineDescriptor&, CreateComputePipelineAsyncPromise&&);
     using CreateRenderPipelineAsyncPromise = DOMPromiseDeferred<IDLInterface<GPURenderPipeline>>;
     ExceptionOr<void> createRenderPipelineAsync(const GPURenderPipelineDescriptor&, CreateRenderPipelineAsyncPromise&&);
 
-    Ref<GPUCommandEncoder> createCommandEncoder(const std::optional<GPUCommandEncoderDescriptor>&);
+    ExceptionOr<Ref<GPUCommandEncoder>> createCommandEncoder(const std::optional<GPUCommandEncoderDescriptor>&);
     ExceptionOr<Ref<GPURenderBundleEncoder>> createRenderBundleEncoder(const GPURenderBundleEncoderDescriptor&);
 
     ExceptionOr<Ref<GPUQuerySet>> createQuerySet(const GPUQuerySetDescriptor&);
@@ -147,7 +147,7 @@ private:
     // ActiveDOMObject.
     // FIXME: We probably need to override more methods to make this work properly.
     const char* activeDOMObjectName() const final { return "GPUDevice"; }
-    Ref<GPUPipelineLayout> createAutoPipelineLayout();
+    RefPtr<GPUPipelineLayout> createAutoPipelineLayout();
 
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::GPUDevice; }
@@ -158,7 +158,7 @@ private:
     UniqueRef<LostPromise> m_lostPromise;
     Ref<WebGPU::Device> m_backing;
     Ref<GPUQueue> m_queue;
-    Ref<GPUPipelineLayout> m_autoPipelineLayout;
+    RefPtr<GPUPipelineLayout> m_autoPipelineLayout;
     WeakHashSet<GPUBuffer> m_buffersToUnmap;
     GPUExternalTexture* externalTextureForDescriptor(const GPUExternalTextureDescriptor&);
 

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
@@ -33,10 +33,11 @@
 
 namespace WebCore {
 
-void GPUPresentationContext::configure(const GPUCanvasConfiguration& canvasConfiguration, GPUIntegerCoordinate width, GPUIntegerCoordinate height)
+bool GPUPresentationContext::configure(const GPUCanvasConfiguration& canvasConfiguration, GPUIntegerCoordinate width, GPUIntegerCoordinate height)
 {
     m_device = canvasConfiguration.device.get();
-    m_backing->configure(canvasConfiguration.convertToBacking());
+    if (!m_backing->configure(canvasConfiguration.convertToBacking()))
+        return false;
     m_textureDescriptor = GPUTextureDescriptor {
         { "canvas backing"_s },
         GPUExtent3DDict { width, height, 1 },
@@ -47,6 +48,7 @@ void GPUPresentationContext::configure(const GPUCanvasConfiguration& canvasConfi
         canvasConfiguration.usage,
         canvasConfiguration.viewFormats
     };
+    return true;
 }
 
 void GPUPresentationContext::unconfigure()

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
@@ -49,7 +49,7 @@ public:
         return adoptRef(*new GPUPresentationContext(WTFMove(backing)));
     }
 
-    void configure(const GPUCanvasConfiguration&, GPUIntegerCoordinate, GPUIntegerCoordinate);
+    WARN_UNUSED_RETURN bool configure(const GPUCanvasConfiguration&, GPUIntegerCoordinate, GPUIntegerCoordinate);
     void unconfigure();
 
     RefPtr<GPUTexture> getCurrentTexture();

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
@@ -125,9 +125,12 @@ static WebGPU::RenderBundleDescriptor convertToBacking(const std::optional<GPURe
     return renderBundleDescriptor->convertToBacking();
 }
 
-Ref<GPURenderBundle> GPURenderBundleEncoder::finish(const std::optional<GPURenderBundleDescriptor>& renderBundleDescriptor)
+ExceptionOr<Ref<GPURenderBundle>> GPURenderBundleEncoder::finish(const std::optional<GPURenderBundleDescriptor>& renderBundleDescriptor)
 {
-    return GPURenderBundle::create(m_backing->finish(convertToBacking(renderBundleDescriptor)));
+    RefPtr bundle = m_backing->finish(convertToBacking(renderBundleDescriptor));
+    if (!bundle)
+        return Exception { ExceptionCode::InvalidStateError, "dynamic offsets overflowed"_s };
+    return GPURenderBundle::create(bundle.releaseNonNull());
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h
@@ -81,7 +81,7 @@ public:
     void popDebugGroup();
     void insertDebugMarker(String&& markerLabel);
 
-    Ref<GPURenderBundle> finish(const std::optional<GPURenderBundleDescriptor>&);
+    ExceptionOr<Ref<GPURenderBundle>> finish(const std::optional<GPURenderBundleDescriptor>&);
 
     WebGPU::RenderBundleEncoder& backing() { return m_backing; }
     const WebGPU::RenderBundleEncoder& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
@@ -104,7 +104,10 @@ ExceptionOr<Ref<GPUTextureView>> GPUTexture::createView(const std::optional<GPUT
         if (!m_device->isSupportedFormat(*textureViewDescriptor->format))
             return Exception { ExceptionCode::TypeError, "GPUTexture.createView: Unsupported texture format."_s };
     }
-    return GPUTextureView::create(m_backing->createView(convertToBacking(textureViewDescriptor)));
+    RefPtr view = m_backing->createView(convertToBacking(textureViewDescriptor));
+    if (!view)
+        return Exception { ExceptionCode::InvalidStateError, "GPUTexture.createView: Unable to create view."_s };
+    return GPUTextureView::create(view.releaseNonNull());
 }
 
 void GPUTexture::destroy()

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -48,7 +48,7 @@ CommandEncoderImpl::CommandEncoderImpl(WebGPUPtr<WGPUCommandEncoder>&& commandEn
 
 CommandEncoderImpl::~CommandEncoderImpl() = default;
 
-Ref<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDescriptor& descriptor)
+RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -117,7 +117,7 @@ Ref<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDescr
     return RenderPassEncoderImpl::create(adoptWebGPU(wgpuCommandEncoderBeginRenderPass(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
 }
 
-Ref<ComputePassEncoder> CommandEncoderImpl::beginComputePass(const std::optional<ComputePassDescriptor>& descriptor)
+RefPtr<ComputePassEncoder> CommandEncoderImpl::beginComputePass(const std::optional<ComputePassDescriptor>& descriptor)
 {
     CString label = descriptor ? descriptor->label.utf8() : CString("");
 
@@ -266,7 +266,7 @@ void CommandEncoderImpl::resolveQuerySet(
     wgpuCommandEncoderResolveQuerySet(m_backing.get(), m_convertToBackingContext->convertToBacking(querySet), firstQuery, queryCount, m_convertToBackingContext->convertToBacking(destination), destinationOffset);
 }
 
-Ref<CommandBuffer> CommandEncoderImpl::finish(const CommandBufferDescriptor& descriptor)
+RefPtr<CommandBuffer> CommandEncoderImpl::finish(const CommandBufferDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.h
@@ -57,8 +57,8 @@ private:
 
     WGPUCommandEncoder backing() const { return m_backing.get(); }
 
-    Ref<RenderPassEncoder> beginRenderPass(const RenderPassDescriptor&) final;
-    Ref<ComputePassEncoder> beginComputePass(const std::optional<ComputePassDescriptor>&) final;
+    RefPtr<RenderPassEncoder> beginRenderPass(const RenderPassDescriptor&) final;
+    RefPtr<ComputePassEncoder> beginComputePass(const std::optional<ComputePassDescriptor>&) final;
 
     void copyBufferToBuffer(
         const Buffer& source,
@@ -100,7 +100,7 @@ private:
         const Buffer& destination,
         Size64 destinationOffset) final;
 
-    Ref<CommandBuffer> finish(const CommandBufferDescriptor&) final;
+    RefPtr<CommandBuffer> finish(const CommandBufferDescriptor&) final;
 
     void setLabelInternal(const String&) final;
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -96,7 +96,7 @@ void DeviceImpl::destroy()
     wgpuDeviceDestroy(m_backing.get());
 }
 
-Ref<Buffer> DeviceImpl::createBuffer(const BufferDescriptor& descriptor)
+RefPtr<Buffer> DeviceImpl::createBuffer(const BufferDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -111,7 +111,7 @@ Ref<Buffer> DeviceImpl::createBuffer(const BufferDescriptor& descriptor)
     return BufferImpl::create(adoptWebGPU(wgpuDeviceCreateBuffer(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
 }
 
-Ref<Texture> DeviceImpl::createTexture(const TextureDescriptor& descriptor)
+RefPtr<Texture> DeviceImpl::createTexture(const TextureDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -135,7 +135,7 @@ Ref<Texture> DeviceImpl::createTexture(const TextureDescriptor& descriptor)
     return TextureImpl::create(adoptWebGPU(wgpuDeviceCreateTexture(m_backing.get(), &backingDescriptor)), descriptor.format, descriptor.dimension, m_convertToBackingContext);
 }
 
-Ref<Sampler> DeviceImpl::createSampler(const SamplerDescriptor& descriptor)
+RefPtr<Sampler> DeviceImpl::createSampler(const SamplerDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -167,7 +167,7 @@ static WGPUColorSpace convertToWGPUColorSpace(const PredefinedColorSpace& colorS
     }
 }
 
-Ref<ExternalTexture> DeviceImpl::importExternalTexture(const ExternalTextureDescriptor& descriptor)
+RefPtr<ExternalTexture> DeviceImpl::importExternalTexture(const ExternalTextureDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -181,7 +181,7 @@ Ref<ExternalTexture> DeviceImpl::importExternalTexture(const ExternalTextureDesc
     return ExternalTextureImpl::create(adoptWebGPU(wgpuDeviceImportExternalTexture(m_backing.get(), &backingDescriptor)), descriptor, m_convertToBackingContext);
 }
 
-Ref<BindGroupLayout> DeviceImpl::createBindGroupLayout(const BindGroupLayoutDescriptor& descriptor)
+RefPtr<BindGroupLayout> DeviceImpl::createBindGroupLayout(const BindGroupLayoutDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -226,7 +226,7 @@ Ref<BindGroupLayout> DeviceImpl::createBindGroupLayout(const BindGroupLayoutDesc
     return BindGroupLayoutImpl::create(adoptWebGPU(wgpuDeviceCreateBindGroupLayout(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
 }
 
-Ref<PipelineLayout> DeviceImpl::createPipelineLayout(const PipelineLayoutDescriptor& descriptor)
+RefPtr<PipelineLayout> DeviceImpl::createPipelineLayout(const PipelineLayoutDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -247,7 +247,7 @@ Ref<PipelineLayout> DeviceImpl::createPipelineLayout(const PipelineLayoutDescrip
     return PipelineLayoutImpl::create(adoptWebGPU(wgpuDeviceCreatePipelineLayout(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
 }
 
-Ref<BindGroup> DeviceImpl::createBindGroup(const BindGroupDescriptor& descriptor)
+RefPtr<BindGroup> DeviceImpl::createBindGroup(const BindGroupDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -283,7 +283,7 @@ Ref<BindGroup> DeviceImpl::createBindGroup(const BindGroupDescriptor& descriptor
     return BindGroupImpl::create(adoptWebGPU(wgpuDeviceCreateBindGroup(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
 }
 
-Ref<ShaderModule> DeviceImpl::createShaderModule(const ShaderModuleDescriptor& descriptor)
+RefPtr<ShaderModule> DeviceImpl::createShaderModule(const ShaderModuleDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -363,7 +363,7 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
     return callback(backingDescriptor);
 }
 
-Ref<ComputePipeline> DeviceImpl::createComputePipeline(const ComputePipelineDescriptor& descriptor)
+RefPtr<ComputePipeline> DeviceImpl::createComputePipeline(const ComputePipelineDescriptor& descriptor)
 {
     return convertToBacking(descriptor, m_convertToBackingContext, [backing = m_backing, &convertToBackingContext = m_convertToBackingContext.get()](const WGPUComputePipelineDescriptor& backingDescriptor) {
         return ComputePipelineImpl::create(adoptWebGPU(wgpuDeviceCreateComputePipeline(backing.get(), &backingDescriptor)), convertToBackingContext);
@@ -561,7 +561,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
     return callback(backingDescriptor);
 }
 
-Ref<RenderPipeline> DeviceImpl::createRenderPipeline(const RenderPipelineDescriptor& descriptor)
+RefPtr<RenderPipeline> DeviceImpl::createRenderPipeline(const RenderPipelineDescriptor& descriptor)
 {
     return convertToBacking(descriptor, m_convertToBackingContext, [backing = m_backing.copyRef(), &convertToBackingContext = m_convertToBackingContext.get()](const WGPURenderPipelineDescriptor& backingDescriptor) {
         return RenderPipelineImpl::create(adoptWebGPU(wgpuDeviceCreateRenderPipeline(backing.get(), &backingDescriptor)), convertToBackingContext);
@@ -608,7 +608,7 @@ void DeviceImpl::createRenderPipelineAsync(const RenderPipelineDescriptor& descr
     });
 }
 
-Ref<CommandEncoder> DeviceImpl::createCommandEncoder(const std::optional<CommandEncoderDescriptor>& descriptor)
+RefPtr<CommandEncoder> DeviceImpl::createCommandEncoder(const std::optional<CommandEncoderDescriptor>& descriptor)
 {
     CString label = descriptor ? descriptor->label.utf8() : CString("");
 
@@ -620,7 +620,7 @@ Ref<CommandEncoder> DeviceImpl::createCommandEncoder(const std::optional<Command
     return CommandEncoderImpl::create(adoptWebGPU(wgpuDeviceCreateCommandEncoder(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
 }
 
-Ref<RenderBundleEncoder> DeviceImpl::createRenderBundleEncoder(const RenderBundleEncoderDescriptor& descriptor)
+RefPtr<RenderBundleEncoder> DeviceImpl::createRenderBundleEncoder(const RenderBundleEncoderDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 
@@ -642,7 +642,7 @@ Ref<RenderBundleEncoder> DeviceImpl::createRenderBundleEncoder(const RenderBundl
     return RenderBundleEncoderImpl::create(adoptWebGPU(wgpuDeviceCreateRenderBundleEncoder(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
 }
 
-Ref<QuerySet> DeviceImpl::createQuerySet(const QuerySetDescriptor& descriptor)
+RefPtr<QuerySet> DeviceImpl::createQuerySet(const QuerySetDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h
@@ -65,25 +65,25 @@ private:
 
     void destroy() final;
 
-    Ref<Buffer> createBuffer(const BufferDescriptor&) final;
-    Ref<Texture> createTexture(const TextureDescriptor&) final;
-    Ref<Sampler> createSampler(const SamplerDescriptor&) final;
-    Ref<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) final;
+    RefPtr<Buffer> createBuffer(const BufferDescriptor&) final;
+    RefPtr<Texture> createTexture(const TextureDescriptor&) final;
+    RefPtr<Sampler> createSampler(const SamplerDescriptor&) final;
+    RefPtr<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) final;
 
-    Ref<BindGroupLayout> createBindGroupLayout(const BindGroupLayoutDescriptor&) final;
-    Ref<PipelineLayout> createPipelineLayout(const PipelineLayoutDescriptor&) final;
-    Ref<BindGroup> createBindGroup(const BindGroupDescriptor&) final;
+    RefPtr<BindGroupLayout> createBindGroupLayout(const BindGroupLayoutDescriptor&) final;
+    RefPtr<PipelineLayout> createPipelineLayout(const PipelineLayoutDescriptor&) final;
+    RefPtr<BindGroup> createBindGroup(const BindGroupDescriptor&) final;
 
-    Ref<ShaderModule> createShaderModule(const ShaderModuleDescriptor&) final;
-    Ref<ComputePipeline> createComputePipeline(const ComputePipelineDescriptor&) final;
-    Ref<RenderPipeline> createRenderPipeline(const RenderPipelineDescriptor&) final;
+    RefPtr<ShaderModule> createShaderModule(const ShaderModuleDescriptor&) final;
+    RefPtr<ComputePipeline> createComputePipeline(const ComputePipelineDescriptor&) final;
+    RefPtr<RenderPipeline> createRenderPipeline(const RenderPipelineDescriptor&) final;
     void createComputePipelineAsync(const ComputePipelineDescriptor&, CompletionHandler<void(RefPtr<ComputePipeline>&&)>&&) final;
     void createRenderPipelineAsync(const RenderPipelineDescriptor&, CompletionHandler<void(RefPtr<RenderPipeline>&&)>&&) final;
 
-    Ref<CommandEncoder> createCommandEncoder(const std::optional<CommandEncoderDescriptor>&) final;
-    Ref<RenderBundleEncoder> createRenderBundleEncoder(const RenderBundleEncoderDescriptor&) final;
+    RefPtr<CommandEncoder> createCommandEncoder(const std::optional<CommandEncoderDescriptor>&) final;
+    RefPtr<RenderBundleEncoder> createRenderBundleEncoder(const RenderBundleEncoderDescriptor&) final;
 
-    Ref<QuerySet> createQuerySet(const QuerySetDescriptor&) final;
+    RefPtr<QuerySet> createQuerySet(const QuerySetDescriptor&) final;
 
     void pushErrorScope(ErrorFilter) final;
     void popErrorScope(CompletionHandler<void(bool, std::optional<Error>&&)>&&) final;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
@@ -82,7 +82,7 @@ static WTF::Function<void(CompletionHandler<void()>&&)> convert(WGPUOnSubmittedW
     };
 }
 
-Ref<PresentationContext> GPUImpl::createPresentationContext(const PresentationContextDescriptor& presentationContextDescriptor)
+RefPtr<PresentationContext> GPUImpl::createPresentationContext(const PresentationContextDescriptor& presentationContextDescriptor)
 {
     auto& compositorIntegration = m_convertToBackingContext->convertToBacking(presentationContextDescriptor.compositorIntegration);
 
@@ -108,7 +108,7 @@ Ref<PresentationContext> GPUImpl::createPresentationContext(const PresentationCo
     return result;
 }
 
-Ref<CompositorIntegration> GPUImpl::createCompositorIntegration()
+RefPtr<CompositorIntegration> GPUImpl::createCompositorIntegration()
 {
     return CompositorIntegrationImpl::create(m_convertToBackingContext);
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
@@ -73,9 +73,9 @@ private:
 
     void requestAdapter(const RequestAdapterOptions&, CompletionHandler<void(RefPtr<Adapter>&&)>&&) final;
 
-    Ref<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) final;
+    RefPtr<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) final;
 
-    Ref<CompositorIntegration> createCompositorIntegration() final;
+    RefPtr<CompositorIntegration> createCompositorIntegration() final;
 
     WebGPUPtr<WGPUInstance> m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
@@ -49,7 +49,7 @@ PresentationContextImpl::PresentationContextImpl(WebGPUPtr<WGPUSurface>&& surfac
 
 PresentationContextImpl::~PresentationContextImpl() = default;
 
-void PresentationContextImpl::configure(const CanvasConfiguration& canvasConfiguration)
+bool PresentationContextImpl::configure(const CanvasConfiguration& canvasConfiguration)
 {
     m_swapChain = nullptr;
 
@@ -69,6 +69,7 @@ void PresentationContextImpl::configure(const CanvasConfiguration& canvasConfigu
     };
 
     m_swapChain = adoptWebGPU(wgpuDeviceCreateSwapChain(m_convertToBackingContext->convertToBacking(canvasConfiguration.device), m_backing.get(), &backingDescriptor));
+    return true;
 }
 
 void PresentationContextImpl::unconfigure()

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h
@@ -69,7 +69,7 @@ private:
     PresentationContextImpl& operator=(const PresentationContextImpl&) = delete;
     PresentationContextImpl& operator=(PresentationContextImpl&&) = delete;
 
-    void configure(const CanvasConfiguration&) final;
+    bool configure(const CanvasConfiguration&) final;
     void unconfigure() final;
 
     RefPtr<Texture> getCurrentTexture() final;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
@@ -115,7 +115,7 @@ void RenderBundleEncoderImpl::insertDebugMarker(String&& markerLabel)
     wgpuRenderBundleEncoderInsertDebugMarker(m_backing.get(), markerLabel.utf8().data());
 }
 
-Ref<RenderBundle> RenderBundleEncoderImpl::finish(const RenderBundleDescriptor& descriptor)
+RefPtr<RenderBundle> RenderBundleEncoderImpl::finish(const RenderBundleDescriptor& descriptor)
 {
     auto label = descriptor.label.utf8();
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
@@ -85,7 +85,7 @@ private:
     void popDebugGroup() final;
     void insertDebugMarker(String&& markerLabel) final;
 
-    Ref<RenderBundle> finish(const RenderBundleDescriptor&) final;
+    RefPtr<RenderBundle> finish(const RenderBundleDescriptor&) final;
 
     void setLabelInternal(const String&) final;
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -46,7 +46,7 @@ TextureImpl::TextureImpl(WebGPUPtr<WGPUTexture>&& texture, TextureFormat format,
 
 TextureImpl::~TextureImpl() = default;
 
-Ref<TextureView> TextureImpl::createView(const std::optional<TextureViewDescriptor>& descriptor)
+RefPtr<TextureView> TextureImpl::createView(const std::optional<TextureViewDescriptor>& descriptor)
 {
     CString label = descriptor ? descriptor->label.utf8() : CString("");
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h
@@ -60,7 +60,7 @@ private:
 
     WGPUTexture backing() const { return m_backing.get(); }
 
-    Ref<TextureView> createView(const std::optional<TextureViewDescriptor>&) final;
+    RefPtr<TextureView> createView(const std::optional<TextureViewDescriptor>&) final;
 
     void destroy() final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
@@ -54,9 +54,9 @@ public:
     virtual void ref() const = 0;
     virtual void deref() const = 0;
 
-    virtual Ref<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) = 0;
+    virtual RefPtr<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) = 0;
 
-    virtual Ref<CompositorIntegration> createCompositorIntegration() = 0;
+    virtual RefPtr<CompositorIntegration> createCompositorIntegration() = 0;
     virtual void paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&) = 0;
 
 protected:

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandEncoder.h
@@ -57,8 +57,8 @@ public:
         setLabelInternal(m_label);
     }
 
-    virtual Ref<RenderPassEncoder> beginRenderPass(const RenderPassDescriptor&) = 0;
-    virtual Ref<ComputePassEncoder> beginComputePass(const std::optional<ComputePassDescriptor>&) = 0;
+    virtual RefPtr<RenderPassEncoder> beginRenderPass(const RenderPassDescriptor&) = 0;
+    virtual RefPtr<ComputePassEncoder> beginComputePass(const std::optional<ComputePassDescriptor>&) = 0;
 
     virtual void copyBufferToBuffer(
         const Buffer& source,
@@ -100,7 +100,7 @@ public:
         const Buffer& destination,
         Size64 destinationOffset) = 0;
 
-    virtual Ref<CommandBuffer> finish(const CommandBufferDescriptor&) = 0;
+    virtual RefPtr<CommandBuffer> finish(const CommandBufferDescriptor&) = 0;
 
 protected:
     CommandEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
@@ -98,25 +98,25 @@ public:
 
     virtual void destroy() = 0;
 
-    virtual Ref<Buffer> createBuffer(const BufferDescriptor&) = 0;
-    virtual Ref<Texture> createTexture(const TextureDescriptor&) = 0;
-    virtual Ref<Sampler> createSampler(const SamplerDescriptor&) = 0;
-    virtual Ref<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) = 0;
+    virtual RefPtr<Buffer> createBuffer(const BufferDescriptor&) = 0;
+    virtual RefPtr<Texture> createTexture(const TextureDescriptor&) = 0;
+    virtual RefPtr<Sampler> createSampler(const SamplerDescriptor&) = 0;
+    virtual RefPtr<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) = 0;
 
-    virtual Ref<BindGroupLayout> createBindGroupLayout(const BindGroupLayoutDescriptor&) = 0;
-    virtual Ref<PipelineLayout> createPipelineLayout(const PipelineLayoutDescriptor&) = 0;
-    virtual Ref<BindGroup> createBindGroup(const BindGroupDescriptor&) = 0;
+    virtual RefPtr<BindGroupLayout> createBindGroupLayout(const BindGroupLayoutDescriptor&) = 0;
+    virtual RefPtr<PipelineLayout> createPipelineLayout(const PipelineLayoutDescriptor&) = 0;
+    virtual RefPtr<BindGroup> createBindGroup(const BindGroupDescriptor&) = 0;
 
-    virtual Ref<ShaderModule> createShaderModule(const ShaderModuleDescriptor&) = 0;
-    virtual Ref<ComputePipeline> createComputePipeline(const ComputePipelineDescriptor&) = 0;
-    virtual Ref<RenderPipeline> createRenderPipeline(const RenderPipelineDescriptor&) = 0;
+    virtual RefPtr<ShaderModule> createShaderModule(const ShaderModuleDescriptor&) = 0;
+    virtual RefPtr<ComputePipeline> createComputePipeline(const ComputePipelineDescriptor&) = 0;
+    virtual RefPtr<RenderPipeline> createRenderPipeline(const RenderPipelineDescriptor&) = 0;
     virtual void createComputePipelineAsync(const ComputePipelineDescriptor&, CompletionHandler<void(RefPtr<ComputePipeline>&&)>&&) = 0;
     virtual void createRenderPipelineAsync(const RenderPipelineDescriptor&, CompletionHandler<void(RefPtr<RenderPipeline>&&)>&&) = 0;
 
-    virtual Ref<CommandEncoder> createCommandEncoder(const std::optional<CommandEncoderDescriptor>&) = 0;
-    virtual Ref<RenderBundleEncoder> createRenderBundleEncoder(const RenderBundleEncoderDescriptor&) = 0;
+    virtual RefPtr<CommandEncoder> createCommandEncoder(const std::optional<CommandEncoderDescriptor>&) = 0;
+    virtual RefPtr<RenderBundleEncoder> createRenderBundleEncoder(const RenderBundleEncoderDescriptor&) = 0;
 
-    virtual Ref<QuerySet> createQuerySet(const QuerySetDescriptor&) = 0;
+    virtual RefPtr<QuerySet> createQuerySet(const QuerySetDescriptor&) = 0;
 
     virtual void pushErrorScope(ErrorFilter) = 0;
     virtual void popErrorScope(CompletionHandler<void(bool, std::optional<Error>&&)>&&) = 0;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
@@ -43,7 +43,7 @@ class PresentationContext : public RefCounted<PresentationContext> {
 public:
     virtual ~PresentationContext() = default;
 
-    virtual void configure(const CanvasConfiguration&) = 0;
+    WARN_UNUSED_RETURN virtual bool configure(const CanvasConfiguration&) = 0;
     virtual void unconfigure() = 0;
 
     virtual RefPtr<Texture> getCurrentTexture() = 0;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h
@@ -82,7 +82,7 @@ public:
     virtual void popDebugGroup() = 0;
     virtual void insertDebugMarker(String&& markerLabel) = 0;
 
-    virtual Ref<RenderBundle> finish(const RenderBundleDescriptor&) = 0;
+    virtual RefPtr<RenderBundle> finish(const RenderBundleDescriptor&) = 0;
 
 protected:
     RenderBundleEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
@@ -48,7 +48,7 @@ public:
         setLabelInternal(m_label);
     }
 
-    virtual Ref<TextureView> createView(const std::optional<TextureViewDescriptor>&) = 0;
+    virtual RefPtr<TextureView> createView(const std::optional<TextureViewDescriptor>&) = 0;
 
     virtual void destroy() = 0;
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -103,8 +103,8 @@ private:
     std::optional<Configuration> m_configuration;
 
     Ref<GPUDisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
-    Ref<GPUCompositorIntegration> m_compositorIntegration;
-    Ref<GPUPresentationContext> m_presentationContext;
+    RefPtr<GPUCompositorIntegration> m_compositorIntegration;
+    RefPtr<GPUPresentationContext> m_presentationContext;
     RefPtr<GPUTexture> m_currentTexture;
 
     GPUIntegerCoordinate m_width { 0 };

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -206,7 +206,9 @@ void PresentationContextIOSurface::unconfigure()
 
 void PresentationContextIOSurface::present()
 {
-    ASSERT(m_ioSurfaces.count == m_renderBuffers.size());
+    if (m_ioSurfaces.count != m_renderBuffers.size())
+        return;
+
     auto& textureRefPtr = m_renderBuffers[m_currentIndex].luminanceClampTexture;
     if (Texture* texturePtr = textureRefPtr.get(); texturePtr && m_computePipelineState) {
         MTLCommandBufferDescriptor *descriptor = [MTLCommandBufferDescriptor new];

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -347,7 +347,7 @@ void RemoteRenderingBackend::cacheNativeImage(ShareableBitmap::Handle&& handle, 
     m_remoteResourceCache.cacheNativeImage(image.releaseNonNull());
 }
 
-void RemoteRenderingBackend::cacheFont(const Font::Attributes& fontAttributes, FontPlatformData::Attributes platformData, std::optional<RenderingResourceIdentifier> fontCustomPlatformDataIdentifier)
+void RemoteRenderingBackend::cacheFont(const Font::Attributes& fontAttributes, FontPlatformDataAttributes platformData, std::optional<RenderingResourceIdentifier> fontCustomPlatformDataIdentifier)
 {
     ASSERT(!RunLoop::isMain());
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -147,7 +147,7 @@ private:
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&);
     void cacheFilter(Ref<WebCore::Filter>&&);
-    void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformData::Attributes, std::optional<WebCore::RenderingResourceIdentifier>);
+    void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformDataAttributes, std::optional<WebCore::RenderingResourceIdentifier>);
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
     void releaseAllDrawingResources();
     void releaseAllImageResources();

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -27,7 +27,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     ReleaseImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
     DestroyGetPixelBufferSharedMemory()
     CacheNativeImage(WebCore::ShareableBitmap::Handle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
-    CacheFont(WebCore::Font::Attributes data, WebCore::FontPlatformData::Attributes platformData, std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier) NotStreamEncodable
+    CacheFont(WebCore::Font::Attributes data, struct WebCore::FontPlatformDataAttributes platformData, std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier) NotStreamEncodable
     CacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData> customPlatformData) NotStreamEncodable
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
     CacheGradient(Ref<WebCore::Gradient> gradient) NotStreamEncodable

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -63,12 +63,11 @@ void RemoteCommandEncoder::stopListeningForIPC()
 void RemoteCommandEncoder::beginRenderPass(const WebGPU::RenderPassDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto renderPassEncoder = m_backing->beginRenderPass(*convertedDescriptor);
-    auto remoteRenderPassEncoder = RemoteRenderPassEncoder::create(renderPassEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(renderPassEncoder);
+    auto remoteRenderPassEncoder = RemoteRenderPassEncoder::create(*renderPassEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteRenderPassEncoder);
 }
 
@@ -77,14 +76,13 @@ void RemoteCommandEncoder::beginComputePass(const std::optional<WebGPU::ComputeP
     std::optional<WebCore::WebGPU::ComputePassDescriptor> convertedDescriptor;
     if (descriptor) {
         auto resultDescriptor = m_objectHeap.convertFromBacking(*descriptor);
-        ASSERT(resultDescriptor);
+        RELEASE_ASSERT(resultDescriptor);
         convertedDescriptor = WTFMove(resultDescriptor);
-        if (!convertedDescriptor)
-            return;
     }
 
     auto computePassEncoder = m_backing->beginComputePass(convertedDescriptor);
-    auto computeRenderPassEncoder = RemoteComputePassEncoder::create(computePassEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(computePassEncoder);
+    auto computeRenderPassEncoder = RemoteComputePassEncoder::create(*computePassEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, computeRenderPassEncoder);
 }
 
@@ -214,12 +212,11 @@ void RemoteCommandEncoder::resolveQuerySet(
 void RemoteCommandEncoder::finish(const WebGPU::CommandBufferDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto commandBuffer = m_backing->finish(*convertedDescriptor);
-    auto remoteCommandBuffer = RemoteCommandBuffer::create(commandBuffer, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(commandBuffer);
+    auto remoteCommandBuffer = RemoteCommandBuffer::create(*commandBuffer, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteCommandBuffer);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -126,36 +126,33 @@ void RemoteDevice::destruct()
 void RemoteDevice::createBuffer(const WebGPU::BufferDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto buffer = m_backing->createBuffer(*convertedDescriptor);
-    auto remoteBuffer = RemoteBuffer::create(buffer, m_objectHeap, m_streamConnection.copyRef(), descriptor.mappedAtCreation, identifier);
+    RELEASE_ASSERT(buffer);
+    auto remoteBuffer = RemoteBuffer::create(*buffer, m_objectHeap, m_streamConnection.copyRef(), descriptor.mappedAtCreation, identifier);
     m_objectHeap.addObject(identifier, remoteBuffer);
 }
 
 void RemoteDevice::createTexture(const WebGPU::TextureDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto texture = m_backing->createTexture(*convertedDescriptor);
-    auto remoteTexture = RemoteTexture::create(texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(texture);
+    auto remoteTexture = RemoteTexture::create(texture.releaseNonNull(), m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteTexture);
 }
 
 void RemoteDevice::createSampler(const WebGPU::SamplerDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto sampler = m_backing->createSampler(*convertedDescriptor);
-    auto remoteSampler = RemoteSampler::create(sampler, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(sampler);
+    auto remoteSampler = RemoteSampler::create(*sampler, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteSampler);
 }
 
@@ -188,12 +185,11 @@ void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTex
     }
 
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor, pixelBuffer);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto externalTexture = m_backing->importExternalTexture(*convertedDescriptor);
-    auto remoteExternalTexture = RemoteExternalTexture::create(externalTexture, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(externalTexture);
+    auto remoteExternalTexture = RemoteExternalTexture::create(*externalTexture, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteExternalTexture);
 #else
     UNUSED_PARAM(identifier);
@@ -204,71 +200,66 @@ void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTex
 void RemoteDevice::createBindGroupLayout(const WebGPU::BindGroupLayoutDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto bindGroupLayout = m_backing->createBindGroupLayout(*convertedDescriptor);
-    auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(bindGroupLayout);
+    auto remoteBindGroupLayout = RemoteBindGroupLayout::create(*bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteBindGroupLayout);
 }
 
 void RemoteDevice::createPipelineLayout(const WebGPU::PipelineLayoutDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto pipelineLayout = m_backing->createPipelineLayout(*convertedDescriptor);
-    auto remotePipelineLayout = RemotePipelineLayout::create(pipelineLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(pipelineLayout);
+    auto remotePipelineLayout = RemotePipelineLayout::create(*pipelineLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remotePipelineLayout);
 }
 
 void RemoteDevice::createBindGroup(const WebGPU::BindGroupDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto bindGroup = m_backing->createBindGroup(*convertedDescriptor);
-    auto remoteBindGroup = RemoteBindGroup::create(bindGroup, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(bindGroup);
+    auto remoteBindGroup = RemoteBindGroup::create(*bindGroup, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteBindGroup);
 }
 
 void RemoteDevice::createShaderModule(const WebGPU::ShaderModuleDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto shaderModule = m_backing->createShaderModule(*convertedDescriptor);
-    auto remoteShaderModule = RemoteShaderModule::create(shaderModule, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(shaderModule);
+    auto remoteShaderModule = RemoteShaderModule::create(*shaderModule, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteShaderModule);
 }
 
 void RemoteDevice::createComputePipeline(const WebGPU::ComputePipelineDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto computePipeline = m_backing->createComputePipeline(*convertedDescriptor);
-    auto remoteComputePipeline = RemoteComputePipeline::create(computePipeline, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(computePipeline);
+    auto remoteComputePipeline = RemoteComputePipeline::create(*computePipeline, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteComputePipeline);
 }
 
 void RemoteDevice::createRenderPipeline(const WebGPU::RenderPipelineDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto renderPipeline = m_backing->createRenderPipeline(*convertedDescriptor);
-    auto remoteRenderPipeline = RemoteRenderPipeline::create(renderPipeline, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(renderPipeline);
+    auto remoteRenderPipeline = RemoteRenderPipeline::create(*renderPipeline, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteRenderPipeline);
 }
 
@@ -315,37 +306,34 @@ void RemoteDevice::createCommandEncoder(const std::optional<WebGPU::CommandEncod
     std::optional<WebCore::WebGPU::CommandEncoderDescriptor> convertedDescriptor;
     if (descriptor) {
         auto resultDescriptor = m_objectHeap.convertFromBacking(*descriptor);
-        ASSERT(resultDescriptor);
+        RELEASE_ASSERT(resultDescriptor);
         convertedDescriptor = WTFMove(resultDescriptor);
-        if (!convertedDescriptor)
-            return;
     }
     auto commandEncoder = m_backing->createCommandEncoder(convertedDescriptor);
-    auto remoteCommandEncoder = RemoteCommandEncoder::create(commandEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(commandEncoder);
+    auto remoteCommandEncoder = RemoteCommandEncoder::create(*commandEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteCommandEncoder);
 }
 
 void RemoteDevice::createRenderBundleEncoder(const WebGPU::RenderBundleEncoderDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto renderBundleEncoder = m_backing->createRenderBundleEncoder(*convertedDescriptor);
-    auto remoteRenderBundleEncoder = RemoteRenderBundleEncoder::create(renderBundleEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(renderBundleEncoder);
+    auto remoteRenderBundleEncoder = RemoteRenderBundleEncoder::create(*renderBundleEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteRenderBundleEncoder);
 }
 
 void RemoteDevice::createQuerySet(const WebGPU::QuerySetDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto querySet = m_backing->createQuerySet(*convertedDescriptor);
-    auto remoteQuerySet = RemoteQuerySet::create(querySet, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(querySet);
+    auto remoteQuerySet = RemoteQuerySet::create(*querySet, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteQuerySet);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -182,12 +182,11 @@ void RemoteGPU::createPresentationContext(const WebGPU::PresentationContextDescr
     ASSERT(m_backing);
 
     auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto presentationContext = m_backing->createPresentationContext(*convertedDescriptor);
-    auto remotePresentationContext = RemotePresentationContext::create(presentationContext, m_objectHeap, *m_streamConnection, identifier);
+    RELEASE_ASSERT(presentationContext);
+    auto remotePresentationContext = RemotePresentationContext::create(*presentationContext, m_objectHeap, *m_streamConnection, identifier);
     m_objectHeap->addObject(identifier, remotePresentationContext);
 }
 
@@ -197,7 +196,8 @@ void RemoteGPU::createCompositorIntegration(WebGPUIdentifier identifier)
     ASSERT(m_backing);
 
     auto compositorIntegration = m_backing->createCompositorIntegration();
-    auto remoteCompositorIntegration = RemoteCompositorIntegration::create(compositorIntegration, m_objectHeap, *m_streamConnection, *this, identifier);
+    RELEASE_ASSERT(compositorIntegration);
+    auto remoteCompositorIntegration = RemoteCompositorIntegration::create(*compositorIntegration, m_objectHeap, *m_streamConnection, *this, identifier);
     m_objectHeap->addObject(identifier, remoteCompositorIntegration);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -61,7 +61,8 @@ void RemotePresentationContext::configure(const WebGPU::CanvasConfiguration& can
     if (!convertedConfiguration)
         return;
 
-    m_backing->configure(*convertedConfiguration);
+    bool success = m_backing->configure(*convertedConfiguration);
+    ASSERT_UNUSED(success, success);
 }
 
 void RemotePresentationContext::unconfigure()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -156,12 +156,11 @@ void RemoteRenderBundleEncoder::insertDebugMarker(String&& markerLabel)
 void RemoteRenderBundleEncoder::finish(const WebGPU::RenderBundleDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
+    RELEASE_ASSERT(convertedDescriptor);
 
     auto renderBundle = m_backing->finish(*convertedDescriptor);
-    auto remoteRenderBundle = RemoteRenderBundle::create(renderBundle, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(renderBundle);
+    auto remoteRenderBundle = RemoteRenderBundle::create(*renderBundle, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteRenderBundle);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -60,14 +60,12 @@ void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor
     std::optional<WebCore::WebGPU::TextureViewDescriptor> convertedDescriptor;
     if (descriptor) {
         auto resultDescriptor = m_objectHeap.convertFromBacking(*descriptor);
-        ASSERT(resultDescriptor);
+        RELEASE_ASSERT(resultDescriptor);
         convertedDescriptor = WTFMove(resultDescriptor);
-        if (!convertedDescriptor)
-            return;
     }
-    ASSERT(convertedDescriptor);
     auto textureView = m_backing->createView(convertedDescriptor);
-    auto remoteTextureView = RemoteTextureView::create(textureView, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    RELEASE_ASSERT(textureView);
+    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteTextureView);
 }
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -812,6 +812,7 @@ def headers_for_type(type):
         'WebCore::FillLightMode': ['<WebCore/FillLightMode.h>'],
         'WebCore::FirstPartyWebsiteDataRemovalMode': ['<WebCore/NetworkStorageSession.h>'],
         'WebCore::FontChanges': ['<WebCore/FontAttributeChanges.h>'],
+        'WebCore::FontPlatformDataAttributes': ['<WebCore/FontPlatformData.h>'],
         'WebCore::FontSmoothingMode': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::FrameLoadType': ['<WebCore/FrameLoaderTypes.h>'],
         'WebCore::GenericCueData': ['<WebCore/InbandGenericCue.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -266,7 +266,7 @@ std::optional<Ref<FontCustomPlatformData>> ArgumentCoder<FontCustomPlatformData>
     return fontCustomPlatformData.releaseNonNull();
 }
 
-void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encode(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
+void ArgumentCoder<WebCore::FontPlatformDataAttributes>::encode(Encoder& encoder, const WebCore::FontPlatformDataAttributes& data)
 {
     encoder << data.m_orientation;
     encoder << data.m_widthVariant;
@@ -278,7 +278,7 @@ void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encode(Encoder& encod
     encodePlatformData(encoder, data);
 }
 
-std::optional<FontPlatformData::Attributes> ArgumentCoder<FontPlatformData::Attributes>::decode(Decoder& decoder)
+std::optional<FontPlatformDataAttributes> ArgumentCoder<FontPlatformDataAttributes>::decode(Decoder& decoder)
 {
     std::optional<WebCore::FontOrientation> orientation;
     decoder >> orientation;
@@ -310,7 +310,7 @@ std::optional<FontPlatformData::Attributes> ArgumentCoder<FontPlatformData::Attr
     if (!syntheticOblique)
         return std::nullopt;
 
-    FontPlatformData::Attributes result(size.value(), orientation.value(), widthVariant.value(), textRenderingMode.value(), syntheticBold.value(), syntheticOblique.value());
+    FontPlatformDataAttributes result(size.value(), orientation.value(), widthVariant.value(), textRenderingMode.value(), syntheticBold.value(), syntheticOblique.value());
 
     if (!decodePlatformData(decoder, result))
         return std::nullopt;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -129,11 +129,11 @@ template<> struct ArgumentCoder<WebCore::Font> {
     static std::optional<WebCore::FontPlatformData> decodePlatformData(Decoder&);
 };
 
-template<> struct ArgumentCoder<WebCore::FontPlatformData::Attributes> {
-    static void encode(Encoder&, const WebCore::FontPlatformData::Attributes&);
-    static std::optional<WebCore::FontPlatformData::Attributes> decode(Decoder&);
-    static void encodePlatformData(Encoder&, const WebCore::FontPlatformData::Attributes&);
-    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::FontPlatformData::Attributes&);
+template<> struct ArgumentCoder<WebCore::FontPlatformDataAttributes> {
+    static void encode(Encoder&, const WebCore::FontPlatformDataAttributes&);
+    static std::optional<WebCore::FontPlatformDataAttributes> decode(Decoder&);
+    static void encodePlatformData(Encoder&, const WebCore::FontPlatformDataAttributes&);
+    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::FontPlatformDataAttributes&);
 };
 
 template<> struct ArgumentCoder<WebCore::FontCustomPlatformData> {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -312,7 +312,7 @@ void RemoteRenderingBackendProxy::cacheNativeImage(ShareableBitmap::Handle&& han
     send(Messages::RemoteRenderingBackend::CacheNativeImage(WTFMove(handle), renderingResourceIdentifier));
 }
 
-void RemoteRenderingBackendProxy::cacheFont(const WebCore::Font::Attributes& fontAttributes, const WebCore::FontPlatformData::Attributes& platformData, std::optional<WebCore::RenderingResourceIdentifier> ident)
+void RemoteRenderingBackendProxy::cacheFont(const WebCore::Font::Attributes& fontAttributes, const WebCore::FontPlatformDataAttributes& platformData, std::optional<WebCore::RenderingResourceIdentifier> ident)
 {
     send(Messages::RemoteRenderingBackend::CacheFont(fontAttributes, platformData, ident));
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -105,7 +105,7 @@ public:
     void putPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat);
     RefPtr<WebCore::ShareableBitmap> getShareableBitmap(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution);
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
-    void cacheFont(const WebCore::Font::Attributes&, const WebCore::FontPlatformData::Attributes&, std::optional<WebCore::RenderingResourceIdentifier>);
+    void cacheFont(const WebCore::Font::Attributes&, const WebCore::FontPlatformDataAttributes&, std::optional<WebCore::RenderingResourceIdentifier>);
     void cacheFontCustomPlatformData(Ref<const WebCore::FontCustomPlatformData>&&);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -49,13 +49,8 @@ RemoteBufferProxy::~RemoteBufferProxy()
 void RemoteBufferProxy::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(bool)>&& callback)
 {
     auto sendResult = sendWithAsyncReply(Messages::RemoteBuffer::MapAsync(mapModeFlags, offset, size), [callback = WTFMove(callback), mapModeFlags, protectedThis = Ref { *this }](auto data) mutable {
-
-        if (!data) {
-            // FIXME: Implement error handling.
-            callback(false);
-            return;
-        }
-
+        if (!data)
+            return callback(false);
         protectedThis->m_data = WTFMove(data);
         protectedThis->m_mapModeFlags = mapModeFlags;
         callback(true);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -49,37 +49,35 @@ RemoteCommandEncoderProxy::~RemoteCommandEncoderProxy()
     UNUSED_VARIABLE(sendResult);
 }
 
-Ref<WebCore::WebGPU::RenderPassEncoder> RemoteCommandEncoderProxy::beginRenderPass(const WebCore::WebGPU::RenderPassDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::RenderPassEncoder> RemoteCommandEncoderProxy::beginRenderPass(const WebCore::WebGPU::RenderPassDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteRenderPassEncoderProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteCommandEncoder::BeginRenderPass(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteRenderPassEncoderProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::ComputePassEncoder> RemoteCommandEncoderProxy::beginComputePass(const std::optional<WebCore::WebGPU::ComputePassDescriptor>& descriptor)
+RefPtr<WebCore::WebGPU::ComputePassEncoder> RemoteCommandEncoderProxy::beginComputePass(const std::optional<WebCore::WebGPU::ComputePassDescriptor>& descriptor)
 {
     std::optional<WebKit::WebGPU::ComputePassDescriptor> convertedDescriptor;
     if (descriptor) {
         convertedDescriptor = m_convertToBackingContext->convertToBacking(*descriptor);
-        if (!convertedDescriptor) {
-            // FIXME: Implement error handling.
-            return RemoteComputePassEncoderProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-        }
+        if (!convertedDescriptor)
+            return nullptr;
     }
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteCommandEncoder::BeginComputePass(convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteComputePassEncoderProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
@@ -219,17 +217,16 @@ void RemoteCommandEncoderProxy::resolveQuerySet(
     UNUSED_VARIABLE(sendResult);
 }
 
-Ref<WebCore::WebGPU::CommandBuffer> RemoteCommandEncoderProxy::finish(const WebCore::WebGPU::CommandBufferDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::CommandBuffer> RemoteCommandEncoderProxy::finish(const WebCore::WebGPU::CommandBufferDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteCommandBufferProxy::create(m_parent, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteCommandEncoder::Finish(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteCommandBufferProxy::create(m_parent, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -72,8 +72,8 @@ private:
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
-    Ref<WebCore::WebGPU::RenderPassEncoder> beginRenderPass(const WebCore::WebGPU::RenderPassDescriptor&) final;
-    Ref<WebCore::WebGPU::ComputePassEncoder> beginComputePass(const std::optional<WebCore::WebGPU::ComputePassDescriptor>&) final;
+    RefPtr<WebCore::WebGPU::RenderPassEncoder> beginRenderPass(const WebCore::WebGPU::RenderPassDescriptor&) final;
+    RefPtr<WebCore::WebGPU::ComputePassEncoder> beginComputePass(const std::optional<WebCore::WebGPU::ComputePassDescriptor>&) final;
 
     void copyBufferToBuffer(
         const WebCore::WebGPU::Buffer& source,
@@ -115,7 +115,7 @@ private:
         const WebCore::WebGPU::Buffer& destination,
         WebCore::WebGPU::Size64 destinationOffset) final;
 
-    Ref<WebCore::WebGPU::CommandBuffer> finish(const WebCore::WebGPU::CommandBufferDescriptor&) final;
+    RefPtr<WebCore::WebGPU::CommandBuffer> finish(const WebCore::WebGPU::CommandBufferDescriptor&) final;
 
     void setLabelInternal(const String&) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -61,7 +61,7 @@ RemoteDeviceProxy::RemoteDeviceProxy(Ref<WebCore::WebGPU::SupportedFeatures>&& f
 RemoteDeviceProxy::~RemoteDeviceProxy()
 {
     auto sendResult = send(Messages::RemoteDevice::Destruct());
-    UNUSED_VARIABLE(sendResult);
+    UNUSED_PARAM(sendResult);
 }
 
 Ref<WebCore::WebGPU::Queue> RemoteDeviceProxy::queue()
@@ -72,73 +72,68 @@ Ref<WebCore::WebGPU::Queue> RemoteDeviceProxy::queue()
 void RemoteDeviceProxy::destroy()
 {
     auto sendResult = send(Messages::RemoteDevice::Destroy());
-    UNUSED_VARIABLE(sendResult);
+    UNUSED_PARAM(sendResult);
 }
 
-Ref<WebCore::WebGPU::Buffer> RemoteDeviceProxy::createBuffer(const WebCore::WebGPU::BufferDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::Buffer> RemoteDeviceProxy::createBuffer(const WebCore::WebGPU::BufferDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteBufferProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateBuffer(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteBufferProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::Texture> RemoteDeviceProxy::createTexture(const WebCore::WebGPU::TextureDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::Texture> RemoteDeviceProxy::createTexture(const WebCore::WebGPU::TextureDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteTextureProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateTexture(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const WebCore::WebGPU::SamplerDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const WebCore::WebGPU::SamplerDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteSamplerProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateSampler(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteSamplerProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTexture(const WebCore::WebGPU::ExternalTextureDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTexture(const WebCore::WebGPU::ExternalTextureDescriptor& descriptor)
 {
     auto identifier = WebGPUIdentifier::generate();
 
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteExternalTextureProxy::create(*this, m_convertToBackingContext, identifier);
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     if (!convertedDescriptor->mediaIdentifier) {
-        auto videoFrame = std::get_if<RefPtr<WebCore::VideoFrame>>(&descriptor.videoBacking);
+        auto* videoFrame = std::get_if<RefPtr<WebCore::VideoFrame>>(&descriptor.videoBacking);
         if (videoFrame && videoFrame->get()) {
             convertedDescriptor->sharedFrame = m_sharedVideoFrameWriter.write(*videoFrame->get(), [&](auto& semaphore) {
                 auto sendResult = send(Messages::RemoteDevice::SetSharedVideoFrameSemaphore { semaphore });
@@ -152,7 +147,8 @@ Ref<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTexture(c
     }
 
     auto sendResult = send(Messages::RemoteDevice::ImportExternalTextureFromVideoFrame(WTFMove(*convertedDescriptor), identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 #endif
 
     auto result = RemoteExternalTextureProxy::create(*this, m_convertToBackingContext, identifier);
@@ -160,102 +156,96 @@ Ref<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTexture(c
     return result;
 }
 
-Ref<WebCore::WebGPU::BindGroupLayout> RemoteDeviceProxy::createBindGroupLayout(const WebCore::WebGPU::BindGroupLayoutDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::BindGroupLayout> RemoteDeviceProxy::createBindGroupLayout(const WebCore::WebGPU::BindGroupLayoutDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteBindGroupLayoutProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateBindGroupLayout(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteBindGroupLayoutProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::PipelineLayout> RemoteDeviceProxy::createPipelineLayout(const WebCore::WebGPU::PipelineLayoutDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::PipelineLayout> RemoteDeviceProxy::createPipelineLayout(const WebCore::WebGPU::PipelineLayoutDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemotePipelineLayoutProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreatePipelineLayout(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemotePipelineLayoutProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::BindGroup> RemoteDeviceProxy::createBindGroup(const WebCore::WebGPU::BindGroupDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::BindGroup> RemoteDeviceProxy::createBindGroup(const WebCore::WebGPU::BindGroupDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteBindGroupProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateBindGroup(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteBindGroupProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::ShaderModule> RemoteDeviceProxy::createShaderModule(const WebCore::WebGPU::ShaderModuleDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::ShaderModule> RemoteDeviceProxy::createShaderModule(const WebCore::WebGPU::ShaderModuleDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteShaderModuleProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateShaderModule(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteShaderModuleProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::ComputePipeline> RemoteDeviceProxy::createComputePipeline(const WebCore::WebGPU::ComputePipelineDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::ComputePipeline> RemoteDeviceProxy::createComputePipeline(const WebCore::WebGPU::ComputePipelineDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteComputePipelineProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateComputePipeline(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteComputePipelineProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::RenderPipeline> RemoteDeviceProxy::createRenderPipeline(const WebCore::WebGPU::RenderPipelineDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::RenderPipeline> RemoteDeviceProxy::createRenderPipeline(const WebCore::WebGPU::RenderPipelineDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteRenderPipelineProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateRenderPipeline(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteRenderPipelineProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
@@ -288,9 +278,8 @@ void RemoteDeviceProxy::createComputePipelineAsync(const WebCore::WebGPU::Comput
 void RemoteDeviceProxy::createRenderPipelineAsync(const WebCore::WebGPU::RenderPipelineDescriptor& descriptor, CompletionHandler<void(RefPtr<WebCore::WebGPU::RenderPipeline>&&)>&& callback)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    ASSERT(convertedDescriptor);
     if (!convertedDescriptor)
-        return;
+        return callback(nullptr);
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::CreateRenderPipelineAsync(*convertedDescriptor, identifier), [identifier, callback = WTFMove(callback), protectedThis = Ref { *this }, label = WTFMove(convertedDescriptor->label)](auto result) mutable {
@@ -306,54 +295,51 @@ void RemoteDeviceProxy::createRenderPipelineAsync(const WebCore::WebGPU::RenderP
     UNUSED_PARAM(sendResult);
 }
 
-Ref<WebCore::WebGPU::CommandEncoder> RemoteDeviceProxy::createCommandEncoder(const std::optional<WebCore::WebGPU::CommandEncoderDescriptor>& descriptor)
+RefPtr<WebCore::WebGPU::CommandEncoder> RemoteDeviceProxy::createCommandEncoder(const std::optional<WebCore::WebGPU::CommandEncoderDescriptor>& descriptor)
 {
     std::optional<CommandEncoderDescriptor> convertedDescriptor;
     if (descriptor) {
         convertedDescriptor = m_convertToBackingContext->convertToBacking(*descriptor);
-        if (!convertedDescriptor) {
-            // FIXME: Implement error handling.
-            return RemoteCommandEncoderProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-        }
+        if (!convertedDescriptor)
+            return nullptr;
     }
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateCommandEncoder(WTFMove(convertedDescriptor), identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteCommandEncoderProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::RenderBundleEncoder> RemoteDeviceProxy::createRenderBundleEncoder(const WebCore::WebGPU::RenderBundleEncoderDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::RenderBundleEncoder> RemoteDeviceProxy::createRenderBundleEncoder(const WebCore::WebGPU::RenderBundleEncoderDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteRenderBundleEncoderProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateRenderBundleEncoder(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteRenderBundleEncoderProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
     return result;
 }
 
-Ref<WebCore::WebGPU::QuerySet> RemoteDeviceProxy::createQuerySet(const WebCore::WebGPU::QuerySetDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::QuerySet> RemoteDeviceProxy::createQuerySet(const WebCore::WebGPU::QuerySetDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteQuerySetProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateQuerySet(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteQuerySetProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
@@ -363,7 +349,7 @@ Ref<WebCore::WebGPU::QuerySet> RemoteDeviceProxy::createQuerySet(const WebCore::
 void RemoteDeviceProxy::pushErrorScope(WebCore::WebGPU::ErrorFilter errorFilter)
 {
     auto sendResult = send(Messages::RemoteDevice::PushErrorScope(errorFilter));
-    UNUSED_VARIABLE(sendResult);
+    UNUSED_PARAM(sendResult);
 }
 
 void RemoteDeviceProxy::popErrorScope(CompletionHandler<void(bool, std::optional<WebCore::WebGPU::Error>&&)>&& callback)
@@ -382,7 +368,6 @@ void RemoteDeviceProxy::popErrorScope(CompletionHandler<void(bool, std::optional
             callback(success, { WebCore::WebGPU::InternalError::create(WTFMove(internalError.message)) });
         });
     });
-
     UNUSED_PARAM(sendResult);
 }
 
@@ -402,7 +387,6 @@ void RemoteDeviceProxy::resolveUncapturedErrorEvent(CompletionHandler<void(bool,
             callback(success, { WebCore::WebGPU::InternalError::create(WTFMove(internalError.message)) });
         });
     });
-
     UNUSED_PARAM(sendResult);
 }
 
@@ -417,7 +401,6 @@ void RemoteDeviceProxy::resolveDeviceLostPromise(CompletionHandler<void(WebCore:
     auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::ResolveDeviceLostPromise(), [callback = WTFMove(callback)] (WebCore::WebGPU::DeviceLostReason reason) mutable {
         callback(reason);
     });
-
     UNUSED_PARAM(sendResult);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -85,25 +85,25 @@ private:
 
     void destroy() final;
 
-    Ref<WebCore::WebGPU::Buffer> createBuffer(const WebCore::WebGPU::BufferDescriptor&) final;
-    Ref<WebCore::WebGPU::Texture> createTexture(const WebCore::WebGPU::TextureDescriptor&) final;
-    Ref<WebCore::WebGPU::Sampler> createSampler(const WebCore::WebGPU::SamplerDescriptor&) final;
-    Ref<WebCore::WebGPU::ExternalTexture> importExternalTexture(const WebCore::WebGPU::ExternalTextureDescriptor&) final;
+    RefPtr<WebCore::WebGPU::Buffer> createBuffer(const WebCore::WebGPU::BufferDescriptor&) final;
+    RefPtr<WebCore::WebGPU::Texture> createTexture(const WebCore::WebGPU::TextureDescriptor&) final;
+    RefPtr<WebCore::WebGPU::Sampler> createSampler(const WebCore::WebGPU::SamplerDescriptor&) final;
+    RefPtr<WebCore::WebGPU::ExternalTexture> importExternalTexture(const WebCore::WebGPU::ExternalTextureDescriptor&) final;
 
-    Ref<WebCore::WebGPU::BindGroupLayout> createBindGroupLayout(const WebCore::WebGPU::BindGroupLayoutDescriptor&) final;
-    Ref<WebCore::WebGPU::PipelineLayout> createPipelineLayout(const WebCore::WebGPU::PipelineLayoutDescriptor&) final;
-    Ref<WebCore::WebGPU::BindGroup> createBindGroup(const WebCore::WebGPU::BindGroupDescriptor&) final;
+    RefPtr<WebCore::WebGPU::BindGroupLayout> createBindGroupLayout(const WebCore::WebGPU::BindGroupLayoutDescriptor&) final;
+    RefPtr<WebCore::WebGPU::PipelineLayout> createPipelineLayout(const WebCore::WebGPU::PipelineLayoutDescriptor&) final;
+    RefPtr<WebCore::WebGPU::BindGroup> createBindGroup(const WebCore::WebGPU::BindGroupDescriptor&) final;
 
-    Ref<WebCore::WebGPU::ShaderModule> createShaderModule(const WebCore::WebGPU::ShaderModuleDescriptor&) final;
-    Ref<WebCore::WebGPU::ComputePipeline> createComputePipeline(const WebCore::WebGPU::ComputePipelineDescriptor&) final;
-    Ref<WebCore::WebGPU::RenderPipeline> createRenderPipeline(const WebCore::WebGPU::RenderPipelineDescriptor&) final;
+    RefPtr<WebCore::WebGPU::ShaderModule> createShaderModule(const WebCore::WebGPU::ShaderModuleDescriptor&) final;
+    RefPtr<WebCore::WebGPU::ComputePipeline> createComputePipeline(const WebCore::WebGPU::ComputePipelineDescriptor&) final;
+    RefPtr<WebCore::WebGPU::RenderPipeline> createRenderPipeline(const WebCore::WebGPU::RenderPipelineDescriptor&) final;
     void createComputePipelineAsync(const WebCore::WebGPU::ComputePipelineDescriptor&, CompletionHandler<void(RefPtr<WebCore::WebGPU::ComputePipeline>&&)>&&) final;
     void createRenderPipelineAsync(const WebCore::WebGPU::RenderPipelineDescriptor&, CompletionHandler<void(RefPtr<WebCore::WebGPU::RenderPipeline>&&)>&&) final;
 
-    Ref<WebCore::WebGPU::CommandEncoder> createCommandEncoder(const std::optional<WebCore::WebGPU::CommandEncoderDescriptor>&) final;
-    Ref<WebCore::WebGPU::RenderBundleEncoder> createRenderBundleEncoder(const WebCore::WebGPU::RenderBundleEncoderDescriptor&) final;
+    RefPtr<WebCore::WebGPU::CommandEncoder> createCommandEncoder(const std::optional<WebCore::WebGPU::CommandEncoderDescriptor>&) final;
+    RefPtr<WebCore::WebGPU::RenderBundleEncoder> createRenderBundleEncoder(const WebCore::WebGPU::RenderBundleEncoderDescriptor&) final;
 
-    Ref<WebCore::WebGPU::QuerySet> createQuerySet(const WebCore::WebGPU::QuerySetDescriptor&) final;
+    RefPtr<WebCore::WebGPU::QuerySet> createQuerySet(const WebCore::WebGPU::QuerySetDescriptor&) final;
 
     void pushErrorScope(WebCore::WebGPU::ErrorFilter) final;
     void popErrorScope(CompletionHandler<void(bool, std::optional<WebCore::WebGPU::Error>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -101,9 +101,9 @@ private:
 
     void requestAdapter(const WebCore::WebGPU::RequestAdapterOptions&, CompletionHandler<void(RefPtr<WebCore::WebGPU::Adapter>&&)>&&) final;
 
-    Ref<WebCore::WebGPU::PresentationContext> createPresentationContext(const WebCore::WebGPU::PresentationContextDescriptor&) final;
+    RefPtr<WebCore::WebGPU::PresentationContext> createPresentationContext(const WebCore::WebGPU::PresentationContextDescriptor&) final;
 
-    Ref<WebCore::WebGPU::CompositorIntegration> createCompositorIntegration() final;
+    RefPtr<WebCore::WebGPU::CompositorIntegration> createCompositorIntegration() final;
 
     void abandonGPUProcess();
     void disconnectGpuProcessIfNeeded();

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -44,16 +44,14 @@ RemotePresentationContextProxy::RemotePresentationContextProxy(RemoteGPUProxy& p
 
 RemotePresentationContextProxy::~RemotePresentationContextProxy() = default;
 
-void RemotePresentationContextProxy::configure(const WebCore::WebGPU::CanvasConfiguration& canvasConfiguration)
+bool RemotePresentationContextProxy::configure(const WebCore::WebGPU::CanvasConfiguration& canvasConfiguration)
 {
     auto convertedConfiguration = m_convertToBackingContext->convertToBacking(canvasConfiguration);
-    if (!convertedConfiguration) {
-        // FIXME: Implement error handling.
-        return;
-    }
+    if (!convertedConfiguration)
+        return false;
 
     auto sendResult = send(Messages::RemotePresentationContext::Configure(*convertedConfiguration));
-    UNUSED_VARIABLE(sendResult);
+    return sendResult == IPC::Error::NoError;
 }
 
 void RemotePresentationContextProxy::unconfigure()
@@ -67,7 +65,8 @@ RefPtr<WebCore::WebGPU::Texture> RemotePresentationContextProxy::getCurrentTextu
     if (!m_currentTexture) {
         auto identifier = WebGPUIdentifier::generate();
         auto sendResult = send(Messages::RemotePresentationContext::GetCurrentTexture(identifier));
-        UNUSED_VARIABLE(sendResult);
+        if (sendResult != IPC::Error::NoError)
+            return nullptr;
 
         m_currentTexture = RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -76,7 +76,7 @@ private:
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
-    void configure(const WebCore::WebGPU::CanvasConfiguration&) final;
+    bool configure(const WebCore::WebGPU::CanvasConfiguration&) final;
     void unconfigure() final;
 
     RefPtr<WebCore::WebGPU::Texture> getCurrentTexture() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -169,18 +169,16 @@ void RemoteRenderBundleEncoderProxy::insertDebugMarker(String&& markerLabel)
     UNUSED_VARIABLE(sendResult);
 }
 
-Ref<WebCore::WebGPU::RenderBundle> RemoteRenderBundleEncoderProxy::finish(const WebCore::WebGPU::RenderBundleDescriptor& descriptor)
+RefPtr<WebCore::WebGPU::RenderBundle> RemoteRenderBundleEncoderProxy::finish(const WebCore::WebGPU::RenderBundleDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteRenderBundleProxy::create(m_parent, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
+    if (!convertedDescriptor)
+        return nullptr;
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::Finish(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     return RemoteRenderBundleProxy::create(m_parent, m_convertToBackingContext, identifier);
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -100,7 +100,7 @@ private:
     void popDebugGroup() final;
     void insertDebugMarker(String&& markerLabel) final;
 
-    Ref<WebCore::WebGPU::RenderBundle> finish(const WebCore::WebGPU::RenderBundleDescriptor&) final;
+    RefPtr<WebCore::WebGPU::RenderBundle> finish(const WebCore::WebGPU::RenderBundleDescriptor&) final;
 
     void setLabelInternal(const String&) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -48,20 +48,19 @@ RemoteTextureProxy::~RemoteTextureProxy()
     UNUSED_VARIABLE(sendResult);
 }
 
-Ref<WebCore::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>& descriptor)
+RefPtr<WebCore::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>& descriptor)
 {
     std::optional<TextureViewDescriptor> convertedDescriptor;
     if (descriptor) {
         convertedDescriptor = m_convertToBackingContext->convertToBacking(*descriptor);
-        if (!convertedDescriptor) {
-            // FIXME: Implement error handling.
-            return RemoteTextureViewProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-        }
+        if (!convertedDescriptor)
+            return nullptr;
     }
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteTexture::CreateView(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
+    if (sendResult != IPC::Error::NoError)
+        return nullptr;
 
     auto result = RemoteTextureViewProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -75,7 +75,7 @@ private:
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
-    Ref<WebCore::WebGPU::TextureView> createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>&) final;
+    RefPtr<WebCore::WebGPU::TextureView> createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>&) final;
 
     void destroy() final;
 

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
@@ -34,6 +34,7 @@
 
 namespace WebKit {
 
+class MediaPlaybackTargetContextSerialized;
 class WebProcess;
 
 class RemoteMediaSessionHelper final


### PR DESCRIPTION
#### f816a1743b89245484a0ea3462c76fe88d593d3e
<pre>
Fix some assertions when using a canvas without a layer with webgpu
<a href="https://bugs.webkit.org/show_bug.cgi?id=270705">https://bugs.webkit.org/show_bug.cgi?id=270705</a>
<a href="https://rdar.apple.com/124213314">rdar://124213314</a>

Reviewed by Mike Wyrzykowski.

The test in this PR hit several issues:
1. PresentationContextIOSurface::present asserted, which I changed to an early return.
2. I handle errors when creating objects by returning nullptr instead of an object that
   has no corresponding object in the GPU process, and propogate those errors to JS.
3. I added a WeakPtr check in the lambda in GPUCanvasContextCocoa::prepareForDisplay
4. In order to keep Windows building after this change, I needed to change
   FontPlatformData::Attributes to FontPlatformDataAttributes in WebKit.

* LayoutTests/fast/webgpu/use-canvas-without-layer-expected.txt: Added.
* LayoutTests/fast/webgpu/use-canvas-without-layer.html: Added.
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::dispatchStreamMessages):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::~RemoteTextureProxy):
(WebKit::WebGPU::RemoteTextureProxy::createView):
(WebKit::WebGPU::RemoteTextureProxy::destroy):
(WebKit::WebGPU::RemoteTextureProxy::setLabelInternal):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:

Canonical link: <a href="https://commits.webkit.org/276005@main">https://commits.webkit.org/276005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24c7b3bb74cec914da456438e84b7e7736602ea5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35831 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16810 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43214 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38394 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47522 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42617 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41275 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19973 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5919 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->