### PR TITLE
Update Speedometer3 plan file to checkout a specific branch.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
@@ -139,8 +139,17 @@ class BenchmarkBuilder(object):
             subprocess.check_call(['tar', 'zxvf', output, '-C', temp_extract_path])
             shutil.copytree(os.path.join(temp_extract_path, relpath_in_repo), self._dest)
 
-    def _clone_git_repository(self, repository_url):
-        subprocess.check_call(['git', 'clone', repository_url, self._dest])
+    def _clone_git_repository(self, repository):
+        if isinstance(repository, str):
+            repository_url = repository
+            branch_args = []
+        else:
+            assert isinstance(repository, dict), 'repository must be a dictionary if it\'s not a string'
+            assert 'url' in repository, '"url" must be specified in "git_repository" dictionary'
+            repository_url = repository['url']
+            branch_args = ['--branch', repository['branch']] if 'branch' in repository else []
+        command = ['git', 'clone'] + branch_args + [repository_url, self._dest]
+        subprocess.check_call(command)
         git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=self._dest).strip().decode()
         _log.info('Latest commit is {}'.format(git_hash))
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan
@@ -1,7 +1,7 @@
 {
     "timeout": 600,
     "count": 4,
-    "git_repository": "https://github.com/WebKit/Speedometer.git",
+    "git_repository": {"url": "https://github.com/WebKit/Speedometer.git", "branch": "release/3.0"},
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer3.patch",
     "signpost_patch": "data/patches/signposts/Speedometer3.patch",
     "entry_point": "index.html",


### PR DESCRIPTION
#### a7b3c6bd87abfa58d1502de0f2ba38658af8b089
<pre>
Update Speedometer3 plan file to checkout a specific branch.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270773">https://bugs.webkit.org/show_bug.cgi?id=270773</a>
<a href="https://rdar.apple.com/124291738">rdar://124291738</a>

Reviewed by Ryosuke Niwa.

Add support to run-benchmark script to checkout a specific branch from a git repository.
Update Speedometer3 plan file to use benchmark content from &apos;release/3.0&apos; branch.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py:
(BenchmarkBuilder._clone_git_repository):
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan:

Canonical link: <a href="https://commits.webkit.org/275919@main">https://commits.webkit.org/275919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d843b0c2e4a36e634c473daaedfd13332b2b0c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22326 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/45706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19744 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/45930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43870 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/45706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43167 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/45706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/1352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/45706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/47475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/45706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9629 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->