### PR TITLE
WebExtensionContext::permissionsRequest needs to properly capture completionHandler.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -226,7 +226,7 @@ void WebExtensionContext::runtimeSendNativeMessage(const String& applicationID, 
         }
 
         if (replyMessage)
-            THROW_UNLESS(isValidJSONObject(replyMessage, JSONOptions::FragmentsAllowed), @"reply message is not JSON-serializable");
+            THROW_UNLESS(isValidJSONObject(replyMessage, JSONOptions::FragmentsAllowed), @"Reply message is not JSON-serializable");
 
         completionHandler(String(encodeJSONString(replyMessage, JSONOptions::FragmentsAllowed)));
     }).get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
@@ -96,7 +96,7 @@ TEST(WKWebExtensionAPIPermissions, Errors)
     Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
 }
 
-TEST(WKWebExtensionAPIPermissions, PermissionsTest)
+TEST(WKWebExtensionAPIPermissions, Basics)
 {
     auto *manifest = @{
         @"manifest_version": @3,
@@ -150,7 +150,7 @@ TEST(WKWebExtensionAPIPermissions, PermissionsTest)
     [manager loadAndRun];
 }
 
-TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequestTest)
+TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)
 {
     auto *manifest = @{
         @"manifest_version": @3,
@@ -161,9 +161,11 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequestTest)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        // Finish
-        @"browser.test.yield()",
-        @"browser.test.notifyPass()"
+        @"window.runTest = async () => {",
+        @"  await browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
+        @"}",
+
+        @"browser.test.yield('Ready')",
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
@@ -187,19 +189,25 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequestTest)
     requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
         EXPECT_EQ(requestedMatchPatterns.count, matchPatterns.count);
         EXPECT_TRUE([requestedMatchPatterns isEqualToSet:matchPatterns]);
-        callback(requestedMatchPatterns);
-        requestComplete = true;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            callback(requestedMatchPatterns);
+            requestComplete = true;
+        });
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
+
     [manager loadAndRun];
 
-    runScriptWithUserGesture("await browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))"_s, manager.get().context._backgroundWebView);
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
+
+    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
-TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequestTest)
+TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)
 {
     auto *manifest = @{
         @"manifest_version": @3,
@@ -209,9 +217,11 @@ TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequestTest)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        // Finish
-        @"browser.test.yield()",
-        @"browser.test.notifyPass()"
+        @"window.runTest = async () => {",
+        @"  await browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
+        @"}",
+
+        @"browser.test.yield('Ready')",
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
@@ -225,24 +235,26 @@ TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequestTest)
 
     // Implement the delegate methods, but don't grant the permissions.
     requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
-        requestComplete = true;
-        callback(nil);
+        callback(NSSet.set);
     };
 
     requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
-        ASSERT_NOT_REACHED();
-        callback(nil);
+        requestComplete = true;
+        callback(NSSet.set);
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
+
     [manager loadAndRun];
 
-    runScriptWithUserGesture("await browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))"_s, manager.get().context._backgroundWebView);
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
+
+    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
-TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequestTest)
+TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)
 {
     auto *manifest = @{
         @"manifest_version": @3,
@@ -252,9 +264,11 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequestTest
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        // Finish
-        @"browser.test.yield()",
-        @"browser.test.notifyPass()"
+        @"window.runTest = async () => {",
+        @"  await browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
+        @"}",
+
+        @"browser.test.yield('Ready')",
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
@@ -274,18 +288,21 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequestTest
     // Deny the requested match patterns.
     requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
         requestComplete = true;
-        callback(nil);
+        callback(NSSet.set);
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
+
     [manager loadAndRun];
 
-    runScriptWithUserGesture("await browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))"_s, manager.get().context._backgroundWebView);
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
+
+    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
-TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnlyTest)
+TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)
 {
     auto *manifest = @{
         @"manifest_version": @3,
@@ -295,9 +312,11 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnlyTest)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        // Finish
-        @"browser.test.yield()",
-        @"browser.test.notifyPass()"
+        @"window.runTest = async () => {",
+        @"  await browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest']}))",
+        @"}",
+
+        @"browser.test.yield('Ready')",
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
@@ -311,24 +330,29 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnlyTest)
 
     // Grant the requested permissions.
     requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
-        callback(requestedPermissions);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            requestComplete = true;
+            callback(requestedPermissions);
+        });
     };
 
-    // Grant the requested match patterns.
+    // Match patterns method should not be called.
     requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
-        requestComplete = true;
-        callback(requestedMatchPatterns);
+        ASSERT_NOT_REACHED();
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
+
     [manager loadAndRun];
 
-    runScriptWithUserGesture("await browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest']}))"_s, manager.get().context._backgroundWebView);
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
+
+    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
-TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnlyTest)
+TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
 {
     auto *manifest = @{
         @"manifest_version": @3,
@@ -338,9 +362,61 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnlyTest)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        // Finish
-        @"browser.test.yield()",
-        @"browser.test.notifyPass()"
+        @"window.runTest = async () => {",
+        @"  await browser.test.assertTrue(await browser.permissions.request({'origins': ['*://*.apple.com/*']}))",
+        @"}",
+
+        @"browser.test.yield('Ready')",
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    __block bool requestComplete = false;
+
+    // Permissions method should not be called.
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+        ASSERT_NOT_REACHED();
+    };
+
+    // Grant the requested match patterns.
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            requestComplete = true;
+            callback(requestedMatchPatterns);
+        });
+    };
+
+    manager.get().controllerDelegate = requestDelegate.get();
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
+
+    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+
+    TestWebKitAPI::Util::run(&requestComplete);
+}
+
+TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"optional_permissions": @[ @"declarativeNetRequest", @"alarms" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"window.runTest = async () => {",
+        @"  await browser.test.assertFalse(await browser.permissions.request({'permissions': ['alarms', 'declarativeNetRequest']}))",
+        @"}",
+
+        @"browser.test.yield('Ready')",
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
@@ -354,19 +430,72 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnlyTest)
 
     // Grant the requested permissions.
     requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
-        callback(requestedPermissions);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            requestComplete = true;
+            callback(requestedPermissions);
+        });
     };
 
-    // Grant the requested match patterns.
+    // Match patterns method should not be called.
     requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
-        requestComplete = true;
-        callback(requestedMatchPatterns);
+        ASSERT_NOT_REACHED();
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
+
     [manager loadAndRun];
 
-    runScriptWithUserGesture("await browser.test.assertTrue(await browser.permissions.request({'origins': ['*://*.apple.com/*']}))"_s, manager.get().context._backgroundWebView);
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
+
+    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
+
+    TestWebKitAPI::Util::run(&requestComplete);
+}
+
+TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"optional_permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"optional_host_permissions": @[ @"*://*.apple.com/*", @"*://*.example.com/*" ]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"window.runTest = async () => {",
+        @"  await browser.test.assertFalse(await browser.permissions.request({'origins': ['*://*.apple.com/*', '*://*.example.com/*']}))",
+        @"}",
+
+        @"browser.test.yield('Ready')",
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    __block bool requestComplete = false;
+
+    // Permissions method should not be called.
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+        ASSERT_NOT_REACHED();
+    };
+
+    // Grant only one of the requested match patterns.
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+        requestComplete = true;
+        callback([NSSet setWithObject:requestedMatchPatterns.anyObject]);
+    };
+
+    manager.get().controllerDelegate = requestDelegate.get();
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Ready");
+
+    runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }


### PR DESCRIPTION
#### f606e5e964d5dcd860e4a6625db8092664bbc05c
<pre>
WebExtensionContext::permissionsRequest needs to properly capture completionHandler.
<a href="https://webkit.org/b/269678">https://webkit.org/b/269678</a>
<a href="https://rdar.apple.com/problem/123197187">rdar://problem/123197187</a>

Reviewed by Brian Weinstein.

Rework permissions.request() to only call the delegate if needed, never with an empty set.
Also the completionHandler only worked if it was called immediately, but we need to support
it being called later. To support all this, a CallbackAggregator was needed and it now waits
for both delegates to be called (in either order) since they both retain the aggregator.

This also changes the handling to better match the permissions.request() API, by only
allowing granting all or none, not some. Added a test for this.

Also updated the tests to not use nil, since the block parameters are not nullable.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::permissionsRequest):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeSendNativeMessage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm:
(TEST(WKWebExtensionAPIPermissions, Basics)): Renamed.
(TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)): Updated.
(TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)): Updated.
(TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)): Updated.
(TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)): Updated.
(TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)): Updated.
(TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)): Added.
(TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)): Added.

Canonical link: <a href="https://commits.webkit.org/275859@main">https://commits.webkit.org/275859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60ac2ba8316490342cdd5654e3e45a7d9d4aaf0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43085 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19533 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16616 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38172 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38500 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18000 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42406 "layout-tests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19537 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41060 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19715 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5840 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->