### PR TITLE
Some more assorted downcast<> cleanup in WebCore

### DIFF
--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -184,7 +184,8 @@ CachedFrame::CachedFrame(Frame& frame)
         document->suspend(ReasonForSuspension::BackForwardCache);
     }
 
-    m_cachedFrameScriptData = is<LocalFrame>(frame) ? makeUnique<ScriptCachedFrameData>(downcast<LocalFrame>(frame)) : nullptr;
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
+    m_cachedFrameScriptData = localFrame ? makeUnique<ScriptCachedFrameData>(*localFrame) : nullptr;
 
     if (document)
         document->protectedWindow()->suspendForBackForwardCache();
@@ -195,7 +196,6 @@ CachedFrame::CachedFrame(Frame& frame)
         localFrameView->resetLayoutMilestones();
 
     // The main frame is reused for the navigation and the opener link to its should thus persist.
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
     if (localFrame) {
         CheckedRef frameLoader = localFrame->loader();
         if (!frame.isMainFrame())

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -60,7 +60,11 @@ public:
 
     virtual void removeFlowChildInfo(RenderElement&);
 #ifndef NDEBUG
-    bool hasChildInfo(RenderObject* child) const { return is<RenderBox>(child) && m_fragmentRangeMap.contains(downcast<RenderBox>(child)); }
+    bool hasChildInfo(RenderObject* child) const
+    {
+        auto* renderBox = dynamicDowncast<RenderBox>(child);
+        return renderBox && m_fragmentRangeMap.contains(*renderBox);
+    }
 #endif
 
 #if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -55,7 +55,7 @@ static bool canMergeContiguousAnonymousBlocks(RenderObject& oldChild, RenderObje
     if (oldChild.isInline())
         return false;
 
-    if (is<RenderBoxModelObject>(oldChild) && downcast<RenderBoxModelObject>(oldChild).continuation())
+    if (auto* boxModelObject = dynamicDowncast<RenderBoxModelObject>(oldChild); boxModelObject && boxModelObject->continuation())
         return false;
 
     if (previous) {


### PR DESCRIPTION
#### b7a02278b2762da954a9c8a26360d77ff0e58304
<pre>
Some more assorted downcast&lt;&gt; cleanup in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=270782">https://bugs.webkit.org/show_bug.cgi?id=270782</a>

Reviewed by Charlie Wolfe.

For security &amp; performance.

* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrame::CachedFrame):
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::canMergeContiguousAnonymousBlocks):

Canonical link: <a href="https://commits.webkit.org/275961@main">https://commits.webkit.org/275961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d62d7989f5edee2772c25a94c680c12f24142b34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35803 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38326 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47413 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42549 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19687 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41199 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9655 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19869 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->