### PR TITLE
REGRESSION (274626@main): [ iOS Debug ]media/video-autoplay.html and media/video-element-other-n amespace-crash.html are constant crashes (270485)

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2401,7 +2401,3 @@ webkit.org/b/269321 webgl/1.0.3/conformance/uniforms/out-of-bounds-uniform-array
 webkit.org/b/269760 mathml/presentation/scripts-underover.html [ Failure ]
 
 webkit.org/b/270477 [ Debug ] accessibility/text-marker/text-marker-range-stale-node-crash.html [ Skip ]
-
-# webkit.org/b/268557 REGRESSION (274621@main-274598@main?): [ iOS Debug ]media/video-autoplay.html and media/video-element-other-namespace-crash.html are constant crashes 
-[ Debug ] media/video-autoplay.html [ Skip ]
-[ Debug ] media/video-element-other-namespace-crash.html  [ Skip ]

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
@@ -58,8 +58,8 @@ public:
     WEBCORE_EXPORT bool mayAutomaticallyShowVideoPictureInPicture() const;
     bool isPlayingVideoInEnhancedFullscreen() const;
     bool allowsPictureInPicturePlayback() const { return m_allowsPictureInPicturePlayback; }
-    void presentFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&&) final;
-    void dismissFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&&) final;
+    void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
+    void dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
 
 private:
     WEBCORE_EXPORT VideoPresentationInterfaceAVKit(PlaybackSessionInterfaceIOS&);

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -852,12 +852,12 @@ void VideoPresentationInterfaceAVKit::invalidatePlayerViewController()
     m_playerViewController = nil;
 }
 
-void VideoPresentationInterfaceAVKit::presentFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&& completionHandler)
+void VideoPresentationInterfaceAVKit::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     [m_playerViewController enterFullScreenAnimated:animated completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
 }
 
-void VideoPresentationInterfaceAVKit::dismissFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&& completionHandler)
+void VideoPresentationInterfaceAVKit::dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     [m_playerViewController exitFullScreenAnimated:animated completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
 }

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -213,8 +213,8 @@ protected:
     WEBCORE_EXPORT void exitFullscreenHandler(BOOL success, NSError *, NextActions = NextActions());
     void doEnterFullscreen();
     void doExitFullscreen();
-    virtual void presentFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&&) = 0;
-    virtual void dismissFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&&) = 0;
+    virtual void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) = 0;
+    virtual void dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) = 0;
     virtual void tryToStartPictureInPicture() = 0;
     virtual void stopPictureInPicture() = 0;
     virtual void setShowsPlaybackControls(bool) = 0;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -62,8 +62,8 @@ private:
     UIViewController *playerViewController() const final;
     void tryToStartPictureInPicture() final { }
     void stopPictureInPicture() final { }
-    void presentFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&&) final;
-    void dismissFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&&) final;
+    void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
+    void dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
     void setShowsPlaybackControls(bool) final;
     void setContentDimensions(const FloatSize&) final;
     void setAllowsPictureInPicturePlayback(bool) final { }

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -81,14 +81,14 @@ void VideoPresentationInterfaceLMK::invalidatePlayerViewController()
     m_playerViewController = nil;
 }
 
-void VideoPresentationInterfaceLMK::presentFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&& completionHandler)
+void VideoPresentationInterfaceLMK::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     linearMediaPlayer().presentationMode = WKSLinearMediaPresentationModeFullscreenFromInline;
     // FIXME: Wait until -linearMediaPlayer:didEnterFullscreenWithError: is called before calling completionHandler
     completionHandler(YES, nil);
 }
 
-void VideoPresentationInterfaceLMK::dismissFullscreen(bool animated, CompletionHandler<void(BOOL, NSError *)>&& completionHandler)
+void VideoPresentationInterfaceLMK::dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
     linearMediaPlayer().presentationMode = WKSLinearMediaPresentationModeInline;
     // FIXME: Wait until -linearMediaPlayer:didExitFullscreenWithError: is called before calling completionHandler


### PR DESCRIPTION
#### 26d42d0752d10c46cedc862ef032622f47b174e0
<pre>
REGRESSION (274626@main): [ iOS Debug ]media/video-autoplay.html and media/video-element-other-n amespace-crash.html are constant crashes (270485)
<a href="https://bugs.webkit.org/show_bug.cgi?id=270715">https://bugs.webkit.org/show_bug.cgi?id=270715</a>
<a href="https://rdar.apple.com/124034839">rdar://124034839</a>

Reviewed by Jer Noble.

Replacing CompletionHandler with Function to fix crash caused by not calling
the completion handler in all cases. Unskipping tests that were affected.

* LayoutTests/platform/ios-wk2/TestExpectations:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm:
(WebCore::VideoPresentationInterfaceAVKit::presentFullscreen):
(WebCore::VideoPresentationInterfaceAVKit::dismissFullscreen):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::presentFullscreen):
(WebKit::VideoPresentationInterfaceLMK::dismissFullscreen):

Canonical link: <a href="https://commits.webkit.org/275930@main">https://commits.webkit.org/275930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a0ff7ca5264d6cafe0794459de5df4bcc20ad56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35622 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16619 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38175 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1145 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39274 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47253 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42409 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19542 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41065 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->