### PR TITLE
Reduce use of downcast<>() in StyleProperties

### DIFF
--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -52,9 +52,9 @@ constexpr unsigned maxShorthandsForLonghand = 4; // FIXME: Generate this from CS
 
 Ref<ImmutableStyleProperties> StyleProperties::immutableCopyIfNeeded() const
 {
-    if (auto* immutableProperties = dynamicDowncast<ImmutableStyleProperties>(*this))
-        return const_cast<ImmutableStyleProperties&>(*immutableProperties);
-    return downcast<MutableStyleProperties>(*this).immutableDeduplicatedCopy();
+    if (m_isMutable)
+        return uncheckedDowncast<MutableStyleProperties>(*this).immutableDeduplicatedCopy();
+    return const_cast<ImmutableStyleProperties&>(uncheckedDowncast<ImmutableStyleProperties>(*this));
 }
 
 String serializeLonghandValue(CSSPropertyID property, const CSSValue& value)

--- a/Source/WebCore/css/StylePropertiesInlines.h
+++ b/Source/WebCore/css/StylePropertiesInlines.h
@@ -45,16 +45,16 @@ inline StyleProperties::StyleProperties(CSSParserMode mode, unsigned immutableAr
 
 inline StyleProperties::PropertyReference StyleProperties::propertyAt(unsigned index) const
 {
-    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
-        return mutableProperties->propertyAt(index);
-    return downcast<ImmutableStyleProperties>(*this).propertyAt(index);
+    if (m_isMutable)
+        return uncheckedDowncast<MutableStyleProperties>(*this).propertyAt(index);
+    return uncheckedDowncast<ImmutableStyleProperties>(*this).propertyAt(index);
 }
 
 inline unsigned StyleProperties::propertyCount() const
 {
-    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
-        return mutableProperties->propertyCount();
-    return downcast<ImmutableStyleProperties>(*this).propertyCount();
+    if (m_isMutable)
+        return uncheckedDowncast<MutableStyleProperties>(*this).propertyCount();
+    return uncheckedDowncast<ImmutableStyleProperties>(*this).propertyCount();
 }
 
 inline void StyleProperties::deref() const
@@ -72,16 +72,16 @@ inline void StyleProperties::deref() const
 
 inline int StyleProperties::findPropertyIndex(CSSPropertyID propertyID) const
 {
-    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
-        return mutableProperties->findPropertyIndex(propertyID);
-    return downcast<ImmutableStyleProperties>(*this).findPropertyIndex(propertyID);
+    if (m_isMutable)
+        return uncheckedDowncast<MutableStyleProperties>(*this).findPropertyIndex(propertyID);
+    return uncheckedDowncast<ImmutableStyleProperties>(*this).findPropertyIndex(propertyID);
 }
 
 inline int StyleProperties::findCustomPropertyIndex(StringView propertyName) const
 {
-    if (auto* mutableProperties = dynamicDowncast<MutableStyleProperties>(*this))
-        return mutableProperties->findCustomPropertyIndex(propertyName);
-    return downcast<ImmutableStyleProperties>(*this).findCustomPropertyIndex(propertyName);
+    if (m_isMutable)
+        return uncheckedDowncast<MutableStyleProperties>(*this).findCustomPropertyIndex(propertyName);
+    return uncheckedDowncast<ImmutableStyleProperties>(*this).findCustomPropertyIndex(propertyName);
 }
 
 inline bool StyleProperties::isEmpty() const


### PR DESCRIPTION
#### 348b9cd5aacbe2ecba06be5f435123e331a411b1
<pre>
Reduce use of downcast&lt;&gt;() in StyleProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=270758">https://bugs.webkit.org/show_bug.cgi?id=270758</a>

Reviewed by Anne van Kesteren.

Reduce use of downcast&lt;&gt;() in StyleProperties, for performance.

* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::immutableCopyIfNeeded const):
* Source/WebCore/css/StylePropertiesInlines.h:
(WebCore::StyleProperties::propertyAt const):
(WebCore::StyleProperties::propertyCount const):
(WebCore::StyleProperties::findPropertyIndex const):
(WebCore::StyleProperties::findCustomPropertyIndex const):

Canonical link: <a href="https://commits.webkit.org/275896@main">https://commits.webkit.org/275896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a560f1b52927a3ffa2a9d7721fdc2bfe86ac730f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35703 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38271 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1237 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47361 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42500 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19634 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41160 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19812 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5856 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->