### PR TITLE
Remove iPhone 7 from run-webkit-tests simulator testing.

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -1035,11 +1035,9 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
             run_webkit_tests.run(port, run_webkit_tests.parse_args(['--debug-rwt-logging', '-n', '--no-build', '--root', '/build'])[0], [], logging_stream=logging)
 
         for line in logging.getvalue():
-            if str(DeviceType.from_string('iPhone SE')) in line:
-                self.assertTrue('Skipping 2 tests' in line)
-            elif str(DeviceType.from_string('iPad (9th generation)')) in line:
+            if str(DeviceType.from_string('iPhone 12')) in line:
                 self.assertTrue('Skipping 1 test' in line)
-            elif str(DeviceType.from_string('iPhone 7')) in line:
+            elif str(DeviceType.from_string('iPad (9th generation)')) in line:
                 self.assertTrue('Skipping 0 tests' in line)
 
     def test_device_type_specific_listing(self):
@@ -1065,10 +1063,9 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
                 continue
             by_type[current_type].append(line)
 
-        self.assertEqual(3, len(by_type.keys()))
+        self.assertEqual(2, len(by_type.keys()))
         self.assertEqual(2, len(by_type[DeviceType.from_string('iPhone 12')]))
         self.assertEqual(1, len(by_type[DeviceType.from_string('iPad (9th generation)')]))
-        self.assertEqual(0, len(by_type[DeviceType.from_string('iPhone 7')]))
 
     def test_ipad_test_division(self):
         host = MockHost()

--- a/Tools/Scripts/webkitpy/port/ios_simulator.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator.py
@@ -46,7 +46,6 @@ class IOSSimulatorPort(IOSPort):
     DEFAULT_DEVICE_TYPES = [
         DeviceType(hardware_family='iPhone', hardware_type='12'),
         DeviceType(hardware_family='iPad', hardware_type='(9th generation)'),
-        DeviceType(hardware_family='iPhone', hardware_type='7'),
     ]
     SDK = apple_additions().get_sdk('iphonesimulator') if apple_additions() else 'iphonesimulator'
 
@@ -114,7 +113,6 @@ class IPhoneSimulatorPort(IOSSimulatorPort):
     DEVICE_TYPE = DeviceType(hardware_family='iPhone')
     DEFAULT_DEVICE_TYPES = [
         DeviceType(hardware_family='iPhone', hardware_type='12'),
-        DeviceType(hardware_family='iPhone', hardware_type='7'),
     ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
#### 88f3f506d43c730daa25817facdf855d1d379334
<pre>
Remove iPhone 7 from run-webkit-tests simulator testing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270708">https://bugs.webkit.org/show_bug.cgi?id=270708</a>
<a href="https://rdar.apple.com/124253881">rdar://124253881</a>

Reviewed by Ryan Haddad.

run-webkit-tests will check for the existence of iPhone 7-specific test expectations as one of its steps. As we have not tested on iPhone 7 simulators for many years, this PR removes that call.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py: Removed iPhone 7 device configuration presence unit test.
(RunTest.test_device_type_test_division): Removed iPhone 7 device configuration presence unit test.
(RunTest.test_device_type_specific_listing): Removed iPhone 7 device configuration presence unit test.
* Tools/Scripts/webkitpy/port/ios_simulator.py: Removed iPhone 7 device configuration.
(IOSSimulatorPort): Removed iPhone 7 device configuration.
(IPhoneSimulatorPort): Removed iPhone 7 device configuration.

Canonical link: <a href="https://commits.webkit.org/275871@main">https://commits.webkit.org/275871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/061f649c73f5bc4b5a8e9586b621ac0decf2e7dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45705 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39205 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35618 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16612 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/42954 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38167 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1136 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38496 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47270 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14785 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42404 "layout-tests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19533 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9594 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19711 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->