### PR TITLE
[Clang] GeneratedSerializers.cpp(3716,11): error: offset of on non-standard-layout type 'WebKit::AudioTrackPrivateRemoteConfiguration' [-Werror,-Winvalid-offsetof]

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1128,11 +1128,9 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
     result.append('};')
     result.append('template<> struct VirtualTableAndRefCountOverhead<false, false> { };')
     result.append('')
-    # GCC is less generous with its interpretation of "Use of the offsetof macro with a
-    # type other than a standard-layout class is conditionally-supported".
-    result.append('#if COMPILER(GCC)')
+    # GCC and Clang>=18 are less generous with their interpretation of "Use of the offsetof macro
+    # with a type other than a standard-layout class is conditionally-supported".
     result.append('IGNORE_WARNINGS_BEGIN("invalid-offsetof")')
-    result.append('#endif')
     result.append('')
     result.append('namespace IPC {')
     result.append('')
@@ -1215,9 +1213,7 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
     result.append('')
     result.append('} // namespace WTF')
     result.append('')
-    result.append('#if COMPILER(GCC)')
     result.append('IGNORE_WARNINGS_END')
-    result.append('#endif')
     result.append('')
     return '\n'.join(result)
 


### PR DESCRIPTION
#### ca6b301ae49e5d0317d016fcb053e88c5dfd2dde
<pre>
[Clang] GeneratedSerializers.cpp(3716,11): error: offset of on non-standard-layout type &apos;WebKit::AudioTrackPrivateRemoteConfiguration&apos; [-Werror,-Winvalid-offsetof]
<a href="https://bugs.webkit.org/show_bug.cgi?id=270770">https://bugs.webkit.org/show_bug.cgi?id=270770</a>

Reviewed by Alex Christensen.

Clang 18.1.1 reports a warning for GeneratedSerializers.cpp:

&gt; DerivedSources\GeneratedSerializers.cpp(3716,11): error: offset of on non-standard-layout type &apos;WebKit::AudioTrackPrivateRemoteConfiguration&apos; [-Werror,-Winvalid-offsetof]
&gt;  3716 |         , offsetof(WebKit::AudioTrackPrivateRemoteConfiguration, enabled)
&gt;       |           ^                                                      ~~~~~~~

generate-serializers.py already suppresses the warning for GCC.

* Source/WebKit/Scripts/generate-serializers.py:
Ignore `invalid-offsetof` warning both for GCC and Clang.

Canonical link: <a href="https://commits.webkit.org/275934@main">https://commits.webkit.org/275934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13694350cb27c6c26b97d2aa1766ef92dd722ba7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45959 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39450 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19772 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19375 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43195 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1380 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39505 "re-run-api-tests (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47503 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19775 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9635 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->