### PR TITLE
[Invokers] Auto should be empty value.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
@@ -5,11 +5,11 @@ PASS invokeTargetElement reflects set value
 PASS invokeTargetElement reflects set value across shadow root into light dom
 PASS invokeTargetElement does not reflect set value inside shadowroot
 PASS invokeTargetElement throws error on assignment of non Element
-FAIL invokeAction reflects '' when attribute not present assert_equals: expected "" but got "auto"
-FAIL invokeAction reflects '' when attribute empty, setAttribute version assert_equals: expected "" but got "auto"
+PASS invokeAction reflects '' when attribute not present
+PASS invokeAction reflects '' when attribute empty, setAttribute version
 PASS invokeAction reflects same casing
-FAIL invokeAction reflects '' when attribute empty, IDL version assert_equals: expected "" but got "auto"
+PASS invokeAction reflects '' when attribute empty, IDL version
 PASS invokeAction reflects tostring value
-FAIL invokeAction reflects '' when attribute set to [] assert_equals: expected "" but got "auto"
+PASS invokeAction reflects '' when attribute set to []
 PASS invokeAction reflects tostring value 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL action is a readonly defaulting to '' assert_equals: expected "" but got "auto"
+PASS action is a readonly defaulting to ''
 PASS invoker is readonly defaulting to null
 PASS action reflects initialized attribute
-FAIL action set to undefined assert_equals: expected "" but got "auto"
+PASS action set to undefined
 PASS action set to null
 PASS action set to false
 PASS action explicitly set to empty string

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL event dispatches on click assert_equals: action expected "" but got "auto"
+PASS event dispatches on click
 PASS event action is set to invokeAction
 PASS event action is set to invokeaction attribute
 PASS event does not dispatch if click:preventDefault is called

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl
@@ -1,6 +1,6 @@
 interface mixin InvokerElement {
   [CEReactions,Reflect=invoketarget] attribute Element? invokeTargetElement;
-  [CEReactions,Reflect,ReflectMissing="auto",ReflectEmpty="auto"] attribute DOMString invokeAction;
+  [CEReactions,Reflect=invokeaction] attribute DOMString invokeAction;
 };
 
 interface InvokeEvent : Event {
@@ -11,5 +11,5 @@ interface InvokeEvent : Event {
 
 dictionary InvokeEventInit : EventInit {
     Element? invoker = null;
-    DOMString action = "auto";
+    DOMString action = "";
 };

--- a/Source/WebCore/dom/InvokeEvent.idl
+++ b/Source/WebCore/dom/InvokeEvent.idl
@@ -35,5 +35,5 @@
 
 dictionary InvokeEventInit : EventInit {
     Element? invoker = null;
-    DOMString action = "auto";
+    DOMString action = "";
 };

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -426,27 +426,15 @@ RefPtr<Element> HTMLFormControlElement::invokeTargetElement() const
     return getElementAttribute(invoketargetAttr);
 }
 
-const AtomString& HTMLFormControlElement::invokeAction() const
-{
-    const AtomString& value = attributeWithoutSynchronization(HTMLNames::invokeactionAttr);
-
-    if (!value || value.isNull() || value.isEmpty())
-        return autoAtom();
-    return value;
-}
-
-void HTMLFormControlElement::setInvokeAction(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(HTMLNames::invokeactionAttr, value);
-}
-
 void HTMLFormControlElement::handleInvokeAction()
 {
     RefPtr invokee = invokeTargetElement();
     if (!invokee)
         return;
 
-    auto action = invokeAction();
+    auto action = attributeWithoutSynchronization(HTMLNames::invokeactionAttr);
+    if (action.isNull())
+        action = emptyAtom();
 
     InvokeEvent::Init init;
     init.bubbles = false;

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -103,8 +103,6 @@ public:
     void setPopoverTargetAction(const AtomString& value);
 
     RefPtr<Element> invokeTargetElement() const;
-    const AtomString& invokeAction() const;
-    void setInvokeAction(const AtomString& value);
 
     using Node::ref;
     using Node::deref;

--- a/Source/WebCore/html/InvokerElement.idl
+++ b/Source/WebCore/html/InvokerElement.idl
@@ -26,5 +26,5 @@
 [EnabledBySetting=InvokerAttributesEnabled]
 interface mixin InvokerElement {
     [CEReactions=NotNeeded, Reflect=invoketarget] attribute Element? invokeTargetElement;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString invokeAction;
+    [CEReactions=NotNeeded, Reflect=invokeaction] attribute DOMString invokeAction;
 };


### PR DESCRIPTION
#### 49417ee685e5cd2e86b3a4a36e72610ad922169f
<pre>
[Invokers] Auto should be empty value.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270771">https://bugs.webkit.org/show_bug.cgi?id=270771</a>

Reviewed by Tim Nguyen.

This updates the `invokeaction` in the Invoker IDls to use the empty
string rather than `auto`. This fixes some new failing WPTs.

See: <a href="https://github.com/whatwg/html/pull/9841">https://github.com/whatwg/html/pull/9841</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl:
* Source/WebCore/dom/InvokeEvent.idl:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::handleInvokeAction):
(WebCore::HTMLFormControlElement::invokeAction const): Deleted.
(WebCore::HTMLFormControlElement::setInvokeAction): Deleted.
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/InvokerElement.idl:

Canonical link: <a href="https://commits.webkit.org/275910@main">https://commits.webkit.org/275910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1abb76b876680f2cc1d71bd3fa6ed6e87d20ea79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19681 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43807 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1288 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47411 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19685 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41198 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9617 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19863 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->