### PR TITLE
build.webkit.org bots should upload archives directly to S3

### DIFF
--- a/Tools/CISupport/Shared/generate-s3-url
+++ b/Tools/CISupport/Shared/generate-s3-url
@@ -15,6 +15,7 @@ if 'uat' in hostname:
 
 S3_DEFAULT_BUCKET = f'archives.webkit{custom_suffix}.org'
 S3_EWS_BUCKET = f'ews-archives.webkit{custom_suffix}.org'
+S3_MINIFIED_BUCKET = f'minified-archives.webkit{custom_suffix}.org'
 
 def generateS3URL(bucket, identifier, revision, extension=None, content_type=None):
     key = f"{identifier}/{revision}.{extension or 'zip'}"
@@ -37,11 +38,15 @@ def main():
     parser.add_argument('--identifier', action="store", required=True, help='S3 destination identifier, in the form of fullPlatform-architecture-configuration. [mac-mojave-x86_64-release]')
     parser.add_argument('--extension', action='store', required=False, default=None, help='File extension of uploaded file')
     parser.add_argument('--content-type', action='store', required=False, default=None, help='Content type of file to be uploaded')
+    parser.add_argument('--minified', action='store_true', required=False, default=False, help='If the content being uploaded is minified')
+
     args = parser.parse_args()
 
     s3_bucket = S3_DEFAULT_BUCKET
     if args.change_id:
         s3_bucket = S3_EWS_BUCKET
+    if args.minified:
+        s3_bucket = S3_MINIFIED_BUCKET
 
     url = generateS3URL(
         s3_bucket, args.identifier, args.revision or args.change_id,

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -30,9 +30,9 @@ class Factory(factory.BuildFactory):
     shouldInstallDependencies = True
     shouldUseCrossTargetImage = False
 
-    def __init__(self, platform, configuration, architectures, buildOnly, additionalArguments, device_model):
+    def __init__(self, platform, configuration, architectures, buildOnly, additionalArguments, device_model, triggers=None):
         factory.BuildFactory.__init__(self)
-        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architecture=" ".join(architectures), buildOnly=buildOnly, additionalArguments=additionalArguments, device_model=device_model))
+        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architecture=" ".join(architectures), buildOnly=buildOnly, additionalArguments=additionalArguments, device_model=device_model, triggers=triggers))
         self.addStep(PrintConfiguration())
         self.addStep(CheckOutSource())
         self.addStep(CheckOutSpecificRevision())
@@ -57,7 +57,7 @@ class BuildFactory(Factory):
     shouldRunMiniBrowserBundleStep = False
 
     def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None):
-        Factory.__init__(self, platform, configuration, architectures, True, additionalArguments, device_model)
+        Factory.__init__(self, platform, configuration, architectures, True, additionalArguments, device_model, triggers=triggers)
 
         if platform == "win" or platform.startswith("playstation"):
             self.addStep(CompileWebKit(timeout=2 * 60 * 60))
@@ -74,13 +74,6 @@ class BuildFactory(Factory):
         if triggers:
             if platform.startswith("gtk"):
                 self.addStep(InstallBuiltProduct())
-
-            self.addStep(ArchiveBuiltProduct())
-            self.addStep(UploadBuiltProduct())
-            if platform.startswith('mac') or platform.startswith('ios-simulator') or platform.startswith('tvos-simulator') or platform.startswith('watchos-simulator'):
-                self.addStep(ArchiveMinifiedBuiltProduct())
-                self.addStep(UploadMinifiedBuiltProduct())
-            self.addStep(TransferToS3())
             self.addStep(trigger.Trigger(schedulerNames=triggers))
 
 

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -39,11 +39,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'prune-coresymbolicationd-cache-if-too-large',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'archive-minified-built-product',
-            'upload-minified-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'Apple-Sonoma-Release-WK1-Tests': [
@@ -165,11 +160,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'prune-coresymbolicationd-cache-if-too-large',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'archive-minified-built-product',
-            'upload-minified-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'Apple-Sonoma-Debug-WK1-Tests': [
@@ -370,11 +360,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'prune-coresymbolicationd-cache-if-too-large',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'archive-minified-built-product',
-            'upload-minified-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'Apple-Ventura-Release-WK1-Tests': [
@@ -496,11 +481,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'prune-coresymbolicationd-cache-if-too-large',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'archive-minified-built-product',
-            'upload-minified-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'Apple-Ventura-Debug-WK1-Tests': [
@@ -622,11 +602,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'prune-coresymbolicationd-cache-if-too-large',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'archive-minified-built-product',
-            'upload-minified-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'Apple-Monterey-Release-Test262-Tests': [
@@ -758,11 +733,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'prune-coresymbolicationd-cache-if-too-large',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'archive-minified-built-product',
-            'upload-minified-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'Apple-Monterey-Debug-Test262-Tests': [
@@ -932,11 +902,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-WebKitBuild-directory',
             'delete-stale-build-files',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'archive-minified-built-product',
-            'upload-minified-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'Apple-iOS-17-Simulator-Debug-Build': [
@@ -949,11 +914,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-WebKitBuild-directory',
             'delete-stale-build-files',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'archive-minified-built-product',
-            'upload-minified-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'Apple-iOS-17-Simulator-Release-WK2-Tests': [
@@ -1113,9 +1073,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'compile-webkit',
             'generate-jsc-bundle',
             'install-built-product',
-            'archive-built-product',
-            'upload-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'GTK-Linux-64-bit-Release-Clang-Build': [
@@ -1195,9 +1152,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'jhbuild',
             'compile-webkit',
             'install-built-product',
-            'archive-built-product',
-            'upload-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'GTK-Linux-64-bit-Debug-Tests': [
@@ -1405,9 +1359,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-WebKitBuild-directory',
             'delete-stale-build-files',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'WinCairo-64-bit-Release-Tests': [
@@ -1480,9 +1431,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-WebKitBuild-directory',
             'delete-stale-build-files',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'WinCairo-64-bit-Debug-Tests': [
@@ -1600,9 +1548,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'jhbuild',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'WPE-Linux-64-bit-Release-Tests': [
@@ -1669,9 +1614,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'jhbuild',
             'compile-webkit',
-            'archive-built-product',
-            'upload-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'WPE-Linux-64-bit-Debug-Tests': [
@@ -1819,9 +1761,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit',
             'check-if-deployed-cross-target-image-is-updated',
-            'archive-built-product',
-            'upload-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Build': [
@@ -1835,9 +1774,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit',
             'check-if-deployed-cross-target-image-is-updated',
-            'archive-built-product',
-            'upload-built-product',
-            'transfer-to-s3',
             'trigger'
         ],
         'WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Tests': [


### PR DESCRIPTION
#### 62e3e1d1b472669a287ee124839475ad4fe07cbd
<pre>
build.webkit.org bots should upload archives directly to S3
<a href="https://bugs.webkit.org/show_bug.cgi?id=270655">https://bugs.webkit.org/show_bug.cgi?id=270655</a>
<a href="https://rdar.apple.com/124300568">rdar://124300568</a>

Reviewed by Aakash Jain and Jonathan Bedard.

Use GenerateS3URL and UploadFileToS3 in CompileWebKit to upload archives to S3.

* Tools/CISupport/Shared/generate-s3-url:
(main): Adds --minified argument and corresponding bucket.

* Tools/CISupport/build-webkit-org/steps.py:
(ConfigureBuild.__init__):
(ConfigureBuild.start): Adds triggers as a build property so it can be accessed in CompileWebKit.
(DownloadBuiltProduct.run): Allows downloading from master on test instances.
(CompileWebKit.evaluateCommand):
(GenerateS3URL.__init__):
(GenerateS3URL.run):

* Tools/CISupport/build-webkit-org/factories.py:
(Factory.__init__): Adds triggers argument.
(BuildFactory.__init__): Removes archive, upload, and transfer steps. These are added in CompileWebKit.
Also adds triggers argument so that it can be set as a property.

* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/276500@main">https://commits.webkit.org/276500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/662d6ccbb7254847c40fa7077fb5f8abdafd29a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47495 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40846 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47144 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/27994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21335 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45419 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/27994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17898 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/27994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39753 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2888 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/27994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40045 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49160 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19809 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/44882 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42569 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6211 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20802 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->