### PR TITLE
Reduce use of downcast<>() in DataTransfer.cpp

### DIFF
--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -261,10 +261,10 @@ void DataTransfer::setData(Document& document, const String& type, const String&
 void DataTransfer::setDataFromItemList(Document& document, const String& type, const String& data)
 {
     ASSERT(canWriteData());
-    RELEASE_ASSERT(is<StaticPasteboard>(*m_pasteboard));
 
+    auto& pasteboard = checkedDowncast<StaticPasteboard>(*m_pasteboard);
     if (!DeprecatedGlobalSettings::customPasteboardDataEnabled()) {
-        m_pasteboard->writeString(type, data);
+        pasteboard.writeString(type, data);
         return;
     }
 
@@ -284,10 +284,10 @@ void DataTransfer::setDataFromItemList(Document& document, const String& type, c
     }
 
     if (sanitizedData != data)
-        downcast<StaticPasteboard>(*m_pasteboard).writeStringInCustomData(type, data);
+        pasteboard.writeStringInCustomData(type, data);
 
     if (Pasteboard::isSafeTypeForDOMToReadAndWrite(type) && !sanitizedData.isNull())
-        m_pasteboard->writeString(type, sanitizedData);
+        pasteboard.writeString(type, sanitizedData);
 }
 
 void DataTransfer::updateFileList(ScriptExecutionContext* context)
@@ -451,7 +451,7 @@ Ref<DataTransfer> DataTransfer::createForInputEvent(const String& plainText, con
 
 void DataTransfer::commitToPasteboard(Pasteboard& nativePasteboard)
 {
-    ASSERT(is<StaticPasteboard>(*m_pasteboard) && !is<StaticPasteboard>(nativePasteboard));
+    ASSERT(!is<StaticPasteboard>(nativePasteboard));
     auto& staticPasteboard = downcast<StaticPasteboard>(*m_pasteboard);
     if (!staticPasteboard.hasNonDefaultData()) {
         // We clear the platform pasteboard here to ensure that the pasteboard doesn't contain any data


### PR DESCRIPTION
#### fd1434216dd280879d32557dee3ff83614bf4458
<pre>
Reduce use of downcast&lt;&gt;() in DataTransfer.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=270759">https://bugs.webkit.org/show_bug.cgi?id=270759</a>

Reviewed by Anne van Kesteren.

Reduce use of downcast&lt;&gt;() in DataTransfer.cpp, for performance.

* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::setDataFromItemList):
(WebCore::DataTransfer::commitToPasteboard):

Canonical link: <a href="https://commits.webkit.org/275894@main">https://commits.webkit.org/275894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a41dff6ccdcffbc37c3ba3fab3b397a1000a204c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35705 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38278 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1238 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47360 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42499 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19635 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41158 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19813 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5854 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->