### PR TITLE
LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html is flaky on arm64 bots

### DIFF
--- a/LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html
+++ b/LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html
@@ -111,7 +111,7 @@ async function waitForVideoSize(video, width, height)
     const max = 200
     let counter = 0;
     while (++counter < max && video.videoWidth != width && video.videoHeight != height)
-        await waitFor(50);
+        await new Promise(resolve => setTimeout(resolve, 50));
 
     if (counter === max)
         return Promise.reject("Video size not expected : " + video.videoWidth + " " + video.videoHeight);


### PR DESCRIPTION
#### cbdb72d59d20bd0cbc52b9e2bc409bf0b4e8d115
<pre>
LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html is flaky on arm64 bots
<a href="https://rdar.apple.com/124381982">rdar://124381982</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270785">https://bugs.webkit.org/show_bug.cgi?id=270785</a>

Reviewed by Eric Carlson and Jean-Yves Avenard.

* LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html:
waitFor was not defined, let&apos;s implement it directly using setTimeout.

Canonical link: <a href="https://commits.webkit.org/275965@main">https://commits.webkit.org/275965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/943c58500e4d0f0fc8135c0b694913b4dbdbfca7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45883 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39370 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38329 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1300 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47427 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42562 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41217 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9659 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->