### PR TITLE
REGRESSION(272743@main): WebVTT default styling is broken

### DIFF
--- a/LayoutTests/media/track/captions-webvtt/inline.vtt
+++ b/LayoutTests/media/track/captions-webvtt/inline.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:05.000 align:left
+<i>i</i><b>b</b><u>u</u><c.hidden>hidden</c>

--- a/LayoutTests/media/track/webvtt-inline-expected.txt
+++ b/LayoutTests/media/track/webvtt-inline-expected.txt
@@ -1,0 +1,14 @@
+
+EVENT(canplay)
+EVENT(addtrack)
+EXPECTED (video.textTracks.length == '1') OK
+RUN(video.textTracks[0].mode = 'showing')
+RUN(video.currentTime = 1)
+EVENT(seeked)
+EXPECTED (window.internals.shadowRoot(video).querySelector('i') != 'null') OK
+EXPECTED (getComputedStyle(i).fontStyle == 'italic') OK
+EXPECTED (getComputedStyle(b).fontWeight == '700') OK
+EXPECTED (getComputedStyle(u).textDecoration == 'underline') OK
+EXPECTED (getComputedStyle(c).display == 'none') OK
+END OF TEST
+

--- a/LayoutTests/media/track/webvtt-inline.html
+++ b/LayoutTests/media/track/webvtt-inline.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+    <head>
+        <title>WebVTTRubyText elements should appear above WebVTTRuby elements</title>
+        <script src=../../resources/js-test-pre.js></script>
+        <script src=../video-test.js></script>
+        <script src=../media-file.js></script>
+        <script>
+            async function runTest()
+            {
+                video = document.getElementById('video');
+                video.src = findMediaFile('video', '../content/test');
+                await waitFor(video, 'canplay');
+                let track = document.createElement('track');
+                track.src = 'captions-webvtt/inline.vtt';
+                video.appendChild(track)
+
+                await waitFor(video.textTracks, 'addtrack');
+                testExpected("video.textTracks.length", 1);
+                run("video.textTracks[0].mode = 'showing'");
+
+                run("video.currentTime = 1");
+                await waitFor(video, 'seeked');
+
+                window.internals.ensureUserAgentShadowRoot(video);
+                await testExpectedEventually("window.internals.shadowRoot(video).querySelector('i')", null, "!=", 1000);
+                i = window.internals.shadowRoot(video).querySelector('i');
+                b = window.internals.shadowRoot(video).querySelector('b');
+                u = window.internals.shadowRoot(video).querySelector('u');
+                c = window.internals.shadowRoot(video).querySelector('c');
+                testExpected("getComputedStyle(i).fontStyle", "italic");
+                testExpected("getComputedStyle(b).fontWeight", "700");
+                testExpected("getComputedStyle(u).textDecoration", "underline");
+                testExpected("getComputedStyle(c).display", "none");
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <video id="video" width="320px" height="240px" paused></video>
+    </body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -94,18 +94,7 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
     color: gray;
 }
 
-[pseudo="-webkit-media-text-track-display"] b {
-    font-weight: bold;
-}
-
-[pseudo="-webkit-media-text-track-display"] u {
-    text-decoration: underline;
-}
-
-[pseudo="-webkit-media-text-track-display"] i {
-    font-style: italic;
-}
-
-[pseudo="-webkit-media-text-track-display"] .hidden {
-    display: none;
-}
+[useragentpart="-webkit-media-text-track-display"] b { font-weight: bold; }
+[useragentpart="-webkit-media-text-track-display"] u { text-decoration: underline; }
+[useragentpart="-webkit-media-text-track-display"] i { font-style: italic; }
+[useragentpart="-webkit-media-text-track-display"] .hidden { display: none; }

--- a/Source/WebCore/css/mediaControls.css
+++ b/Source/WebCore/css/mediaControls.css
@@ -273,16 +273,9 @@ video::cue(:future) {
     color: gray;
 }
 
-[pseudo="-webkit-media-text-track-display"] b {
-    font-weight: bold;
-}
-
-[pseudo="-webkit-media-text-track-display"] u {
-    text-decoration: underline;
-}
-
-[pseudo="-webkit-media-text-track-display"] i {
-    font-style: italic;
-}
+[useragentpart="-webkit-media-text-track-display"] b { font-weight: bold; }
+[useragentpart="-webkit-media-text-track-display"] u { text-decoration: underline; }
+[useragentpart="-webkit-media-text-track-display"] i { font-style: italic; }
+[useragentpart="-webkit-media-text-track-display"] .hidden { display: none; }
 
 #endif


### PR DESCRIPTION
#### 472c2a9abc39ccee3c44f9bbe1c2f97cc257780d
<pre>
REGRESSION(272743@main): WebVTT default styling is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=270783">https://bugs.webkit.org/show_bug.cgi?id=270783</a>
<a href="https://rdar.apple.com/124380882">rdar://124380882</a>

Reviewed by Anne van Kesteren.

272743@main changed the attribute name for pseudo elements.
The WebVTT styling relied on those names.

* LayoutTests/media/track/captions-webvtt/inline.vtt: Added.
* LayoutTests/media/track/webvtt-inline-expected.txt: Added.
* LayoutTests/media/track/webvtt-inline.html: Added.

Add a test. We had no coverage.

* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
([useragentpart=&quot;-webkit-media-text-track-display&quot;]):
(u):
(i):
(.hidden):
([pseudo=&quot;-webkit-media-text-track-display&quot;] b): Deleted.
([pseudo=&quot;-webkit-media-text-track-display&quot;] u): Deleted.
([pseudo=&quot;-webkit-media-text-track-display&quot;] i): Deleted.
([pseudo=&quot;-webkit-media-text-track-display&quot;] .hidden): Deleted.
* Source/WebCore/css/mediaControls.css:
([useragentpart=&quot;-webkit-media-text-track-display&quot;]):
(u):
(i):
(.hidden):

Also add missing .hidden to this legacy stylesheet.

([pseudo=&quot;-webkit-media-text-track-display&quot;] b): Deleted.
([pseudo=&quot;-webkit-media-text-track-display&quot;] u): Deleted.
([pseudo=&quot;-webkit-media-text-track-display&quot;] i): Deleted.

Canonical link: <a href="https://commits.webkit.org/275918@main">https://commits.webkit.org/275918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ce034218ed69c1d7499e25625536032595b29d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22320 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/45700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19738 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/45924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43861 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/45700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/45700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/1346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/45700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/47469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/45700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9626 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->