### PR TITLE
Remove WTF::LegacyThreadSafeIdentified now that it is no longer used

### DIFF
--- a/Source/WTF/wtf/Identified.h
+++ b/Source/WTF/wtf/Identified.h
@@ -92,34 +92,6 @@ private:
 };
 
 template <typename T>
-class LegacyThreadSafeIdentified : public IdentifiedBase<uint64_t> {
-protected:
-    LegacyThreadSafeIdentified()
-        : IdentifiedBase<uint64_t>(generateIdentifier())
-    {
-    }
-
-    LegacyThreadSafeIdentified(const LegacyThreadSafeIdentified&) = default;
-    LegacyThreadSafeIdentified& operator=(const LegacyThreadSafeIdentified&) = default;
-
-    explicit LegacyThreadSafeIdentified(uint64_t identifier)
-        : IdentifiedBase<uint64_t>(identifier)
-    {
-    }
-
-private:
-    static uint64_t generateIdentifier()
-    {
-        static LazyNeverDestroyed<std::atomic<uint64_t>> currentIdentifier;
-        static std::once_flag initializeCurrentIdentifier;
-        std::call_once(initializeCurrentIdentifier, [] {
-            currentIdentifier.construct(0);
-        });
-        return ++currentIdentifier.get();
-    }
-};
-
-template <typename T>
 class UUIDIdentified : public IdentifiedBase<UUID> {
 protected:
     UUIDIdentified()
@@ -134,5 +106,4 @@ protected:
 
 using WTF::Identified;
 using WTF::LegacyIdentified;
-using WTF::LegacyThreadSafeIdentified;
 using WTF::UUIDIdentified;


### PR DESCRIPTION
#### 71f4504aff74ff64373f68844fe991bf7dd0ab6a
<pre>
Remove WTF::LegacyThreadSafeIdentified now that it is no longer used
<a href="https://bugs.webkit.org/show_bug.cgi?id=270730">https://bugs.webkit.org/show_bug.cgi?id=270730</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/Identified.h:
(WTF::LegacyThreadSafeIdentified::LegacyThreadSafeIdentified): Deleted.
(WTF::LegacyThreadSafeIdentified::generateIdentifier): Deleted.

Canonical link: <a href="https://commits.webkit.org/275870@main">https://commits.webkit.org/275870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d652a59ae443fbefa8424d5df1c6125ac2241c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45747 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39243 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19567 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16643 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38209 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1174 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/36576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39309 "re-run-api-tests (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47291 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42745 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14817 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19571 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9593 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19749 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49755 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19203 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10058 "Passed tests") | 
<!--EWS-Status-Bubble-End-->