### PR TITLE
[WebRTC] Incorrect length check in getSequenceHeaderOBU() for AV1 decoder support

### DIFF
--- a/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #import <span>
 #import <webrtc/modules/video_coding/include/video_error_codes.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/CheckedArithmetic.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/RetainPtr.h>
 
@@ -53,9 +54,10 @@ public:
     }
 
     std::optional<uint64_t> read(size_t);
-    std::optional<bool> readBit();
 
 private:
+    std::optional<bool> readBit();
+
     std::span<const uint8_t> m_data;
     size_t m_index { 0 };
     uint8_t m_currentByte { 0 };
@@ -100,9 +102,9 @@ static size_t readULEBSize(std::span<const uint8_t> data, size_t& index)
 
         uint8_t dataByte = data[index++];
         uint8_t decodedByte = dataByte & 0x7f;
+        value |= decodedByte << (7 * cptr);
         if (value >= std::numeric_limits<uint32_t>::max())
             return 0;
-        value |= decodedByte << (7 * cptr);
         if (!(dataByte & 0x80))
             break;
     }
@@ -129,8 +131,8 @@ static std::optional<std::pair<std::span<const uint8_t>, std::span<const uint8_t
         if (hasExtension)
             ++index;
 
-        size_t payloadSize = readULEBSize(data, index);
-        if (index >= data.size())
+        Checked<size_t> payloadSize = readULEBSize(data, index);
+        if (index + payloadSize >= data.size())
             return { };
 
         if (headerType == 1) {


### PR DESCRIPTION
#### 25257b2a5f814303f58c5f826d2ce6b05a9bd56a
<pre>
[WebRTC] Incorrect length check in getSequenceHeaderOBU() for AV1 decoder support
<a href="https://bugs.webkit.org/show_bug.cgi?id=270760">https://bugs.webkit.org/show_bug.cgi?id=270760</a>
&lt;<a href="https://rdar.apple.com/124334942">rdar://124334942</a>&gt;

Reviewed by Youenn Fablet.

* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm:
(BitReader::readBit):
- Make method private since it&apos;s only used within the class.
(readULEBSize):
- Move std::numeric_limits&lt;uint32_t&gt;::max() check after `value` is
  computed.  This was a secondary bug that caused unsigned integer
  overflow in getSequenceHeaderOBU().
(getSequenceHeaderOBU):
- Change `payloadSize` to be a Checked&lt;size_t&gt; variable.
- Fix length check to include `index + payloadSize`.  This was the
  original bug that caused more than data.size() bytes to be read.

Canonical link: <a href="https://commits.webkit.org/275904@main">https://commits.webkit.org/275904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27cd7fb748912bea0e77030e860cfd1b11a792a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35707 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38273 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1240 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47363 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42502 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19637 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41162 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19815 "Built successfully") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/5870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->