### PR TITLE
Web Inspector: the frontend should be able to prevent the inspected page from clearing the console

### DIFF
--- a/LayoutTests/inspector/console/setConsoleClearAPIEnabled-expected.txt
+++ b/LayoutTests/inspector/console/setConsoleClearAPIEnabled-expected.txt
@@ -1,0 +1,22 @@
+CONSOLE MESSAGE: Clear disabled.
+CONSOLE MESSAGE: Clear enabled.
+Tests for Console.setConsoleClearAPIEnabled.
+
+
+== Running test suite: Console.setConsoleClearAPIEnabled
+-- Running test case: Console.setConsoleClearAPIEnabled.API.Disabled
+PASS: Should not clear console.
+PASS: Should not send a message.
+
+-- Running test case: Console.setConsoleClearAPIEnabled.API.Enabled
+PASS: Should clear console.
+PASS: Should not send a message.
+
+-- Running test case: Console.setConsoleClearAPIEnabled.Frontend.Disabled
+PASS: Should clear console.
+PASS: Should not send a message.
+
+-- Running test case: Console.setConsoleClearAPIEnabled.Frontend.Enabled
+PASS: Should clear console.
+PASS: Should not send a message.
+

--- a/LayoutTests/inspector/console/setConsoleClearAPIEnabled.html
+++ b/LayoutTests/inspector/console/setConsoleClearAPIEnabled.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Console.setConsoleClearAPIEnabled");
+
+    suite.addTestCase({
+        name: "Console.setConsoleClearAPIEnabled.API.Disabled",
+        description: "Check that console.clear() doesn't clear the console when disallowed.",
+        async test() {
+            await ConsoleAgent.setConsoleClearAPIEnabled(false);
+
+            let cleared = false;
+            let clearedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.Cleared, (event) => {
+                cleared = true;
+            });
+
+            let [messageAddedEvent] = await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`console.clear(); console.log("Clear disabled.");`),
+            ]);
+
+            InspectorTest.expectFalse(cleared, "Should not clear console.");
+            InspectorTest.expectEqual(messageAddedEvent.data.message.messageText, "Clear disabled.", "Should not send a message.");
+
+            WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.Cleared, clearedListener);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Console.setConsoleClearAPIEnabled.API.Enabled",
+        description: "Check that console.clear() does clear the console when allowed.",
+        async test() {
+            await ConsoleAgent.setConsoleClearAPIEnabled(true);
+
+            let cleared = false;
+            let clearedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.Cleared, (event) => {
+                cleared = true;
+            });
+
+            let [messageAddedEvent] = await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`console.clear(); console.log("Clear enabled.");`),
+            ]);
+
+            InspectorTest.expectTrue(cleared, "Should clear console.");
+            InspectorTest.expectEqual(messageAddedEvent.data.message.messageText, "Clear enabled.", "Should not send a message.");
+
+            WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.Cleared, clearedListener);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Console.setConsoleClearAPIEnabled.Frontend.Disabled",
+        description: "Check that the frontend can still clear the console when console.clear() is disallowed.",
+        async test() {
+            await ConsoleAgent.setConsoleClearAPIEnabled(false);
+
+            let messageAdded = false;
+            let messageAddedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                messageAdded = true;
+            });
+
+            WI.consoleManager.requestClearMessages();
+            await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared);
+
+            InspectorTest.pass("Should clear console.");
+            InspectorTest.expectFalse(messageAdded, "Should not send a message.");
+
+            WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, messageAddedListener);
+        },
+    });
+
+    suite.addTestCase({
+        name: "Console.setConsoleClearAPIEnabled.Frontend.Enabled",
+        description: "Check that the frontend can still clear the console when console.clear() is allowed.",
+        async test() {
+            await ConsoleAgent.setConsoleClearAPIEnabled(true);
+
+            let messageAdded = false;
+            let messageAddedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                messageAdded = true;
+            });
+
+            WI.consoleManager.requestClearMessages();
+            await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared);
+
+            InspectorTest.pass("Should clear console.");
+            InspectorTest.expectFalse(messageAdded, "Should not send a message.");
+
+            WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, messageAddedListener);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for Console.setConsoleClearAPIEnabled.</p>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
@@ -340,8 +340,24 @@ void ConsoleMessage::updateRepeatCountInConsole(ConsoleFrontendDispatcher& conso
     consoleFrontendDispatcher.messageRepeatCountUpdated(m_repeatCount, timestamp.secondsSinceEpoch().value());
 }
 
+static bool isGroupMessage(MessageType type)
+{
+    return type == MessageType::StartGroup
+        || type == MessageType::StartGroupCollapsed
+        || type == MessageType::EndGroup;
+}
+
 bool ConsoleMessage::isEqual(ConsoleMessage* msg) const
 {
+    // `console.clear()` might not always clear the console if the frontend doesn't allow it to, so
+    // ensure that the repeat count is never updated by treating each `console.clear()` as unique.
+    if (m_type == MessageType::Clear || msg->m_type == MessageType::Clear)
+        return false;
+
+    // Groups should always be considered unique.
+    if (isGroupMessage(m_type) || isGroupMessage(msg->m_type))
+        return false;
+
     if (m_arguments) {
         if (!msg->m_arguments || !m_arguments->isEqual(*msg->m_arguments))
             return false;

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
@@ -64,6 +64,7 @@ public:
     Protocol::ErrorStringOr<void> enable() final;
     Protocol::ErrorStringOr<void> disable() final;
     Protocol::ErrorStringOr<void> clearMessages() override;
+    Protocol::ErrorStringOr<void> setConsoleClearAPIEnabled(bool) override;
     Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Console::Channel>>> getLoggingChannels() override;
     Protocol::ErrorStringOr<void> setLoggingChannelLevel(Protocol::Console::ChannelSource, Protocol::Console::ChannelLevel) override;
 
@@ -99,6 +100,7 @@ protected:
     HashMap<String, MonotonicTime> m_times;
     bool m_enabled { false };
     bool m_isAddingMessageToFrontend { false };
+    bool m_consoleClearAPIEnabled { true };
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/protocol/Console.json
+++ b/Source/JavaScriptCore/inspector/protocol/Console.json
@@ -37,7 +37,7 @@
         {
             "id": "ClearReason",
             "type": "string",
-            "enum": ["console-api", "main-frame-navigation"],
+            "enum": ["console-api", "frontend", "main-frame-navigation"],
             "description": "The reason the console is being cleared."
         },
         {
@@ -104,6 +104,13 @@
         {
             "name": "clearMessages",
             "description": "Clears console messages collected in the browser."
+        },
+        {
+           "name": "setConsoleClearAPIEnabled",
+           "description": "Control whether calling <code>console.clear()</code> has an effect in Web Inspector. Defaults to true.",
+           "parameters": [
+               { "name": "enable", "type": "boolean" }
+           ]
         },
         {
             "name": "getLoggingChannels",

--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -163,18 +163,6 @@ void CommandLineAPIHost::gatherRTCLogs(JSGlobalObject& globalObject, RefPtr<RTCL
 }
 #endif
 
-void CommandLineAPIHost::clearConsoleMessages()
-{
-    if (!m_instrumentingAgents)
-        return;
-
-    auto* consoleAgent = m_instrumentingAgents->webConsoleAgent();
-    if (!consoleAgent)
-        return;
-
-    consoleAgent->clearMessages();
-}
-
 void CommandLineAPIHost::copyText(const String& text)
 {
     Pasteboard::createForCopyAndPaste({ })->writePlainText(text, Pasteboard::CannotSmartReplace);

--- a/Source/WebCore/inspector/CommandLineAPIHost.h
+++ b/Source/WebCore/inspector/CommandLineAPIHost.h
@@ -64,7 +64,6 @@ public:
 
     void disconnect();
 
-    void clearConsoleMessages();
     void copyText(const String& text);
 
     class InspectableObject {

--- a/Source/WebCore/inspector/CommandLineAPIHost.idl
+++ b/Source/WebCore/inspector/CommandLineAPIHost.idl
@@ -33,7 +33,6 @@
 [
     LegacyNoInterfaceObject,
 ] interface CommandLineAPIHost {
-    undefined clearConsoleMessages();
     undefined copyText(DOMString text);
 
     [CallWith=CurrentGlobalObject] undefined inspect(any objectToInspect, any hints);

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -177,6 +177,7 @@ localizedStrings["All items in \u0022%s\u0022 must be valid DOM nodes"] = "All i
 /* Label for setting that allows the user to inspect the Web Inspector user interface. */
 localizedStrings["Allow Inspecting Web Inspector @ Experimental Settings"] = "Allow Inspecting Web Inspector";
 localizedStrings["Allow media capture on insecure sites"] = "Allow media capture on insecure sites";
+localizedStrings["Allow page to clear Console"] = "Allow page to clear Console";
 /* Label for checkbox that controls whether network throttling functionality is enabled. */
 localizedStrings["Allow throttling"] = "Allow throttling";
 localizedStrings["Also defer evaluating breakpoint conditions, ignore counts, and actions until execution has continued outside of the related script instead of at the breakpoint\u2019s location."] = "Also defer evaluating breakpoint conditions, ignore counts, and actions until execution has continued outside of the related script instead of at the breakpoint\u2019s location.";
@@ -366,6 +367,7 @@ localizedStrings["Clear log (%s or %s)"] = "Clear log (%s or %s)";
 localizedStrings["Clear object store"] = "Clear object store";
 localizedStrings["Clear samples"] = "Clear samples";
 localizedStrings["Clear watch expressions"] = "Clear watch expressions";
+localizedStrings["Clear:"] = "Clear:";
 localizedStrings["Click Listener"] = "Click Listener";
 localizedStrings["Click to create a Local Override from this content"] = "Click to create a Local Override from this content";
 localizedStrings["Click to import a file and create a Local Override\nShift-click to create a Local Override from this content"] = "Click to import a file and create a Local Override\nShift-click to create a Local Override from this content";

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -188,6 +188,7 @@ WI.settings = {
     canvasRecordingAutoCaptureEnabled: new WI.Setting("canvas-recording-auto-capture-enabled", false),
     canvasRecordingAutoCaptureFrameCount: new WI.Setting("canvas-recording-auto-capture-frame-count", 1),
     consoleAutoExpandTrace: new WI.Setting("console-auto-expand-trace", true),
+    consoleClearAPIEnabled: new WI.Setting("console-clear-api-enabled", true),
     consoleSavedResultAlias: new WI.Setting("console-saved-result-alias", ""),
     cssChangesPerNode: new WI.Setting("css-changes-per-node", false),
     clearLogOnNavigate: new WI.Setting("clear-log-on-navigate", true),

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -46,6 +46,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
         this._failedSourceMapConsoleMessages = new Set;
 
+        WI.settings.consoleClearAPIEnabled.addEventListener(WI.Setting.Event.Changed, this._handleConsoleClearAPIEnabledSettingChanged, this);
+
         WI.ConsoleSnippet.addEventListener(WI.SourceCode.Event.ContentDidChange, this._handleSnippetContentChanged, this);
 
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
@@ -82,6 +84,18 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         if (sourceCode instanceof WI.Script)
             return issue.sourceCodeLocation && issue.sourceCodeLocation.sourceCode === sourceCode;
         return false;
+    }
+
+    // Target
+
+    initializeTarget(target)
+    {
+        // Intentionally defer ConsoleAgent initialization to the end. We do this so that any
+        // previous initialization messages will have their responses arrive before a stream
+        // of console message added events come in after enabling Console.
+        // See WI.Target.prototype.initialize.
+
+        this._setConsoleClearAPIEnabled(target);
     }
 
     // Public
@@ -200,6 +214,12 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         }
 
         switch (reason) {
+        case WI.ConsoleManager.ClearReason.Frontend:
+            // COMPATIBILITY (iOS X.Y, macOS X.Y): `Console.ClearReason.Frontend` did not exist yet.
+            // COMPATIBILITY (iOS X.Y, macOS X.Y): `Console.setConsoleClearAPIEnabled` did not exist yet.
+            console.assert(InspectorBackend.hasCommand("Console.setConsoleClearAPIEnabled"));
+            console.assert(WI.settings.consoleClearAPIEnabled.value);
+            // fallthrough
         case WI.ConsoleManager.ClearReason.ConsoleAPI:
             this._clearMessages();
             return;
@@ -276,6 +296,13 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
         this.dispatchEventToListeners(WI.ConsoleManager.Event.Cleared);
     }
+
+    _setConsoleClearAPIEnabled(target)
+    {
+        // COMPATIBILITY (iOS X.Y, macOS X.Y): `Console.setConsoleClearAPIEnabled` did not exist yet.
+        if (target.hasCommand("Console.setConsoleClearAPIEnabled"))
+            target.ConsoleAgent.setConsoleClearAPIEnabled(WI.settings.consoleClearAPIEnabled.value);
+    }
     
     _collectFailedSourceMapConsoleMessage(message)
     {
@@ -299,6 +326,12 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         }
 
         this._clearMessages();
+    }
+
+    _handleConsoleClearAPIEnabledSettingChanged(event)
+    {
+        for (let target of WI.targets)
+            this._setConsoleClearAPIEnabled(target);
     }
 
     _handleSnippetContentChanged(event)
@@ -339,5 +372,6 @@ WI.ConsoleManager.Event = {
 
 WI.ConsoleManager.ClearReason = {
     ConsoleAPI: "console-api",
+    Frontend: "frontend",
     MainFrameNavigation: "main-frame-navigation",
 }

--- a/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
@@ -29,7 +29,7 @@ WI.ConsoleObserver = class ConsoleObserver extends InspectorBackend.Dispatcher
 
     messageAdded(message)
     {
-        if (message.source === "console-api" && message.type === "clear")
+        if (message.type === "clear")
             return;
 
         if (message.type === "assert" && !message.text)

--- a/Source/WebInspectorUI/UserInterface/Protocol/Target.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Target.js
@@ -82,6 +82,7 @@ WI.Target = class Target extends WI.Object
         // Intentionally defer ConsoleAgent initialization to the end. We do this so that any
         // previous initialization messages will have their responses arrive before a stream
         // of console message added events come in after enabling Console.
+        // See WI.ConsoleManager.prototype.initializeTarget.
         this.ConsoleAgent.enable();
 
         setTimeout(() => {

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -363,6 +363,10 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         consoleSettingsView.addSetting(WI.UIString("Traces:"), WI.settings.consoleAutoExpandTrace, WI.UIString("Auto-expand"));
         consoleSettingsView.addSetting(WI.UIString("Show:"), WI.settings.showConsoleMessageTimestamps, WI.UIString("Timestamps"));
 
+        // COMPATIBILITY (iOS X.Y, macOS X.Y): `Console.setConsoleClearAPIEnabled` did not exist yet.
+        if (InspectorBackend.hasCommand("Console.setConsoleClearAPIEnabled"))
+            consoleSettingsView.addSetting(WI.UIString("Clear:"), WI.settings.consoleClearAPIEnabled, WI.UIString("Allow page to clear Console"));
+
         if (WI.ConsoleManager.supportsLogChannels()) {
             consoleSettingsView.addSeparator();
 


### PR DESCRIPTION
#### 80d190d733833b4730f5acdf7ccd8eb6ef98227d
<pre>
Web Inspector: the frontend should be able to prevent the inspected page from clearing the console
<a href="https://bugs.webkit.org/show_bug.cgi?id=270753">https://bugs.webkit.org/show_bug.cgi?id=270753</a>

Reviewed by Patrick Angle.

&quot;malicious&quot; pages can sometimes repeatedly call `console.clear()` to prevent logging from being readable by the developer.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createConsoleSettingsView):
Add a checkbox in the Console pane of the Settings Tab to control this.

* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager):
(WI.ConsoleManager.prototype.initializeTarget): Added.
(WI.ConsoleManager.prototype.messagesCleared):
(WI.ConsoleManager.prototype._setConsoleClearAPIEnabled): Added.
(WI.ConsoleManager.prototype._handleConsoleClearAPIEnabledSettingChanged): Added.
* Source/WebInspectorUI/UserInterface/Protocol/Target.js:
(WI.Target.prototype.initialize):
Notify all `WI.Target` whenever the above checkbox changes (and when Web Inspector is first opened).

* Source/JavaScriptCore/inspector/protocol/Console.json:
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp:
(Inspector::InspectorConsoleAgent::clearMessages):
(Inspector::InspectorConsoleAgent::setConsoleClearAPIEnabled): Added.
(Inspector::InspectorConsoleAgent::addMessageToConsole):
(Inspector::InspectorConsoleAgent::addConsoleMessage):
(Inspector::isGroupMessage): Deleted.
Listen for the above checkbox changes and prevent clearing existing `ConsoleMessages` if desired (which also means `Console.messagesCleared` is not sent).

* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
(Inspector::isGroupMessage): Added.
(Inspector::ConsoleMessage::isEqual const):
Previously, any `console.clear()` would remove all `ConsoleMessage`, meaning that there&apos;d never be a way for it to have a repeat count other than 1.  Now, `console.clear()` might not do that (depending on the above checkbox in the frontend), so make sure the backend treats all `console.clear()` as unique.
Drive-by: do the same for `console.group()`, `console.groupCollapsed()`, and `console.groupEnd()`.

* Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js:
(WI.ConsoleObserver.prototype.messageAdded):
Drive-by: make sure to ignore all `console.clear()` regardless of reason.

* Source/WebCore/inspector/CommandLineAPIHost.idl:
* Source/WebCore/inspector/CommandLineAPIHost.h:
* Source/WebCore/inspector/CommandLineAPIHost.cpp:
(WebCore::CommandLineAPIHost::clearConsoleMessages): Deleted.
Drive-by: remove unused code.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/inspector/console/setConsoleClearAPIEnabled.html: Added.
* LayoutTests/inspector/console/setConsoleClearAPIEnabled-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/276362@main">https://commits.webkit.org/276362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6497dccf5013d0207e905f75aed554cf989a0f4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36210 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38873 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1940 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37405 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48109 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43484 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18892 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15855 "Found 1 new test failure: http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43042 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9887 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20489 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50516 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19909 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10194 "Passed tests") | 
<!--EWS-Status-Bubble-End-->