### PR TITLE
Remove WTF::LegacyIdentified now that it is no longer used

### DIFF
--- a/Source/WTF/wtf/Identified.h
+++ b/Source/WTF/wtf/Identified.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,11 +25,6 @@
 
 #pragma once
 
-#include <atomic>
-#include <type_traits>
-#include <wtf/NeverDestroyed.h>
-#include <wtf/ObjectIdentifier.h>
-#include <wtf/ThreadAssertions.h>
 #include <wtf/UUID.h>
 
 namespace WTF {
@@ -66,33 +61,6 @@ protected:
 };
 
 template <typename T>
-class LegacyIdentified : public IdentifiedBase<uint64_t> {
-protected:
-    LegacyIdentified()
-        : IdentifiedBase<uint64_t>(generateIdentifier())
-    {
-    }
-
-    LegacyIdentified(const LegacyIdentified&) = default;
-    LegacyIdentified& operator=(const LegacyIdentified&) = default;
-
-    explicit LegacyIdentified(uint64_t identifier)
-        : IdentifiedBase<uint64_t>(identifier)
-    {
-    }
-
-private:
-    static uint64_t generateIdentifier()
-    {
-        static NeverDestroyed<ThreadLikeAssertion> initializationThread;
-        assertIsCurrent(initializationThread); // You should be using ThreadSafeIdentified if you hit this assertion.
-
-        static uint64_t currentIdentifier;
-        return ++currentIdentifier;
-    }
-};
-
-template <typename T>
 class UUIDIdentified : public IdentifiedBase<UUID> {
 protected:
     UUIDIdentified()
@@ -106,5 +74,4 @@ protected:
 } // namespace WTF
 
 using WTF::Identified;
-using WTF::LegacyIdentified;
 using WTF::UUIDIdentified;


### PR DESCRIPTION
#### ad04066591e960e1f631ea7c40ebcd92cca20752
<pre>
Remove WTF::LegacyIdentified now that it is no longer used
<a href="https://bugs.webkit.org/show_bug.cgi?id=270766">https://bugs.webkit.org/show_bug.cgi?id=270766</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/Identified.h:
(WTF::LegacyIdentified::LegacyIdentified): Deleted.
(WTF::LegacyIdentified::generateIdentifier): Deleted.

Canonical link: <a href="https://commits.webkit.org/275900@main">https://commits.webkit.org/275900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf3e327b448c637fe1f088161aef5303244872bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/25992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35737 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43787 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16730 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16881 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1268 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/36672 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39420 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47391 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42839 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42525 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19665 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41185 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19843 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49849 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5863 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19297 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10068 "Passed tests") | 
<!--EWS-Status-Bubble-End-->