### PR TITLE
Convert AppleInterchangeNewline and AppleConvertedSpace to be constant expressions instead of macros

### DIFF
--- a/Source/WebCore/editing/HTMLInterchange.cpp
+++ b/Source/WebCore/editing/HTMLInterchange.cpp
@@ -41,8 +41,7 @@ String convertHTMLTextToInterchangeFormat(const String& in, const Text* node)
     if (node->renderer() && node->renderer()->style().preserveNewline())
         return in;
 
-    const char convertedSpaceString[] = "<span class=\"" AppleConvertedSpace "\">\xA0</span>";
-    static_assert((static_cast<unsigned char>('\xA0') == noBreakSpace), "ConvertedSpaceStringSpace is NoBreakSpace");
+    static NeverDestroyed<const String> convertedSpaceString { makeString("<span class=\"", AppleConvertedSpace, "\">", noBreakSpace, "</span>") };
 
     StringBuilder s;
 
@@ -61,24 +60,24 @@ String convertHTMLTextToInterchangeFormat(const String& in, const Text* node)
                 unsigned add = count % 3;
                 switch (add) {
                     case 0:
-                        s.append(convertedSpaceString, ' ', convertedSpaceString);
+                        s.append(convertedSpaceString.get(), ' ', convertedSpaceString.get());
                         add = 3;
                         break;
                     case 1:
                         if (i == 0 || i + 1 == in.length()) // at start or end of string
-                            s.append(convertedSpaceString);
+                            s.append(convertedSpaceString.get());
                         else
                             s.append(' ');
                         break;
                     case 2:
                         if (i == 0) {
                              // at start of string
-                            s.append(convertedSpaceString, ' ');
+                            s.append(convertedSpaceString.get(), ' ');
                         } else if (i + 2 == in.length()) {
                              // at end of string
-                            s.append(convertedSpaceString, convertedSpaceString);
+                            s.append(convertedSpaceString.get(), convertedSpaceString.get());
                         } else {
-                            s.append(convertedSpaceString, ' ');
+                            s.append(convertedSpaceString.get(), ' ');
                         }
                         break;
                 }

--- a/Source/WebCore/editing/HTMLInterchange.h
+++ b/Source/WebCore/editing/HTMLInterchange.h
@@ -32,8 +32,8 @@ namespace WebCore {
 
 class Text;
 
-#define AppleInterchangeNewline   "Apple-interchange-newline"
-#define AppleConvertedSpace       "Apple-converted-space"
+constexpr auto AppleInterchangeNewline = "Apple-interchange-newline"_s;
+constexpr auto AppleConvertedSpace = "Apple-converted-space"_s;
 constexpr auto WebKitMSOListQuirksStyle = "WebKit-mso-list-quirks-style"_s;
 
 constexpr auto ApplePasteAsQuotation = "Apple-paste-as-quotation"_s;

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -122,16 +122,14 @@ private:
 
 static bool isInterchangeNewlineNode(const Node& node)
 {
-    static NeverDestroyed<String> interchangeNewlineClassString = AppleInterchangeNewline ""_s;
     RefPtr br = dynamicDowncast<HTMLBRElement>(node);
-    return br && br->attributeWithoutSynchronization(classAttr) == interchangeNewlineClassString;
+    return br && br->attributeWithoutSynchronization(classAttr) == AppleInterchangeNewline;
 }
 
 static bool isInterchangeConvertedSpaceSpan(const Node& node)
 {
-    static NeverDestroyed<String> convertedSpaceSpanClassString = AppleConvertedSpace ""_s;
     RefPtr element = dynamicDowncast<HTMLElement>(node);
-    return element && element->attributeWithoutSynchronization(classAttr) == convertedSpaceSpanClassString;
+    return element && element->attributeWithoutSynchronization(classAttr) == AppleConvertedSpace;
 }
 
 static Position positionAvoidingPrecedingNodes(Position position)
@@ -1086,7 +1084,7 @@ static bool isInlineNodeWithStyle(const Node& node)
     // one of our internal classes.
     const AtomString& classAttributeValue = element->attributeWithoutSynchronization(classAttr);
     if (classAttributeValue == AppleTabSpanClass
-        || classAttributeValue == AppleConvertedSpace ""_s
+        || classAttributeValue == AppleConvertedSpace
         || classAttributeValue == ApplePasteAsQuotation)
         return true;
 

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1825,7 +1825,7 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
         Element* blockElement = _blockLevelElementForNode(element.parentInComposedTree());
         NSString *breakClass = element.getAttribute(classAttr);
         NSString *blockTag = blockElement ? (NSString *)blockElement->tagName() : nil;
-        BOOL isExtraBreak = [@"Apple-interchange-newline" isEqualToString:breakClass];
+        BOOL isExtraBreak = [AppleInterchangeNewline.createNSString() isEqualToString:breakClass];
         BOOL blockElementIsParagraph = ([@"P" isEqualToString:blockTag] || [@"LI" isEqualToString:blockTag] || ([blockTag hasPrefix:@"H"] && 2 == [blockTag length]));
         if (isExtraBreak)
             _flags.hasTrailingNewline = YES;

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -995,7 +995,7 @@ static RefPtr<Node> highestAncestorToWrapMarkup(const Position& start, const Pos
 static String serializePreservingVisualAppearanceInternal(const Position& start, const Position& end, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializeComposedTree serializeComposedTree, IgnoreUserSelectNone ignoreUserSelectNone,
     AnnotateForInterchange annotate, ConvertBlocksToInlines convertBlocksToInlines, StandardFontFamilySerializationMode standardFontFamilySerializationMode, MSOListMode msoListMode, PreserveBaseElement preserveBaseElement)
 {
-    static NeverDestroyed<const String> interchangeNewlineString(MAKE_STATIC_STRING_IMPL("<br class=\"" AppleInterchangeNewline "\">"));
+    static NeverDestroyed<const String> interchangeNewlineString { makeString("<br class=\"", AppleInterchangeNewline, "\">") };
 
     if (!(start < end))
         return emptyString();
@@ -1285,7 +1285,7 @@ Ref<DocumentFragment> createFragmentFromText(const SimpleRange& context, const S
 
     auto createHTMLBRElement = [document]() {
         auto element = HTMLBRElement::create(document);
-        element->setAttributeWithoutSynchronization(classAttr, AppleInterchangeNewline ""_s);
+        element->setAttributeWithoutSynchronization(classAttr, AppleInterchangeNewline);
         return element;
     };
 


### PR DESCRIPTION
#### f2cb2e25ea8d52946b02a1b93b17cc031c24c7ac
<pre>
Convert AppleInterchangeNewline and AppleConvertedSpace to be constant expressions instead of macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=270710">https://bugs.webkit.org/show_bug.cgi?id=270710</a>
<a href="https://rdar.apple.com/124290908">rdar://124290908</a>

Reviewed by Abrar Rahman Protyasha and Ryosuke Niwa.

* Source/WebCore/editing/HTMLInterchange.cpp:
(WebCore::convertHTMLTextToInterchangeFormat):
* Source/WebCore/editing/HTMLInterchange.h:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::isInterchangeNewlineNode):
(WebCore::isInterchangeConvertedSpaceSpan):
(WebCore::isInlineNodeWithStyle):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_processElement):
* Source/WebCore/editing/markup.cpp:
(WebCore::serializePreservingVisualAppearanceInternal):
(WebCore::createFragmentFromText):

Canonical link: <a href="https://commits.webkit.org/275856@main">https://commits.webkit.org/275856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f4f80d06ef7a8ee5d3792304b7a7830fe2a3299

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39194 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19518 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16726 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38156 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1125 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47234 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/17978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14776 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19522 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41053 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9589 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->