### PR TITLE
Support `world` in `content_scripts` for Web Extension manifests.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -94,9 +94,6 @@
 /* window title for a standalone image (uses multiplication symbol, not x) */
 "%s %d×%d pixels" = "%s %d×%d pixels";
 
-/* Name of application's single WebCrypto master key in Keychain */
-"%s WebCrypto Master Key" = "%s WebCrypto Master Key";
-
 /* Present the number of selected <option> items in a <select multiple> element (iOS only) */
 "%zu Items" = "%zu Items";
 
@@ -123,9 +120,6 @@
 
 /* 2× media controls context menu playback speed label */
 "2× (Media Controls Menu Playback Speed)" = "2×";
-
-/* Name of application's single WebCrypto master key in Keychain */
-"<application> WebCrypto Master Key" = "<application> WebCrypto Master Key";
 
 /* window title for a standalone image (uses multiplication symbol, not x) */
 "<filename> %d×%d pixels" = "<filename> %d×%d pixels";
@@ -730,6 +724,9 @@
 /* Inspect Element context menu item */
 "Inspect Element" = "Inspect Element";
 
+/* Message when a PDF fails to unlock with the given password */
+"Invalid Password" = "Invalid Password";
+
 /* WKWebExtensionErrorInvalidManifestEntry description for commands */
 "Invalid `commands` manifest entry." = "Invalid `commands` manifest entry.";
 
@@ -750,9 +747,6 @@
 
 /* WKWebExtensionErrorInvalidManifestEntry description for web_accessible_resources */
 "Invalid `web_accessible_resources` manifest entry." = "Invalid `web_accessible_resources` manifest entry.";
-
-/* Message when a PDF fails to unlock with the given password */
-"Invalid Password" = "Invalid Password";
 
 /* Validation message for input form controls with a value not matching type */
 "Invalid value" = "Invalid value";
@@ -967,6 +961,9 @@
 /* WKWebExtensionErrorInvalidContentScripts description for unknown 'run_at' value */
 "Manifest `content_scripts` entry has unknown `run_at` value." = "Manifest `content_scripts` entry has unknown `run_at` value.";
 
+/* WKWebExtensionErrorInvalidContentScripts description for unknown 'world' value */
+"Manifest `content_scripts` entry has unknown `world` value." = "Manifest `content_scripts` entry has unknown `world` value.";
+
 /* _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for missing declarativeNetRequest permission */
 "Manifest has no `declarativeNetRequest` permission." = "Manifest has no `declarativeNetRequest` permission.";
 
@@ -1149,6 +1146,9 @@
 
 /* Playback Speed media controls context menu title */
 "Playback Speed (Media Controls Menu)" = "Playback Speed";
+
+/* Subtitle when a PDF needs a password to be unlocked */
+"Please enter the password below." = "Please enter the password below.";
 
 /* Label text to be used when a plug-in was blocked from loading because it was too small */
 "Plug-In too small" = "Plug-In too small";
@@ -1395,6 +1395,9 @@
 
 /* Label for the support with Apple Pay button. */
 "Support with Apple Pay" = "Support with Apple Pay";
+
+/* Swap characters context menu item */
+"Swap characters" = "Swap characters";
 
 /* File Upload alert sheet camera button string for taking only photos */
 "Take Photo (file upload action sheet)" = "Take Photo";
@@ -1795,6 +1798,9 @@
 /* accessibility role description for a mark element */
 "highlighted" = "highlighted";
 
+/* accessibility label for hour fields. */
+"hour" = "hour";
+
 /* accessibility role description for image map */
 "image map" = "image map";
 
@@ -1824,6 +1830,15 @@
 
 /* An ARIA accessibility group that contains mathematical symbols. */
 "math" = "math";
+
+/* accessibility label for meridiem fields. */
+"meridiem" = "meridiem";
+
+/* accessibility label for milliseconds fields. */
+"milliseconds" = "milliseconds";
+
+/* accessibility label for minutes fields. */
+"minutes" = "minutes";
 
 /* accessibility label for a date field month input. */
 "month" = "month";
@@ -1888,9 +1903,6 @@
 /* accessibility label for play button */
 "play" = "play";
 
-/* Subtitle when a PDF needs a password to be unlocked */
-"Please enter the password below." = "Please enter the password below.";
-
 /* Verb stating the action that will occur when a button is pressed, as used by accessibility */
 "press" = "press";
 
@@ -1917,6 +1929,9 @@
 
 /* An ARIA accessibility group that contains a search feature of a website. */
 "search" = "search";
+
+/* accessibility label for seconds fields. */
+"seconds" = "seconds";
 
 /* accessibility help text for jump back 30 seconds button */
 "seek movie back 30 seconds" = "seek movie back 30 seconds";
@@ -2016,13 +2031,6 @@
 
 /* accessibility label for a date field year input. */
 "year" = "year";
-
-/* Accessibility labels for time fields. */
-"hour" = "hour";
-"minutes" = "minutes";
-"seconds" = "seconds";
-"milliseconds" = "milliseconds";
-"meridiem" = "meridiem";
 
 /* Message for requesting access to the device motion and orientation */
 "“%@” Would Like to Access Motion and Orientation" = "“%@” Would Like to Access Motion and Orientation";

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1839,7 +1839,6 @@ localizedStrings["Ungrouped @ Computed Style variables grouping mode"] = "Ungrou
 /* Property value for `font-variant-capitals: unicase`. */
 localizedStrings["Unicase @ Font Details Sidebar Property Value"] = "Unicase";
 localizedStrings["Unique"] = "Unique";
-localizedStrings["Unknown"] = "Unknown";
 localizedStrings["Unknown Location"] = "Unknown Location";
 localizedStrings["Unknown error"] = "Unknown error";
 localizedStrings["Unknown node"] = "Unknown node";

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 struct WebExtensionFrameParameters {
-    bool errorOccurred;
+    bool errorOccurred { false };
     std::optional<URL> url;
     WebKit::WebExtensionFrameIdentifier parentFrameIdentifier;
     std::optional<WebKit::WebExtensionFrameIdentifier> frameIdentifier;

--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h
@@ -39,7 +39,7 @@ struct WebExtensionMessageSenderParameters {
     std::optional<WebExtensionTabParameters> tabParameters;
     std::optional<WebExtensionFrameIdentifier> frameIdentifier;
     WebPageProxyIdentifier pageProxyIdentifier;
-    WebExtensionContentWorldType contentWorldType;
+    WebExtensionContentWorldType contentWorldType { WebExtensionContentWorldType::ContentScript };
     URL url;
 };
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -82,7 +82,7 @@ void WebExtensionContext::scriptingExecuteScript(const WebExtensionScriptInjecti
     }
 
     auto scriptPairs = getSourcePairsForParameters(parameters, m_extension);
-    Ref executionWorld = parameters.world == WebExtensionContentWorldType::Main ? API::ContentWorld::pageContentWorld() : *m_contentScriptWorld;
+    Ref executionWorld = toContentWorld(parameters.world);
 
     executeScript(scriptPairs, webView, executionWorld, tab.get(), parameters, *this, [completionHandler = WTFMove(completionHandler)](InjectionResults&& injectionResults) mutable {
         completionHandler(WTFMove(injectionResults));
@@ -390,9 +390,9 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         injectedContentData.identifier = parameters.identifier;
         injectedContentData.includeMatchPatterns = WTFMove(includeMatchPatterns);
         injectedContentData.excludeMatchPatterns = WTFMove(excludeMatchPatterns);
-        injectedContentData.injectionTime = parameters.injectionTime.value();
-        injectedContentData.injectsIntoAllFrames = parameters.allFrames.value();
-        injectedContentData.forMainWorld = parameters.world.value() == WebExtensionContentWorldType::Main;
+        injectedContentData.injectionTime = parameters.injectionTime.value_or(WebExtension::InjectionTime::DocumentIdle);
+        injectedContentData.injectsIntoAllFrames = parameters.allFrames.value_or(false);
+        injectedContentData.contentWorldType = parameters.world.value_or(WebExtensionContentWorldType::ContentScript);
         injectedContentData.scriptPaths = scriptPaths;
         injectedContentData.styleSheetPaths = styleSheetPaths;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -112,6 +112,9 @@ static NSString * const contentScriptsDocumentEndManifestKey = @"document_end";
 static NSString * const contentScriptsAllFramesManifestKey = @"all_frames";
 static NSString * const contentScriptsJSManifestKey = @"js";
 static NSString * const contentScriptsCSSManifestKey = @"css";
+static NSString * const contentScriptsWorldManifestKey = @"world";
+static NSString * const contentScriptsIsolatedManifestKey = @"ISOLATED";
+static NSString * const contentScriptsMainManifestKey = @"MAIN";
 
 static NSString * const permissionsManifestKey = @"permissions";
 static NSString * const optionalPermissionsManifestKey = @"optional_permissions";
@@ -1950,13 +1953,22 @@ void WebExtension::populateContentScriptPropertiesIfNeeded()
         else
             recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `run_at` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'run_at' value")));
 
+        WebExtensionContentWorldType contentWorldType = WebExtensionContentWorldType::ContentScript;
+        NSString *worldString = objectForKey<NSString>(dictionary, contentScriptsWorldManifestKey);
+        if (!worldString || [worldString isEqualToString:contentScriptsIsolatedManifestKey])
+            contentWorldType = WebExtensionContentWorldType::ContentScript;
+        else if ([worldString isEqualToString:contentScriptsMainManifestKey])
+            contentWorldType = WebExtensionContentWorldType::Main;
+        else
+            recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `world` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'world' value")));
+
         InjectedContentData injectedContentData;
         injectedContentData.includeMatchPatterns = WTFMove(includeMatchPatterns);
         injectedContentData.excludeMatchPatterns = WTFMove(excludeMatchPatterns);
         injectedContentData.injectionTime = injectionTime;
         injectedContentData.matchesAboutBlank = matchesAboutBlank;
         injectedContentData.injectsIntoAllFrames = injectsIntoAllFrames;
-        injectedContentData.forMainWorld = false;
+        injectedContentData.contentWorldType = contentWorldType;
         injectedContentData.scriptPaths = scriptPaths;
         injectedContentData.styleSheetPaths = styleSheetPaths;
         injectedContentData.includeGlobPatternStrings = includeGlobPatternStrings;

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -29,6 +29,7 @@
 
 #include "APIObject.h"
 #include "CocoaImage.h"
+#include "WebExtensionContentWorldType.h"
 #include "WebExtensionMatchPattern.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
@@ -155,7 +156,7 @@ public:
 
         bool matchesAboutBlank { false };
         bool injectsIntoAllFrames { false };
-        bool forMainWorld { false };
+        WebExtensionContentWorldType contentWorldType { WebExtensionContentWorldType::ContentScript };
 
         RetainPtr<NSArray> scriptPaths;
         RetainPtr<NSArray> styleSheetPaths;
@@ -174,7 +175,7 @@ public:
 
     struct DeclarativeNetRequestRulesetData {
         String rulesetID;
-        bool enabled;
+        bool enabled { false };
         String jsonPath;
     };
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -578,6 +578,8 @@ private:
     HashSet<Ref<WebProcessProxy>> processes(const API::InspectorExtension&) const;
 #endif // ENABLE(INSPECTOR_EXTENSIONS)
 
+    API::ContentWorld& toContentWorld(WebExtensionContentWorldType) const;
+
     void addInjectedContent() { addInjectedContent(injectedContents()); }
     void addInjectedContent(const InjectedContentVector&);
     void addInjectedContent(const InjectedContentVector&, MatchPatternSet&);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -223,6 +223,12 @@ TEST(WKWebExtension, ContentScriptsParsing)
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_TRUE(testExtension.hasInjectedContent);
 
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"world": @"MAIN" } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+    EXPECT_TRUE(testExtension.hasInjectedContent);
+
     // Invalid cases
 
     testManifestDictionary[@"content_scripts"] = @[ ];
@@ -247,6 +253,13 @@ TEST(WKWebExtension, ContentScriptsParsing)
     EXPECT_FALSE(testExtension.hasInjectedContent);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"run_at": @"invalid" } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
+    EXPECT_TRUE(testExtension.hasInjectedContent);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"world": @"INVALID" } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NE(testExtension.errors.count, 0ul);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -427,6 +427,15 @@ TEST(WKWebExtensionContext, ContentScriptsParsing)
     EXPECT_FALSE([testContext hasInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testContext hasInjectedContentForURL:exampleURL]);
 
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"world": @"MAIN" } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
+
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+    EXPECT_TRUE(testContext.hasInjectedContent);
+    EXPECT_FALSE([testContext hasInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testContext hasInjectedContentForURL:exampleURL]);
+
     // Invalid cases
 
     testManifestDictionary[@"content_scripts"] = @[ ];
@@ -457,6 +466,15 @@ TEST(WKWebExtensionContext, ContentScriptsParsing)
     EXPECT_FALSE([testContext hasInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"run_at": @"invalid" } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
+
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_TRUE(testContext.hasInjectedContent);
+    EXPECT_FALSE([testContext hasInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testContext hasInjectedContentForURL:exampleURL]);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"world": @"INVALID" } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 


### PR DESCRIPTION
#### 38949431399cb8ca2a55db3cd3f1292f4fb0f1ca
<pre>
Support `world` in `content_scripts` for Web Extension manifests.
<a href="https://webkit.org/b/270748">https://webkit.org/b/270748</a>
<a href="https://rdar.apple.com/problem/124331541">rdar://problem/124331541</a>

Reviewed by Brian Weinstein.

Add support for the `world` key in `content_scripts`. Also changed the `forMainWorld`
boolean to be `contentWorldType` and use `WebExtensionContentWorldType` for consistency.

Drive-by fixes to provide missing default values for plain types to avoid random memory.

* Source/WebCore/en.lproj/Localizable.strings: Updated with the script.
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js: Ditto.
* Source/WebKit/Shared/Extensions/WebExtensionFrameParameters.h: Add default value.
* Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h: Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingExecuteScript): Use toContentWorld().
(WebKit::WebExtensionContext::createInjectedContentForScripts): Use contentWorldType. Also
use value_or() in case the web process does not set the value.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::populateContentScriptPropertiesIfNeeded): Parse the `world` key.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::toContentWorld const): Added.
(WebKit::WebExtensionContext::addInjectedContent): Use toContentWorld().
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TEST(WKWebExtension, ContentScriptsParsing)): Added `world` tests.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TEST(WKWebExtensionAPIScripting, MainWorld)): Added.
(TEST(WKWebExtensionAPIScripting, IsolatedWorld)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
(TEST(WKWebExtensionContext, ContentScriptsParsing)): Added `world` tests.

Canonical link: <a href="https://commits.webkit.org/275909@main">https://commits.webkit.org/275909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceae966cd1f71280fd5043f83cb47c7126cd43aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45797 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39287 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35685 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38250 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1218 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42475 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19615 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41134 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19793 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5873 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->