### PR TITLE
REGRESSION(272180@main): Crash in CSSCalcOperationNode::simplifyRecursive with xywh() and rect() clip-paths

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed-expected.txt
@@ -8,10 +8,12 @@ PASS Property clip-path value 'xywh(0px 1% 2px 0.5em round 0)'
 PASS Property clip-path value 'xywh(0px 1% 2px 3% round 0 1px)'
 PASS Property clip-path value 'xywh(0px 1% 2px 3% round 0px 1px 2em)'
 PASS Property clip-path value 'xywh(0px 1% 2px 3% round 0px 1px 2% 3px)'
+FAIL Property clip-path value 'xywh(calc(0px) calc(1px + 1%) calc(2px + 2%) calc(3px + 3%))' assert_equals: expected "inset(calc(1% + 1px) calc(98% - 2px) calc(96% - 4px) 0px)" but got "inset(calc(1% + 1px) calc(100% - (2% + 2px)) calc(100% - (4% + 4px)) 0px)"
 PASS Property clip-path value 'rect(auto auto auto auto)'
 PASS Property clip-path value 'rect(0 1% 2px 0.5em)'
 PASS Property clip-path value 'rect(0px 1% auto 0.5em round 0)'
 PASS Property clip-path value 'rect(0px 1% auto 3% round 0 1px)'
 PASS Property clip-path value 'rect(0px 1% auto 3% round 0px 1px 2em)'
 PASS Property clip-path value 'rect(0px 1% auto 3% round 0px 1px 2% 3px)'
+FAIL Property clip-path value 'rect(calc(0px) calc(1px + 1%) calc(2px + 2%) calc(3px + 3%))' assert_equals: expected "inset(0px calc(99% - 1px) calc(98% - 2px) calc(3% + 3px))" but got "inset(0px calc(100% - (1% + 1px)) calc(100% - (2% + 2px)) calc(3% + 3px))"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed.html
@@ -32,6 +32,7 @@ test_computed_value("clip-path", "xywh(0px 1% 2px 0.5em round 0)", "inset(1% cal
 test_computed_value("clip-path", "xywh(0px 1% 2px 3% round 0 1px)", "inset(1% calc(100% - 2px) 96% 0px round 0px 1px)");
 test_computed_value("clip-path", "xywh(0px 1% 2px 3% round 0px 1px 2em)", "inset(1% calc(100% - 2px) 96% 0px round 0px 1px 80px)");
 test_computed_value("clip-path", "xywh(0px 1% 2px 3% round 0px 1px 2% 3px)", "inset(1% calc(100% - 2px) 96% 0px round 0px 1px 2% 3px)");
+test_computed_value("clip-path", "xywh(calc(0px) calc(1px + 1%) calc(2px + 2%) calc(3px + 3%))", "inset(calc(1% + 1px) calc(98% - 2px) calc(96% - 4px) 0px)");
 // Given "rect(t r b l)", the equivalent function is
 // "inset(t calc(100% - r) calc(100% - b) l)".
 test_computed_value("clip-path", "rect(auto auto auto auto)", "inset(0%)");
@@ -40,6 +41,7 @@ test_computed_value("clip-path", "rect(0px 1% auto 0.5em round 0)", "inset(0px 9
 test_computed_value("clip-path", "rect(0px 1% auto 3% round 0 1px)", "inset(0px 99% 0% 3% round 0px 1px)");
 test_computed_value("clip-path", "rect(0px 1% auto 3% round 0px 1px 2em)", "inset(0px 99% 0% 3% round 0px 1px 80px)");
 test_computed_value("clip-path", "rect(0px 1% auto 3% round 0px 1px 2% 3px)", "inset(0px 99% 0% 3% round 0px 1px 2% 3px)");
+test_computed_value("clip-path", "rect(calc(0px) calc(1px + 1%) calc(2px + 2%) calc(3px + 3%))", "inset(0px calc(99% - 1px) calc(98% - 2px) calc(3% + 3px))");
 </script>
 </body>
 </html>

--- a/Source/WebCore/css/BasicShapeFunctions.cpp
+++ b/Source/WebCore/css/BasicShapeFunctions.cpp
@@ -94,32 +94,15 @@ Ref<CSSValue> valueForBasicShape(const RenderStyle& style, const BasicShape& bas
     auto createPair = [&](const LengthSize& size) {
         return CSSValuePair::create(createValue(size.width), createValue(size.height));
     };
-
-    auto createSumValue = [&](Vector<Ref<CSSCalcExpressionNode>> expressions) -> Ref<CSSValue> {
-        auto node = CSSCalcOperationNode::simplify(CSSCalcOperationNode::createSum(WTFMove(expressions)).releaseNonNull());
-        if (RefPtr operation = dynamicDowncast<CSSCalcOperationNode>(node); operation && operation->isIdentity()) {
-            if (RefPtr child = dynamicDowncast<CSSCalcPrimitiveValueNode>(operation->children()[0]))
-                return const_cast<CSSPrimitiveValue&>(child->value());
-        }
-        return CSSCalcValue::create(WTFMove(node));
-    };
-
-    auto createNode = [&](const Length& length) {
-        return CSSCalcPrimitiveValueNode::create(createValue(length));
-    };
-    auto create100PercentNode = [&]() {
-        return createNode(Length(100, LengthType::Percent));
-    };
-    auto createNegatedNode = [&](const Length& length) {
-        return CSSCalcNegateNode::create(createNode(length));
-    };
     auto createReflectedSumValue = [&](const Length& a, const Length& b) {
-        return createSumValue({ create100PercentNode(), createNegatedNode(a), createNegatedNode(b) });
+        auto reflected = convertTo100PercentMinusLengthSum(a, b);
+        return CSSPrimitiveValue::create(reflected, style);
     };
     auto createReflectedValue = [&](const Length& length) -> Ref<CSSValue> {
         if (length.isAuto())
             return createValue(Length(0, LengthType::Percent));
-        return createSumValue({ create100PercentNode(), createNegatedNode(length) });
+        auto reflected = convertTo100PercentMinusLength(length);
+        return CSSPrimitiveValue::create(reflected, style);
     };
 
     switch (basicShape.type()) {

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -357,6 +357,26 @@ Length convertTo100PercentMinusLength(const Length& length)
     return makeCalculated(CalcOperator::Subtract, Length(100, LengthType::Percent), length);
 }
 
+Length convertTo100PercentMinusLengthSum(const Length& a, const Length& b)
+{
+    // FIXME: The main simplification code does not deal with substract expressions so this does some basic steps.
+    // A seperate calc node type for pixel-and-percent values would make simplifications easier.
+
+    if (a.isPercent() && b.isPercent())
+        return Length(100 - a.value() - b.value(), LengthType::Percent);
+
+    if (a.isPercent()) {
+        auto percent = Length(100 - a.value(), LengthType::Percent);
+        return makeCalculated(CalcOperator::Subtract, percent, b);
+    }
+    if (b.isPercent()) {
+        auto percent = Length(100 - b.value(), LengthType::Percent);
+        return makeCalculated(CalcOperator::Subtract, percent, a);
+    }
+    auto sum = makeCalculated(CalcOperator::Add, a, b);
+    return convertTo100PercentMinusLength(sum);
+}
+
 static Length blendMixedTypes(const Length& from, const Length& to, const BlendingContext& context)
 {
     if (context.compositeOperation != CompositeOperation::Replace)

--- a/Source/WebCore/platform/Length.h
+++ b/Source/WebCore/platform/Length.h
@@ -585,6 +585,7 @@ inline bool Length::isContent() const
 }
 
 Length convertTo100PercentMinusLength(const Length&);
+Length convertTo100PercentMinusLengthSum(const Length&, const Length&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, Length);
 


### PR DESCRIPTION
#### 040cadd0e752cb1b5b307278fbd635097c729efd
<pre>
REGRESSION(272180@main): Crash in CSSCalcOperationNode::simplifyRecursive with xywh() and rect() clip-paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=270296">https://bugs.webkit.org/show_bug.cgi?id=270296</a>
<a href="https://rdar.apple.com/123508905">rdar://123508905</a>

Reviewed by Darin Adler.

Clip path serialization produces inset() values which requires constructing calc expressions if the original
values are not insets. The code for this didn&apos;t work correctly if the values were calc expressions thenselves.

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed-expected.txt:

The results are correct though FAILs because they are not maximally simplified.

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/parsing/clip-path-computed.html:

Update from the WPT repo.

* Source/WebCore/css/BasicShapeFunctions.cpp:

Use the existing convertTo100PercentMinusLength instead of trying to do this manually.

(WebCore::valueForBasicShape):
* Source/WebCore/platform/Length.cpp:
(WebCore::convertTo100PercentMinusLengthSum):

Add a separate dual-argument version. This is needed so we can do some manual simplification (see the comment).

* Source/WebCore/platform/Length.h:

Canonical link: <a href="https://commits.webkit.org/277500@main">https://commits.webkit.org/277500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb0fed09cf90a654d86e9e984a8ec148202cdf88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43831 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24453 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24641 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/20189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22119 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5825 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52353 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19165 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46197 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45237 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10541 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->