### PR TITLE
Try to fix older visionOS builds (linker)

### DIFF
--- a/Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift
+++ b/Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift
@@ -81,6 +81,10 @@ public final class PreviewWindowController: NSObject {
     }
 }
 
+#else
+import Foundation
+@objc(WKSPreviewWindowController)
+public final class PreviewWindowController: NSObject { }
 #endif
 
 #endif


### PR DESCRIPTION
#### e8e13caa503dedb4e2b082974e94f74c3948571a
<pre>
Try to fix older visionOS builds (linker)
<a href="https://bugs.webkit.org/show_bug.cgi?id=270763">https://bugs.webkit.org/show_bug.cgi?id=270763</a>
&lt;<a href="https://rdar.apple.com/124349498">rdar://124349498</a>&gt;

Reviewed by Tim Horton.

`WKSPreviewWindowController.h` needs to be part of `WebKitSwift.h`
because of the delegate. So it can&apos;t be included only based on a
(compile-time) feature flag.
Introduce a stub `WKSPreviewWindowController` instead for older SDKs,
where the feature is turned off anyway.

* Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift:

Canonical link: <a href="https://commits.webkit.org/275893@main">https://commits.webkit.org/275893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ab2e551f48d98446446926ed6c02fa9dee08fe5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35714 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16852 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42508 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19643 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41168 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9608 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->