### PR TITLE
Advanced Tracking and Fingerprinting Protection Issue with Service Workers

### DIFF
--- a/LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/service-worker-block-everything-if-localhost.html from loading a resource from http://127.0.0.1:8000/security/resources/abe-allow-star.py
+CONSOLE MESSAGE: Resource blocked by content blocker
+CONSOLE MESSAGE: Fetch API cannot load http://127.0.0.1:8000/security/resources/abe-allow-star.py due to access control checks.
+
+PASS Setup service worker
+PASS Validate that localhost load is blocked
+PASS Validate that localhost load is not blocked if content extension is off
+

--- a/LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost-serviceworker.js
+++ b/LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost-serviceworker.js
@@ -1,0 +1,8 @@
+onmessage = async e => {
+    await self.clients.claim();
+    e.source.postMessage("done");
+}
+
+onfetch = e => {
+   e.respondWith(fetch(e.request));
+};

--- a/LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost.html
+++ b/LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function waitForState(worker, state)
+{
+    if (worker.state === state)
+        return Promise.resolve(state);
+
+    return new Promise(function(resolve) {
+      worker.addEventListener('statechange', function() {
+          if (worker.state === state)
+            resolve(state);
+        });
+    });
+}
+
+promise_test(async t => {
+    const registration = await navigator.serviceWorker.register("service-worker-block-everything-if-localhost-serviceworker.js", {});
+   await waitForState(registration.installing, "activated");
+
+   registration.active.postMessage("claim");
+   await new Promise(resolve => navigator.serviceWorker.onmessage = resolve);
+}, "Setup service worker");
+
+promise_test(async t => {
+    assert_true(!!navigator.serviceWorker.controller);
+    return fetch("/security/resources/abe-allow-star.py").then(assert_unreached, () => {});
+}, "Validate that localhost load is blocked");
+
+promise_test(async t => {
+    if (window.internals)
+        internals.disableContentExtensionsChecks();
+
+    return fetch("/security/resources/abe-allow-star.py").then(() => {}, assert_unreached);
+}, "Validate that localhost load is not blocked if content extension is off");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost.html.json
+++ b/LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost.html.json
@@ -1,0 +1,10 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": "abe-allow-star.py"
+        }
+    }
+]

--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -94,6 +94,8 @@ void FetchLoader::start(ScriptExecutionContext& context, const FetchRequest& req
     if (context.settingsValues().fetchPriorityEnabled)
         options.fetchPriorityHint = request.fetchPriorityHint();
 
+    options.shouldEnableContentExtensionsCheck = request.shouldEnableContentExtensionsCheck() ? ShouldEnableContentExtensionsCheck::Yes : ShouldEnableContentExtensionsCheck::No;
+
     ResourceRequest fetchRequest = request.resourceRequest();
 
     ASSERT(context.contentSecurityPolicy());

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -225,6 +225,7 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
     m_options = input.m_options;
     m_referrer = input.m_referrer;
     m_fetchPriorityHint = input.m_fetchPriorityHint;
+    m_enableContentExtensionsCheck = input.m_enableContentExtensionsCheck;
 
     auto optionsResult = initializeOptions(init);
     if (optionsResult.hasException())
@@ -352,6 +353,7 @@ ExceptionOr<Ref<FetchRequest>> FetchRequest::clone()
     clone->suspendIfNeeded();
     clone->cloneBody(*this);
     clone->setNavigationPreloadIdentifier(m_navigationPreloadIdentifier);
+    clone->m_enableContentExtensionsCheck = m_enableContentExtensionsCheck;
     clone->protectedSignal()->signalFollow(m_signal);
     return clone;
 }

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -89,6 +89,9 @@ public:
 
     RequestPriority fetchPriorityHint() const { return m_fetchPriorityHint; }
 
+    bool shouldEnableContentExtensionsCheck() const { return m_enableContentExtensionsCheck; }
+    void disableContentExtensionsCheck() { m_enableContentExtensionsCheck = false; }
+
 private:
     FetchRequest(ScriptExecutionContext&, std::optional<FetchBody>&&, Ref<FetchHeaders>&&, ResourceRequest&&, FetchOptions&&, String&& referrer);
 
@@ -110,6 +113,7 @@ private:
     String m_referrer;
     Ref<AbortSignal> m_signal;
     FetchIdentifier m_navigationPreloadIdentifier;
+    bool m_enableContentExtensionsCheck { true };
 };
 
 WebCoreOpaqueRoot root(FetchRequest*);

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -152,6 +152,9 @@ enum class PreflightPolicy : uint8_t {
 };
 static constexpr unsigned bitWidthOfPreflightPolicy = 2;
 
+enum class ShouldEnableContentExtensionsCheck : bool { No, Yes };
+static constexpr unsigned bitWidthOfShouldEnableContentExtensionsCheck = 1;
+
 enum class LoadedFromOpaqueSource : bool { No, Yes };
 static constexpr unsigned bitWidthOfLoadedFromOpaqueSource = 1;
 
@@ -186,6 +189,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         , loadedFromOpaqueSource(LoadedFromOpaqueSource::No)
         , loadedFromPluginElement(LoadedFromPluginElement::No)
         , fetchPriorityHint(RequestPriority::Auto)
+        , shouldEnableContentExtensionsCheck(ShouldEnableContentExtensionsCheck::Yes)
     { }
 
     ResourceLoaderOptions(SendCallbackPolicy sendLoadCallbacks, ContentSniffingPolicy sniffContent, DataBufferingPolicy dataBufferingPolicy, StoredCredentialsPolicy storedCredentialsPolicy, ClientCredentialPolicy credentialPolicy, FetchOptions::Credentials credentials, SecurityCheckPolicy securityCheck, FetchOptions::Mode mode, CertificateInfoPolicy certificateInfoPolicy, ContentSecurityPolicyImposition contentSecurityPolicyImposition, DefersLoadingPolicy defersLoadingPolicy, CachingPolicy cachingPolicy)
@@ -209,6 +213,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         , loadedFromOpaqueSource(LoadedFromOpaqueSource::No)
         , loadedFromPluginElement(LoadedFromPluginElement::No)
         , fetchPriorityHint(RequestPriority::Auto)
+        , shouldEnableContentExtensionsCheck(ShouldEnableContentExtensionsCheck::Yes)
     {
         this->credentials = credentials;
         this->mode = mode;
@@ -241,6 +246,7 @@ struct ResourceLoaderOptions : public FetchOptions {
     LoadedFromOpaqueSource loadedFromOpaqueSource : bitWidthOfLoadedFromOpaqueSource;
     LoadedFromPluginElement loadedFromPluginElement : bitWidthOfLoadedFromPluginElement;
     RequestPriority fetchPriorityHint : bitWidthOfFetchPriorityHint;
+    ShouldEnableContentExtensionsCheck shouldEnableContentExtensionsCheck : bitWidthOfShouldEnableContentExtensionsCheck;
 
     FetchIdentifier navigationPreloadIdentifier;
     String nonce;

--- a/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/Source/WebCore/loader/ThreadableLoader.cpp
@@ -100,6 +100,7 @@ ThreadableLoaderOptions ThreadableLoaderOptions::isolatedCopy() const
     copy.preflightPolicy = this->preflightPolicy;
     copy.navigationPreloadIdentifier = this->navigationPreloadIdentifier;
     copy.fetchPriorityHint = this->fetchPriorityHint;
+    copy.shouldEnableContentExtensionsCheck = this->shouldEnableContentExtensionsCheck;
 
     // ThreadableLoaderOptions
     copy.contentSecurityPolicyEnforcement = this->contentSecurityPolicyEnforcement;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6440,6 +6440,14 @@ void Internals::reloadWithoutContentExtensions()
         frame->loader().reload(ReloadOption::DisableContentBlockers);
 }
 
+void Internals::disableContentExtensionsChecks()
+{
+    RefPtr frame = this->frame();
+    RefPtr loader = frame ? frame->loader().documentLoader() : nullptr;
+    if (loader)
+        loader->setContentExtensionEnablement({ ContentExtensionDefaultEnablement::Disabled, { } });
+}
+
 void Internals::setUseSystemAppearance(bool value)
 {
     if (!contextDocument() || !contextDocument()->page())

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1178,6 +1178,7 @@ public:
     String ongoingLoadsDescriptions() const;
 
     void reloadWithoutContentExtensions();
+    void disableContentExtensionsChecks();
 
     void setUseSystemAppearance(bool);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1185,6 +1185,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined setCaptureExtraNetworkLoadMetricsEnabled(boolean value);
 
     undefined reloadWithoutContentExtensions();
+    undefined disableContentExtensionsChecks();
 
     undefined setUseSystemAppearance(boolean value);
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -188,6 +188,9 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
     URL requestURL = request.url();
     auto fetchRequest = FetchRequest::create(globalScope, WTFMove(body), WTFMove(requestHeaders),  WTFMove(request), WTFMove(options), WTFMove(referrer));
 
+    // The request has already passed content extension checks, no need to reapply them if service worker does the fetch itself.
+    fetchRequest->disableContentExtensionsCheck();
+
     // If service worker navigation preload is not enabled, we do not want to reuse any preload directly.
     if (!isServiceWorkerNavigationPreloadEnabled)
         fetchRequest->setNavigationPreloadIdentifier(fetchIdentifier);


### PR DESCRIPTION
#### 40efee6a397a9ef0fadc63c54c180b99ac713ba5
<pre>
Advanced Tracking and Fingerprinting Protection Issue with Service Workers
<a href="https://rdar.apple.com/117522948">rdar://117522948</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=263366">https://bugs.webkit.org/show_bug.cgi?id=263366</a>

Reviewed by Chris Dumez.

Requests exposed to service worker via the fetch events have already gone through content extension checks.
We can safely disable content extension checks for those requests.

We add a corresponding ResourceLoaderOptions which is tested in CachedResourceLoader::requestResource before apply content extension checks.
This new option is always enforcing content extension checks except for service worker fetch event requests.
We do so in ServiceWorkerFetch::dispatchFetchEvent, and we ensure that cloned requests or requests created from fetch event requests keep the same flag.

* LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost-serviceworker.js: Added.
(onmessage.async e):
* LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost.html: Added.
* LayoutTests/http/tests/contentextensions/service-worker-block-everything-if-localhost.html.json: Added.
* Source/WebCore/Modules/fetch/FetchLoader.cpp:
(WebCore::FetchLoader::start):
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeWith):
(WebCore::FetchRequest::clone):
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
(WebCore::ResourceLoaderOptions::shouldEnableContentExtensionsCheck):
(WebCore::ResourceLoaderOptions::ResourceLoaderOptions):
(WebCore::ResourceLoaderOptions::fetchPriorityHint): Deleted.
* Source/WebCore/loader/ThreadableLoader.cpp:
(WebCore::ThreadableLoaderOptions::isolatedCopy const):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::disableContentExtensionsChecks):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):

Canonical link: <a href="https://commits.webkit.org/275970@main">https://commits.webkit.org/275970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8abe15718ccd6c353fe34a1ebe7b96ebd5b372d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35888 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19473 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16865 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1469 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47592 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15078 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42674 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41338 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9661 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->