### PR TITLE
DigitalCredential interface must expose a "protocol" attribute

### DIFF
--- a/LayoutTests/http/wpt/identity/idl.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/idl.https-expected.txt
@@ -83,6 +83,6 @@ PASS DigitalCredential interface object name
 PASS DigitalCredential interface: existence and properties of interface prototype object
 PASS DigitalCredential interface: existence and properties of interface prototype object's "constructor" property
 PASS DigitalCredential interface: existence and properties of interface prototype object's @@unscopables property
-FAIL DigitalCredential interface: attribute protocol assert_true: The prototype object must have a property "protocol" expected true got false
+PASS DigitalCredential interface: attribute protocol
 PASS DigitalCredential interface: attribute data
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -32,15 +32,16 @@
 
 namespace WebCore {
 
-Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& data)
+Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& data, IdentityCredentialProtocol protocol)
 {
-    return adoptRef(*new DigitalCredential(WTFMove(data)));
+    return adoptRef(*new DigitalCredential(WTFMove(data), protocol));
 }
 
 DigitalCredential::~DigitalCredential() = default;
 
-DigitalCredential::DigitalCredential(Ref<ArrayBuffer>&& data)
+DigitalCredential::DigitalCredential(Ref<ArrayBuffer>&& data, IdentityCredentialProtocol protocol)
     : BasicCredential(base64URLEncodeToString(data->data(), data->byteLength()), Type::DigitalCredential, Discovery::CredentialStore)
+    , m_protocol(protocol)
     , m_data(WTFMove(data))
 {
 }

--- a/Source/WebCore/Modules/identity/DigitalCredential.h
+++ b/Source/WebCore/Modules/identity/DigitalCredential.h
@@ -29,6 +29,7 @@
 
 #include "BasicCredential.h"
 #include "IDLTypes.h"
+#include "IdentityCredentialProtocol.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -42,7 +43,7 @@ using DigitalCredentialPromise = DOMPromiseDeferred<IDLInterface<DigitalCredenti
 
 class DigitalCredential final : public BasicCredential {
 public:
-    static Ref<DigitalCredential> create(Ref<ArrayBuffer>&& data);
+    static Ref<DigitalCredential> create(Ref<ArrayBuffer>&& data, IdentityCredentialProtocol);
 
     virtual ~DigitalCredential();
 
@@ -51,11 +52,17 @@ public:
         return m_data.get();
     };
 
+    IdentityCredentialProtocol protocol() const
+    {
+        return m_protocol;
+    }
+
 private:
-    DigitalCredential(Ref<ArrayBuffer>&& data);
+    DigitalCredential(Ref<ArrayBuffer>&& data, IdentityCredentialProtocol);
 
     Type credentialType() const final { return Type::DigitalCredential; }
 
+    IdentityCredentialProtocol m_protocol;
     RefPtr<ArrayBuffer> m_data;
 };
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredential.idl
@@ -30,4 +30,5 @@
     Conditional=WEB_AUTHN,
 ] interface DigitalCredential : BasicCredential {
     [SameObject] readonly attribute ArrayBuffer data;
+    readonly attribute IdentityCredentialProtocol protocol;
 };


### PR DESCRIPTION
#### bf9bfb5b39381e185808dedaed839b86cd4d52ec
<pre>
DigitalCredential interface must expose a &quot;protocol&quot; attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=270774">https://bugs.webkit.org/show_bug.cgi?id=270774</a>
<a href="https://rdar.apple.com/124366214">rdar://124366214</a>

Reviewed by Anne van Kesteren.

Implemented the &quot;protocol&quot; attribute on the DigitalCredential interface.

* LayoutTests/http/wpt/identity/idl.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/idl.https.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::create):
(WebCore::DigitalCredential::DigitalCredential):
* Source/WebCore/Modules/identity/DigitalCredential.h:
* Source/WebCore/Modules/identity/DigitalCredential.idl:

Canonical link: <a href="https://commits.webkit.org/276248@main">https://commits.webkit.org/276248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c91b7516dfbd63f905b2f3883f33e07117feab7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46065 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39556 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16884 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38476 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47609 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42695 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19882 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9812 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->