### PR TITLE
Resync Invoker WPTs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative-expected.txt
@@ -1,0 +1,18 @@
+
+
+FAIL interestTargetElement reflects interestee HTML element assert_equals: expected (object) Element node <div id="interestee"></div> but got (undefined) undefined
+FAIL interestTargetElement reflects set value assert_equals: expected "" but got "interestee"
+FAIL interestTargetElement reflects set value across shadow root into light dom assert_equals: expected "" but got "interestee"
+FAIL interestTargetElement does not reflect set value inside shadowroot assert_equals: expected null but got Element node <div></div>
+FAIL interestTargetElement does not reflect invalid value assert_equals: expected null but got Element node <div></div>
+FAIL interestTargetElement throws error on assignment of non Element assert_throws_js: interestTargetElement attribute value must be an instance of Element function "function () {
+        buttonInvoker.interestTargetElement = {};
+      }" did not throw
+FAIL interestAction reflects '' when attribute not present assert_equals: expected (string) "" but got (undefined) undefined
+FAIL interestAction reflects '' when attribute empty, setAttribute version assert_equals: expected (string) "" but got (undefined) undefined
+FAIL interestAction reflects '' when attribute empty, IDL setter version assert_equals: expected (string) "" but got (object) null
+FAIL interestAction reflects same casing assert_equals: expected "fooBarBaz" but got ""
+FAIL interestAction reflects '' when attribute set to [] assert_equals: expected (string) "" but got (object) []
+FAIL interestAction reflects tostring value assert_equals: expected "1,2,3" but got ""
+FAIL interestAction reflects tostring value 2 assert_equals: expected (string) "[object Object]" but got (object) object "[object Object]"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" />
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<button id="buttonInvoker" interesttarget="interestee"></button>
+<a id="aInvoker" interesttarget="interestee"></a>
+<input type="button" id="inputInvoker" interesttarget="interestee" />
+<div id="interestee"></div>
+
+<script>
+  test(function () {
+    assert_equals(buttonInvoker.interestTargetElement, interestee);
+    assert_equals(aInvoker.interestTargetElement, interestee);
+    assert_equals(inputInvoker.interestTargetElement, interestee);
+  }, "interestTargetElement reflects interestee HTML element");
+
+  test(function () {
+    const div = document.body.appendChild(document.createElement("div"));
+    buttonInvoker.interestTargetElement = div;
+    aInvoker.interestTargetElement = div;
+    inputInvoker.interestTargetElement = div;
+    assert_equals(buttonInvoker.interestTargetElement, div);
+    assert_equals(buttonInvoker.getAttribute("interesttarget"), "");
+    assert_equals(aInvoker.interestTargetElement, div);
+    assert_equals(aInvoker.getAttribute("interesttarget"), "");
+    assert_equals(inputInvoker.interestTargetElement, div);
+    assert_equals(inputInvoker.getAttribute("interesttarget"), "");
+  }, "interestTargetElement reflects set value");
+
+  test(function () {
+    const host = document.body.appendChild(document.createElement("div"));
+    const shadow = host.attachShadow({ mode: "open" });
+    const button = shadow.appendChild(document.createElement("button"));
+    button.interestTargetElement = interestee;
+    assert_equals(button.interestTargetElement, interestee);
+    assert_equals(buttonInvoker.getAttribute("interesttarget"), "");
+  }, "interestTargetElement reflects set value across shadow root into light dom");
+
+  test(function () {
+    const host = document.body.appendChild(document.createElement("div"));
+    const shadow = host.attachShadow({ mode: "open" });
+    const div = shadow.appendChild(document.createElement("div"));
+    buttonInvoker.interestTargetElement = div;
+    assert_equals(buttonInvoker.interestTargetElement, null);
+    assert_equals(buttonInvoker.getAttribute("interesttarget"), "");
+  }, "interestTargetElement does not reflect set value inside shadowroot");
+
+  test(function () {
+    buttonInvoker.setAttribute('interesttarget', 'invalid');
+    assert_equals(buttonInvoker.interestTargetElement, null);
+    assert_equals(buttonInvoker.getAttribute("interesttarget"), "invalid");
+    aInvoker.setAttribute('interesttarget', 'invalid');
+    assert_equals(aInvoker.interestTargetElement, null);
+    assert_equals(aInvoker.getAttribute("interesttarget"), "invalid");
+    inputInvoker.setAttribute('interesttarget', 'invalid');
+    assert_equals(inputInvoker.interestTargetElement, null);
+    assert_equals(inputInvoker.getAttribute("interesttarget"), "invalid");
+  }, "interestTargetElement does not reflect invalid value");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        buttonInvoker.interestTargetElement = {};
+      },
+      "interestTargetElement attribute value must be an instance of Element",
+    );
+    assert_throws_js(
+      TypeError,
+      function () {
+        aInvoker.interestTargetElement = {};
+      },
+      "interestTargetElement attribute value must be an instance of Element",
+    );
+    assert_throws_js(
+      TypeError,
+      function () {
+        inputInvoker.interestTargetElement = {};
+      },
+      "interestTargetElement attribute value must be an instance of Element",
+    );
+  }, "interestTargetElement throws error on assignment of non Element");
+
+  test(function () {
+    assert_false(buttonInvoker.hasAttribute("interestaction"));
+    assert_equals(buttonInvoker.interestAction, "");
+    assert_false(aInvoker.hasAttribute("interestaction"));
+    assert_equals(aInvoker.interestAction, "");
+    assert_false(inputInvoker.hasAttribute("interestaction"));
+    assert_equals(inputInvoker.interestAction, "");
+  }, "interestAction reflects '' when attribute not present");
+
+  test(function () {
+    buttonInvoker.setAttribute("interestaction", "");
+    assert_equals(buttonInvoker.getAttribute("interestaction"), "");
+    assert_equals(buttonInvoker.interestAction, "");
+    aInvoker.setAttribute("interestaction", "");
+    assert_equals(aInvoker.getAttribute("interestaction"), "");
+    assert_equals(aInvoker.interestAction, "");
+    inputInvoker.setAttribute("interestaction", "");
+    assert_equals(inputInvoker.getAttribute("interestaction"), "");
+    assert_equals(inputInvoker.interestAction, "");
+  }, "interestAction reflects '' when attribute empty, setAttribute version");
+
+  test(function () {
+      buttonInvoker.interestAction = "";
+      assert_equals(buttonInvoker.getAttribute("interestaction"), "");
+      assert_equals(buttonInvoker.interestAction, "");
+      aInvoker.interestAction = "";
+      assert_equals(aInvoker.getAttribute("interestaction"), "");
+      assert_equals(aInvoker.interestAction, "");
+      inputInvoker.interestAction = "";
+      assert_equals(inputInvoker.getAttribute("interestaction"), "");
+      assert_equals(inputInvoker.interestAction, "");
+  }, "interestAction reflects '' when attribute empty, IDL setter version");
+
+  test(function () {
+      buttonInvoker.interestAction = "fooBarBaz";
+      assert_equals(buttonInvoker.getAttribute("interestaction"), "fooBarBaz");
+      assert_equals(buttonInvoker.interestAction, "fooBarBaz");
+      aInvoker.interestAction = "fooBarBaz";
+      assert_equals(aInvoker.getAttribute("interestaction"), "fooBarBaz");
+      assert_equals(aInvoker.interestAction, "fooBarBaz");
+      inputInvoker.interestAction = "fooBarBaz";
+      assert_equals(inputInvoker.getAttribute("interestaction"), "fooBarBaz");
+      assert_equals(inputInvoker.interestAction, "fooBarBaz");
+  }, "interestAction reflects same casing");
+
+  test(function () {
+      buttonInvoker.interestAction = [];
+      assert_equals(buttonInvoker.getAttribute("interestaction"), "");
+      assert_equals(buttonInvoker.interestAction, "");
+      aInvoker.interestAction = [];
+      assert_equals(aInvoker.getAttribute("interestaction"), "");
+      assert_equals(aInvoker.interestAction, "");
+      inputInvoker.interestAction = [];
+      assert_equals(inputInvoker.getAttribute("interestaction"), "");
+      assert_equals(inputInvoker.interestAction, "");
+  }, "interestAction reflects '' when attribute set to []");
+
+  test(function () {
+      buttonInvoker.interestAction = [1, 2, 3];
+      assert_equals(buttonInvoker.getAttribute("interestaction"), "1,2,3");
+      assert_equals(buttonInvoker.interestAction, "1,2,3");
+      aInvoker.interestAction = [1, 2, 3];
+      assert_equals(aInvoker.getAttribute("interestaction"), "1,2,3");
+      assert_equals(aInvoker.interestAction, "1,2,3");
+      inputInvoker.interestAction = [1, 2, 3];
+      assert_equals(inputInvoker.getAttribute("interestaction"), "1,2,3");
+      assert_equals(inputInvoker.interestAction, "1,2,3");
+  }, "interestAction reflects tostring value");
+
+  test(function () {
+      buttonInvoker.interestAction = {};
+      assert_equals(buttonInvoker.interestAction, "[object Object]");
+      aInvoker.interestAction = {};
+      assert_equals(aInvoker.interestAction, "[object Object]");
+      inputInvoker.interestAction = {};
+      assert_equals(inputInvoker.interestAction, "[object Object]");
+  }, "interestAction reflects tostring value 2");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
@@ -5,11 +5,11 @@ PASS invokeTargetElement reflects set value
 PASS invokeTargetElement reflects set value across shadow root into light dom
 PASS invokeTargetElement does not reflect set value inside shadowroot
 PASS invokeTargetElement throws error on assignment of non Element
-PASS invokeAction reflects 'auto' when attribute not present
-PASS invokeAction reflects 'auto' when attribute empty
+FAIL invokeAction reflects '' when attribute not present assert_equals: expected "" but got "auto"
+FAIL invokeAction reflects '' when attribute empty, setAttribute version assert_equals: expected "" but got "auto"
 PASS invokeAction reflects same casing
-PASS invokeAction reflects 'auto' when attribute empty 2
+FAIL invokeAction reflects '' when attribute empty, IDL version assert_equals: expected "" but got "auto"
 PASS invokeAction reflects tostring value
-PASS invokeAction reflects 'auto' when attribute set to []
+FAIL invokeAction reflects '' when attribute set to [] assert_equals: expected "" but got "auto"
 PASS invokeAction reflects tostring value 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
@@ -53,14 +53,14 @@
 
   test(function () {
     assert_false(invoker.hasAttribute("invokeaction"));
-    assert_equals(invoker.invokeAction, "auto");
-  }, "invokeAction reflects 'auto' when attribute not present");
+    assert_equals(invoker.invokeAction, "");
+  }, "invokeAction reflects '' when attribute not present");
 
   test(function () {
     invoker.setAttribute("invokeaction", "");
     assert_equals(invoker.getAttribute("invokeaction"), "");
-    assert_equals(invoker.invokeAction, "auto");
-  }, "invokeAction reflects 'auto' when attribute empty");
+    assert_equals(invoker.invokeAction, "");
+  }, "invokeAction reflects '' when attribute empty, setAttribute version");
 
   test(function () {
     invoker.invokeAction = "fooBarBaz";
@@ -71,8 +71,8 @@
   test(function () {
     invoker.invokeAction = "";
     assert_equals(invoker.getAttribute("invokeaction"), "");
-    assert_equals(invoker.invokeAction, "auto");
-  }, "invokeAction reflects 'auto' when attribute empty 2");
+    assert_equals(invoker.invokeAction, "");
+  }, "invokeAction reflects '' when attribute empty, IDL version");
 
   test(function () {
     invoker.invokeAction = [1, 2, 3];
@@ -83,8 +83,8 @@
   test(function () {
     invoker.invokeAction = [];
     assert_equals(invoker.getAttribute("invokeaction"), "");
-    assert_equals(invoker.invokeAction, "auto");
-  }, "invokeAction reflects 'auto' when attribute set to []");
+    assert_equals(invoker.invokeAction, "");
+  }, "invokeAction reflects '' when attribute set to []");
 
   test(function () {
     invoker.invokeAction = {};

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
@@ -1,9 +1,9 @@
 
 
-PASS action is a readonly defaulting to 'auto'
+FAIL action is a readonly defaulting to '' assert_equals: expected "" but got "auto"
 PASS invoker is readonly defaulting to null
 PASS action reflects initialized attribute
-PASS action set to undefined
+FAIL action set to undefined assert_equals: expected "" but got "auto"
 PASS action set to null
 PASS action set to false
 PASS action explicitly set to empty string

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
@@ -15,9 +15,9 @@
 <script>
   test(function () {
     const event = new InvokeEvent("test");
-    assert_equals(event.action, "auto");
+    assert_equals(event.action, "");
     assert_readonly(event, "action", "readonly attribute value");
-  }, "action is a readonly defaulting to 'auto'");
+  }, "action is a readonly defaulting to ''");
 
   test(function () {
     const event = new InvokeEvent("test");
@@ -32,7 +32,7 @@
 
   test(function () {
     const event = new InvokeEvent("test", { action: undefined });
-    assert_equals(event.action, "auto");
+    assert_equals(event.action, "");
   }, "action set to undefined");
 
   test(function () {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 
-PASS event dispatches on click
+FAIL event dispatches on click assert_equals: action expected "" but got "auto"
 PASS event action is set to invokeAction
 PASS event action is set to invokeaction attribute
 PASS event does not dispatch if click:preventDefault is called

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
@@ -22,7 +22,7 @@
     assert_equals(event.bubbles, false, "bubbles");
     assert_equals(event.composed, true, "composed");
     assert_equals(event.isTrusted, true, "isTrusted");
-    assert_equals(event.action, "auto", "action");
+    assert_equals(event.action, "", "action");
     assert_equals(event.target, invokee, "target");
     assert_equals(event.invoker, invokerbutton, "invoker");
   }, "event dispatches on click");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html


### PR DESCRIPTION
#### 4d43d6cf919e3ca92769de9455757ee77a5ad2ae
<pre>
Resync Invoker WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=270718">https://bugs.webkit.org/show_bug.cgi?id=270718</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/92088377f8a8f322333f5ca2efc6f077e5bedeb6">https://github.com/web-platform-tests/wpt/commit/92088377f8a8f322333f5ca2efc6f077e5bedeb6</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/275884@main">https://commits.webkit.org/275884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b5c37654c1de9c0a39b30175a67e151333a413e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45762 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39259 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35659 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16657 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16798 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38224 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1190 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47306 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42450 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9603 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->